### PR TITLE
Keep pinned workspaces inside groups

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14502,11 +14502,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let candidateIds: [UUID] = orderedSelectedIds
         // Match the workspace context-menu eligibility filter so the shortcut
         // doesn't silently create an anchor-only group when every selected
-        // target is pinned or is already an existing group's anchor.
+        // target is already an existing group's anchor.
         let existingAnchorIds = Set(tabManager.workspaceGroups.map(\.anchorWorkspaceId))
         let eligibleIds: [UUID] = candidateIds.filter { id in
-            guard let tab = tabManager.tabs.first(where: { $0.id == id }) else { return false }
-            return !tab.isPinned && !existingAnchorIds.contains(id)
+            tabManager.tabs.contains(where: { $0.id == id }) && !existingAnchorIds.contains(id)
         }
         guard eligibleIds.count >= 2 else {
             // Don't consume the event — let it propagate to the next handler

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -17843,6 +17843,11 @@ struct SidebarTabDropDelegate: DropDelegate {
             forDraggedWorkspaceId: draggedTabId,
             targetWorkspaceId: targetTabId
         )
+        let legalInsertionRange = tabManager.sidebarReorderLegalInsertionRange(
+            forDraggedWorkspaceId: draggedTabId,
+            targetWorkspaceId: targetTabId,
+            usesTopLevelRows: usesTopLevelRows
+        )
         guard let fromIndex = reorderTabIds.firstIndex(of: draggedTabId) else {
 #if DEBUG
             cmuxDebugLog("sidebar.drop.abort reason=draggedTabMissing tab=\(draggedTabId.uuidString.prefix(5))")
@@ -17854,7 +17859,8 @@ struct SidebarTabDropDelegate: DropDelegate {
             targetTabId: targetTabId,
             indicator: dragState.dropIndicator,
             tabIds: reorderTabIds,
-            pinnedTabIds: pinnedTabIds
+            pinnedTabIds: pinnedTabIds,
+            legalInsertionRange: legalInsertionRange
         ) else {
 #if DEBUG
             cmuxDebugLog(
@@ -17997,11 +18003,17 @@ struct SidebarTabDropDelegate: DropDelegate {
             targetWorkspaceId: targetTabId,
             usesTopLevelRows: usesTopLevelRows
         )
+        let legalInsertionRange = tabManager.sidebarReorderLegalInsertionRange(
+            forDraggedWorkspaceId: dragState.draggedTabId,
+            targetWorkspaceId: targetTabId,
+            usesTopLevelRows: usesTopLevelRows
+        )
         let nextIndicator = SidebarDropPlanner.indicator(
             draggedTabId: dragState.draggedTabId,
             targetTabId: targetTabId,
             tabIds: tabIds,
             pinnedTabIds: pinnedTabIds,
+            legalInsertionRange: legalInsertionRange,
             pointerY: targetTabId == nil ? nil : info.location.y,
             targetHeight: targetRowHeight
         )

--- a/Sources/Sidebar/SidebarDropPlanner.swift
+++ b/Sources/Sidebar/SidebarDropPlanner.swift
@@ -17,6 +17,7 @@ enum SidebarDropPlanner {
         targetTabId: UUID?,
         tabIds: [UUID],
         pinnedTabIds: Set<UUID>,
+        legalInsertionRange: ClosedRange<Int>? = nil,
         pointerY: CGFloat? = nil,
         targetHeight: CGFloat? = nil
     ) -> SidebarDropIndicator? {
@@ -41,7 +42,8 @@ enum SidebarDropPlanner {
             draggedTabId: draggedTabId,
             proposedInsertionPosition: insertionPosition,
             tabIds: tabIds,
-            pinnedTabIds: pinnedTabIds
+            pinnedTabIds: pinnedTabIds,
+            legalInsertionRange: legalInsertionRange
         )
         let legalTargetIndex = resolvedTargetIndex(
             from: fromIndex,
@@ -57,7 +59,8 @@ enum SidebarDropPlanner {
         targetTabId: UUID?,
         indicator: SidebarDropIndicator?,
         tabIds: [UUID],
-        pinnedTabIds: Set<UUID>
+        pinnedTabIds: Set<UUID>,
+        legalInsertionRange: ClosedRange<Int>? = nil
     ) -> Int? {
         guard let fromIndex = tabIds.firstIndex(of: draggedTabId) else { return nil }
 
@@ -78,7 +81,8 @@ enum SidebarDropPlanner {
             draggedTabId: draggedTabId,
             proposedInsertionPosition: insertionPosition,
             tabIds: tabIds,
-            pinnedTabIds: pinnedTabIds
+            pinnedTabIds: pinnedTabIds,
+            legalInsertionRange: legalInsertionRange
         )
         return resolvedTargetIndex(from: fromIndex, insertionPosition: legalInsertionPosition, totalCount: tabIds.count)
     }
@@ -278,22 +282,30 @@ enum SidebarDropPlanner {
         draggedTabId: UUID,
         proposedInsertionPosition: Int,
         tabIds: [UUID],
-        pinnedTabIds: Set<UUID>
+        pinnedTabIds: Set<UUID>,
+        legalInsertionRange: ClosedRange<Int>?
     ) -> Int {
-        let clampedInsertion = max(0, min(proposedInsertionPosition, tabIds.count))
-        guard !pinnedTabIds.isEmpty else { return clampedInsertion }
+        var clampedInsertion = max(0, min(proposedInsertionPosition, tabIds.count))
 
-        let pinnedCount = tabIds.reduce(into: 0) { count, tabId in
-            if pinnedTabIds.contains(tabId) {
-                count += 1
+        if !pinnedTabIds.isEmpty {
+            let pinnedCount = tabIds.reduce(into: 0) { count, tabId in
+                if pinnedTabIds.contains(tabId) {
+                    count += 1
+                }
+            }
+            if pinnedCount > 0 {
+                if pinnedTabIds.contains(draggedTabId) {
+                    clampedInsertion = min(clampedInsertion, pinnedCount)
+                } else {
+                    clampedInsertion = max(clampedInsertion, pinnedCount)
+                }
             }
         }
-        guard pinnedCount > 0 else { return clampedInsertion }
 
-        if pinnedTabIds.contains(draggedTabId) {
-            return min(clampedInsertion, pinnedCount)
+        if let legalInsertionRange {
+            return min(max(clampedInsertion, legalInsertionRange.lowerBound), legalInsertionRange.upperBound)
         }
-        return max(clampedInsertion, pinnedCount)
+        return clampedInsertion
     }
 
     static func edgeForPointer(locationY: CGFloat, targetHeight: CGFloat) -> SidebarDropEdge {

--- a/Sources/TabItemView+WorkspaceGroups.swift
+++ b/Sources/TabItemView+WorkspaceGroups.swift
@@ -9,7 +9,8 @@ extension TabItemView {
         let targetWorkspaces = targetIds.compactMap { id in
             tabManager.tabs.first(where: { $0.id == id })
         }
-        let eligibleTargets = targetWorkspaces.filter { !$0.isPinned }
+        let existingAnchorIds = Set(tabManager.workspaceGroups.map(\.anchorWorkspaceId))
+        let eligibleTargets = targetWorkspaces.filter { !existingAnchorIds.contains($0.id) }
         let eligibleTargetIds = eligibleTargets.map(\.id)
         if !eligibleTargetIds.isEmpty {
             let groups = workspaceGroupMenuSnapshot.items

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3712,6 +3712,44 @@ class TabManager: ObservableObject {
         return sidebarTopLevelPinnedWorkspaceIds()
     }
 
+    func sidebarReorderLegalInsertionRange(
+        forDraggedWorkspaceId draggedWorkspaceId: UUID?,
+        targetWorkspaceId: UUID? = nil,
+        usesTopLevelRows: Bool = false
+    ) -> ClosedRange<Int>? {
+        guard !usesTopLevelRows,
+              !sidebarReorderUsesTopLevelRows(
+                  forDraggedWorkspaceId: draggedWorkspaceId,
+                  targetWorkspaceId: targetWorkspaceId
+              ),
+              let draggedWorkspaceId,
+              let draggedWorkspace = tabs.first(where: { $0.id == draggedWorkspaceId }),
+              let groupId = draggedWorkspace.groupId,
+              let group = workspaceGroups.first(where: { $0.id == groupId }),
+              draggedWorkspace.id != group.anchorWorkspaceId else {
+            return nil
+        }
+        let memberIndices = tabs.indices.filter { tabs[$0].groupId == groupId }
+        guard let firstIndex = memberIndices.first,
+              let lastIndex = memberIndices.last else {
+            return nil
+        }
+        let pinnedMemberCount = memberIndices.reduce(into: 0) { count, index in
+            let member = tabs[index]
+            if member.id != group.anchorWorkspaceId, member.isPinned {
+                count += 1
+            }
+        }
+        if draggedWorkspace.isPinned {
+            let lower = min(firstIndex + 1, tabs.count)
+            let upper = min(firstIndex + 1 + pinnedMemberCount, tabs.count)
+            return lower...max(lower, upper)
+        }
+        let lower = min(firstIndex + 1 + pinnedMemberCount, tabs.count)
+        let upper = min(lastIndex + 1, tabs.count)
+        return min(lower, upper)...max(lower, upper)
+    }
+
     @discardableResult
     func reorderSidebarWorkspace(
         tabId: UUID,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3707,7 +3707,7 @@ class TabManager: ObservableObject {
             forDraggedWorkspaceId: draggedWorkspaceId,
             targetWorkspaceId: targetWorkspaceId
         ) else {
-            return Set(tabs.filter(\.isPinned).map(\.id))
+            return Set(tabs.filter { $0.groupId == nil && $0.isPinned }.map(\.id))
         }
         return sidebarTopLevelPinnedWorkspaceIds()
     }
@@ -3789,7 +3789,6 @@ class TabManager: ObservableObject {
     private func applyDragInferredGroupMembership(workspaceId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == workspaceId }) else { return }
         let tab = tabs[index]
-        if tab.isPinned { return }
         let isAnchor = workspaceGroups.contains(where: { $0.anchorWorkspaceId == workspaceId })
         if isAnchor {
             // Anchors don't change group membership via drag (their group
@@ -3803,8 +3802,8 @@ class TabManager: ObservableObject {
         }
         let before: Workspace? = index > 0 ? tabs[index - 1] : nil
         let after: Workspace? = (index + 1) < tabs.count ? tabs[index + 1] : nil
-        let beforeGroup = before.flatMap { $0.isPinned ? nil : $0.groupId }
-        let afterGroup = after.flatMap { $0.isPinned ? nil : $0.groupId }
+        let beforeGroup = before?.groupId
+        let afterGroup = after?.groupId
         let currentGroup = tab.groupId
         // Three cases:
         //  A. Both neighbors share the same value (incl. both nil): land in
@@ -4031,24 +4030,7 @@ class TabManager: ObservableObject {
     func setPinned(_ tab: Workspace, pinned: Bool) {
         guard tab.isPinned != pinned else { return }
         tab.isPinned = pinned
-        // Pinned workspaces never belong to a group. Pinning a grouped member
-        // ungroups it; if that member was the anchor, the group dissolves so
-        // other members become ungrouped.
-        if pinned, let groupId = tab.groupId {
-            if let group = workspaceGroups.first(where: { $0.id == groupId }),
-               group.anchorWorkspaceId == tab.id {
-                ungroupWorkspaceGroup(groupId: groupId)
-            } else {
-                tab.groupId = nil
-            }
-        }
         reorderTabForPinnedState(tab)
-        // Unpinning a single workspace lands it at the front of the unpinned
-        // segment via reorderTabForPinnedState. Renormalize so group runs stay
-        // contiguous around that new top-level position.
-        if !workspaceGroups.isEmpty {
-            normalizeWorkspaceGroupContiguity()
-        }
         postWorkspaceOrderDidChange(movedWorkspaceIds: [tab.id])
     }
 
@@ -4076,23 +4058,18 @@ class TabManager: ObservableObject {
             changedIdSet.insert(workspace.id)
         }
 
-        // Apply the same group-membership cleanup the single-workspace
-        // setPinned path runs: pinned workspaces never belong to a group.
-        // Anchor pins dissolve the group; non-anchor pins just clear groupId.
-        if pinned {
-            for id in changedIdSet {
-                guard let tab = workspacesById[id], let groupId = tab.groupId else { continue }
-                if let group = workspaceGroups.first(where: { $0.id == groupId }),
-                   group.anchorWorkspaceId == id {
-                    ungroupWorkspaceGroup(groupId: groupId)
-                } else {
-                    tab.groupId = nil
-                }
-            }
-        }
-
         guard !changedIdSet.isEmpty else { return [] }
         let changedIds = orderedTargetIds.filter { changedIdSet.contains($0) }
+
+        if !workspaceGroups.isEmpty {
+            for id in changedIds {
+                if let workspace = workspacesById[id] {
+                    reorderTabForPinnedState(workspace)
+                }
+            }
+            postWorkspaceOrderDidChange(movedWorkspaceIds: changedIds)
+            return changedIds
+        }
 
         let changedWorkspaces: [Workspace]
         if pinned {
@@ -4103,24 +4080,21 @@ class TabManager: ObservableObject {
             // batch in one pass must reverse the changed input order.
             changedWorkspaces = changedIds.reversed().compactMap { workspacesById[$0] }
         }
-
         let remainingPinned = tabs.filter { $0.isPinned && !changedIdSet.contains($0.id) }
         let remainingUnpinned = tabs.filter { !$0.isPinned && !changedIdSet.contains($0.id) }
         tabs = remainingPinned + changedWorkspaces + remainingUnpinned
-        // Multi-unpin uses a simple rebuild that doesn't know about contiguous
-        // group runs. Normalize so grouped members stay together around the new
-        // top-level positions.
-        if !workspaceGroups.isEmpty {
-            normalizeWorkspaceGroupContiguity()
-        }
         postWorkspaceOrderDidChange(movedWorkspaceIds: changedIds)
         return changedIds
     }
 
     private func reorderTabForPinnedState(_ tab: Workspace) {
         guard let index = tabs.firstIndex(where: { $0.id == tab.id }) else { return }
+        if tab.groupId != nil {
+            normalizeWorkspaceGroupContiguity()
+            return
+        }
         tabs.remove(at: index)
-        let pinnedCount = tabs.filter { $0.isPinned }.count
+        let pinnedCount = leadingGlobalPinnedRowCount()
         let insertIndex = min(pinnedCount, tabs.count)
         tabs.insert(tab, at: insertIndex)
     }
@@ -4128,8 +4102,7 @@ class TabManager: ObservableObject {
     // MARK: - Workspace Groups
 
     /// Create a new group, inserting a fresh anchor workspace above the given
-    /// child workspaces. Pinned children are skipped (groups only apply to
-    /// unpinned workspaces). Returns the new group id.
+    /// child workspaces. Returns the new group id.
     ///
     /// The anchor is always brand new (never promoted from an existing
     /// workspace). Its cwd defaults to `anchorWorkingDirectory`, or the first
@@ -4142,14 +4115,13 @@ class TabManager: ObservableObject {
         selectAnchor: Bool = true,
         collapseSidebarSelection: Bool = true
     ) -> UUID? {
-        // Eligible children: not pinned and not currently an anchor of a
-        // different group. Pulling an anchor into a new group would orphan the
+        // Eligible children: not currently an anchor of a different group.
+        // Pulling an anchor into a new group would orphan the
         // source group (its anchorWorkspaceId would no longer match), so we
         // reject those silently and let the user explicitly ungroup first.
         let existingAnchorIds = Set(workspaceGroups.map(\.anchorWorkspaceId))
         let eligibleChildren = childWorkspaceIds.compactMap { id -> UUID? in
-            guard let tab = tabs.first(where: { $0.id == id }),
-                  !tab.isPinned,
+            guard tabs.contains(where: { $0.id == id }),
                   !existingAnchorIds.contains(id) else { return nil }
             return id
         }
@@ -4325,8 +4297,8 @@ class TabManager: ObservableObject {
     }
 
     /// Add an existing workspace to an existing group as a non-anchor member.
-    /// No-op for pinned workspaces or workspaces that are the anchor of a
-    /// different group (those must be ungrouped first to avoid orphaning the
+    /// No-op for workspaces that are the anchor of a different group (those
+    /// must be ungrouped first to avoid orphaning the
     /// source group). If the workspace is the currently selected one and the
     /// target group is collapsed, the group auto-expands so the focused
     /// workspace stays visible.
@@ -4336,7 +4308,7 @@ class TabManager: ObservableObject {
         placement: WorkspaceGroupNewPlacement? = nil,
         referenceWorkspaceId: UUID? = nil
     ) {
-        guard let tab = tabs.first(where: { $0.id == workspaceId }), !tab.isPinned else { return }
+        guard let tab = tabs.first(where: { $0.id == workspaceId }) else { return }
         guard workspaceGroups.contains(where: { $0.id == groupId }) else { return }
         guard tab.groupId != groupId else { return }
         let isAnchorOfOtherGroup = workspaceGroups.contains { group in
@@ -4972,18 +4944,17 @@ class TabManager: ObservableObject {
     }
 
     /// Helper for `normalizeWorkspaceGroupContiguity`: hoist the anchor to
-    /// the front of its group's member list while preserving the relative
-    /// order of the remaining members. No-op when the anchor isn't actually
-    /// in the list (anchor lifecycle elsewhere ensures it always should be).
+    /// the front of its group's member list, then keep pinned member
+    /// workspaces above unpinned member workspaces while preserving relative
+    /// order inside each tier. No-op when the anchor isn't actually in the
+    /// list (anchor lifecycle elsewhere ensures it always should be).
     private func anchorFirst(_ members: [Workspace], anchorId: UUID) -> [Workspace] {
-        guard let anchorIndex = members.firstIndex(where: { $0.id == anchorId }),
-              anchorIndex != 0 else {
+        guard let anchorIndex = members.firstIndex(where: { $0.id == anchorId }) else {
             return members
         }
-        var reordered = members
-        let anchor = reordered.remove(at: anchorIndex)
-        reordered.insert(anchor, at: 0)
-        return reordered
+        let anchor = members[anchorIndex]
+        let nonAnchors = members.filter { $0.id != anchorId }
+        return [anchor] + nonAnchors.filter(\.isPinned) + nonAnchors.filter { !$0.isPinned }
     }
 
     /// Compatibility shim. With anchor-bound group lifecycle, "empty" groups
@@ -4993,11 +4964,63 @@ class TabManager: ObservableObject {
 
     private func clampedReorderIndex(for workspace: Workspace, targetIndex: Int) -> Int {
         let clamped = max(0, min(targetIndex, tabs.count - 1))
-        let pinnedCount = tabs.filter { $0.isPinned }.count
+        if let groupClamp = clampedGroupedMemberReorderIndex(
+            for: workspace,
+            clampedTargetIndex: clamped
+        ) {
+            return groupClamp
+        }
+        let pinnedCount = leadingGlobalPinnedRowCount()
         if workspace.isPinned {
             return min(clamped, max(0, pinnedCount - 1))
         }
         return max(clamped, pinnedCount)
+    }
+
+    private func clampedGroupedMemberReorderIndex(
+        for workspace: Workspace,
+        clampedTargetIndex: Int
+    ) -> Int? {
+        guard let groupId = workspace.groupId,
+              let group = workspaceGroups.first(where: { $0.id == groupId }),
+              workspace.id != group.anchorWorkspaceId else {
+            return nil
+        }
+        let memberIndices = tabs.indices.filter { tabs[$0].groupId == groupId }
+        guard let firstIndex = memberIndices.first,
+              let lastIndex = memberIndices.last else {
+            return nil
+        }
+        let pinnedMemberCount = memberIndices.reduce(into: 0) { count, index in
+            let member = tabs[index]
+            if member.id != group.anchorWorkspaceId, member.isPinned {
+                count += 1
+            }
+        }
+        let lowerBound = workspace.isPinned
+            ? min(firstIndex + 1, lastIndex)
+            : min(firstIndex + 1 + pinnedMemberCount, lastIndex)
+        let upperBound = workspace.isPinned
+            ? max(firstIndex + pinnedMemberCount, lowerBound)
+            : lastIndex
+        return min(max(clampedTargetIndex, lowerBound), upperBound)
+    }
+
+    private func leadingGlobalPinnedRowCount() -> Int {
+        var count = 0
+        for tab in tabs {
+            guard isGlobalPinnedRow(tab) else { break }
+            count += 1
+        }
+        return count
+    }
+
+    private func isGlobalPinnedRow(_ tab: Workspace) -> Bool {
+        if let groupId = tab.groupId,
+           let group = workspaceGroups.first(where: { $0.id == groupId }) {
+            return group.isPinned
+        }
+        return tab.isPinned
     }
 
     // MARK: - Surface Directory Updates (Backwards Compatibility)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3821,8 +3821,9 @@ class TabManager: ObservableObject {
     /// - If only one neighbor is in a group, join that neighbor's group when
     ///   that group's anchor is the neighbor or another existing member
     ///   (i.e. the dragged workspace sits "inside" the section).
-    /// - Otherwise, clear groupId. Pinned workspaces never gain a group via
-    ///   drag.
+    /// - Otherwise, clear groupId.
+    /// Pinned workspaces may join a group when the same neighbor-based rules
+    /// place them inside that group's section.
     /// Anchors keep their group: their lifecycle is gated by group existence.
     private func applyDragInferredGroupMembership(workspaceId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == workspaceId }) else { return }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4839,16 +4839,16 @@ class TerminalController {
         }
         let childIds = parsedChildIds
         // When the caller explicitly listed children, refuse to create an
-        // anchor-only group if every one of them was ineligible (pinned or
-        // already an anchor of another group). The keyboard-shortcut path
+        // anchor-only group if every one of them was already an anchor of
+        // another group. The keyboard-shortcut path
         // already enforces this; the socket/CLI path used to return OK with
         // a fresh empty group, hiding the real failure.
         if childrenExplicit, !parsedChildIds.isEmpty {
             let ineligible: [String] = v2MainSync {
                 let existingAnchorIds = Set(tabManager.workspaceGroups.map(\.anchorWorkspaceId))
                 return parsedChildIds.compactMap { id -> String? in
-                    guard let tab = tabManager.tabs.first(where: { $0.id == id }) else { return nil }
-                    if tab.isPinned || existingAnchorIds.contains(id) {
+                    guard tabManager.tabs.contains(where: { $0.id == id }) else { return nil }
+                    if existingAnchorIds.contains(id) {
                         return id.uuidString
                     }
                     return nil
@@ -4857,7 +4857,10 @@ class TerminalController {
             if ineligible.count == parsedChildIds.count {
                 return .err(
                     code: "invalid_state",
-                    message: "All requested children are ineligible (pinned or already an anchor); ungroup or unpin them first",
+                    message: String(
+                        localized: "workspaceGroup.error.allChildrenAreAnchors",
+                        defaultValue: "All requested children are ineligible because they are already group anchors; ungroup them first"
+                    ),
                     data: ["ineligible_workspace_ids": ineligible]
                 )
             }
@@ -5002,20 +5005,19 @@ class TerminalController {
             guard let tab = tabManager.tabs.first(where: { $0.id == wsId }), hasGroup else {
                 return
             }
-            // addWorkspaceToGroup silently no-ops for pinned workspaces and
-            // for anchors of other groups. Confirm membership actually
-            // changed before reporting success so scripts don't get OK on a
-            // no-op.
+            // addWorkspaceToGroup silently no-ops for anchors of other
+            // groups. Confirm membership actually changed before reporting
+            // success so scripts don't get OK on a no-op.
             tabManager.addWorkspaceToGroup(workspaceId: wsId, groupId: gid)
             if tab.groupId == gid {
                 ok = true
             } else {
-                if tab.isPinned {
+                if tabManager.workspaceGroups.contains(where: { $0.id != gid && $0.anchorWorkspaceId == wsId }) {
                     failureCode = "invalid_state"
-                    failureMessage = "Workspace is pinned and cannot join a group"
-                } else if tabManager.workspaceGroups.contains(where: { $0.id != gid && $0.anchorWorkspaceId == wsId }) {
-                    failureCode = "invalid_state"
-                    failureMessage = "Workspace is the anchor of another group; ungroup it first"
+                    failureMessage = String(
+                        localized: "workspaceGroup.error.workspaceIsOtherGroupAnchor",
+                        defaultValue: "Workspace is the anchor of another group; ungroup it first"
+                    )
                 }
             }
         }

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -353,6 +353,59 @@ struct WorkspaceGroupTests {
         ])
     }
 
+    @Test func pinningGroupedWorkspaceKeepsItAtTopOfGroup() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            originalIds[1],
+            originalIds[2],
+            originalIds[3],
+        ]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let pinnedChild = try #require(manager.tabs.first { $0.id == originalIds[3] })
+
+        manager.setPinned(pinnedChild, pinned: true)
+
+        #expect(pinnedChild.groupId == groupId)
+        #expect(manager.tabs.filter { $0.groupId == groupId }.map(\.id) == [
+            group.anchorWorkspaceId,
+            originalIds[3],
+            originalIds[1],
+            originalIds[2],
+        ])
+    }
+
+    @Test func pinnedGroupedWorkspaceDoesNotPromoteUnpinnedGroup() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+        let globallyPinned = try #require(manager.tabs.first { $0.id == originalIds[0] })
+        manager.setPinned(globallyPinned, pinned: true)
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            originalIds[2],
+            originalIds[3],
+        ]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let pinnedChild = try #require(manager.tabs.first { $0.id == originalIds[3] })
+
+        manager.setPinned(pinnedChild, pinned: true)
+
+        #expect(manager.tabs.map(\.id) == [
+            originalIds[0],
+            originalIds[1],
+            group.anchorWorkspaceId,
+            originalIds[3],
+            originalIds[2],
+        ])
+        #expect(!group.isPinned)
+        #expect(pinnedChild.groupId == groupId)
+    }
+
     @Test func movingGroupMemberToTopKeepsScriptableGroupOrderInVisibleOrder() throws {
         let manager = makeTabManager()
         manager.addWorkspace(autoWelcomeIfNeeded: false)

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -406,6 +406,41 @@ struct WorkspaceGroupTests {
         #expect(pinnedChild.groupId == groupId)
     }
 
+    @Test func draggingUnpinnedGroupedWorkspaceAbovePinnedGroupedWorkspaceShowsNoIndicator() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            originalIds[1],
+            originalIds[2],
+            originalIds[3],
+        ]))
+        let pinnedChild = try #require(manager.tabs.first { $0.id == originalIds[2] })
+        manager.setPinned(pinnedChild, pinned: true)
+
+        let draggedUnpinnedId = originalIds[3]
+        let tabIds = manager.sidebarReorderWorkspaceIds(
+            forDraggedWorkspaceId: draggedUnpinnedId,
+            targetWorkspaceId: pinnedChild.id
+        )
+        let pinnedIds = manager.sidebarReorderPinnedWorkspaceIds(
+            forDraggedWorkspaceId: draggedUnpinnedId,
+            targetWorkspaceId: pinnedChild.id
+        )
+
+        #expect(manager.tabs.first { $0.id == draggedUnpinnedId }?.groupId == groupId)
+        #expect(SidebarDropPlanner.indicator(
+            draggedTabId: draggedUnpinnedId,
+            targetTabId: pinnedChild.id,
+            tabIds: tabIds,
+            pinnedTabIds: pinnedIds,
+            pointerY: 2,
+            targetHeight: 40
+        ) == nil)
+    }
+
     @Test func movingGroupMemberToTopKeepsScriptableGroupOrderInVisibleOrder() throws {
         let manager = makeTabManager()
         manager.addWorkspace(autoWelcomeIfNeeded: false)

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -429,16 +429,30 @@ struct WorkspaceGroupTests {
             forDraggedWorkspaceId: draggedUnpinnedId,
             targetWorkspaceId: pinnedChild.id
         )
+        let legalInsertionRange = manager.sidebarReorderLegalInsertionRange(
+            forDraggedWorkspaceId: draggedUnpinnedId,
+            targetWorkspaceId: pinnedChild.id
+        )
 
         #expect(manager.tabs.first { $0.id == draggedUnpinnedId }?.groupId == groupId)
-        #expect(SidebarDropPlanner.indicator(
+        let indicator = SidebarDropPlanner.indicator(
             draggedTabId: draggedUnpinnedId,
             targetTabId: pinnedChild.id,
             tabIds: tabIds,
             pinnedTabIds: pinnedIds,
+            legalInsertionRange: legalInsertionRange,
             pointerY: 2,
             targetHeight: 40
-        ) == nil)
+        )
+        #expect(indicator == nil)
+        #expect(SidebarDropPlanner.targetIndex(
+            draggedTabId: draggedUnpinnedId,
+            targetTabId: pinnedChild.id,
+            indicator: SidebarDropIndicator(tabId: pinnedChild.id, edge: .top),
+            tabIds: tabIds,
+            pinnedTabIds: pinnedIds,
+            legalInsertionRange: legalInsertionRange
+        ) == tabIds.firstIndex(of: draggedUnpinnedId))
     }
 
     @Test func movingGroupMemberToTopKeepsScriptableGroupOrderInVisibleOrder() throws {


### PR DESCRIPTION
Summary
- Keeps workspace pinning local inside a workspace group instead of ejecting the workspace from the group.
- Sorts group rows as header, pinned children, then unpinned children.
- Allows pinned workspaces through group creation, row context menu, shortcut, and socket add/create paths.

Tests
- Added regression coverage in cmuxTests/WorkspaceGroupTests.swift.
- jq empty Resources/Localizable.xcstrings
- ./scripts/lint-pbxproj-test-wiring.sh
- git diff --check origin/main..HEAD
- ./scripts/reload-cloud.sh --tag pgrp

Dogfood
- Built tag pgrp: http://127.0.0.1:17320/pgrp
- In the tagged app, created workspace_group:1 from workspace:2 and workspace:3, pinned workspace:2, and confirmed the group payload stayed [workspace:4, workspace:2, workspace:3] with is_pinned=false.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783338833&installation_id=133855650&pr_number=5541&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5541&signature=9530f261e297a1d1bc78afe63bdb81fa20c95baddc7b28857b2688be45088118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TabManager ordering, pinning, and sidebar drag logic plus socket group APIs; behavior changes are broad but covered by new regression tests.
> 
> **Overview**
> **Pinned workspaces can remain group members** instead of being ejected or blocking group actions. Pinning a grouped workspace reorders it to the **pinned tier inside that group** (anchor first, then pinned children, then unpinned), and drag/reorder paths clamp insertion with `sidebarReorderLegalInsertionRange` so members don’t cross anchor/pinned/unpinned boundaries—invalid drops suppress the indicator.
> 
> **Group eligibility** is aligned across the **⌘⇧G shortcut**, row context menu, and socket/CLI: only **existing group anchors** are excluded (pinned is allowed). Socket failures use new localized strings when all explicit children are anchors or when adding a workspace that anchors another group.
> 
> **Top-level sidebar pinning** now treats only **ungrouped pinned rows** (and group-level pin state via `isGlobalPinnedRow`) as the global pinned segment; pinned members inside a group no longer count toward that leading block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0791150cebf5995ee78645c131d6aa20fa43e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned workspaces now stay inside their workspace group and reorder within it. Drag and drop is clamped so members can’t cross anchor/pinned/unpinned boundaries; top-level pinned rows ignore pinned group members.

- **New Features**
  - Allow pinning grouped workspaces; groups render as anchor → pinned members → unpinned members.
  - Support pin/group actions via group creation, row menu, keyboard shortcut, and socket/CLI.
  - Drag and reorder keep members inside their group with legal insertion ranges that respect the pinned tier.

- **Bug Fixes**
  - Prevent creating a group with explicit children when all requested children are anchors; return a localized error.
  - Adding to a group now errors when the workspace is the anchor of another group; pinned status no longer blocks this path.
  - Suppress/clamp drop indicators and target indices when an unpinned member is dragged over a pinned member in the same group.

<sup>Written for commit c0791150cebf5995ee78645c131d6aa20fa43e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar pinning, group ordering, and drag/reorder behavior so pinned and grouped workspaces display and move more predictably; refined insertion clamping and drop indicator logic.
  * Tightened eligibility for creating/moving workspaces into groups to prevent invalid targets.

* **Documentation / Localization**
  * Added two localized error messages for group creation/membership failures (English and Japanese).

* **Tests**
  * Added tests covering pinning, grouping, and drag/reorder interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->