### PR TITLE
Batch workspace close mutations

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5224,7 +5224,6 @@ class TabManager: ObservableObject {
         sidebarSelectedWorkspaceIds.remove(workspace.id)
         invalidateFocusHistoryTarget(workspaceId: workspace.id, panelId: nil)
 
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         workspace.withClosedPanelHistorySuppressed {
             workspace.teardownAllPanels()
         }
@@ -5296,7 +5295,6 @@ class TabManager: ObservableObject {
             clearWorkspacePullRequestTracking(workspaceId: workspace.id)
             invalidateFocusHistoryTarget(workspaceId: workspace.id, panelId: nil)
 
-            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
             workspace.withClosedPanelHistorySuppressed {
                 workspace.teardownAllPanels()
             }
@@ -9658,7 +9656,6 @@ extension TabManager {
         // Session restore replaces the bootstrap workspace objects with freshly
         // restored ones. Tear the old graph down after the atomic swap so late
         // panel/socket callbacks cannot keep mutating hidden pre-restore state.
-        AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
         workspace.teardownAllPanels()
         workspace.teardownRemoteConnection()
         workspace.owningTabManager = nil

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5253,6 +5253,88 @@ class TabManager: ObservableObject {
         publishCmuxWorkspaceClosed(workspace)
     }
 
+    @discardableResult
+    func closeWorkspaces(_ workspaces: [Workspace], recordHistory: Bool = true) -> Int {
+        guard tabs.count > 1 else { return 0 }
+        let targetIds = Set(workspaces.map(\.id))
+        guard !targetIds.isEmpty else { return 0 }
+
+        let originalTabs = tabs
+        let originalIndexById = Dictionary(uniqueKeysWithValues: originalTabs.enumerated().map { ($0.element.id, $0.offset) })
+        var closeCandidates = originalTabs.filter { targetIds.contains($0.id) }
+        guard !closeCandidates.isEmpty else { return 0 }
+        if closeCandidates.count >= originalTabs.count {
+            closeCandidates = Array(closeCandidates.prefix(originalTabs.count - 1))
+        }
+        let closingIds = Set(closeCandidates.map(\.id))
+        guard !closingIds.isEmpty else { return 0 }
+
+        let selectedIdBeforeClose = selectedTabId
+        let selectedReplacementIndex: Int? = selectedIdBeforeClose.flatMap { selectedId in
+            guard closingIds.contains(selectedId),
+                  let selectedOriginalIndex = originalIndexById[selectedId] else { return nil }
+            return originalTabs[..<selectedOriginalIndex].filter { !closingIds.contains($0.id) }.count
+        }
+
+        for workspace in closeCandidates {
+            sentryBreadcrumb("workspace.close", data: ["tabCount": originalTabs.count - closingIds.count])
+            if recordHistory,
+               workspace.isRestorableInSessionSnapshot,
+               let index = originalIndexById[workspace.id] {
+                let snapshot = workspace.sessionSnapshot(
+                    includeScrollback: true,
+                    restorableAgentIndex: RestorableAgentSessionIndex.load()
+                )
+                ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
+                    workspaceId: workspace.id,
+                    windowId: AppDelegate.shared?.windowId(for: self),
+                    workspaceIndex: index,
+                    snapshot: snapshot
+                )))
+            }
+            clearWorkspaceGitProbes(workspaceId: workspace.id)
+            clearWorkspacePullRequestTracking(workspaceId: workspace.id)
+            invalidateFocusHistoryTarget(workspaceId: workspace.id, panelId: nil)
+
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
+            workspace.withClosedPanelHistorySuppressed {
+                workspace.teardownAllPanels()
+            }
+            workspace.teardownRemoteConnection()
+            unwireClosedBrowserTracking(for: workspace)
+            recentlyClosedBrowsers.removeSnapshots(forWorkspaceId: workspace.id)
+            workspace.owningTabManager = nil
+        }
+
+        sidebarSelectedWorkspaceIds.subtract(closingIds)
+        let dissolvedGroupIds = Set(
+            workspaceGroups
+                .filter { closingIds.contains($0.anchorWorkspaceId) }
+                .map(\.id)
+        )
+        if !dissolvedGroupIds.isEmpty {
+            for tab in originalTabs where !closingIds.contains(tab.id) && tab.groupId.map(dissolvedGroupIds.contains) == true {
+                tab.groupId = nil
+            }
+            workspaceGroups.removeAll { dissolvedGroupIds.contains($0.id) }
+        }
+
+        let remainingTabs = originalTabs.filter { !closingIds.contains($0.id) }
+        tabs = remainingTabs
+        if selectedIdBeforeClose.map(closingIds.contains) == true, !tabs.isEmpty {
+            let newIndex = min(selectedReplacementIndex ?? 0, max(0, tabs.count - 1))
+            selectedTabId = tabs[newIndex].id
+        }
+        if !dissolvedGroupIds.isEmpty {
+            normalizeWorkspaceGroupContiguity()
+        }
+
+        for workspace in closeCandidates {
+            publishCmuxWorkspaceClosed(workspace)
+        }
+        return closeCandidates.count
+    }
+
     /// If `closedWorkspaceId` was the anchor of any group, dissolve that group:
     /// remaining members lose their `groupId` and stay in `tabs` as ungrouped
     /// workspaces. Caller is responsible for having already removed the closed
@@ -5468,6 +5550,11 @@ class TabManager: ObservableObject {
                 AppDelegate.shared?.closeMainWindowContainingTabId(firstWorkspace.id)
                 return
             }
+        }
+
+        if !plan.workspaces.contains(where: { requiresAnchorCloseConfirmation($0) }) {
+            closeWorkspaces(plan.workspaces)
+            return
         }
 
         for workspace in plan.workspaces {
@@ -5687,6 +5774,15 @@ class TabManager: ObservableObject {
             message: message,
             acceptCmdD: willCloseWindow
         )
+    }
+
+    private func requiresAnchorCloseConfirmation(_ workspace: Workspace) -> Bool {
+        guard !WorkspaceGroupAnchorCloseSettings.suppressed(),
+              let groupId = workspace.groupId,
+              let group = workspaceGroups.first(where: { $0.id == groupId }) else {
+            return false
+        }
+        return group.anchorWorkspaceId == workspace.id
     }
 
     private func closeWorkspaceDisplayTitle(_ title: String?) -> String {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -261,20 +261,22 @@ class TerminalController {
     private var browserDownloadObserver: NSObjectProtocol?
 
     func cleanupSurfaceState(surfaceIds: [UUID]) {
-        for surfaceId in Set(surfaceIds) {
+        let surfaceIdSet = Set(surfaceIds)
+        guard !surfaceIdSet.isEmpty else { return }
+        for surfaceId in surfaceIdSet {
             v2BrowserFrameSelectorBySurface.removeValue(forKey: surfaceId)
             v2BrowserInitScriptsBySurface.removeValue(forKey: surfaceId)
             v2BrowserInitStylesBySurface.removeValue(forKey: surfaceId)
             v2BrowserDialogQueueBySurface.removeValue(forKey: surfaceId)
             v2BrowserDownloadEventsBySurface.removeValue(forKey: surfaceId)
             v2BrowserUnsupportedNetworkRequestsBySurface.removeValue(forKey: surfaceId)
-            v2BrowserElementRefs = v2BrowserElementRefs.filter { $0.value.surfaceId != surfaceId }
 
             if let surfaceRef = v2RefByUUID[.surface]?[surfaceId] {
                 v2UUIDByRef[.surface]?.removeValue(forKey: surfaceRef)
             }
             v2RefByUUID[.surface]?.removeValue(forKey: surfaceId)
         }
+        v2BrowserElementRefs = v2BrowserElementRefs.filter { !surfaceIdSet.contains($0.value.surfaceId) }
     }
 
     /// Bridges the package server's event closures back to the controller.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6827,16 +6827,7 @@ class TerminalController {
 
             @MainActor
             func closeWorkspaces(_ workspaces: [Workspace]) -> Int {
-                var closed = 0
-                for candidate in workspaces where candidate.id != workspace.id {
-                    let existedBefore = tabManager.tabs.contains(where: { $0.id == candidate.id })
-                    guard existedBefore else { continue }
-                    tabManager.closeWorkspace(candidate)
-                    if !tabManager.tabs.contains(where: { $0.id == candidate.id }) {
-                        closed += 1
-                    }
-                }
-                return closed
+                tabManager.closeWorkspaces(workspaces.filter { $0.id != workspace.id })
             }
 
             @MainActor

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -15496,25 +15496,45 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Tear down all panels in this workspace, freeing their Ghostty surfaces.
     /// Called before TabManager removes the workspace so child processes receive SIGHUP even if ARC deallocation is delayed.
-    func teardownAllPanels() {
+    func teardownAllPanels(
+        clearNotifications: Bool = true,
+        cleanupControllerSurfaceState: Bool = true
+    ) {
         portalRenderingEnabled = false
         clearLayoutFollowUp()
         hideAllTerminalPortalViews()
         hideAllBrowserPortalViews()
+        if clearNotifications {
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id)
+        }
         let panelEntries = Array(panels)
+        var cleanupSurfaceIds: [UUID] = []
+        if cleanupControllerSurfaceState {
+            cleanupSurfaceIds.reserveCapacity(panelEntries.count * 2)
+        }
         for (panelId, panel) in panelEntries {
+            let tabId = surfaceIdFromPanelId(panelId)
+            if cleanupControllerSurfaceState {
+                cleanupSurfaceIds.append(panelId)
+                if let tabId {
+                    cleanupSurfaceIds.append(tabId.uuid)
+                }
+            }
             discardClosedPanelLifecycleState(
                 panelId: panelId,
-                tabId: surfaceIdFromPanelId(panelId),
+                tabId: tabId,
                 paneId: paneId(forPanelId: panelId),
                 panel: panel,
                 origin: "workspace_teardown",
                 closePanel: true,
                 publishSurfaceClosedEvent: true,
-                clearSurfaceNotifications: true,
+                clearSurfaceNotifications: false,
                 requestTransferredRemoteCleanup: true,
-                cleanupControllerSurfaceState: true
+                cleanupControllerSurfaceState: false
             )
+        }
+        if !cleanupSurfaceIds.isEmpty {
+            TerminalController.shared.cleanupSurfaceState(surfaceIds: cleanupSurfaceIds)
         }
         pruneSurfaceMetadata(validSurfaceIds: [])
         syncRemotePortScanTTYs()

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -7,6 +7,7 @@ import ObjectiveC.runtime
 import Bonsplit
 import UserNotifications
 import CmuxGit
+import Combine
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -1126,6 +1127,43 @@ final class TabManagerCloseWorkspacesWithConfirmationTests: XCTestCase {
         XCTAssertEqual(prompts.first?.message, expectedMessage)
         XCTAssertEqual(prompts.first?.acceptCmdD, false)
         XCTAssertEqual(manager.tabs.map(\.title), ["Gamma"])
+    }
+
+    func testCloseWorkspacesWithConfirmationPublishesOneWorkspaceListMutation() {
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace()
+        let third = manager.addWorkspace()
+        let fourth = manager.addWorkspace()
+        let fifth = manager.addWorkspace()
+        manager.selectWorkspace(third)
+
+        var prompts = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            prompts += 1
+            return true
+        }
+
+        var publishedTabCounts: [Int] = []
+        let cancellable = manager.$tabs.dropFirst().sink { tabs in
+            publishedTabCounts.append(tabs.count)
+        }
+
+        manager.closeWorkspacesWithConfirmation([second.id, third.id, fourth.id], allowPinned: true)
+        withExtendedLifetime(cancellable) {}
+
+        XCTAssertEqual(prompts, 1)
+        XCTAssertEqual(publishedTabCounts, [2])
+        XCTAssertEqual(manager.tabs.map(\.id), [first.id, fifth.id])
+        XCTAssertEqual(
+            manager.selectedTabId,
+            fifth.id,
+            "Selection should match the same-index survivor after the selected workspace is batch-closed"
+        )
+        XCTAssertEqual(ClosedItemHistoryStore.shared.menuSnapshot().totalCount, 3)
     }
 
     func testCloseWorkspacesWithConfirmationKeepsWorkspacesWhenCancelled() {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1163,7 +1163,7 @@ final class TabManagerCloseWorkspacesWithConfirmationTests: XCTestCase {
             fifth.id,
             "Selection should match the same-index survivor after the selected workspace is batch-closed"
         )
-        XCTAssertEqual(ClosedItemHistoryStore.shared.menuSnapshot().totalCount, 3)
+        XCTAssertEqual(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount, 3)
     }
 
     func testCloseWorkspacesWithConfirmationKeepsWorkspacesWhenCancelled() {

--- a/cmuxTests/TerminalNotificationClearAllTests.swift
+++ b/cmuxTests/TerminalNotificationClearAllTests.swift
@@ -221,6 +221,90 @@ final class TerminalNotificationClearAllTests: XCTestCase {
         XCTAssertTrue(store.notifications.isEmpty)
     }
 
+    func testClosingWorkspaceRemovesAllOwnedNotificationsOnly() throws {
+        let store = TerminalNotificationStore.shared
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+        AppFocusState.overrideIsFocused = false
+
+        let closingWorkspace = manager.addWorkspace(select: true)
+        let siblingWorkspace = manager.addWorkspace(select: false)
+        defer {
+            if manager.tabs.contains(where: { $0.id == closingWorkspace.id }) {
+                manager.closeWorkspace(closingWorkspace)
+            }
+            if manager.tabs.contains(where: { $0.id == siblingWorkspace.id }) {
+                manager.closeWorkspace(siblingWorkspace)
+            }
+            store.replaceNotificationsForTesting([])
+            store.resetNotificationDeliveryHandlerForTesting()
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+        }
+
+        let firstPanelId = try XCTUnwrap(closingWorkspace.focusedPanelId)
+        let secondPanel = try XCTUnwrap(
+            closingWorkspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal)
+        )
+        let siblingPanelId = try XCTUnwrap(siblingWorkspace.focusedPanelId)
+
+        store.addNotification(
+            tabId: closingWorkspace.id,
+            surfaceId: firstPanelId,
+            title: "First pane",
+            subtitle: "",
+            body: "Workspace close should remove this"
+        )
+        store.addNotification(
+            tabId: closingWorkspace.id,
+            surfaceId: secondPanel.id,
+            title: "Second pane",
+            subtitle: "",
+            body: "Workspace close should remove this too"
+        )
+        store.addNotification(
+            tabId: closingWorkspace.id,
+            surfaceId: nil,
+            title: "Workspace",
+            subtitle: "",
+            body: "Workspace close should remove workspace-level rows"
+        )
+        store.addNotification(
+            tabId: siblingWorkspace.id,
+            surfaceId: siblingPanelId,
+            title: "Sibling",
+            subtitle: "",
+            body: "Sibling notification should remain"
+        )
+
+        XCTAssertEqual(store.unreadCount(forTabId: closingWorkspace.id), 3)
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: firstPanelId))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: secondPanel.id))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: nil))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: siblingWorkspace.id, surfaceId: siblingPanelId))
+
+        manager.closeWorkspace(closingWorkspace)
+
+        XCTAssertFalse(manager.tabs.contains(where: { $0.id == closingWorkspace.id }))
+        XCTAssertEqual(store.unreadCount(forTabId: closingWorkspace.id), 0)
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: firstPanelId))
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: secondPanel.id))
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: closingWorkspace.id, surfaceId: nil))
+        XCTAssertFalse(store.notifications.contains { $0.tabId == closingWorkspace.id })
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: siblingWorkspace.id, surfaceId: siblingPanelId))
+        XCTAssertEqual(store.notifications.map(\.tabId), [siblingWorkspace.id])
+    }
+
     func testClosingPaneClearsPanelOwnedAgentRuntimeState() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()

--- a/cmuxTests/WorkspaceStressProfileTests.swift
+++ b/cmuxTests/WorkspaceStressProfileTests.swift
@@ -228,6 +228,7 @@ final class WorkspaceStressProfileTests: XCTestCase {
         var scrollBarSamples: [TimedSample] = []
         var pinSamples: [TimedSample] = []
         var unpinSamples: [TimedSample] = []
+        var closeSamples: [TimedSample] = []
 
         for pass in 0..<config.switchPasses {
             timed("pass-\(label(for: pass))-color-apply", collectInto: &colorSamples) {
@@ -277,12 +278,29 @@ final class WorkspaceStressProfileTests: XCTestCase {
         XCTAssertTrue(manager.tabs.allSatisfy { $0.customColor == nil })
         XCTAssertTrue(manager.tabs.allSatisfy { !$0.terminalScrollBarHidden })
 
+        let closeManager = TabManager(autoWelcomeIfNeeded: false)
+        for workspaceIndex in 1..<config.workspaceCount {
+            _ = closeManager.addWorkspace(
+                title: "Close Workspace \(label(for: workspaceIndex))",
+                select: false,
+                eagerLoadTerminal: false,
+                autoWelcomeIfNeeded: false
+            )
+        }
+        closeManager.confirmCloseHandler = { _, _, _ in true }
+        let closeTargetIds = closeManager.tabs.dropFirst().map(\.id)
+        timed("close-all-but-anchor", collectInto: &closeSamples) {
+            closeManager.closeWorkspacesWithConfirmation(closeTargetIds, allowPinned: true)
+        }
+        XCTAssertEqual(closeManager.tabs.count, 1)
+
         let report = [
             "Workspace batch action stress config workspaces=\(config.workspaceCount) passes=\(config.switchPasses)",
             reportLine(title: "color", summary: TimingSummary(samples: colorSamples), slowest: slowest(colorSamples)),
             reportLine(title: "scrollbar", summary: TimingSummary(samples: scrollBarSamples), slowest: slowest(scrollBarSamples)),
             reportLine(title: "pin", summary: TimingSummary(samples: pinSamples), slowest: slowest(pinSamples)),
-            reportLine(title: "unpin", summary: TimingSummary(samples: unpinSamples), slowest: slowest(unpinSamples))
+            reportLine(title: "unpin", summary: TimingSummary(samples: unpinSamples), slowest: slowest(unpinSamples)),
+            reportLine(title: "close", summary: TimingSummary(samples: closeSamples), slowest: slowest(closeSamples))
         ].joined(separator: "\n")
 
         print(report)

--- a/cmuxTests/WorkspaceStressProfileTests.swift
+++ b/cmuxTests/WorkspaceStressProfileTests.swift
@@ -229,6 +229,7 @@ final class WorkspaceStressProfileTests: XCTestCase {
         var pinSamples: [TimedSample] = []
         var unpinSamples: [TimedSample] = []
         var closeSamples: [TimedSample] = []
+        var closeSingleSamples: [TimedSample] = []
 
         for pass in 0..<config.switchPasses {
             timed("pass-\(label(for: pass))-color-apply", collectInto: &colorSamples) {
@@ -294,13 +295,32 @@ final class WorkspaceStressProfileTests: XCTestCase {
         }
         XCTAssertEqual(closeManager.tabs.count, 1)
 
+        let closeSingleManager = TabManager(autoWelcomeIfNeeded: false)
+        guard let closeSingleTarget = closeSingleManager.selectedWorkspace else {
+            XCTFail("Expected bootstrap workspace for single close profile")
+            return
+        }
+        populate(workspace: closeSingleTarget, tabsPerWorkspace: config.tabsPerWorkspace)
+        _ = closeSingleManager.addWorkspace(
+            title: "Single Close Sibling",
+            select: false,
+            eagerLoadTerminal: false,
+            autoWelcomeIfNeeded: false
+        )
+        timed("close-single-populated-workspace", collectInto: &closeSingleSamples) {
+            closeSingleManager.closeWorkspace(closeSingleTarget)
+        }
+        XCTAssertFalse(closeSingleManager.tabs.contains(where: { $0.id == closeSingleTarget.id }))
+        XCTAssertEqual(closeSingleManager.tabs.count, 1)
+
         let report = [
             "Workspace batch action stress config workspaces=\(config.workspaceCount) passes=\(config.switchPasses)",
             reportLine(title: "color", summary: TimingSummary(samples: colorSamples), slowest: slowest(colorSamples)),
             reportLine(title: "scrollbar", summary: TimingSummary(samples: scrollBarSamples), slowest: slowest(scrollBarSamples)),
             reportLine(title: "pin", summary: TimingSummary(samples: pinSamples), slowest: slowest(pinSamples)),
             reportLine(title: "unpin", summary: TimingSummary(samples: unpinSamples), slowest: slowest(unpinSamples)),
-            reportLine(title: "close", summary: TimingSummary(samples: closeSamples), slowest: slowest(closeSamples))
+            reportLine(title: "close", summary: TimingSummary(samples: closeSamples), slowest: slowest(closeSamples)),
+            reportLine(title: "close.single", summary: TimingSummary(samples: closeSingleSamples), slowest: slowest(closeSingleSamples))
         ].joined(separator: "\n")
 
         print(report)


### PR DESCRIPTION
## Summary
- Batch multi-workspace close into one `tabs` mutation while preserving teardown, closed history, selection, group dissolution, and close events.
- Route socket workspace close-above/below/others through the same batch path.
- Batch single-workspace teardown so notification cleanup still happens once per workspace and browser surface state cleanup filters once by Set.
- Add regression/stress coverage for batch close publish churn, single populated-workspace close timing, and scoped notification removal on workspace close.

## Testing
- `git diff --check`
- Standalone Swift cleanup benchmark, repeated element-ref filter avg 2125.28 ms p95 2520.93 ms, single Set filter avg 4.09 ms p95 7.71 ms
- Earlier remove-loop benchmark for 1000 ids, old p95 0.715 ms, new p95 0.378 ms
- `./scripts/reload-cloud.sh --tag closefast2` succeeded
- AWS focused XCTest attempted with `cmux-unit`, but the runner failed before executing tests due host setup/cache issues: first no Rust default toolchain, then Ghostty Zig helper `FileNotFound`, then `NoSpaceLeft` while priming the helper. CI should run this on a clean hosted runner.

## Issues
- Related: user-reported lag closing single or multiple workspaces with many splits and workspace notification state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace lifecycle, selection, group dissolution, and notification teardown—behavior-sensitive but covered by new regression and stress tests.
> 
> **Overview**
> **Batch multi-workspace close** so closing several tabs updates `tabs` once instead of once per workspace, cutting UI publish churn while keeping closed-history, selection (same-index survivor), group dissolution, and per-workspace close events.
> 
> `closeWorkspacesWithConfirmation` now calls the batch path when none of the targets need **group-anchor** close dialogs; anchor confirmation still uses the per-workspace loop. Socket “close others/above/below” routes through `closeWorkspaces` as well.
> 
> **Teardown performance:** workspace notification clearing moves into `teardownAllPanels` (once per workspace); panel teardown defers per-surface controller cleanup and runs a **single** `cleanupSurfaceState` pass. `TerminalController.cleanupSurfaceState` filters browser element refs with one `Set` instead of repeated filters per surface.
> 
> Tests cover one `$tabs` emission on confirmed batch close, notification scoping on workspace close, and stress timings for batch vs single populated close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88fb110680fa0762f34c18f27d91d68a6e95c4c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->