### PR TITLE
iOS: drop the "Download via TestFlight" CTA (keep it on macOS)

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -10,11 +10,6 @@ struct DisconnectedWorkspaceShellView: View {
     let showAddDevice: () -> Void
     let signOut: () -> Void
 
-    /// The Founders Edition page (Mac download + TestFlight enrollment) the
-    /// onboarding "Download via TestFlight" link points at while TestFlight is
-    /// still private.
-    private static let testFlightURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
-
     var body: some View {
         NavigationStack {
             ContentUnavailableView {
@@ -31,12 +26,6 @@ struct DisconnectedWorkspaceShellView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(.blue)
                 .accessibilityIdentifier("MobileShowAddDeviceButton")
-                Link(
-                    L10n.string("mobile.testflight.link", defaultValue: "Download via TestFlight"),
-                    destination: Self.testFlightURL
-                )
-                .font(.callout)
-                .accessibilityIdentifier("MobileTestFlightLink")
             }
             .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
             .mobileInlineNavigationTitle()

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
@@ -19,10 +19,6 @@ struct PairingView: View {
     let cancelPairing: () -> Void
     let cancel: () -> Void
 
-    /// The Founders Edition page (Mac download + TestFlight enrollment) the
-    /// "Download via TestFlight" link points at while TestFlight is private.
-    private static let testFlightURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
-
     @State private var isShowingScanner = false
     @State private var deviceName = UITestConfig.addDeviceName
         ?? L10n.string("mobile.addDevice.namePlaceholder", defaultValue: "Work Mac")
@@ -119,19 +115,6 @@ struct PairingView: View {
                     .accessibilityIdentifier("MobileScanQRCodeButton")
                 }
                 #endif
-
-                Section {
-                    Link(destination: Self.testFlightURL) {
-                        Label(
-                            L10n.string("mobile.testflight.link", defaultValue: "Download via TestFlight"),
-                            systemImage: "arrow.down.circle"
-                        )
-                        .frame(maxWidth: .infinity)
-                    }
-                    .accessibilityIdentifier("MobileTestFlightLink")
-                } footer: {
-                    Text(L10n.string("mobile.testflight.help", defaultValue: "TestFlight is invite-only for now. Get the Founders Edition to enroll and to download cmux for Mac."))
-                }
 
                 if let manualRouteWarningText {
                     Section {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2873,40 +2873,6 @@
           }
         }
       }
-    },
-    "mobile.testflight.link": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download via TestFlight"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight でダウンロード"
-          }
-        }
-      }
-    },
-    "mobile.testflight.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight is invite-only for now. Get the Founders Edition to enroll and to download cmux for Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight は現在招待制です。Founders Edition から登録し、Mac 版 cmux をダウンロードしてください。"
-          }
-        }
-      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Summary
- Remove the "Download via TestFlight" CTA from the iOS app, where the user is already running a TestFlight build (the link was redundant there).
- Keep the TestFlight CTA on macOS, in the "Pair an iPhone" onboarding window (`MobilePairingView`, step 1: "Install cmux on your iPhone"), which is where prompting a TestFlight install actually helps.
- Removed the link + footer from the iOS `PairingView` (Add device form) and the link from `DisconnectedWorkspaceShellView` (the "No devices" empty state), plus the now-unused `testFlightURL` statics and the orphaned `mobile.testflight.link` / `mobile.testflight.help` strings in `ios/cmux/Resources/Localizable.xcstrings`.

The TestFlight CTA now lives only on macOS, not on iOS.

## Note
The removed iOS link's footer also read "...to download cmux for Mac" and pointed at the Founders Edition page, so iOS loses that Mac-discovery path. That follows the request (TestFlight download CTA on macOS only). If you'd rather keep a Mac-download link on iOS under different wording, say so and I'll restore a reworded variant.

## Testing
- Built the tagged iOS app for the simulator (`ios/scripts/reload.sh --tag tfm`).
- No automated test added: these views are UIKit-bound, iOS-only, and the package's only test is a placeholder smoke test; an absence-of-link assertion would be implementation-shape, which the repo test-quality policy discourages. Verified by build + visual dogfood.

## Localization
- iOS catalog only: removed the two orphaned TestFlight keys (en + ja) so no locale carries a now-unused string. No new user-facing strings were added. The macOS `mobile.pairing.testflight.*` keys are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of external links and unused localization keys; pairing and auth flows are untouched.
> 
> **Overview**
> Removes the redundant **Download via TestFlight** call-to-action from the iOS mobile shell, since users on that app are already on a TestFlight (or equivalent) build.
> 
> The link and its Founders Edition URL are dropped from **`DisconnectedWorkspaceShellView`** (no-devices empty state) and from **`PairingView`** (add-device form), including the TestFlight help footer on pairing. Unused `testFlightURL` statics go away with those views.
> 
> The iOS **`Localizable.xcstrings`** catalog loses the orphaned `mobile.testflight.link` and `mobile.testflight.help` keys (en/ja). macOS **`mobile.pairing.testflight.*`** strings and the TestFlight link in **`MobilePairingView`** are unchanged—that is where prompting an iPhone TestFlight install still makes sense.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279206ad20962a911d52f36a2c3186847c88d9dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783326794&installation_id=133855650&pr_number=5516&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5516&signature=0a34aee1e0375748925f69544dd4626c2d3e7c93d081a850cde5e91f99da9528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the redundant “Download via TestFlight” CTA from the iOS app and keep it only on macOS. This cleans up iOS onboarding and avoids a confusing link.

- **Refactors**
  - Removed the TestFlight link from iOS `PairingView` and `DisconnectedWorkspaceShellView`.
  - Kept the TestFlight CTA on macOS in the MobilePairingView (“Install cmux on your iPhone”).
  - Deleted unused `testFlightURL` constants and removed `mobile.testflight.link` / `mobile.testflight.help` from iOS `Localizable.xcstrings` (en, ja).

<sup>Written for commit 279206ad20962a911d52f36a2c3186847c88d9dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed TestFlight download promotion links from the disconnected workspace and pairing onboarding screens. The empty-state interface now exclusively displays the "Add device" button for workspace management. Associated help documentation and localization strings have been removed to maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->