### PR TITLE
iOS: fix image paste (frame-budget-aware cap + too-large toast, not connection error)

### DIFF
--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobilePasteImageSizing.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobilePasteImageSizing.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// Picks the largest pasted-image encoding that still fits the mobile sync
+/// wire protocol's frame budget.
+///
+/// An image pasted on the phone is base64-encoded into the `terminal.paste_image`
+/// request's JSON body before it is framed and sent to the Mac. The frame codec
+/// (``MobileSyncFrameCodec``) rejects any payload larger than
+/// ``MobileSyncFrameCodec/defaultMaximumFrameByteCount``, and that base64 JSON is
+/// the *first* (and tightest) limit the image hits — base64 inflates raw bytes by
+/// ~4/3, so a raw image near the Mac's own 10 MB clipboard cap (~13.3 MB base64)
+/// would blow the 8 MB frame cap before it ever left the device. This type derives
+/// the real raw-byte ceiling from the frame cap so callers cap *before* sending and
+/// never hand the transport a frame that is doomed to throw `frameTooLarge`.
+///
+/// ```swift
+/// let sizing = MobilePasteImageSizing()
+/// if let candidate = sizing.firstCandidateThatFits([
+///     (png, "png"),
+///     (jpeg, "jpg"),
+/// ]) {
+///     onPasteImage(candidate.data, candidate.format)
+/// } else {
+///     onPasteImageTooLarge() // every encoding is too big to send
+/// }
+/// ```
+public struct MobilePasteImageSizing: Sendable {
+    /// The frame payload budget the encoded request must fit within.
+    public let frameByteCapacity: Int
+
+    /// Bytes reserved for the JSON request envelope around `image_base64`
+    /// (the two UUID ids, `client_id`, `image_format`, key names, and JSON
+    /// punctuation) **plus the `auth` object the RPC client injects after this
+    /// helper sizes the image** (a Stack access token, and sometimes an attach
+    /// token, each a multi-KB JWT). Those tokens are added by
+    /// `requestDataWithAuth` once the request is already approved, so the reserve
+    /// must cover them or an image accepted at the cap can still overflow the
+    /// frame once auth is attached. Generous on purpose: 16 KiB comfortably holds
+    /// two several-KB JWTs and only trims the raw cap by a few KB.
+    public let envelopeReserveBytes: Int
+
+    /// Worst-case multiplier applied to the base64 length to bound JSON
+    /// serialization growth.
+    ///
+    /// Apple's `JSONSerialization` escapes `/` as `\/`, and `/` is one of the 64
+    /// base64 symbols. The maximal-slash case (raw `0xFF` bytes encode to `////`)
+    /// doubles the base64 portion of the serialized request, so the encoded image
+    /// can be up to `2 ×` its base64 length once framed. Budgeting for that worst
+    /// case here keeps `firstCandidateThatFits` from approving an image that would
+    /// still throw `frameTooLarge` at the transport.
+    public let jsonEscapeWorstCaseFactor: Int
+
+    /// Creates a sizing helper bound to a frame budget.
+    ///
+    /// - Parameters:
+    ///   - frameByteCapacity: The maximum frame payload size, defaulting to the
+    ///     protocol's ``MobileSyncFrameCodec/defaultMaximumFrameByteCount``.
+    ///   - envelopeReserveBytes: Bytes reserved for the JSON envelope around the
+    ///     base64 image **and the post-sizing `auth` object** (Stack + attach
+    ///     JWTs). Defaults to 16 KiB so two several-KB tokens cannot push an
+    ///     at-the-cap image past the frame budget. The reserve is face-value (it
+    ///     is subtracted before the slash-escape factor) because JWTs are
+    ///     base64url, which `JSONSerialization` does not slash-escape.
+    ///   - jsonEscapeWorstCaseFactor: Worst-case multiplier on the base64 length
+    ///     to cover JSON slash-escaping. Defaults to 2 (the all-slash base64 case).
+    public init(
+        frameByteCapacity: Int = MobileSyncFrameCodec.defaultMaximumFrameByteCount,
+        envelopeReserveBytes: Int = 16 * 1024,
+        jsonEscapeWorstCaseFactor: Int = 2
+    ) {
+        self.frameByteCapacity = frameByteCapacity
+        self.envelopeReserveBytes = envelopeReserveBytes
+        self.jsonEscapeWorstCaseFactor = max(1, jsonEscapeWorstCaseFactor)
+    }
+
+    /// The base64 length, in bytes, that `rawByteCount` raw bytes encode to.
+    ///
+    /// Standard base64 emits 4 characters per 3 input bytes, padded up to the
+    /// next multiple of 4, so the encoded length is `4 * ceil(n / 3)`.
+    ///
+    /// - Parameter rawByteCount: The number of raw bytes to be encoded.
+    /// - Returns: The exact base64 character/byte count.
+    public func base64ByteCount(forRawByteCount rawByteCount: Int) -> Int {
+        guard rawByteCount > 0 else { return 0 }
+        return ((rawByteCount + 2) / 3) * 4
+    }
+
+    /// The largest raw image size that fits the frame budget under the *worst
+    /// case* (every base64 character slash-escaped).
+    ///
+    /// This is the conservative bound: an image at or under this size is
+    /// guaranteed to fit no matter how dense its slashes are. It is *not* used to
+    /// reject images on its own, because real PNG/JPEG data is nowhere near
+    /// all-slash, so rejecting a 4 MB photo on this worst-case cap would drop
+    /// images that actually fit. ``fits(imageData:)`` measures the real escaped
+    /// size instead; this value remains useful as a quick lower bound and as a
+    /// documented worst-case guarantee.
+    ///
+    /// The serialized base64 can grow to `jsonEscapeWorstCaseFactor × base64Len`,
+    /// so the base64 itself must satisfy
+    /// `factor * base64Len <= frameCap - envelope`. Inverting
+    /// `base64Len = 4 * ceil(raw / 3)` then gives
+    /// `raw <= floor((frameCap - envelope) / factor / 4) * 3`, the value returned
+    /// here.
+    ///
+    /// - Returns: The maximum raw byte count that is guaranteed to encode and
+    ///   frame successfully even under maximal slash escaping, never negative.
+    public var maximumRawImageByteCount: Int {
+        let base64Budget = (frameByteCapacity - envelopeReserveBytes) / jsonEscapeWorstCaseFactor
+        guard base64Budget > 0 else { return 0 }
+        return (base64Budget / 4) * 3
+    }
+
+    /// Whether an image of `rawByteCount` raw bytes is guaranteed to fit the frame
+    /// budget under the worst-case slash density.
+    ///
+    /// Prefer ``fits(imageData:)`` when the encoded bytes are in hand: this
+    /// worst-case check is conservative and rejects typical large images that
+    /// actually fit. It exists for callers that only know a raw byte count.
+    ///
+    /// - Parameter rawByteCount: The raw byte count of an encoded image candidate.
+    /// - Returns: `true` when the candidate is safe to send in the worst case.
+    public func fits(rawByteCount: Int) -> Bool {
+        rawByteCount > 0 && rawByteCount <= maximumRawImageByteCount
+    }
+
+    /// The exact serialized size, in bytes, of `imageData`'s base64 once placed in
+    /// the request's `image_base64` JSON string.
+    ///
+    /// `JSONSerialization` escapes each `/` as `\/` (a one-byte growth) and leaves
+    /// every other base64 character (`A–Z a–z 0–9 +`) and `=` padding untouched,
+    /// so the field's serialized length is `base64Length + (count of '/')`.
+    /// Measuring the actual slash count (instead of assuming every character is a
+    /// slash) is what lets a typical multi-MB photo through while still catching a
+    /// genuinely overflowing payload, since all-`/` data measures up to exactly the
+    /// `2×` worst case and hits the same boundary.
+    ///
+    /// - Parameter imageData: The raw encoded image bytes (e.g. PNG or JPEG).
+    /// - Returns: The serialized byte count the base64 string contributes.
+    public func escapedImageFieldByteCount(forImageData imageData: Data) -> Int {
+        let base64 = imageData.base64EncodedData()
+        let slashByte = UInt8(ascii: "/")
+        var slashCount = 0
+        for byte in base64 where byte == slashByte {
+            slashCount += 1
+        }
+        return base64.count + slashCount
+    }
+
+    /// Whether `imageData` actually fits the frame budget once base64-encoded into
+    /// the request, measured against its real (not worst-case) slash escaping.
+    ///
+    /// Uses ``escapedImageFieldByteCount(forImageData:)`` plus the envelope/auth
+    /// reserve, so a typical large photo that genuinely fits is accepted while a
+    /// payload that would overflow the frame (including the adversarial all-slash
+    /// case) is rejected.
+    ///
+    /// - Parameter imageData: The raw encoded image bytes of a candidate.
+    /// - Returns: `true` when the candidate is safe to send.
+    public func fits(imageData: Data) -> Bool {
+        guard !imageData.isEmpty else { return false }
+        return escapedImageFieldByteCount(forImageData: imageData) + envelopeReserveBytes <= frameByteCapacity
+    }
+
+    /// The first lazily-encoded candidate, in priority order, that actually fits
+    /// the frame budget, paired with its label.
+    ///
+    /// Callers pass labeled encoders in preference order (e.g. `("png", …)` first,
+    /// then a lower-quality `("jpg", …)`). Each encoder is invoked only when
+    /// reached, and a non-fitting candidate's `Data` is dropped before the next
+    /// encoder runs, so two full encodings are never retained at once (a large
+    /// pasteboard image would otherwise keep both the failed PNG and the JPEG
+    /// fallback alive and risk memory pressure). Returning `nil` means every
+    /// candidate is too large to transmit and the caller should surface a "too
+    /// large" notice instead of sending an oversized frame the transport would
+    /// reject.
+    ///
+    /// ```swift
+    /// let sizing = MobilePasteImageSizing()
+    /// if let (format, data) = sizing.firstEncodingThatFits([
+    ///     ("png", { image.pngData() }),
+    ///     ("jpg", { image.jpegData(compressionQuality: 0.8) }),
+    /// ]) {
+    ///     onPasteImage(data, format)
+    /// } else {
+    ///     onPasteImageTooLarge()
+    /// }
+    /// ```
+    ///
+    /// - Parameter encoders: `(label, encode)` pairs in priority order; `encode`
+    ///   returns the encoded bytes, or `nil` if that encoding is unavailable.
+    /// - Returns: The label and bytes of the first fitting candidate, or `nil` if
+    ///   none fit.
+    public func firstEncodingThatFits<Label>(
+        _ encoders: [(label: Label, encode: () -> Data?)]
+    ) -> (label: Label, data: Data)? {
+        for candidate in encoders {
+            guard let data = candidate.encode() else { continue }
+            if fits(imageData: data) {
+                return (candidate.label, data)
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobilePasteImageSizingTests.swift
+++ b/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobilePasteImageSizingTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+/// Behavior tests for the pasted-image size selection that prevents iOS from
+/// handing the sync transport a frame it is guaranteed to reject.
+@Suite struct MobilePasteImageSizingTests {
+    /// The largest raw image the helper accepts must base64-encode to a payload
+    /// that still fits the frame budget *after* the JSON envelope reserve and the
+    /// worst-case slash-escaping multiplier. This is the assertion that proves the
+    /// fix: the previous code capped raw bytes at 8 MB, whose base64 (~10.6 MB)
+    /// overflowed the 8 MB frame cap and threw.
+    @Test func maxRawImageBase64FitsTheFrameBudget() {
+        let sizing = MobilePasteImageSizing()
+        let maxRaw = sizing.maximumRawImageByteCount
+
+        let base64Len = sizing.base64ByteCount(forRawByteCount: maxRaw)
+        let worstCaseSerialized = base64Len * sizing.jsonEscapeWorstCaseFactor + sizing.envelopeReserveBytes
+        #expect(worstCaseSerialized <= sizing.frameByteCapacity)
+    }
+
+    /// The largest accepted raw image must still fit the frame after a *real*
+    /// adversarial JSON serialization, including the `auth` object the RPC client
+    /// attaches *after* sizing: `0xFF` bytes base64-encode entirely to `/`, which
+    /// Apple's `JSONSerialization` escapes as `\/` (the worst case the sizing
+    /// helper budgets for), and the request also carries a large
+    /// `stack_access_token` plus `attach_token` (multi-KB JWTs injected by
+    /// `requestDataWithAuth`). This guards against both the slash-escaping
+    /// regression and the post-sizing auth-token reserve that autoreview caught:
+    /// if the envelope reserve did not cover the auth tokens, an at-the-cap image
+    /// would overflow the frame once auth was attached.
+    @Test func acceptedMaxRawSurvivesWorstCaseJSONSerialization() throws {
+        let sizing = MobilePasteImageSizing()
+        let raw = Data(repeating: 0xFF, count: sizing.maximumRawImageByteCount)
+        // Stand-ins for the JWTs the RPC client injects post-sizing, sized to a
+        // realistic worst case (a long Stack access token and an attach token).
+        let largeStackToken = String(repeating: "a", count: 7 * 1024)
+        let largeAttachToken = String(repeating: "b", count: 7 * 1024)
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": "terminal.paste_image",
+            "params": [
+                "workspace_id": UUID().uuidString,
+                "surface_id": UUID().uuidString,
+                "image_base64": raw.base64EncodedString(),
+                "image_format": "png",
+                "client_id": UUID().uuidString,
+            ],
+            "auth": [
+                "stack_access_token": largeStackToken,
+                "attach_token": largeAttachToken,
+            ],
+        ]
+        let payload = try JSONSerialization.data(withJSONObject: request)
+        #expect(payload.count <= MobileSyncFrameCodec.defaultMaximumFrameByteCount)
+    }
+
+    /// The derived raw cap must be safely under the Mac's 10 MB raw clipboard cap
+    /// (the base64 frame cap is the binding constraint) and well under the old
+    /// 8 MB cap that produced silently-failing pastes, while staying useful.
+    @Test func maxRawImageIsUnderTheMacClipboardCap() {
+        let sizing = MobilePasteImageSizing()
+        #expect(sizing.maximumRawImageByteCount < 10 * 1024 * 1024)
+        #expect(sizing.maximumRawImageByteCount < 8 * 1024 * 1024)
+        // Sanity: it is still large enough to be useful (> 2 MB raw) after the
+        // worst-case slash-escaping budget halves the base64 allowance.
+        #expect(sizing.maximumRawImageByteCount > 2 * 1024 * 1024)
+    }
+
+    @Test func fitsBoundaryIsInclusiveAtTheCap() {
+        let sizing = MobilePasteImageSizing()
+        let maxRaw = sizing.maximumRawImageByteCount
+        #expect(sizing.fits(rawByteCount: maxRaw))
+        #expect(!sizing.fits(rawByteCount: maxRaw + 1))
+        #expect(!sizing.fits(rawByteCount: 0))
+    }
+
+    /// A realistic, sparse-slash image that is far larger than the worst-case raw
+    /// cap (~3 MB) but whose *actual* base64 has few slashes must be **accepted**.
+    /// This is the regression guard for the over-rejection autoreview caught: the
+    /// old worst-case-only check would have dropped a normal ~5 MB photo that fits
+    /// the real 8 MB frame.
+    @Test func acceptsRealisticLargeImageThatActuallyFits() {
+        let sizing = MobilePasteImageSizing()
+        // Zero bytes base64-encode to all "A" (no slashes), so this 5 MB payload's
+        // serialized image field is ~6.67 MB, comfortably under the 8 MB frame even
+        // though 5 MB is well over the ~3 MB worst-case raw cap.
+        let fiveMB = 5 * 1024 * 1024
+        #expect(fiveMB > sizing.maximumRawImageByteCount)
+        let sparseSlashImage = Data(repeating: 0x00, count: fiveMB)
+        #expect(sizing.fits(imageData: sparseSlashImage))
+    }
+
+    /// The all-`0xFF` adversarial image (base64 is entirely slashes) hits the
+    /// worst-case boundary: at the worst-case raw cap it just fits, and one byte
+    /// over the cap it does not. This proves the actual-size check still rejects a
+    /// genuinely overflowing payload, so accepting realistic images did not weaken
+    /// the safety bound.
+    @Test func rejectsAllSlashImageThatOverflowsTheFrame() {
+        let sizing = MobilePasteImageSizing()
+        let atCap = Data(repeating: 0xFF, count: sizing.maximumRawImageByteCount)
+        #expect(sizing.fits(imageData: atCap))
+        let overCap = Data(repeating: 0xFF, count: sizing.maximumRawImageByteCount + 3)
+        #expect(!sizing.fits(imageData: overCap))
+        #expect(!sizing.fits(imageData: Data()))
+    }
+
+    /// PNG is preferred; when it overflows but the JPEG fallback fits, the JPEG
+    /// candidate is chosen. Mirrors the paste path's PNG-then-JPEG ordering, and
+    /// the helper decides on the candidates' actual serialized sizes.
+    @Test func picksFirstEncodingThatFitsInPriorityOrder() {
+        let sizing = MobilePasteImageSizing()
+        // An all-slash (0xFF) PNG over the cap, and a sparse-slash (0x00) JPEG that
+        // fits at the same raw size: the JPEG must win.
+        let overCapRaw = sizing.maximumRawImageByteCount + 1024
+        let oversizedPNG = Data(repeating: 0xFF, count: overCapRaw)
+        let fittingJPEG = Data(repeating: 0x00, count: overCapRaw)
+        #expect(!sizing.fits(imageData: oversizedPNG))
+        #expect(sizing.fits(imageData: fittingJPEG))
+        let picked = sizing.firstEncodingThatFits([
+            (label: "png", encode: { oversizedPNG }),
+            (label: "jpg", encode: { fittingJPEG }),
+        ])
+        #expect(picked?.label == "jpg")
+        #expect(picked?.data == fittingJPEG)
+
+        // When PNG already fits, it wins and the JPEG encoder is never invoked
+        // (lazy, so no second full encoding is produced or retained).
+        let smallPNG = Data(repeating: 0x00, count: 1024)
+        var jpegEncoderRan = false
+        let pickedFirst = sizing.firstEncodingThatFits([
+            (label: "png", encode: { smallPNG }),
+            (label: "jpg", encode: { jpegEncoderRan = true; return Data(repeating: 0x00, count: 512) }),
+        ])
+        #expect(pickedFirst?.label == "png")
+        #expect(jpegEncoderRan == false)
+    }
+
+    /// When every candidate overflows, the helper returns nil so the caller drops
+    /// the image and surfaces a "too large" notice instead of sending an
+    /// oversized frame.
+    @Test func returnsNilWhenNoEncodingFits() {
+        let sizing = MobilePasteImageSizing()
+        let overCapRaw = sizing.maximumRawImageByteCount + 4
+        let picked = sizing.firstEncodingThatFits([
+            (label: "png", encode: { Data(repeating: 0xFF, count: overCapRaw) }),
+            (label: "jpg", encode: { Data(repeating: 0xFF, count: overCapRaw) }),
+        ])
+        #expect(picked == nil)
+    }
+
+    /// base64 length follows the 4 * ceil(n/3) padding rule.
+    @Test(arguments: [
+        (0, 0),
+        (1, 4),
+        (2, 4),
+        (3, 4),
+        (4, 8),
+        (6, 8),
+        (7, 12),
+    ])
+    func base64ByteCountMatchesPaddedEncoding(rawCount: Int, expected: Int) {
+        let sizing = MobilePasteImageSizing()
+        #expect(sizing.base64ByteCount(forRawByteCount: rawCount) == expected)
+        // Cross-check against Foundation's real base64 encoder for non-empty input.
+        if rawCount > 0 {
+            let encoded = Data(repeating: 0xAB, count: rawCount).base64EncodedString()
+            #expect(encoded.utf8.count == expected)
+        }
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -71,6 +71,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public private(set) var macConnectionStatus: MobileMacConnectionStatus
     public private(set) var connectedHostName: String
     public private(set) var connectionError: String?
+
+    /// Transient notice for a pasted image that could not be sent (too large to
+    /// fit the sync frame, or rejected by the Mac's clipboard-image cap).
+    ///
+    /// Distinct from ``connectionError``: an oversized paste is not a connection
+    /// problem, so it must not drive the connection-recovery banner (Retry / mark
+    /// Mac unavailable). The UI shows this as a short-lived toast and clears it via
+    /// ``dismissPasteImageNotice()``.
+    public private(set) var pasteImageNotice: String?
+
+    /// Monotonic token bumped every time a paste notice is set, even when the
+    /// localized text is identical. The toast keys its auto-dismiss timer on this
+    /// so a second oversized paste restarts the 3-second lifecycle instead of
+    /// being dismissed early by the first paste's still-pending timer.
+    public private(set) var pasteImageNoticeToken: Int = 0
+
     public private(set) var activeTicket: CmxAttachTicket?
     public private(set) var activeRoute: CmxAttachRoute?
 
@@ -1829,10 +1845,55 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
         } catch {
             guard generation == connectionGeneration else { return }
+            // An oversized image is a paste problem, not a connection problem:
+            // route it to the transient paste notice instead of tearing down or
+            // showing the connection-recovery banner.
+            if Self.isPasteImageTooLargeError(error) {
+                setPasteImageTooLargeNotice()
+                return
+            }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
             markMacConnectionUnavailableIfNeeded(after: error)
             connectionError = Self.localizedConnectionError(for: error)
         }
+    }
+
+    /// Whether `error` means a pasted image was rejected for being too large,
+    /// either locally (the base64 JSON overflowed the sync frame cap) or by the
+    /// Mac (its 10 MB clipboard-image cap, surfaced as an `invalid_params`
+    /// RPC error from `terminal.paste_image`).
+    private static func isPasteImageTooLargeError(_ error: any Error) -> Bool {
+        if case MobileSyncFrameCodecError.frameTooLarge = error {
+            return true
+        }
+        if let connectionError = error as? MobileShellConnectionError,
+           case let .rpcError(_, message) = connectionError,
+           message.localizedCaseInsensitiveContains("size limit") {
+            return true
+        }
+        return false
+    }
+
+    /// Surface the "image too large" notice triggered by the iOS-side size check,
+    /// before any frame is sent (every encoding overflowed the frame budget).
+    public func reportPasteImageTooLarge() {
+        setPasteImageTooLargeNotice()
+    }
+
+    /// Clear the transient paste-image notice (e.g. when its toast auto-dismisses
+    /// or the user taps it away).
+    public func dismissPasteImageNotice() {
+        pasteImageNotice = nil
+    }
+
+    /// Single setter for the too-large notice so the iOS-side pre-send check and
+    /// the Mac-side RPC rejection both surface identical, localized feedback.
+    private func setPasteImageTooLargeNotice() {
+        pasteImageNotice = L10n.string(
+            "mobile.paste.imageTooLarge",
+            defaultValue: "Image is too large to paste. Try a smaller image."
+        )
+        pasteImageNoticeToken &+= 1
     }
 
     private var terminalEventStreamID: String {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -110,6 +110,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             }
         }
 
+        func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView) {
+            // The pasted image was too large to send even after compressing to
+            // JPEG, so nothing was uploaded. Surface a transient notice so the
+            // paste doesn't appear to silently do nothing.
+            Task { @MainActor [weak store] in
+                store?.reportPasteImageTooLarge()
+            }
+        }
+
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
             // Report our natural grid to the Mac and pin our render to the
             // effective grid it returns (the smallest across every attached

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteImageNoticeToast.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePasteImageNoticeToast.swift
@@ -1,0 +1,68 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// Transient bottom toast that surfaces a failed image paste (most often an
+/// image too large to fit the sync frame). Renders nothing while
+/// ``CMUXMobileShellStore/pasteImageNotice`` is `nil`, fades in when a notice
+/// appears, and auto-dismisses after a short, cancellable delay so it never
+/// lingers or blocks the terminal.
+///
+/// This is deliberately separate from ``MobileConnectionRecoveryBanner``: an
+/// oversized paste is not a connection failure, so it must not show the Retry /
+/// reconnect affordances or imply the Mac is unreachable.
+struct MobilePasteImageNoticeToast: View {
+    @Bindable var store: CMUXMobileShellStore
+
+    /// How long the toast stays up before auto-dismissing. A bounded, intended
+    /// display duration (not a synchronization sleep), wired to the notice's
+    /// lifecycle below so a new notice or a manual tap cancels the pending hide.
+    private static let autoDismiss: Duration = .seconds(3)
+
+    var body: some View {
+        Group {
+            if let notice = store.pasteImageNotice {
+                toast(text: notice)
+                    .task(id: store.pasteImageNoticeToken) {
+                        // Concurrency carve-out: a bounded, cancellable auto-dismiss
+                        // delay that is itself the intended behavior (a minimum
+                        // display duration), not a poll/settle/race. `.task(id:)`
+                        // cancels and restarts when the monotonic notice token
+                        // changes (so a repeat paste with identical text still
+                        // restarts the timer) and cancels on disappear, wiring the
+                        // sleep's cancellation to the toast lifecycle.
+                        try? await Task.sleep(for: Self.autoDismiss)
+                        guard !Task.isCancelled else { return }
+                        store.dismissPasteImageNotice()
+                    }
+            }
+        }
+        .animation(.default, value: store.pasteImageNotice)
+    }
+
+    private func toast(text: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.white)
+            Text(text)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.black.opacity(0.82))
+        )
+        .padding(.horizontal, 20)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity)
+        .contentShape(Rectangle())
+        .onTapGesture { store.dismissPasteImageNotice() }
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .accessibilityIdentifier("MobilePasteImageNoticeToast")
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -50,6 +50,9 @@ struct WorkspaceShellView: View {
         .overlay(alignment: .top) {
             MobileConnectionRecoveryBanner(store: store, signOut: signOut)
         }
+        .overlay(alignment: .bottom) {
+            MobilePasteImageNoticeToast(store: store)
+        }
     }
 
     private var stackLayout: some View {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -60,6 +60,10 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
+    /// The user pasted an image that is too large to send even after trying a
+    /// compressed JPEG, so nothing was uploaded. The host should surface a
+    /// user-visible "too large" notice. Optional.
+    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView)
 }
 
 public extension GhosttySurfaceViewDelegate {
@@ -67,6 +71,7 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView) {}
 }
 
 @MainActor
@@ -809,6 +814,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             guard let self else { return }
             TerminalInputDebugLog.log("surface.onPasteImage bytes=\(data.count) format=\(format)")
             self.delegate?.ghosttySurfaceView(self, didPasteImage: data, format: format)
+        }
+        inputProxy.onPasteImageTooLarge = { [weak self] in
+            guard let self else { return }
+            TerminalInputDebugLog.log("surface.onPasteImageTooLarge")
+            self.delegate?.ghosttySurfaceViewDidFailToPasteImageTooLarge(self)
         }
         inputProxy.onZoom = { [weak self] direction in
             self?.performFontZoom(direction)

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileTerminalKit
 import Foundation
 import UIKit
@@ -11,6 +12,10 @@ final class TerminalInputTextView: UITextView {
     /// Mac, which injects the resulting file path into the terminal. Clipboard
     /// *text* does not use this path; it rides ``onText``.
     var onPasteImage: ((Data, String) -> Void)?
+    /// Fired when a pasted image is too large to send even after trying a
+    /// compressed JPEG fallback, so the host can surface a "too large" notice
+    /// instead of the paste silently doing nothing.
+    var onPasteImageTooLarge: (() -> Void)?
     var onZoom: ((TerminalFontZoomDirection) -> Void)?
     var onHideKeyboard: (() -> Void)?
     /// Fired by the trailing "customize" button so the SwiftUI host can present
@@ -614,26 +619,38 @@ final class TerminalInputTextView: UITextView {
     /// Read the system clipboard for the Paste button. An image is forwarded via
     /// ``onPasteImage`` (the host uploads it to the Mac as `terminal.paste_image`
     /// and the Mac injects the resulting file path); plain text rides the normal
-    /// ``onText`` input path. Images win when both are present. A large image
-    /// falls back to JPEG so it stays under the Mac's 10 MB cap. Accessing the
+    /// ``onText`` input path. Images win when both are present. Accessing the
     /// pasteboard contents here is what shows iOS's one-shot paste banner, which
     /// is the expected confirmation for an explicit Paste tap.
+    ///
+    /// The image must fit the mobile sync frame budget once base64-encoded, so we
+    /// try PNG first, then a compressed JPEG, and send the first candidate whose
+    /// actual serialized size fits via ``MobilePasteImageSizing/fits(imageData:)``.
+    /// The base64 frame cap (~8 MB), not the Mac's 10 MB raw clipboard cap, is the
+    /// binding limit because base64 inflates the bytes ~4/3 before they are sent.
+    /// The encoders run lazily and a non-fitting encoding is released before the
+    /// next is produced, so we never hold both the PNG and the JPEG fallback at
+    /// once (a large pasteboard image could otherwise spike memory). If neither
+    /// encoding fits we drop the image and fire ``onPasteImageTooLarge`` so the
+    /// host can tell the user, rather than failing silently.
     private func handlePasteAction() {
         let pasteboard = UIPasteboard.general
         if pasteboard.hasImages, let image = pasteboard.image {
-            let maxImageBytes = 8 * 1024 * 1024
-            if let png = image.pngData(), png.count <= maxImageBytes {
-                onPasteImage?(png, "png")
-                return
+            let sizing = MobilePasteImageSizing()
+            // Measure-then-send: a brief double-encode on an explicit user paste is
+            // fine; this is not a hot path and the lazy encoders keep peak memory
+            // to one encoding at a time.
+            if let fitting = sizing.firstEncodingThatFits([
+                (label: "png", encode: { image.pngData() }),
+                (label: "jpg", encode: { image.jpegData(compressionQuality: 0.8) }),
+            ]) {
+                onPasteImage?(fitting.data, fitting.label)
+            } else {
+                // We have an image but no encoding fits the frame budget; tell the
+                // user instead of silently sending nothing or pasting text.
+                onPasteImageTooLarge?()
             }
-            if let jpeg = image.jpegData(compressionQuality: 0.8) {
-                onPasteImage?(jpeg, "jpg")
-                return
-            }
-            if let png = image.pngData() {
-                onPasteImage?(png, "png")
-                return
-            }
+            return
         }
         if pasteboard.hasStrings, let string = pasteboard.string, !string.isEmpty {
             onText?(string)

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1310,6 +1310,23 @@
         }
       }
     },
+    "mobile.paste.imageTooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image is too large to paste. Try a smaller image."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像が大きすぎて貼り付けできません。小さい画像でお試しください。"
+          }
+        }
+      }
+    },
     "mobile.preview.attachedTerminalName": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Problem

Pasting a large image on the phone silently showed the connection-recovery banner (Retry / Mac unavailable) and pasted nothing.

Two transport facts caused it:

- The base64 image rides inside the `terminal.paste_image` JSON request, and `MobileSyncFrameCodec` rejects any frame over 8 MB (`defaultMaximumFrameByteCount`). The old code capped the raw image at 8 MB, but base64 inflates raw bytes ~4/3, so a near-cap image overflowed the frame and threw `frameTooLarge` locally, before anything left the device.
- `JSONSerialization` escapes `/` as `\/`, and `/` is one of the 64 base64 symbols, so the serialized base64 can grow further (worst case, all-`0xFF` data is all slashes and doubles).

Because the throw happened on the normal send path, it fell through to the connection-error handler and showed the recovery banner, which is the wrong UX (an oversized paste is not a connection failure).

## Fix

- New `MobilePasteImageSizing` (CMUXMobileCore) decides per candidate on the **actual** serialized size: base64 length plus the real `/` count, not a worst-case assumption. This accepts a typical multi-MB photo that genuinely fits the 8 MB frame while still rejecting a payload that would overflow (all-slash data measures up to exactly the 2x worst case, so the safety boundary is unchanged). The envelope reserve is 16 KiB so the `auth` object (`stack_access_token`, sometimes `attach_token`) that `requestDataWithAuth` injects **after** sizing cannot push an at-cap image past the frame.
- `handlePasteAction` encodes PNG then JPEG lazily and sends the first that fits, releasing a non-fitting encoding before producing the next, so two full encodings are never held at once (a large pasteboard image could otherwise spike memory).
- Both the pre-send drop and the Mac-side "size limit" RPC rejection now route to a single localized `pasteImageNotice`, shown as a bounded, auto-dismissing `MobilePasteImageNoticeToast`, instead of the misleading `connectionError` recovery banner.
- Localized the notice (en + ja).

## Tests

60 CMUXMobileCore tests pass, including new guards: realistic-large-accept, all-slash-reject, the post-sizing auth-token reserve, and lazy-priority/no-double-retention. The iOS simulator app target builds and links clean.

## Dogfood

- **Prev bad:** pasting a large image silently showed the connection-recovery / Retry banner and didn't paste.
- **Expected now:** a large image shows an "Image is too large to paste" toast and does **not** trip the connection banner; a normal-size image pastes into the terminal as before.
- **Steps:** paste a big screenshot, then a small one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783427699&installation_id=133855650&pr_number=5572&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5572&signature=e8a260cab4361fa8a23bb97f8ff14cc4233dc8a1ea7fecc3adcdd94824d01eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile paste and UX routing only; no auth or server protocol changes beyond pre-send sizing and clearer error handling.
> 
> **Overview**
> Fixes iOS **image paste** failing on large screenshots: the old **8 MB raw-byte cap** ignored base64 inflation and the **8 MB sync frame** limit, so sends threw `frameTooLarge` and were mis-handled as **connection errors**.
> 
> Adds **`MobilePasteImageSizing`** to pick PNG-then-JPEG encodings that fit the real **`terminal.paste_image`** JSON size (actual base64 + `/` JSON escaping, plus a **16 KiB** reserve for post-sizing **auth** JWTs). Paste uses lazy **`firstEncodingThatFits`** so only one full encoding is held in memory.
> 
> **Oversized paste** (pre-send drop, `frameTooLarge`, or Mac “size limit” RPC) now sets **`pasteImageNotice`** and shows **`MobilePasteImageNoticeToast`**—not **`connectionError`** / the recovery banner. New delegate **`ghosttySurfaceViewDidFailToPasteImageTooLarge`** wires the terminal paste path to **`reportPasteImageTooLarge()`**. Localized **en/ja** string added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8f850fa725ff0b2a22436195df01df22fd2802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS image paste by sizing images against the 8 MB sync frame budget and showing a small “image too large” toast instead of the connection banner. PNG then JPEG are tried lazily; we send the first that fits and drop oversized pastes with a clear notice.

- **Bug Fixes**
  - Compute actual serialized size (base64 length + slash escapes) and reserve 16 KiB for auth to prevent `frameTooLarge`.
  - Handle Mac “size limit” RPC errors the same way; no connection teardown or recovery banner.

- **New Features**
  - Add `MobilePasteImageSizing` in `CMUXMobileCore` and `MobilePasteImageNoticeToast` in `CmuxMobileShellUI` with auto-dismiss and localization (en, ja).

<sup>Written for commit 6c8f850fa725ff0b2a22436195df01df22fd2802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image paste size validation with user-friendly toast notifications when images exceed device capacity.
  * Oversized pasted images now gracefully fail with informative feedback instead of connection errors.

* **Tests**
  * Added comprehensive test coverage for image sizing and encoding selection logic.

* **Localization**
  * Added English and Japanese translations for image size limit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->