### PR TITLE
CodeRabbit: stop blocking merges (request_changes_workflow=false)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@ knowledge_base:
 
 reviews:
   profile: assertive
-  request_changes_workflow: true
+  request_changes_workflow: false
   path_instructions:
     - path: "**/*"
       instructions: |


### PR DESCRIPTION
CodeRabbit was submitting its reviews in the **Request Changes** state (`reviews.request_changes_workflow: true` in `.coderabbit.yaml`), which shows up as a blocker in the PR merge box. CodeRabbit is not a required status check in the `main` ruleset (only `web-typecheck`, `workflow-guard-tests`, `web-db-migrations`, `remote-daemon-tests` are), so this review state was the sole thing making it feel like CodeRabbit blocks merges.

Setting `request_changes_workflow: false` keeps CodeRabbit reviewing every PR and posting the exact same findings, just as plain **Comment** reviews that never enter a blocking state.

Config-only change, no runtime impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783337319&installation_id=133855650&pr_number=5538&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5538&signature=09d81525e54ecc9b9f2ad027b19455c0aa855af18b75d8297a15e4d37983e63f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CodeRabbit config toggle with no application or CI check behavior changes beyond review state on GitHub.
> 
> **Overview**
> Disables CodeRabbit’s **Request changes** review workflow by setting `reviews.request_changes_workflow` to `false` in `.coderabbit.yaml`.
> 
> Reviews still run with the same assertive profile, path instructions, and pre-merge custom checks; only the GitHub review state changes from blocking **Request changes** to non-blocking **Comment** reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ae1de653dbbcc83fb16fca07ab0a8d3aba9428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop CodeRabbit reviews from blocking merges by setting `reviews.request_changes_workflow: false` in `.coderabbit.yaml`. It still reviews every PR and posts the same findings as Comment reviews, with no runtime impact.

<sup>Written for commit 35ae1de653dbbcc83fb16fca07ab0a8d3aba9428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal review configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->