### PR TITLE
Show unread ring for live agents after quit

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -190,6 +190,7 @@ extension Workspace {
                     panelId: panelId,
                     includeScrollback: includeScrollback,
                     restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId),
+                    liveRestorableAgentProcess: restorableAgentIndex?.hasLiveProcess(workspaceId: id, panelId: panelId) ?? false,
                     resumeBinding: effectiveSurfaceResumeBinding(
                         panelId: panelId,
                         surfaceResumeBindingIndex: surfaceResumeBindingIndex
@@ -469,6 +470,7 @@ extension Workspace {
         panelId: UUID,
         includeScrollback: Bool,
         restorableAgent: SessionRestorableAgentSnapshot?,
+        liveRestorableAgentProcess: Bool,
         resumeBinding: SurfaceResumeBindingSnapshot?
     ) -> SessionPanelSnapshot? {
         guard let panel = panels[panelId] else { return nil }
@@ -512,12 +514,17 @@ extension Workspace {
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
         let panelNotificationSnapshots = notificationSnapshots(surfaceId: panelId)
         let panelHasUnreadNotification = hasUnreadNotification(panelId: panelId)
+        let liveRestorableAgentNeedsUnreadIndicator = liveRestorableAgentProcess && effectiveRestorableAgent != nil
         let hasUnreadIndicator =
             restoredUnreadPanelIds.contains(panelId) ||
-            hasVisibleNotificationIndicator(panelId: panelId)
+            hasVisibleNotificationIndicator(panelId: panelId) ||
+            liveRestorableAgentNeedsUnreadIndicator
         let restoredUnreadContributesToWorkspace: Bool? = {
             if let restoredIndicator = restoredUnreadPanelIndicators[panelId] {
                 return restoredIndicator.contributesToWorkspaceUnread
+            }
+            if liveRestorableAgentNeedsUnreadIndicator && !panelHasUnreadNotification {
+                return true
             }
             if hasUnreadIndicator && !panelHasUnreadNotification {
                 return false
@@ -740,6 +747,7 @@ extension Workspace {
             panelId: panelId,
             includeScrollback: true,
             restorableAgent: restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId),
+            liveRestorableAgentProcess: restorableAgentIndex.hasLiveProcess(workspaceId: id, panelId: panelId),
             resumeBinding: effectiveSurfaceResumeBinding(
                 panelId: panelId,
                 surfaceResumeBindingIndex: nil

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -166,6 +166,126 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
     }
 
+    func testLiveRestorableAgentSnapshotMarksWorkspaceUnreadForSidebarOnRestore() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let restorableAgent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "live-agent-survived-quit",
+            workingDirectory: source.currentDirectory,
+            launchCommand: nil
+        )
+        let agentIndex = Self.restorableAgentIndex(
+            workspaceId: source.id,
+            panelId: sourcePanelId,
+            snapshot: restorableAgent,
+            processIDs: [42]
+        )
+
+        let snapshot = source.sessionSnapshot(
+            includeScrollback: false,
+            restorableAgentIndex: agentIndex
+        )
+        let sourcePanelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == sourcePanelId })
+        XCTAssertEqual(sourcePanelSnapshot.terminal?.agent?.sessionId, "live-agent-survived-quit")
+        XCTAssertEqual(sourcePanelSnapshot.hasUnreadIndicator, true)
+        XCTAssertEqual(sourcePanelSnapshot.restoredUnreadContributesToWorkspace, true)
+        XCTAssertNil(sourcePanelSnapshot.notifications)
+
+        store.replaceNotificationsForTesting([])
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+    }
+
+    func testRestorableAgentWithoutLiveProcessDoesNotMarkWorkspaceUnreadForSidebarOnRestore() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let restorableAgent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "restorable-agent-without-live-process",
+            workingDirectory: source.currentDirectory,
+            launchCommand: nil
+        )
+        let agentIndex = Self.restorableAgentIndex(
+            workspaceId: source.id,
+            panelId: sourcePanelId,
+            snapshot: restorableAgent,
+            processIDs: []
+        )
+
+        let snapshot = source.sessionSnapshot(
+            includeScrollback: false,
+            restorableAgentIndex: agentIndex
+        )
+        let sourcePanelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == sourcePanelId })
+        XCTAssertEqual(sourcePanelSnapshot.terminal?.agent?.sessionId, "restorable-agent-without-live-process")
+        XCTAssertEqual(sourcePanelSnapshot.hasUnreadIndicator, false)
+        XCTAssertNil(sourcePanelSnapshot.restoredUnreadContributesToWorkspace)
+
+        store.replaceNotificationsForTesting([])
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+    }
+
+    private static func restorableAgentIndex(
+        workspaceId: UUID,
+        panelId: UUID,
+        snapshot: SessionRestorableAgentSnapshot,
+        processIDs: Set<Int>
+    ) -> RestorableAgentSessionIndex {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-live-agent-unread-\(UUID().uuidString)", isDirectory: true)
+        return RestorableAgentSessionIndex.load(
+            homeDirectory: home.path,
+            fileManager: .default,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: [
+                RestorableAgentSessionIndex.PanelKey(workspaceId: workspaceId, panelId: panelId): (
+                    snapshot: snapshot,
+                    updatedAt: 1,
+                    processIDs: processIDs
+                ),
+            ],
+            processArgumentsProvider: { _ in nil }
+        )
+    }
+
     func testLegacyRestoredPanelUnreadIndicatorMarksWorkspaceUnreadForSidebar() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared


### PR DESCRIPTION
## Summary
- Mark restored panel and workspace unread when the hook-backed restorable agent index still has a live process after quit.
- Keep restorable agents without a live process from creating the sidebar notification ring.

## Testing
- `./scripts/reload-cloud.sh --tag agquit`
- `ssh aws-m4pro-6 ... xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS" -derivedDataPath /tmp/cmux-agquit-unit -resultBundlePath /tmp/cmux-agquit-unit.xcresult -only-testing:cmuxTests/WorkspaceManualUnreadTests/testLiveRestorableAgentSnapshotMarksWorkspaceUnreadForSidebarOnRestore -only-testing:cmuxTests/WorkspaceManualUnreadTests/testRestorableAgentWithoutLiveProcessDoesNotMarkWorkspaceUnreadForSidebarOnRestore`

## Notes
- No new user-facing strings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783328974&installation_id=133855650&pr_number=5527&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5527&signature=02018b27293a5b5fe5070beedce85f7fe222fc41d98d1af310eff28221934913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 30cd805319b591cb298e18b3ea8e9a7154ed8e56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sidebar unread ring after restore when a restorable agent still has a live process, and suppress it when no process exists. This makes the restored panel and workspace reflect real, ongoing agent activity.

- **Bug Fixes**
  - Pass `liveRestorableAgentProcess` into session snapshots and factor it into `hasUnreadIndicator` and workspace unread contribution when a restorable agent exists and there are no notifications.
  - Added unit tests to verify: live agent after quit marks workspace unread; no live process does not create a ring.

<sup>Written for commit 30cd805319b591cb298e18b3ea8e9a7154ed8e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread indicator accuracy when restoring sessions with active restorable agent processes.
  * Enhanced workspace sidebar unread state to correctly reflect live agent activity during session restoration.
  * Fixed unread notification tracking to ensure live restorable agents properly contribute to workspace unread indicators as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->