### PR TITLE
Pair onboarding: drop leading row icons, keep text

### DIFF
--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -67,10 +67,7 @@ struct MobilePairingView: View {
     }
 
     private var signInRow: some View {
-        let signedIn = model.signedInEmail != nil
-        return requirementRow(
-            systemImage: signedIn ? "checkmark.circle.fill" : "person.crop.circle",
-            tint: signedIn ? .green : .secondary,
+        requirementRow(
             title: String(localized: "mobile.pairing.req.signIn.title", defaultValue: "Signed in to cmux"),
             subtitle: model.signedInEmail
                 ?? String(localized: "mobile.pairing.req.signIn.subtitle", defaultValue: "Sign in to authorize this Mac for pairing.")
@@ -82,8 +79,6 @@ struct MobilePairingView: View {
     private var tailscaleRow: some View {
         let reachable = tailscaleReachable
         return requirementRow(
-            systemImage: reachable == true ? "checkmark.circle.fill" : (reachable == false ? "exclamationmark.triangle.fill" : "network"),
-            tint: reachable == true ? .green : (reachable == false ? .orange : .secondary),
             title: String(localized: "mobile.pairing.req.tailscale.title", defaultValue: "Tailscale"),
             subtitle: tailscaleSubtitle(reachable: reachable)
         ) {
@@ -118,16 +113,11 @@ struct MobilePairingView: View {
     }
 
     private func requirementRow<Trailing: View>(
-        systemImage: String,
-        tint: Color,
         title: String,
         subtitle: String,
         @ViewBuilder trailing: () -> Trailing
     ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Image(systemName: systemImage)
-                .foregroundStyle(tint)
-                .frame(width: 18)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title).font(.callout.weight(.medium))
                 Text(subtitle)

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -42,18 +42,13 @@ struct MobilePairingView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "desktopcomputer.and.iphone")
-                .font(.system(size: 28))
-                .foregroundStyle(.tint)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(localized: "mobile.pairing.window.heading", defaultValue: "Pair your iPhone"))
-                    .font(.title2.weight(.semibold))
-                Text(String(localized: "mobile.pairing.window.subheading", defaultValue: "Scan this code with the cmux app on your iPhone to sync your terminal workspaces."))
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+        VStack(alignment: .leading, spacing: 2) {
+            Text(String(localized: "mobile.pairing.window.heading", defaultValue: "Pair your iPhone"))
+                .font(.title2.weight(.semibold))
+            Text(String(localized: "mobile.pairing.window.subheading", defaultValue: "Scan this code with the cmux app on your iPhone to sync your terminal workspaces."))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove the leading icons from the macOS "Pair your iPhone" pairing card (Settings → Mobile → Pair a Device), leaving just text:
  - header `desktopcomputer.and.iphone` glyph next to "Pair your iPhone"
  - per-row glyph for "Signed in to cmux" (person/checkmark)
  - per-row glyph for "Tailscale" (globe/checkmark/warning)
- Heading, sign-in row, and Tailscale row are now all text-only and flush-left at the same inset.
- The "Get Tailscale" trailing link and all state-driven subtitles ("Reachable over Tailscale.", "Not detected…", etc.) are unchanged. The gated content below (QR code, sign-in prompt, step list) is untouched.

## Testing
- `./scripts/reload-cloud.sh --tag pair-noicon` builds clean (tagged Debug app).

## Issues
- Plain-text task: drop the icons from the pairing onboarding card, leave just the text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SwiftUI changes in the pairing settings view; no auth, networking, or pairing logic is modified.
> 
> **Overview**
> Simplifies the macOS **Pair your iPhone** onboarding UI by removing decorative SF Symbol icons from the header and requirements checklist.
> 
> The header no longer shows the desktop/phone glyph beside the title; it is title and subheading only. **Signed in to cmux** and **Tailscale** checklist rows drop leading status icons (checkmarks, person, network, warning) and the green/orange tinting tied to sign-in and reachability. Row copy, dynamic subtitles, and the trailing **Get Tailscale** link are unchanged; `requirementRow` is refactored to drop `systemImage` and `tint` parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12701d674175d54c6c1ddc29aa9574d200927a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->