### PR TITLE
iOS: show workspaces from all Mac windows, not just the front one

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -21075,10 +21075,6 @@ class TerminalController {
         createdWorkspaceID: String? = nil,
         createdTerminalID: String? = nil
     ) -> V2CallResult {
-        guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
-            return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
-        }
-
         let requestedWorkspaceID = v2UUID(params, "workspace_id")
         if v2HasNonNullParam(params, "workspace_id"), requestedWorkspaceID == nil {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
@@ -21094,54 +21090,87 @@ class TerminalController {
         case .conflict:
             return .err(code: "invalid_params", message: "Conflicting terminal identifiers", data: nil)
         }
-        let visibleWorkspaces = requestedWorkspaceID.map { workspaceID in
-            tabManager.tabs.filter { $0.id == workspaceID }
-        } ?? tabManager.tabs
-        if let requestedWorkspaceID, visibleWorkspaces.isEmpty {
-            return .err(
-                code: "not_found",
-                message: "Workspace not found",
-                data: ["workspace_id": requestedWorkspaceID.uuidString]
-            )
-        }
 
-        let workspaces = visibleWorkspaces.enumerated().map { _, workspace in
-            let terminals = mobileTerminalPanels(in: workspace).compactMap { terminal -> [String: Any]? in
-                if let requestedTerminalID, terminal.id != requestedTerminalID {
-                    return nil
-                }
-                return [
-                    "id": terminal.id.uuidString,
-                    "title": workspace.panelTitle(panelId: terminal.id) ?? terminal.displayTitle,
-                    "current_directory": v2OrNull(
-                        mobileNonEmpty(workspace.panelDirectories[terminal.id])
-                            ?? mobileNonEmpty(terminal.directory)
-                            ?? mobileNonEmpty(terminal.requestedWorkingDirectory)
-                    ),
-                    "is_ready": terminal.surface.surface != nil,
-                    "is_focused": terminal.id == workspace.focusedPanelId
-                ]
+        // The phone shows workspaces from *every* open Mac window. Enumerate all
+        // registered main windows and flatten their workspaces into one list,
+        // but only when the caller has not named a specific target. When a
+        // `workspace_id`, `window_id`, terminal alias, or an explicit
+        // `resolvedTabManager` (the create/terminal-create paths pass one) is
+        // present, keep today's single-window scoped behavior so those requests
+        // resolve exactly the named target.
+        let scopeToSingleWindow = resolvedTabManager != nil
+            || requestedWorkspaceID != nil
+            || v2HasNonNullParam(params, "window_id")
+            || requestedTerminalID != nil
+
+        // `is_selected` has no single answer across multiple windows. Mark only
+        // the frontmost/key window's selected workspace as selected; in the old
+        // single-window path this is exactly the one selected workspace. Using
+        // `currentScriptableMainWindow()` (not `isKeyWindow`) means a backgrounded
+        // app, where no window is key, still reports the same selection the old
+        // path would have, instead of marking nothing selected.
+        let selectedWorkspaceID = scopeToSingleWindow
+            ? nil
+            : AppDelegate.shared?.currentScriptableMainWindow()?.tabManager.selectedTabId
+
+        let workspaces: [[String: Any]]
+        if scopeToSingleWindow {
+            guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
+                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
             }
-
-            return [
-                "id": workspace.id.uuidString,
-                "title": workspace.title,
-                "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
-                "is_selected": workspace.id == tabManager.selectedTabId,
-                "is_pinned": workspace.isPinned,
-                "terminals": terminals
-            ]
-        }
-        if let requestedTerminalID,
-           !workspaces.contains(where: { workspace in
-               guard let terminals = workspace["terminals"] as? [[String: Any]] else { return false }
-               return terminals.contains { ($0["id"] as? String) == requestedTerminalID.uuidString }
-           }) {
-            return .err(
-                code: "not_found",
-                message: "Terminal not found",
-                data: ["surface_id": requestedTerminalID.uuidString]
-            )
+            let visibleWorkspaces = requestedWorkspaceID.map { workspaceID in
+                tabManager.tabs.filter { $0.id == workspaceID }
+            } ?? tabManager.tabs
+            if let requestedWorkspaceID, visibleWorkspaces.isEmpty {
+                return .err(
+                    code: "not_found",
+                    message: "Workspace not found",
+                    data: ["workspace_id": requestedWorkspaceID.uuidString]
+                )
+            }
+            let scopedWorkspaces = visibleWorkspaces.map { workspace in
+                mobileWorkspacePayload(
+                    workspace: workspace,
+                    isSelected: workspace.id == tabManager.selectedTabId,
+                    requestedTerminalID: requestedTerminalID
+                )
+            }
+            if let requestedTerminalID,
+               !scopedWorkspaces.contains(where: { workspace in
+                   guard let terminals = workspace["terminals"] as? [[String: Any]] else { return false }
+                   return terminals.contains { ($0["id"] as? String) == requestedTerminalID.uuidString }
+               }) {
+                return .err(
+                    code: "not_found",
+                    message: "Terminal not found",
+                    data: ["surface_id": requestedTerminalID.uuidString]
+                )
+            }
+            workspaces = scopedWorkspaces
+        } else {
+            guard let app = AppDelegate.shared else {
+                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+            }
+            var flattened: [[String: Any]] = []
+            // `listMainWindowSummaries()` already dedupes window ids, but guard
+            // against the same window or workspace appearing twice anyway: a
+            // workspace lives in exactly one window, and ids are globally unique.
+            var seenWindowIDs: Set<UUID> = []
+            var seenWorkspaceIDs: Set<UUID> = []
+            for summary in app.listMainWindowSummaries() {
+                guard seenWindowIDs.insert(summary.windowId).inserted else { continue }
+                guard let windowTabManager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                for workspace in windowTabManager.tabs where seenWorkspaceIDs.insert(workspace.id).inserted {
+                    flattened.append(
+                        mobileWorkspacePayload(
+                            workspace: workspace,
+                            isSelected: workspace.id == selectedWorkspaceID,
+                            requestedTerminalID: requestedTerminalID
+                        )
+                    )
+                }
+            }
+            workspaces = flattened
         }
 
         var payload: [String: Any] = [
@@ -21154,6 +21183,46 @@ class TerminalController {
             payload["created_terminal_id"] = createdTerminalID
         }
         return .ok(payload)
+    }
+
+    /// Serializes one workspace into the iOS-facing mobile workspace list shape.
+    ///
+    /// Shared by the single-window (scoped) and all-windows enumeration branches
+    /// of `v2MobileWorkspaceList` so the two never diverge. When
+    /// `requestedTerminalID` is non-nil the terminals array is filtered to that
+    /// one terminal (only the scoped branch passes it; the all-windows branch
+    /// always passes nil, so it lists every terminal). The scoped
+    /// terminal-not-found check is enforced by the caller after the list is built.
+    private func mobileWorkspacePayload(
+        workspace: Workspace,
+        isSelected: Bool,
+        requestedTerminalID: UUID?
+    ) -> [String: Any] {
+        let terminals = mobileTerminalPanels(in: workspace).compactMap { terminal -> [String: Any]? in
+            if let requestedTerminalID, terminal.id != requestedTerminalID {
+                return nil
+            }
+            return [
+                "id": terminal.id.uuidString,
+                "title": workspace.panelTitle(panelId: terminal.id) ?? terminal.displayTitle,
+                "current_directory": v2OrNull(
+                    mobileNonEmpty(workspace.panelDirectories[terminal.id])
+                        ?? mobileNonEmpty(terminal.directory)
+                        ?? mobileNonEmpty(terminal.requestedWorkingDirectory)
+                ),
+                "is_ready": terminal.surface.surface != nil,
+                "is_focused": terminal.id == workspace.focusedPanelId
+            ]
+        }
+
+        return [
+            "id": workspace.id.uuidString,
+            "title": workspace.title,
+            "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
+            "is_selected": isSelected,
+            "is_pinned": workspace.isPinned,
+            "terminals": terminals
+        ]
     }
 
     private enum MobileTerminalAliasUUID {

--- a/tests_v2/test_mobile_workspace_list_all_windows.py
+++ b/tests_v2/test_mobile_workspace_list_all_windows.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Regression test: mobile.workspace.list must include workspaces from EVERY open
+Mac window, not just the key/front window.
+
+Why: the iOS data-plane RPC `mobile.workspace.list` resolved a single window's
+TabManager (the key window) and returned only that window's workspaces, so the
+phone could never see workspaces that lived in other Mac windows.
+
+Coverage:
+- Two windows, each with a uniquely-named workspace. An unscoped
+  `mobile.workspace.list` returns both windows' workspaces.
+- `is_selected` is set for exactly one workspace: the selected workspace of the
+  frontmost/key window. No multi-selection.
+- Routing is unaffected: a `mobile.workspace.list` scoped to a workspace that
+  lives in the NON-key window still resolves that workspace via its owning
+  window, proving create/input/select resource resolution still works for
+  non-key-window workspaces.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+
+def _mobile_workspaces(client: cmux, params=None) -> list:
+    res = client._call("mobile.workspace.list", params or {}) or {}
+    return list(res.get("workspaces") or [])
+
+
+def _find(workspaces: list, workspace_id: str) -> dict:
+    for ws in workspaces:
+        if str(ws.get("id") or "").lower() == workspace_id.lower():
+            return ws
+    return {}
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        client.activate_app()
+        time.sleep(0.2)
+
+        # Collapse to a single known window first.
+        window_a = client.current_window()
+        for row in client.list_windows():
+            other_id = str(row.get("id") or "")
+            if other_id and other_id != window_a:
+                client.close_window(other_id)
+        time.sleep(0.2)
+
+        client.focus_window(window_a)
+        client.activate_app()
+        time.sleep(0.2)
+
+        # Open a second window.
+        window_b = client.new_window()
+        time.sleep(0.25)
+
+        token = f"{int(time.time() * 1000)}"
+        title_a = f"mobile-list-a-{token}"
+        title_b = f"mobile-list-b-{token}"
+
+        workspace_a = client.new_workspace(window_id=window_a)
+        client.rename_workspace(title_a, workspace=workspace_a)
+
+        workspace_b = client.new_workspace(window_id=window_b)
+        client.rename_workspace(title_b, workspace=workspace_b)
+        time.sleep(0.25)
+
+        # Make window A the key/front window so its selected workspace is the
+        # one expected to carry is_selected. Select workspace_a explicitly.
+        client.focus_window(window_a)
+        client.activate_app()
+        client.select_workspace(workspace_a)
+        time.sleep(0.25)
+
+        # --- Assertion 1: both windows' workspaces appear in one list. ---
+        workspaces = _mobile_workspaces(client)
+        ids = {str(ws.get("id") or "").lower() for ws in workspaces}
+        if workspace_a.lower() not in ids:
+            raise cmuxError(
+                f"mobile.workspace.list missing window-A workspace {workspace_a}; "
+                f"got {sorted(ids)}"
+            )
+        if workspace_b.lower() not in ids:
+            raise cmuxError(
+                f"mobile.workspace.list missing window-B (non-key) workspace "
+                f"{workspace_b}; got {sorted(ids)}. This is the bug: the phone "
+                f"only saw the key window's workspaces."
+            )
+
+        # --- Assertion 2: exactly one is_selected, and it is window A's. ---
+        selected = [
+            str(ws.get("id") or "").lower()
+            for ws in workspaces
+            if bool(ws.get("is_selected"))
+        ]
+        if selected != [workspace_a.lower()]:
+            raise cmuxError(
+                f"expected exactly window-A workspace {workspace_a} to be "
+                f"is_selected; got selected={selected}"
+            )
+
+        # --- Assertion 3: routing to the NON-key window's workspace works. ---
+        # A scoped list naming workspace_b (which lives in window B, not the key
+        # window) must still resolve and return that workspace, proving resource
+        # resolution for non-key-window workspaces is intact.
+        scoped = _mobile_workspaces(client, {"workspace_id": workspace_b})
+        scoped_b = _find(scoped, workspace_b)
+        if not scoped_b:
+            raise cmuxError(
+                f"scoped mobile.workspace.list(workspace_id={workspace_b}) did "
+                f"not resolve the non-key-window workspace; got {scoped}"
+            )
+        # Scoped to a single workspace, the result should be exactly that one.
+        if len(scoped) != 1:
+            raise cmuxError(
+                f"scoped mobile.workspace.list(workspace_id={workspace_b}) "
+                f"should return exactly one workspace; got {len(scoped)}: {scoped}"
+            )
+
+    print(
+        "PASS: mobile.workspace.list includes workspaces from all windows, "
+        "marks only the key window's selection, and still routes scoped "
+        "non-key-window requests"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Fixes the iOS app only showing workspaces from one Mac window. `v2MobileWorkspaceList` (Mac-side) resolved a single window's `TabManager` (key window) and returned only its tabs.
- When no `workspace_id`/`window_id` is named, it now iterates ALL registered main windows (`listMainWindowSummaries()` + `tabManagerFor(windowId:)`) and flattens every window's tabs into one deduped list. `is_selected` is computed from the frontmost window only (exactly one). Scoped requests keep single-window behavior, so create/input/select routing via `v2ResolveTabManager` is unaffected (a non-key-window workspace_id still resolves its owning window).

## Testing
- New `tests_v2/test_mobile_workspace_list_all_windows.py`: opens two windows, asserts the unscoped list returns BOTH windows' workspaces (red→green), exactly the front window's selection has `is_selected`, and a scoped list of a non-key-window workspace still resolves (routing proof). Runs against a tagged instance in CI.
- Autoreview: patch correct (0.84), clean.

## Notes
- Composes with the in-flight all-devices feature (iOS aggregates all Macs × all windows). Known minor limitation: a pure cross-window focus change won't re-push `is_selected` until the next mutation refresh (pre-existing, not a regression).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783421739&installation_id=133855650&pr_number=5565&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5565&signature=c34c4f8c87eb2ffb160ea37e927e5863e190216221aaaed2cbf91f6b4af612cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS-facing RPC enumeration and selection semantics across multiple windows; scoped paths are preserved but unscoped clients now see a larger, deduped list.
> 
> **Overview**
> **Unscoped** `mobile.workspace.list` (`v2MobileWorkspaceList`) no longer reads only one window’s `TabManager`; it walks every registered main window via `listMainWindowSummaries()` and `tabManagerFor(windowId:)`, dedupes window/workspace IDs, and returns one flattened workspace list so iOS can see tabs in non-front windows.
> 
> **Scoped** calls are unchanged: when `workspace_id`, `window_id`, a terminal alias, or an explicit `resolvedTabManager` is present, listing still goes through `v2ResolveTabManager` in a single window, including terminal-not-found handling. In the all-windows path, **`is_selected`** is true only for the selected tab of `currentScriptableMainWindow()` (one workspace app-wide). Workspace JSON is centralized in **`mobileWorkspacePayload`** so both branches stay aligned.
> 
> Adds **`tests_v2/test_mobile_workspace_list_all_windows.py`** for two-window listing, single `is_selected`, and scoped resolution of a workspace on a non-key window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b316fdc31dd0dcf415f95e78b44cd6c4b5d22df6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show all workspaces from every open Mac window in the iOS workspace list. Unscoped `mobile.workspace.list` now flattens across windows; scoped requests keep single-window behavior.

- **Bug Fixes**
  - Unscoped calls aggregate and dedupe workspaces from all main windows.
  - Only the frontmost window’s selected workspace is marked `is_selected`.
  - Scoped requests (`workspace_id`, `window_id`, terminal alias, or a provided `resolvedTabManager`) keep single-window routing and terminal-not-found checks; added a regression test covering two windows, selection, and scoped resolution.

<sup>Written for commit b316fdc31dd0dcf415f95e78b44cd6c4b5d22df6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace listing now includes workspaces from all open windows (not just the front window).
  * Selection state correctly reflects the selected workspace even when apps are backgrounded.
  * Workspaces are deduplicated across windows and scoped listing validates requested workspace presence.

* **Tests**
  * Added regression test to verify multi-window workspace listing and scoped workspace resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->