### PR TITLE
ios: add --external flag to upload-testflight.sh for external TestFlight groups

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -5,7 +5,7 @@ usage() {
   cat <<'EOF'
 Usage:
   ios/scripts/upload-testflight.sh [--lane beta] [--build-number <number>]
-                                  [--signing manual|automatic]
+                                  [--signing manual|automatic] [--external]
                                   [--archive-path <path>] [--export-only]
 
 Archives cmux iOS, exports an App Store Connect IPA, and uploads it to
@@ -49,6 +49,14 @@ Options:
                             uses Xcode cloud-managed signing via the ASC API key
                             and -allowProvisioningUpdates, so CI does not need an
                             iOS distribution cert/profile in the keychain.
+  --external                Make the build eligible for EXTERNAL TestFlight
+                            testers (sets testFlightInternalTestingOnly=NO).
+                            Default is internal-only: builds reach internal
+                            groups (e.g. "cmux beta") instantly but can never
+                            be added to an external group. External-eligible
+                            builds must pass Apple Beta App Review (~24h) before
+                            external testers can install. Also set via
+                            CMUX_TESTFLIGHT_EXTERNAL=1.
   --archive-path <path>     Reuse an existing archive instead of archiving.
   --export-only             Stop after exporting the signed IPA.
   -h, --help                Show this help.
@@ -84,6 +92,15 @@ EXPORT_ONLY=0
 # "automatic" switches the export to Xcode cloud-managed signing (used by CI,
 # which has no iOS distribution cert/profile, only the ASC API key).
 SIGNING="manual"
+# Whether the exported build is eligible for external TestFlight testers.
+# Default 0 keeps the historical internal-only behavior (fast dogfood, no Apple
+# review). Set to 1 by --external or CMUX_TESTFLIGHT_EXTERNAL=1 to drop the
+# testFlightInternalTestingOnly flag so the build can be added to an external
+# group; such builds then require a one-time Apple Beta App Review per version.
+EXTERNAL_TESTING=0
+if [[ "${CMUX_TESTFLIGHT_EXTERNAL:-}" == "1" ]]; then
+  EXTERNAL_TESTING=1
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -107,6 +124,10 @@ while [[ $# -gt 0 ]]; do
       require_option_value "$1" "${2:-}"
       ARCHIVE_PATH="$2"
       shift 2
+      ;;
+    --external)
+      EXTERNAL_TESTING=1
+      shift
       ;;
     --export-only)
       EXPORT_ONLY=1
@@ -329,7 +350,14 @@ plutil -insert method -string app-store-connect "$EXPORT_OPTIONS"
 plutil -insert destination -string export "$EXPORT_OPTIONS"
 plutil -insert teamID -string "$DEVELOPMENT_TEAM" "$EXPORT_OPTIONS"
 plutil -insert manageAppVersionAndBuildNumber -bool NO "$EXPORT_OPTIONS"
-plutil -insert testFlightInternalTestingOnly -bool YES "$EXPORT_OPTIONS"
+if [[ "$EXTERNAL_TESTING" == "1" ]]; then
+  # External-eligible: omit/clear the internal-only restriction so the build can
+  # be added to an external group (after Apple Beta App Review).
+  plutil -insert testFlightInternalTestingOnly -bool NO "$EXPORT_OPTIONS"
+  echo "note: --external set; build will be eligible for external TestFlight testers (requires Apple Beta App Review per version)." >&2
+else
+  plutil -insert testFlightInternalTestingOnly -bool YES "$EXPORT_OPTIONS"
+fi
 plutil -insert uploadSymbols -bool YES "$EXPORT_OPTIONS"
 if [[ "$SIGNING" == "automatic" ]]; then
   # Cloud-managed signing: Xcode mints the distribution cert/profile on demand


### PR DESCRIPTION
## Why

Every iOS TestFlight upload was hardcoded to `testFlightInternalTestingOnly=YES` (`ios/scripts/upload-testflight.sh:332`), so builds could only reach **internal** groups (e.g. `cmux beta`, which has `hasAccessToAllBuilds`). They were never eligible for an **external** group, so a group like `cmux founders edition` stayed permanently empty regardless of how many builds were uploaded (`externalBuildState: NOT_APPLICABLE` on every build).

## What

Add an opt-in `--external` flag (and `CMUX_TESTFLIGHT_EXTERNAL=1` env) that sets the export option to `NO`, making the build eligible for external testers.

- Default behavior is unchanged: internal-only, fast dogfood, no Apple review.
- `--external` builds require a one-time Apple Beta App Review per version (~24h) before external testers can install. The help text states this.

## Test

Script-only change (not compiled into the app), so no tagged reload. Verified `bash -n` passes and `--help` renders the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783372747&installation_id=133855650&pr_number=5552&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5552&signature=e3353cc06663a379ba09680c5e2dd12f3fc4f5aecae6f1f560b6e3167ae28944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to export plist options; default internal-only uploads are unchanged.
> 
> **Overview**
> Adds an opt-in **`--external`** flag and **`CMUX_TESTFLIGHT_EXTERNAL=1`** to `ios/scripts/upload-testflight.sh` so TestFlight exports can target **external** tester groups instead of being locked to internal-only.
> 
> **Default behavior is unchanged:** `testFlightInternalTestingOnly` stays **YES** for fast internal dogfood. When external mode is enabled, export options set it to **NO** and the script logs that Apple Beta App Review is required per version before external testers can install. Help text documents the tradeoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bcd4af3f2392cf9a9654bb75a10c58b76c181f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in `--external` flag (or `CMUX_TESTFLIGHT_EXTERNAL=1`) to `ios/scripts/upload-testflight.sh` to set `testFlightInternalTestingOnly=NO`, making builds eligible for external TestFlight groups. Default stays internal-only; external-eligible builds require per-version Apple Beta App Review before external testers can install.

<sup>Written for commit 46bcd4af3f2392cf9a9654bb75a10c58b76c181f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line option and environment variable support to control TestFlight testing configuration, enabling selection between internal and external testing modes for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->