### PR TITLE
Notifications: cross-device dismiss-sync + stable id end-to-end

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileNotificationDismissedEvent.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileNotificationDismissedEvent.swift
@@ -1,0 +1,36 @@
+public import Foundation
+
+/// Typed decoder for a `notification.dismissed` push-event payload.
+///
+/// Emitted by the Mac when one or more delivered notifications are dismissed or
+/// cleared on the Mac (a banner swipe, "Mark read", or "Clear All"), so an
+/// attached phone can clear the matching mirrored banners. The payload carries
+/// only the stable notification ids (`{"ids": ["<uuid>", …]}`) and never any
+/// terminal content, so dismiss-sync is safe even when phone-forward
+/// hideContent is enabled.
+public struct MobileNotificationDismissedEvent: Decodable, Sendable {
+    /// The stable notification ids the Mac dismissed. These match the
+    /// `apns-collapse-id` of the corresponding delivered remote notifications, so
+    /// the phone can target them with
+    /// `removeDeliveredNotifications(withIdentifiers:)`.
+    public let ids: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case ids
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawIDs = try container.decodeIfPresent([String].self, forKey: .ids) ?? []
+        ids = rawIDs
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Decode a `notification.dismissed` event from a raw JSON payload.
+    /// - Parameter data: The event payload JSON.
+    /// - Returns: The decoded event, or `nil` when the payload is malformed.
+    public static func decode(_ data: Data) -> MobileNotificationDismissedEvent? {
+        try? JSONDecoder().decode(Self.self, from: data)
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeliveredNotificationClearing.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeliveredNotificationClearing.swift
@@ -1,0 +1,18 @@
+public import Foundation
+
+/// Clears already-delivered local notifications by identifier.
+///
+/// A seam over `UNUserNotificationCenter.removeDeliveredNotifications(withIdentifiers:)`
+/// so ``MobileShellComposite`` can react to a Mac-side `notification.dismissed`
+/// event without hardcoding the `UNUserNotificationCenter.current()` singleton.
+/// The production conformance is ``SystemDeliveredNotificationClearer``; tests
+/// inject a fake to assert which ids were cleared.
+///
+/// The identifiers are the delivered remote notifications' `request.identifier`,
+/// which (because the Mac stamps each push with `apns-collapse-id = notificationId`)
+/// equal the stable Mac-side notification ids carried in the dismiss event.
+public protocol DeliveredNotificationClearing: Sendable {
+    /// Remove the delivered notifications with the given identifiers, if present.
+    /// - Parameter ids: The delivered-notification identifiers to clear.
+    func removeDelivered(ids: [String])
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -40,9 +40,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         var eventTopics: [String] {
             switch self {
             case .renderGrid:
-                return ["workspace.updated", "terminal.render_grid"]
+                return ["workspace.updated", "terminal.render_grid", "notification.dismissed"]
             case .rawBytes:
-                return ["workspace.updated", "terminal.bytes"]
+                return ["workspace.updated", "terminal.bytes", "notification.dismissed"]
             }
         }
     }
@@ -155,6 +155,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private let pairedMacStore: (any MobilePairedMacStoring)?
     private let identityProvider: (any MobileIdentityProviding)?
     private let reachability: any ReachabilityProviding
+    private let deliveredNotificationClearer: any DeliveredNotificationClearing
     private let pairingHintDefaults: UserDefaults
     private let clientID: String
     private var remoteClient: MobileCoreRPCClient? {
@@ -234,12 +235,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         clientIDRepository: MobileClientIDRepository = MobileClientIDRepository(defaults: .standard),
         identityProvider: (any MobileIdentityProviding)? = nil,
         reachability: any ReachabilityProviding = ReachabilityService(),
+        deliveredNotificationClearer: any DeliveredNotificationClearing = SystemDeliveredNotificationClearer(),
         pairingHintDefaults: UserDefaults = .standard
     ) {
         self.runtime = runtime
         self.pairedMacStore = pairedMacStore
         self.identityProvider = identityProvider
         self.reachability = reachability
+        self.deliveredNotificationClearer = deliveredNotificationClearer
         self.pairingHintDefaults = pairingHintDefaults
         // Distinguish "key absent" (an install that predates the hint and may
         // already have a paired Mac in SQLite) from "key present and false" (we
@@ -447,6 +450,50 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
+    }
+
+    // MARK: - Notification dismiss-sync
+
+    /// Tell the Mac that one or more mirrored notifications were dismissed on
+    /// this phone (a swipe/clear on the delivered banner). The Mac marks them
+    /// read and clears its own banner; its store then emits `notification.dismissed`
+    /// back, which is a harmless no-op for the already-removed phone banner.
+    ///
+    /// Fire-and-forget against the authoritative Mac store. Carries only opaque
+    /// notification UUIDs, never terminal content, so it is safe regardless of
+    /// the Mac's phone-forward hideContent setting.
+    /// - Parameter ids: The stable notification ids the user dismissed.
+    public func dismissNotification(ids: [String]) async {
+        let trimmed = ids
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !trimmed.isEmpty, let client = remoteClient else { return }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "notification.dismiss",
+                params: [
+                    "notification_ids": trimmed,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            mobileShellLog.error("notification dismiss sync failed count=\(trimmed.count, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Clear delivered banners on this phone in response to a Mac-side dismiss
+    /// (`notification.dismissed` peer event). The stable notification id was sent
+    /// to APNs as the `apns-collapse-id`, so the delivered remote notification's
+    /// `request.identifier` equals that id, which is what the injected
+    /// ``DeliveredNotificationClearing`` seam matches on.
+    /// - Parameter ids: The notification ids the Mac dismissed.
+    public func clearDeliveredNotifications(ids: [String]) {
+        let trimmed = ids
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !trimmed.isEmpty else { return }
+        deliveredNotificationClearer.removeDelivered(ids: trimmed)
     }
 
     // MARK: - Network recovery
@@ -1984,6 +2031,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     // pty-tee. This is the compatibility fallback when the Mac
                     // host does not advertise `terminal.render_grid.v1`.
                     self.handleTerminalBytesEvent(event)
+                } else if event.topic == "notification.dismissed" {
+                    // The Mac dismissed/cleared notifications; clear the matching
+                    // mirrored banners on this phone.
+                    self.handleNotificationDismissedEvent(event)
                 }
             }
             guard let self else { return }
@@ -2398,6 +2449,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         #endif
         guard !bytes.isEmpty else { return }
         deliverTerminalBytes(bytes, surfaceID: renderGrid.surfaceID)
+    }
+
+    private func handleNotificationDismissedEvent(_ event: MobileEventEnvelope) {
+        guard
+            let json = event.payloadJSON,
+            let payload = MobileNotificationDismissedEvent.decode(json),
+            !payload.ids.isEmpty
+        else {
+            return
+        }
+        clearDeliveredNotifications(ids: payload.ids)
     }
 
     private func handleTerminalBytesEvent(_ event: MobileEventEnvelope) {

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/SystemDeliveredNotificationClearer.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/SystemDeliveredNotificationClearer.swift
@@ -1,0 +1,19 @@
+public import Foundation
+internal import UserNotifications
+
+/// Production ``DeliveredNotificationClearing`` backed by the system
+/// `UNUserNotificationCenter`.
+///
+/// `removeDeliveredNotifications(withIdentifiers:)` is available on both iOS and
+/// macOS; clearing is a best-effort fire-and-forget that never blocks the
+/// caller. This is the default the app composition root supplies to
+/// ``MobileShellComposite``.
+public struct SystemDeliveredNotificationClearer: DeliveredNotificationClearing {
+    /// Creates a clearer over the shared notification center.
+    public init() {}
+
+    public func removeDelivered(ids: [String]) {
+        guard !ids.isEmpty else { return }
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: ids)
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellDismissSyncTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellDismissSyncTests.swift
@@ -1,0 +1,67 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Records the ids passed to `removeDelivered` so a test can assert the Mac→iOS
+/// dismiss-sync clears exactly the notifications the Mac dismissed, without
+/// touching the real `UNUserNotificationCenter`. `@MainActor`-isolated because
+/// the composite under test calls `removeDelivered` synchronously on the main
+/// actor, so no lock is needed to keep the recorded state consistent.
+@MainActor
+private final class RecordingDeliveredNotificationClearer: DeliveredNotificationClearing {
+    private(set) var clearedIDs: [[String]] = []
+
+    nonisolated init() {}
+
+    nonisolated func removeDelivered(ids: [String]) {
+        MainActor.assumeIsolated {
+            clearedIDs.append(ids)
+        }
+    }
+}
+
+/// Behavior tests for the phone-side half of cross-device notification
+/// dismiss-sync: a Mac `notification.dismissed` event must clear the matching
+/// delivered banners through the injected ``DeliveredNotificationClearing`` seam.
+@MainActor
+@Suite struct MobileShellDismissSyncTests {
+    private func makeStore(
+        clearer: any DeliveredNotificationClearing
+    ) -> MobileShellComposite {
+        MobileShellComposite(
+            workspaces: [],
+            deliveredNotificationClearer: clearer,
+            pairingHintDefaults: UserDefaults(suiteName: "dismiss-sync-\(UUID().uuidString)")!
+        )
+    }
+
+    @Test func clearsDeliveredBannersForDismissedIDs() {
+        let clearer = RecordingDeliveredNotificationClearer()
+        let store = makeStore(clearer: clearer)
+
+        store.clearDeliveredNotifications(ids: ["n-1", "n-2"])
+
+        #expect(clearer.clearedIDs == [["n-1", "n-2"]])
+    }
+
+    @Test func trimsAndDropsBlankIDsBeforeClearing() {
+        let clearer = RecordingDeliveredNotificationClearer()
+        let store = makeStore(clearer: clearer)
+
+        store.clearDeliveredNotifications(ids: ["  n-3  ", "", "   "])
+
+        #expect(clearer.clearedIDs == [["n-3"]])
+    }
+
+    @Test func noOpsWhenNoUsableIDs() {
+        let clearer = RecordingDeliveredNotificationClearer()
+        let store = makeStore(clearer: clearer)
+
+        store.clearDeliveredNotifications(ids: ["", "   "])
+
+        #expect(clearer.clearedIDs.isEmpty)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
@@ -26,6 +26,14 @@ public final class MobilePushCoordinator {
     private nonisolated(unsafe) let defaults: UserDefaults
     private static let enabledKey = "cmux.notifications.pushEnabled"
 
+    /// APNs `aps.category` the web sets on every cmux terminal push (see
+    /// `CMUX_APNS_CATEGORY` in `web/services/apns/payload.ts`). The matching
+    /// ``UNNotificationCategory`` registered below carries
+    /// `.customDismissAction`, so a swipe/clear delivers
+    /// `UNNotificationDismissActionIdentifier` to the app and we can forward the
+    /// dismiss to the Mac. Keep these two ids in sync.
+    public static let dismissSyncCategoryIdentifier = "cmux.terminal"
+
     @ObservationIgnored private weak var store: CMUXMobileShellStore?
 
     /// Creates a push coordinator.
@@ -46,11 +54,23 @@ public final class MobilePushCoordinator {
         self.store = store
     }
 
-    /// Install the notification-center delegate and, if already opted in,
-    /// re-assert remote registration so a rotated token re-uploads. Call once at
-    /// launch from the AppDelegate.
+    /// Install the notification-center delegate, register the dismiss-sync
+    /// notification category, and, if already opted in, re-assert remote
+    /// registration so a rotated token re-uploads. Call once at launch from the
+    /// AppDelegate.
     public func configure(delegate: any UNUserNotificationCenterDelegate) {
-        UNUserNotificationCenter.current().delegate = delegate
+        let center = UNUserNotificationCenter.current()
+        center.delegate = delegate
+        // The category must carry `.customDismissAction` so a swipe/clear of a
+        // cmux banner delivers `UNNotificationDismissActionIdentifier` to the
+        // delegate; that is what lets us tell the Mac the user dismissed it.
+        let dismissSyncCategory = UNNotificationCategory(
+            identifier: Self.dismissSyncCategoryIdentifier,
+            actions: [],
+            intentIdentifiers: [],
+            options: [.customDismissAction]
+        )
+        center.setNotificationCategories([dismissSyncCategory])
         if isEnabled {
             UIApplication.shared.registerForRemoteNotifications()
         }
@@ -111,6 +131,19 @@ public final class MobilePushCoordinator {
         if let surfaceId {
             store.selectTerminal(MobileTerminalPreview.ID(rawValue: surfaceId))
         }
+    }
+
+    /// Forward a phone-side notification dismissal to the paired Mac so it marks
+    /// the notification read and clears its own banner. Fire-and-forget over the
+    /// attach channel; carries only the opaque notification id, never content.
+    /// - Parameter notificationId: The stable id of the dismissed notification.
+    ///   For a remote push this is `request.identifier` (the `apns-collapse-id`),
+    ///   with `cmux.notificationId` as a fallback.
+    public func handleDismiss(notificationId: String?) async {
+        guard let store,
+              let notificationId,
+              !notificationId.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        await store.dismissNotification(ids: [notificationId])
     }
 }
 #endif

--- a/Sources/Cloud/PhonePushClient.swift
+++ b/Sources/Cloud/PhonePushClient.swift
@@ -56,6 +56,7 @@ final class PhonePushClient {
             body: notification.body,
             workspaceId: notification.tabId.uuidString,
             surfaceId: notification.surfaceId?.uuidString,
+            notificationId: notification.id.uuidString,
             hideContent: hideContent
         )
         Task { await send(payload) }
@@ -67,6 +68,11 @@ final class PhonePushClient {
         let body: String
         let workspaceId: String
         let surfaceId: String?
+        /// Stable notification id (the Mac store ``TerminalNotification/id``).
+        /// Travels to APNs as both an `apns-collapse-id` (so a later Mac→iOS
+        /// dismiss can target the delivered banner) and `cmux.notificationId`
+        /// (so an iOS swipe can tell the Mac which notification was dismissed).
+        let notificationId: String
         let hideContent: Bool
     }
 
@@ -95,6 +101,8 @@ final class PhonePushClient {
             "subtitle": payload.hideContent ? "" : payload.subtitle,
             "body": payload.hideContent ? "New terminal activity" : payload.body,
             "workspaceId": payload.workspaceId,
+            // Opaque UUID, not content: safe to send even when hideContent is on.
+            "notificationId": payload.notificationId,
             "hideContent": payload.hideContent,
         ]
         if let surfaceId = payload.surfaceId { bodyDict["surfaceId"] = surfaceId }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -299,6 +299,7 @@ final class MobileHostService {
     /// like rename/pin on the entries present here.
     nonisolated static let mobileHostCapabilities: [String] = [
         "events.v1",
+        "notification.dismiss.v1",
         "terminal.bytes.v1",
         "terminal.render_grid.v1",
         "terminal.replay.v1",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20686,12 +20686,61 @@ class TerminalController {
             result = v2MobileTerminalMouse(params: request.params)
         case "workspace.action":
             result = v2MobileWorkspaceAction(params: request.params)
+        case "notification.dismiss":
+            result = v2MobileNotificationDismiss(params: request.params)
         default:
             result = .err(code: "method_not_found", message: "Unknown mobile method", data: [
                 "method": request.method
             ])
         }
         return mobileHostResult(result)
+    }
+
+    /// Mark notifications read on the Mac in response to the user dismissing the
+    /// mirrored banner on a paired phone. Accepts either a single `notification_id`
+    /// or a `notification_ids` array; ignores unknown/malformed ids.
+    ///
+    /// Deliberately uses ``TerminalNotificationStore/markRead(id:)`` — NOT
+    /// `remove` — so it mirrors a Mac banner *swipe* (which the Mac's own
+    /// `UNUserNotificationCenterDelegate` handles via `markRead`, keeping the
+    /// entry in the notification list while clearing the banner + unread). This
+    /// is distinct from the socket `notification.dismiss` verb
+    /// (``v2NotificationDismiss(params:)``), which fully `remove`s the entry. The
+    /// resulting `markRead` emits `notification.dismissed` back, a harmless no-op
+    /// for the already-removed phone banner. Carries only opaque UUIDs, never
+    /// terminal content.
+    private func v2MobileNotificationDismiss(params: [String: Any]) -> V2CallResult {
+        var rawIDs: [String] = []
+        if let single = v2OptionalTrimmedRawString(params, "notification_id") {
+            rawIDs.append(single)
+        }
+        if let array = params["notification_ids"] as? [Any] {
+            for value in array {
+                if let string = (value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !string.isEmpty {
+                    rawIDs.append(string)
+                }
+            }
+        }
+        let ids = rawIDs.compactMap { UUID(uuidString: $0) }
+        guard !ids.isEmpty else {
+            return .err(
+                code: "invalid_params",
+                message: "Missing or invalid notification_id / notification_ids",
+                data: nil
+            )
+        }
+        let store = TerminalNotificationStore.shared
+        // `dismissed` counts notifications that actually transitioned unread→read,
+        // not the number of ids supplied: unknown or already-read ids are no-ops,
+        // so a stale/duplicate phone dismiss reports 0 rather than a misleading hit.
+        let unreadIDs = Set(store.notifications.filter { !$0.isRead }.map(\.id))
+        var dismissed = 0
+        for id in ids where unreadIDs.contains(id) {
+            store.markRead(id: id)
+            dismissed += 1
+        }
+        return .ok(["dismissed": dismissed])
     }
 
     /// The `workspace.action` sub-actions the mobile data plane may invoke.

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -837,6 +837,28 @@ final class TerminalNotificationStore: ObservableObject {
 
     static let categoryIdentifier = "com.cmuxterm.app.userNotification"
     static let actionShowIdentifier = "com.cmuxterm.app.userNotification.show"
+
+    /// Mobile-host event topic the Mac emits when one or more delivered
+    /// notifications are dismissed/cleared on this Mac, so an attached phone can
+    /// clear the matching banners it is mirroring. Payload carries only the
+    /// stable notification ids (`["ids": [String]]`) — never any terminal
+    /// content — so dismiss-sync is safe even with phone-forward hideContent on.
+    static let dismissedEventTopic = "notification.dismissed"
+
+    /// Forwards a dismiss/clear to any attached phone over the peer mobile-host
+    /// channel. Call only from the change-confirmed branch of a user-driven
+    /// read/clear/remove path, so the Mac→iOS→Mac echo can't loop. Session
+    /// restore / surface rebind paths must NOT call this: they reassign ids on
+    /// churn and would clear a phone banner that should persist.
+    private func emitNotificationsDismissed(ids: [String]) {
+        guard !ids.isEmpty else { return }
+        // nonisolated static fan-out; short-circuits when no phone is subscribed.
+        MobileHostService.emitEvent(
+            topic: Self.dismissedEventTopic,
+            payload: ["ids": ids]
+        )
+    }
+
     private enum AuthorizationRequestOrigin: String {
         case notificationDelivery = "notification_delivery"
         case settingsButton = "settings_button"
@@ -1542,6 +1564,11 @@ final class TerminalNotificationStore: ObservableObject {
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            // A newer notification for this tab+surface superseded the old one and
+            // its Mac banner was just cleared; clear the superseded phone banner
+            // too. The new notification carries a different id (and APNs
+            // collapse-id), so without this the phone would stack both.
+            emitNotificationsDismissed(ids: idsToClear)
         }
         deliverNotificationSideEffects(
             notification,
@@ -1647,6 +1674,7 @@ final class TerminalNotificationStore: ObservableObject {
         updated[index].isRead = true
         notifications = updated
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
+        emitNotificationsDismissed(ids: [id.uuidString])
     }
 
     func markUnread(id: UUID) {
@@ -1684,6 +1712,7 @@ final class TerminalNotificationStore: ObservableObject {
         setWorkspaceRestoredUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
+            emitNotificationsDismissed(ids: idsToClear)
         }
     }
 
@@ -1709,6 +1738,7 @@ final class TerminalNotificationStore: ObservableObject {
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            emitNotificationsDismissed(ids: idsToClear)
         }
     }
 
@@ -1786,6 +1816,7 @@ final class TerminalNotificationStore: ObservableObject {
         if !idsToClear.isEmpty {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            emitNotificationsDismissed(ids: idsToClear)
         }
     }
 
@@ -1800,6 +1831,7 @@ final class TerminalNotificationStore: ObservableObject {
             clearFocusedReadIndicator(forTabId: removed.tabId, surfaceId: removed.surfaceId)
         }
         center.removeDeliveredNotificationsOffMain(withIdentifiers: [id.uuidString])
+        emitNotificationsDismissed(ids: [id.uuidString])
     }
 
     func restoreSessionNotifications(_ restoredNotifications: [TerminalNotification], forTabId tabId: UUID) {
@@ -1876,6 +1908,7 @@ final class TerminalNotificationStore: ObservableObject {
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
         center.removePendingNotificationRequestsOffMain(withIdentifiers: ids)
+        emitNotificationsDismissed(ids: ids)
     }
 
     func clearNotifications(
@@ -1908,6 +1941,7 @@ final class TerminalNotificationStore: ObservableObject {
             CmuxEventBus.shared.publishNotificationCleared(ids: idsToClear, workspaceId: tabId, surfaceId: surfaceId)
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            emitNotificationsDismissed(ids: idsToClear)
         }
     }
 
@@ -1973,6 +2007,7 @@ final class TerminalNotificationStore: ObservableObject {
             CmuxEventBus.shared.publishNotificationCleared(ids: idsToClear, workspaceId: tabId, surfaceId: nil)
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
+            emitNotificationsDismissed(ids: idsToClear)
         }
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1661,6 +1661,116 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         )
     }
 
+    // MARK: - notification.dismiss (cross-device dismiss-sync)
+
+    /// A phone-side banner swipe routes `notification.dismiss` over the mobile
+    /// host channel and must mark the matching Mac notification *read* (banner
+    /// cleared, entry retained), mirroring a Mac-side banner swipe — NOT remove
+    /// it like the socket `notification.dismiss` verb.
+    func testMobileNotificationDismissMarksReadAndKeepsEntry() async throws {
+        let store = TerminalNotificationStore.shared
+        let previousNotifications = store.notifications
+        defer { store.replaceNotificationsForTesting(previousNotifications) }
+
+        let tabId = UUID()
+        let target = TerminalNotification(
+            id: UUID(), tabId: tabId, surfaceId: UUID(),
+            title: "Dismiss me", subtitle: "", body: "body",
+            createdAt: Date(timeIntervalSince1970: 1_778_000_000), isRead: false
+        )
+        let sibling = TerminalNotification(
+            id: UUID(), tabId: tabId, surfaceId: UUID(),
+            title: "Keep me", subtitle: "", body: "body",
+            createdAt: Date(timeIntervalSince1970: 1_778_000_001), isRead: false
+        )
+        store.replaceNotificationsForTesting([target, sibling])
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "dismiss",
+                method: "notification.dismiss",
+                params: ["notification_id": target.id.uuidString],
+                auth: nil
+            )
+        )
+
+        guard case let .ok(rawPayload) = response,
+              let payload = rawPayload as? [String: Any] else {
+            XCTFail("Expected notification.dismiss to succeed, got \(response)")
+            return
+        }
+        XCTAssertEqual(payload["dismissed"] as? Int, 1)
+        // markRead, not remove: both entries remain in the store.
+        XCTAssertEqual(store.notifications.first(where: { $0.id == target.id })?.isRead, true)
+        XCTAssertEqual(store.notifications.first(where: { $0.id == sibling.id })?.isRead, false)
+        XCTAssertEqual(store.notifications.count, 2)
+    }
+
+    /// A batched Mac clear (e.g. "Mark all read" on the phone) sends an id array;
+    /// every listed notification is marked read, unknown ids are ignored.
+    func testMobileNotificationDismissAcceptsIdArrayAndIgnoresUnknownIds() async throws {
+        let store = TerminalNotificationStore.shared
+        let previousNotifications = store.notifications
+        defer { store.replaceNotificationsForTesting(previousNotifications) }
+
+        let tabId = UUID()
+        let first = TerminalNotification(
+            id: UUID(), tabId: tabId, surfaceId: UUID(),
+            title: "One", subtitle: "", body: "body",
+            createdAt: Date(timeIntervalSince1970: 1_778_000_000), isRead: false
+        )
+        let second = TerminalNotification(
+            id: UUID(), tabId: tabId, surfaceId: UUID(),
+            title: "Two", subtitle: "", body: "body",
+            createdAt: Date(timeIntervalSince1970: 1_778_000_001), isRead: false
+        )
+        store.replaceNotificationsForTesting([first, second])
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "dismiss-batch",
+                method: "notification.dismiss",
+                params: [
+                    "notification_ids": [
+                        first.id.uuidString,
+                        UUID().uuidString, // unknown id, ignored by markRead
+                        second.id.uuidString,
+                    ]
+                ],
+                auth: nil
+            )
+        )
+
+        guard case let .ok(rawPayload) = response,
+              let payload = rawPayload as? [String: Any] else {
+            XCTFail("Expected batched notification.dismiss to succeed, got \(response)")
+            return
+        }
+        // dismissed counts real unread→read transitions: the two known unread
+        // notifications, not the ignored unknown id.
+        XCTAssertEqual(payload["dismissed"] as? Int, 2)
+        XCTAssertEqual(store.notifications.first(where: { $0.id == first.id })?.isRead, true)
+        XCTAssertEqual(store.notifications.first(where: { $0.id == second.id })?.isRead, true)
+    }
+
+    /// A request with no usable id is a client bug, not a silent no-op.
+    func testMobileNotificationDismissRejectsMissingId() async throws {
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "dismiss-bad",
+                method: "notification.dismiss",
+                params: ["notification_id": "not-a-uuid"],
+                auth: nil
+            )
+        )
+
+        guard case let .failure(error) = response else {
+            XCTFail("Expected malformed notification.dismiss to fail, got \(response)")
+            return
+        }
+        XCTAssertEqual(error.code, "invalid_params")
+    }
+
 #if DEBUG
     func testMobileWorkspaceCreateSkipsHiddenMacSideWorkAndReturnsCreatedScopeOnly() async throws {
         let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()

--- a/ios/cmux/CmuxAppDelegate.swift
+++ b/ios/cmux/CmuxAppDelegate.swift
@@ -48,10 +48,27 @@ final class CmuxAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
-        let ids = Self.cmuxIDs(from: response.notification.request.content.userInfo)
+        let request = response.notification.request
+        // A swipe/clear of a cmux banner delivers the custom dismiss action
+        // (enabled via the `cmux.terminal` category's `.customDismissAction`).
+        // Forward it to the Mac so the desktop banner + store entry clear too.
+        if response.actionIdentifier == UNNotificationDismissActionIdentifier {
+            await pushCoordinator?.handleDismiss(
+                notificationId: Self.notificationID(from: request)
+            )
+            return
+        }
+        // A tap (default action) deep-links to the workspace/terminal AND marks
+        // the notification read on the Mac, mirroring the Mac's own tap path
+        // (which opens + marks read). The two compose: deep-link locally, clear
+        // on the Mac.
+        let ids = Self.cmuxIDs(from: request.content.userInfo)
         await pushCoordinator?.handleTap(
             workspaceId: ids.workspaceId,
             surfaceId: ids.surfaceId
+        )
+        await pushCoordinator?.handleDismiss(
+            notificationId: Self.notificationID(from: request)
         )
     }
 
@@ -60,5 +77,24 @@ final class CmuxAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
     ) -> (workspaceId: String?, surfaceId: String?) {
         guard let cmux = userInfo["cmux"] as? [String: Any] else { return (nil, nil) }
         return (cmux["workspaceId"] as? String, cmux["surfaceId"] as? String)
+    }
+
+    /// The stable Mac-side notification id for a delivered request, or `nil` when
+    /// this push does not carry one.
+    ///
+    /// The `cmux.notificationId` payload key is authoritative: the Mac stamps the
+    /// same value as `apns-collapse-id`, so it equals `request.identifier` for a
+    /// modern push. We deliberately do NOT fall back to a bare `request.identifier`
+    /// when the payload key is absent: a push without `notificationId` (an older
+    /// Mac, or any push that omitted it) has an OS-assigned random identifier that
+    /// matches no Mac notification, so forwarding it would mark the wrong (or no)
+    /// notification read. Returning `nil` degrades cleanly to "no dismiss-sync".
+    private nonisolated static func notificationID(from request: UNNotificationRequest) -> String? {
+        guard let cmux = request.content.userInfo["cmux"] as? [String: Any],
+              let id = (cmux["notificationId"] as? String)?.trimmingCharacters(in: .whitespaces),
+              !id.isEmpty else {
+            return nil
+        }
+        return id
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -1851,7 +1851,7 @@ final class TerminalOutputCollector {
     await store.connectPairingURL(try attachURL(for: ticket).absoluteString)
 
     let subscribeRequests = try await waitForRequestCount("mobile.events.subscribe", count: 1, router: router)
-    #expect(subscribeRequests.first?.topics == ["workspace.updated", "terminal.render_grid"])
+    #expect(subscribeRequests.first?.topics == ["workspace.updated", "terminal.render_grid", "notification.dismissed"])
 
     collector.mount(store: store, surfaceID: "live-terminal")
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)

--- a/web/services/apns/payload.ts
+++ b/web/services/apns/payload.ts
@@ -19,15 +19,33 @@ export interface ApnsNotificationInput {
   readonly body: string;
   readonly workspaceId?: string | null;
   readonly surfaceId?: string | null;
+  /**
+   * Stable Mac-side notification id. Surfaced in the payload as
+   * `cmux.notificationId` so an iOS swipe-dismiss can tell the Mac which
+   * notification was cleared. The sender also stamps it as `apns-collapse-id`
+   * so a later Mac→iOS dismiss can target this exact delivered banner.
+   */
+  readonly notificationId?: string | null;
   /** When true, replace real terminal text with a generic fallback. Keep the
    * fallback literal until device tokens carry client localization capability. */
   readonly hideContent?: boolean;
 }
 
 /**
- * Build the APNs JSON payload. Adds `cmux.workspaceId`/`cmux.surfaceId` custom
- * keys so a tapped notification can deep-link to the right terminal, and marks
- * the alert time-sensitive (the app holds that entitlement).
+ * APNs `aps.category` set on every cmux terminal push. iOS registers a
+ * matching ``UNNotificationCategory`` with `customDismissAction` so a
+ * swipe/clear delivers `UNNotificationDismissActionIdentifier` to the app,
+ * which forwards the dismiss to the Mac. Keep this in sync with the iOS
+ * category id.
+ */
+export const CMUX_APNS_CATEGORY = "cmux.terminal";
+
+/**
+ * Build the APNs JSON payload. Adds `cmux.workspaceId`/`cmux.surfaceId`/
+ * `cmux.notificationId` custom keys so a tapped notification can deep-link to
+ * the right terminal and a swipe can be dismiss-synced, sets the dismiss-action
+ * `category`, and marks the alert time-sensitive (the app holds that
+ * entitlement).
  */
 export function buildApnsPayload(input: ApnsNotificationInput): Record<string, unknown> {
   const hidden = input.hideContent === true;
@@ -43,11 +61,13 @@ export function buildApnsPayload(input: ApnsNotificationInput): Record<string, u
     alert,
     sound: "default",
     "interruption-level": "time-sensitive",
+    category: CMUX_APNS_CATEGORY,
   };
 
   const cmux: Record<string, string> = {};
   if (input.workspaceId) cmux.workspaceId = input.workspaceId;
   if (input.surfaceId) cmux.surfaceId = input.surfaceId;
+  if (input.notificationId) cmux.notificationId = input.notificationId;
 
   return Object.keys(cmux).length > 0 ? { aps, cmux } : { aps };
 }

--- a/web/services/apns/routePolicy.ts
+++ b/web/services/apns/routePolicy.ts
@@ -17,6 +17,12 @@ export type PushPayload = {
   readonly body: string;
   readonly workspaceId: string | null;
   readonly surfaceId: string | null;
+  /**
+   * Stable Mac-side notification id. Sent to APNs as `apns-collapse-id` and as
+   * `cmux.notificationId` so cross-device dismiss-sync can target the exact
+   * delivered banner. An opaque id, never terminal content.
+   */
+  readonly notificationId: string | null;
   readonly hideContent: boolean;
 };
 
@@ -58,12 +64,14 @@ export function parsePushPayload(body: Record<string, unknown>): PushPayloadResu
   const text = boundedString(body.body, MAX_PUSH_BODY_CHARS);
   const workspaceId = body.workspaceId == null ? "" : boundedString(body.workspaceId, MAX_PUSH_ID_CHARS);
   const surfaceId = body.surfaceId == null ? "" : boundedString(body.surfaceId, MAX_PUSH_ID_CHARS);
+  const notificationId = body.notificationId == null ? "" : boundedString(body.notificationId, MAX_PUSH_ID_CHARS);
 
   if (title == null) return { ok: false, error: "title_too_long" };
   if (subtitle == null) return { ok: false, error: "subtitle_too_long" };
   if (text == null) return { ok: false, error: "body_too_long" };
   if (workspaceId == null) return { ok: false, error: "workspace_id_too_long" };
   if (surfaceId == null) return { ok: false, error: "surface_id_too_long" };
+  if (notificationId == null) return { ok: false, error: "notification_id_too_long" };
   if (!title && !text) return { ok: false, error: "empty_notification" };
 
   return {
@@ -74,6 +82,7 @@ export function parsePushPayload(body: Record<string, unknown>): PushPayloadResu
       body: text,
       workspaceId: workspaceId || null,
       surfaceId: surfaceId || null,
+      notificationId: notificationId || null,
       hideContent: body.hideContent === true,
     },
   };

--- a/web/services/apns/sender.ts
+++ b/web/services/apns/sender.ts
@@ -104,6 +104,10 @@ export async function sendApnsNotification(
   if (targets.length === 0) return [];
   const jwt = providerToken(config);
   const body = Buffer.from(JSON.stringify(buildApnsPayload(input)));
+  // The delivered banner's identifier (the lever for Mac→iOS dismiss) IS the
+  // apns-collapse-id when set. APNs caps it at 64 bytes; a UUID is 36, but guard
+  // anyway so an over-long id degrades to "no collapse" instead of a 400.
+  const collapseId = collapseIdFor(input.notificationId);
 
   const byHost = new Map<string, ApnsTarget[]>();
   for (const t of targets) {
@@ -113,12 +117,19 @@ export async function sendApnsNotification(
 
   const results = await Promise.all(
     [...byHost.entries()].map(([host, hostTargets]) =>
-      sendHostGroup(transport, host, hostTargets, jwt, body, timeoutMs).catch(() =>
+      sendHostGroup(transport, host, hostTargets, jwt, body, timeoutMs, collapseId).catch(() =>
         connectionErrorResults(hostTargets),
       ),
     ),
   );
   return results.flat();
+}
+
+/** A valid (≤64-byte) apns-collapse-id for the notification id, or undefined. */
+function collapseIdFor(notificationId: string | null | undefined): string | undefined {
+  const id = notificationId?.trim();
+  if (!id) return undefined;
+  return Buffer.byteLength(id, "utf8") <= 64 ? id : undefined;
 }
 
 function connectionErrorResults(hostTargets: readonly ApnsTarget[]): ApnsSendResult[] {
@@ -137,6 +148,7 @@ async function sendHostGroup(
   jwt: string,
   body: Buffer,
   timeoutMs: number,
+  collapseId: string | undefined,
 ): Promise<ApnsSendResult[]> {
   let client: ApnsHttp2Session | null = null;
   try {
@@ -146,7 +158,9 @@ async function sendHostGroup(
     const connError: Promise<null> = new Promise((resolve) => {
       connectedClient.once("error", () => resolve(null));
     });
-    return await Promise.all(hostTargets.map((t) => sendOne(connectedClient, jwt, t, body, timeoutMs, connError)));
+    return await Promise.all(
+      hostTargets.map((t) => sendOne(connectedClient, jwt, t, body, timeoutMs, connError, collapseId)),
+    );
   } catch {
     return connectionErrorResults(hostTargets);
   } finally {
@@ -161,6 +175,7 @@ function sendOne(
   body: Buffer,
   timeoutMs: number,
   connError: Promise<null>,
+  collapseId: string | undefined,
 ): Promise<ApnsSendResult> {
   return new Promise<ApnsSendResult>((resolve) => {
     let settled = false;
@@ -173,7 +188,7 @@ function sendOne(
 
     let req: http2.ClientHttp2Stream;
     try {
-      req = client.request({
+      const headers: http2.OutgoingHttpHeaders = {
         ":method": "POST",
         ":path": `/3/device/${target.deviceToken}`,
         "apns-topic": target.bundleId,
@@ -181,7 +196,12 @@ function sendOne(
         authorization: `bearer ${jwt}`,
         "content-type": "application/json",
         "content-length": String(body.length),
-      });
+      };
+      // Sets the delivered notification's identifier on iOS, so a later
+      // notification.dismissed event can clear this exact banner. Also collapses
+      // repeated updates for the same notification into one.
+      if (collapseId) headers["apns-collapse-id"] = collapseId;
+      req = client.request(headers);
     } catch (err) {
       finish(0, err instanceof Error ? err.message : "request_error");
       return;

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -1,15 +1,18 @@
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
+import type http2 from "node:http2";
 import { describe, expect, test } from "bun:test";
 import {
   apnsHostForEnvironment,
   buildApnsPayload,
+  CMUX_APNS_CATEGORY,
   shouldPruneToken,
 } from "../services/apns/payload";
 import { summarizeApnsSendResults } from "../services/apns/response";
 import { sendApnsNotification, signApnsJwt, normalizeP8 } from "../services/apns/sender";
 import {
   MAX_PUSH_BODY_CHARS,
+  MAX_PUSH_ID_CHARS,
   normalizeApnsBundle,
   parsePushPayload,
   readBoundedJsonObject,
@@ -34,6 +37,33 @@ describe("apns payload", () => {
   test("omits cmux block when no ids", () => {
     const payload = buildApnsPayload({ title: "t", body: "b" }) as Record<string, unknown>;
     expect("cmux" in payload).toBe(false);
+  });
+
+  test("carries the stable notification id and dismiss-sync category", () => {
+    const payload = buildApnsPayload({
+      title: "claude",
+      body: "Agent finished",
+      workspaceId: "ws-1",
+      notificationId: "n-42",
+    }) as { aps: Record<string, unknown>; cmux: Record<string, string> };
+
+    // The category is what arms iOS customDismissAction; the cmux key lets an
+    // iOS swipe tell the Mac which notification was dismissed.
+    expect(payload.aps.category).toBe(CMUX_APNS_CATEGORY);
+    expect(payload.cmux).toEqual({ workspaceId: "ws-1", notificationId: "n-42" });
+  });
+
+  test("keeps the notification id even when content is hidden (id is not content)", () => {
+    const payload = buildApnsPayload({
+      title: "secret",
+      body: "secret output",
+      notificationId: "n-9",
+      hideContent: true,
+    }) as { aps: { alert: Record<string, string>; category: string }; cmux: Record<string, string> };
+
+    expect(payload.aps.alert.title).toBe("cmux");
+    expect(payload.aps.category).toBe(CMUX_APNS_CATEGORY);
+    expect(payload.cmux).toEqual({ notificationId: "n-9" });
   });
 
   test("hideContent redacts terminal content but keeps a generic compatibility body and deep-link", () => {
@@ -119,6 +149,7 @@ describe("apns route policy", () => {
       body: " done ",
       workspaceId: " ws-1 ",
       surfaceId: " sf-1 ",
+      notificationId: " n-1 ",
       hideContent: true,
     });
 
@@ -130,6 +161,7 @@ describe("apns route policy", () => {
         body: "done",
         workspaceId: "ws-1",
         surfaceId: "sf-1",
+        notificationId: "n-1",
         hideContent: true,
       },
     });
@@ -142,6 +174,26 @@ describe("apns route policy", () => {
       ok: false,
       error: "body_too_long",
     });
+  });
+
+  test("absent notificationId parses to null and over-long is rejected", () => {
+    const parsed = parsePushPayload({ title: "agent", body: "done" });
+    expect(parsed).toEqual({
+      ok: true,
+      value: {
+        title: "agent",
+        subtitle: null,
+        body: "done",
+        workspaceId: null,
+        surfaceId: null,
+        notificationId: null,
+        hideContent: false,
+      },
+    });
+
+    expect(
+      parsePushPayload({ title: "agent", body: "done", notificationId: "x".repeat(MAX_PUSH_ID_CHARS + 1) }),
+    ).toEqual({ ok: false, error: "notification_id_too_long" });
   });
 
   test("reads only bounded JSON objects from requests", async () => {
@@ -433,5 +485,93 @@ describe("apns sender transport", () => {
       { deviceToken: "b".repeat(64), status: 0, reason: "request failed", prune: false },
     ]);
     expect(closed).toEqual([productionHost]);
+  });
+
+  test("stamps apns-collapse-id from the notification id so the banner is dismiss-syncable", async () => {
+    const capturedHeaders: http2.OutgoingHttpHeaders[] = [];
+
+    class FakeRequest extends EventEmitter {
+      setTimeout() {
+        return this;
+      }
+      close() {
+        return this;
+      }
+      end() {
+        this.emit("response", { ":status": 200 });
+        this.emit("end");
+        return this;
+      }
+    }
+
+    class FakeSession extends EventEmitter {
+      request(headers: http2.OutgoingHttpHeaders) {
+        capturedHeaders.push(headers);
+        return new FakeRequest();
+      }
+      close() {}
+    }
+
+    const transport = {
+      connect: () => new FakeSession(),
+    } as unknown as Parameters<typeof sendApnsNotification>[4];
+
+    const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const p8 = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+    await sendApnsNotification(
+      { keyP8: p8, keyId: "KID-COLLAPSE", teamId: "TEAM456" },
+      [{ deviceToken: "a".repeat(64), bundleId: "com.cmuxterm.app", environment: "production" }],
+      { title: "agent", body: "done", notificationId: "n-7" },
+      1000,
+      transport,
+    );
+
+    expect(capturedHeaders).toHaveLength(1);
+    expect(capturedHeaders[0]["apns-collapse-id"]).toBe("n-7");
+  });
+
+  test("omits apns-collapse-id when there is no notification id", async () => {
+    const capturedHeaders: http2.OutgoingHttpHeaders[] = [];
+
+    class FakeRequest extends EventEmitter {
+      setTimeout() {
+        return this;
+      }
+      close() {
+        return this;
+      }
+      end() {
+        this.emit("response", { ":status": 200 });
+        this.emit("end");
+        return this;
+      }
+    }
+
+    class FakeSession extends EventEmitter {
+      request(headers: http2.OutgoingHttpHeaders) {
+        capturedHeaders.push(headers);
+        return new FakeRequest();
+      }
+      close() {}
+    }
+
+    const transport = {
+      connect: () => new FakeSession(),
+    } as unknown as Parameters<typeof sendApnsNotification>[4];
+
+    const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const p8 = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+
+    await sendApnsNotification(
+      { keyP8: p8, keyId: "KID-NO-COLLAPSE", teamId: "TEAM456" },
+      [{ deviceToken: "a".repeat(64), bundleId: "com.cmuxterm.app", environment: "production" }],
+      { title: "agent", body: "done" },
+      1000,
+      transport,
+    );
+
+    expect(capturedHeaders).toHaveLength(1);
+    expect("apns-collapse-id" in capturedHeaders[0]).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Mac notifications now carry their stable id through APNs (`cmux.notificationId` + `apns-collapse-id`), so a dismiss on one surface targets the same notification on the other (also fixes show-on-iOS: the delivered banner previously had an OS-random id unlinked from the Mac store).
- **iOS→Mac:** iOS `cmux.terminal` category gets `.customDismissAction`; swipe/tap → `notification.dismiss` mobile-host RPC → `TerminalNotificationStore.markRead`.
- **Mac→iOS:** user dismiss/clear emits a `notification.dismissed` peer event → iOS `removeDeliveredNotifications`. No-op guards break the echo loop.
- No central Durable Object (Mac stays source of truth, peer channel + APNs).

## Testing
- web apns suite (22), CmuxMobileShell dismiss-sync (15), app-target `notification.dismiss` id-routing — all pass. Autoreview clean (patch correct).
- App-target Swift compile gated by CI (GhosttyKit-heavy build kept off this Mac).

## Caveat / follow-up
- iOS→Mac dismiss only fires while the phone is attached + foregrounded. The common lock-screen swipe needs a reverse web/APNs "mark read" path — deferred Phase-2 follow-up (same shape as the deferred detached Mac→iOS silent push).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783424517&installation_id=133855650&pr_number=5568&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5568&signature=b15d38d837ffdbdf80d7b7e925abfeb2cdd2ec6678805be46cce44b75dc53f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification delivery, mobile RPC, and APNs payload shape; behavior is mostly id-only and mark-read, but older pushes without `notificationId` skip iOS→Mac sync and Mac-side emit paths must avoid dismiss loops.
> 
> **Overview**
> Adds **bidirectional notification dismiss-sync** between Mac and iPhone so clearing a mirrored terminal alert on one device clears the matching banner on the other.
> 
> **Stable notification id through APNs:** Mac phone-forwarding and the web push path now include `notificationId` as `cmux.notificationId` and `apns-collapse-id`, plus APNs category `cmux.terminal`. Delivered iOS banners can be targeted by id even when `hideContent` hides body text.
> 
> **iOS → Mac:** Registers a `UNNotificationCategory` with `customDismissAction`. Swipe or tap dismiss routes through `MobilePushCoordinator` / app delegate (only when `cmux.notificationId` is present) to mobile RPC `notification.dismiss`, which **marks read** on the Mac—not full socket `remove`.
> 
> **Mac → iOS:** `TerminalNotificationStore` emits peer event `notification.dismissed` with id-only payloads on user-driven read/clear/remove paths. `MobileShellComposite` subscribes and clears delivered notifications via an injectable `DeliveredNotificationClearing` seam.
> 
> Advertises `notification.dismiss.v1` on the mobile host; tests cover RPC behavior, APNs payload/collapse-id, and shell id trimming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b22af7b5255913ca3b4839c6e734ba1cab40760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs notification dismisses between Mac and iOS using a stable notification ID end-to-end. Dismissing a banner on one device now clears the matching banner on the other and fixes iOS delivery by avoiding OS-random IDs.

- **New Features**
  - APNs: adds `cmux.notificationId`, stamps `apns-collapse-id`, and sets category `cmux.terminal` for dismiss actions.
  - iOS: registers `cmux.terminal` with `.customDismissAction`; swipes/taps call `notification.dismiss` to the Mac.
  - Mac: handles `notification.dismiss` by marking read (not removing) and emits `notification.dismissed`; advertises `notification.dismiss.v1`.
  - iOS: subscribes to `notification.dismissed` and removes delivered banners by ID.
  - Loop-safe and privacy-safe: only opaque IDs are shared, never terminal content.

- **Migration**
  - No action required. Phase 1 limit: iOS→Mac dismiss fires only when the app is foregrounded and attached; lock-screen swipes will be handled in a follow-up.

<sup>Written for commit 9b22af7b5255913ca3b4839c6e734ba1cab40760. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cross-device notification dismissal: Dismiss a notification on your iPhone, iPad, or Mac, and it automatically removes the notification from all your other connected devices. Notification state now stays consistent across your entire system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->