### PR TITLE
fix(web): read changelog PNG height from correct IHDR offset

### DIFF
--- a/web/app/[locale]/docs/changelog/page.tsx
+++ b/web/app/[locale]/docs/changelog/page.tsx
@@ -5,17 +5,8 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { buildAlternates } from "../../../../i18n/seo";
 import { changelogMedia, type VersionMedia } from "./changelog-media";
+import { pngDimensions } from "./png-dimensions";
 import { DocsHeading } from "../../components/docs-heading";
-
-/** Read PNG dimensions from the IHDR chunk (bytes 16-23). */
-function pngDimensions(filePath: string): { width: number; height: number } {
-  const abs = path.join(process.cwd(), "public", filePath);
-  const buf = fs.readFileSync(abs);
-  return {
-    width: buf.readUInt32BE(16),
-    height: buf.readUInt32BE(24),
-  };
-}
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;

--- a/web/app/[locale]/docs/changelog/png-dimensions.ts
+++ b/web/app/[locale]/docs/changelog/png-dimensions.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import path from "path";
 
-/** Read PNG dimensions from the IHDR chunk (bytes 16-23). */
+/** Read PNG dimensions from the IHDR chunk: width at byte 16, height at byte 20. */
 export function pngDimensions(filePath: string): { width: number; height: number } {
   const abs = path.join(process.cwd(), "public", filePath);
   const buf = fs.readFileSync(abs);
   return {
     width: buf.readUInt32BE(16),
-    height: buf.readUInt32BE(24),
+    height: buf.readUInt32BE(20),
   };
 }

--- a/web/app/[locale]/docs/changelog/png-dimensions.ts
+++ b/web/app/[locale]/docs/changelog/png-dimensions.ts
@@ -4,7 +4,15 @@ import path from "path";
 /** Read PNG dimensions from the IHDR chunk: width at byte 16, height at byte 20. */
 export function pngDimensions(filePath: string): { width: number; height: number } {
   const abs = path.join(process.cwd(), "public", filePath);
-  const buf = fs.readFileSync(abs);
+  // The IHDR width/height live in the first 24 bytes; read only those instead
+  // of pulling the whole (multi-MB) image into memory at render time.
+  const buf = Buffer.alloc(24);
+  const fd = fs.openSync(abs, "r");
+  try {
+    fs.readSync(fd, buf, 0, 24, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
   return {
     width: buf.readUInt32BE(16),
     height: buf.readUInt32BE(20),

--- a/web/app/[locale]/docs/changelog/png-dimensions.ts
+++ b/web/app/[locale]/docs/changelog/png-dimensions.ts
@@ -9,7 +9,12 @@ export function pngDimensions(filePath: string): { width: number; height: number
   const buf = Buffer.alloc(24);
   const fd = fs.openSync(abs, "r");
   try {
-    fs.readSync(fd, buf, 0, 24, 0);
+    const bytesRead = fs.readSync(fd, buf, 0, 24, 0);
+    if (bytesRead !== 24) {
+      throw new Error(
+        `Invalid PNG header for ${filePath}: expected 24 bytes, got ${bytesRead}`,
+      );
+    }
   } finally {
     fs.closeSync(fd);
   }

--- a/web/app/[locale]/docs/changelog/png-dimensions.ts
+++ b/web/app/[locale]/docs/changelog/png-dimensions.ts
@@ -1,0 +1,12 @@
+import fs from "fs";
+import path from "path";
+
+/** Read PNG dimensions from the IHDR chunk (bytes 16-23). */
+export function pngDimensions(filePath: string): { width: number; height: number } {
+  const abs = path.join(process.cwd(), "public", filePath);
+  const buf = fs.readFileSync(abs);
+  return {
+    width: buf.readUInt32BE(16),
+    height: buf.readUInt32BE(24),
+  };
+}

--- a/web/tests/png-dimensions.test.ts
+++ b/web/tests/png-dimensions.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { pngDimensions } from "../app/[locale]/docs/changelog/png-dimensions";
+
+describe("pngDimensions", () => {
+  test("reads true width and height from the IHDR chunk", () => {
+    // The IHDR header packs width at byte 16 and height at byte 20. Reading the
+    // wrong offset (e.g. 24) lands on bit-depth/color-type bytes and yields a
+    // garbage ~134M height, which blew up the changelog images.
+    const { width, height } = pngDimensions(
+      "/changelog/0.61.0-command-palette.png",
+    );
+    expect(width).toBe(1172);
+    expect(height).toBe(1006);
+  });
+});


### PR DESCRIPTION
- The docs changelog page reads PNG dimensions by hand from the IHDR chunk, but takes the height from byte offset **24** instead of **20**. Offset 24 lands on the bit-depth/color-type/compression/filter bytes, so every changelog image gets a constant garbage height of **134610944** (width is read correctly at offset 16).
- `next/image` turns that into `aspect-ratio: <width> / 1.34611e+08` (~1:114000). With `w-full h-auto` each image computes to tens of millions of pixels tall and is clamped to the browser's max element size. Chrome clamps at 33,554,432px; Firefox's max differs, so the page renders inconsistently between browsers and every changelog entry below the first image is effectively unreachable.
- This is live on cmux.com today: the rendered HTML serves `height="134610944"` on all 8 changelog images. It only *looks* fine because the newest entries at the top are text-only; the breakage starts at the first version that has an image (0.61.0).

Height lives at offset 20 (width 16-19, height 20-23). Reading the correct offset restores normal dimensions. The helper was extracted into `png-dimensions.ts` so it can be unit tested; the page behavior is otherwise unchanged.

Measured on a real changelog PNG (`0.61.0-command-palette.png`, true size 1172x1006):

| | body scroll height | image rendered height |
|---|---|---|
| before (offset 24) | 33,554,432 px | 33,554,432 px |
| after (offset 20) | ~57,800 px | 549 px |

## Test plan
- [x] `cd web && bun test` (new `tests/png-dimensions.test.ts` decodes a real PNG and asserts 1172x1006; verified red on offset 24, green on offset 20)
- [x] `cd web && bun tsc --noEmit`
- [ ] Run `cd web && bun dev`, open `/docs/changelog`, scroll to the 0.61.0 / 0.60.0 entries, and confirm images render at normal sizes (no multi-million-px gaps) in both Chrome and Firefox

The two commits are split red/green per the repo's regression-test policy: the first adds the failing test (and the extraction), the second applies the one-line offset fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783361639&installation_id=133855650&pr_number=5551&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5551&signature=aba1635a3ba7b6894e1892a5f831b115c2ec5235f67b68d3d54d3dc5154f9379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PNG height parsing for docs changelog images by reading IHDR height at byte 20 and only reading the 24‑byte PNG header, with a guard for short reads. Restores correct image dimensions so `next/image` renders normally and reduces I/O at render time.

- **Bug Fixes**
  - Read PNG height from IHDR byte 20 (width at 16 unchanged).
  - Guard against short header reads; throw if fewer than 24 bytes are read.

- **Refactors**
  - Extracted `png-dimensions.ts` with `png-dimensions.test.ts` verifying a real changelog image (1172x1006).
  - Read only the first 24 bytes for dimensions instead of loading the entire image.

<sup>Written for commit 09ae99c8810ab004ac2a7cfee1e003cc4a2816d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extracted and centralized PNG dimension parsing into a reusable utility to make changelog image handling more reliable.

* **Tests**
  * Added tests that validate PNG dimension parsing to prevent incorrect image sizing in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->