### PR TITLE
iOS: paste images into the terminal from the phone clipboard

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -243,6 +243,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         case "mobile.terminal.create", "terminal.create":
             return false
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport":
             return !ticketCoversTerminalRequest(

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1639,6 +1639,66 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    /// Forward an image the user pasted on the phone to the currently selected
+    /// remote terminal. The bytes travel as base64 in `terminal.paste_image`; the
+    /// Mac writes them to a temp file and injects the path into the terminal so
+    /// the running TUI (e.g. Claude Code) attaches the image the same way a local
+    /// clipboard-image paste does.
+    ///
+    /// - Parameters:
+    ///   - data: The encoded image bytes (PNG/JPEG/…).
+    ///   - format: A lowercase file-extension hint (e.g. `"png"`). The Mac
+    ///     sanitizes it and defaults to `png` for anything unrecognized.
+    public func submitTerminalPasteImage(_ data: Data, format: String) async {
+        guard !data.isEmpty else { return }
+        guard let workspaceID = selectedWorkspace?.id,
+              let terminalID = selectedTerminalID else {
+            return
+        }
+        guard remoteClient != nil else { return }
+        await sendRemoteTerminalPasteImage(
+            data,
+            format: format,
+            workspaceID: workspaceID,
+            terminalID: terminalID
+        )
+    }
+
+    private func sendRemoteTerminalPasteImage(
+        _ data: Data,
+        format: String,
+        workspaceID: MobileWorkspacePreview.ID,
+        terminalID: MobileTerminalPreview.ID
+    ) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            #if DEBUG
+            mobileShellLog.debug("send remote terminal paste image byteCount=\(data.count, privacy: .public) format=\(format, privacy: .public)")
+            #endif
+            let params: [String: Any] = [
+                "workspace_id": workspaceID.rawValue,
+                "surface_id": terminalID.rawValue,
+                "image_base64": data.base64EncodedString(),
+                "image_format": format,
+                "client_id": clientID,
+            ]
+            let responseData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "terminal.paste_image",
+                    params: params
+                )
+            )
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
+            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+        } catch {
+            guard generation == connectionGeneration else { return }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            connectionError = Self.localizedConnectionError(for: error)
+        }
+    }
+
     private var terminalEventStreamID: String {
         "ios-terminal-events-\(clientID)"
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -101,6 +101,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             }
         }
 
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {
+            // An image the user pasted on the phone. Upload it to the Mac, which
+            // writes a temp file and injects its path into the terminal so the
+            // running TUI (e.g. Claude Code) attaches it.
+            Task { @MainActor [weak store] in
+                await store?.submitTerminalPasteImage(data, format: format)
+            }
+        }
+
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
             // Report our natural grid to the Mac and pin our render to the
             // effective grid it returns (the smallest across every attached

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -55,12 +55,18 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// The user tapped the "customize" button at the end of the input-accessory
     /// bar; the host should present the toolbar shortcuts editor. Optional.
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView)
+    /// Forward an image the user pasted from the system clipboard. The host
+    /// uploads `data` to the Mac, which materializes a temp file and injects its
+    /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
+    /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
 }
 
 public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didScrollLines lines: Double, atCol col: Int, row: Int) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
 }
 
 @MainActor
@@ -257,6 +263,11 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     case end
     case pageUp
     case pageDown
+    /// Paste the system clipboard into the terminal: an image is forwarded to
+    /// the Mac as `terminal.paste_image`, plain text rides the normal input
+    /// path. Unlike the other actions it carries no fixed byte ``output``; the
+    /// host reads the pasteboard when it is tapped.
+    case paste
     var title: String {
         title(isMacRemote: false)
     }
@@ -317,6 +328,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return "@"
         case .pageDown:
             return String(localized: "terminal.input_accessory.title.pageDown", defaultValue: "PgDn")
+        case .paste:
+            return ""
         }
     }
 
@@ -349,6 +362,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .end: return "terminal.inputAccessory.end"
         case .pageUp: return "terminal.inputAccessory.pageUp"
         case .pageDown: return "terminal.inputAccessory.pageDown"
+        case .paste: return "terminal.inputAccessory.paste"
         }
     }
 
@@ -358,6 +372,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return String(localized: "terminal.input_accessory.zoom_out", defaultValue: "Zoom Out")
         case .zoomIn:
             return String(localized: "terminal.input_accessory.zoom_in", defaultValue: "Zoom In")
+        case .paste:
+            return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
         default:
             return nil
         }
@@ -369,6 +385,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return "minus.magnifyingglass"
         case .zoomIn:
             return "plus.magnifyingglass"
+        case .paste:
+            return "doc.on.clipboard"
         default:
             return nil
         }
@@ -395,7 +413,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
 
     var output: Data? {
         switch self {
-        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn:
+        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn, .paste:
             return nil
         case .escape:
             return Data([0x1B])
@@ -505,6 +523,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .end: return String(localized: "terminal.shortcut.name.end", defaultValue: "End")
         case .pageUp: return String(localized: "terminal.shortcut.name.pageUp", defaultValue: "Page Up")
         case .pageDown: return String(localized: "terminal.shortcut.name.pageDown", defaultValue: "Page Down")
+        case .paste: return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
         case .control, .alternate, .command, .shift, .zoomIn, .zoomOut:
             return title
         }
@@ -785,6 +804,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             TerminalInputDebugLog.log("surface.onEscape data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
+        }
+        inputProxy.onPasteImage = { [weak self] data, format in
+            guard let self else { return }
+            TerminalInputDebugLog.log("surface.onPasteImage bytes=\(data.count) format=\(format)")
+            self.delegate?.ghosttySurfaceView(self, didPasteImage: data, format: format)
         }
         inputProxy.onZoom = { [weak self] direction in
             self?.performFontZoom(direction)

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -6,6 +6,11 @@ final class TerminalInputTextView: UITextView {
     var onText: ((String) -> Void)?
     var onBackspace: (() -> Void)?
     var onEscapeSequence: ((Data) -> Void)?
+    /// Invoked when the Paste accessory button reads an image off the system
+    /// clipboard. The host forwards the bytes (+ a lowercase format hint) to the
+    /// Mac, which injects the resulting file path into the terminal. Clipboard
+    /// *text* does not use this path; it rides ``onText``.
+    var onPasteImage: ((Data, String) -> Void)?
     var onZoom: ((TerminalFontZoomDirection) -> Void)?
     var onHideKeyboard: (() -> Void)?
     /// Fired by the trailing "customize" button so the SwiftUI host can present
@@ -195,7 +200,7 @@ final class TerminalInputTextView: UITextView {
     /// user-configurable shortcuts. Command is created but kept out of the
     /// stack until ``applyModifierPresentation()`` inserts it for a Mac remote.
     private static let pinnedLeadingActions: [TerminalInputAccessoryAction] = [
-        .control, .alternate, .command,
+        .control, .alternate, .command, .paste,
     ]
 
     /// The structural buttons pinned to the end of the bar, after the
@@ -541,6 +546,15 @@ final class TerminalInputTextView: UITextView {
     }
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
+        if action == .paste {
+            // Paste is a clipboard read, not a key sequence: ignore any armed
+            // modifier and route clipboard content to the host directly.
+            disarmAllModifiers()
+            refreshAccessoryButtonStyles()
+            handlePasteAction()
+            return
+        }
+
         if let zoomDirection = action.zoomDirection {
             disarmAllModifiers()
             refreshAccessoryButtonStyles()
@@ -594,6 +608,35 @@ final class TerminalInputTextView: UITextView {
             if let output = action.output {
                 onEscapeSequence?(output)
             }
+        }
+    }
+
+    /// Read the system clipboard for the Paste button. An image is forwarded via
+    /// ``onPasteImage`` (the host uploads it to the Mac as `terminal.paste_image`
+    /// and the Mac injects the resulting file path); plain text rides the normal
+    /// ``onText`` input path. Images win when both are present. A large image
+    /// falls back to JPEG so it stays under the Mac's 10 MB cap. Accessing the
+    /// pasteboard contents here is what shows iOS's one-shot paste banner, which
+    /// is the expected confirmation for an explicit Paste tap.
+    private func handlePasteAction() {
+        let pasteboard = UIPasteboard.general
+        if pasteboard.hasImages, let image = pasteboard.image {
+            let maxImageBytes = 8 * 1024 * 1024
+            if let png = image.pngData(), png.count <= maxImageBytes {
+                onPasteImage?(png, "png")
+                return
+            }
+            if let jpeg = image.jpegData(compressionQuality: 0.8) {
+                onPasteImage?(jpeg, "jpg")
+                return
+            }
+            if let png = image.pngData() {
+                onPasteImage?(png, "png")
+                return
+            }
+        }
+        if pasteboard.hasStrings, let string = pasteboard.string, !string.isEmpty {
+            onText?(string)
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -949,6 +949,39 @@ enum GhosttyPasteboardHelper {
             .map { escapeForShell($0.path) }
     }
 
+    /// Writes raw image bytes forwarded from a remote client (e.g. an image
+    /// pasted on the paired iOS app) to a temporary file and returns its
+    /// shell-escaped path, ready to inject as terminal input exactly the way
+    /// ``saveClipboardImageIfNeeded(from:assumeNoText:)`` does for a local paste.
+    ///
+    /// Returns `nil` when the payload is empty, exceeds the 10 MB clipboard-image
+    /// cap, or cannot be written. The temp file is registered as owned so the
+    /// usual cleanup paths reclaim it.
+    static func saveImageData(_ data: Data, fileExtension: String) -> String? {
+        // Mirrors the cap in materializeImageFileURLs(from:).
+        let maxClipboardImageSize = 10 * 1024 * 1024  // 10 MB
+        guard !data.isEmpty, data.count <= maxClipboardImageSize else { return nil }
+
+        let fileURL = temporaryImageFileURL(fileExtension: sanitizedImageFileExtension(fileExtension))
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            try? FileManager.default.removeItem(at: fileURL)
+            return nil
+        }
+        registerOwnedTemporaryImageFile(fileURL)
+        return escapeForShell(fileURL.path)
+    }
+
+    /// Constrains a client-supplied image extension to a known-good lowercase
+    /// token, defaulting to `png`, so the temp filename can never carry path
+    /// separators or other hostile characters.
+    private static func sanitizedImageFileExtension(_ raw: String) -> String {
+        let token = raw.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "heic", "heif", "tiff", "bmp"]
+        return allowed.contains(token) ? token : "png"
+    }
+
     static func cleanupTransferredTemporaryImageFiles(_ fileURLs: [URL]) {
         for fileURL in fileURLs {
             let normalizedURL = fileURL.standardizedFileURL

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1225,6 +1225,7 @@ final class MobileHostService {
         case "mobile.terminal.create", "terminal.create":
             return nil
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport",
              "mobile.terminal.scroll", "terminal.scroll":

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20674,6 +20674,8 @@ class TerminalController {
             result = v2MobileTerminalCreate(params: request.params)
         case "mobile.terminal.input", "terminal.input":
             result = v2MobileTerminalInput(params: request.params)
+        case "mobile.terminal.paste_image", "terminal.paste_image":
+            result = v2MobileTerminalPasteImage(params: request.params)
         case "mobile.terminal.replay", "terminal.replay":
             result = v2MobileTerminalReplay(params: request.params)
         case "mobile.terminal.viewport", "terminal.viewport":
@@ -21335,6 +21337,60 @@ class TerminalController {
             payload["terminal_seq"] = seq
         }
         return .ok(payload)
+    }
+
+    /// Handle `terminal.paste_image`: a paired client (the iOS app) forwards an
+    /// image it pasted as base64 bytes. We materialize it to a temp file on the
+    /// Mac and inject the shell-escaped path as terminal input, exactly the way a
+    /// local clipboard-image paste does, so the running TUI (e.g. Claude Code)
+    /// attaches the image from the path.
+    private func v2MobileTerminalPasteImage(params: [String: Any]) -> V2CallResult {
+        guard let base64 = v2RawString(params, "image_base64"),
+              let imageData = Data(base64Encoded: base64), !imageData.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing or invalid image_base64", data: nil)
+        }
+        let format = v2RawString(params, "image_format") ?? "png"
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        if let error = mobileTerminalAliasValidationError(params: params) {
+            return error
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
+
+        guard let escapedPath = GhosttyPasteboardHelper.saveImageData(imageData, fileExtension: format) else {
+            return .err(code: "invalid_params", message: "Image payload was empty or exceeded the size limit", data: nil)
+        }
+
+        let sendResult = terminalPanel.surface.sendInputResult(escapedPath)
+        switch sendResult {
+        case .sent:
+            terminalPanel.surface.forceRefresh(reason: "mobileHost.terminalPasteImage")
+        case .queued:
+            break
+        case .inputQueueFull:
+            return .err(code: "input_queue_full", message: Self.terminalInputQueueFullMessage, data: ["surface_id": surfaceId.uuidString])
+        case .surfaceUnavailable:
+            return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+        case .processExited:
+            return .err(code: "process_exited", message: Self.terminalProcessExitedMessage, data: ["surface_id": surfaceId.uuidString])
+        }
+        #if DEBUG
+        cmuxDebugLog(
+            "mobile.terminal.paste_image workspace=\(resolved.workspace.id.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) bytes=\(imageData.count) format=\(format)"
+        )
+        #endif
+        return .ok([
+            "workspace_id": resolved.workspace.id.uuidString,
+            "surface_id": terminalPanel.id.uuidString,
+            "queued": sendResult == .queued,
+        ])
     }
 
     private func applyMobileViewportReport(

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3469,40 +3469,6 @@
         }
       }
     },
-    "mobile.testflight.link": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download via TestFlight"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight でダウンロード"
-          }
-        }
-      }
-    },
-    "mobile.testflight.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight is invite-only for now. Get the Founders Edition to enroll and to download cmux for Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "TestFlight は現在招待制です。Founders Edition から登録し、Mac 版 cmux をダウンロードしてください。"
-          }
-        }
-      }
-    },
     "mobile.notifications.enable": {
       "extractionState": "manual",
       "localizations": {
@@ -3533,6 +3499,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "エージェント通知をオフにする"
+          }
+        }
+      }
+    },
+    "terminal.input_accessory.paste": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Paste"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペースト"
           }
         }
       }


### PR DESCRIPTION
Adds a **Paste** button to the iOS terminal accessory bar so you can paste an image (or text) from the phone clipboard straight into the terminal. Requested alongside the composer work; this is the image-paste slice.

## Behavior
- Tap **Paste**. If the clipboard holds an **image**, it is forwarded to the paired Mac over a new `terminal.paste_image` RPC (base64 bytes + a format hint; PNG, JPEG fallback above 8 MB). The Mac writes it to a temp file (reusing the existing owned-temp-image machinery) and injects the shell-escaped path as terminal input, exactly the way a local clipboard-image paste does, so a running TUI like Claude Code attaches it.
- If the clipboard holds **text**, it rides the normal input path (no RPC).

## Touch points
- **Mac:** `GhosttyPasteboardHelper.saveImageData(_:fileExtension:)`; `v2MobileTerminalPasteImage` handler + dispatch case in `TerminalController.mobileHostHandleRPC`; `terminal.paste_image` added to the client token-selection group (`MobileCoreRPCClient`) and the server ticket-authorization group (`MobileHostService`) so it is scoped exactly like `terminal.input`. `executionPolicy` already defaults it to the main actor.
- **iOS:** pinned `.paste` accessory action; `TerminalInputTextView.handlePasteAction` reads `UIPasteboard`; `onPasteImage` callback chains `GhosttySurfaceView` → delegate → `MobileShellComposite.submitTerminalPasteImage`.
- Localized **Paste** label (en + ja).

## Notes / coordination
- Overlaps the open composer PR #5511 (touches the same 6 files). Independent off `main`; expects to land first per the "image paste first" call, with #5511 rebasing.
- The image-size cap mirrors the existing 10 MB clipboard-image cap; the iOS side recompresses to JPEG above 8 MB to stay under it.

## Test
Needs a real device + paired Mac (mobile-host RPC round trip), so verified by dogfood: copy an image on the phone, tap Paste in a Claude Code terminal, confirm `[Image #N]` attaches. A unit test of the byte→tempfile→path Mac helper is a reasonable follow-up; the cross-process RPC path is exercised end-to-end by the dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339675&installation_id=133855650&pr_number=5546&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5546&signature=94bcdd71d6fc208bf9814eb5a3cdd41a8428810d17126247600e2529b66ae639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New RPC carries large base64 payloads and writes temp files before injecting paths into the PTY; auth is aligned with terminal.input but size limits and extension sanitization are the main guardrails.
> 
> **Overview**
> Adds **Paste** on the iOS terminal accessory bar so clipboard content on the phone can reach the Mac-hosted terminal. **Images** are sent over a new **`terminal.paste_image`** RPC as base64 plus a format hint; the Mac writes a temp file and injects a shell-escaped path as input (same behavior as a local clipboard-image paste for TUIs like Claude Code). **Text** still uses the existing terminal input path—no new RPC.
> 
> On iOS, **`handlePasteAction`** reads `UIPasteboard` (images preferred over text, JPEG fallback when PNG exceeds ~8 MB). **`submitTerminalPasteImage`** in the shell composite issues the RPC with the same attach-ticket scoping as **`terminal.input`**. On Mac, **`GhosttyPasteboardHelper.saveImageData`**, **`v2MobileTerminalPasteImage`**, and auth grouping in **`MobileCoreRPCClient`** / **`MobileHostService`** wire the handler. Localized **Paste** strings (en/ja) are included; unrelated TestFlight strings were removed from **`Localizable.xcstrings`** in the same diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377697021fbbfded8099529c078cdb0a5fb9bb6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Paste button to the iOS terminal accessory bar so you can paste images or text from the phone clipboard into the Mac-hosted terminal. Images go over a new `terminal.paste_image` RPC and appear as file paths so TUIs (e.g., Claude Code) can attach them.

- New Features
  - iOS: pinned `.paste` accessory button reads `UIPasteboard`; images prefer PNG, fall back to JPEG over 8 MB; text uses the normal input path.
  - Wiring: `onPasteImage` flows `TerminalInputTextView` → `GhosttySurfaceView` → delegate → `MobileShellComposite.submitTerminalPasteImage`.
  - RPC/Host: new `terminal.paste_image` added to `MobileCoreRPCClient` and `MobileHostService` auth groups (scoped like `terminal.input`); `TerminalController.v2MobileTerminalPasteImage` decodes base64, uses `GhosttyPasteboardHelper.saveImageData(_:fileExtension:)` to create a temp file, then injects the shell-escaped path as input.
  - Limits/Safety: 10 MB cap on image payloads; sanitize file-extension hint; reuses owned-temp-image cleanup paths.
  - UI: Localized “Paste” label (en, ja) with `doc.on.clipboard` icon.

<sup>Written for commit 377697021fbbfded8099529c078cdb0a5fb9bb6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste images from the clipboard directly into remote terminals via a new Paste action in the terminal input UI (PNG/JPEG supported, size limits and retries handled).
* **Reliability**
  * Improved handling of image-send failures with clearer connection/error feedback and retry/queue behavior so paste operations are less likely to be lost.
* **Localization**
  * Added localized label for the Paste action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->