### PR TITLE
iOS: toggleable iMessage-style terminal composer (text, PR1)

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -132,6 +132,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// than offer actions that would fail with `method_not_found`.
     public private(set) var supportsWorkspaceActions: Bool = false
     public var terminalInputText: String
+    /// Whether the iMessage-style composer is shown above the terminal. Toggled
+    /// from the input accessory bar's composer button and observed by the
+    /// terminal screen to present ``terminalInputText`` for multi-line editing.
+    public var isComposerPresented: Bool = false
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             syncSelectedTerminalForWorkspace()
@@ -1194,6 +1198,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         await sendRemoteTerminalInput(text + "\r")
     }
 
+    /// Show or hide the iMessage-style composer from the input accessory bar.
+    public func toggleComposer() {
+        isComposerPresented.toggle()
+    }
+
+    /// Submit the composer's text to the selected terminal as a bracketed paste
+    /// plus a single Return, then clear the field while keeping the composer
+    /// open. Unlike ``submitTerminalInput()``, this delivers a multi-line block
+    /// as one paste + one submit (via `terminal.paste`) so interior newlines do
+    /// not fragment into multiple submissions in a TUI agent.
+    public func submitComposerInput() async {
+        let text = terminalInputText
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        terminalInputText = ""
+        guard remoteClient != nil else { return }
+        await sendRemoteTerminalPaste(text, submitKey: "return")
+    }
+
     public func sendTerminalRawInput(_ text: String) {
         #if DEBUG
         mobileShellLog.debug("enqueue raw terminal input byteCount=\(text.utf8.count, privacy: .public)")
@@ -1822,6 +1844,67 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let responseData = try await client.sendRequest(
                 MobileCoreRPCClient.requestData(
                     method: "terminal.paste_image",
+                    params: params
+                )
+            )
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
+            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+        } catch {
+            guard generation == connectionGeneration else { return }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            connectionError = Self.localizedConnectionError(for: error)
+        }
+    }
+
+    private func sendRemoteTerminalPaste(_ text: String, submitKey: String) async {
+        guard let workspaceID = selectedWorkspace?.id,
+              let terminalID = selectedTerminalID else {
+            #if DEBUG
+            mobileShellLog.info("skip remote terminal paste selectedWorkspace=\(self.selectedWorkspace == nil ? 0 : 1, privacy: .public) selectedTerminal=\(self.selectedTerminalID == nil ? 0 : 1, privacy: .public)")
+            #endif
+            return
+        }
+        await sendRemoteTerminalPaste(text, submitKey: submitKey, workspaceID: workspaceID, terminalID: terminalID)
+    }
+
+    /// Deliver a composed block to the Mac surface via `terminal.paste`: a
+    /// bracketed paste (so multi-line text is inserted as one literal block)
+    /// followed by an optional submit key. Mirrors ``sendRemoteTerminalInput(_:workspaceID:terminalID:)``
+    /// but takes the dedicated paste path instead of the raw `terminal.input`
+    /// path, which rewrites newlines to carriage returns.
+    private func sendRemoteTerminalPaste(
+        _ text: String,
+        submitKey: String,
+        workspaceID: MobileWorkspacePreview.ID,
+        terminalID: MobileTerminalPreview.ID
+    ) async {
+        guard let client = remoteClient else {
+            #if DEBUG
+            mobileShellLog.info("skip remote terminal paste remoteClient=0")
+            #endif
+            return
+        }
+        let generation = connectionGeneration
+        do {
+            #if DEBUG
+            mobileShellLog.debug("send remote terminal paste byteCount=\(text.utf8.count, privacy: .public) submit=\(submitKey, privacy: .public) workspace=\(workspaceID.rawValue, privacy: .private) terminal=\(terminalID.rawValue, privacy: .private)")
+            #endif
+            let key = viewportKey(workspaceID: workspaceID, terminalID: terminalID)
+            var params: [String: Any] = [
+                "workspace_id": workspaceID.rawValue,
+                "surface_id": terminalID.rawValue,
+                "text": text,
+                "submit_key": submitKey,
+                "client_id": clientID,
+            ]
+            if let viewportSize = reportedViewportSizesByTerminalKey[key] {
+                params["viewport_columns"] = viewportSize.columns
+                params["viewport_rows"] = viewportSize.rows
+            }
+            let responseData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "terminal.paste",
                     params: params
                 )
             )

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1208,12 +1208,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// open. Unlike ``submitTerminalInput()``, this delivers a multi-line block
     /// as one paste + one submit (via `terminal.paste`) so interior newlines do
     /// not fragment into multiple submissions in a TUI agent.
+    ///
+    /// The field is cleared only after the Mac acknowledges the paste. If the
+    /// send fails (no connection, or an older host that does not implement
+    /// `terminal.paste` and answers `method_not_found`), the composed text is
+    /// kept so the user can retry instead of silently losing the message.
     public func submitComposerInput() async {
         let text = terminalInputText
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        terminalInputText = ""
         guard remoteClient != nil else { return }
-        await sendRemoteTerminalPaste(text, submitKey: "return")
+        let sent = await sendRemoteTerminalPaste(text, submitKey: "return")
+        // Only clear if the field still holds exactly what we sent, so a value
+        // the user typed while the send was in flight is not discarded.
+        if sent, terminalInputText == text {
+            terminalInputText = ""
+        }
     }
 
     public func sendTerminalRawInput(_ text: String) {
@@ -1857,15 +1866,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func sendRemoteTerminalPaste(_ text: String, submitKey: String) async {
+    /// - Returns: `true` when the Mac acknowledged the paste, `false` when there
+    ///   is no selected workspace/terminal or the send failed.
+    @discardableResult
+    private func sendRemoteTerminalPaste(_ text: String, submitKey: String) async -> Bool {
         guard let workspaceID = selectedWorkspace?.id,
               let terminalID = selectedTerminalID else {
             #if DEBUG
             mobileShellLog.info("skip remote terminal paste selectedWorkspace=\(self.selectedWorkspace == nil ? 0 : 1, privacy: .public) selectedTerminal=\(self.selectedTerminalID == nil ? 0 : 1, privacy: .public)")
             #endif
-            return
+            return false
         }
-        await sendRemoteTerminalPaste(text, submitKey: submitKey, workspaceID: workspaceID, terminalID: terminalID)
+        return await sendRemoteTerminalPaste(text, submitKey: submitKey, workspaceID: workspaceID, terminalID: terminalID)
     }
 
     /// Deliver a composed block to the Mac surface via `terminal.paste`: a
@@ -1873,17 +1885,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// followed by an optional submit key. Mirrors ``sendRemoteTerminalInput(_:workspaceID:terminalID:)``
     /// but takes the dedicated paste path instead of the raw `terminal.input`
     /// path, which rewrites newlines to carriage returns.
+    ///
+    /// - Returns: `true` when the Mac acknowledged the paste, `false` on any
+    ///   failure (no client, a stale generation, or an RPC error such as
+    ///   `method_not_found` from an older host). Callers use this to keep the
+    ///   composer text on failure instead of clearing it optimistically.
+    @discardableResult
     private func sendRemoteTerminalPaste(
         _ text: String,
         submitKey: String,
         workspaceID: MobileWorkspacePreview.ID,
         terminalID: MobileTerminalPreview.ID
-    ) async {
+    ) async -> Bool {
         guard let client = remoteClient else {
             #if DEBUG
             mobileShellLog.info("skip remote terminal paste remoteClient=0")
             #endif
-            return
+            return false
         }
         let generation = connectionGeneration
         do {
@@ -1908,13 +1926,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     params: params
                 )
             )
-            guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return false }
             handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+            return true
         } catch {
-            guard generation == connectionGeneration else { return }
-            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            guard generation == connectionGeneration else { return false }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return false }
             markMacConnectionUnavailableIfNeeded(after: error)
             connectionError = Self.localizedConnectionError(for: error)
+            return false
         }
     }
 

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -136,6 +136,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// from the input accessory bar's composer button and observed by the
     /// terminal screen to present ``terminalInputText`` for multi-line editing.
     public var isComposerPresented: Bool = false
+    /// Guards ``submitComposerInput()`` against re-entrancy. A quick double tap
+    /// on Send would otherwise start two sends that both capture the same text
+    /// (the field is cleared only on ack), pasting the message to the agent
+    /// twice. Not observed: it gates an async flow, not view state.
+    @ObservationIgnored private var isSubmittingComposerInput = false
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             syncSelectedTerminalForWorkspace()
@@ -1217,6 +1222,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let text = terminalInputText
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         guard remoteClient != nil else { return }
+        // Reject a re-entrant send (e.g. a double tap on Send) so the same text
+        // is not pasted twice. The flag is set/cleared on the main actor around
+        // the await, so no second call can slip past it.
+        guard !isSubmittingComposerInput else { return }
+        isSubmittingComposerInput = true
+        defer { isSubmittingComposerInput = false }
         let sent = await sendRemoteTerminalPaste(text, submitKey: "return")
         // Only clear if the field still holds exactly what we sent, so a value
         // the user typed while the send was in flight is not discarded.

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -21,6 +21,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     /// actions (create workspace/terminal, switch terminal) do not pop the
     /// software keyboard.
     var autoFocusOnWindowAttach: Bool = true
+    /// Whether the SwiftUI composer is open. When true the surface hides its
+    /// docked accessory bar and releases its reserved grid height so the composer
+    /// can own the bottom edge and the keyboard.
+    var isComposerActive: Bool = false
 
     func makeCoordinator() -> Coordinator {
         Coordinator(surfaceID: surfaceID, store: store)
@@ -49,7 +53,12 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        (uiView as? GhosttySurfaceView)?.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        // Bytes flow via the byte sink; the prop-driven mutations are the
+        // autofocus suppression and the composer's claim on the bottom edge +
+        // keyboard.
+        guard let surfaceView = uiView as? GhosttySurfaceView else { return }
+        surfaceView.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        surfaceView.setComposerActive(isComposerActive)
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
@@ -165,6 +174,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             guard let presenter = presentingController(for: surfaceView) else { return }
             let editor = UIHostingController(rootView: TerminalShortcutsSettingsView())
             presenter.present(editor, animated: true)
+        }
+
+        func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {
+            // The composer button on the docked accessory bar was tapped. Flip the
+            // store flag; the terminal screen observes it and presents/dismisses
+            // the iMessage-style composer.
+            Task { @MainActor [weak store] in
+                store?.toggleComposer()
+            }
         }
 
         /// Walk up from `view` to the nearest owning `UIViewController`, then to

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -15,13 +15,18 @@ struct TerminalComposerView: View {
     @Bindable var store: CMUXMobileShellStore
     @FocusState private var isFieldFocused: Bool
 
+    /// Single-line height shared by the field pill and the round buttons so they
+    /// line up. The field grows taller for multi-line input; the buttons stay
+    /// pinned to the bottom edge.
+    private let controlHeight: CGFloat = 40
+
     private var trimmedIsEmpty: Bool {
         store.terminalInputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     var body: some View {
         composerSurface
-            .onAppear { isFieldFocused = true }
+            .onAppear { focusField() }
     }
 
     /// On iOS 26 the glass controls float in a `GlassEffectContainer` over the
@@ -46,7 +51,7 @@ struct TerminalComposerView: View {
             } label: {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 15, weight: .semibold))
-                    .frame(width: 36, height: 36)
+                    .frame(width: controlHeight, height: controlHeight)
             }
             .buttonStyle(.plain)
             .foregroundStyle(TerminalPalette.foreground.opacity(0.7))
@@ -65,6 +70,7 @@ struct TerminalComposerView: View {
             .foregroundStyle(TerminalPalette.foreground)
             .padding(.horizontal, 14)
             .padding(.vertical, 9)
+            .frame(minHeight: controlHeight)
             .mobileGlassField(cornerRadius: 20)
             .accessibilityIdentifier("MobileComposerField")
 
@@ -73,7 +79,7 @@ struct TerminalComposerView: View {
             } label: {
                 Image(systemName: "arrow.up")
                     .font(.system(size: 17, weight: .bold))
-                    .frame(width: 36, height: 36)
+                    .frame(width: controlHeight, height: controlHeight)
                     .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.35) : Color.accentColor)
             }
             .buttonStyle(.plain)
@@ -84,6 +90,17 @@ struct TerminalComposerView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+    }
+
+    /// Focus the field one runloop after appearing. Setting `@FocusState` inline
+    /// in `onAppear` is unreliable (the field may not be in the window yet);
+    /// deferring lets it take first responder from the terminal input proxy
+    /// while that keyboard is still up, so the keyboard hands over in place
+    /// instead of dropping and re-animating.
+    private func focusField() {
+        Task { @MainActor in
+            isFieldFocused = true
+        }
     }
 
     private func send() {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -67,6 +67,7 @@ struct TerminalComposerView: View {
             .lineLimit(1...8)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled(true)
+            .focused($isFieldFocused)
             .foregroundStyle(TerminalPalette.foreground)
             .padding(.horizontal, 14)
             .padding(.vertical, 9)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -5,8 +5,9 @@ import SwiftUI
 
 /// iMessage-style composer pinned above the terminal.
 ///
-/// A growing multi-line text field plus a send button. Send delivers the text
-/// as a bracketed paste followed by a single Return (via `terminal.paste`), so a
+/// A growing multi-line text field plus a send button, rendered with Liquid
+/// Glass (iOS 26+, with a thin-material fallback). Send delivers the text as a
+/// bracketed paste followed by a single Return (via `terminal.paste`), so a
 /// multi-line message lands as one submission instead of fragmenting on every
 /// interior newline. Toggled from the input accessory bar's composer button; the
 /// chevron dismisses it.
@@ -19,16 +20,37 @@ struct TerminalComposerView: View {
     }
 
     var body: some View {
+        composerSurface
+            .onAppear { isFieldFocused = true }
+    }
+
+    /// On iOS 26 the glass controls float in a `GlassEffectContainer` over the
+    /// terminal (no opaque bar — that would be glass-on-glass). Earlier OSes get
+    /// a `.bar` material backing behind the material controls.
+    @ViewBuilder
+    private var composerSurface: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer {
+                composerBar
+            }
+        } else {
+            composerBar
+                .background(.bar)
+        }
+    }
+
+    private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 8) {
             Button {
                 store.toggleComposer()
             } label: {
                 Image(systemName: "chevron.down")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 32, height: 32)
+                    .font(.system(size: 15, weight: .semibold))
+                    .frame(width: 36, height: 36)
             }
             .buttonStyle(.plain)
             .foregroundStyle(TerminalPalette.foreground.opacity(0.7))
+            .mobileGlassCircle()
             .accessibilityIdentifier("MobileComposerClose")
             .accessibilityLabel(L10n.string("mobile.composer.close", defaultValue: "Hide Composer"))
 
@@ -40,32 +62,28 @@ struct TerminalComposerView: View {
             .lineLimit(1...8)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled(true)
-            .focused($isFieldFocused)
             .foregroundStyle(TerminalPalette.foreground)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(TerminalPalette.foreground.opacity(0.25), lineWidth: 1)
-            )
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .mobileGlassField(cornerRadius: 20)
             .accessibilityIdentifier("MobileComposerField")
 
             Button {
                 send()
             } label: {
-                Image(systemName: "arrow.up.circle.fill")
-                    .font(.system(size: 30))
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 17, weight: .bold))
+                    .frame(width: 36, height: 36)
+                    .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.35) : Color.accentColor)
             }
             .buttonStyle(.plain)
+            .mobileGlassCircle()
             .disabled(trimmedIsEmpty)
-            .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.3) : Color.accentColor)
             .accessibilityIdentifier("MobileComposerSend")
             .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(.bar)
-        .onAppear { isFieldFocused = true }
     }
 
     private func send() {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -1,0 +1,79 @@
+#if os(iOS)
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// iMessage-style composer pinned above the terminal.
+///
+/// A growing multi-line text field plus a send button. Send delivers the text
+/// as a bracketed paste followed by a single Return (via `terminal.paste`), so a
+/// multi-line message lands as one submission instead of fragmenting on every
+/// interior newline. Toggled from the input accessory bar's composer button; the
+/// chevron dismisses it.
+struct TerminalComposerView: View {
+    @Bindable var store: CMUXMobileShellStore
+    @FocusState private var isFieldFocused: Bool
+
+    private var trimmedIsEmpty: Bool {
+        store.terminalInputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            Button {
+                store.toggleComposer()
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 16, weight: .semibold))
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(TerminalPalette.foreground.opacity(0.7))
+            .accessibilityIdentifier("MobileComposerClose")
+            .accessibilityLabel(L10n.string("mobile.composer.close", defaultValue: "Hide Composer"))
+
+            TextField(
+                L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
+                text: $store.terminalInputText,
+                axis: .vertical
+            )
+            .lineLimit(1...8)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .focused($isFieldFocused)
+            .foregroundStyle(TerminalPalette.foreground)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(TerminalPalette.foreground.opacity(0.25), lineWidth: 1)
+            )
+            .accessibilityIdentifier("MobileComposerField")
+
+            Button {
+                send()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 30))
+            }
+            .buttonStyle(.plain)
+            .disabled(trimmedIsEmpty)
+            .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.3) : Color.accentColor)
+            .accessibilityIdentifier("MobileComposerSend")
+            .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .onAppear { isFieldFocused = true }
+    }
+
+    private func send() {
+        guard !trimmedIsEmpty else { return }
+        isFieldFocused = true
+        Task { @MainActor in
+            await store.submitComposerInput()
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
@@ -60,4 +60,44 @@ extension View {
             .overlay(Capsule().stroke(.white.opacity(0.18), lineWidth: 1))
         #endif
     }
+
+    /// Glass (iOS 26+) or thin-material rounded-rect background for a multi-line
+    /// composer field. A capsule (``mobileGlassPill()``) over-rounds once the
+    /// field grows to several lines, so the composer uses a fixed corner radius.
+    @ViewBuilder
+    func mobileGlassField(cornerRadius: CGFloat = 20) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: shape)
+        } else {
+            self
+                .background(.thinMaterial, in: shape)
+                .overlay(shape.stroke(.white.opacity(0.18), lineWidth: 1))
+        }
+        #else
+        self
+            .background(.thinMaterial, in: shape)
+            .overlay(shape.stroke(.white.opacity(0.18), lineWidth: 1))
+        #endif
+    }
+
+    /// Glass (iOS 26+) or thin-material circular background for a composer icon
+    /// button (send / dismiss). Pair with a fixed-size icon label.
+    @ViewBuilder
+    func mobileGlassCircle() -> some View {
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            self
+                .background(.thinMaterial, in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.18), lineWidth: 1))
+        }
+        #else
+        self
+            .background(.thinMaterial, in: Circle())
+            .overlay(Circle().stroke(.white.opacity(0.18), lineWidth: 1))
+        #endif
+    }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -45,7 +45,11 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
-                    autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID),
+                    // While the composer is open it owns the keyboard, so a
+                    // surface re-create from switching terminals must not let the
+                    // hidden terminal input proxy grab first responder back.
+                    autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
+                        && !store.isComposerPresented,
                     isComposerActive: store.isComposerPresented
                 )
                 // Identity must track the selected terminal. The representable's

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -45,7 +45,8 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
-                    autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
+                    autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID),
+                    isComposerActive: store.isComposerPresented
                 )
                 // Identity must track the selected terminal. The representable's
                 // coordinator binds its byte sink to the surfaceID at make time and
@@ -80,6 +81,11 @@ struct WorkspaceDetailView: View {
                 .padding(.leading, 10)
         }
         #if os(iOS)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if store.isComposerPresented {
+                TerminalComposerView(store: store)
+            }
+        }
         .mobileTerminalSafeAreaExpansion(
             context: safeAreaContext,
             includesBottom: true

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1092,10 +1092,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard dockedToolbar?.isHidden != active || reservedToolbarHeight != reserved else { return }
         dockedToolbar?.isHidden = active
         reservedToolbarHeight = reserved
-        if active, inputProxy.isFirstResponder {
-            // Let the composer's text field own the keyboard.
-            inputProxy.resignFirstResponder()
-        }
+        // Deliberately do NOT resign the terminal input proxy here. The composer's
+        // text field becomes first responder while this keyboard is still up, so
+        // iOS hands the keyboard over in place. Resigning first tore the keyboard
+        // down and the composer immediately re-summoned it (the visible
+        // disappear/reappear flicker).
         setNeedsGeometrySync()
         setNeedsLayout()
     }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -60,6 +60,9 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
+    /// The composer accessory button was tapped; the host should toggle the
+    /// iMessage-style composer above the terminal. Optional.
+    func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView)
 }
 
 public extension GhosttySurfaceViewDelegate {
@@ -67,6 +70,7 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {}
 }
 
 @MainActor
@@ -268,6 +272,9 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     /// path. Unlike the other actions it carries no fixed byte ``output``; the
     /// host reads the pasteboard when it is tapped.
     case paste
+    // Appended at the end so existing persisted raw values (user accessory bar
+    // order/enabled set) are preserved.
+    case composer
     var title: String {
         title(isMacRemote: false)
     }
@@ -285,6 +292,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .zoomOut:
             return ""
         case .zoomIn:
+            return ""
+        case .composer:
             return ""
         case .escape:
             return String(localized: "terminal.input_accessory.title.escape", defaultValue: "Esc")
@@ -341,6 +350,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .shift: return "terminal.inputAccessory.shift"
         case .zoomOut: return "terminal.inputAccessory.zoomOut"
         case .zoomIn: return "terminal.inputAccessory.zoomIn"
+        case .composer: return "terminal.inputAccessory.composer"
         case .escape: return "terminal.inputAccessory.escape"
         case .tab: return "terminal.inputAccessory.tab"
         case .upArrow: return "terminal.inputAccessory.up"
@@ -374,6 +384,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return String(localized: "terminal.input_accessory.zoom_in", defaultValue: "Zoom In")
         case .paste:
             return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
+        case .composer:
+            return String(localized: "terminal.input_accessory.composer", defaultValue: "Composer")
         default:
             return nil
         }
@@ -387,6 +399,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return "plus.magnifyingglass"
         case .paste:
             return "doc.on.clipboard"
+        case .composer:
+            return "square.and.pencil"
         default:
             return nil
         }
@@ -413,7 +427,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
 
     var output: Data? {
         switch self {
-        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn, .paste:
+        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn, .paste, .composer:
             return nil
         case .escape:
             return Data([0x1B])
@@ -524,7 +538,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .pageUp: return String(localized: "terminal.shortcut.name.pageUp", defaultValue: "Page Up")
         case .pageDown: return String(localized: "terminal.shortcut.name.pageDown", defaultValue: "Page Down")
         case .paste: return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
-        case .control, .alternate, .command, .shift, .zoomIn, .zoomOut:
+        case .control, .alternate, .command, .shift, .zoomIn, .zoomOut, .composer:
             return title
         }
     }
@@ -813,6 +827,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         inputProxy.onZoom = { [weak self] direction in
             self?.performFontZoom(direction)
         }
+        inputProxy.onToggleComposer = { [weak self] in
+            guard let self else { return }
+            self.delegate?.ghosttySurfaceViewDidRequestComposerToggle(self)
+        }
         inputProxy.onHideKeyboard = { [weak self] in
             guard let self else { return }
             // Toggle: dismiss when the keyboard is up, bring it back when down.
@@ -1062,6 +1080,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         dockedToolbar = toolbar
         reservedToolbarHeight = Self.persistentToolbarHeight
         layoutDockedToolbar()
+    }
+
+    /// Hide or restore the docked accessory bar while the SwiftUI composer is
+    /// open. The composer owns the bottom edge (and the keyboard) when active, so
+    /// the docked bar would otherwise collide with it above the keyboard. Hiding
+    /// it and releasing its reserved grid height lets the composer sit flush
+    /// below the terminal grid.
+    public func setComposerActive(_ active: Bool) {
+        let reserved: CGFloat = active ? 0 : Self.persistentToolbarHeight
+        guard dockedToolbar?.isHidden != active || reservedToolbarHeight != reserved else { return }
+        dockedToolbar?.isHidden = active
+        reservedToolbarHeight = reserved
+        if active, inputProxy.isFirstResponder {
+            // Let the composer's text field own the keyboard.
+            inputProxy.resignFirstResponder()
+        }
+        setNeedsGeometrySync()
+        setNeedsLayout()
     }
 
     /// Full-width bar whose bottom sits on the keyboard (when up) or the very

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -16,6 +16,9 @@ final class TerminalInputTextView: UITextView {
     /// Fired by the trailing "customize" button so the SwiftUI host can present
     /// the toolbar shortcuts editor.
     var onOpenToolbarSettings: (() -> Void)?
+    /// Invoked when the composer accessory button is tapped. The host toggles
+    /// the iMessage-style composer above the terminal.
+    var onToggleComposer: (() -> Void)?
     var accessoryLayoutInsetsProvider: (() -> UIEdgeInsets)?
     /// The leftmost toolbar button. Toggles its glyph between dismiss-keyboard
     /// (when the keyboard is up) and show-keyboard (when down) via
@@ -200,7 +203,7 @@ final class TerminalInputTextView: UITextView {
     /// user-configurable shortcuts. Command is created but kept out of the
     /// stack until ``applyModifierPresentation()`` inserts it for a Mac remote.
     private static let pinnedLeadingActions: [TerminalInputAccessoryAction] = [
-        .control, .alternate, .command, .paste,
+        .composer, .control, .alternate, .command, .paste,
     ]
 
     /// The structural buttons pinned to the end of the bar, after the
@@ -546,6 +549,11 @@ final class TerminalInputTextView: UITextView {
     }
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
+        if action == .composer {
+            onToggleComposer?()
+            return
+        }
+
         if action == .paste {
             // Paste is a clipboard read, not a key sequence: ignore any armed
             // modifier and route clipboard content to the host directly.

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -550,6 +550,12 @@ final class TerminalInputTextView: UITextView {
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
         if action == .composer {
+            // Opening the composer hides the accessory bar, so clear any armed
+            // modifier first (like Paste/Zoom do); otherwise a Ctrl/Alt/Cmd/Shift
+            // armed before opening would linger invisibly and modify the next key
+            // after the composer is dismissed.
+            disarmAllModifiers()
+            refreshAccessoryButtonStyles()
             onToggleComposer?()
             return
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -21415,12 +21415,17 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing text", data: nil)
         }
         // Resolve the optional submit key up front so an unsupported value fails
-        // before any text is pasted (no partial application).
+        // before any text is pasted (no partial application). The phone sends
+        // `return` as the default submit *intent*; the agent-aware upgrade to
+        // `ctrl+enter` happens below once the surface (and its agent context) is
+        // resolved, because only the Mac knows which agent is running.
         let submitKeyRaw = (v2String(params, "submit_key") ?? "return").lowercased()
-        let submitKeyName: String?
+        var submitKeyName: String?
+        var submitKeyWasReturnIntent = false
         switch submitKeyRaw {
         case "", "return", "enter":
             submitKeyName = "return"
+            submitKeyWasReturnIntent = true
         case "ctrl+enter":
             submitKeyName = "ctrl+enter"
         case "none":
@@ -21438,6 +21443,21 @@ class TerminalController {
               let surfaceId = resolved.surfaceId,
               let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
             return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        // Mirror the macOS TextBox composer's submit-key selection
+        // (`TextBoxInput.dispatchEvents`): Claude Code needs `ctrl+enter` to
+        // submit a multi-line block, while plain `return` submits a newline mid
+        // prompt. The phone cannot know the running agent, so it always asks for
+        // `return`; upgrade that intent here when the surface is Claude and the
+        // composed text spans multiple lines. Explicit `ctrl+enter`/`none` from
+        // the client are honored as-is.
+        if submitKeyWasReturnIntent,
+           text.contains("\n") || text.contains("\r"),
+           TextBoxAgentDetection.isClaudeCode(
+               context: WorkspaceContentView.terminalAgentContext(panel: terminalPanel, workspace: resolved.workspace)
+           ) {
+            submitKeyName = "ctrl+enter"
         }
 
         applyMobileViewportReport(params: params, terminalPanel: terminalPanel)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20676,6 +20676,8 @@ class TerminalController {
             result = v2MobileTerminalInput(params: request.params)
         case "mobile.terminal.paste_image", "terminal.paste_image":
             result = v2MobileTerminalPasteImage(params: request.params)
+        case "mobile.terminal.paste", "terminal.paste":
+            result = v2MobileTerminalPaste(params: request.params)
         case "mobile.terminal.replay", "terminal.replay":
             result = v2MobileTerminalReplay(params: request.params)
         case "mobile.terminal.viewport", "terminal.viewport":
@@ -21391,6 +21393,95 @@ class TerminalController {
             "surface_id": terminalPanel.id.uuidString,
             "queued": sendResult == .queued,
         ])
+    }
+
+    /// Deliver a composed block from the mobile composer as a bracketed paste
+    /// followed by an optional single submit key.
+    ///
+    /// This mirrors the macOS TextBox composer dispatch
+    /// (`[.pasteText(payload), .namedKey(submitKey)]`): the text goes through
+    /// `sendText` (libghostty `ghostty_surface_text`), which bracketed-pastes it
+    /// (`ESC[200~ … ESC[201~` when DECSET 2004 is active) so the agent's line
+    /// editor inserts the whole, possibly multi-line, block as literal text
+    /// instead of treating every interior newline as a submit. A single named
+    /// submit key then commits it once. The `terminal.input` path is wrong for a
+    /// composed block: `parsedSocketInputEvents` rewrites every `\n`/`\r` to a
+    /// raw CR, so an N-line message fragments into N submissions.
+    ///
+    /// `submit_key` is optional: `return`/`enter` (default) or `ctrl+enter`
+    /// submit; `none` pastes without submitting so the composer can keep editing.
+    private func v2MobileTerminalPaste(params: [String: Any]) -> V2CallResult {
+        guard let text = v2RawString(params, "text"), !text.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing text", data: nil)
+        }
+        // Resolve the optional submit key up front so an unsupported value fails
+        // before any text is pasted (no partial application).
+        let submitKeyRaw = (v2String(params, "submit_key") ?? "return").lowercased()
+        let submitKeyName: String?
+        switch submitKeyRaw {
+        case "", "return", "enter":
+            submitKeyName = "return"
+        case "ctrl+enter":
+            submitKeyName = "ctrl+enter"
+        case "none":
+            submitKeyName = nil
+        default:
+            return .err(code: "invalid_params", message: "Unsupported submit_key", data: ["submit_key": submitKeyRaw])
+        }
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        if let error = mobileTerminalAliasValidationError(params: params) {
+            return error
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
+
+        let surface = terminalPanel.surface
+        guard surface.sendText(text) else {
+            return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+        }
+
+        var submitted = false
+        if let submitKeyName {
+            let keyResult = surface.sendNamedKey(submitKeyName)
+            guard keyResult.accepted else {
+                switch keyResult {
+                case .inputQueueFull:
+                    return .err(code: "input_queue_full", message: Self.terminalInputQueueFullMessage, data: ["surface_id": surfaceId.uuidString])
+                case .surfaceUnavailable:
+                    return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+                case .processExited:
+                    return .err(code: "process_exited", message: Self.terminalProcessExitedMessage, data: ["surface_id": surfaceId.uuidString])
+                case .unknownKey, .sent, .queued:
+                    return .err(code: "invalid_params", message: "Unsupported submit_key", data: ["submit_key": submitKeyRaw])
+                }
+            }
+            submitted = true
+        }
+
+        surface.forceRefresh(reason: "mobileHost.terminalPaste")
+
+        #if DEBUG
+        cmuxDebugLog(
+            "mobile.terminal.paste workspace=\(resolved.workspace.id.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) chars=\(text.count) submitted=\(submitted ? 1 : 0)"
+        )
+        #endif
+
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspace.id.uuidString,
+            "surface_id": terminalPanel.id.uuidString,
+            "submitted": submitted,
+        ]
+        if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
+            payload["terminal_seq"] = seq
+        }
+        return .ok(payload)
     }
 
     private func applyMobileViewportReport(

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1257,7 +1257,7 @@ func textBoxCommandShortcutKey(
     return normalizedCharacters(event).lowercased()
 }
 
-private enum TextBoxAgentDetection: CaseIterable {
+enum TextBoxAgentDetection: CaseIterable {
     case claudeCode
     case codex
     case opencode

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3519,6 +3519,74 @@
           }
         }
       }
+    },
+    "terminal.input_accessory.composer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ作成"
+          }
+        }
+      }
+    },
+    "mobile.composer.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Composer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ作成を閉じる"
+          }
+        }
+      }
+    },
+    "mobile.composer.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ"
+          }
+        }
+      }
+    },
+    "mobile.composer.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Summary
- Adds a toggleable iMessage-style composer above the iOS terminal (PR1 of a phased feature). A new composer button on the input accessory bar shows/hides a growing multi-line text field with a Send button.
- Send delivers the text as a **bracketed paste + a single Return** via a new `mobile.terminal.paste` / `terminal.paste` RPC, so a multi-line message lands as **one** submission. The existing `terminal.input` path is wrong for a composed block: its Mac handler rewrites every `\n`/`\r` to a raw CR, so an N-line message fragments into N submissions in a TUI agent.
- Mac: `v2MobileTerminalPaste` bracketed-pastes via `TerminalSurface.sendText` (`ghostty_surface_text`, respects DECSET 2004) then sends an optional submit key via `sendNamedKey`, mirroring the macOS TextBox composer dispatch `[.pasteText(payload), .namedKey(submitKey)]`. Reuses the proven surface send paths; no new libghostty code.
- iOS: new `.composer` accessory action (appended at the end of the enum to preserve persisted raw values) + `onToggleComposer` callback wired through a new `GhosttySurfaceViewDelegate` method to a store `isComposerPresented` flag. While the composer is open the docked accessory bar yields the bottom edge + keyboard (`setComposerActive`). New `sendRemoteTerminalPaste` send path + `submitComposerInput()`.

## Out of scope (follow-up PRs)
- PR2: inline image/file attachments (needs a new `mobile.terminal.upload_file` RPC; render-grid transport is display+input only today).
- PR3: `@` file / `$` skill autocomplete (needs new cwd file-search + skill-list RPCs). When added, mirror the macOS insertion format exactly (`[label](path)` for `@`, bare `$skill-name` for `$`).
- Submit key is `return` for all agents. The macOS Claude+multiline→`ctrl+enter` heuristic is deferred (`submit_key` is already overridable on the RPC); this is the first knob if Claude multi-line submit misbehaves.

## Testing
- iOS app builds for the simulator; Mac app builds (tagged). No automated behavior test: the surface-write path needs a live libghostty surface and the paste RPC travels over the paired NWListener (not the debug socket), so a meaningful end-to-end test is not practical here. Per the repo test-quality policy, a source-shape test is intentionally not added.
- Behavior is **pending device dogfood** (the simulator can't pair to a Mac host). Dogfood steps:
  1. Toggle the composer on; type a 3-line message (include a blank interior line); Send. Confirm it lands as **one** submission, not three, against both a bare `zsh` prompt and a running Claude/codex.
  2. Confirm the composer sits above the keyboard without overlapping the terminal or leaving a dead strip where the docked accessory bar was.
  3. Confirm the chevron closes the composer and restores the accessory bar (with its composer button).

## Localization
- Added en + ja for the 4 new composer keys (`terminal.input_accessory.composer`, `mobile.composer.close`, `mobile.composer.placeholder`, `mobile.composer.send`) in `ios/cmux/Resources/Localizable.xcstrings`. The composer-toggle string is accessibility-only (the button is symbol-based).

## Design
- Full phased design: `plans/feat-ios-composer-textbox/DESIGN.md` (in the cmuxterm-hq control repo).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783322578&installation_id=133855650&pr_number=5511&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5511&signature=1bc602d05d86a2d59a325e5ba7b2dcb2db53332d07ade968dcce94a0d00f88bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Mac RPC path that writes directly to terminal surfaces and agent-specific submit-key heuristics; failures are mitigated by keeping composer text on RPC errors, but behavior depends on paired Mac version supporting `terminal.paste`.
> 
> **Overview**
> Adds a **toggleable iMessage-style composer** on iOS for multi-line messages above the remote terminal, wired end-to-end through a new **`terminal.paste`** mobile RPC instead of `terminal.input`.
> 
> On **iOS**, a new **Composer** accessory button toggles `isComposerPresented`; `TerminalComposerView` (multi-line field + send/chevron) sits in a bottom `safeAreaInset` and reuses `terminalInputText`. While open, `GhosttySurfaceView.setComposerActive` **hides the docked accessory bar** and releases grid height; autofocus is suppressed so the composer keeps the keyboard without flicker. **Send** calls `submitComposerInput()` → `sendRemoteTerminalPaste` with `submit_key: "return"`, clears text only after Mac ack, and blocks double-send re-entrancy.
> 
> On **Mac**, `v2MobileTerminalPaste` **bracketed-pastes** via `sendText` then optionally **`sendNamedKey`** (mirroring macOS TextBox). For multi-line text on a **Claude Code** surface, `return` intent upgrades to **`ctrl+enter`**. `TextBoxAgentDetection` is exposed for that check.
> 
> UI polish: Liquid Glass helpers (`mobileGlassField` / `mobileGlassCircle`) and en/ja localization for composer strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d0fd6287bc3273d8dedf64f19cf713a032bfe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a toggleable iMessage-style composer above the iOS terminal to draft multi-line messages and send them as one paste+submit via a new `terminal.paste` RPC, with Liquid Glass styling and a flicker-free keyboard handoff. On Mac, Return is upgraded to `ctrl+enter` for Claude multi-line blocks, mirroring the desktop TextBox behavior.

- **New Features**
  - New `.composer` accessory button opens a growing multi-line field with Send; it owns the bottom edge + keyboard and stays open after send.
  - Send path: `submitComposerInput()` → `sendRemoteTerminalPaste()` → Mac `v2MobileTerminalPaste` (bracketed paste via `sendText` + optional `sendNamedKey`), reusing existing surface paths (no new `libghostty`).
  - Layout: composer sits in a bottom `safeAreaInset`; `setComposerActive` hides the docked bar and releases grid height; autofocus is deferred for a smooth handoff.
  - Localization: added `terminal.input_accessory.composer`, `mobile.composer.close`, `mobile.composer.placeholder`, `mobile.composer.send` (en, ja).

- **Bug Fixes**
  - Clear the field only after Mac ack; preserve text on failure and during in-flight edits.
  - Guard against double-tap sends to prevent duplicate pastes.
  - Disarm accessory modifiers when opening the composer; suppress terminal autofocus while it’s presented to keep input in the composer.

<sup>Written for commit 56d0fd6287bc3273d8dedf64f19cf713a032bfe0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-line iOS terminal composer with chevron toggle, auto-focus, and disabled Send when input is empty.
  * Submit sends composed text as a single block and keeps composer open on failures for retry.
* **UI**
  * Terminal claims/releases bottom/keyboard area and adds a Composer accessory button; new glass-style backgrounds for composer controls.
* **Localization**
  * Added English and Japanese strings for composer labels, placeholder, send, and hide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->