### PR TITLE
iOS: terminal surface reaches the screen bottom (fix keyboard-hidden bottom gap)

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceHostingController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceHostingController.swift
@@ -1,0 +1,51 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Hosts the terminal surface (or a fallback view) edge-to-edge so it can
+/// extend under the bottom safe area (home indicator) and reach the physical
+/// screen bottom.
+///
+/// `GhosttySurfaceRepresentable` is a `UIViewControllerRepresentable` rather than
+/// a `UIViewRepresentable` specifically because of this controller: SwiftUI
+/// honors `.ignoresSafeArea(.container, edges: .bottom)` for a hosted view
+/// *controller's* view, but leaves a bare `UIViewRepresentable`'s hosted view
+/// frame clamped to the bottom safe area when it sits inside a `NavigationStack`.
+/// That clamp left a ~34pt empty strip below the live terminal after the
+/// keyboard hid. The content is pinned to the controller view's own edges (not
+/// its safe-area guide), so when SwiftUI extends the controller view to the
+/// screen edge the terminal fills it. `GhosttySurfaceView` already docks its
+/// accessory bar at `bounds.height` and lets the home indicator overlay the
+/// bar's lower edge, so no inner change is needed once the bounds reach bottom.
+final class GhosttySurfaceHostingController: UIViewController {
+    private let content: UIView
+
+    /// Creates a controller hosting `content` edge-to-edge.
+    ///
+    /// - Parameter content: The view to host full-bleed (the live terminal
+    ///   surface, or a runtime-failure fallback label).
+    init(content: UIView) {
+        self.content = content
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(content)
+        // Pin to the view's own edges, NOT the safe-area layout guide, so the
+        // terminal reaches the screen bottom when SwiftUI extends this view
+        // under the bottom safe area.
+        NSLayoutConstraint.activate([
+            content.topAnchor.constraint(equalTo: view.topAnchor),
+            content.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            content.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -12,7 +12,7 @@ import UIKit
 /// runs the same libghostty terminal core + Metal renderer as the Mac,
 /// fed by the Mac's own read thread byte-for-byte. No Swift VT parser,
 /// no snapshot rehydration, no cell-by-cell SwiftUI tree.
-struct GhosttySurfaceRepresentable: UIViewRepresentable {
+struct GhosttySurfaceRepresentable: UIViewControllerRepresentable {
     let surfaceID: String
     let store: CMUXMobileShellStore
     let fontSize: Float32
@@ -21,7 +21,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         Coordinator(surfaceID: surfaceID, store: store)
     }
 
-    func makeUIView(context: Context) -> UIView {
+    // A view *controller* representable (not a bare `UIViewRepresentable`) so the
+    // surface honors `.ignoresSafeArea(.container, edges: .bottom)` inside a
+    // `NavigationStack` and reaches the screen bottom. See
+    // ``GhosttySurfaceHostingController``.
+    func makeUIViewController(context: Context) -> GhosttySurfaceHostingController {
         let runtime: GhosttyRuntime
         do {
             runtime = try GhosttyRuntime.shared()
@@ -31,7 +35,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             fallback.textColor = .white
             fallback.backgroundColor = UIColor(red: 0x27/255.0, green: 0x28/255.0, blue: 0x22/255.0, alpha: 1)
             fallback.text = "Ghostty runtime failed to initialise:\n\(error.localizedDescription)"
-            return fallback
+            return GhosttySurfaceHostingController(content: fallback)
         }
         let view = GhosttySurfaceView(
             runtime: runtime,
@@ -39,14 +43,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             fontSize: fontSize
         )
         context.coordinator.attach(surfaceView: view)
-        return view
+        return GhosttySurfaceHostingController(content: view)
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIViewController(_ uiViewController: GhosttySurfaceHostingController, context: Context) {
         // No prop-driven mutations yet; bytes flow via the byte sink.
     }
 
-    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+    static func dismantleUIViewController(_ uiViewController: GhosttySurfaceHostingController, coordinator: Coordinator) {
         coordinator.detach()
     }
 


### PR DESCRIPTION
## Summary
The live iOS terminal stopped ~34pt short of the screen bottom (the home-indicator safe area) after the keyboard was hidden, leaving an empty strip below it. This fixes it so the terminal fills to the bottom edge.

## Root cause
A bare `UIViewRepresentable`'s hosted view frame stays clamped to the bottom safe area when it sits inside a `NavigationStack`, so the existing `.ignoresSafeArea(.container, edges: .bottom)` on the surface (applied via `mobileTerminalSafeAreaExpansion`, portrait included) was **inert** — it moved only the native `Color` background, not the representable. The terminal surface frame stayed `(0,116,402,724)` (maxY 840) on a 402×874 iPhone window.

This is the failure the `testTUITerminalUsesAvailableViewportAndResizes` UI test has gated on, which had been red on **every** iOS PR (previously written off as a "pre-existing upstream layout limitation"; the prior SwiftUI `.ignoresSafeArea` attempts were inert for exactly this reason).

## Fix
Host `GhosttySurfaceView` in a `UIViewControllerRepresentable` via a new `GhosttySurfaceHostingController` that pins the surface to its view's **own** edges (not the safe-area guide). SwiftUI honors `.ignoresSafeArea` for a hosted view *controller's* view, so the surface bounds now reach the screen bottom. `GhosttySurfaceView` already docks its accessory bar at `bounds.height` with the home indicator overlaying the bar's lower edge, so no inner change was needed. The Coordinator / byte-sink wiring is unchanged.

## Testing
- Targeted CI run of `cmuxUITests/testTUITerminalUsesAvailableViewportAndResizes` on iphone → **TEST SUCCEEDED** (surface now reaches ≥870 vs previous 840). That test also covers dropdown-switching, rendering, resize, and portrait/landscape rotation, so the representable conversion is regression-checked across the core terminal flow.
- Dogfooded on a physical iPhone: terminal fills to the bottom after hiding the keyboard.

## Notes
- `ios-simulator (iphone)` will remain red until `testWorkspaceToolbarCreatesWorkspaceAndTerminal` (an **independent** new-workspace/new-terminal mock timing flake — empty vs stale rows across runs, unrelated to this layout change) is also addressed. That is a separate follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783348727&installation_id=133855650&pr_number=5548&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5548&signature=c8adb5bb7a8fe0916e83a3e243eaf300adc40f9f3cade4ff4395b8ae7f629c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS SwiftUI/UIKit layout hosting change; terminal I/O and coordinator behavior are unchanged.
> 
> **Overview**
> Fixes the iOS live terminal stopping ~34pt above the physical screen bottom (home-indicator safe area) after the keyboard dismisses, which left an empty strip under the surface inside a `NavigationStack`.
> 
> **`GhosttySurfaceRepresentable`** is switched from `UIViewRepresentable` to **`UIViewControllerRepresentable`**, wrapping the live `GhosttySurfaceView` (and the runtime-failure label) in a new **`GhosttySurfaceHostingController`** that pins content to the controller view’s edges—not the safe-area layout guide—so existing `.ignoresSafeArea(.container, edges: .bottom)` / `mobileTerminalSafeAreaExpansion` actually extends the hosted surface. Coordinator byte-sink and delegate wiring are unchanged; only the SwiftUI hosting layer changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ba9ac29deaa07ea591443ccc923abb494ac6ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bottom gap in the iOS terminal after hiding the keyboard. The terminal now extends under the home indicator and fills to the bottom edge.

- **Bug Fixes**
  - Added `GhosttySurfaceHostingController` and switched `GhosttySurfaceRepresentable` to a `UIViewControllerRepresentable` so `.ignoresSafeArea(.container, edges: .bottom)` works inside a `NavigationStack`.
  - The controller pins the surface to its view edges (not the safe-area guide). Coordinator wiring unchanged. `cmuxUITests/testTUITerminalUsesAvailableViewportAndResizes` now passes.

<sup>Written for commit a6ba9ac29deaa07ea591443ccc923abb494ac6ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved view hosting architecture for enhanced stability and performance.

* **Bug Fixes**
  * Added fallback UI to gracefully handle initialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->