### PR TITLE
Support cmux ssh without creating a workspace

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7443,6 +7443,7 @@ struct CMUXCLI {
         let agentSocketPath: String?
         let localSocketPath: String
         let remoteRelayPort: Int
+        let noWorkspace: Bool
         /// True when the remote is a cloud VM with cmuxd-remote pre-baked in the image.
         /// Set by `cmux vm new/shell/attach`; false for plain `cmux ssh`.
         let skipDaemonBootstrap: Bool
@@ -7460,6 +7461,7 @@ struct CMUXCLI {
             agentSocketPath: String? = nil,
             localSocketPath: String,
             remoteRelayPort: Int,
+            noWorkspace: Bool = false,
             skipDaemonBootstrap: Bool = false
         ) {
             self.destination = destination
@@ -7474,6 +7476,7 @@ struct CMUXCLI {
             self.agentSocketPath = agentSocketPath
             self.localSocketPath = localSocketPath
             self.remoteRelayPort = remoteRelayPort
+            self.noWorkspace = noWorkspace
             self.skipDaemonBootstrap = skipDaemonBootstrap
         }
     }
@@ -7726,6 +7729,21 @@ struct CMUXCLI {
             "extraArgs=\(sshOptions.extraArguments.count)"
         )
 
+        if sshOptions.noWorkspace {
+            try runSSHWithoutCreatingWorkspace(
+                sshOptions: sshOptions,
+                relayID: relayID,
+                relayToken: relayToken,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                remoteSSHOptions: remoteSSHOptions,
+                reusableTerminalStartupCommand: reusableTerminalStartupCommand,
+                configuredForegroundAuthToken: configuredForegroundAuthToken
+            )
+            return
+        }
+
         var workspaceCreateParams: [String: Any] = [
             "initial_command": initialSSHStartupCommand,
         ]
@@ -7896,6 +7914,110 @@ struct CMUXCLI {
         }
     }
 
+    private func runSSHWithoutCreatingWorkspace(
+        sshOptions: SSHCommandOptions,
+        relayID: String,
+        relayToken: String,
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        remoteSSHOptions: [String],
+        reusableTerminalStartupCommand: String,
+        configuredForegroundAuthToken: String?
+    ) throws {
+        if sshOptions.workspaceName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            throw CLIError(message: "ssh: --name cannot be used with --no-workspace")
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let windowHandle = try normalizeWindowHandle(sshOptions.windowRaw, client: client)
+        let envWorkspace = windowHandle == nil ? env["CMUX_WORKSPACE_ID"] : nil
+        guard let workspaceId = try normalizeWorkspaceHandle(
+            envWorkspace,
+            client: client,
+            windowHandle: windowHandle,
+            allowCurrent: true
+        ) else {
+            throw CLIError(message: "ssh: --no-workspace requires a current cmux workspace")
+        }
+        let activeSurfaceId = try resolveNoWorkspaceSSHActiveSurface(
+            workspaceId: workspaceId,
+            windowHandle: windowHandle,
+            client: client
+        )
+
+        var configureParams: [String: Any] = [
+            "workspace_id": workspaceId,
+            "destination": sshOptions.displayDestination,
+            "auto_connect": configuredForegroundAuthToken == nil,
+            "terminal_startup_command": reusableTerminalStartupCommand,
+        ]
+        if let configuredForegroundAuthToken {
+            configureParams["foreground_auth_token"] = configuredForegroundAuthToken
+        }
+        if let port = sshOptions.port {
+            configureParams["port"] = port
+        }
+        if let identityFile = normalizedSSHIdentityPath(sshOptions.identityFile) {
+            configureParams["identity_file"] = identityFile
+        }
+        if !remoteSSHOptions.isEmpty {
+            configureParams["ssh_options"] = remoteSSHOptions
+        }
+        if let agentSocketPath = sshOptions.agentSocketPath {
+            configureParams["ssh_auth_sock"] = agentSocketPath
+        }
+        if sshOptions.remoteRelayPort > 0 {
+            configureParams["relay_port"] = sshOptions.remoteRelayPort
+            configureParams["relay_id"] = relayID
+            configureParams["relay_token"] = relayToken
+            configureParams["local_socket_path"] = sshOptions.localSocketPath
+        }
+        if sshOptions.skipDaemonBootstrap {
+            configureParams["skip_daemon_bootstrap"] = true
+        }
+        if let activeSurfaceId {
+            configureParams["active_terminal_surface_id"] = activeSurfaceId
+        }
+
+        let configuredPayload = try client.sendV2(method: "workspace.remote.configure", params: configureParams)
+        if ProcessInfo.processInfo.environment["CMUX_SSH_NO_WORKSPACE_SKIP_EXEC_FOR_TESTING"] == "1" {
+            if jsonOutput {
+                print(jsonString(formatIDs(configuredPayload, mode: idFormat)))
+            } else {
+                let workspaceHandle = formatHandle(configuredPayload, kind: "workspace", idFormat: idFormat) ?? workspaceId
+                let remote = configuredPayload["remote"] as? [String: Any]
+                let state = (remote?["state"] as? String) ?? "unknown"
+                print("OK workspace=\(workspaceHandle) target=\(sshOptions.displayDestination) state=\(state)")
+            }
+            return
+        }
+
+        let sshArguments = buildSSHCommandArguments(sshOptions)
+        guard let launchPath = sshArguments.first else {
+            throw CLIError(message: "ssh: could not construct ssh command")
+        }
+        client.close()
+        try execInteractiveProgram(
+            launchPath: launchPath,
+            arguments: Array(sshArguments.dropFirst())
+        )
+    }
+
+    private func resolveNoWorkspaceSSHActiveSurface(
+        workspaceId: String,
+        windowHandle: String?,
+        client: SocketClient
+    ) throws -> String? {
+        let env = ProcessInfo.processInfo.environment
+        if windowHandle == nil,
+           let envSurface = env["CMUX_SURFACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !envSurface.isEmpty {
+            return try normalizeSurfaceHandle(envSurface, client: client, workspaceHandle: workspaceId)
+        }
+        return try? resolveSurfaceId(nil, workspaceId: workspaceId, client: client)
+    }
+
     private func parseSSHCommandOptions(
         _ commandArgs: [String],
         localSocketPath: String = "",
@@ -7908,6 +8030,7 @@ struct CMUXCLI {
         var workspaceName: String?
         var windowRaw: String?
         var noFocus = false
+        var noWorkspace = false
         var sshOptions: [String] = []
         var extraArguments: [String] = []
         var forwardAgentOverride: Bool?
@@ -7955,6 +8078,9 @@ struct CMUXCLI {
                 index += 2
             case "--no-focus":
                 noFocus = true
+                index += 1
+            case "--no-workspace":
+                noWorkspace = true
                 index += 1
             case "-A", "--forward-agent":
                 forwardAgentOverride = true
@@ -8007,7 +8133,8 @@ struct CMUXCLI {
             extraArguments: extraArguments,
             agentSocketPath: agentForwarding.agentSocketPath,
             localSocketPath: localSocketPath,
-            remoteRelayPort: remoteRelayPort
+            remoteRelayPort: remoteRelayPort,
+            noWorkspace: noWorkspace
         )
     }
 
@@ -13544,9 +13671,11 @@ struct CMUXCLI {
               --ssh-option <opt>      Extra SSH -o option (repeatable)
               --window <id|ref|index> Target window for the managed workspace
               --no-focus              Create workspace without switching to it
+              --no-workspace          Run ssh in this terminal and associate this workspace with the remote
 
             Example:
               cmux ssh dev@my-host
+              cmux ssh --no-workspace dev@my-host
               cmux ssh dev@my-host --name "gpu-box" --port 2222 --identity ~/.ssh/id_ed25519
               cmux ssh dev@my-host --forward-agent
               cmux ssh dev@my-host --ssh-option UserKnownHostsFile=/dev/null --ssh-option StrictHostKeyChecking=no
@@ -31936,7 +32065,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           move-tab-to-new-workspace [--tab <id|ref|index>] [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--title <text>] [--focus <true|false>]
           list-workspaces [--window <id|ref|index>]
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
-          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [-A|--forward-agent] [-a|--no-forward-agent] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [-- <remote-command-args>]
+          ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [-A|--forward-agent] [-a|--no-forward-agent] [--ssh-option <opt>] [--window <id|ref|index>] [--no-focus] [--no-workspace] [-- <remote-command-args>]
           ssh-session-list [--workspace <id|ref|index> | --all-workspaces]
           ssh-session-attach --session-id <id> [--workspace <id|ref|index>] [--pane <id|ref|index> | --split <left|right|up|down>]
           ssh-session-cleanup [--workspace <id|ref|index> | --all-workspaces] (--session-id <id> | --all)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5538,6 +5538,14 @@ class TerminalController {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let terminalStartupCommand = v2RawString(params, "terminal_startup_command")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let activeTerminalSurfaceId = v2UUID(params, "active_terminal_surface_id")
+        if v2HasNonNullParam(params, "active_terminal_surface_id"), activeTerminalSurfaceId == nil {
+            return .err(
+                code: "invalid_params",
+                message: "active_terminal_surface_id must be a valid surface id",
+                data: nil
+            )
+        }
         var persistentDaemonSlot = v2RawString(params, "persistent_daemon_slot")?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if v2HasNonNullParam(params, "persistent_daemon_slot") {
@@ -5639,6 +5647,18 @@ class TerminalController {
                   let workspace = owner.tabs.first(where: { $0.id == workspaceId }) else {
                 return
             }
+            if let activeTerminalSurfaceId,
+               workspace.terminalPanel(for: activeTerminalSurfaceId) == nil {
+                result = .err(
+                    code: "invalid_params",
+                    message: "active_terminal_surface_id must identify a terminal surface in the configured workspace",
+                    data: [
+                        "workspace_id": workspaceId.uuidString,
+                        "surface_id": activeTerminalSurfaceId.uuidString,
+                    ]
+                )
+                return
+            }
 
             let config = WorkspaceRemoteConfiguration(
                 transport: transport,
@@ -5664,6 +5684,9 @@ class TerminalController {
                 skipDaemonBootstrap: skipDaemonBootstrap
             )
             workspace.configureRemoteConnection(config, autoConnect: autoConnect)
+            if let activeTerminalSurfaceId {
+                _ = workspace.markActiveRemoteTerminalSurface(activeTerminalSurfaceId)
+            }
             notifyRemotePTYControllerAvailabilityChanged()
 
             let windowId = v2ResolveWindowId(tabManager: owner)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -13010,6 +13010,14 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @MainActor
+    @discardableResult
+    func markActiveRemoteTerminalSurface(_ panelId: UUID) -> Bool {
+        guard panels[panelId] is TerminalPanel else { return false }
+        trackRemoteTerminalSurface(panelId)
+        return true
+    }
+
+    @MainActor
     func shouldKeepPersistentRemoteSurfaceOpenAfterChildExit(_ panelId: UUID) -> Bool {
         guard remoteConfiguration?.preserveAfterTerminalExit == true else { return false }
         return activeRemoteTerminalSurfaceIds.contains(panelId) ||

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2371,6 +2371,41 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
     }
 
     @MainActor
+    func testActiveRemoteTerminalSurfaceCanBeMarkedAfterRemoteConfiguration() throws {
+        let workspace = Workspace()
+        let initialPanelID = try XCTUnwrap(workspace.focusedTerminalPanel?.id)
+        let paneID = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let secondPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneID, focus: true))
+
+        let config = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64010,
+            relayID: String(repeating: "a", count: 16),
+            relayToken: String(repeating: "b", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini",
+            preserveAfterTerminalExit: false
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        XCTAssertFalse(workspace.isRemoteTerminalSurface(initialPanelID))
+        XCTAssertFalse(workspace.isRemoteTerminalSurface(secondPanel.id))
+
+        XCTAssertTrue(workspace.markActiveRemoteTerminalSurface(secondPanel.id))
+        XCTAssertFalse(workspace.isRemoteTerminalSurface(initialPanelID))
+        XCTAssertTrue(workspace.isRemoteTerminalSurface(secondPanel.id))
+        XCTAssertEqual(workspace.activeRemoteTerminalSessionCount, 1)
+
+        let inheritedPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneID, focus: true))
+        XCTAssertTrue(workspace.isRemoteTerminalSurface(inheritedPanel.id))
+        XCTAssertEqual(inheritedPanel.surface.debugInitialCommand(), "ssh cmux-macmini")
+    }
+
+    @MainActor
     func testRemoteDisconnectClearsExplicitRemotePTYSessionIDBeforeReseed() throws {
         let workspace = Workspace()
         let explicitSessionConfig = WorkspaceRemoteConfiguration(
@@ -6380,6 +6415,109 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         XCTAssertNil(configureParams["foreground_auth_token"])
         let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
         XCTAssertTrue(sshOptions.contains("ControlMaster no"))
+        XCTAssertTrue(sshOptions.contains("ControlPath /tmp/cmux-ssh-%C"))
+    }
+
+    @MainActor
+    func testSSHNoWorkspaceConfiguresCallerWorkspaceAndSurfaceWithoutCreatingWorkspace() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ssh-no-workspace")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceID = "11111111-1111-1111-1111-111111111111"
+        let surfaceID = "22222222-2222-2222-2222-222222222222"
+        let workspaceRef = "workspace:9"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let data = line.data(using: .utf8),
+                  let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.v2Response(
+                    id: "unknown",
+                    ok: false,
+                    error: ["code": "unexpected", "message": "Unexpected payload"]
+                )
+            }
+
+            switch method {
+            case "workspace.remote.configure":
+                return self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: [
+                        "workspace_id": workspaceID,
+                        "workspace_ref": workspaceRef,
+                        "remote": [
+                            "enabled": true,
+                            "state": "disconnected",
+                        ],
+                    ]
+                )
+            default:
+                return self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected", "message": "Unexpected method \(method)"]
+                )
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceID
+        environment["CMUX_SURFACE_ID"] = surfaceID
+        environment["CMUX_SSH_NO_WORKSPACE_SKIP_EXEC_FOR_TESTING"] = "1"
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: [
+                "ssh",
+                "--no-workspace",
+                "--port", "2222",
+                "--ssh-option", "ControlPath /tmp/cmux-ssh-%C",
+                "cmux-macmini",
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "OK workspace=\(workspaceRef) target=cmux-macmini state=disconnected\n")
+        XCTAssertTrue(result.stderr.isEmpty, result.stderr)
+
+        let requests = try state.commands.map { line -> [String: Any] in
+            let data = try XCTUnwrap(line.data(using: .utf8))
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data, options: []) as? [String: Any])
+        }
+        XCTAssertEqual(
+            requests.compactMap { $0["method"] as? String },
+            ["workspace.remote.configure"]
+        )
+
+        let configureParams = try XCTUnwrap(requests[0]["params"] as? [String: Any])
+        XCTAssertEqual(configureParams["workspace_id"] as? String, workspaceID)
+        XCTAssertEqual(configureParams["active_terminal_surface_id"] as? String, surfaceID)
+        XCTAssertEqual(configureParams["destination"] as? String, "cmux-macmini")
+        XCTAssertEqual(configureParams["port"] as? Int, 2222)
+        XCTAssertEqual(configureParams["local_socket_path"] as? String, socketPath)
+        XCTAssertEqual(configureParams["auto_connect"] as? Bool, false)
+        XCTAssertNil(configureParams["initial_command"])
+        let terminalStartupCommand = try XCTUnwrap(configureParams["terminal_startup_command"] as? String)
+        XCTAssertFalse(terminalStartupCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let sshOptions = try XCTUnwrap(configureParams["ssh_options"] as? [String])
+        XCTAssertTrue(sshOptions.contains("ControlMaster=auto"))
+        XCTAssertTrue(sshOptions.contains("ControlPersist=600"))
         XCTAssertTrue(sshOptions.contains("ControlPath /tmp/cmux-ssh-%C"))
     }
 


### PR DESCRIPTION
## Summary
- Add `cmux ssh --no-workspace` to configure the current workspace and exec ssh in the current terminal.
- Mark the caller terminal as the active remote surface so new tabs and splits inherit the remote startup.
- Add coverage for no-workspace CLI RPC behavior and active remote surface tracking.

## Testing
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('Resources/Localizable.xcstrings','utf8')); console.log('Localizable.xcstrings JSON OK')"`
- `./scripts/reload-cloud.sh --tag sshnw`
- Attempted AWS targeted xcodebuild for `WorkspaceRemoteConnectionTests/testActiveRemoteTerminalSurfaceCanBeMarkedAfterRemoteConfiguration` and `CLINotifyProcessIntegrationTests/testSSHNoWorkspaceConfiguresCallerWorkspaceAndSurfaceWithoutCreatingWorkspace`; blocked by AWS runner infrastructure. First run failed during package extraction because the runner was out of disk, then after cleanup repeated runs exited 133 immediately after Swift package checkout without a result bundle or compile/test output.

## Issues
- Plain-text task: cmux ssh should support running without creating a workspace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783328211&installation_id=133855650&pr_number=5523&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5523&signature=4c87a61eef884f3462a2e374006a7076a8419ff1027b4bf9fe4980dea1c60642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote SSH configuration and workspace surface tracking, but the new path is gated by a flag with explicit validation and does not replace the default workspace-create flow.
> 
> **Overview**
> Adds **`cmux ssh --no-workspace`**, an alternate SSH path that **does not create a workspace**. It requires a current cmux workspace (from context or `CMUX_WORKSPACE_ID`), rejects `--name`, calls **`workspace.remote.configure`** on that workspace with relay/SSH options, then **`exec`s `ssh` in the calling terminal** (after closing the socket client).
> 
> The configure RPC now accepts **`active_terminal_surface_id`** (from `CMUX_SURFACE_ID` or resolved surface). **`Workspace.markActiveRemoteTerminalSurface`** marks that terminal so new tabs/splits inherit the remote startup command. **`TerminalController`** validates the surface exists in the workspace before applying.
> 
> Help text and **`Localizable.xcstrings`** document the flag; integration/unit tests cover the no-workspace CLI RPC and active-surface marking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba9832ac8cf6eb6c3bdae8c2506a2408256d293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cmux ssh --no-workspace` to run SSH in the caller terminal without creating a new workspace. It configures the current workspace and marks the caller surface as active so new tabs and splits inherit the remote.

- **New Features**
  - Add `--no-workspace` to `cmux ssh`. Runs SSH in-place, rejects `--name`, and requires a current workspace (`CMUX_WORKSPACE_ID`); uses `CMUX_SURFACE_ID` or the focused surface.
  - Send `workspace.remote.configure` with `active_terminal_surface_id`, then exec `ssh`. New tabs/splits inherit the remote startup.
  - Validate `active_terminal_surface_id` in `TerminalController` and add `Workspace.markActiveRemoteTerminalSurface`. Update CLI help and localized strings. Add tests for no-workspace flow and surface tracking.

<sup>Written for commit 3ba9832ac8cf6eb6c3bdae8c2506a2408256d293. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

