### PR TITLE
iOS: redesign default terminal toolbar layout

### DIFF
--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -295,7 +295,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable {
         case .ctrlZ:
             return "^Z"
         case .ctrlL:
-            return "^L"
+            return String(localized: "terminal.input_accessory.title.clear", defaultValue: "Clear")
         case .upArrow:
             return "↑"
         case .downArrow:
@@ -458,10 +458,35 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable {
         output != nil && !isModifier
     }
 
-    /// Every user-configurable action in canonical (enum) order. This is both
-    /// the default arrangement and the full set the settings editor lists.
+    /// Every user-configurable action in canonical (enum) order. This is the full
+    /// set the settings editor lists and the valid identifier set; it is *not* the
+    /// default on-bar arrangement (see ``defaultConfigurableOrder``).
     public static var configurableActions: [TerminalInputAccessoryAction] {
         allCases.filter { $0.isUserConfigurable }
+    }
+
+    /// The default on-bar arrangement of the configurable shortcuts: the
+    /// high-traffic agent and control keys first (Tab, ^C/^D, the Claude/Codex
+    /// launchers, the arrow keys, Clear), then the punctuation and navigation
+    /// keys. Curated independently of the enum's `rawValue` order so the default
+    /// bar can be arranged without perturbing the persisted identifiers, which are
+    /// the `rawValue`s.
+    ///
+    /// Must stay a permutation of ``configurableActions``;
+    /// ``TerminalAccessoryLayoutReducer`` defensively appends any omission, so a
+    /// gap here can never drop an action from the bar.
+    public static var defaultConfigurableOrder: [TerminalInputAccessoryAction] {
+        [
+            .tab,
+            .ctrlC, .ctrlD,
+            .claude, .codex,
+            .upArrow, .downArrow, .leftArrow, .rightArrow,
+            .ctrlL,
+            .escape,
+            .tilde, .dollar, .slash, .atSign, .pipe,
+            .ctrlZ,
+            .home, .end, .pageUp, .pageDown,
+        ]
     }
 
     /// Human-readable name for the shortcuts settings editor (the bar itself
@@ -484,7 +509,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable {
         case .ctrlC: return String(localized: "terminal.shortcut.name.ctrlC", defaultValue: "Control-C")
         case .ctrlD: return String(localized: "terminal.shortcut.name.ctrlD", defaultValue: "Control-D")
         case .ctrlZ: return String(localized: "terminal.shortcut.name.ctrlZ", defaultValue: "Control-Z")
-        case .ctrlL: return String(localized: "terminal.shortcut.name.ctrlL", defaultValue: "Control-L")
+        case .ctrlL: return String(localized: "terminal.shortcut.name.ctrlL", defaultValue: "Clear (Control-L)")
         case .home: return String(localized: "terminal.shortcut.name.home", defaultValue: "Home")
         case .end: return String(localized: "terminal.shortcut.name.end", defaultValue: "End")
         case .pageUp: return String(localized: "terminal.shortcut.name.pageUp", defaultValue: "Page Up")

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalAccessoryConfiguration.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalAccessoryConfiguration.swift
@@ -45,7 +45,8 @@ public final class TerminalAccessoryConfiguration {
     /// `CmuxMobileTerminalKit` so it is testable from `swift test`; this type is
     /// the thin `@Observable` + persistence shell around it.
     private let reducer = TerminalAccessoryLayoutReducer(
-        configurable: TerminalInputAccessoryAction.configurableActions.map(\.rawValue)
+        configurable: TerminalInputAccessoryAction.configurableActions.map(\.rawValue),
+        defaultOrder: TerminalInputAccessoryAction.defaultConfigurableOrder.map(\.rawValue)
     )
 
     init(defaults: UserDefaults = .standard) {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -192,12 +192,19 @@ final class TerminalInputTextView: UITextView {
     /// user-configurable shortcuts. Command is created but kept out of the
     /// stack until ``applyModifierPresentation()`` inserts it for a Mac remote.
     private static let pinnedLeadingActions: [TerminalInputAccessoryAction] = [
-        .control, .alternate, .command, .zoomOut, .zoomIn,
+        .control, .alternate, .command,
     ]
 
-    /// Build (or rebuild) the bar's buttons: the pinned modifier/zoom controls
-    /// followed by the user-configurable shortcuts in their saved order. Safe to
-    /// call repeatedly; it clears the stack first.
+    /// The structural buttons pinned to the end of the bar, after the
+    /// user-configurable shortcuts. The zoom controls live here so the
+    /// high-traffic shortcuts sit directly after the modifier keys.
+    private static let pinnedTrailingActions: [TerminalInputAccessoryAction] = [
+        .zoomOut, .zoomIn,
+    ]
+
+    /// Build (or rebuild) the bar's buttons: the pinned modifier controls, the
+    /// user-configurable shortcuts in their saved order, then the pinned zoom
+    /// controls. Safe to call repeatedly; it clears the stack first.
     private func populateAccessoryActions() {
         guard let stack = accessoryStackView else { return }
         for view in stack.arrangedSubviews {
@@ -207,7 +214,9 @@ final class TerminalInputTextView: UITextView {
         commandAccessoryButton?.removeFromSuperview()
         commandAccessoryButton = nil
 
-        let actions = Self.pinnedLeadingActions + TerminalAccessoryConfiguration.shared.enabledActions
+        let actions = Self.pinnedLeadingActions
+            + TerminalAccessoryConfiguration.shared.enabledActions
+            + Self.pinnedTrailingActions
         for action in actions {
             let button = makeAccessoryButton(for: action)
             // Command is Mac-only; kept out of the stack and inserted by

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalAccessoryLayoutReducer.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalAccessoryLayoutReducer.swift
@@ -27,19 +27,45 @@ public import Foundation
 /// ```
 public struct TerminalAccessoryLayoutReducer: Sendable {
     /// The configurable action identifiers in canonical (enum) order. This is the
-    /// complete set the reducer will ever surface and the default arrangement.
+    /// complete valid set of identifiers the reducer will ever surface; every
+    /// value it returns is drawn from here.
     public let configurable: [Int]
+
+    /// The identifiers in their default on-bar arrangement, used on a fresh
+    /// install and by ``defaultLayout()``, and as the tail order for forward-compat
+    /// appends in ``load(savedOrder:savedEnabled:)``.
+    ///
+    /// Always a permutation of ``configurable``: the init drops unknown ids and
+    /// appends any configurable id the caller omitted, so a curated default
+    /// arrangement can never make an action vanish from the bar.
+    public let defaultOrder: [Int]
 
     private let configurableSet: Set<Int>
 
     /// Creates a reducer over the given configurable action identifiers.
     ///
-    /// - Parameter configurable: The `rawValue`s of every user-configurable
-    ///   action, in canonical (enum) order. Order matters: it is the default
-    ///   arrangement and the tail order for forward-compat appends.
-    public init(configurable: [Int]) {
+    /// - Parameters:
+    ///   - configurable: The `rawValue`s of every user-configurable action, in
+    ///     canonical (enum) order. This is the valid identifier set.
+    ///   - defaultOrder: The default on-bar arrangement of those identifiers. Pass
+    ///     `nil` (the default) to arrange them in canonical order. Unknown ids are
+    ///     dropped and any omitted configurable id is appended, so the resolved
+    ///     ``defaultOrder`` is always a permutation of `configurable`.
+    public init(configurable: [Int], defaultOrder: [Int]? = nil) {
+        let configurableSet = Set(configurable)
         self.configurable = configurable
-        self.configurableSet = Set(configurable)
+        self.configurableSet = configurableSet
+
+        var seen = Set<Int>()
+        var resolved: [Int] = []
+        for identifier in defaultOrder ?? configurable
+        where configurableSet.contains(identifier) && seen.insert(identifier).inserted {
+            resolved.append(identifier)
+        }
+        for identifier in configurable where seen.insert(identifier).inserted {
+            resolved.append(identifier)
+        }
+        self.defaultOrder = resolved
     }
 
     /// An immutable snapshot of the configurable region's state.
@@ -81,7 +107,7 @@ public struct TerminalAccessoryLayoutReducer: Sendable {
     public func load(savedOrder: [Int], savedEnabled: [Int]?) -> Layout {
         var order = savedOrder.filter { configurableSet.contains($0) }
         var seen = Set(order)
-        for identifier in configurable where !seen.contains(identifier) {
+        for identifier in defaultOrder where !seen.contains(identifier) {
             order.append(identifier)
             seen.insert(identifier)
         }
@@ -136,8 +162,8 @@ public struct TerminalAccessoryLayoutReducer: Sendable {
         return Layout(order: order, enabled: layout.enabled)
     }
 
-    /// The default layout: canonical order with every shortcut shown.
+    /// The default layout: ``defaultOrder`` with every shortcut shown.
     public func defaultLayout() -> Layout {
-        Layout(order: configurable, enabled: configurableSet)
+        Layout(order: defaultOrder, enabled: configurableSet)
     }
 }

--- a/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalAccessoryLayoutReducerTests.swift
+++ b/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalAccessoryLayoutReducerTests.swift
@@ -61,4 +61,38 @@ struct TerminalAccessoryLayoutReducerTests {
         #expect(layout.order == [0, 1, 2, 3])
         #expect(layout.enabled == Set([0, 1, 2, 3]))
     }
+
+    @Test("a custom default order drives the fresh-install layout")
+    func customDefaultOrderFirstLaunch() {
+        let curated = TerminalAccessoryLayoutReducer(configurable: [0, 1, 2, 3], defaultOrder: [2, 3, 0, 1])
+        let layout = curated.load(savedOrder: [], savedEnabled: nil)
+        #expect(layout.order == [2, 3, 0, 1])
+        #expect(layout.enabled == Set([0, 1, 2, 3]))
+        #expect(layout.visibleOrder == [2, 3, 0, 1])
+    }
+
+    @Test("a default order omitting an id appends it so nothing vanishes")
+    func defaultOrderAppendsOmitted() {
+        let curated = TerminalAccessoryLayoutReducer(configurable: [0, 1, 2, 3], defaultOrder: [2, 0])
+        // Omitted 1 and 3 are appended in canonical order, never dropped.
+        #expect(curated.defaultOrder == [2, 0, 1, 3])
+        let layout = curated.defaultLayout()
+        #expect(layout.order == [2, 0, 1, 3])
+        #expect(layout.visibleOrder == [2, 0, 1, 3])
+    }
+
+    @Test("a default order with unknown ids drops them")
+    func defaultOrderDropsUnknown() {
+        let curated = TerminalAccessoryLayoutReducer(configurable: [0, 1, 2, 3], defaultOrder: [9, 2, 0, 7])
+        #expect(curated.defaultOrder == [2, 0, 1, 3])
+    }
+
+    @Test("forward-compat append follows the default order, not canonical")
+    func forwardCompatUsesDefaultOrder() {
+        let curated = TerminalAccessoryLayoutReducer(configurable: [0, 1, 2, 3], defaultOrder: [3, 2, 1, 0])
+        let layout = curated.load(savedOrder: [2, 0], savedEnabled: [2, 0])
+        // Saved [2, 0] honored, then missing 3 and 1 appended in default order.
+        #expect(layout.order == [2, 0, 3, 1])
+        #expect(layout.visibleOrder == [2, 0])
+    }
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2721,6 +2721,40 @@
         }
       }
     },
+    "terminal.input_accessory.title.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリア"
+          }
+        }
+      }
+    },
+    "terminal.shortcut.name.ctrlL": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear (Control-L)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリア (Control-L)"
+          }
+        }
+      }
+    },
     "terminal.input_accessory.title.escape": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
Redesign the **default** layout of the iOS terminal accessory bar (the shortcut row above the keyboard). Left to right on a Mac remote it now reads:

`Ctrl Alt Cmd  Tab ^C ^D Claude Codex  ↑ ↓ ← →  Clear  Esc ~ $ / @ | ^Z  Home End PgUp PgDn   −🔍 +🔍`

- **Zoom controls move to the end.** They were pinned right after `Cmd`; a new trailing pinned region holds them at the far end so the high-traffic keys sit next to the modifier keys.
- **Tab moves directly after the modifier keys**, followed by `^C`/`^D`, the Claude/Codex launchers, the arrow keys, then **Clear**.
- **New "Clear" button.** This is the existing `^L` action (0x0C, clear screen) relabeled to `Clear` for discoverability. The bar sends raw bytes to the Mac, so a true `⌘K` (clear screen + scrollback) is not possible without new key-event plumbing; `^L` is the real clear this bar can send.
- **Pipe `|` stays**, repositioned after `@`. The remaining punctuation/navigation keys keep their slots.

Everything stays user-customizable in Settings → Terminal Shortcuts; this only changes the default arrangement.

## Implementation
- `TerminalInputAccessoryAction.defaultConfigurableOrder` is a new curated default arrangement, kept **separate from the enum `rawValue` order** so persisted display-order identifiers are untouched (no UserDefaults migration, no silent reset of users who customized their bar).
- `TerminalAccessoryLayoutReducer` gains a `defaultOrder` parameter and **defensively appends** any configurable id the curated list omits, so a gap in the curated array can never drop an action from the bar. Forward-compat appends now follow the default order.
- `pinnedLeadingActions` drops the zoom controls; new `pinnedTrailingActions` holds them.
- `Clear` title + `Control-L` settings name localized (en + ja) in `ios/cmux/Resources/Localizable.xcstrings`.

## Testing
- `swift test --package-path Packages/CmuxMobileTerminalKit --filter TerminalAccessoryLayoutReducer` → 11/11 pass (7 existing + 4 new covering custom default order, defensive append of omitted ids, dropping unknown ids, and default-order forward-compat).
- iOS Debug simulator build (tag `tbar2`) compiles the changed `CmuxMobileTerminal` sources.

## Notes
- The bar only renders attached to a live terminal, which requires sign-in + pairing through the web API, so the visual layout is verified on a paired iPhone, not the autonomous simulator.
- macOS app is unaffected: `CmuxMobileTerminal` is an iOS-only package the macOS target does not link.

## Issues
- Plain-text task (no GitHub issue): iOS terminal toolbar default layout request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783330588&installation_id=133855650&pr_number=5532&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5532&signature=352c6316bee0360b9b7b9ebcf538bbeae4b6e12cfba437d2eae362348dd30622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI defaults and labeling only; persisted shortcut order/enabled state and key bytes are unchanged unless the user resets to defaults.
> 
> **Overview**
> Redesigns the **default** iOS terminal accessory bar so high-traffic keys sit next to the modifier row: **zoom (−/+)** moves from immediately after modifiers to a new **trailing pinned** region; configurable shortcuts use a new **`defaultConfigurableOrder`** (Tab, ^C/^D, Claude/Codex, arrows, Clear, then punctuation/nav) **without changing enum `rawValue`s**, so existing `UserDefaults` layouts are untouched.
> 
> The **^L** shortcut is unchanged on the wire (`0x0C`) but labeled **Clear** on the bar and in Terminal Shortcuts (en/ja). **`TerminalAccessoryLayoutReducer`** gains **`defaultOrder`** for fresh installs, reset-to-defaults, and forward-compat appends (with defensive append of any omitted id). Four reducer tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d1e22802f273a39e168de4e7bafef34202ee3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the default iOS terminal toolbar to put high‑traffic keys right after the modifiers and added a Clear button (sends ^L). Zoom controls now sit at the far right; existing custom layouts are preserved.

- **New Features**
  - Default order updated: Tab, ^C/^D, Claude/Codex, arrows, Clear, then punctuation/navigation; zoom controls pinned at the end.
  - "^L" is now labeled "Clear" in the bar; settings show "Clear (Control‑L)". Localized for en and ja.

- **Refactors**
  - Added `TerminalInputAccessoryAction.defaultConfigurableOrder` and passed it to `TerminalAccessoryLayoutReducer`; reducer accepts `defaultOrder` and appends omitted ids to avoid drops.
  - Split pinned actions: leading modifiers only; new trailing pinned zoom controls. Updated `TerminalAccessoryConfiguration` and button construction.
  - Expanded tests to cover custom default order, defensive appends, unknown id drops, and forward‑compat behavior.

<sup>Written for commit 15d1e22802f273a39e168de4e7bafef34202ee3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Terminal Ctrl+L action now displays the localized "Clear" label instead of "^L."
  * Toolbar layout refined: zoom controls moved to the right side of the terminal input bar.
  * Shortcut configuration now uses a curated default ordering.

* **Localization**
  * Added localized strings for the clear action in English and Japanese languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->