### PR TITLE
Fix changelog heading clipped on left edge

### DIFF
--- a/web/app/[locale]/docs/changelog/page.tsx
+++ b/web/app/[locale]/docs/changelog/page.tsx
@@ -251,7 +251,7 @@ export default function ChangelogPage() {
   const versions = parseChangelog(markdown);
 
   return (
-    <div className="max-w-[640px] overflow-hidden">
+    <div className="max-w-[640px]">
       <DocsHeading level={1} id="title" className="docs-heading-compact">{t("title")}</DocsHeading>
 
       <div style={{ paddingTop: 16 }}>


### PR DESCRIPTION
The docs changelog page wrapped its content in `max-w-[640px] overflow-hidden`. The `#` heading anchor has `margin-left: -1.45rem` (`globals.css`), which pulls the heading text ~4px past the wrapper's left edge, and `overflow-hidden` clipped it, shaving the left side off the "Changelog" title.

Every other docs page lets that same overhang sit harmlessly inside the `px-6` gutter, and `<main>` already has `overflow-x-hidden`, so the wrapper's own clipping was redundant. Removing it fixes the clip and renders the title consistently with every other docs heading.

Web/docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783337882&installation_id=133855650&pr_number=5539&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5539&signature=83a4ec8cc32676523c200d18a2c53b60a483ef36020c103d434da963abdb26d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class docs layout tweak with no auth, data, or API impact.
> 
> **Overview**
> Removes **`overflow-hidden`** from the docs changelog page content wrapper (`max-w-[640px]`), leaving only the max-width constraint.
> 
> That wrapper was clipping the **Changelog** `DocsHeading` because the `#` anchor uses a negative left margin and sits slightly outside the box—unlike other docs pages, which don’t clip that overhang. Horizontal overflow is still handled at the layout level (`main` / page padding), so dropping the extra clip restores the title without changing behavior elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8f224941750a84b76b7adb1f1c156a7887eb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix clipped "Changelog" title by removing `overflow-hidden` from the changelog page wrapper. The H1 now renders like other docs pages; `max-w-[640px]` stays, and `<main>` already handles horizontal overflow.

<sup>Written for commit 6e8f224941750a84b76b7adb1f1c156a7887eb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted changelog page container styling to improve content visibility and layout flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->