### PR TITLE
iOS: repaint terminal on foreground (fix render-freeze after home-button background)

### DIFF
--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -617,6 +617,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// GPU is available so any in-flight render drains — and gate dispatch so
     /// no `render_now` is sent into the background.
     private var renderingSuspended: Bool = false
+    /// Set when a foreground transition (`didBecomeActive` / `willEnterForeground`)
+    /// reached this view but could not finish resuming the render loop because the
+    /// view was momentarily off-window or surfaceless. The next ``didMoveToWindow``
+    /// (window non-nil) completes the resume so the terminal repaints. Without
+    /// this, a foreground that races the SwiftUI representable re-attach would
+    /// clear suspension but never restart the display link, leaving the terminal
+    /// frozen on stale content while input (a separate RPC) still worked — the
+    /// home-button background→foreground render-freeze.
+    private var pendingForegroundResume: Bool = false
     #if DEBUG
     /// Last time the display-link heartbeat logged (DEBUG diagnostic). The
     /// per-frame callback runs on the main thread, so a steady heartbeat proves
@@ -935,6 +944,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     @objc private func handleAppWillEnterForeground() {
+        // `willEnterForeground` fires before `didBecomeActive` on every foreground
+        // (including the home-button case), so resume the render loop here too,
+        // not only from `didBecomeActive`. `resumeRendering` is idempotent and, if
+        // the view is momentarily off-window, arms `pendingForegroundResume` so
+        // `didMoveToWindow` completes the resume — the terminal repaints regardless
+        // of how the foreground notifications and the SwiftUI re-attach interleave.
+        resumeRendering()
         guard surface != nil, window != nil else { return }
         // The Mac drops this device's sticky viewport pin a few seconds after the
         // connection backgrounds, so on reconnect it reverts to its own (often
@@ -962,19 +978,53 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Resume the render loop once the app is active again.
     ///
-    /// A `render_now` in flight at suspend either drained (the GPU was still
-    /// available before background) or never dispatched, and its main-thread
-    /// completion may have been deferred while the queue was suspended — so clear
-    /// the in-flight flag to guarantee the first foreground frame can dispatch,
-    /// re-mark the surface visible, and restart the frame pump. Idempotent.
+    /// Called from both `willEnterForeground` and `didBecomeActive` (and indirectly
+    /// from `didMoveToWindow` via the pending-resume completion), so it must be
+    /// idempotent: the in-flight render gate is reset only on the suspended→active
+    /// transition, never on a second call while already running. Resetting it
+    /// unconditionally would race a `render_now` that a display-link tick enqueued
+    /// between the two foreground notifications — marking it not-in-flight defeats
+    /// the coalescing guard and lets extra renders pile on `outputQueue`.
     private func resumeRendering() {
+        let wasSuspended = renderingSuspended
         renderingSuspended = false
-        renderInFlight = false
-        needsAnotherRender = false
-        guard let surface, window != nil else { return }
-        ghostty_surface_set_occlusion(surface, true)  // true = visible
+        if wasSuspended {
+            // A `render_now` in flight at suspend either drained (the GPU was
+            // still available before background) or never dispatched, and its
+            // main-thread completion may have been deferred while the queue was
+            // suspended — clear the in-flight flag so the first foreground frame
+            // can dispatch. Safe here because no live render can be enqueued while
+            // suspended (`requestRender` early-returns on `renderingSuspended`).
+            renderInFlight = false
+            needsAnotherRender = false
+        }
+        guard let surface, window != nil else {
+            // The foreground notification reached this view before it was back
+            // on-window (a SwiftUI representable re-attach can race the scene
+            // becoming active). Suspension is already cleared, but the display
+            // link can't restart while detached — arm a pending resume so the
+            // next `didMoveToWindow` (window non-nil) finishes the job and the
+            // terminal repaints instead of staying frozen on stale content.
+            pendingForegroundResume = true
+            MobileDebugLog.anchormux("resume.skip hasSurface=\(surface != nil) win=\(window != nil) armedPending")
+            return
+        }
+        pendingForegroundResume = false
+        MobileDebugLog.anchormux("resume.enter restartingDisplayLink")
+        // Re-assert occlusion against the current view state (not unconditionally
+        // visible): a still-hidden/zero-size surface stays occluded so a stale
+        // present can't flash. `syncSurfaceVisibility` updates the cursor overlay.
+        syncSurfaceVisibility()
         setFocus(true)
+        // Force a fresh repaint at the correct size: the IOSurface may have lost
+        // its backing while backgrounded, so a single stale-size draw can land
+        // blank. Clearing `lastReportedSize` forces the natural grid to re-report
+        // even if it is unchanged (the Mac drops the sticky viewport pin while
+        // backgrounded), and the geometry resync guarantees the first foreground
+        // frame is sized and drawn from current content.
+        lastReportedSize = nil
         needsDraw = true
+        setNeedsGeometrySync(reassertNaturalSize: true)
         startDisplayLink()
     }
 
@@ -1395,12 +1445,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             #if DEBUG
             debugAccessibilityProxy.isAccessibilityElement = true
             #endif
-            setNeedsGeometrySync()
             setFocus(true)
             if autoFocusOnWindowAttach {
                 focusInput()
             }
-            startDisplayLink()
+            // Complete a foreground resume that arrived while the view was still
+            // off-window. `resumeRendering` (now back on-window) clears suspension
+            // — otherwise `requestRender` early-returns on every tick and the loop
+            // never paints again — and forces the full repaint (occlusion,
+            // viewport reassert, geometry resync, display link). For a normal
+            // attach (no pending resume) keep the lighter geometry sync + link
+            // restart so an unrelated reattach does not force a viewport re-report.
+            if pendingForegroundResume {
+                MobileDebugLog.anchormux("resume.completeOnAttach")
+                resumeRendering()
+            } else {
+                setNeedsGeometrySync()
+                startDisplayLink()
+            }
         } else {
             prepareForReuseAfterDetach()
         }
@@ -1810,7 +1872,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 ? Int((nowHeartbeat - lastOutputAppliedTime) * 1000)
                 : -1
             MobileDebugLog.anchormux(
-                "tick.alive win=\(window != nil) renderInFlight=\(renderInFlight) "
+                "tick.alive win=\(window != nil) suspended=\(renderingSuspended) "
+                + "renderInFlight=\(renderInFlight) "
                 + "needsDraw=\(needsDraw) contents=\(renderLayer?.contents != nil) "
                 + "surf=\(Int(renderSize.width))x\(Int(renderSize.height)) "
                 + "sinceOutput=\(sinceOutputMs)ms"


### PR DESCRIPTION
## Prior bad behavior

Backgrounding the iOS app with the home button (the app stays alive, not terminated) and then foregrounding it left the terminal frozen on stale content while typed keystrokes still reached the Mac. Input still works because it is a separate RPC; rendering is driven locally by a `CADisplayLink` over this device's own libghostty surface, and that render loop did not reliably restart on the foreground transition.

## Root cause

The local render loop is suspended on `willResignActive`/`didEnterBackground` (display link stopped, `renderingSuspended` set, surface occluded) and was resumed only from `didBecomeActive` via `resumeRendering()`. That resume bailed entirely if the view was momentarily off-window or surfaceless when `didBecomeActive` fired (a SwiftUI representable re-attach can race the scene becoming active): it cleared suspension but never restarted the display link, and nothing completed the resume afterward, so the surface stayed frozen even as fresh render-grid VT bytes arrived from the Mac. Even on the happy path it only flagged `needsDraw` without re-asserting occlusion or re-syncing geometry, so a stale-size draw against an IOSurface that lost its backing while backgrounded could land blank.

The render-grid stream re-subscribe + replay on foreground was already handled at the shell layer (`CMUXMobileRootView` → `resumeForegroundRefresh()` → `resyncTerminalOutput(restartEventStream: true)`), so the remaining gap was the local surface render loop.

## Fix

Make foreground resume robust and idempotent, independent of how the foreground notifications and the window re-attach interleave (all in `GhosttySurfaceView`):

- Resume from `willEnterForeground` too (fires before `didBecomeActive` on every foreground), not only `didBecomeActive`.
- When `resumeRendering()` can't finish because the view is off-window, arm `pendingForegroundResume`; `didMoveToWindow` (window non-nil) then completes the resume so the loop restarts and the terminal repaints.
- On resume, re-assert occlusion against actual view state (`syncSurfaceVisibility`), clear `lastReportedSize`, and force a geometry resync so the first foreground frame is sized and drawn from current content.
- Reset the in-flight render gate only on the suspended→active transition, so a second resume call cannot race a `render_now` enqueued between the two notifications and defeat the render-coalescing guard.

## Verification

- Builds clean for the iOS Simulator (`cmux-ios`, Debug).
- `autoreview --mode branch` clean (patch correct, 0.86; both initial findings on viewport reassert + render coalescing addressed).

## Needs on-device dogfood

This is a lifecycle/render-timing fix that can't be proven in the simulator alone. On a paired iPhone: background via the **home button** (do not kill the app), reopen it, and confirm the terminal **repaints immediately** (previously it stayed frozen on stale content even though typed keystrokes still reached the Mac).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783426330&installation_id=133855650&pr_number=5571&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5571&signature=9f61ad1baf57941bcdd780e32cf03632e848f3879745b7629d9f6be4045758f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app lifecycle, display link, and render coalescing in the hot terminal render path; logic is localized but timing-sensitive and needs on-device verification.
> 
> **Overview**
> Fixes the iOS terminal staying **frozen on stale pixels** after home-button background→foreground while keystrokes still reach the Mac, by making **`GhosttySurfaceView`**’s local `CADisplayLink` render loop resume reliably.
> 
> **Foreground resume** now runs from **`willEnterForeground`** as well as **`didBecomeActive`**, and **`resumeRendering()`** is idempotent: it clears `renderInFlight` only on the suspended→active transition (avoiding a race with render coalescing between the two notifications). If resume hits the view before it is back on-window, **`pendingForegroundResume`** is set and **`didMoveToWindow`** finishes the full resume path instead of only restarting the display link.
> 
> On a successful resume, the change **re-syncs visibility** via `syncSurfaceVisibility()` (not forced visible), clears **`lastReportedSize`**, forces **geometry resync**, and restarts the display link so the first foreground frame repaints at the right size after IOSurface backing may have been lost. DEBUG heartbeat logging now includes **`suspended=`** for diagnosis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e8193438cccea6a07f8361e4bb78e865bfc8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS terminal freeze after returning from the background (Home button) by reliably resuming the render loop so the terminal repaints immediately at the correct size.

- **Bug Fixes**
  - Resume the render loop on `willEnterForeground` and `didBecomeActive`; if off-window, arm `pendingForegroundResume` and complete in `didMoveToWindow`.
  - On resume, sync surface visibility, clear `lastReportedSize`, force geometry sync, and restart the display link for a fresh repaint.
  - Reset the in-flight render gate only on the suspended→active transition to preserve render coalescing.

<sup>Written for commit 61e8193438cccea6a07f8361e4bb78e865bfc8fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rendering stability during app foreground transitions when the surface view is temporarily off-window. Improved synchronization between app lifecycle events and rendering state management for more reliable display updates and prevention of rendering interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->