### PR TITLE
iOS: Liquid Glass for the terminal accessory bar buttons

### DIFF
--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -475,11 +475,12 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     }
 
     /// The default on-bar arrangement of the configurable shortcuts: the
-    /// high-traffic agent and control keys first (Tab, ^C/^D, the Claude/Codex
-    /// launchers, the arrow keys, Clear), then the punctuation and navigation
-    /// keys. Curated independently of the enum's `rawValue` order so the default
-    /// bar can be arranged without perturbing the persisted identifiers, which are
-    /// the `rawValue`s.
+    /// high-traffic agent and control keys first (Tab then Esc, ^C/^D, the
+    /// Claude/Codex launchers, the arrow keys, Clear), then the punctuation and
+    /// navigation keys. Esc sits immediately to the right of Tab so the two most
+    /// common terminal keys are adjacent. Curated independently of the enum's
+    /// `rawValue` order so the default bar can be arranged without perturbing the
+    /// persisted identifiers, which are the `rawValue`s.
     ///
     /// Must stay a permutation of ``configurableActions``;
     /// ``TerminalAccessoryLayoutReducer`` defensively appends any omission, so a
@@ -487,11 +488,11 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     public static var defaultConfigurableOrder: [TerminalInputAccessoryAction] {
         [
             .tab,
+            .escape,
             .ctrlC, .ctrlD,
             .claude, .codex,
             .upArrow, .downArrow, .leftArrow, .rightArrow,
             .ctrlL,
-            .escape,
             .tilde, .dollar, .slash, .atSign, .pipe,
             .ctrlZ,
             .home, .end, .pageUp, .pageDown,

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -56,7 +56,7 @@ final class TerminalInputTextView: UITextView {
     private static let accessoryHorizontalInset: CGFloat = 16
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
     private static let accessoryButtonSymbolConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-    private static let accessoryButtonInsets = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
+    private static let accessoryButtonContentInsets = NSDirectionalEdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10)
     private static let accessoryButtonCornerRadius: CGFloat = 6
     private static let accessoryButtonHeight: CGFloat = 28
     private static let accessoryButtonMinWidth: CGFloat = 44
@@ -273,17 +273,12 @@ final class TerminalInputTextView: UITextView {
     /// configuration-driven rebuild can re-apply it without toggling the flag.
     private func applyModifierPresentation() {
         guard let stack = accessoryStackView else { return }
-        for case let button as AccessoryActionButton in stack.arrangedSubviews {
-            guard case let .builtin(action) = button.item else { continue }
-            button.setTitle(action.title(isMacRemote: isMacRemote), for: .normal)
-        }
-        // Insert/remove the command button based on whether this is a Mac terminal.
-        // We manage it outside the normal loop because it's not always in arrangedSubviews.
+        // Insert/remove the command button first (it is not always in
+        // arrangedSubviews) so the restyle pass below covers it when present.
         if let cmdButton = commandAccessoryButton {
             if isMacRemote {
                 if cmdButton.superview == nil {
-                    // Insert after alternate (index 2 in original enum order: ctrl, alt, cmd)
-                    // Find the alt button's index in the current arrangedSubviews
+                    // Insert after alternate (ctrl, alt, cmd order).
                     var insertIndex = stack.arrangedSubviews.count
                     for (idx, view) in stack.arrangedSubviews.enumerated() {
                         if let button = view as? AccessoryActionButton,
@@ -294,12 +289,25 @@ final class TerminalInputTextView: UITextView {
                     }
                     stack.insertArrangedSubview(cmdButton, at: insertIndex)
                 }
-            } else {
-                if cmdButton.superview != nil {
-                    stack.removeArrangedSubview(cmdButton)
-                    cmdButton.removeFromSuperview()
-                }
+            } else if cmdButton.superview != nil {
+                stack.removeArrangedSubview(cmdButton)
+                cmdButton.removeFromSuperview()
             }
+        }
+        // Restyle every visible button for the current remote (built-in titles
+        // depend on `isMacRemote`) and its armed/sticky state. Custom actions
+        // never arm.
+        for case let button as AccessoryActionButton in stack.arrangedSubviews {
+            let armed: Bool
+            let sticky: Bool
+            if case let .builtin(action) = button.item {
+                armed = isAccessoryActionArmed(action)
+                sticky = isAccessoryActionSticky(action)
+            } else {
+                armed = false
+                sticky = false
+            }
+            applyAccessoryButtonStyle(button, item: button.item, armed: armed, sticky: sticky)
         }
         // Disarm command state if switching away from Mac remote (clears a
         // sticky lock too, matching the legacy unconditional setter).
@@ -479,16 +487,17 @@ final class TerminalInputTextView: UITextView {
         button.addTarget(self, action: #selector(handleAccessoryButton(_:)), for: .touchUpInside)
         button.accessibilityIdentifier = action.accessibilityIdentifier
         button.accessibilityLabel = action.accessibilityLabel
-        button.titleLabel?.font = Self.accessoryButtonFont
-
-        if let symbolName = action.symbolName {
-            button.setImage(UIImage(systemName: symbolName), for: .normal)
-            button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
+        applyAccessoryButtonStyle(button, item: .builtin(action), armed: false, sticky: false)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
+        if action.isModifier || action.symbolName != nil {
+            // Single-glyph modifiers (⌃⌥⌘⇧) and icon buttons (zoom) get a fixed
+            // width so they stay uniform — their glyph metrics differ, and a
+            // greater-than-or-equal min-width let some (e.g. the glass capsule)
+            // grow wider than others. Variable-text buttons keep growing.
+            button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         } else {
-            button.setTitle(action.title, for: .normal)
+            button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
         }
-
-        applyAccessoryButtonBaseStyle(button)
         return button
     }
 
@@ -498,26 +507,25 @@ final class TerminalInputTextView: UITextView {
         button.addTarget(self, action: #selector(handleAccessoryButton(_:)), for: .touchUpInside)
         button.accessibilityIdentifier = "terminal.inputAccessory.custom.\(custom.id.uuidString)"
         button.accessibilityLabel = custom.title
-        button.titleLabel?.font = Self.accessoryButtonFont
-
+        // Custom actions never arm; they always render in the resting style.
+        applyAccessoryButtonStyle(button, item: .custom(custom), armed: false, sticky: false)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
         if let symbolName = custom.symbolName,
            !symbolName.isEmpty,
            UIImage(systemName: symbolName) != nil {
-            button.setImage(UIImage(systemName: symbolName), for: .normal)
-            button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
-            button.accessibilityLabel = custom.title
+            // Icon-only custom actions match the fixed-width modifier/zoom keys.
+            button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         } else {
-            button.setTitle(custom.title, for: .normal)
+            // Text custom actions (e.g. "Claude") grow with their title.
+            button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
         }
-
-        applyAccessoryButtonBaseStyle(button)
         return button
     }
 
     /// The trailing button that opens the toolbar shortcuts editor. A plain
     /// `UIButton` (not an ``AccessoryActionButton``) so the armed-modifier
-    /// styling/relabel loops skip it, and styled to read as a control rather
-    /// than an insertable key.
+    /// styling/relabel loops skip it, and styled to read as a de-emphasized
+    /// control rather than an insertable key.
     private func makeToolbarSettingsButton() -> UIButton {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -527,22 +535,86 @@ final class TerminalInputTextView: UITextView {
             localized: "terminal.input_accessory.customize",
             defaultValue: "Customize Toolbar"
         )
-        button.setImage(UIImage(systemName: "slider.horizontal.3"), for: .normal)
-        button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
-        applyAccessoryButtonBaseStyle(button)
-        button.backgroundColor = .clear
+        // Read as a control, not a glass key: no glass/fill background, a muted
+        // gray tint, and a flat content layout matching the other buttons.
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "slider.horizontal.3")
+        config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+        config.baseForegroundColor = UIColor(white: 0.7, alpha: 1)
+        config.contentInsets = Self.accessoryButtonContentInsets
+        button.configuration = config
         button.tintColor = UIColor(white: 0.7, alpha: 1)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
+        button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         return button
     }
 
-    private func applyAccessoryButtonBaseStyle(_ button: UIButton) {
-        button.contentEdgeInsets = Self.accessoryButtonInsets
-        button.backgroundColor = Self.accessoryButtonNormalBackground
-        button.setTitleColor(.white, for: .normal)
-        button.tintColor = .white
-        button.layer.cornerRadius = Self.accessoryButtonCornerRadius
-        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
-        button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
+    /// Build (or rebuild) a button's configuration for `item` and its current
+    /// armed/sticky state. On iOS 26 the bar uses real Liquid Glass
+    /// (`.glass()` resting, `.prominentGlass()` armed/sticky); earlier OSes keep
+    /// the flat gray/blue fill the bar shipped with. Built-in modifier titles
+    /// follow `isMacRemote`; custom actions render their saved title/icon and
+    /// never arm.
+    private func applyAccessoryButtonStyle(
+        _ button: UIButton,
+        item: ResolvedToolbarItem,
+        armed: Bool,
+        sticky: Bool
+    ) {
+        var config = Self.accessoryButtonConfiguration(armed: armed, sticky: sticky)
+        let symbolName: String?
+        let title: String
+        switch item {
+        case let .builtin(action):
+            symbolName = action.symbolName
+            title = action.title(isMacRemote: isMacRemote)
+        case let .custom(custom):
+            // Only honor a custom symbol when it resolves to a real SF Symbol.
+            if let name = custom.symbolName, !name.isEmpty, UIImage(systemName: name) != nil {
+                symbolName = name
+            } else {
+                symbolName = nil
+            }
+            title = custom.title
+        }
+        if let symbolName {
+            config.image = UIImage(systemName: symbolName)
+            config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+            config.attributedTitle = nil
+        } else {
+            var attributed = AttributedString(title)
+            attributed.font = Self.accessoryButtonFont
+            config.attributedTitle = attributed
+            config.image = nil
+        }
+        config.contentInsets = Self.accessoryButtonContentInsets
+        button.configuration = config
+    }
+
+    private static func accessoryButtonConfiguration(armed: Bool, sticky: Bool) -> UIButton.Configuration {
+        if #available(iOS 26.0, *) {
+            var config: UIButton.Configuration = (armed || sticky) ? .prominentGlass() : .glass()
+            config.baseForegroundColor = .white
+            if armed || sticky {
+                config.baseBackgroundColor = .systemBlue
+            }
+            return config
+        }
+        var config = UIButton.Configuration.plain()
+        var background = UIBackgroundConfiguration.clear()
+        if sticky {
+            background.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.85)
+            background.strokeColor = .white
+            background.strokeWidth = 2
+        } else if armed {
+            background.backgroundColor = .systemBlue
+        } else {
+            background.backgroundColor = accessoryButtonNormalBackground
+        }
+        background.cornerRadius = accessoryButtonCornerRadius
+        config.background = background
+        config.baseForegroundColor = .white
+        return config
     }
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
@@ -677,23 +749,7 @@ final class TerminalInputTextView: UITextView {
                 armed = false
                 sticky = false
             }
-            if sticky {
-                button.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.85)
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 2
-                button.layer.borderColor = UIColor.white.cgColor
-            } else if armed {
-                button.backgroundColor = .systemBlue
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 0
-            } else {
-                button.backgroundColor = Self.accessoryButtonNormalBackground
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 0
-            }
+            applyAccessoryButtonStyle(button, item: button.item, armed: armed, sticky: sticky)
         }
     }
 


### PR DESCRIPTION
## Summary
- Render the iOS terminal input accessory bar buttons (modifiers `⌃⌥⌘⇧`, `Esc`/`Tab`/arrows/`$`/`@`/`/`, zoom, agent launchers) with real iOS 26 Liquid Glass via `UIButton.Configuration.glass()` (resting) / `.prominentGlass()` (armed/sticky). Flat gray/blue fill remains the fallback below iOS 26. Styling + the armed/sticky restyle now flow through one configuration builder.
- Pin single-glyph modifiers and icon (zoom) buttons to a fixed width so they stay uniform — fixes Ctrl/Option rendering wider than Cmd. Variable-text buttons (Claude/Codex) still grow to content.

## Why a separate PR
Independent of the in-flight iOS composer (https://github.com/manaflow-ai/cmux/pull/5511, still buggy). This only improves the existing accessory bar that ships today, so it can review/merge on its own.

## Testing
- iOS simulator + device builds succeed. Behavior is visual; verify on device (iOS 26 shows glass, the modifier/zoom buttons are uniform width).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783335320&installation_id=133855650&pr_number=5536&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5536&signature=2130160921e96f01dd0f856a4eae5fd37c506a4aabdc83795d212b7a27f3c0ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only changes to the iOS input accessory bar; terminal input semantics are unchanged aside from default shortcut ordering for users without a saved layout.
> 
> **Overview**
> **iOS terminal accessory bar** gets unified button styling through `UIButton.Configuration`, with **Liquid Glass on iOS 26** (`.glass()` at rest, `.prominentGlass()` when modifiers are armed or sticky) and the **existing flat gray/blue look** on older OS versions.
> 
> Styling, titles/icons, and armed/sticky updates now go through **`applyAccessoryButtonStyle`** instead of per-button `setTitle`/`setImage`/layer tweaks. **Modifier and icon keys** use a **fixed width** so ⌃/⌥/⌘ and zoom stay even; text keys (e.g. Claude/Codex) still grow. The **customize** control is a **plain, muted** button without glass. **Mac ⌘** insert/remove runs **before** the restyle pass so labels and glass state stay in sync.
> 
> **Default toolbar order** moves **Esc** next to **Tab** for new/default layouts (persisted user order unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914562e4af6f081382d514226bd9b57b0af09739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real iOS 26 Liquid Glass styling to the terminal accessory bar buttons, with a flat fill fallback on older iOS. Also moves Esc next to Tab in the default toolbar order.

- **New Features**
  - Use `UIButton.Configuration.glass()` (resting) and `.prominentGlass()` (armed/sticky) on iOS 26; keep the prior flat fill below iOS 26.
  - Centralize titles/icons and state via one configuration builder for built-in and custom actions; the settings button stays a plain, de-emphasized control.
  - Place Esc immediately to the right of Tab in the default arrangement; existing saved layouts are unchanged.

- **Bug Fixes**
  - Pin single-glyph modifiers (`⌃⌥⌘⇧`) and icon buttons to a fixed width for uniform sizing; text buttons still grow.
  - Insert/remove the Mac `⌘` key before the restyle pass to keep labels and states in sync.

<sup>Written for commit 914562e4af6f081382d514226bd9b57b0af09739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified accessory toolbar button behavior and streamlined command-key handling for Mac-remote vs non‑Mac-remote sessions.
  * Standardized button construction and sizing for consistent layout.
  * Updated default ordering for configurable shortcut keys so Escape now follows Tab.

* **Style**
  * Updated modifier/accessory button visuals to use modern iOS glass effects where available (iOS 26+) and preserved compatible styling elsewhere.
  * Simplified the customize-toolbar control appearance and excluded it from modifier relabel styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->