### PR TITLE
Support group-scoped workspace creation

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6918,10 +6918,11 @@ struct CMUXCLI {
         let (nameOpt, rem2) = parseOption(rem1, name: "--name")
         let (descriptionOpt, rem3) = parseOption(rem2, name: "--description")
         let (layoutOpt, rem4) = parseOption(rem3, name: "--layout")
-        let (windowOpt, rem5) = parseOption(rem4, name: "--window")
-        let (focusOpt, remaining) = parseOption(rem5, name: "--focus")
+        let (groupOpt, rem5) = parseOption(rem4, name: "--group")
+        let (windowOpt, rem6) = parseOption(rem5, name: "--window")
+        let (focusOpt, remaining) = parseOption(rem6, name: "--focus")
         if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-            throw CLIError(message: "\(commandName): unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>, --layout <json>, --window <id|ref|index>, --focus <true|false>")
+            throw CLIError(message: "\(commandName): unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>, --layout <json>, --group <id|ref>, --window <id|ref|index>, --focus <true|false>")
         }
         var params: [String: Any] = [:]
         try applyWindowOrCallerContext(to: &params, client: client, windowRaw: windowOpt ?? windowOverride)
@@ -6930,6 +6931,7 @@ struct CMUXCLI {
         }
         if let nameOpt { params["title"] = nameOpt }
         if let descriptionOpt { params["description"] = descriptionOpt }
+        if let groupOpt { params["group_id"] = groupOpt }
         if let layoutOpt {
             guard let layoutData = layoutOpt.data(using: .utf8),
                   let layoutObj = try? JSONSerialization.jsonObject(with: layoutData) as? [String: Any] else {
@@ -13426,7 +13428,7 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
+            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--group <id|ref>] [--window <id|ref|index>] [--focus <true|false>]
 
             Create a new workspace in the caller's window.
 
@@ -13438,6 +13440,7 @@ struct CMUXCLI {
               --layout <json>      Create workspace with a predefined split layout (inline JSON).
                                    Uses the same schema as cmux.json layout definitions.
                                    When provided, --command is ignored (layout surfaces define their own commands).
+              --group <id|ref>     Add the workspace to an existing group
               --window <id|ref|index>
                                    Target window (default: caller's window from $CMUX_WORKSPACE_ID/$CMUX_SURFACE_ID)
               --focus <true|false> Focus the new workspace (default: false)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4044,6 +4044,8 @@ class TerminalController {
             "description": v2OrNull(workspace.customDescription),
             "selected": selected,
             "pinned": workspace.isPinned,
+            "group_id": v2OrNull(workspace.groupId?.uuidString),
+            "group_ref": v2Ref(kind: .workspaceGroup, uuid: workspace.groupId),
             "listening_ports": workspace.listeningPorts,
             "remote": workspace.remoteStatusPayload(),
             "current_directory": v2OrNull(workspace.currentDirectory),
@@ -4284,6 +4286,15 @@ class TerminalController {
         params: [String: Any],
         tabManager resolvedTabManager: TabManager? = nil
     ) -> V2CallResult {
+        let requestedGroupId: UUID?
+        if v2HasNonNullParam(params, "group_id") {
+            guard let groupId = v2UUID(params, "group_id") else {
+                return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+            }
+            requestedGroupId = groupId
+        } else {
+            requestedGroupId = nil
+        }
         guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
@@ -4333,10 +4344,17 @@ class TerminalController {
 
         var newId: UUID?
         var initialSurfaceId: UUID?
+        var assignedGroupId: UUID?
+        var groupWasMissing = false
         let shouldFocus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? false)
         let shouldEagerLoadTerminal = v2Bool(params, "eager_load_terminal") ?? !shouldFocus
         let shouldAutoRefreshMetadata = v2Bool(params, "auto_refresh_metadata") ?? true
         v2MainSync {
+            if let requestedGroupId,
+               !tabManager.workspaceGroups.contains(where: { $0.id == requestedGroupId }) {
+                groupWasMissing = true
+                return
+            }
             let ws = tabManager.addWorkspace(
                 title: title,
                 workingDirectory: cwd,
@@ -4350,8 +4368,32 @@ class TerminalController {
             if let layoutNode {
                 ws.applyCustomLayout(layoutNode, baseCwd: cwd ?? ws.currentDirectory)
             }
+            if let requestedGroupId {
+                let group = tabManager.workspaceGroups.first { $0.id == requestedGroupId }
+                let anchorCwd = group.flatMap { group in
+                    tabManager.tabs.first(where: { $0.id == group.anchorWorkspaceId })?.currentDirectory
+                }
+                let configStore = AppDelegate.shared?.mainWindowContexts.values.first {
+                    $0.tabManager === tabManager
+                }?.cmuxConfigStore
+                let placement = configStore?.resolveWorkspaceGroupConfig(forCwd: anchorCwd)?.newWorkspacePlacement
+                    ?? WorkspaceGroupNewWorkspacePlacementSettings.resolved()
+                tabManager.addWorkspaceToGroup(
+                    workspaceId: ws.id,
+                    groupId: requestedGroupId,
+                    placement: placement
+                )
+            }
             newId = ws.id
             initialSurfaceId = ws.focusedPanelId
+            assignedGroupId = ws.groupId
+        }
+
+        if groupWasMissing, let requestedGroupId {
+            return .err(code: "not_found", message: "Group not found", data: [
+                "group_id": requestedGroupId.uuidString,
+                "group_ref": v2Ref(kind: .workspaceGroup, uuid: requestedGroupId)
+            ])
         }
 
         guard let newId else {
@@ -4363,6 +4405,8 @@ class TerminalController {
             "window_ref": v2Ref(kind: .window, uuid: windowId),
             "workspace_id": newId.uuidString,
             "workspace_ref": v2Ref(kind: .workspace, uuid: newId),
+            "group_id": v2OrNull(assignedGroupId?.uuidString),
+            "group_ref": v2Ref(kind: .workspaceGroup, uuid: assignedGroupId),
             "surface_id": v2OrNull(initialSurfaceId?.uuidString),
             "surface_ref": v2Ref(kind: .surface, uuid: initialSurfaceId)
         ])

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -20,6 +20,7 @@ NEW_PANE_ID = "44444444-4444-4444-8444-444444444444"
 NEW_SURFACE_ID = "55555555-5555-4555-8555-555555555555"
 WINDOW_ID = "66666666-6666-4666-8666-666666666666"
 WINDOW_REF = "window:7"
+GROUP_REF = "workspace_group:2"
 
 
 class FakeCmuxState:
@@ -182,6 +183,13 @@ def main() -> int:
         try:
             run_cli(cli, socket_path, ["new-workspace", "--name", "agent"])
             assert_last_call(state, "workspace.create", {"title": "agent", "focus": False})
+
+            run_cli(cli, socket_path, ["workspace", "create", "--name", "agent-in-group", "--group", GROUP_REF])
+            assert_last_call(
+                state,
+                "workspace.create",
+                {"title": "agent-in-group", "group_id": GROUP_REF, "focus": False},
+            )
 
             run_cli(
                 cli,


### PR DESCRIPTION
## Summary
- Expose workspace `group_id` / `group_ref` in `workspace.list`.
- Let `workspace.create` accept `group_id` and place the new workspace in that group using configured group placement.
- Add `cmux workspace create --group` and a fake-socket CLI contract test.

## Testing
- `./scripts/reload-cloud.sh --tag homegrp` passed.
- `python3 tests/test_cli_layout_focus_contract.py` passed with the freshly built `homegrp` CLI.

## Issues
- Related: cmux-home group-scoped launcher task from chat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783330190&installation_id=133855650&pr_number=5531&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5531&signature=3e98c7393ad41c65935e253be8c5f84eef6b9702a1c7ae876ba346a373403219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace creation and tab/group ordering on the main thread; invalid group IDs fail cleanly, but placement behavior depends on existing group config resolution.
> 
> **Overview**
> Adds **group-scoped workspace creation** end-to-end: `cmux new-workspace` / `workspace create` accept **`--group <id|ref>`**, which is sent as `group_id` on **`workspace.create`**.
> 
> On the v2 API, **`workspace.create`** optionally takes `group_id`, verifies the group exists (otherwise **`not_found`**), then places the new tab in that group using the same **new-workspace placement** rules as the UI (from group/CWD config). Create responses and **`workspace.list`** entries now expose **`group_id`** / **`group_ref`**.
> 
> A fake-socket CLI contract test asserts `workspace create --group` maps to the expected v2 params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dc4ff4deac1093b2a0453c03c811f4a674e8ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable group-scoped workspace creation from API and CLI. Lets users place new workspaces into an existing group and surface group refs in list/create responses.

- **New Features**
  - `workspace.list` now includes `group_id` and `group_ref`.
  - `workspace.create` accepts `group_id`, validates the group, applies configured placement, and returns `group_id`/`group_ref`.
  - CLI adds `--group <id|ref>` to `cmux workspace create` and `cmux new-workspace`; help text updated.
  - Contract test updated to cover `--group` usage.

<sup>Written for commit 1dc4ff4deac1093b2a0453c03c811f4a674e8ef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

