### PR TITLE
Add sign in and sign out to command palette

### DIFF
--- a/Sources/ContentView+AuthCommandPalette.swift
+++ b/Sources/ContentView+AuthCommandPalette.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+
+extension ContentView {
+    static let commandPaletteAuthSignInCommandId = "palette.auth.signIn"
+    static let commandPaletteAuthSignOutCommandId = "palette.auth.signOut"
+
+    static func commandPaletteAuthCommandContributions() -> [CommandPaletteCommandContribution] {
+        func constant(_ value: String) -> (CommandPaletteContextSnapshot) -> String {
+            { _ in value }
+        }
+
+        return [
+            CommandPaletteCommandContribution(
+                commandId: commandPaletteAuthSignInCommandId,
+                title: constant(String(localized: "command.auth.signIn.title", defaultValue: "Sign In")),
+                subtitle: constant(String(localized: "command.auth.subtitle", defaultValue: "Account")),
+                keywords: ["account", "auth", "authenticate", "authentication", "login", "log in", "signin", "sign in"],
+                when: { context in
+                    !context.bool(CommandPaletteContextKeys.authSignedIn)
+                        && !context.bool(CommandPaletteContextKeys.authWorking)
+                }
+            ),
+            CommandPaletteCommandContribution(
+                commandId: commandPaletteAuthSignOutCommandId,
+                title: constant(String(localized: "command.auth.signOut.title", defaultValue: "Sign Out")),
+                subtitle: constant(String(localized: "command.auth.subtitle", defaultValue: "Account")),
+                keywords: ["account", "auth", "logout", "log out", "signout", "sign out"],
+                when: { context in
+                    context.bool(CommandPaletteContextKeys.authSignedIn)
+                        && !context.bool(CommandPaletteContextKeys.authWorking)
+                }
+            ),
+        ]
+    }
+
+    func registerAuthCommandHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
+        registry.register(commandId: Self.commandPaletteAuthSignInCommandId) {
+#if DEBUG
+            cmuxDebugLog("palette.auth.signIn.invoke")
+#endif
+            guard let auth = AppDelegate.shared?.auth else {
+                NSSound.beep()
+                return
+            }
+            auth.browserSignIn.beginSignIn()
+        }
+        registry.register(commandId: Self.commandPaletteAuthSignOutCommandId) {
+#if DEBUG
+            cmuxDebugLog("palette.auth.signOut.invoke")
+#endif
+            guard let auth = AppDelegate.shared?.auth else {
+                NSSound.beep()
+                return
+            }
+            Task { @MainActor in
+                await auth.browserSignIn.signOut()
+            }
+        }
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1495,6 +1495,8 @@ struct ContentView: View {
         static let cliInstalledInPATH = "cli.installedInPATH"
         static let defaultTerminalIsDefault = "defaultTerminal.isDefault"
         static let browserDisabled = "browser.disabled"
+        static let authSignedIn = "auth.signedIn"
+        static let authWorking = "auth.working"
         static func terminalOpenTargetAvailable(_ target: TerminalDirectoryOpenTarget) -> String {
             "terminal.openTarget.\(target.rawValue).available"
         }
@@ -6559,6 +6561,13 @@ struct ContentView: View {
         snapshot.setBool(CommandPaletteContextKeys.workspaceMinimalModeEnabled, isMinimalMode)
         snapshot.setBool(CommandPaletteContextKeys.sidebarMatchTerminalBackground, sidebarMatchTerminalBackground)
         snapshot.setBool(CommandPaletteContextKeys.browserDisabled, BrowserAvailabilitySettings.isDisabled())
+        if let auth = AppDelegate.shared?.auth {
+            snapshot.setBool(CommandPaletteContextKeys.authSignedIn, auth.coordinator.isAuthenticated)
+            snapshot.setBool(
+                CommandPaletteContextKeys.authWorking,
+                auth.coordinator.isLoading || auth.coordinator.isRestoringSession || auth.browserSignIn.isSigningIn
+            )
+        }
 
         if let workspace = tabManager.selectedWorkspace {
             let pinTarget = WorkspaceActionDispatcher.Target.single(workspace.id)
@@ -6990,6 +6999,7 @@ struct ContentView: View {
                 keywords: Self.commandPaletteMobileConnectKeywords
             )
         )
+        contributions.append(contentsOf: Self.commandPaletteAuthCommandContributions())
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.makeDefaultTerminal",
@@ -8097,6 +8107,7 @@ struct ContentView: View {
 #endif
             MobilePairingWindowController.shared.show()
         }
+        registerAuthCommandHandlers(&registry)
         registry.register(commandId: "palette.makeDefaultTerminal") {
             DefaultTerminalUserAction.setAsDefault(debugSource: "palette.makeDefaultTerminal")
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		C1713002C1713002C1713002 /* CommandPaletteShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1713001C1713001C1713001 /* CommandPaletteShortcutRouting.swift */; };
 		3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1013023B1013023B101 /* ConfigSettingsView.swift */; };
 		3023A1003023A1003023A100 /* ConfigSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1003023B1003023B100 /* ConfigSource.swift */; };
+		C0DEA7710000000000000001 /* ContentView+AuthCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEA7710000000000000002 /* ContentView+AuthCommandPalette.swift */; };
 		C0DEF0A90000000000000001 /* ContentView+ForkAgentConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A90000000000000002 /* ContentView+ForkAgentConversation.swift */; };
 		D7AB00000000000000000003 /* ContentView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */; };
 		C3408A000000000000000001 /* ContentView+RightSidebarCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */; };
@@ -900,6 +901,7 @@
 		C1713001C1713001C1713001 /* CommandPaletteShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CommandPaletteShortcutRouting.swift; sourceTree = "<group>"; };
 		3023B1013023B1013023B101 /* ConfigSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSettingsView.swift; sourceTree = "<group>"; };
 		3023B1003023B1003023B100 /* ConfigSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSource.swift; sourceTree = "<group>"; };
+		C0DEA7710000000000000002 /* ContentView+AuthCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+AuthCommandPalette.swift"; sourceTree = "<group>"; };
 		C0DEF0A90000000000000002 /* ContentView+ForkAgentConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+ForkAgentConversation.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+RightSidebarCommandPalette.swift"; sourceTree = "<group>"; };
@@ -1561,6 +1563,7 @@
 				C0DE35010000000000000002 /* SidebarScrim.swift */,
 				D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */,
 				D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */,
+				C0DEA7710000000000000002 /* ContentView+AuthCommandPalette.swift */,
 				C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */,
 				C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */,
 				C0DEF0A90000000000000002 /* ContentView+ForkAgentConversation.swift */,
@@ -2542,6 +2545,7 @@
 				C1713002C1713002C1713002 /* CommandPaletteShortcutRouting.swift in Sources */,
 				3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */,
 				3023A1003023A1003023A100 /* ConfigSource.swift in Sources */,
+				C0DEA7710000000000000001 /* ContentView+AuthCommandPalette.swift in Sources */,
 				C0DEF0A90000000000000001 /* ContentView+ForkAgentConversation.swift in Sources */,
 				D7AB00000000000000000003 /* ContentView+MoveTabToNewWorkspace.swift in Sources */,
 				C3408A000000000000000001 /* ContentView+RightSidebarCommandPalette.swift in Sources */,

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -824,6 +824,44 @@ final class CommandPaletteRenameSelectionSettingsTests: XCTestCase {
     }
 }
 
+final class CommandPaletteAuthCommandTests: XCTestCase {
+    func testSignedOutContextShowsSignInCommandOnly() {
+        var context = ContentView.CommandPaletteContextSnapshot()
+        context.setBool(ContentView.CommandPaletteContextKeys.authSignedIn, false)
+        context.setBool(ContentView.CommandPaletteContextKeys.authWorking, false)
+
+        let visibleCommandIds = visibleAuthCommandIds(context)
+
+        XCTAssertEqual(visibleCommandIds, [ContentView.commandPaletteAuthSignInCommandId])
+    }
+
+    func testSignedInContextShowsSignOutCommandOnly() {
+        var context = ContentView.CommandPaletteContextSnapshot()
+        context.setBool(ContentView.CommandPaletteContextKeys.authSignedIn, true)
+        context.setBool(ContentView.CommandPaletteContextKeys.authWorking, false)
+
+        let visibleCommandIds = visibleAuthCommandIds(context)
+
+        XCTAssertEqual(visibleCommandIds, [ContentView.commandPaletteAuthSignOutCommandId])
+    }
+
+    func testWorkingAuthContextHidesSignInAndSignOutCommands() {
+        for signedIn in [false, true] {
+            var context = ContentView.CommandPaletteContextSnapshot()
+            context.setBool(ContentView.CommandPaletteContextKeys.authSignedIn, signedIn)
+            context.setBool(ContentView.CommandPaletteContextKeys.authWorking, true)
+
+            XCTAssertTrue(visibleAuthCommandIds(context).isEmpty)
+        }
+    }
+
+    private func visibleAuthCommandIds(_ context: ContentView.CommandPaletteContextSnapshot) -> [String] {
+        ContentView.commandPaletteAuthCommandContributions()
+            .filter { $0.when(context) }
+            .map(\.commandId)
+    }
+}
+
 
 final class CommandPaletteSelectionScrollBehaviorTests: XCTestCase {
     func testFirstEntryPinsToTopAnchor() {


### PR DESCRIPTION
## Summary
- Add Sign In and Sign Out entries to the command palette, gated by current auth state.
- Route the commands through the existing macOS auth browser sign-in/sign-out flow.
- Add localized English and Japanese command labels plus behavior coverage for auth-state visibility.

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- `./scripts/reload-cloud.sh --tag signin`

## Issues
- Plain-text task: add sign in and sign out to cmd shift p

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783329258&installation_id=133855650&pr_number=5529&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5529&signature=e261d09256fd4b39f378aa3833fe2e9c889db06da70811d576dd3f8b6241fa87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes account sign-in/out from the palette but delegates to existing auth APIs; main risk is user-facing auth actions during loading/sign-in, which the PR hides via `authWorking`.
> 
> **Overview**
> Adds **Sign In** and **Sign Out** to the command palette (Cmd+Shift+P), with visibility driven by auth state.
> 
> A new `ContentView+AuthCommandPalette` extension registers two palette commands under the **Account** subtitle. **Sign In** appears only when signed out and not busy; **Sign Out** when signed in and not busy. Handlers call the existing `browserSignIn.beginSignIn()` and `signOut()` paths (beep if auth is unavailable). `commandPaletteContextSnapshot` now sets `auth.signedIn` and `auth.working` from the auth coordinator and browser sign-in state.
> 
> English and Japanese strings were added in `Localizable.xcstrings`, and unit tests cover which auth commands are visible for signed-in, signed-out, and in-progress states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e9ec68a889e56f4d9bf92caedbdde27312dcf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Sign In and Sign Out to the command palette (Cmd+Shift+P). Commands appear based on auth state and use the existing macOS browser sign-in/sign-out flow.

- **New Features**
  - New commands: `palette.auth.signIn` and `palette.auth.signOut` with auth-related keywords.
  - New context keys: `auth.signedIn` and `auth.working` control visibility; both commands hide while auth is busy.
  - Localized titles and "Account" subtitle in English and Japanese.
  - Tests verify visibility for signed-in, signed-out, and working states.

<sup>Written for commit 68e9ec68a889e56f4d9bf92caedbdde27312dcf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sign In and Sign Out commands are now available in the command palette for convenient authentication access.
  * Commands dynamically show or hide based on your current authentication status.
  * English and Japanese localization support added for authentication UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->