### PR TITLE
Fix OSC 11 sequences appearing as literal text in cmux send

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5204,6 +5204,30 @@ final class TerminalSurfaceRegistry {
     }
 }
 
+private final class TerminalSharedBackdropCutoutFilter: CIFilter {
+    private static let filterInputKeys = [kCIInputImageKey, kCIInputBackgroundImageKey]
+    private static let filterOutputKeys = [kCIOutputImageKey]
+
+    @objc dynamic var inputImage: CIImage?
+    @objc dynamic var inputBackgroundImage: CIImage?
+
+    override var inputKeys: [String] {
+        Self.filterInputKeys
+    }
+
+    override var outputKeys: [String] {
+        Self.filterOutputKeys
+    }
+
+    override var outputImage: CIImage? {
+        guard let inputImage, let inputBackgroundImage else { return nil }
+        return CIBlendKernel.destinationOut.apply(
+            foreground: inputImage,
+            background: inputBackgroundImage
+        )
+    }
+}
+
 // MARK: - Terminal Surface (owns the ghostty_surface_t lifecycle)
 
 enum TerminalSurfaceFocusPlacement: Equatable {
@@ -5249,11 +5273,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private enum PendingSocketInput {
         case pasteText(Data)
         case inputText(Data)
+        case processOutput(Data)
         case key(PendingKeyEvent)
 
         var estimatedBytes: Int {
             switch self {
-            case .pasteText(let data), .inputText(let data):
+            case .pasteText(let data), .inputText(let data), .processOutput(let data):
                 return data.count
             case .key(let event):
                 return event.queuedByteCost
@@ -5263,6 +5288,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private enum ParsedSocketInput {
         case rawBytes(Data)
+        case terminalBytes(Data)
         case key(PendingKeyEvent)
     }
 
@@ -7212,9 +7238,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     /// Send text with control characters (Return, Tab, etc.) delivered as key
-    /// events so the shell processes them, while regular text is sent via the
-    /// normal key-text path. Cold surfaces queue the same ordered events and
-    /// flush them after runtime creation.
+    /// events so the shell processes them, while complete terminal control
+    /// sequences are routed through Ghostty's PTY-output parser. Cold surfaces
+    /// queue the same ordered events and flush them after runtime creation.
     @MainActor
     @discardableResult
     func sendInput(_ text: String) -> Bool {
@@ -7249,6 +7275,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
             switch event {
             case .rawBytes(let data):
                 writeInputTextData(data, to: surface)
+            case .terminalBytes(let data):
+                writeProcessOutputData(data, to: surface)
             case .key(let event):
                 sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
             }
@@ -7261,6 +7289,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
             switch event {
             case .rawBytes(let data):
                 return data.isEmpty ? nil : .inputText(data)
+            case .terminalBytes(let data):
+                return data.isEmpty ? nil : .processOutput(data)
             case .key(let event):
                 return .key(event)
             }
@@ -7276,6 +7306,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         var bufferedText = ""
         bufferedText.reserveCapacity(text.count)
         var previousWasCR = false
+        let scalars = Array(text.unicodeScalars)
 
         func flushBufferedText() {
             guard !bufferedText.isEmpty else { return }
@@ -7297,7 +7328,16 @@ final class TerminalSurface: Identifiable, ObservableObject {
             events.append(.rawBytes(Data([0x0D])))
         }
 
-        let scalars = Array(text.unicodeScalars)
+        func appendTerminalBytes(length: Int, from start: Int) {
+            guard length > 0 else { return }
+            var sequence = ""
+            for offset in start..<(start + length) {
+                sequence.unicodeScalars.append(scalars[offset])
+            }
+            guard let data = sequence.data(using: .utf8), !data.isEmpty else { return }
+            events.append(.terminalBytes(data))
+        }
+
         var index = 0
         while index < scalars.count {
             let scalar = scalars[index]
@@ -7330,6 +7370,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
                     flushBufferedText()
                     appendKey(nav.keycode, mods: nav.mods, label: nav.label)
                     index += nav.length
+                } else if let length = terminalControlSequenceLength(scalars, from: index) {
+                    flushBufferedText()
+                    appendTerminalBytes(length: length, from: index)
+                    index += length
                 } else {
                     flushBufferedText()
                     appendKey(UInt32(kVK_Escape), label: "escape")
@@ -7349,6 +7393,43 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
         flushBufferedText()
         return events
+    }
+
+    private static func terminalControlSequenceLength(
+        _ scalars: [Unicode.Scalar],
+        from start: Int
+    ) -> Int? {
+        guard start + 1 < scalars.count, scalars[start].value == 0x1B else { return nil }
+
+        switch scalars[start + 1].value {
+        case 0x5D: // OSC: ESC ] ... (BEL | ST)
+            return stringControlSequenceLength(scalars, from: start, terminatesWithBEL: true)
+        case 0x50, 0x5E, 0x5F: // DCS / PM / APC: ESC P/^/_ ... ST
+            return stringControlSequenceLength(scalars, from: start, terminatesWithBEL: false)
+        default:
+            return nil
+        }
+    }
+
+    private static func stringControlSequenceLength(
+        _ scalars: [Unicode.Scalar],
+        from start: Int,
+        terminatesWithBEL: Bool
+    ) -> Int? {
+        var index = start + 2
+        while index < scalars.count {
+            let value = scalars[index].value
+            if terminatesWithBEL, value == 0x07 {
+                return index - start + 1
+            }
+            if value == 0x1B,
+               index + 1 < scalars.count,
+               scalars[index + 1].value == 0x5C {
+                return index - start + 2
+            }
+            index += 1
+        }
+        return nil
     }
 
     /// Match a CSI (`ESC [ …`) or SS3 (`ESC O …`) cursor/navigation escape
@@ -7543,6 +7624,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
         data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
             ghostty_surface_text_input(surface, baseAddress, UInt(rawBuffer.count))
+        }
+    }
+
+    private func writeProcessOutputData(_ data: Data, to surface: ghostty_surface_t) {
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
+            ghostty_surface_process_output(surface, baseAddress, UInt(rawBuffer.count))
         }
     }
 
@@ -7775,6 +7863,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 writeTextData(chunk, to: surface)
             case .inputText(let chunk):
                 writeInputTextData(chunk, to: surface)
+            case .processOutput(let chunk):
+                writeProcessOutputData(chunk, to: surface)
             case .key(let event):
                 queuedKeys += 1
                 sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
@@ -7850,10 +7940,11 @@ final class TerminalSurface: Identifiable, ObservableObject {
         bytes: Int,
         keyEvents: Int,
         pasteTextItems: Int,
-        inputTextItems: Int
+        inputTextItems: Int,
+        processOutputItems: Int
     ) {
         let counts = pendingSocketInputQueue.reduce(
-            into: (keyEvents: 0, pasteTextItems: 0, inputTextItems: 0)
+            into: (keyEvents: 0, pasteTextItems: 0, inputTextItems: 0, processOutputItems: 0)
         ) { counts, item in
             switch item {
             case .key:
@@ -7862,6 +7953,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 counts.pasteTextItems += 1
             case .inputText:
                 counts.inputTextItems += 1
+            case .processOutput:
+                counts.processOutputItems += 1
             }
         }
         return (
@@ -7869,7 +7962,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
             pendingSocketInputBytes,
             counts.keyEvents,
             counts.pasteTextItems,
-            counts.inputTextItems
+            counts.inputTextItems,
+            counts.processOutputItems
         )
     }
 
@@ -8310,15 +8404,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             renderingMode: renderingMode,
             sharesWindowBackdrop: sharesWindowBackdrop
         )
-        // The window root backdrop is the single surface fill for solid-color
-        // terminal backgrounds. Painting the terminal host layer too would
-        // double-composite it against the surrounding chrome.
-        let usesHostLayerFill = renderingMode.usesWindowHostBackdrop &&
-            !sharesWindowBackdrop &&
-            !usesBonsplitPaneBackdrop
-        let color = usesHostLayerFill
-            ? effectiveBackgroundColor()
-            : .clear
+        let fillPlan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: renderingMode,
+            surfaceBackgroundColor: backgroundColor,
+            defaultBackgroundColor: GhosttyApp.shared.defaultBackgroundColor,
+            backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity,
+            sharesWindowBackdrop: sharesWindowBackdrop,
+            usesBonsplitPaneBackdrop: usesBonsplitPaneBackdrop
+        )
+        let color = fillPlan.hostLayerColor
         if let layer {
             CATransaction.begin()
             CATransaction.setDisableActions(true)
@@ -8328,23 +8422,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             layer.isOpaque = false
             CATransaction.commit()
         }
-        terminalSurface?.hostedView.setBackgroundColor(color)
+        terminalSurface?.hostedView.setBackgroundColor(
+            color,
+            clearsSharedWindowBackdrop: fillPlan.clearsSharedWindowBackdrop
+        )
         if GhosttyApp.shared.backgroundLogEnabled {
-            let signature = "\(usesHostLayerFill ? color.hexString() : "transparent-host"):\(String(format: "%.3f", color.alphaComponent)):\(sharesWindowBackdrop ? "shared" : (usesBonsplitPaneBackdrop ? "bonsplit-pane" : "terminal"))"
+            let signature = "\(fillPlan.usesHostLayerFill ? color.hexString() : "transparent-host"):\(String(format: "%.3f", color.alphaComponent)):\(fillPlan.logBackdropLabel)"
             if signature != lastLoggedSurfaceBackgroundSignature {
                 lastLoggedSurfaceBackgroundSignature = signature
                 let hasOverride = backgroundColor != nil
                 let overrideHex = backgroundColor?.hexString() ?? "nil"
                 let defaultHex = GhosttyApp.shared.defaultBackgroundColor.hexString()
-                let source = usesHostLayerFill
-                    ? (hasOverride ? "surfaceOverride" : "defaultBackground")
-                    : (
-                        sharesWindowBackdrop
-                            ? "sharedWindowBackdrop"
-                            : (usesBonsplitPaneBackdrop ? "bonsplitPaneBackdrop" : "ghosttyNativeBackground")
-                    )
                 GhosttyApp.shared.logBackground(
-                    "surface background applied tab=\(tabId?.uuidString ?? "unknown") surface=\(terminalSurface?.id.uuidString ?? "unknown") source=\(source) override=\(overrideHex) default=\(defaultHex) sharedWindowBackdrop=\(sharesWindowBackdrop ? 1 : 0) bonsplitPaneBackdrop=\(usesBonsplitPaneBackdrop ? 1 : 0) color=\(color.hexString()) opacity=\(String(format: "%.3f", color.alphaComponent))"
+                    "surface background applied tab=\(tabId?.uuidString ?? "unknown") surface=\(terminalSurface?.id.uuidString ?? "unknown") source=\(fillPlan.logSource(hasSurfaceOverride: hasOverride)) override=\(overrideHex) default=\(defaultHex) sharedWindowBackdrop=\(sharesWindowBackdrop ? 1 : 0) bonsplitPaneBackdrop=\(usesBonsplitPaneBackdrop ? 1 : 0) color=\(color.hexString()) opacity=\(String(format: "%.3f", color.alphaComponent))"
                 )
             }
         }
@@ -12147,6 +12237,7 @@ final class GhosttySurfaceScrollView: NSView {
         static let lineWidth = PanelOverlayRingMetrics.lineWidth
     }
 
+    private var sharedBackdropCutoutView: NSView?
     private let backgroundView: NSView
     private let scrollView: GhosttyScrollView
     private let documentView: NSView
@@ -12835,6 +12926,9 @@ final class GhosttySurfaceScrollView: NSView {
 
         let didScrollbarAppearanceChange = synchronizeScrollbarAppearance()
         let previousSurfaceSize = surfaceView.frame.size
+        if let sharedBackdropCutoutView {
+            _ = setFrameIfNeeded(sharedBackdropCutoutView, to: bounds)
+        }
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         _ = setFrameIfNeeded(scrollView, to: bounds)
         let targetSize = scrollView.bounds.size
@@ -13101,13 +13195,41 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.onTriggerFlash = handler
     }
 
-    func setBackgroundColor(_ color: NSColor) {
+    func setBackgroundColor(_ color: NSColor, clearsSharedWindowBackdrop: Bool = false) {
         guard let layer = backgroundView.layer else { return }
         CATransaction.begin()
         CATransaction.setDisableActions(true)
+        synchronizeSharedBackdropCutout(visible: clearsSharedWindowBackdrop)
         layer.backgroundColor = color.cgColor
         layer.isOpaque = color.alphaComponent >= 1.0
         CATransaction.commit()
+    }
+
+    private func synchronizeSharedBackdropCutout(visible: Bool) {
+        if visible {
+            let cutoutView = sharedBackdropCutoutView ?? makeSharedBackdropCutoutView()
+            _ = setFrameIfNeeded(cutoutView, to: bounds)
+            return
+        }
+
+        sharedBackdropCutoutView?.removeFromSuperview()
+        sharedBackdropCutoutView = nil
+    }
+
+    // AppKit requires layerUsesCoreImageFilters to be configured before display.
+    // Create the filtered view only while a pane-local cutout is needed.
+    private func makeSharedBackdropCutoutView() -> NSView {
+        let sharedBackdropCutoutFilter = TerminalSharedBackdropCutoutFilter()
+        sharedBackdropCutoutFilter.name = "terminalSharedBackdropCutout"
+        let cutoutView = NSView(frame: bounds)
+        cutoutView.wantsLayer = true
+        cutoutView.layerUsesCoreImageFilters = true
+        cutoutView.compositingFilter = sharedBackdropCutoutFilter
+        cutoutView.layer?.backgroundColor = NSColor.white.cgColor
+        cutoutView.layer?.isOpaque = true
+        addSubview(cutoutView, positioned: .below, relativeTo: backgroundView)
+        sharedBackdropCutoutView = cutoutView
+        return cutoutView
     }
 
     func setInactiveOverlay(color: NSColor, opacity: CGFloat, visible: Bool) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5204,21 +5204,28 @@ final class TerminalSurfaceRegistry {
     }
 }
 
+/// Core Image filter that cuts a pane-local terminal fill out of the shared window backdrop.
 private final class TerminalSharedBackdropCutoutFilter: CIFilter {
     private static let filterInputKeys = [kCIInputImageKey, kCIInputBackgroundImageKey]
     private static let filterOutputKeys = [kCIOutputImageKey]
 
+    /// The mask image supplied by AppKit for the cutout view.
     @objc dynamic var inputImage: CIImage?
+
+    /// The already-rendered shared backdrop behind the terminal surface.
     @objc dynamic var inputBackgroundImage: CIImage?
 
+    /// Input keys advertised to AppKit's Core Image compositing pipeline.
     override var inputKeys: [String] {
         Self.filterInputKeys
     }
 
+    /// Output keys advertised to AppKit's Core Image compositing pipeline.
     override var outputKeys: [String] {
         Self.filterOutputKeys
     }
 
+    /// The backdrop image with the cutout mask removed.
     override var outputImage: CIImage? {
         guard let inputImage, let inputBackgroundImage else { return nil }
         return CIBlendKernel.destinationOut.apply(
@@ -5273,6 +5280,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private enum PendingSocketInput {
         case pasteText(Data)
         case inputText(Data)
+        /// Bytes that must be processed as terminal output, not user input.
         case processOutput(Data)
         case key(PendingKeyEvent)
 
@@ -5288,6 +5296,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private enum ParsedSocketInput {
         case rawBytes(Data)
+        /// A complete terminal string control sequence such as OSC, DCS, PM, or APC.
         case terminalBytes(Data)
         case key(PendingKeyEvent)
     }
@@ -7395,6 +7404,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return events
     }
 
+    /// Returns the byte-like scalar length for a complete terminal string control sequence.
     private static func terminalControlSequenceLength(
         _ scalars: [Unicode.Scalar],
         from start: Int
@@ -7411,6 +7421,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    /// Finds the terminator for ESC-prefixed string controls without accepting partial sequences.
     private static func stringControlSequenceLength(
         _ scalars: [Unicode.Scalar],
         from start: Int,
@@ -7627,6 +7638,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    /// Sends bytes through Ghostty's PTY-output parser so OSC commands affect terminal state.
     private func writeProcessOutputData(_ data: Data, to surface: ghostty_surface_t) {
         data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress?.assumingMemoryBound(to: CChar.self) else { return }
@@ -13195,6 +13207,7 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.onTriggerFlash = handler
     }
 
+    /// Applies the host-layer terminal fill and optionally clears the shared backdrop behind it.
     func setBackgroundColor(_ color: NSColor, clearsSharedWindowBackdrop: Bool = false) {
         guard let layer = backgroundView.layer else { return }
         CATransaction.begin()
@@ -13205,6 +13218,7 @@ final class GhosttySurfaceScrollView: NSView {
         CATransaction.commit()
     }
 
+    /// Keeps the shared-backdrop cutout view present only while a pane-local fill needs it.
     private func synchronizeSharedBackdropCutout(visible: Bool) {
         if visible {
             let cutoutView = sharedBackdropCutoutView ?? makeSharedBackdropCutoutView()
@@ -13216,8 +13230,10 @@ final class GhosttySurfaceScrollView: NSView {
         sharedBackdropCutoutView = nil
     }
 
-    // AppKit requires layerUsesCoreImageFilters to be configured before display.
-    // Create the filtered view only while a pane-local cutout is needed.
+    /// Creates the Core Image filtered view that subtracts pane-local fills from shared backdrop.
+    ///
+    /// AppKit requires `layerUsesCoreImageFilters` to be configured before display, so the
+    /// cutout view is created lazily only when a pane-local OSC background override needs it.
     private func makeSharedBackdropCutoutView() -> NSView {
         let sharedBackdropCutoutFilter = TerminalSharedBackdropCutoutFilter()
         sharedBackdropCutoutFilter.name = "terminalSharedBackdropCutout"

--- a/Sources/Windowing/WindowAppearanceSnapshot.swift
+++ b/Sources/Windowing/WindowAppearanceSnapshot.swift
@@ -93,6 +93,81 @@ enum WindowBackdropPolicy {
     }
 }
 
+enum TerminalSurfaceBackgroundFillOwner: Equatable {
+    case surfaceHostLayer
+    case sharedWindowBackdrop
+    case bonsplitPaneBackdrop
+    case ghosttyNativeRenderer
+}
+
+struct TerminalSurfaceBackgroundFillPlan {
+    let owner: TerminalSurfaceBackgroundFillOwner
+    let hostLayerColor: NSColor
+    let clearsSharedWindowBackdrop: Bool
+
+    var usesHostLayerFill: Bool {
+        owner == .surfaceHostLayer
+    }
+
+    var logBackdropLabel: String {
+        switch owner {
+        case .surfaceHostLayer:
+            return "terminal"
+        case .sharedWindowBackdrop:
+            return "shared"
+        case .bonsplitPaneBackdrop:
+            return "bonsplit-pane"
+        case .ghosttyNativeRenderer:
+            return "ghostty-native"
+        }
+    }
+
+    func logSource(hasSurfaceOverride: Bool) -> String {
+        switch owner {
+        case .surfaceHostLayer:
+            return hasSurfaceOverride ? "surfaceOverride" : "defaultBackground"
+        case .sharedWindowBackdrop:
+            return "sharedWindowBackdrop"
+        case .bonsplitPaneBackdrop:
+            return "bonsplitPaneBackdrop"
+        case .ghosttyNativeRenderer:
+            return "ghosttyNativeBackground"
+        }
+    }
+
+    static func resolve(
+        renderingMode: GhosttyTerminalBackdropRenderingMode,
+        surfaceBackgroundColor: NSColor?,
+        defaultBackgroundColor: NSColor,
+        backgroundOpacity: Double,
+        sharesWindowBackdrop: Bool,
+        usesBonsplitPaneBackdrop: Bool
+    ) -> Self {
+        let resolvedColor = (surfaceBackgroundColor ?? defaultBackgroundColor)
+            .withAlphaComponent(WindowAppearanceSnapshot.clampedOpacity(backgroundOpacity))
+        let owner: TerminalSurfaceBackgroundFillOwner
+        let usesPaneLocalSurfaceFill = surfaceBackgroundColor != nil &&
+            renderingMode.usesWindowHostBackdrop &&
+            !usesBonsplitPaneBackdrop
+        if !renderingMode.usesWindowHostBackdrop {
+            owner = .ghosttyNativeRenderer
+        } else if usesPaneLocalSurfaceFill {
+            owner = .surfaceHostLayer
+        } else if !sharesWindowBackdrop && !usesBonsplitPaneBackdrop {
+            owner = .surfaceHostLayer
+        } else if sharesWindowBackdrop {
+            owner = .sharedWindowBackdrop
+        } else {
+            owner = .bonsplitPaneBackdrop
+        }
+        return Self(
+            owner: owner,
+            hostLayerColor: owner == .surfaceHostLayer ? resolvedColor : .clear,
+            clearsSharedWindowBackdrop: usesPaneLocalSurfaceFill && sharesWindowBackdrop
+        )
+    }
+}
+
 struct SidebarBackdropSettingsSnapshot {
     let materialRawValue: String
     let blendModeRawValue: String

--- a/Sources/Windowing/WindowAppearanceSnapshot.swift
+++ b/Sources/Windowing/WindowAppearanceSnapshot.swift
@@ -93,22 +93,38 @@ enum WindowBackdropPolicy {
     }
 }
 
+/// Identifies the layer responsible for painting a terminal surface background.
 enum TerminalSurfaceBackgroundFillOwner: Equatable {
+    /// The terminal hosting view should paint the resolved background color.
     case surfaceHostLayer
+
+    /// The shared root backdrop should remain the only visible background fill.
     case sharedWindowBackdrop
+
+    /// The Bonsplit pane backdrop should remain the only visible background fill.
     case bonsplitPaneBackdrop
+
+    /// Ghostty's renderer owns the background instead of cmux's host layers.
     case ghosttyNativeRenderer
 }
 
+/// Resolved background painting decision for one terminal surface.
 struct TerminalSurfaceBackgroundFillPlan {
+    /// The layer or renderer that owns the visible terminal background.
     let owner: TerminalSurfaceBackgroundFillOwner
+
+    /// The color to apply to the terminal host layer, or clear when another layer owns the fill.
     let hostLayerColor: NSColor
+
+    /// Whether a host-layer fill must subtract itself from the shared window backdrop.
     let clearsSharedWindowBackdrop: Bool
 
+    /// Whether the terminal host layer should paint a non-clear fill.
     var usesHostLayerFill: Bool {
         owner == .surfaceHostLayer
     }
 
+    /// Compact label used by debug logging for the selected backdrop owner.
     var logBackdropLabel: String {
         switch owner {
         case .surfaceHostLayer:
@@ -122,6 +138,7 @@ struct TerminalSurfaceBackgroundFillPlan {
         }
     }
 
+    /// Returns the debug-log source label for the selected owner.
     func logSource(hasSurfaceOverride: Bool) -> String {
         switch owner {
         case .surfaceHostLayer:
@@ -135,6 +152,7 @@ struct TerminalSurfaceBackgroundFillPlan {
         }
     }
 
+    /// Computes the terminal background owner and host-layer color for current appearance state.
     static func resolve(
         renderingMode: GhosttyTerminalBackdropRenderingMode,
         surfaceBackgroundColor: NSColor?,

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1192,6 +1192,32 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         )
     }
 
+    func testColdSocketInputQueuesOSC11AsRawTerminalBytes() {
+        let panel = TerminalPanel(workspaceId: UUID())
+
+        panel.surface.releaseSurfaceForTesting()
+        let osc11 = "\u{1B}]11;#341c1c\u{1B}\\"
+        XCTAssertTrue(panel.surface.sendInput(osc11))
+
+        let pending = panel.surface.debugPendingSocketInputForTesting()
+        XCTAssertEqual(
+            pending.keyEvents,
+            0,
+            "OSC 11 must not be split into Escape key events plus literal text."
+        )
+        XCTAssertEqual(
+            pending.inputTextItems,
+            0,
+            "OSC 11 must bypass committed text input so Ghostty consumes it as a terminal control sequence."
+        )
+        XCTAssertEqual(
+            pending.pasteTextItems,
+            1,
+            "OSC 11 must be queued as one raw terminal-byte payload."
+        )
+        XCTAssertEqual(pending.bytes, osc11.utf8.count)
+    }
+
     func testColdSocketInputChunksLongCommittedTextInput() {
         let panel = TerminalPanel(workspaceId: UUID())
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1192,6 +1192,7 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         )
     }
 
+    /// Verifies OSC 11 is queued as terminal output bytes instead of literal shell input.
     func testColdSocketInputQueuesOSC11AsRawTerminalBytes() {
         let panel = TerminalPanel(workspaceId: UUID())
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1212,8 +1212,13 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         )
         XCTAssertEqual(
             pending.pasteTextItems,
+            0,
+            "OSC 11 must bypass paste input so it is not echoed by the shell."
+        )
+        XCTAssertEqual(
+            pending.processOutputItems,
             1,
-            "OSC 11 must be queued as one raw terminal-byte payload."
+            "OSC 11 must be queued as one terminal output payload."
         )
         XCTAssertEqual(pending.bytes, osc11.utf8.count)
     }

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -228,6 +228,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertTrue(plan.usesWindowGlass)
     }
 
+    /// Verifies pane-local OSC colors paint on the host layer over a shared root backdrop.
     func testOSCOverrideUsesSurfaceHostFillWhenWindowRootBackdropIsShared() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .windowHostBackdrop,
@@ -243,6 +244,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertTrue(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies translucent OSC colors use one host-layer fill with configured opacity.
     func testTranslucentOSCOverrideUsesOneSurfaceHostFillWithConfiguredOpacity() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .windowHostBackdrop,
@@ -259,6 +261,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertTrue(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies default backgrounds keep the shared backdrop intact.
     func testSharedWindowBackdropDoesNotCutOutForDefaultBackgrounds() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .windowHostBackdrop,
@@ -274,6 +277,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertFalse(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies Bonsplit-owned pane backdrops stay authoritative when no cutout is available.
     func testOSCOverrideKeepsBonsplitPaneBackdropOwnerWhenNoCutoutIsAvailable() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .windowHostBackdrop,
@@ -289,6 +293,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertFalse(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies non-shared window backdrops let OSC colors paint directly on the host layer.
     func testOSCOverrideUsesSurfaceHostFillWhenWindowBackdropIsNotShared() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .windowHostBackdrop,
@@ -305,6 +310,7 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertFalse(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies renderer-owned backgrounds keep cmux host layers clear.
     func testRendererOwnedOSCOverrideKeepsHostLayerClearWhenWindowRootBackdropIsShared() {
         let plan = TerminalSurfaceBackgroundFillPlan.resolve(
             renderingMode: .ghosttyRendererOwnedBackgroundImage,

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -228,6 +228,98 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertTrue(plan.usesWindowGlass)
     }
 
+    func testOSCOverrideUsesSurfaceHostFillWhenWindowRootBackdropIsShared() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .windowHostBackdrop,
+            surfaceBackgroundColor: NSColor(hex: "#D2EEF9") ?? .white,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 1.0,
+            sharesWindowBackdrop: true,
+            usesBonsplitPaneBackdrop: false
+        )
+
+        XCTAssertEqual(plan.owner, .surfaceHostLayer)
+        XCTAssertEqual(plan.hostLayerColor.hexString(includeAlpha: true), "#D2EEF9FF")
+        XCTAssertTrue(plan.clearsSharedWindowBackdrop)
+    }
+
+    func testTranslucentOSCOverrideUsesOneSurfaceHostFillWithConfiguredOpacity() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .windowHostBackdrop,
+            surfaceBackgroundColor: NSColor(hex: "#E2D2F0") ?? .white,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 0.42,
+            sharesWindowBackdrop: true,
+            usesBonsplitPaneBackdrop: false
+        )
+
+        XCTAssertEqual(plan.owner, .surfaceHostLayer)
+        XCTAssertEqual(plan.hostLayerColor.hexString(), "#E2D2F0")
+        XCTAssertEqual(plan.hostLayerColor.alphaComponent, 0.42, accuracy: 0.0001)
+        XCTAssertTrue(plan.clearsSharedWindowBackdrop)
+    }
+
+    func testSharedWindowBackdropDoesNotCutOutForDefaultBackgrounds() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .windowHostBackdrop,
+            surfaceBackgroundColor: nil,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 0.42,
+            sharesWindowBackdrop: true,
+            usesBonsplitPaneBackdrop: false
+        )
+
+        XCTAssertEqual(plan.owner, .sharedWindowBackdrop)
+        XCTAssertEqual(plan.hostLayerColor.hexString(includeAlpha: true), "#00000000")
+        XCTAssertFalse(plan.clearsSharedWindowBackdrop)
+    }
+
+    func testOSCOverrideKeepsBonsplitPaneBackdropOwnerWhenNoCutoutIsAvailable() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .windowHostBackdrop,
+            surfaceBackgroundColor: NSColor(hex: "#D2EEF9") ?? .white,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 0.42,
+            sharesWindowBackdrop: false,
+            usesBonsplitPaneBackdrop: true
+        )
+
+        XCTAssertEqual(plan.owner, .bonsplitPaneBackdrop)
+        XCTAssertEqual(plan.hostLayerColor.hexString(includeAlpha: true), "#00000000")
+        XCTAssertFalse(plan.clearsSharedWindowBackdrop)
+    }
+
+    func testOSCOverrideUsesSurfaceHostFillWhenWindowBackdropIsNotShared() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .windowHostBackdrop,
+            surfaceBackgroundColor: NSColor(hex: "#B5EAD7") ?? .white,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 0.73,
+            sharesWindowBackdrop: false,
+            usesBonsplitPaneBackdrop: false
+        )
+
+        XCTAssertEqual(plan.owner, .surfaceHostLayer)
+        XCTAssertEqual(plan.hostLayerColor.hexString(), "#B5EAD7")
+        XCTAssertEqual(plan.hostLayerColor.alphaComponent, 0.73, accuracy: 0.0001)
+        XCTAssertFalse(plan.clearsSharedWindowBackdrop)
+    }
+
+    func testRendererOwnedOSCOverrideKeepsHostLayerClearWhenWindowRootBackdropIsShared() {
+        let plan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: .ghosttyRendererOwnedBackgroundImage,
+            surfaceBackgroundColor: NSColor(hex: "#D2EEF9") ?? .white,
+            defaultBackgroundColor: NSColor(hex: "#272822") ?? .black,
+            backgroundOpacity: 1.0,
+            sharesWindowBackdrop: true,
+            usesBonsplitPaneBackdrop: false
+        )
+
+        XCTAssertEqual(plan.owner, .ghosttyNativeRenderer)
+        XCTAssertEqual(plan.hostLayerColor.hexString(includeAlpha: true), "#00000000")
+        XCTAssertFalse(plan.clearsSharedWindowBackdrop)
+    }
+
     private func makeSnapshot(
         unifySurfaceBackdrops: Bool,
         backgroundHex: String = "#272822",


### PR DESCRIPTION
Closes #5478

## Summary
- Preserve complete terminal string control sequences (OSC/DCS/PM/APC) sent through `surface.send_text` by routing them through Ghostty's PTY-output parser instead of the shell input/paste path.
- Keep normal input behavior for command text, Return, Tab, backspace, bare Escape, and recognized navigation escape sequences.
- Restore the OSC 11 pane-local background fill plan removed by the #5106 revert so consumed OSC 11 background overrides still paint the correct pane under shared window backdrops.

## Culprit analysis
- Verified PR #3886 (`073804c8e`) and the #5106 revert (`7d8e64b84`) are both ancestors of `v0.64.13` (`beb0d8f93`), and the revert is on current `main`.
- Ghostty's OSC 11 parser/model path was not removed: the terminal model and live stream handler still set dynamic background colors.
- On current `main`, the deterministic tagged repro showed PTY output and direct `/dev/ttys000` already consume OSC 11. The literal-cell repro was specific to raw `cmux send`, where the programmatic input path treated ESC as keyboard input and sent the OSC payload through shell input semantics.
- The #5106 revert was still relevant because it removed the single fill-owner plan for pane-local OSC 11 backgrounds under shared backdrops, so this restores that guard without reintroducing the #3799 inactive-pane loss.

## Before buffer evidence
Tagged debug socket: `/tmp/cmux-debug-issue-5478-osc11-literal-text.sock`

PTY shell output path, already clean on current main:
```text
(base) austinwang@mac ~ % printf '\033]11;#341c1c\033\\'
(base) austinwang@mac ~ % 
```

Raw `cmux send --surface surface:1 $'\033]11;#341c1c\033\\'`, reproduces literal cells on current main:
```text
(base) austinwang@mac ~ % printf '\033]11;#341c1c\033\\'
(base) austinwang@mac ~ % 11;#341c1c
```

Direct `/dev/ttys000`, already clean on current main:
```text
(base) austinwang@mac ~ % 
```

## After buffer evidence
PTY shell output path:
```text
(base) austinwang@mac ~ % printf '\033]11;#341c1c\033\\'
(base) austinwang@mac ~ % 
```

Raw `cmux send --surface surface:1 $'\033]11;#341c1c\033\\'`:
```text
(base) austinwang@mac ~ % printf '\033]11;#341c1c\033\\'
(base) austinwang@mac ~ % 
```

Direct `/dev/ttys000`:
```text
(base) austinwang@mac ~ % printf '\033]11;#341c1c\033\\'
(base) austinwang@mac ~ % 
```

## Verification
- Built with `./scripts/reload.sh --tag issue-5478-osc11-literal-text`.
- Launched via `http://127.0.0.1:17320/issue-5478-osc11-literal-text`.
- Re-ran PTY shell output, raw `cmux send`, and direct `/dev/ttys000` probes against the tagged socket only.
- Added regression coverage for cold socket OSC 11 routing and restored fill-plan coverage for pane-local OSC backgrounds.
- No user-facing strings changed; localization audit: no SwiftUI/AppKit labels, menu text, docs, alerts, or tooltips were added or changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783317977&installation_id=133855650&pr_number=5509&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5509&signature=42568865d2aec225202510247b986080f2c98a9b181773d8aa3e4594c9863115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches programmatic terminal input parsing and window backdrop compositing; wrong sequence detection could mis-route user input, but behavior is covered by new tests and scoped to complete ESC-prefixed controls.
> 
> **Overview**
> Fixes **OSC 11 (and other string control sequences) showing as literal text** when sent via programmatic/socket input (`cmux send`) by **parsing complete OSC/DCS/PM/APC sequences** and feeding them through **`ghostty_surface_process_output`** instead of shell text/key input, while keeping Return, Tab, navigation CSI/SS3, and normal text on the existing paths (including cold-surface queuing as `.processOutput`).
> 
> Restores **pane-local OSC 11 background painting** under **shared window backdrops** via **`TerminalSurfaceBackgroundFillPlan.resolve`**, and adds a **Core Image destination-out cutout view** so a pane’s host-layer fill does not double-stack on the shared backdrop. Adds regression tests for OSC 11 socket routing and fill-plan cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4c16f0a02369c5320ec3d027b1ca35ebb54a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OSC/OSC 11 text showing up literally when sent via `cmux send` by routing complete OSC/DCS/PM/APC strings through Ghostty’s PTY-output parser. Restores pane‑local OSC 11 backgrounds under shared backdrops so only the correct pane is painted.

- **Bug Fixes**
  - Detect complete OSC/DCS/PM/APC string controls from socket input and route them to `ghostty_surface_process_output`; keep Return/Tab/Backspace/bare ESC and known CSI/SS3 navigations as key events, with other text sent as normal input.
  - Preserve event order on cold surfaces by queueing terminal‑output chunks alongside key/input events.
  - Reinstate a single fill‑owner plan via `TerminalSurfaceBackgroundFillPlan.resolve` and add a Core Image cutout for shared backdrops to avoid double composition and cross‑pane bleed; adds tests and docs for OSC 11 routing and fill‑plan behavior.

<sup>Written for commit ef4c16f0a02369c5320ec3d027b1ca35ebb54a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal now distinguishes ESC-prefixed control/string sequences from typed text, routing control payloads through the output pipeline
  * Surface background rendering uses a fill planning model to determine host-layer color and whether to cut out the shared window backdrop
  * Optional backdrop cutout is supported with synchronized layout to keep visuals aligned

* **Tests**
  * Added regression test for cold-start escape-sequence input queuing
  * Added tests validating background fill plan outcomes across scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->