### PR TITLE
Match iOS viewport border to pane divider color

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12214,10 +12214,11 @@ private final class TerminalViewportBorderOverlayView: NSView {
             path.move(to: NSPoint(x: 0, y: y))
             path.line(to: NSPoint(x: x, y: y))
         }
-        // Match the pane/split divider color (single source of truth) so the
-        // iOS-connected viewport border looks like every other border in the app,
-        // instead of the previous hardcoded near-white separator stroke.
-        GhosttyConfig.load().resolvedSplitDividerColor.setStroke()
+        // Stroke the exact window-chrome separator color used by the pane outline,
+        // sidebar trailing edge, and tab-bar separators (one source of truth), so the
+        // iOS-connected viewport border is pixel-identical to every other border in the
+        // app instead of the previous hardcoded near-white separator stroke.
+        WindowChromeSeparatorColor.current().setStroke()
         path.stroke()
     }
 }
@@ -13219,9 +13220,9 @@ final class GhosttySurfaceScrollView: NSView {
         layer.backgroundColor = color.cgColor
         layer.isOpaque = color.alphaComponent >= 1.0
         CATransaction.commit()
-        // The viewport border strokes the resolved split-divider color, which tracks the
-        // terminal background. Repaint it when the background changes (e.g. theme switch)
-        // so a connected iOS device's visible-area border stays in sync.
+        // The viewport border strokes the window-chrome separator color, which tracks the
+        // terminal background/theme. Repaint it when the background changes (e.g. theme
+        // switch) so a connected iOS device's visible-area border stays in sync.
         if !mobileViewportBorderOverlayView.isHidden {
             mobileViewportBorderOverlayView.needsDisplay = true
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12214,7 +12214,10 @@ private final class TerminalViewportBorderOverlayView: NSView {
             path.move(to: NSPoint(x: 0, y: y))
             path.line(to: NSPoint(x: x, y: y))
         }
-        NSColor.separatorColor.withAlphaComponent(0.95).setStroke()
+        // Match the pane/split divider color (single source of truth) so the
+        // iOS-connected viewport border looks like every other border in the app,
+        // instead of the previous hardcoded near-white separator stroke.
+        GhosttyConfig.load().resolvedSplitDividerColor.setStroke()
         path.stroke()
     }
 }
@@ -13216,6 +13219,12 @@ final class GhosttySurfaceScrollView: NSView {
         layer.backgroundColor = color.cgColor
         layer.isOpaque = color.alphaComponent >= 1.0
         CATransaction.commit()
+        // The viewport border strokes the resolved split-divider color, which tracks the
+        // terminal background. Repaint it when the background changes (e.g. theme switch)
+        // so a connected iOS device's visible-area border stays in sync.
+        if !mobileViewportBorderOverlayView.isHidden {
+            mobileViewportBorderOverlayView.needsDisplay = true
+        }
     }
 
     /// Keeps the shared-backdrop cutout view present only while a pane-local fill needs it.


### PR DESCRIPTION
## Summary
- When an iOS device is connected, macOS draws a border marking the area visible to the phone. It hardcoded `NSColor.separatorColor.withAlphaComponent(0.95)`, which renders as a bright near-white line in dark mode and matches no other border in the app.
- Stroke `GhosttyConfig.resolvedSplitDividerColor` instead, the single source of truth the pane/split dividers already use (`TerminalPanelView.swift`). The viewport border now matches every other border and the color lives in one place (DRY).
- Repaint the overlay on background changes (`GhosttySurfaceScrollView.setBackgroundColor`) so the border tracks theme switches while a device is connected.

## Testing
- `./scripts/reload-cloud.sh --tag vpbord` builds clean (exit 0).
- No practical automated test: asserting the stroked color is matched would require pixel-sampling a rendered overlay (a flaky UI test), and source-shape tests are disallowed by repo policy. Verified by tagged build + visual dogfood instead.

## Issues
- None (plain-text task).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783329999&installation_id=133855650&pr_number=5530&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5530&signature=e34c400ff31f16083b5bd709f1480a33258f3b49e52c22d9ff1492699fbbfa4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic border stroke and overlay repaint only; no auth, data, or terminal behavior changes.
> 
> **Overview**
> The macOS **iOS-connected visible-area border** no longer uses a fixed `NSColor.separatorColor` stroke (which looked near-white in dark mode). It now strokes **`WindowChromeSeparatorColor.current()`**, the same separator color used for pane outlines, sidebar edges, and tab-bar dividers.
> 
> When the terminal **background is updated** (e.g. theme change), **`GhosttySurfaceScrollView.setBackgroundColor`** forces a repaint of the mobile viewport border overlay if it is visible, so the border stays aligned with chrome/theme changes while a device is connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c4e92134cbdbe5f84ccc92ae1f67e7e0983e802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `WindowChromeSeparatorColor.current()` for the iOS viewport border instead of the hardcoded `NSColor.separatorColor` so it exactly matches pane outlines, the sidebar trailing edge, and tab-bar separators across themes. Redraw the overlay on background changes so the border stays in sync during theme switches while a device is connected.

<sup>Written for commit 6c4e92134cbdbe5f84ccc92ae1f67e7e0983e802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connected device terminal viewport border now uses the app’s shared separator color, ensuring consistent divider styling across the interface.
  * Viewport border appearance refreshes automatically when the app background or theme changes, keeping the connected viewport visually synchronized without manual intervention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->