### PR TITLE
iOS: drop Mac host name from workspace titles + add wrap-titles toggle

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Observation
+
+/// User-tunable display preferences for the mobile workspace UI, persisted to an
+/// injected ``UserDefaults``.
+///
+/// Constructed once at the app composition root and injected into the SwiftUI
+/// environment (no singleton). Views read it through `@Environment` and bind to
+/// it with `@Bindable`; the `@Observable` conformance drives re-renders when a
+/// preference changes. The backing store is injected so tests pass a scoped
+/// `UserDefaults(suiteName:)` instead of polluting `.standard`.
+///
+/// ```swift
+/// let settings = MobileDisplaySettings(defaults: UserDefaults(suiteName: "test")!)
+/// settings.wrapWorkspaceTitles = true // persisted to the injected defaults
+/// ```
+@MainActor
+@Observable
+public final class MobileDisplaySettings {
+    // UserDefaults is Apple-documented thread-safe; the synchronous read in
+    // `init` and the write-through in `didSet` are safe nonisolated.
+    private nonisolated(unsafe) let defaults: UserDefaults
+    private static let wrapWorkspaceTitlesKey = "cmux.mobile.wrapWorkspaceTitles"
+
+    /// Whether workspace-list row titles wrap onto multiple lines instead of
+    /// truncating to a single line. Defaults to `false` (single-line). Mutating
+    /// this writes through to the injected ``UserDefaults``.
+    public var wrapWorkspaceTitles: Bool {
+        didSet { defaults.set(wrapWorkspaceTitles, forKey: Self.wrapWorkspaceTitlesKey) }
+    }
+
+    /// Creates the display settings, seeding stored values from `defaults`.
+    /// - Parameter defaults: The store backing the persisted preferences.
+    ///   Defaults to `.standard`; tests pass a scoped suite. The stored property
+    ///   is initialized from `defaults` and absent keys read as `false`, which
+    ///   yields the single-line default without a write.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.wrapWorkspaceTitles = defaults.bool(forKey: Self.wrapWorkspaceTitlesKey)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct MobileSettingsView: View {
     @Environment(AuthCoordinator.self) private var authManager
     @Environment(MobilePushCoordinator.self) private var pushCoordinator
+    @Environment(MobileDisplaySettings.self) private var displaySettings
     let connectedHostName: String
     let rescanQR: (() -> Void)?
     let signOut: (() -> Void)?
@@ -28,7 +29,8 @@ struct MobileSettingsView: View {
     @State private var showingHostPicker = false
 
     var body: some View {
-        NavigationStack {
+        @Bindable var displaySettings = displaySettings
+        return NavigationStack {
             Form {
                 Section {
                     LabeledContent {
@@ -103,6 +105,13 @@ struct MobileSettingsView: View {
                         )
                     }
                     .accessibilityIdentifier("MobileSettingsTerminalShortcuts")
+                }
+
+                Section(L10n.string("mobile.settings.display", defaultValue: "Display")) {
+                    Toggle(isOn: $displaySettings.wrapWorkspaceTitles) {
+                        Text(L10n.string("mobile.settings.wrapTitles", defaultValue: "Wrap Workspace Titles"))
+                    }
+                    .accessibilityIdentifier("MobileSettingsWrapTitles")
                 }
 
                 Section(L10n.string("mobile.settings.notifications", defaultValue: "Notifications")) {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
@@ -35,13 +35,15 @@ extension MobileWorkspacePreview {
         return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
     }
 
-    func timestampOrStatus(host: String, connectionStatus: MobileMacConnectionStatus) -> String {
+    func timestampOrStatus(connectionStatus: MobileMacConnectionStatus) -> String {
         if connectionStatus != .connected {
             return connectionStatus.label
         }
         let date = latestActivityDate
+        // A healthy connection shows no host name here; without a real activity
+        // timestamp the trailing slot stays empty rather than echoing the Mac.
         guard date.timeIntervalSince1970 > 1 else {
-            return host.isEmpty ? (terminals.first?.name ?? "") : host
+            return ""
         }
         if Calendar.current.isDateInToday(date) {
             return date.formatted(date: .omitted, time: .shortened)
@@ -49,19 +51,14 @@ extension MobileWorkspacePreview {
         return date.formatted(.dateTime.month(.defaultDigits).day(.defaultDigits))
     }
 
-    func detailLine(host: String, connectionStatus: MobileMacConnectionStatus) -> String {
-        let count = L10n.terminalCount(terminals.count)
-        guard connectionStatus == .connected else {
-            return count
-        }
-        guard !host.isEmpty else {
-            return count
-        }
-        return "\(host), \(count)"
+    func detailLine(connectionStatus: MobileMacConnectionStatus) -> String {
+        // The connected row shows only the terminal count; the host Mac name
+        // lives in Settings and the disconnected status row, never the row body.
+        L10n.terminalCount(terminals.count)
     }
 
-    func accessibilitySummary(host: String, connectionStatus: MobileMacConnectionStatus) -> String {
-        let detail = detailLine(host: host, connectionStatus: connectionStatus)
+    func accessibilitySummary(connectionStatus: MobileMacConnectionStatus) -> String {
+        let detail = detailLine(connectionStatus: connectionStatus)
         // A healthy connection contributes no status text anywhere, including VoiceOver.
         guard connectionStatus != .connected else {
             return "\(previewLine), \(detail)"

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -14,6 +14,10 @@ struct WorkspaceListView: View {
     let host: String
     let connectionStatus: MobileMacConnectionStatus
     let navigationStyle: WorkspaceNavigationStyle
+    /// Whether workspace-row titles wrap (multi-line) instead of truncating to a
+    /// single line. Passed in as a value snapshot so no `@Observable` store
+    /// crosses the `List` boundary.
+    let wrapWorkspaceTitles: Bool
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     let createWorkspace: () -> Void
     /// Optional: when present, the toolbar shows a "settings" menu offering
@@ -71,10 +75,10 @@ struct WorkspaceListView: View {
                 ForEach(filteredWorkspaces) { workspace in
                     WorkspaceNavigationRow(
                         workspace: workspace,
-                        host: host,
                         connectionStatus: connectionStatus,
                         isSelected: navigationStyle == .sidebar && selectedWorkspaceID == workspace.id,
                         navigationStyle: navigationStyle,
+                        wrapWorkspaceTitles: wrapWorkspaceTitles,
                         selectWorkspace: selectWorkspace,
                         renameWorkspace: renameWorkspace,
                         setPinned: setPinned

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -4,10 +4,10 @@ import SwiftUI
 
 struct WorkspaceNavigationRow: View {
     let workspace: MobileWorkspacePreview
-    let host: String
     let connectionStatus: MobileMacConnectionStatus
     let isSelected: Bool
     let navigationStyle: WorkspaceNavigationStyle
+    let wrapWorkspaceTitles: Bool
     let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
     /// Rename the workspace on the Mac. When `nil` (e.g. previews) the rename
     /// affordance is hidden.
@@ -23,7 +23,12 @@ struct WorkspaceNavigationRow: View {
             switch navigationStyle {
             case .push:
                 NavigationLink(value: workspace.id) {
-                    WorkspaceRow(workspace: workspace, host: host, connectionStatus: connectionStatus, isSelected: false)
+                    WorkspaceRow(
+                        workspace: workspace,
+                        connectionStatus: connectionStatus,
+                        isSelected: false,
+                        wrapWorkspaceTitles: wrapWorkspaceTitles
+                    )
                 }
                 .simultaneousGesture(TapGesture().onEnded {
                     selectWorkspace(workspace.id)
@@ -32,7 +37,12 @@ struct WorkspaceNavigationRow: View {
                 Button {
                     selectWorkspace(workspace.id)
                 } label: {
-                    WorkspaceRow(workspace: workspace, host: host, connectionStatus: connectionStatus, isSelected: isSelected)
+                    WorkspaceRow(
+                        workspace: workspace,
+                        connectionStatus: connectionStatus,
+                        isSelected: isSelected,
+                        wrapWorkspaceTitles: wrapWorkspaceTitles
+                    )
                 }
                 .buttonStyle(.plain)
             }
@@ -42,7 +52,7 @@ struct WorkspaceNavigationRow: View {
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")
         .accessibilityLabel(workspace.name)
-        .accessibilityValue(workspace.accessibilitySummary(host: host, connectionStatus: connectionStatus))
+        .accessibilityValue(workspace.accessibilitySummary(connectionStatus: connectionStatus))
         .sheet(isPresented: $isRenaming) {
             WorkspaceRenameSheet(currentName: workspace.name) { newName in
                 renameWorkspace?(workspace.id, newName)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -4,9 +4,11 @@ import SwiftUI
 
 struct WorkspaceRow: View {
     let workspace: MobileWorkspacePreview
-    let host: String
     let connectionStatus: MobileMacConnectionStatus
     let isSelected: Bool
+    /// When `true`, the workspace title wraps onto multiple lines instead of
+    /// truncating to one (driven by the "Wrap Workspace Titles" setting).
+    let wrapWorkspaceTitles: Bool
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -24,11 +26,11 @@ struct WorkspaceRow: View {
                     Text(workspace.name)
                         .font(.headline)
                         .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
-                        .lineLimit(1)
+                        .lineLimit(wrapWorkspaceTitles ? nil : 1)
 
                     Spacer(minLength: 8)
 
-                    Text(workspace.timestampOrStatus(host: host, connectionStatus: connectionStatus))
+                    Text(workspace.timestampOrStatus(connectionStatus: connectionStatus))
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -44,7 +46,7 @@ struct WorkspaceRow: View {
                         .fill(workspace.statusColor(connectionStatus: connectionStatus))
                         .frame(width: 7, height: 7)
 
-                    Text(workspace.detailLine(host: host, connectionStatus: connectionStatus))
+                    Text(workspace.detailLine(connectionStatus: connectionStatus))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -12,6 +12,7 @@ import AppKit
 struct WorkspaceShellView: View {
     @Bindable var store: CMUXMobileShellStore
     let signOut: () -> Void
+    @Environment(MobileDisplaySettings.self) private var displaySettings
     @State private var compactNavigationPath: [MobileWorkspacePreview.ID] = []
     @State private var pendingCompactCreateNavigationWorkspaceIDs: Set<MobileWorkspacePreview.ID>?
     @State private var hasPresentedSplitDetail = false
@@ -60,6 +61,7 @@ struct WorkspaceShellView: View {
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .push,
+                wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
                 selectWorkspace: selectWorkspace,
                 createWorkspace: createWorkspaceInCompactStack,
                 rescanQR: { store.disconnectAndForgetActiveMac() },
@@ -113,6 +115,7 @@ struct WorkspaceShellView: View {
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .sidebar,
+                wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
                 selectWorkspace: selectWorkspace,
                 createWorkspace: store.createWorkspace,
                 rescanQR: { store.disconnectAndForgetActiveMac() },

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -12,9 +12,9 @@ import CmuxMobileDiagnostics
 /// Holds the de-singletonized graph the `cmuxApp` builds once at launch.
 ///
 /// Owns the mobile runtime, the auth composition (coordinator + push
-/// registration), the process-wide reachability monitor, and the shared push
-/// coordinator. Everything below the app shell receives these by injection
-/// instead of reaching for a singleton.
+/// registration), the process-wide reachability monitor, the shared push
+/// coordinator, and the mobile display settings. Everything below the app shell
+/// receives these by injection instead of reaching for a singleton.
 @MainActor
 final class AppCompositionRoot {
     let runtime: CMUXMobileRuntime
@@ -22,6 +22,7 @@ final class AppCompositionRoot {
     let reachability: any ReachabilityProviding
     let pushCoordinator: MobilePushCoordinator
     let analytics: MobileAnalyticsComposition
+    let displaySettings: MobileDisplaySettings
 
     #if DEBUG
     /// The structured diagnostic log, built once here and injected into the
@@ -48,6 +49,7 @@ final class AppCompositionRoot {
             registration: auth.pushRegistration,
             analytics: analytics.emitter
         )
+        self.displaySettings = MobileDisplaySettings()
         #if DEBUG
         self.diagnosticLog = DiagnosticLog(buildStamp: MobileDebugLog.buildStamp)
         #endif

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1429,6 +1429,23 @@
         }
       }
     },
+    "mobile.settings.display": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
+          }
+        }
+      }
+    },
     "mobile.settings.switchMac": {
       "extractionState": "manual",
       "localizations": {
@@ -1442,6 +1459,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Macを切り替え"
+          }
+        }
+      }
+    },
+    "mobile.settings.wrapTitles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wrap Workspace Titles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのタイトルを折り返す"
           }
         }
       }

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -73,6 +73,7 @@ struct cmuxApp: App {
             reachability: Self.root.reachability,
             analytics: Self.root.analytics.emitter,
             pushCoordinator: Self.root.pushCoordinator,
+            displaySettings: Self.root.displaySettings,
             diagnosticLog: Self.root.diagnosticLog
         )
         #else
@@ -81,7 +82,8 @@ struct cmuxApp: App {
             auth: Self.root.auth,
             reachability: Self.root.reachability,
             analytics: Self.root.analytics.emitter,
-            pushCoordinator: Self.root.pushCoordinator
+            pushCoordinator: Self.root.pushCoordinator,
+            displaySettings: Self.root.displaySettings
         )
         #endif
     }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -33,6 +33,7 @@ public struct CMUXMobileRootScene: View {
     private let analytics: any AnalyticsEmitting
     #if os(iOS)
     private let pushCoordinator: MobilePushCoordinator
+    private let displaySettings: MobileDisplaySettings
     #endif
     private let pairedMacStore: (any MobilePairedMacStoring)?
     #if DEBUG
@@ -52,6 +53,8 @@ public struct CMUXMobileRootScene: View {
     ///   - analytics: The app-root analytics emitter, injected into the store.
     ///   - pushCoordinator: The app-root push coordinator (shared with the app
     ///     delegate) injected into the environment.
+    ///   - displaySettings: The app-root mobile display settings injected into
+    ///     the environment (drives workspace-title wrapping).
     ///   - diagnosticLog: The structured diagnostic log (DEBUG builds only),
     ///     injected into the shell store for the DEV feedback round-trip.
     public init(
@@ -60,6 +63,7 @@ public struct CMUXMobileRootScene: View {
         reachability: any ReachabilityProviding,
         analytics: any AnalyticsEmitting,
         pushCoordinator: MobilePushCoordinator,
+        displaySettings: MobileDisplaySettings,
         diagnosticLog: DiagnosticLog? = nil
     ) {
         self.runtime = runtime
@@ -67,6 +71,7 @@ public struct CMUXMobileRootScene: View {
         self.reachability = reachability
         self.analytics = analytics
         self.pushCoordinator = pushCoordinator
+        self.displaySettings = displaySettings
         self.pairedMacStore = Self.openPairedMacStore()
         #if DEBUG
         self.diagnosticLog = diagnosticLog
@@ -108,6 +113,7 @@ public struct CMUXMobileRootScene: View {
             .analytics(analytics)
             #if os(iOS)
             .environment(pushCoordinator)
+            .environment(displaySettings)
             #endif
     }
 


### PR DESCRIPTION
## Summary
- Removes the paired Mac name (e.g. "Lawrence's MacBook Pro") from both always-on spots of each workspace row (top-right slot + detail line). It stays in Settings → Connection → Mac.
- Adds an injected, testable `MobileDisplaySettings` (`@Observable`, persisted to injected `UserDefaults`) and a "Wrap Workspace Titles" Settings toggle (default off) that wraps row titles instead of truncating. Threaded to rows as a value (snapshot-boundary safe). Localized en + ja.

## Testing
- CI iOS build validates compilation (couldn't build iOS locally — GhosttyKit is empty in fresh worktrees).

## Notes
- Touches `WorkspaceListView` / `WorkspaceShellView` / `MobileSettingsView`, which overlap with #5513; will rebase after it lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339138&installation_id=133855650&pr_number=5544&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5544&signature=b73cb1cc3b04119990cffb9008971368148985d6807740ee5907f199b3031107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only mobile shell changes with local UserDefaults persistence; no auth, networking, or server impact.
> 
> **Overview**
> This PR **simplifies iOS workspace list rows** by removing the paired Mac name from the row body (top-right timestamp slot and detail line). When connected, those areas show activity time or stay empty and **terminal count only**; the Mac name remains in Settings → Connection and on the disconnected status row. Preview helpers drop the `host` parameter and VoiceOver no longer announces the host on connected rows.
> 
> It also adds **`MobileDisplaySettings`** (`@Observable`, `UserDefaults`-backed, injected from `AppCompositionRoot` / `CMUXMobileRootScene`), a Settings **Display** section with **Wrap Workspace Titles** (default off, en/ja), and threads `wrapWorkspaceTitles` as a **Bool snapshot** through `WorkspaceShellView` → `WorkspaceListView` → rows so list cells avoid crossing an observable boundary. Row titles use `lineLimit(nil)` when wrapping is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f731542c9ac730e77a69e7d712fd408261f1ba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the paired Mac name from iOS workspace list rows; it now only appears in Settings. Added a Settings toggle to wrap long workspace titles, persisted across launches.

- **New Features**
  - Added `MobileDisplaySettings` (`@Observable`, `UserDefaults`-backed), created in the app root and injected via `CMUXMobileRootScene` environment.
  - Settings → Display: “Wrap Workspace Titles” (default off), localized in en/ja; rows read a Bool snapshot so no `@Observable` crosses the `List`.

- **Refactors**
  - Dropped host name from the row’s trailing slot and detail; timestamp shows activity time (or stays empty), and detail shows only terminal count.
  - Removed `host` from `WorkspaceRow`, `WorkspaceNavigationRow`, `WorkspaceListView`, and preview helpers; added `wrapWorkspaceTitles` plumbed from `WorkspaceShellView`.
  - VoiceOver: connected rows no longer announce the Mac; trailing slot stays empty when there’s no recent activity.

<sup>Written for commit 3f731542c9ac730e77a69e7d712fd408261f1ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Display" settings section with a "Wrap Workspace Titles" toggle to control whether workspace titles wrap to multiple lines or truncate.

* **Bug Fixes**
  * Tidied workspace preview/details to avoid showing host info where it previously appeared.

* **Accessibility**
  * Improved accessibility summaries for workspace rows to reflect the new display behavior.

* **Localization**
  * Added localized strings for the new Display section and toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->