### PR TITLE
iOS: show Restoring session for a known paired Mac on launch

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -47,6 +47,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    private static let hasKnownPairedMacDefaultsKey = "cmux.mobile.hasKnownPairedMac"
+
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
@@ -71,6 +73,33 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public private(set) var connectionError: String?
     public private(set) var activeTicket: CmxAttachTicket?
     public private(set) var activeRoute: CmxAttachRoute?
+
+    /// True only while an actually-found stored Mac is mid-reconnect.
+    ///
+    /// Set just before awaiting the connect for a Mac resolved from the paired-Mac
+    /// store on launch (or network recovery), and cleared once that attempt
+    /// resolves. Drives the root scene's choice to show ``RestoringSessionView``
+    /// during the reconnect window instead of the empty add-device sheet.
+    public private(set) var isReconnectingStoredMac: Bool = false
+
+    /// True once the first launch reconnect attempt has resolved.
+    ///
+    /// A failed or offline reconnect sets this so the root scene falls through to
+    /// the disconnected/add-device view instead of spinning on
+    /// ``RestoringSessionView`` forever.
+    public private(set) var didFinishStoredMacReconnectAttempt: Bool = false
+
+    /// Persisted hint that this device has previously paired a Mac.
+    ///
+    /// Read synchronously at init from the injected `UserDefaults` so the very
+    /// first rendered frame can show ``RestoringSessionView`` for a returning user
+    /// before the async paired-Mac read runs. Writes persist through to the same
+    /// defaults via the property's `didSet`.
+    public private(set) var hasKnownPairedMac: Bool {
+        didSet {
+            pairingHintDefaults.set(hasKnownPairedMac, forKey: Self.hasKnownPairedMacDefaultsKey)
+        }
+    }
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
               activeTicket.authToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
@@ -109,6 +138,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private let pairedMacStore: (any MobilePairedMacStoring)?
     private let identityProvider: (any MobileIdentityProviding)?
     private let reachability: any ReachabilityProviding
+    private let pairingHintDefaults: UserDefaults
     private let clientID: String
     private var remoteClient: MobileCoreRPCClient? {
         didSet {
@@ -186,12 +216,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         pairedMacStore: (any MobilePairedMacStoring)? = nil,
         clientIDRepository: MobileClientIDRepository = MobileClientIDRepository(defaults: .standard),
         identityProvider: (any MobileIdentityProviding)? = nil,
-        reachability: any ReachabilityProviding = ReachabilityService()
+        reachability: any ReachabilityProviding = ReachabilityService(),
+        pairingHintDefaults: UserDefaults = .standard
     ) {
         self.runtime = runtime
         self.pairedMacStore = pairedMacStore
         self.identityProvider = identityProvider
         self.reachability = reachability
+        self.pairingHintDefaults = pairingHintDefaults
+        self.hasKnownPairedMac = pairingHintDefaults.bool(forKey: Self.hasKnownPairedMacDefaultsKey)
         self.clientID = clientIDRepository.clientID
         self.isSignedIn = isSignedIn
         self.connectionState = connectionState
@@ -261,6 +294,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Drop the cached paired Macs so the next signed-in user never sees the
         // previous user's hosts in the switcher.
         pairedMacs = []
+        // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
+        // the forget path. On a real account switch the next reconnect's no-mac
+        // branch clears the hint.
+        isReconnectingStoredMac = false
+        didFinishStoredMacReconnectAttempt = false
         replaceRemoteClient(with: nil)
         cancelRemoteOperationTasks()
         rawTerminalInputBuffer.clear()
@@ -564,23 +602,62 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func reconnectActiveMacIfAvailable(stackUserID: String?) async -> Bool {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
-        guard let pairedMacStore else { return false }
-        guard isSignedIn else { return false }
+        // No store / not signed in: can't determine a stored Mac here. Resolve the
+        // restoring gate (so a returning user doesn't spin on RestoringSessionView)
+        // but leave the persisted hint intact for a future attempt.
+        guard let pairedMacStore else {
+            finishStoredMacReconnectAttempt()
+            return false
+        }
+        guard isSignedIn else {
+            finishStoredMacReconnectAttempt()
+            return false
+        }
         let saved: MobilePairedMac?
         do {
             saved = try await pairedMacStore.activeMac(stackUserID: stackUserID)
         } catch {
             mobileShellLog.error("paired mac store activeMac failed: \(String(describing: error), privacy: .public)")
+            // A read failure means "couldn't determine," not "no mac": keep the
+            // hint so a transient SQLite error doesn't erase a returning user's
+            // paired state.
+            finishStoredMacReconnectAttempt()
             return false
         }
-        guard let mac = saved else { return false }
+        guard let mac = saved else {
+            // Definitively no active Mac: clear the hint so future launches show
+            // the add-device sheet immediately with no restoring flash.
+            hasKnownPairedMac = false
+            finishStoredMacReconnectAttempt()
+            return false
+        }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         guard let (host, port) = Self.firstReconnectHostPortRoute(
             mac.routes,
             supportedKinds: supportedKinds
-        ) else { return false }
+        ) else {
+            // Found a Mac but no usable route to reach it: treat as no reconnect
+            // target and fall through to add-device.
+            hasKnownPairedMac = false
+            finishStoredMacReconnectAttempt()
+            return false
+        }
+        hasKnownPairedMac = true
+        isReconnectingStoredMac = true
         await connectManualHost(name: mac.displayName ?? host, host: host, port: port)
+        isReconnectingStoredMac = false
+        didFinishStoredMacReconnectAttempt = true
         return connectionState == .connected
+    }
+
+    /// Mark the first launch reconnect attempt resolved without a live connection.
+    ///
+    /// Clears ``isReconnectingStoredMac`` and sets
+    /// ``didFinishStoredMacReconnectAttempt`` so the root scene falls through to
+    /// the disconnected/add-device view instead of spinning on the restoring UI.
+    private func finishStoredMacReconnectAttempt() {
+        isReconnectingStoredMac = false
+        didFinishStoredMacReconnectAttempt = true
     }
 
     // MARK: - Paired Mac switching
@@ -717,6 +794,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 markActive: true,
                 stackUserID: stackUserID
             )
+            // A real, reconnectable Mac is now the active paired Mac: record the
+            // persisted hint so the next launch shows RestoringSessionView during
+            // the reconnect window instead of the empty add-device sheet.
+            hasKnownPairedMac = true
         } catch {
             mobileShellLog.error("paired mac store upsert failed: \(String(describing: error), privacy: .public)")
         }
@@ -785,12 +866,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         clearRemoteConnectionContext()
     }
 
-    /// Disconnect from the currently paired Mac and forget it so the next
-    /// session starts from a fresh QR scan. Clears in-memory state and the
-    /// persisted active flag (other macs in SQLite stay, but none are marked
-    /// active so reconnect-on-launch is a no-op until the user pairs again).
     /// Tear down the live connection and reset connection UI state, without
-    /// touching the paired-Mac store.
+    /// touching the paired-Mac store or the restoring-gate hint. The switcher's
+    /// ``forgetMac(macDeviceID:)`` and ``switchToMac(macDeviceID:)`` reuse this,
+    /// so it must not clear ``hasKnownPairedMac`` (that belongs to the explicit
+    /// forget-active path below).
     private func disconnectLiveConnection() {
         pairingAttemptID = UUID()
         connectionError = nil
@@ -800,12 +880,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         clearRemoteConnectionContext()
     }
 
-    /// Disconnect the live connection and forget the currently-active paired Mac
-    /// (drops it from the store), returning the UI to the pairing flow. Backs the
-    /// "Rescan QR" action.
+    /// Disconnect from the currently paired Mac and forget it so the next
+    /// session starts from a fresh QR scan. Clears in-memory state and the
+    /// persisted active flag (other macs in SQLite stay, but none are marked
+    /// active so reconnect-on-launch is a no-op until the user pairs again).
+    /// Backs the "Rescan QR" action.
     public func disconnectAndForgetActiveMac() {
         let staleMacID = activeTicket?.macDeviceID
         disconnectLiveConnection()
+        // Forgetting the active Mac clears the restoring hint so the next launch
+        // (and the current disconnected view) shows add-device immediately.
+        hasKnownPairedMac = false
+        isReconnectingStoredMac = false
+        didFinishStoredMacReconnectAttempt = false
         if let pairedMacStore, let macID = staleMacID {
             // Fire-and-forget: forgetting the persisted mac is cleanup that must
             // not block the synchronous disconnect UI state update above.

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -98,8 +98,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public private(set) var hasKnownPairedMac: Bool {
         didSet {
             pairingHintDefaults.set(hasKnownPairedMac, forKey: Self.hasKnownPairedMacDefaultsKey)
+            // Writing the hint resolves the "undetermined" upgrade window.
+            pairedMacHintUndetermined = false
         }
     }
+
+    /// Whether the persisted paired-Mac hint has never been written on this
+    /// install (the key was absent at launch). True only for installs that
+    /// predate ``hasKnownPairedMac`` — those users may already have an active Mac
+    /// in the paired-Mac store, so the restoring gate treats "undetermined" like
+    /// "may have a paired Mac" until the first reconnect attempt resolves and
+    /// writes the hint. Cleared the moment ``hasKnownPairedMac`` is written.
+    public private(set) var pairedMacHintUndetermined: Bool
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
               activeTicket.authToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
@@ -224,6 +234,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.identityProvider = identityProvider
         self.reachability = reachability
         self.pairingHintDefaults = pairingHintDefaults
+        // Distinguish "key absent" (an install that predates the hint and may
+        // already have a paired Mac in SQLite) from "key present and false" (we
+        // determined there is no paired Mac). didSet is not called for these
+        // initial assignments, so the undetermined flag is not clobbered here.
+        self.pairedMacHintUndetermined = pairingHintDefaults.object(forKey: Self.hasKnownPairedMacDefaultsKey) == nil
         self.hasKnownPairedMac = pairingHintDefaults.bool(forKey: Self.hasKnownPairedMacDefaultsKey)
         self.clientID = clientIDRepository.clientID
         self.isSignedIn = isSignedIn

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -110,6 +110,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// "may have a paired Mac" until the first reconnect attempt resolves and
     /// writes the hint. Cleared the moment ``hasKnownPairedMac`` is written.
     public private(set) var pairedMacHintUndetermined: Bool
+
+    /// Monotonically-increasing token identifying the latest stored-Mac reconnect
+    /// attempt. Overlapping reconnects (multiple launch paths, network recovery,
+    /// sign-out, forget) each claim a generation; only the current generation may
+    /// resolve the restoring-gate flags, so a superseded older attempt can't clear
+    /// the gate while a newer reconnect is still in progress.
+    private var storedMacReconnectGeneration = 0
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
               activeTicket.authToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
@@ -311,7 +318,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         pairedMacs = []
         // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
         // the forget path. On a real account switch the next reconnect's no-mac
-        // branch clears the hint.
+        // branch clears the hint. Bump the reconnect generation so any in-flight
+        // reconnect is superseded and can't re-set these flags after sign-out.
+        storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = false
         replaceRemoteClient(with: nil)
@@ -617,15 +626,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func reconnectActiveMacIfAvailable(stackUserID: String?) async -> Bool {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
+        // Claim this attempt's generation. Only the current generation may resolve
+        // the restoring-gate flags, so an older superseded attempt can't clear the
+        // gate (or clobber the hint) while a newer reconnect is still running.
+        storedMacReconnectGeneration &+= 1
+        let generation = storedMacReconnectGeneration
         // No store / not signed in: can't determine a stored Mac here. Resolve the
         // restoring gate (so a returning user doesn't spin on RestoringSessionView)
         // but leave the persisted hint intact for a future attempt.
         guard let pairedMacStore else {
-            finishStoredMacReconnectAttempt()
+            finishStoredMacReconnectAttempt(generation: generation)
             return false
         }
         guard isSignedIn else {
-            finishStoredMacReconnectAttempt()
+            finishStoredMacReconnectAttempt(generation: generation)
             return false
         }
         let saved: MobilePairedMac?
@@ -636,14 +650,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // A read failure means "couldn't determine," not "no mac": keep the
             // hint so a transient SQLite error doesn't erase a returning user's
             // paired state.
-            finishStoredMacReconnectAttempt()
+            finishStoredMacReconnectAttempt(generation: generation)
             return false
         }
         guard let mac = saved else {
             // Definitively no active Mac: clear the hint so future launches show
             // the add-device sheet immediately with no restoring flash.
-            hasKnownPairedMac = false
-            finishStoredMacReconnectAttempt()
+            setHasKnownPairedMac(false, generation: generation)
+            finishStoredMacReconnectAttempt(generation: generation)
             return false
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
@@ -653,24 +667,41 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         ) else {
             // Found a Mac but no usable route to reach it: treat as no reconnect
             // target and fall through to add-device.
-            hasKnownPairedMac = false
-            finishStoredMacReconnectAttempt()
+            setHasKnownPairedMac(false, generation: generation)
+            finishStoredMacReconnectAttempt(generation: generation)
             return false
         }
-        hasKnownPairedMac = true
+        // A newer attempt may have started while we awaited the store read; if so,
+        // let it own the flags rather than marking ourselves the active reconnect.
+        guard generation == storedMacReconnectGeneration else { return false }
+        setHasKnownPairedMac(true, generation: generation)
         isReconnectingStoredMac = true
         await connectManualHost(name: mac.displayName ?? host, host: host, port: port)
+        // A newer attempt may have started during the connect; it now owns the flags.
+        guard generation == storedMacReconnectGeneration else { return false }
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = true
         return connectionState == .connected
     }
 
-    /// Mark the first launch reconnect attempt resolved without a live connection.
+    /// Writes the persisted paired-Mac hint only when `generation` is still the
+    /// current reconnect attempt, so a superseded attempt can't clobber a newer
+    /// attempt's determination.
+    private func setHasKnownPairedMac(_ value: Bool, generation: Int) {
+        guard generation == storedMacReconnectGeneration else { return }
+        hasKnownPairedMac = value
+    }
+
+    /// Mark the stored-Mac reconnect attempt resolved without a live connection,
+    /// but only when `generation` is still current.
     ///
     /// Clears ``isReconnectingStoredMac`` and sets
     /// ``didFinishStoredMacReconnectAttempt`` so the root scene falls through to
     /// the disconnected/add-device view instead of spinning on the restoring UI.
-    private func finishStoredMacReconnectAttempt() {
+    /// A superseded attempt (older `generation`) is a no-op so it can't resolve the
+    /// gate while a newer reconnect is in progress.
+    private func finishStoredMacReconnectAttempt(generation: Int) {
+        guard generation == storedMacReconnectGeneration else { return }
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = true
     }
@@ -904,7 +935,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let staleMacID = activeTicket?.macDeviceID
         disconnectLiveConnection()
         // Forgetting the active Mac clears the restoring hint so the next launch
-        // (and the current disconnected view) shows add-device immediately.
+        // (and the current disconnected view) shows add-device immediately. Bump
+        // the reconnect generation first so an in-flight reconnect can't re-set the
+        // hint or the gate flags after the user forgot the Mac.
+        storedMacReconnectGeneration &+= 1
         hasKnownPairedMac = false
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = false

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -48,10 +48,15 @@ struct CMUXMobileRootView: View {
         .onAppear {
             syncShellAuthentication(isAuthenticated)
             store.resumeForegroundRefresh()
-            connectUITestAttachURLIfNeeded()
             #if os(iOS)
             pushCoordinator.bind(store: store)
             #endif
+            // If the view mounts already authenticated (cached session, or a
+            // mock/fixture launch), `onChange(of: isAuthenticated)` never fires,
+            // so kick off the stored-Mac reconnect here too. Without this the
+            // restoring gate could stay on RestoringSessionView forever because
+            // nothing ever resolves `didFinishStoredMacReconnectAttempt`.
+            reconnectStoredMacIfNeeded()
         }
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }
@@ -88,18 +93,7 @@ struct CMUXMobileRootView: View {
                 }
                 return
             }
-            let startedUITestAttachURL = connectUITestAttachURLIfNeeded()
-            if !startedUITestAttachURL,
-               MobileRootAuthGate.shouldReconnectStoredMac(
-                stackAuthenticated: authManager.isAuthenticated,
-                attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
-                connectionState: store.connectionState
-            ) {
-                let stackUserID = authManager.currentUser?.id
-                Task {
-                    await store.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
-                }
-            }
+            reconnectStoredMacIfNeeded()
         }
         .onChange(of: authManager.isRestoringSession) { _, isRestoringSession in
             syncShellAuthentication(isAuthenticated, isRestoringSession: isRestoringSession)
@@ -197,6 +191,26 @@ struct CMUXMobileRootView: View {
             isRestoringSession: isRestoringSession ?? authManager.isRestoringSession,
             store: store
         )
+    }
+
+    /// Starts the stored-Mac reconnect when authenticated, unless a UITest attach
+    /// URL took over. Called from both initial `onAppear` (covers a mount that is
+    /// already authenticated) and `onChange(of: isAuthenticated)` (covers a
+    /// sign-in that completes after mount) so the restoring gate always resolves
+    /// even when the auth state never transitions while this view is mounted.
+    private func reconnectStoredMacIfNeeded() {
+        guard isAuthenticated else { return }
+        let startedUITestAttachURL = connectUITestAttachURLIfNeeded()
+        guard !startedUITestAttachURL,
+              MobileRootAuthGate.shouldReconnectStoredMac(
+                stackAuthenticated: authManager.isAuthenticated,
+                attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
+                connectionState: store.connectionState
+              ) else { return }
+        let stackUserID = authManager.currentUser?.id
+        Task {
+            await store.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
+        }
     }
 
     private func showAddDevice() {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -126,6 +126,8 @@ struct CMUXMobileRootView: View {
             RestoringSessionView()
         } else if !isAuthenticated {
             SignInView()
+        } else if store.connectionState != .connected && shouldShowRestoringStoredMac {
+            RestoringSessionView()
         } else if store.connectionState != .connected {
             DisconnectedWorkspaceShellView(
                 showAddDevice: showAddDevice,
@@ -169,6 +171,16 @@ struct CMUXMobileRootView: View {
             stackAuthenticated: authManager.isAuthenticated,
             attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
             isRestoringSession: authManager.isRestoringSession
+        )
+    }
+
+    private var shouldShowRestoringStoredMac: Bool {
+        MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: isAuthenticated,
+            connectionState: store.connectionState,
+            isReconnectingStoredMac: store.isReconnectingStoredMac,
+            hasKnownPairedMac: store.hasKnownPairedMac,
+            didFinishStoredMacReconnectAttempt: store.didFinishStoredMacReconnectAttempt
         )
     }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -174,6 +174,7 @@ struct CMUXMobileRootView: View {
             connectionState: store.connectionState,
             isReconnectingStoredMac: store.isReconnectingStoredMac,
             hasKnownPairedMac: store.hasKnownPairedMac,
+            pairedMacHintUndetermined: store.pairedMacHintUndetermined,
             didFinishStoredMacReconnectAttempt: store.didFinishStoredMacReconnectAttempt
         )
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -121,7 +121,15 @@ struct CMUXMobileRootView: View {
         } else if !isAuthenticated {
             SignInView()
         } else if store.connectionState != .connected && shouldShowRestoringStoredMac {
-            RestoringSessionView()
+            if store.hasKnownPairedMac || store.isReconnectingStoredMac {
+                // We know a Mac is being reconnected: it is honest to say so.
+                RestoringSessionView()
+            } else {
+                // Still determining whether a paired Mac exists (install predating
+                // the hint, or a fresh sign-in): a neutral spinner, since we do not
+                // yet know if there is a session to restore.
+                MobilePairedMacDeterminingView()
+            }
         } else if store.connectionState != .connected {
             DisconnectedWorkspaceShellView(
                 showAddDevice: showAddDevice,

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairedMacDeterminingView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePairedMacDeterminingView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// A neutral, label-free loading state shown for the brief window where the app
+/// has not yet determined whether a paired Mac exists.
+///
+/// This covers an install that predates the persisted paired-Mac hint (the key is
+/// absent but a Mac may already be in the store) or a fresh sign-in. It is
+/// deliberately label-free: showing "Restoring session…" would mislead a user who
+/// turns out to have no session, and showing the add-device sheet would alarm a
+/// returning user. Once the async paired-Mac lookup resolves, the root view
+/// switches to ``RestoringSessionView`` (a Mac is being reconnected) or the
+/// add-device flow (no Mac).
+struct MobilePairedMacDeterminingView: View {
+    var body: some View {
+        ProgressView()
+            .controlSize(.large)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("MobilePairedMacDetermining")
+    }
+}

--- a/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -91,27 +91,34 @@ public struct MobileRootAuthGate {
     /// existing "Restoring session…" state during the reconnect window instead of
     /// the empty add-device sheet. A genuinely never-paired user still falls
     /// through to add-device immediately. The persisted ``hasKnownPairedMac`` hint
-    /// covers the very first rendered frame before the async paired-Mac read runs;
-    /// ``didFinishStoredMacReconnectAttempt`` lets a failed or offline attempt fall
-    /// through to the disconnected view instead of spinning forever.
+    /// covers the very first rendered frame before the async paired-Mac read runs.
+    /// ``pairedMacHintUndetermined`` covers installs that predate the hint (the key
+    /// was never written but a Mac may already exist in the paired-Mac store): they
+    /// are treated as "may have a paired Mac" until the first reconnect attempt
+    /// resolves and writes the hint, so they do not flash add-device on the first
+    /// launch after updating. ``didFinishStoredMacReconnectAttempt`` lets a failed or
+    /// offline attempt fall through to the disconnected view instead of spinning.
     /// - Parameters:
     ///   - authenticated: Whether the user is authenticated (Stack or attach ticket).
     ///   - connectionState: The current connection state.
     ///   - isReconnectingStoredMac: Whether a found stored Mac is actively mid-reconnect.
     ///   - hasKnownPairedMac: The persisted hint that this device has paired a Mac before.
+    ///   - pairedMacHintUndetermined: Whether the hint has never been written on this install (key absent).
     ///   - didFinishStoredMacReconnectAttempt: Whether the first launch reconnect attempt has resolved.
     /// - Returns: `true` while authenticated, not yet connected, and either actively
-    ///   reconnecting a stored Mac or holding the paired-Mac hint with an unresolved
-    ///   attempt.
+    ///   reconnecting a stored Mac or — before the first attempt resolves — holding
+    ///   the paired-Mac hint or an undetermined hint.
     public static func shouldShowRestoringStoredMac(
         authenticated: Bool,
         connectionState: MobileConnectionState,
         isReconnectingStoredMac: Bool,
         hasKnownPairedMac: Bool,
+        pairedMacHintUndetermined: Bool,
         didFinishStoredMacReconnectAttempt: Bool
     ) -> Bool {
         guard authenticated, connectionState != .connected else { return false }
         if isReconnectingStoredMac { return true }
-        return hasKnownPairedMac && !didFinishStoredMacReconnectAttempt
+        guard !didFinishStoredMacReconnectAttempt else { return false }
+        return hasKnownPairedMac || pairedMacHintUndetermined
     }
 }

--- a/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -83,4 +83,35 @@ public struct MobileRootAuthGate {
     ) -> Bool {
         stackAuthenticated && !attachTicketAuthenticated && connectionState != .connected
     }
+
+    /// Whether the restoring-session UI should be shown while reconnecting a known
+    /// paired Mac.
+    ///
+    /// A returning user (already authenticated, previously paired) should see the
+    /// existing "Restoring session…" state during the reconnect window instead of
+    /// the empty add-device sheet. A genuinely never-paired user still falls
+    /// through to add-device immediately. The persisted ``hasKnownPairedMac`` hint
+    /// covers the very first rendered frame before the async paired-Mac read runs;
+    /// ``didFinishStoredMacReconnectAttempt`` lets a failed or offline attempt fall
+    /// through to the disconnected view instead of spinning forever.
+    /// - Parameters:
+    ///   - authenticated: Whether the user is authenticated (Stack or attach ticket).
+    ///   - connectionState: The current connection state.
+    ///   - isReconnectingStoredMac: Whether a found stored Mac is actively mid-reconnect.
+    ///   - hasKnownPairedMac: The persisted hint that this device has paired a Mac before.
+    ///   - didFinishStoredMacReconnectAttempt: Whether the first launch reconnect attempt has resolved.
+    /// - Returns: `true` while authenticated, not yet connected, and either actively
+    ///   reconnecting a stored Mac or holding the paired-Mac hint with an unresolved
+    ///   attempt.
+    public static func shouldShowRestoringStoredMac(
+        authenticated: Bool,
+        connectionState: MobileConnectionState,
+        isReconnectingStoredMac: Bool,
+        hasKnownPairedMac: Bool,
+        didFinishStoredMacReconnectAttempt: Bool
+    ) -> Bool {
+        guard authenticated, connectionState != .connected else { return false }
+        if isReconnectingStoredMac { return true }
+        return hasKnownPairedMac && !didFinishStoredMacReconnectAttempt
+    }
 }

--- a/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -88,4 +88,55 @@ import Testing
             connectionState: .disconnected
         ))
     }
+
+    @Test func showsRestoringStoredMacWhileReconnectingAKnownPairedMac() {
+        // Actively reconnecting a found stored Mac.
+        #expect(MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: true,
+            hasKnownPairedMac: false,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+        // First frame for a returning user: persisted hint, attempt not yet resolved.
+        #expect(MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: false,
+            hasKnownPairedMac: true,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+        // Failed/offline attempt resolved: fall through to the add-device view.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: false,
+            hasKnownPairedMac: true,
+            didFinishStoredMacReconnectAttempt: true
+        ))
+        // Never paired: add-device immediately, no restoring flash.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: false,
+            hasKnownPairedMac: false,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+        // Already connected: never show the restoring UI, regardless of flags.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .connected,
+            isReconnectingStoredMac: true,
+            hasKnownPairedMac: true,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+        // Not authenticated: the sign-in/restoring-session gates run instead.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: false,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: true,
+            hasKnownPairedMac: true,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+    }
 }

--- a/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -96,6 +96,7 @@ import Testing
             connectionState: .disconnected,
             isReconnectingStoredMac: true,
             hasKnownPairedMac: false,
+            pairedMacHintUndetermined: false,
             didFinishStoredMacReconnectAttempt: false
         ))
         // First frame for a returning user: persisted hint, attempt not yet resolved.
@@ -104,7 +105,27 @@ import Testing
             connectionState: .disconnected,
             isReconnectingStoredMac: false,
             hasKnownPairedMac: true,
+            pairedMacHintUndetermined: false,
             didFinishStoredMacReconnectAttempt: false
+        ))
+        // Existing install that predates the hint (key absent): treat undetermined
+        // as "may have a paired Mac" so it does not flash add-device on first launch.
+        #expect(MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: false,
+            hasKnownPairedMac: false,
+            pairedMacHintUndetermined: true,
+            didFinishStoredMacReconnectAttempt: false
+        ))
+        // Undetermined, but the first attempt resolved with no Mac: fall through.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: false,
+            hasKnownPairedMac: false,
+            pairedMacHintUndetermined: true,
+            didFinishStoredMacReconnectAttempt: true
         ))
         // Failed/offline attempt resolved: fall through to the add-device view.
         #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
@@ -112,14 +133,16 @@ import Testing
             connectionState: .disconnected,
             isReconnectingStoredMac: false,
             hasKnownPairedMac: true,
+            pairedMacHintUndetermined: false,
             didFinishStoredMacReconnectAttempt: true
         ))
-        // Never paired: add-device immediately, no restoring flash.
+        // Never paired (hint determined-false): add-device immediately, no flash.
         #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
             authenticated: true,
             connectionState: .disconnected,
             isReconnectingStoredMac: false,
             hasKnownPairedMac: false,
+            pairedMacHintUndetermined: false,
             didFinishStoredMacReconnectAttempt: false
         ))
         // Already connected: never show the restoring UI, regardless of flags.
@@ -128,6 +151,7 @@ import Testing
             connectionState: .connected,
             isReconnectingStoredMac: true,
             hasKnownPairedMac: true,
+            pairedMacHintUndetermined: true,
             didFinishStoredMacReconnectAttempt: false
         ))
         // Not authenticated: the sign-in/restoring-session gates run instead.
@@ -136,6 +160,7 @@ import Testing
             connectionState: .disconnected,
             isReconnectingStoredMac: true,
             hasKnownPairedMac: true,
+            pairedMacHintUndetermined: true,
             didFinishStoredMacReconnectAttempt: false
         ))
     }


### PR DESCRIPTION
## Summary
- Fixes the iOS cold-launch flash of the empty "Add device" sheet before sessions restore for a returning (already-paired) user.
- Adds `MobileRootAuthGate.shouldShowRestoringStoredMac`, gated by a persisted `hasKnownPairedMac` hint (covers the first rendered frame) plus `isReconnectingStoredMac` / `didFinishStoredMacReconnectAttempt` flags on `MobileShellComposite`. A returning user sees the existing `RestoringSessionView` during reconnect; a never-paired user still gets "Add device" instantly with no flash; a failed/offline reconnect falls through instead of spinning forever.

## Testing
- `MobileRootAuthGateTests.shouldShowRestoringStoredMac` (6 cases) — passing locally via `swift test` on `CmuxMobileWorkspace` (no GhosttyKit needed): 4 tests green.
- CI validates the full iOS build.

## Notes
- Touches `MobileShellComposite` + `CMUXMobileRootView`, which overlap with #5513 and other in-flight iOS PRs; will rebase as those land.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339119&installation_id=133855650&pr_number=5543&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5543&signature=14ec6fc11caf1064ecffc1532bf8590784c1f713c37d341e1b22e914f8fb45b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Launch and reconnect UI routing changed across shell store and root view; overlapping reconnect/sign-out/forget paths rely on generation guards—wrong gating could spin forever or flash the wrong screen, but logic is covered by new auth-gate tests.
> 
> **Overview**
> Fixes the iOS cold-launch flash where authenticated returning users briefly saw the empty **Add device** sheet before stored-Mac reconnect finished.
> 
> **`MobileShellComposite`** persists a **`hasKnownPairedMac`** hint in `UserDefaults` (sync read on init for the first frame), tracks **`isReconnectingStoredMac`**, **`didFinishStoredMacReconnectAttempt`**, and **`pairedMacHintUndetermined`** (missing key = legacy install that may already have SQLite pairings). **`reconnectActiveMacIfAvailable`** now drives those flags, clears the hint only when there is definitively no Mac or no route, keeps the hint on store read failures, and uses a **reconnect generation** so sign-out, forget, and overlapping attempts cannot clobber a newer reconnect. Pairing upsert sets the hint; **`disconnectLiveConnection`** no longer clears it—**`disconnectAndForgetActiveMac`** does.
> 
> **`CMUXMobileRootView`** adds **`reconnectStoredMacIfNeeded()`** on **`onAppear`** and auth changes (fixes stuck restoring when already signed in at mount). While disconnected and gated by **`MobileRootAuthGate.shouldShowRestoringStoredMac`**, it shows **`RestoringSessionView`** when a Mac is known or reconnecting, else **`MobilePairedMacDeterminingView`** until the first attempt resolves, then add-device or workspaces.
> 
> **`MobileRootAuthGate`** gains **`shouldShowRestoringStoredMac`** with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4b898854829ddb9962e88cbfcf6138a00e1ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS cold-launch flash by showing the restoring UI for returning users and reliably starting the stored‑Mac reconnect on initial authenticated mount. Adds a neutral determining state and generation‑guarded reconnects to avoid misleading labels and racey flashes.

- Bug Fixes
  - Added `MobileRootAuthGate.shouldShowRestoringStoredMac`, backed by `hasKnownPairedMac`, `pairedMacHintUndetermined`, `isReconnectingStoredMac`, and `didFinishStoredMacReconnectAttempt`. `CMUXMobileRootView` shows `RestoringSessionView` when reconnecting or hinted, and a neutral `MobilePairedMacDeterminingView` spinner while the hint is undetermined.
  - Persist and manage `hasKnownPairedMac` in `UserDefaults`: treat a missing key as “may have a Mac,” keep the hint on store read failures, clear it when no Mac or no usable route is found, and write true on successful reconnect/upsert. Use generation tokens so only the latest attempt can change hints/flags; bump on sign‑out and forget to prevent stale tasks from resolving the gate.
  - Extracted `reconnectStoredMacIfNeeded()` and call it from both `onAppear` and auth changes so cached‑session mounts always resolve the gate and never stick on restoring. Added unit tests covering the restoring‑stored‑Mac policy.

<sup>Written for commit 4d4b898854829ddb9962e88cbfcf6138a00e1ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App persists a "known paired Mac" hint so returning users see a restoring‑session UI when appropriate.
  * Added a neutral "determining paired Mac" loading screen while the app checks for a paired Mac.

* **Improvements**
  * More robust stored‑Mac reconnect flow with explicit in‑memory reconnect states, centralized UI gating, and predictable sign‑out/forget behavior.

* **Tests**
  * Added unit test coverage for the restoring‑stored‑Mac UI gating logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->