### PR TITLE
Fix React script warning in web layout

### DIFF
--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import {
   getMessages,
@@ -13,6 +12,7 @@ import { buildAlternates } from "../../i18n/seo";
 import { Providers } from "./providers";
 import { DevPanel } from "./components/spacing-control";
 import { SiteFooter } from "./components/site-footer";
+import { ThemeBootstrapScript } from "./theme-bootstrap-script";
 import { DOWNLOAD_URL } from "../lib/download";
 import "../globals.css";
 
@@ -28,7 +28,7 @@ const geistMono = Geist_Mono({
 
 const darkThemeColor = "#0a0a0a";
 const lightThemeColor = "#fafafa";
-const themeColorScript = `(function(){try{var t=localStorage.getItem("theme");if(t!=="light"&&t!=="dark")return;var c=t==="light"?"${lightThemeColor}":"${darkThemeColor}";document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content=c})}catch(e){}})()`;
+const themeBootstrapScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content=light?"${lightThemeColor}":"${darkThemeColor}"})}catch(e){}})()`;
 
 export async function generateMetadata({
   params,
@@ -114,20 +114,9 @@ export default async function LocaleLayout({
   return (
     <html lang={locale} dir={dir} suppressHydrationWarning>
       <head>
-        <meta
-          name="theme-color"
-          content={lightThemeColor}
-          media="(prefers-color-scheme: light)"
-        />
-        <meta
-          name="theme-color"
-          content={darkThemeColor}
-          media="(prefers-color-scheme: dark)"
-        />
+        <meta name="theme-color" content={darkThemeColor} />
         <script type="application/ld+json">{jsonLdScript}</script>
-        <Script id="cmux-theme-color" strategy="afterInteractive">
-          {themeColorScript}
-        </Script>
+        <ThemeBootstrapScript script={themeBootstrapScript} />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -28,7 +28,7 @@ const geistMono = Geist_Mono({
 
 const darkThemeColor = "#0a0a0a";
 const lightThemeColor = "#fafafa";
-const themeColorScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)return;document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content="${lightThemeColor}"})}catch(e){}})()`;
+const themeColorScript = `(function(){try{var t=localStorage.getItem("theme");if(t!=="light"&&t!=="dark")return;var c=t==="light"?"${lightThemeColor}":"${darkThemeColor}";document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content=c})}catch(e){}})()`;
 
 export async function generateMetadata({
   params,
@@ -114,7 +114,16 @@ export default async function LocaleLayout({
   return (
     <html lang={locale} dir={dir} suppressHydrationWarning>
       <head>
-        <meta name="theme-color" content={darkThemeColor} />
+        <meta
+          name="theme-color"
+          content={lightThemeColor}
+          media="(prefers-color-scheme: light)"
+        />
+        <meta
+          name="theme-color"
+          content={darkThemeColor}
+          media="(prefers-color-scheme: dark)"
+        />
         <script type="application/ld+json">{jsonLdScript}</script>
         <Script id="cmux-theme-color" strategy="afterInteractive">
           {themeColorScript}

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import {
   getMessages,
@@ -24,6 +25,8 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+const themeInitScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");var m=document.querySelector('meta[name="theme-color"]');if(m)m.content=light?"#fafafa":"#0a0a0a"}catch(e){}})()`;
 
 export async function generateMetadata({
   params,
@@ -104,20 +107,16 @@ export default async function LocaleLayout({
       "terminal, macOS, Claude Code, Codex, OpenCode, Gemini CLI, Kiro, Aider, AI coding agents, Ghostty",
     offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
   };
+  const jsonLdScript = JSON.stringify(jsonLd).replace(/</g, "\\u003c");
 
   return (
     <html lang={locale} dir={dir} suppressHydrationWarning>
       <head>
         <meta name="theme-color" content="#0a0a0a" />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");var m=document.querySelector('meta[name="theme-color"]');if(m)m.content=light?"#fafafa":"#0a0a0a"}catch(e){}})()`,
-          }}
-        />
+        <script type="application/ld+json">{jsonLdScript}</script>
+        <Script id="cmux-theme-init" strategy="beforeInteractive">
+          {themeInitScript}
+        </Script>
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -13,6 +13,7 @@ import { Providers } from "./providers";
 import { DevPanel } from "./components/spacing-control";
 import { SiteFooter } from "./components/site-footer";
 import { ThemeBootstrapScript } from "./theme-bootstrap-script";
+import { darkThemeColor, lightThemeColor } from "./theme-colors";
 import { DOWNLOAD_URL } from "../lib/download";
 import "../globals.css";
 
@@ -26,8 +27,6 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const darkThemeColor = "#0a0a0a";
-const lightThemeColor = "#fafafa";
 const themeBootstrapScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content=light?"${lightThemeColor}":"${darkThemeColor}"})}catch(e){}})()`;
 
 export async function generateMetadata({

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -26,7 +26,9 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const themeInitScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)document.documentElement.classList.add("dark");var m=document.querySelector('meta[name="theme-color"]');if(m)m.content=light?"#fafafa":"#0a0a0a"}catch(e){}})()`;
+const darkThemeColor = "#0a0a0a";
+const lightThemeColor = "#fafafa";
+const themeColorScript = `(function(){try{var t=localStorage.getItem("theme");var light=t==="light"||(t==="system"&&window.matchMedia("(prefers-color-scheme:light)").matches);if(!light)return;document.querySelectorAll('meta[name="theme-color"]').forEach(function(m){m.content="${lightThemeColor}"})}catch(e){}})()`;
 
 export async function generateMetadata({
   params,
@@ -112,10 +114,10 @@ export default async function LocaleLayout({
   return (
     <html lang={locale} dir={dir} suppressHydrationWarning>
       <head>
-        <meta name="theme-color" content="#0a0a0a" />
+        <meta name="theme-color" content={darkThemeColor} />
         <script type="application/ld+json">{jsonLdScript}</script>
-        <Script id="cmux-theme-init" strategy="beforeInteractive">
-          {themeInitScript}
+        <Script id="cmux-theme-color" strategy="afterInteractive">
+          {themeColorScript}
         </Script>
       </head>
       <body

--- a/web/app/[locale]/theme-bootstrap-script.tsx
+++ b/web/app/[locale]/theme-bootstrap-script.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useServerInsertedHTML } from "next/navigation";
+import { useRef } from "react";
+
+export function ThemeBootstrapScript({ script }: { script: string }) {
+  const insertedRef = useRef(false);
+
+  useServerInsertedHTML(() => {
+    if (insertedRef.current) return null;
+    insertedRef.current = true;
+
+    // next/script queues inline App Router scripts for the client bootstrap,
+    // which is too late for this first-paint theme bootstrap.
+    return (
+      <script
+        id="cmux-theme-bootstrap"
+        dangerouslySetInnerHTML={{ __html: script }}
+      />
+    );
+  });
+
+  return null;
+}

--- a/web/app/[locale]/theme-colors.ts
+++ b/web/app/[locale]/theme-colors.ts
@@ -1,0 +1,2 @@
+export const darkThemeColor = "#0a0a0a";
+export const lightThemeColor = "#fafafa";

--- a/web/app/[locale]/theme.tsx
+++ b/web/app/[locale]/theme.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from "next-themes";
 import { flushSync } from "react-dom";
+import { darkThemeColor, lightThemeColor } from "./theme-colors";
 
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
@@ -14,7 +15,10 @@ export function ThemeToggle() {
       document
         .querySelectorAll('meta[name="theme-color"]')
         .forEach((meta) =>
-          meta.setAttribute("content", next === "dark" ? "#0a0a0a" : "#fafafa")
+          meta.setAttribute(
+            "content",
+            next === "dark" ? darkThemeColor : lightThemeColor
+          )
         );
     };
 

--- a/web/app/[locale]/theme.tsx
+++ b/web/app/[locale]/theme.tsx
@@ -11,8 +11,11 @@ export function ThemeToggle() {
 
     const apply = () => {
       setTheme(next);
-      const meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.setAttribute("content", next === "dark" ? "#0a0a0a" : "#fafafa");
+      document
+        .querySelectorAll('meta[name="theme-color"]')
+        .forEach((meta) =>
+          meta.setAttribute("content", next === "dark" ? "#0a0a0a" : "#fafafa")
+        );
     };
 
     if (


### PR DESCRIPTION
## Summary
- Render JSON-LD as inert data with React children instead of a raw dangerouslySetInnerHTML script.
- Emit the first-paint theme bootstrap with useServerInsertedHTML so it runs during HTML parsing outside the hydrated React tree.
- Share theme color constants between the SSR bootstrap and the client theme toggle.

## Testing
- cd web && bun install
- cd web && bun run lint -- app/[locale]/layout.tsx app/[locale]/theme.tsx app/[locale]/theme-bootstrap-script.tsx app/[locale]/theme-colors.ts
- cd web && CMUX_PORT=3791 bun dev
- curl -fsS -o /tmp/cmux-root.html -w 'GET / %{http_code}\n' http://localhost:3791/
- curl -fsS -o /dev/null -w 'GET /handler/after-sign-in %{http_code}\n' http://localhost:3791/handler/after-sign-in
- Confirmed the dev log has no React script-tag warning for either request and the SSR HTML contains one cmux-theme-bootstrap script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * More reliable theme initialization for faster first-paint and consistent persistence across visits.
  * Theme switching now consistently updates all theme-color metadata so the UI and browser chrome match the selected theme.
* **SEO / Structured Data**
  * Page structured data is emitted more safely to improve robustness of search engine parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->