### PR TITLE
Add Mobile Connect to the command palette

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6654,6 +6654,17 @@ struct ContentView: View {
         return snapshot
     }
 
+    /// Search keywords for the "Mobile Connect" command palette entry.
+    ///
+    /// Kept as a single source of truth so the contribution and its behavioral
+    /// test agree on what queries (e.g. `ios`, `ipados`) must surface the
+    /// command. These are platform/technical terms that read the same across
+    /// locales, so they are not localized.
+    static let commandPaletteMobileConnectKeywords: [String] = [
+        "mobile", "connect", "pair", "pairing", "device",
+        "ios", "ipados", "iphone", "ipad", "phone", "tablet", "qr",
+    ]
+
     private func commandPaletteCommandContributions() -> [CommandPaletteCommandContribution] {
         func constant(_ value: String) -> (CommandPaletteContextSnapshot) -> String {
             { _ in value }
@@ -6969,6 +6980,14 @@ struct ContentView: View {
                     String(localized: "command.openGhosttySettings.subtitle", defaultValue: "Ghostty Config Files")
                 ),
                 keywords: ["open", "ghostty", "settings", "config", "configuration", "file", "textedit", "terminal"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.mobileConnect",
+                title: constant(String(localized: "command.mobileConnect.title", defaultValue: "Mobile Connect")),
+                subtitle: constant(String(localized: "command.mobileConnect.subtitle", defaultValue: "Mobile")),
+                keywords: Self.commandPaletteMobileConnectKeywords
             )
         )
         contributions.append(
@@ -8071,6 +8090,12 @@ struct ContentView: View {
             cmuxDebugLog("palette.openGhosttySettings.invoke")
 #endif
             GhosttyApp.shared.openConfigurationInTextEdit()
+        }
+        registry.register(commandId: "palette.mobileConnect") {
+#if DEBUG
+            cmuxDebugLog("palette.mobileConnect.invoke")
+#endif
+            MobilePairingWindowController.shared.show()
         }
         registry.register(commandId: "palette.makeDefaultTerminal") {
             DefaultTerminalUserAction.setAsDefault(debugSource: "palette.makeDefaultTerminal")

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6985,7 +6985,7 @@ struct ContentView: View {
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.mobileConnect",
-                title: constant(String(localized: "command.mobileConnect.title", defaultValue: "Mobile Connect")),
+                title: constant(String(localized: "command.mobileConnect.title", defaultValue: "Connect iPhone/iPad")),
                 subtitle: constant(String(localized: "command.mobileConnect.subtitle", defaultValue: "Mobile")),
                 keywords: Self.commandPaletteMobileConnectKeywords
             )

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -337,16 +337,16 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testMobileConnectCommandIsFoundByIOSAndIPadOSQueries() {
+    func testMobileConnectCommandIsFoundByMobileDeviceQueries() {
         // Mirror the real command pipeline: a command's searchable corpus is
         // [title, subtitle] + keywords (see CommandPaletteCommand.searchableTexts).
         // Pull the keywords from the production source of truth so this test fails
-        // if "ios"/"ipados" are ever dropped from the contribution.
+        // if any of the expected aliases are ever dropped from the contribution.
         let mobileConnect = FixtureEntry(
             id: "palette.mobileConnect",
             rank: 0,
-            title: "Mobile Connect",
-            searchableTexts: ["Mobile Connect", "Mobile"]
+            title: "Connect iPhone/iPad",
+            searchableTexts: ["Connect iPhone/iPad", "Mobile"]
                 + ContentView.commandPaletteMobileConnectKeywords
         )
         // Dense, realistic decoy corpus so the assertion exercises ranking, not a
@@ -361,11 +361,11 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         }
         let corpus = [mobileConnect] + decoys
 
-        for query in ["ios", "ipados", "iphone", "ipad", "pair", "mobile connect"] {
+        for query in ["ios", "ipados", "iphone", "ipad", "pair", "mobile", "phone", "connect"] {
             XCTAssertEqual(
                 optimizedResults(entries: corpus, query: query).first?.id,
                 "palette.mobileConnect",
-                "Expected Mobile Connect to be the top command palette result for query \"\(query)\""
+                "Expected Connect iPhone/iPad to be the top command palette result for query \"\(query)\""
             )
         }
     }

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -337,6 +337,39 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
+    func testMobileConnectCommandIsFoundByIOSAndIPadOSQueries() {
+        // Mirror the real command pipeline: a command's searchable corpus is
+        // [title, subtitle] + keywords (see CommandPaletteCommand.searchableTexts).
+        // Pull the keywords from the production source of truth so this test fails
+        // if "ios"/"ipados" are ever dropped from the contribution.
+        let mobileConnect = FixtureEntry(
+            id: "palette.mobileConnect",
+            rank: 0,
+            title: "Mobile Connect",
+            searchableTexts: ["Mobile Connect", "Mobile"]
+                + ContentView.commandPaletteMobileConnectKeywords
+        )
+        // Dense, realistic decoy corpus so the assertion exercises ranking, not a
+        // single-item list.
+        let decoys = makeCommandEntries(count: 64).enumerated().map { offset, entry in
+            FixtureEntry(
+                id: entry.id,
+                rank: offset + 1,
+                title: entry.title,
+                searchableTexts: entry.searchableTexts
+            )
+        }
+        let corpus = [mobileConnect] + decoys
+
+        for query in ["ios", "ipados", "iphone", "ipad", "pair", "mobile connect"] {
+            XCTAssertEqual(
+                optimizedResults(entries: corpus, query: query).first?.id,
+                "palette.mobileConnect",
+                "Expected Mobile Connect to be the top command palette result for query \"\(query)\""
+            )
+        }
+    }
+
     func testLimitedSearchReturnsSameTopResultsAsFullSearch() {
         let entries = makeLargeWorkspaceSwitcherEntries(count: 800)
         let queries = [


### PR DESCRIPTION
## Summary
- Add a **Mobile Connect** entry to the Cmd+Shift+P command palette. It opens the iOS/iPadOS pairing window via the same shared `MobilePairingWindowController.shared.show()` path used by Settings → Mobile → Pair a Device, so there is one action path, not a duplicate.
- The entry is findable by `ios`, `ipados`, `iphone`, `ipad`, `pair`, `pairing`, `mobile`, `connect`, `device`, `phone`, `tablet`, `qr`. Title/subtitle are localized (en + ja), matching the neighboring mobile strings.
- Keywords are defined once in `ContentView.commandPaletteMobileConnectKeywords` so the palette contribution and its test share a single source of truth.

## Testing
- Added `CommandPaletteSearchEngineTests.testMobileConnectCommandIsFoundByIOSAndIPadOSQueries`: runs the real `CommandPaletteSearchEngine` fuzzy matcher over a dense decoy corpus and asserts Mobile Connect is the top result for `ios`, `ipados`, `iphone`, `ipad`, `pair`, and `mobile connect`. Pulls keywords from the production constant so dropping `ios`/`ipados` fails the test.
- Unit test runs in the `tests` CI job (local `reload.sh`/`cmux-unit build` does not compile the test bundle).

## Task
- Add "Mobile Connect" to Cmd+Shift+P, triggered when searching ios/ipados too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783327122&installation_id=133855650&pr_number=5518&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5518&signature=5d39b9ea3f8aa6d66664aae4687c5ba7d18843c75e6f7e89d026159b9e820082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only palette wiring reusing an existing pairing window; no auth or data-path changes.
> 
> **Overview**
> Adds a **Connect iPhone/iPad** command to the Cmd+Shift+P palette (`palette.mobileConnect`) that opens the existing iOS/iPadOS pairing flow via `MobilePairingWindowController.shared.show()`, matching Settings → Mobile.
> 
> Search aliases live in `ContentView.commandPaletteMobileConnectKeywords` (e.g. `ios`, `ipados`, `iphone`, `ipad`, `pair`, `qr`) and are wired into the palette contribution. Title/subtitle strings are added to `Localizable.xcstrings` across supported locales.
> 
> A `CommandPaletteSearchEngineTests` case asserts the command ranks first for those queries against a decoy corpus, importing keywords from the production constant so alias regressions fail CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fec58eb4bee96bd9d9966b0cedcef5b4251c25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Connect iPhone/iPad” command to Cmd+Shift+P to quickly start iOS/iPadOS pairing. It opens the same window as Settings → Mobile → Pair a Device via `MobilePairingWindowController.shared.show()`.

- **New Features**
  - Searchable by: ios, ipados, iphone, ipad, pair, pairing, mobile, connect, device, phone, tablet, qr.
  - Title “Connect iPhone/iPad” with subtitle “Mobile,” localized across all supported locales.
  - Keywords centralized in `ContentView.commandPaletteMobileConnectKeywords` and used by the ranking test to assert top results for common queries.

<sup>Written for commit 4fec58eb4bee96bd9d9966b0cedcef5b4251c25b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile Connect command available in the command palette with localized title/subtitle (English/Japanese) and multi-keyword search support.

* **Tests**
  * Added tests ensuring the Mobile Connect command appears as the top search result for various iOS/iPadOS/mobile/phone/connect queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->