### PR TITLE
feat: add New Folder button to Open Folder dialogs

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7264,6 +7264,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
+        // Surface the system "New Folder" button so the user can create a
+        // directory and immediately open it as a workspace.
+        panel.canCreateDirectories = true
         panel.title = String(localized: "menu.file.openFolder.panelTitle", defaultValue: "Open Folder")
         panel.prompt = String(localized: "menu.file.openFolder.panelPrompt", defaultValue: "Open")
         // Seed the panel with the active workspace's directory. Use the shared
@@ -7341,6 +7344,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
+        // Surface the system "New Folder" button so a fresh directory can be
+        // created and opened in VS Code in one step.
+        panel.canCreateDirectories = true
         panel.title = String(
             localized: "menu.file.openFolderInVSCodeInline.panelTitle",
             defaultValue: "Open Folder in VS Code (Inline)"

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7959,6 +7959,9 @@ struct ContentView: View {
                 panel.canChooseFiles = false
                 panel.canChooseDirectories = true
                 panel.allowsMultipleSelection = false
+                // Surface the system "New Folder" button so the user can create a
+                // directory and immediately open it as a workspace.
+                panel.canCreateDirectories = true
                 panel.title = String(localized: "panel.openFolder.title", defaultValue: "Open Folder")
                 panel.prompt = String(localized: "panel.openFolder.prompt", defaultValue: "Open")
                 if panel.runModal() == .OK, let url = panel.url {


### PR DESCRIPTION
## What

Adds the macOS system **New Folder** button to cmux's three folder-open dialogs by setting `NSOpenPanel.canCreateDirectories = true`. Users can now create a directory directly from the Open Folder panel and immediately open it as a workspace, instead of cancelling out to Finder to make the folder first.

## Why

Opening a brand-new project often means "make a folder, then open it." Without `canCreateDirectories`, the standard AppKit Open panel hides the New Folder button, forcing a detour through Finder. This is a one-line capability that AppKit fully implements (button, inline rename field, error handling) — no custom UI.

## Where

Applied consistently to every folder-open entrypoint, per the repo's shared-behavior policy:

- `Sources/AppDelegate.swift` — File menu / ⌘O → Open Folder
- `Sources/AppDelegate.swift` — Open Folder in VS Code (Inline)
- `Sources/ContentView.swift` — Command palette → Open Folder

File-attachment and web-form pickers are intentionally left unchanged (creating folders there makes no sense — they select existing files).

## Notes

- No localization changes needed: the "New Folder" button and its sheet are system-provided and localized by macOS.
- Verified locally: the tagged Debug build launches and the New Folder button appears in the Open Folder dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783393265&installation_id=133855650&pr_number=5559&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5559&signature=7b17e564ddd0b878ed442ff7b27f365eb5bb46dd8b30a6501ac2d7ecfece121a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the macOS New Folder button in all Open Folder dialogs by setting `NSOpenPanel.canCreateDirectories = true`. Users can create a new folder and open it immediately (File menu/⌘O, Command Palette, and Open Folder in VS Code Inline).

<sup>Written for commit f9292b640d3b32f9cb5115d10d499994ea251328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder selection dialogs now support creating new directories directly from the file picker, allowing users to create and immediately open new folders without leaving the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->