### PR TITLE
iOS: cap restoring-session window so a stale stored Mac can't hang it

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -49,6 +49,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private static let hasKnownPairedMacDefaultsKey = "cmux.mobile.hasKnownPairedMac"
 
+    /// Max seconds the launch reconnect may keep the restoring gate
+    /// (``RestoringSessionView``) on screen before resolving to the
+    /// disconnected/add-device UI. A stored Mac whose route went stale makes the
+    /// connect hang on a slow timeout; this caps the visible "Restoring session…"
+    /// window so a returning user is never stuck on it. The connect keeps trying
+    /// in the background, so a later success still flips to the workspaces.
+    private static let storedMacReconnectRestoringDeadlineSeconds: Double = 6
+
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
@@ -923,7 +931,26 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard generation == storedMacReconnectGeneration else { return false }
         setHasKnownPairedMac(true, generation: generation)
         isReconnectingStoredMac = true
+        // Cap how long the restoring gate stays up: a stored Mac whose route went
+        // stale (Tailscale address changed, or it's offline) makes connectManualHost
+        // hang on a slow connect timeout, and the gate shows RestoringSessionView for
+        // that whole time. After the deadline, resolve the gate so the user reaches
+        // add-device quickly; the connect keeps trying, so a later success still
+        // flips connectionState to .connected and shows the workspaces.
+        let restoringDeadline = Task { [weak self] in
+            // Bounded, cancellable deadline (not a poll) — cancelled the instant the
+            // connect resolves; only caps the restoring-gate window.
+            try? await ContinuousClock().sleep(
+                for: .seconds(Self.storedMacReconnectRestoringDeadlineSeconds)
+            )
+            guard let self, !Task.isCancelled,
+                  generation == self.storedMacReconnectGeneration,
+                  self.connectionState != .connected else { return }
+            self.isReconnectingStoredMac = false
+            self.didFinishStoredMacReconnectAttempt = true
+        }
         await connectManualHost(name: mac.displayName ?? host, host: host, port: port)
+        restoringDeadline.cancel()
         // A newer attempt may have started during the connect; it now owns the flags.
         guard generation == storedMacReconnectGeneration else { return false }
         isReconnectingStoredMac = false


### PR DESCRIPTION
## Summary
- Fixes a regression from #5543: on launch a returning user could be stuck on "Restoring session…" for a long time before "Add device" appeared, when the stored Mac's route was stale (e.g. Tailscale address changed after an app update, or the Mac is offline). Re-pairing wrote a fresh route and was fast again.
- Root cause: `reconnectActiveMacIfAvailable` sets `isReconnectingStoredMac = true` then `await connectManualHost(...)`, which blocks for the full connect timeout; the restoring gate shows `RestoringSessionView` that whole time.
- Fix: a bounded, cancellable 6s deadline resolves the restoring gate if the stored Mac hasn't connected, so the user reaches add-device quickly. The connect keeps trying in the background — a later success still flips to the workspaces. Generation-guarded.

## Testing
- `CmuxMobileShell` builds clean. Gate logic unchanged (`MobileRootAuthGate` tests still green). The deadline is integration-level (no injected clock seam yet) — verified by dogfood: a stale/offline stored Mac now resolves to add-device within ~6s instead of hanging.

## Notes
- Reported on the latest beta. Follow-up idea: a dedicated "couldn't reach your Mac — Retry" offline state instead of the raw add-device sheet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783421486&installation_id=133855650&pr_number=5564&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5564&signature=cb76670b99848c066145f442f8295bf32da50ff727429519fa0237bcdc5828fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized launch UX change in stored-Mac reconnect with existing generation guards; no auth or pairing persistence changes.
> 
> **Overview**
> Fixes a launch regression where **"Restoring session…"** could block the UI for the full connect timeout when the saved Mac’s route was stale or offline, because `reconnectActiveMacIfAvailable` held `isReconnectingStoredMac` for the entire `await connectManualHost(...)`.
> 
> **`MobileShellComposite`** now defines a **6s** cap (`storedMacReconnectRestoringDeadlineSeconds`) and starts a **cancellable** `Task` alongside the connect. If the reconnect generation is still current and `connectionState` is not `.connected` after that sleep, it clears the restoring gate (`isReconnectingStoredMac`, `didFinishStoredMacReconnectAttempt`) so the user reaches add-device quickly. The deadline is cancelled when `connectManualHost` returns; a connect that succeeds later can still show workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cda9e5b67c8238300bb3471f865e5f9a46d43b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the iOS “Restoring session…” screen at 6s so a stale stored Mac can’t block launch; reconnect keeps running and will still switch to workspaces if it later succeeds. Fixes a regression where users had to wait for the full connect timeout before seeing Add device.

- **Bug Fixes**
  - Added a cancellable 6s deadline around the launch reconnect to resolve the restoring gate when the stored Mac hasn’t connected.
  - Generation-guarded; the deadline cancels when connect completes, and the background reconnect still flips to workspaces on success.

<sup>Written for commit 7cda9e5b67c8238300bb3471f865e5f9a46d43b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnection flow for stored Mac connections by adding a cancelable timeout so the UI no longer stays indefinitely in the restoring state; the reconnect attempt now resolves automatically if it takes too long and cancels the timeout once a manual connect completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->