### PR TITLE
Make iOS pairing faster: pre-warm the Stack token + prefer the raw Tailscale IP route

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -2,6 +2,12 @@ public import CMUXMobileCore
 internal import CmuxMobileShellModel
 internal import CmuxMobileSupport
 public import Foundation
+#if DEBUG
+import Dispatch
+import OSLog
+
+private let mobileRPCLog = Logger(subsystem: "dev.cmux", category: "mobile-rpc")
+#endif
 
 /// A multiplexed RPC client over a single persistent transport to a paired Mac.
 ///
@@ -195,7 +201,19 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                 throw MobileShellConnectionError.insecureManualRoute
             }
             do {
+                #if DEBUG
+                let tokenFetchStartNanoseconds = DispatchTime.now().uptimeNanoseconds
+                #endif
                 auth["stack_access_token"] = try await runtime.stackAccessTokenProvider()
+                #if DEBUG
+                // RT-A timing: the SDK refreshes a >75s-old token here. Log only
+                // when slow so steady-state per-keystroke cache hits (~0ms) don't
+                // spam; a pre-warmed pair should make this fast at the first send.
+                let tokenFetchMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - tokenFetchStartNanoseconds) / 1_000_000
+                if tokenFetchMilliseconds > 50 {
+                    mobileRPCLog.debug("pairing.rtA stackTokenFetch ms=\(tokenFetchMilliseconds, privacy: .public)")
+                }
+                #endif
             } catch let error as MobileShellConnectionError {
                 // The provider already classified the failure: a transient
                 // token-fetch failure (offline / refresh server hiccup, session

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -119,6 +119,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var createWorkspaceTask: Task<Void, Never>?
     private var createTerminalTask: Task<Void, Never>?
     private var workspaceListRefreshTask: Task<Void, Never>?
+    /// Warms the Stack access token concurrently with the route TCP connect so
+    /// the SDK's >75s-old-token refresh overlaps the connect instead of
+    /// serializing in front of the first authorized send. Best-effort: result
+    /// ignored. Cancelled on the next connect / pairing attempt.
+    private var tokenPrewarmTask: Task<Void, Never>?
     private var createWorkspaceTaskID: UUID?
     private var createTerminalTaskID: UUID?
     private var connectionGeneration: UUID
@@ -948,6 +953,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // therefore cannot authorize, which is intended.
         let routeAllowsStackAuthFallback = allowsStackAuthFallback
             ?? supportedRoutes.allSatisfy(MobileShellRouteAuthPolicy.routeAllowsStackAuth)
+        // Pre-warm the Stack access token concurrently with the upcoming route
+        // TCP connect. The vendored SDK refreshes any token older than ~75s on
+        // the first authorized send; starting that refresh now overlaps it with
+        // the local connect (hiding one Stack round-trip) instead of paying it
+        // serially in front of the first workspace.list. Best-effort only: the
+        // authoritative fetch still runs in the RPC layer, which preserves the
+        // transient-vs-definitive error classification, so a failed pre-warm is
+        // swallowed here and never drives the re-auth prompt.
+        if routeAllowsStackAuthFallback {
+            prewarmStackAccessToken(runtime: runtime)
+        }
         var lastError: (any Error)?
         for route in supportedRoutes {
             activeRoute = route
@@ -1161,6 +1177,28 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         createTerminalTaskID = nil
         workspaceListRefreshTask?.cancel()
         workspaceListRefreshTask = nil
+        tokenPrewarmTask?.cancel()
+        tokenPrewarmTask = nil
+    }
+
+    /// Kicks off a best-effort Stack access-token mint so it overlaps the route
+    /// TCP connect instead of blocking the first authorized send. The result is
+    /// intentionally discarded: this only warms the SDK's token cache. Any
+    /// failure is swallowed so it never surfaces as an auth error (the real send
+    /// does the authoritative, classification-preserving fetch).
+    private func prewarmStackAccessToken(runtime: any MobileSyncRuntime) {
+        tokenPrewarmTask?.cancel()
+        let provider = runtime.stackAccessTokenProvider
+        tokenPrewarmTask = Task.detached(priority: .userInitiated) {
+            #if DEBUG
+            let start = DispatchTime.now().uptimeNanoseconds
+            #endif
+            let didSucceed = ((try? await provider()) != nil)
+            #if DEBUG
+            let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+            mobileShellLog.debug("pairing.prewarm stackToken finished ms=\(elapsedMs, privacy: .public) ok=\(didSucceed ? 1 : 0, privacy: .public)")
+            #endif
+        }
     }
 
     private func resetTerminalOutputTracking() {

--- a/Sources/Mobile/MobileRouteResolver.swift
+++ b/Sources/Mobile/MobileRouteResolver.swift
@@ -55,15 +55,34 @@ final class MobileRouteResolver: @unchecked Sendable {
             }
         }
 
+        // Prefer raw CGNAT IP routes over MagicDNS `.ts.net` names: connecting by
+        // literal IP skips a DNS resolution on the phone (which, for a `.ts.net`
+        // name, depends on Tailscale MagicDNS being active and adds avoidable
+        // latency to the pairing critical path). Both kinds reach the same Mac
+        // over the same WireGuard tunnel, so the only difference is the lookup.
+        // All IP routes get a lower priority value (tried first) than any DNS
+        // route; a within-class counter keeps ordering stable when there are
+        // several of either. The `id` stays keyed to the input index so persisted
+        // reconnect routes are unaffected.
+        var ipLiteralRank = 0
+        var dnsNameRank = 0
         for (index, tailscaleHost) in tailscaleHosts.enumerated() {
             let id = index == 0
                 ? CmxAttachTransportKind.tailscale.rawValue
                 : "\(CmxAttachTransportKind.tailscale.rawValue)_\(index + 1)"
+            let priority: Int
+            if Self.isTailscaleDNSName(tailscaleHost) {
+                priority = 100 + dnsNameRank
+                dnsNameRank += 1
+            } else {
+                priority = 10 + ipLiteralRank
+                ipLiteralRank += 1
+            }
             if let tailscaleRoute = try? CmxAttachRoute(
                 id: id,
                 kind: .tailscale,
                 endpoint: .hostPort(host: tailscaleHost, port: port),
-                priority: 10 + (index * 10)
+                priority: priority
             ) {
                 resolved.append(tailscaleRoute)
             }

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -174,7 +174,7 @@ final class MobileHostAuthorizationTests: XCTestCase {
         XCTAssertNil(request.auth)
     }
 
-    func testMobileRouteResolverPrefersTailscaleMagicDNSBeforeIPv4Fallback() throws {
+    func testMobileRouteResolverPrefersRawTailscaleIPBeforeMagicDNS() throws {
         let resolver = MobileRouteResolver()
 
         let snapshot = resolver.routes(
@@ -185,21 +185,29 @@ final class MobileHostAuthorizationTests: XCTestCase {
             ]
         )
 
-        let tailscaleRoutes = snapshot.routes.filter { $0.kind == .tailscale }
+        // Connecting by literal CGNAT IP skips a DNS lookup, so the raw IP route
+        // gets the lower priority value (tried first) and the .ts.net MagicDNS
+        // name the higher value, regardless of input order. The client tries
+        // routes in priority order, so assert the priority-sorted sequence.
+        let tailscaleRoutes = snapshot.routes
+            .filter { $0.kind == .tailscale }
+            .sorted { $0.priority < $1.priority }
         XCTAssertEqual(tailscaleRoutes.count, 2)
-        XCTAssertEqual(tailscaleRoutes.first?.priority, 10)
-        XCTAssertEqual(tailscaleRoutes.last?.priority, 20)
+        XCTAssertLessThan(
+            tailscaleRoutes.first?.priority ?? .max,
+            tailscaleRoutes.last?.priority ?? .min
+        )
         if case let .hostPort(host, port) = tailscaleRoutes.first?.endpoint {
-            XCTAssertEqual(host, "work-mac.tailnet.ts.net")
-            XCTAssertEqual(port, 61234)
-        } else {
-            XCTFail("Expected first Tailscale route to use a host/port endpoint")
-        }
-        if case let .hostPort(host, port) = tailscaleRoutes.last?.endpoint {
             XCTAssertEqual(host, "100.71.210.41")
             XCTAssertEqual(port, 61234)
         } else {
-            XCTFail("Expected fallback Tailscale route to use a host/port endpoint")
+            XCTFail("Expected the raw Tailscale IP route to be tried first")
+        }
+        if case let .hostPort(host, port) = tailscaleRoutes.last?.endpoint {
+            XCTAssertEqual(host, "work-mac.tailnet.ts.net")
+            XCTAssertEqual(port, 61234)
+        } else {
+            XCTFail("Expected the MagicDNS route to be tried after the IP route")
         }
     }
 


### PR DESCRIPTION
## Summary

iOS QR pairing was uniformly slow because a fresh pair pays sequential round-trips to Stack's auth API on the critical path before `workspace.list` returns. Measured (warm, from the Mac's network):

- **RT-A — iOS SDK token refresh** (`POST /api/v1/auth/oauth/token`): **~580ms**. The vendored SDK refreshes any access token older than ~75s before the first authorized send, with no background refresh, so opening the app to pair almost always blocks on this.
- DNS resolution of the `.ts.net` MagicDNS route (the higher-priority route) adds avoidable latency on the connect.
- **RT-B — Mac `getUser`** (`GET /users/me`, the same-account check): **~250ms**.

This PR removes the two costs that are safe to remove, with **no change to the authorization boundary**:

- **Pre-warm the Stack token** concurrently with the route TCP connect (`MobileShellComposite`), so the ~580ms refresh overlaps the local connect instead of serializing in front of the first send. Best-effort: cancelled on the next connect, errors swallowed so it never drives the re-auth prompt (preserves the transient-vs-definitive token-refresh classification).
- **Prefer the raw Tailscale CGNAT IP over the `.ts.net` MagicDNS name** as the first route (`MobileRouteResolver`), dropping a DNS lookup from the critical path. Both routes reach the same Mac over the same WireGuard tunnel.

### Why not also remove the Mac `getUser`?

An earlier version of this branch verified the Stack token locally (ES256 + JWKS) to drop RT-B off the critical path. Measurement showed `getUser` is only **~250ms**, and a security review (canonical autoreview, P1) flagged that local verification authorizes a **revoked-but-unexpired** same-account token before the network revocation check (the prior code rejected a revoked token immediately on cache miss). Trading a real revocation-boundary regression for ~250ms is not worth it, so that approach was dropped and `getUser` stays the authoritative same-account gate. The local verifier is preserved in git history if a future measurement ever shows `getUser` dominating.

## Testing

- Measured against live Stack (dev project): RT-A refresh ~490-750ms, RT-B `getUser` ~225-335ms, JWKS ~100ms.
- `swift build` clean for `CmuxMobileShell` and `CmuxMobileRPC`.
- Tagged macOS app builds clean (`reload-cloud --tag pairfast`).
- Pairing cannot be reproduced autonomously (the simulator can't pair to the user's Mac), so the win is confirmed by dogfooding a real phone against the tagged Mac. A DEBUG `pairing.rtA stackTokenFetch ms=...` log proves the token is warm at the first send (pre-warm worked). If pairing still feels slow after that log confirms RT-A is hidden, the remaining cost is elsewhere (Tailscale relay RTT, the one-time iOS Local Network permission prompt, or cold TLS) and is out of scope for this PR.

## Issues

- Addresses the post-2026-06-04 pairing slowdown: the pure-Stack-auth gate (`917dc94466` / `d7ee593844`) put a `getUser` on the pairing path, and the SDK's 75s token-refresh + DNS compound it. This PR keeps that gate intact and removes the safe-to-remove costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stack access tokens are now fetched concurrently during connection initialization, improving connection performance.
  * Routes using DNS names are now prioritized higher than IP-based routes for better connectivity.

* **Chores**
  * Added performance monitoring for token operations in debug builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are pairing-path performance only; auth boundaries are unchanged and pre-warm errors are ignored. Route reordering may affect which Tailscale endpoint is tried first when both IP and DNS are present.
> 
> **Overview**
> Speeds up iOS QR pairing by overlapping Stack access-token refresh with the route TCP connect and by trying Tailscale CGNAT IPs before MagicDNS `.ts.net` hostnames.
> 
> **`MobileShellComposite`** starts a best-effort `prewarmStackAccessToken` task when Stack auth is allowed on the route, so the SDK’s ~75s token refresh can run in parallel with connect instead of blocking the first authorized `workspace.list`. Failures are swallowed; the task is cancelled on the next connect/pairing attempt. The authoritative fetch and error classification stay in the RPC layer.
> 
> **`MobileRouteResolver`** assigns lower `priority` values to literal IP endpoints and higher values to `.ts.net` names so the client tries IP first (skipping DNS on the critical path). Route `id`s stay index-based for persisted reconnect routes.
> 
> **`MobileCoreRPCClient`** adds DEBUG-only timing logs when stack token fetch exceeds 50ms (`pairing.rtA stackTokenFetch`). Tests now assert raw IP is tried before MagicDNS regardless of host list order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3bbec148d6c9f7aec3920d455afb5a38a0a8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->