### PR TITLE
Mac pairing window: show connected state when iPhone attaches

### DIFF
--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -323,7 +323,7 @@ final class HostSettingsActions: SettingsHostActions {
 /// doesn't model `Sendable`; the token is immutable and only hands the opaque
 /// observer back to NotificationCenter's thread-safe removal API. CmuxSettings
 /// has an identical internal token, which isn't `public`, so it's duplicated.
-private final class MobileHostStatusObserverToken: @unchecked Sendable {
+final class MobileHostStatusObserverToken: @unchecked Sendable {
     private let token: NSObjectProtocol
 
     init(_ token: NSObjectProtocol) {

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -753,6 +753,45 @@ final class MobileHostService {
         return makeStatus(routes: routes)
     }
 
+    /// Emits the current ``MobileHostServiceStatus`` immediately, then a fresh
+    /// snapshot every time the listener or active-connection set changes (driven by
+    /// `.mobileHostStatusDidChange`). The in-app pairing window consumes this to flip
+    /// from "waiting" to "connected" the instant a phone attaches; it is the same
+    /// signal that backs the Mobile settings connection count. The stream ends when
+    /// the consumer cancels its task.
+    func statusUpdates() -> AsyncStream<MobileHostServiceStatus> {
+        AsyncStream { continuation in
+            // Bridge the notification through a Sendable `Void` signal so the
+            // non-Sendable `Notification` never crosses into the MainActor drain.
+            // Mirrors `HostSettingsActions.mobilePairingStatusUpdates()`.
+            let (signals, signalContinuation) = AsyncStream<Void>.makeStream(
+                bufferingPolicy: .bufferingNewest(1)
+            )
+            let observer = MobileHostStatusObserverToken(
+                NotificationCenter.default.addObserver(
+                    forName: .mobileHostStatusDidChange,
+                    object: nil,
+                    queue: nil
+                ) { _ in
+                    signalContinuation.yield(())
+                }
+            )
+            let drainTask = Task { @MainActor in
+                continuation.yield(MobileHostService.shared.statusSnapshot())
+                for await _ in signals {
+                    if Task.isCancelled { break }
+                    continuation.yield(MobileHostService.shared.statusSnapshot())
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                drainTask.cancel()
+                signalContinuation.finish()
+                observer.remove()
+            }
+        }
+    }
+
     /// Starts the pairing listener (if enabled and not already bound) and
     /// resolves once it can mint attach tickets, so the in-app pairing window
     /// can render a QR code without polling the listener state machine.

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -25,6 +25,9 @@ final class MobilePairingModel {
         case preparing
         /// A ticket is ready to display.
         case ready(Ready)
+        /// A phone has attached to the listener; show a paired/success state
+        /// instead of the QR + spinner.
+        case connected(Ready)
         /// The listener is up but there is no route a phone can reach (no
         /// Tailscale address on this Mac), so no ticket can be minted yet.
         case needsTailscale
@@ -56,6 +59,9 @@ final class MobilePairingModel {
     /// Re-mints the ticket shortly before it expires so the displayed QR is
     /// never stale. Cancelled on every refresh and when the window closes.
     private var autoRefreshTask: Task<Void, Never>?
+    /// Observes the host's connection status while a code is shown, flipping the
+    /// render state between `.ready` and `.connected`. Cancelled on each refresh.
+    private var connectionObservationTask: Task<Void, Never>?
     /// Bumped on each ``refresh()`` so a slower in-flight run (the UI fires
     /// refresh from several places) can't overwrite a newer result with a stale
     /// ticket. Each run captures its value and bails after an `await` if superseded.
@@ -146,6 +152,7 @@ final class MobilePairingModel {
                 )
             )
             scheduleExpiryRefresh()
+            observeConnections()
         } catch MobileAttachTicketStoreError.noRoutes, MobileAttachTicketStoreError.routeUnavailable {
             state = .needsTailscale
         } catch {
@@ -169,6 +176,8 @@ final class MobilePairingModel {
     func stopAutoRefresh() {
         autoRefreshTask?.cancel()
         autoRefreshTask = nil
+        connectionObservationTask?.cancel()
+        connectionObservationTask = nil
     }
 
     /// Schedules a re-mint shortly before the current ticket's TTL elapses, so a
@@ -182,6 +191,43 @@ final class MobilePairingModel {
             try? await ContinuousClock().sleep(for: .seconds(delay))
             guard let self, !Task.isCancelled else { return }
             await self.refresh()
+        }
+    }
+
+    /// Watches the mobile host's connection status while a code is displayed and
+    /// flips between `.ready` (QR shown, waiting) and `.connected` (a phone has
+    /// attached). Cancelled and superseded on each ``refresh()`` via the generation
+    /// guard, and on ``stopAutoRefresh()``.
+    private func observeConnections() {
+        connectionObservationTask?.cancel()
+        let generation = refreshGeneration
+        connectionObservationTask = Task { [weak self] in
+            guard let self else { return }
+            for await status in self.host.statusUpdates() {
+                if Task.isCancelled { return }
+                guard generation == self.refreshGeneration else { return }
+                self.state = Self.connectionTransition(
+                    from: self.state,
+                    activeConnectionCount: status.activeConnectionCount
+                )
+            }
+        }
+    }
+
+    /// Computes the next render state from a connection-count change. A connected
+    /// phone (`activeConnectionCount > 0`) flips a displayed ticket from `.ready`
+    /// to `.connected`; losing the last connection flips back so the QR returns.
+    /// All other states pass through unchanged. Pure, so the transition is unit
+    /// tested without a live host.
+    static func connectionTransition(from current: State, activeConnectionCount: Int) -> State {
+        let connected = activeConnectionCount > 0
+        switch current {
+        case let .ready(ready) where connected:
+            return .connected(ready)
+        case let .connected(ready) where !connected:
+            return .ready(ready)
+        default:
+            return current
         }
     }
 

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -201,6 +201,14 @@ final class MobilePairingModel {
     private func observeConnections() {
         connectionObservationTask?.cancel()
         let generation = refreshGeneration
+        // Connections already present when this code is displayed (another phone
+        // is attached, or we are pairing an additional device). Only a NEW
+        // connection above this baseline means "this freshly minted QR was
+        // scanned"; without the baseline, opening the window while a phone is
+        // already connected would falsely jump to "connected" before the new
+        // ticket is ever used, which also makes pairing an additional device
+        // impossible (the QR would hide immediately).
+        let baseline = host.statusSnapshot().activeConnectionCount
         connectionObservationTask = Task { [weak self] in
             guard let self else { return }
             for await status in self.host.statusUpdates() {
@@ -208,19 +216,26 @@ final class MobilePairingModel {
                 guard generation == self.refreshGeneration else { return }
                 self.state = Self.connectionTransition(
                     from: self.state,
-                    activeConnectionCount: status.activeConnectionCount
+                    activeConnectionCount: status.activeConnectionCount,
+                    baselineConnectionCount: baseline
                 )
             }
         }
     }
 
-    /// Computes the next render state from a connection-count change. A connected
-    /// phone (`activeConnectionCount > 0`) flips a displayed ticket from `.ready`
-    /// to `.connected`; losing the last connection flips back so the QR returns.
-    /// All other states pass through unchanged. Pure, so the transition is unit
-    /// tested without a live host.
-    static func connectionTransition(from current: State, activeConnectionCount: Int) -> State {
-        let connected = activeConnectionCount > 0
+    /// Computes the next render state from a connection-count change, relative to
+    /// the `baselineConnectionCount` captured when the code was displayed. A
+    /// connection *above* the baseline (a phone that attached after the QR was
+    /// shown) flips a displayed ticket from `.ready` to `.connected`; dropping
+    /// back to the baseline flips it back so the QR returns. All other states
+    /// pass through unchanged. Pure, so the transition is unit tested without a
+    /// live host.
+    static func connectionTransition(
+        from current: State,
+        activeConnectionCount: Int,
+        baselineConnectionCount: Int
+    ) -> State {
+        let connected = activeConnectionCount > baselineConnectionCount
         switch current {
         case let .ready(ready) where connected:
             return .connected(ready)

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -91,6 +91,7 @@ struct MobilePairingView: View {
     private var tailscaleReachable: Bool? {
         switch model.state {
         case let .ready(ready): return ready.reachableViaTailscale
+        case let .connected(ready): return ready.reachableViaTailscale
         case .needsTailscale: return false
         default: return nil
         }
@@ -150,6 +151,8 @@ struct MobilePairingView: View {
             failure(message: message)
         case let .ready(ready):
             readyContent(ready)
+        case let .connected(ready):
+            connectedContent(ready)
         }
     }
 
@@ -243,6 +246,22 @@ struct MobilePairingView: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
         }
+    }
+
+    @ViewBuilder
+    private func connectedContent(_ ready: MobilePairingModel.Ready) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.green)
+            Text(String(localized: "mobile.pairing.connected.title", defaultValue: "iPhone connected"))
+                .font(.title3.weight(.semibold))
+            Text(String(localized: "mobile.pairing.connected.subtitle", defaultValue: "Your terminal workspaces are now syncing to your iPhone. You can close this window."))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, minHeight: 200)
     }
 
     private var steps: some View {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 		4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */; };
 		F67FBC88671C40AC3A3284CE /* MobileHostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACA497A6831165EA879C642 /* MobileHostService.swift */; };
 		C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */; };
+		9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */; };
 		0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */; };
 		325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */; };
 		A2538FE83AE79539E3BF9248 /* MobilePairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */; };
@@ -1136,6 +1137,7 @@
 		47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostRPC.swift; sourceTree = "<group>"; };
 		7ACA497A6831165EA879C642 /* MobileHostService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostService.swift; sourceTree = "<group>"; };
 		C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostServiceSettingsTests.swift; sourceTree = "<group>"; };
+		A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePairingConnectionTransitionTests.swift; sourceTree = "<group>"; };
 		04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingModel.swift"; sourceTree = "<group>"; };
 		B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingQRImageView.swift"; sourceTree = "<group>"; };
 		F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingView.swift"; sourceTree = "<group>"; };
@@ -2145,6 +2147,7 @@
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
+				A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
@@ -3197,6 +3200,7 @@
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
+				9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */,
 				F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */,
 				734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 				4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */,

--- a/cmuxTests/MobilePairingConnectionTransitionTests.swift
+++ b/cmuxTests/MobilePairingConnectionTransitionTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Mobile pairing connection transition")
+struct MobilePairingConnectionTransitionTests {
+    private func makeReady() -> MobilePairingModel.Ready {
+        MobilePairingModel.Ready(
+            attachURL: "cmux-ios://attach?ticket=abc",
+            macName: "Test Mac",
+            tailscaleLines: ["100.64.0.1:7777"]
+        )
+    }
+
+    @Test("A connected phone flips a displayed ticket from ready to connected")
+    func readyFlipsToConnectedOnAttach() {
+        let ready = makeReady()
+        let next = MobilePairingModel.connectionTransition(
+            from: .ready(ready),
+            activeConnectionCount: 1
+        )
+        #expect(next == .connected(ready))
+    }
+
+    @Test("A ready ticket with no connections stays in the waiting state")
+    func readyStaysReadyWithoutConnections() {
+        let ready = makeReady()
+        let next = MobilePairingModel.connectionTransition(
+            from: .ready(ready),
+            activeConnectionCount: 0
+        )
+        #expect(next == .ready(ready))
+    }
+
+    @Test("Losing the last connection flips connected back to ready so the QR returns")
+    func connectedFlipsBackToReadyWhenConnectionsDrop() {
+        let ready = makeReady()
+        let next = MobilePairingModel.connectionTransition(
+            from: .connected(ready),
+            activeConnectionCount: 0
+        )
+        #expect(next == .ready(ready))
+    }
+
+    @Test("Connected stays connected while a phone remains attached")
+    func connectedStaysConnectedWithActiveConnections() {
+        let ready = makeReady()
+        let next = MobilePairingModel.connectionTransition(
+            from: .connected(ready),
+            activeConnectionCount: 2
+        )
+        #expect(next == .connected(ready))
+    }
+
+    @Test("Preparing is unaffected by connection-count changes")
+    func preparingIsUnaffected() {
+        let next = MobilePairingModel.connectionTransition(
+            from: .preparing,
+            activeConnectionCount: 1
+        )
+        #expect(next == .preparing)
+    }
+
+    @Test("Signed-out is unaffected by connection-count changes")
+    func signedOutIsUnaffected() {
+        let next = MobilePairingModel.connectionTransition(
+            from: .signedOut,
+            activeConnectionCount: 1
+        )
+        #expect(next == .signedOut)
+    }
+}

--- a/cmuxTests/MobilePairingConnectionTransitionTests.swift
+++ b/cmuxTests/MobilePairingConnectionTransitionTests.swift
@@ -18,42 +18,66 @@ struct MobilePairingConnectionTransitionTests {
         )
     }
 
-    @Test("A connected phone flips a displayed ticket from ready to connected")
+    @Test("A phone attaching above the baseline flips a displayed ticket to connected")
     func readyFlipsToConnectedOnAttach() {
         let ready = makeReady()
         let next = MobilePairingModel.connectionTransition(
             from: .ready(ready),
-            activeConnectionCount: 1
+            activeConnectionCount: 1,
+            baselineConnectionCount: 0
         )
         #expect(next == .connected(ready))
     }
 
-    @Test("A ready ticket with no connections stays in the waiting state")
+    @Test("A ready ticket with no new connections stays in the waiting state")
     func readyStaysReadyWithoutConnections() {
         let ready = makeReady()
         let next = MobilePairingModel.connectionTransition(
             from: .ready(ready),
-            activeConnectionCount: 0
+            activeConnectionCount: 0,
+            baselineConnectionCount: 0
         )
         #expect(next == .ready(ready))
     }
 
-    @Test("Losing the last connection flips connected back to ready so the QR returns")
+    @Test("Pairing an additional device: an already-connected phone does not flip the new QR")
+    func additionalDeviceStaysReadyUntilNewConnectionAboveBaseline() {
+        let ready = makeReady()
+        // One phone already attached when the QR is shown (baseline 1). The same
+        // count must keep showing the QR so a second device can still pair.
+        let stillWaiting = MobilePairingModel.connectionTransition(
+            from: .ready(ready),
+            activeConnectionCount: 1,
+            baselineConnectionCount: 1
+        )
+        #expect(stillWaiting == .ready(ready))
+        // A second device attaches (count rises above the baseline) -> connected.
+        let connected = MobilePairingModel.connectionTransition(
+            from: .ready(ready),
+            activeConnectionCount: 2,
+            baselineConnectionCount: 1
+        )
+        #expect(connected == .connected(ready))
+    }
+
+    @Test("Connected flips back to ready when the new connection drops to the baseline")
     func connectedFlipsBackToReadyWhenConnectionsDrop() {
         let ready = makeReady()
         let next = MobilePairingModel.connectionTransition(
             from: .connected(ready),
-            activeConnectionCount: 0
+            activeConnectionCount: 1,
+            baselineConnectionCount: 1
         )
         #expect(next == .ready(ready))
     }
 
-    @Test("Connected stays connected while a phone remains attached")
+    @Test("Connected stays connected while the new phone remains attached")
     func connectedStaysConnectedWithActiveConnections() {
         let ready = makeReady()
         let next = MobilePairingModel.connectionTransition(
             from: .connected(ready),
-            activeConnectionCount: 2
+            activeConnectionCount: 2,
+            baselineConnectionCount: 1
         )
         #expect(next == .connected(ready))
     }
@@ -62,7 +86,8 @@ struct MobilePairingConnectionTransitionTests {
     func preparingIsUnaffected() {
         let next = MobilePairingModel.connectionTransition(
             from: .preparing,
-            activeConnectionCount: 1
+            activeConnectionCount: 1,
+            baselineConnectionCount: 0
         )
         #expect(next == .preparing)
     }
@@ -71,7 +96,8 @@ struct MobilePairingConnectionTransitionTests {
     func signedOutIsUnaffected() {
         let next = MobilePairingModel.connectionTransition(
             from: .signedOut,
-            activeConnectionCount: 1
+            activeConnectionCount: 1,
+            baselineConnectionCount: 0
         )
         #expect(next == .signedOut)
     }


### PR DESCRIPTION
## Summary
- Fixes the macOS in-app "Pair a Device" window staying stuck on "Waiting for your iPhone…" forever after a phone connects (the pairing model never observed the connection signal; deferred in #5493).
- `MobilePairingModel` now watches `MobileHostService.statusUpdates()` (new AsyncStream over the existing `.mobileHostStatusDidChange` / `activeConnectionCount` signal the Mobile settings section already shows) and flips to an "iPhone connected" success state, reverting to the QR if the phone leaves.
- `MobileHostStatusObserverToken` made internal so the host can reuse the same observer bridge.

## Testing
- New Swift Testing suite `MobilePairingConnectionTransitionTests` (6 cases) for the pure `connectionTransition`; pbxproj wired (`check-pbxproj.sh` + `lint-pbxproj-test-wiring.sh` pass).
- CI ios-simulator/tests/release-build validate compilation.

## Notes
- Reuses the same connection signal as the Settings "active connections" count (one shared source of truth).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339114&installation_id=133855650&pr_number=5542&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5542&signature=5df8b3a679c63c4eb8761aa3780f2f8d8cf9c236ebbd0bdec9a7ea49f6516daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pairing UI and observation only; reuses the existing connection-count notification path with tested state transitions and no auth or listener behavior changes.
> 
> **Overview**
> Fixes the macOS **Pair a Device** window staying on “Waiting for your iPhone…” after a phone connects by reacting to live mobile host connection status.
> 
> `MobileHostService` gains **`statusUpdates()`**, an `AsyncStream` that seeds a snapshot and pushes updates on `.mobileHostStatusDidChange` (same signal as Mobile settings’ active connection count). **`MobilePairingModel`** subscribes while a QR is shown, adds a **`.connected`** state, and uses a **baseline** `activeConnectionCount` so only a *new* attach after the code is minted flips to success—pairing a second device still shows the QR. Disconnecting back to the baseline returns to **`.ready`**. **`MobilePairingView`** shows a green checkmark success screen with new EN/JA strings. **`MobileHostStatusObserverToken`** is internal so the host can share the observer bridge with settings. Unit tests cover the pure **`connectionTransition`** logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa8de5126c6c7325919207c626d8d5173cff74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS “Pair a Device” window getting stuck on “Waiting for your iPhone…” by reacting to live connection status. It now shows “iPhone connected” only when a new phone attaches and returns to the QR when that device disconnects.

- **Bug Fixes**
  - `MobilePairingModel` consumes `MobileHostService.statusUpdates()` and switches between `.ready` and `.connected` using a baseline `activeConnectionCount` to avoid false positives and support pairing additional devices.
  - Added a connected confirmation UI in `MobilePairingView` with new localized strings.
  - Introduced `MobileHostService.statusUpdates()` (seeds a snapshot, updates on `.mobileHostStatusDidChange`); `MobileHostStatusObserverToken` is now internal; added unit tests for the pure `connectionTransition`.

<sup>Written for commit 3aa8de5126c6c7325919207c626d8d5173cff74a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile pairing now detects live connection changes and shows a dedicated "connected" confirmation screen when a device attaches.

* **Documentation**
  * Added localized strings for the mobile pairing connected state (English and Japanese).

* **Tests**
  * Added unit tests validating pairing state transitions between ready and connected based on connection counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->