### PR TITLE
Show ⌘N hint on sidebar workspace group header in always-show mode

### DIFF
--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -34,7 +34,13 @@ extension VerticalTabsSidebar {
             workspaceCount: renderContext.workspaceCount
         )
         let modifierSymbol = renderContext.workspaceNumberShortcut.numberedDigitHintPrefix
+        // Match the regular workspace row's hint gating: show on modifier-hold OR
+        // when always-show is enabled. Reading only `isModifierPressed` here made
+        // the group header skip its ⌘N badge whenever rows showed theirs via the
+        // always-show path (e.g. CMUX_UI_TEST_SHORTCUT_HINTS_ALWAYS_SHOW), leaving
+        // a gap at the anchor's slot. See TabItemView.showsWorkspaceShortcutHint.
         let showsHintForAnchor = modifierKeyMonitor.isModifierPressed
+            || settings.alwaysShowShortcutHints
         let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate.topVisible(
             forTabId: group.anchorWorkspaceId,
             draggedTabId: dragState.draggedTabId,


### PR DESCRIPTION
## Summary
- The collapsible workspace **group header** gated its ⌘N shortcut hint on `modifierKeyMonitor.isModifierPressed` alone, while regular workspace rows gate on `(modifier-hold || alwaysShowShortcutHints)` (`TabItemView.showsWorkspaceShortcutHint`).
- When always-show hints is active, every ungrouped row shows its ⌘N badge but the group header (which stands in for the group's anchor workspace) shows none, leaving a gap at the anchor's slot: ⌘1/⌘2/⌘3, skip, ⌘5/⌘6/⌘7.
- Fix: gate the header hint on the same condition as the row, so the anchor's ⌘N badge appears whenever the surrounding rows' badges do.

## Why ⌘4 was missing (from the report)
The 4th sidebar row is a workspace group header ("adminhub") standing in for the group's anchor workspace; the anchor is not drawn as its own row. The header computes the correct digit from the anchor's index (⌘4) but never rendered the pill because its visibility check omitted the always-show path. Under cmd-hold both rows and header use the same reactive `isModifierPressed` value, so they show together; only the always-show path diverged, which is the single condition that produces "rows show, header doesn't."

## Testing
- Cloud-built tagged DEBUG app (`ghdr`); compiles clean.
- Behavioral check: with always-show hints active, the group header now renders its ⌘N pill in line with the other rows (no gap at the anchor slot).
- A dedicated automated UI regression would require new group-seeding UI-test scaffolding plus an accessibility id on the hint pill; not added for a one-line gating-parity fix, per the repo's "skip low-value tests / smallest real verification" guidance. The fix restores parity with the already-tested row gating.

## Issues
- Reported via screenshot: group header skips its ⌘N keyboard-shortcut hint while ungrouped rows show theirs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783328185&installation_id=133855650&pr_number=5522&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5522&signature=42d8a1722c05e7bf0163a6f7e5e5244761593279844e3daf49e7f949e252b29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single visibility condition change for a sidebar UI hint; no auth, data, or business-logic impact.
> 
> **Overview**
> Aligns **workspace group header** ⌘N shortcut hint visibility with regular sidebar workspace rows.
> 
> `showsHintForAnchor` now uses **modifier held OR `alwaysShowShortcutHints`**, matching `TabItemView.showsWorkspaceShortcutHint`. Previously the header only checked `modifierKeyMonitor.isModifierPressed`, so with always-show hints enabled (e.g. `CMUX_UI_TEST_SHORTCUT_HINTS_ALWAYS_SHOW`) ungrouped rows showed their badges but the group header did not—creating a gap at the anchor workspace’s slot (e.g. ⌘1–⌘3, skip, ⌘5–⌘7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d998de36b3d5aaaeb8edd3ae58ea9d361e7961f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the ⌘N shortcut hint on workspace group headers when always-show hints is on, so the anchor’s slot no longer appears blank. The header now uses the same gating as rows: show when the modifier is held or `settings.alwaysShowShortcutHints` is true.

<sup>Written for commit d998de36b3d5aaaeb8edd3ae58ea9d361e7961f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

