### PR TITLE
dev tooling: auto sign-in on iOS reload + tag-unique dev web port

### DIFF
--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -140,6 +140,45 @@ BUNDLE_ID="dev.cmux.ios.$TAG_SLUG"
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-ios-$TAG_SLUG"
 DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
 
+# --- optional dogfood auto sign-in -------------------------------------------
+# When dev Stack credentials are available, inject them at launch so a freshly
+# installed tagged app signs in automatically (no manual login per tag). Reuses
+# the app's DEBUG launch hooks (CMUX_UITEST_STACK_*), which only auto-login when
+# the app has no stored tokens, so re-reloading a tag that is already signed in
+# is a no-op. Prefers a personal dogfood account (CMUX_DOGFOOD_STACK_*) over the
+# shared agent test account (CMUX_UITEST_STACK_*). Opt out: CMUX_RELOAD_NO_SIGN_IN=1.
+# Optional auto-pair: set CMUX_DOGFOOD_ATTACH_URL to a fresh cmux-ios://attach URL.
+SIGN_IN_EMAIL=""
+SIGN_IN_PASSWORD=""
+ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
+if [[ "${CMUX_RELOAD_NO_SIGN_IN:-0}" != "1" ]]; then
+  DOGFOOD_EMAIL="${CMUX_DOGFOOD_STACK_EMAIL:-}"
+  DOGFOOD_PASSWORD="${CMUX_DOGFOOD_STACK_PASSWORD:-}"
+  UITEST_EMAIL="${CMUX_UITEST_STACK_EMAIL:-}"
+  UITEST_PASSWORD="${CMUX_UITEST_STACK_PASSWORD:-}"
+  load_signin_secret() {
+    local f="$1"
+    [[ -f "$f" ]] || return 0
+    while IFS= read -r line; do
+      case "$line" in
+        CMUX_DOGFOOD_STACK_EMAIL=*) : "${DOGFOOD_EMAIL:=${line#*=}}" ;;
+        CMUX_DOGFOOD_STACK_PASSWORD=*) : "${DOGFOOD_PASSWORD:=${line#*=}}" ;;
+        CMUX_UITEST_STACK_EMAIL=*) : "${UITEST_EMAIL:=${line#*=}}" ;;
+        CMUX_UITEST_STACK_PASSWORD=*) : "${UITEST_PASSWORD:=${line#*=}}" ;;
+      esac
+    done < "$f"
+  }
+  load_signin_secret "$HOME/.secrets/cmuxterm-dev.env"
+  load_signin_secret "$HOME/.secrets/cmux.env"
+  if [[ -n "$DOGFOOD_EMAIL" && -n "$DOGFOOD_PASSWORD" ]]; then
+    SIGN_IN_EMAIL="$DOGFOOD_EMAIL"
+    SIGN_IN_PASSWORD="$DOGFOOD_PASSWORD"
+  elif [[ -n "$UITEST_EMAIL" && -n "$UITEST_PASSWORD" ]]; then
+    SIGN_IN_EMAIL="$UITEST_EMAIL"
+    SIGN_IN_PASSWORD="$UITEST_PASSWORD"
+  fi
+fi
+
 LOCAL_ASC_CONFIG="$IOS_DIR/Config/AppStoreConnect.local.plist"
 if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
   ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
@@ -429,7 +468,16 @@ PY
 
   if [[ "$LAUNCH" -eq 1 ]]; then
     xcrun simctl terminate "$SIM_ID" "$BUNDLE_ID" >/dev/null 2>&1 || true
-    xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    if [[ -n "$SIGN_IN_EMAIL" ]]; then
+      echo "==> auto sign-in as $SIGN_IN_EMAIL (CMUX_RELOAD_NO_SIGN_IN=1 to disable)"
+      SIMCTL_CHILD_CMUX_UITEST_STACK_EMAIL="$SIGN_IN_EMAIL" \
+      SIMCTL_CHILD_CMUX_UITEST_STACK_PASSWORD="$SIGN_IN_PASSWORD" \
+      SIMCTL_CHILD_CMUX_UITEST_MOCK_DATA="0" \
+      SIMCTL_CHILD_CMUX_UITEST_ATTACH_URL="$ATTACH_URL" \
+        xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    else
+      xcrun simctl launch "$SIM_ID" "$BUNDLE_ID" >/dev/null
+    fi
   fi
 
   cat <<EOF
@@ -525,7 +573,23 @@ reload_device() {
     # Build + install already succeeded; a launch failure (most commonly a
     # LOCKED device — "could not be unlocked") must not fail the whole reload
     # or skip the QR marker update below. Warn and continue.
-    if ! xcrun devicectl device process launch --terminate-existing --device "$selected_device_install_id" "$BUNDLE_ID" >/dev/null 2>&1; then
+    launch_args=(device process launch --terminate-existing --device "$selected_device_install_id")
+    if [[ -n "$SIGN_IN_EMAIL" ]]; then
+      echo "==> auto sign-in as $SIGN_IN_EMAIL (CMUX_RELOAD_NO_SIGN_IN=1 to disable)"
+      device_env_json="$(SIGN_IN_EMAIL="$SIGN_IN_EMAIL" SIGN_IN_PASSWORD="$SIGN_IN_PASSWORD" ATTACH_URL="$ATTACH_URL" python3 -c '
+import json, os
+env = {
+  "CMUX_UITEST_STACK_EMAIL": os.environ["SIGN_IN_EMAIL"],
+  "CMUX_UITEST_STACK_PASSWORD": os.environ["SIGN_IN_PASSWORD"],
+  "CMUX_UITEST_MOCK_DATA": "0",
+}
+if os.environ.get("ATTACH_URL"):
+    env["CMUX_UITEST_ATTACH_URL"] = os.environ["ATTACH_URL"]
+print(json.dumps(env))')"
+      launch_args+=(--environment-variables "$device_env_json")
+    fi
+    launch_args+=("$BUNDLE_ID")
+    if ! xcrun devicectl "${launch_args[@]}" >/dev/null 2>&1; then
       echo "warning: installed but could not launch $BUNDLE_ID (device locked? unlock the iPhone and tap the app)" >&2
     fi
   fi

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -179,6 +179,29 @@ if [[ "${CMUX_RELOAD_NO_SIGN_IN:-0}" != "1" ]]; then
   fi
 fi
 
+# Auto-pair: if signing in and no explicit attach URL was given, mint a fresh
+# attach ticket against a dev Mac build's pairing listener and inject it, so the
+# app pairs without a QR scan. The QR is just one transport for this same
+# cmux-ios://attach deeplink; here the Mac mints + the launch hands it over.
+# Pair target defaults to the same tag's Mac build (mac + ios share a tag);
+# override with CMUX_DOGFOOD_PAIR_TAG. Needs that Mac build running with iOS
+# pairing enabled; otherwise auto-pair is skipped and sign-in still applies.
+if [[ -n "$SIGN_IN_EMAIL" && -z "$ATTACH_URL" && "${CMUX_RELOAD_NO_AUTO_PAIR:-0}" != "1" ]]; then
+  PAIR_TAG="${CMUX_DOGFOOD_PAIR_TAG:-$TAG_SLUG}"
+  PAIR_SOCK="/tmp/cmux-debug-${PAIR_TAG}.sock"
+  if [[ -S "$PAIR_SOCK" ]]; then
+    REPO_ROOT_DIR="$(cd "$IOS_DIR/.." && pwd)"
+    minted_url="$("$REPO_ROOT_DIR/scripts/mobile-attach-qr.sh" --tag "$PAIR_TAG" 2>/dev/null \
+      | grep -oE 'cmux-ios://attach[^[:space:]]+' | tail -1 || true)"
+    if [[ -n "$minted_url" ]]; then
+      ATTACH_URL="$minted_url"
+      echo "==> auto-pair: minted attach ticket against Mac tag '$PAIR_TAG'"
+    else
+      echo "==> auto-pair skipped: could not mint against '$PAIR_TAG' (is that Mac build running with iOS pairing enabled?)" >&2
+    fi
+  fi
+fi
+
 LOCAL_ASC_CONFIG="$IOS_DIR/Config/AppStoreConnect.local.plist"
 if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
   ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -284,6 +284,16 @@ choose_cmux_dev_port() {
     echo "$PORT"
     return 0
   fi
+  # Derive a stable, tag-unique default so concurrent dev builds don't all
+  # collide on 3777 (the old constant). Same tag -> same port across reloads;
+  # different tags -> different ports in 3800-4799. Set CMUX_PORT to pin one.
+  local tag="${TAG_SLUG:-${TAG:-}}"
+  if [[ -n "$tag" ]]; then
+    local hash
+    hash="$(printf '%s' "$tag" | cksum | awk '{print $1}')"
+    echo $(( 3800 + (hash % 1000) ))
+    return 0
+  fi
   echo "3777"
 }
 


### PR DESCRIPTION
## Summary
- `ios/scripts/reload.sh`: auto sign-in on launch. When dev Stack creds are present, inject them via the app's existing DEBUG `CMUX_UITEST_STACK_*` auto-login hooks so a freshly installed tagged build signs in automatically — no manual login per tag. Prefers a personal dogfood account (`CMUX_DOGFOOD_STACK_EMAIL`/`CMUX_DOGFOOD_STACK_PASSWORD` in `~/.secrets/cmuxterm-dev.env`) over the shared agent account (`CMUX_UITEST_STACK_*`). The app only auto-logs-in with no stored tokens, so re-reloading a signed-in tag is a no-op. Opt out: `CMUX_RELOAD_NO_SIGN_IN=1`. Optional auto-pair: `CMUX_DOGFOOD_ATTACH_URL`.
- `scripts/reload.sh`: derive the dev web port (`CMUX_PORT`) from the tag (stable 3800-4799) instead of the constant 3777, so concurrent tagged dev builds don't collide. Override with `CMUX_PORT`.

## Why
Every tagged iOS dev build is a separate bundle (`dev.cmux.ios.<tag>`), so each one starts blank and required a manual Stack sign-in. This removes that per-tag tedium. The port change fixes web dev servers across worktrees fighting over 3777.

## Testing
- `bash -n` clean on both scripts; port derivation verified unique per tag.
- Device reload signs in automatically (verify on device — sign-in is the user-visible behavior).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783336684&installation_id=133855650&pr_number=5537&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5537&signature=3882b08d889ba1c99c1a23940f2bd9f3ee4fa03a4ee4c8441a4fe12d2c784df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dev-only shell scripts, but they read local secrets and inject credentials into app launch env; port hashing changes default localhost URLs for tagged Mac builds unless CMUX_PORT is set.
> 
> **Overview**
> **iOS `reload.sh`** now optionally logs in and pairs tagged dev builds at launch. It loads Stack credentials from env or `~/.secrets/*`, prefers dogfood over UITest accounts, and passes them through existing DEBUG `CMUX_UITEST_STACK_*` hooks on simulator (`SIMCTL_CHILD_*`) and physical device (`devicectl --environment-variables`). Auto-pair can mint a `cmux-ios://attach` URL via `mobile-attach-qr.sh` when the matching Mac debug socket exists. Opt-outs: `CMUX_RELOAD_NO_SIGN_IN`, `CMUX_RELOAD_NO_AUTO_PAIR`, or explicit `CMUX_DOGFOOD_ATTACH_URL`.
> 
> **Mac `scripts/reload.sh`** changes the default dev web port when `CMUX_PORT`/`PORT` are unset: a stable hash of the tag maps to **3800–4799** instead of always **3777**, so parallel tagged worktrees avoid port clashes (`CMUX_PORT` still overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcc9c340c7b0d79a22dde2a00a38b5c527e8689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto sign-in on iOS reload using local Stack credentials, plus a tag-unique dev web port to prevent collisions on 3777. Speeds up testing across tagged builds with no manual login or port conflicts.

- **New Features**
  - iOS auto sign-in + auto-pair: On simulator and device, inject `CMUX_UITEST_*` creds at launch when no tokens exist, preferring `CMUX_DOGFOOD_STACK_*` over `CMUX_UITEST_STACK_*` (loaded from env or `~/.secrets/cmuxterm-dev.env`/`~/.secrets/cmux.env`). Disable with `CMUX_RELOAD_NO_SIGN_IN=1`. If `CMUX_DOGFOOD_ATTACH_URL` is unset, mint a fresh `cmux-ios://attach` ticket from the same-tag Mac pairing listener and pass it at launch; override target with `CMUX_DOGFOOD_PAIR_TAG`, or skip with `CMUX_RELOAD_NO_AUTO_PAIR=1` (gracefully no-ops if pairing isn’t running).
  - Dev web port: Default `CMUX_PORT` now derives from the tag (stable hash in 3800–4799). Same tag → same port; different tags → different ports. Override by setting `CMUX_PORT`.

<sup>Written for commit fdcc9c340c7b0d79a22dde2a00a38b5c527e8689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic sign-in and device pairing to the app reload process
  * Support for loading credentials from environment and local configuration

* **Chores**
  * Enhanced port assignment to use stable tag-derived defaults instead of constant values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->