### PR TITLE
iOS: native hold-to-repeat backspace + system dictation (iSH-style text-input conformance)

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -243,6 +243,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         case "mobile.terminal.create", "terminal.create":
             return false
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport":

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1427,6 +1427,34 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         await sendRemoteTerminalInput(text, workspaceID: workspaceID, terminalID: terminalID)
     }
 
+    /// Send a committed block of text (system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text) to the terminal that
+    /// owns `surfaceID` as a *bracketed paste*.
+    ///
+    /// Unlike ``submitTerminalRawInput(_:surfaceID:)``, this routes to the
+    /// Mac's `terminal.paste` RPC, which delivers the text through Ghostty's
+    /// paste path (`ghostty_surface_text`). That keeps embedded newlines part of
+    /// one paste so a running shell or TUI does not execute each line as a
+    /// separate command, and lets bracketed-paste-aware programs treat it as
+    /// pasted content.
+    /// - Parameters:
+    ///   - text: The committed block. Sent verbatim; the Mac applies bracketed
+    ///     paste framing.
+    ///   - surfaceID: The terminal surface id the block targets.
+    public func submitTerminalPasteText(_ text: String, surfaceID: String) async {
+        guard !text.isEmpty else { return }
+        let workspaceCandidate = workspaces.first(where: { workspace in
+            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
+        })
+        guard let workspace = workspaceCandidate else { return }
+        guard remoteClient != nil else { return }
+        await sendRemoteTerminalPasteText(
+            text,
+            workspaceID: workspace.id,
+            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+        )
+    }
+
     private func drainRawTerminalInputBuffer() async {
         while let chunk = rawTerminalInputBuffer.nextBatch() {
             await submitTerminalRawInput(
@@ -2041,6 +2069,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let responseData = try await client.sendRequest(
                 MobileCoreRPCClient.requestData(
                     method: "terminal.paste_image",
+                    params: params
+                )
+            )
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
+            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+        } catch {
+            guard generation == connectionGeneration else { return }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            connectionError = Self.localizedConnectionError(for: error)
+        }
+    }
+
+    private func sendRemoteTerminalPasteText(
+        _ text: String,
+        workspaceID: MobileWorkspacePreview.ID,
+        terminalID: MobileTerminalPreview.ID
+    ) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            #if DEBUG
+            mobileShellLog.debug("send remote terminal paste text byteCount=\(text.utf8.count, privacy: .public) workspace=\(workspaceID.rawValue, privacy: .private) terminal=\(terminalID.rawValue, privacy: .private)")
+            #endif
+            let key = viewportKey(workspaceID: workspaceID, terminalID: terminalID)
+            var params: [String: Any] = [
+                "workspace_id": workspaceID.rawValue,
+                "surface_id": terminalID.rawValue,
+                "text": text,
+                "client_id": clientID,
+            ]
+            if let viewportSize = reportedViewportSizesByTerminalKey[key] {
+                params["viewport_columns"] = viewportSize.columns
+                params["viewport_rows"] = viewportSize.rows
+            }
+            let responseData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "terminal.paste",
                     params: params
                 )
             )

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1748,6 +1748,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalReplaySurfaceIDsInFlight = []
         terminalOutputTransport = .rawBytes
         supportsWorkspaceActions = false
+        // Clear paste support too, so a reconnect to an older host cannot send
+        // `terminal.paste` on a stale `true` before the next status probe lands.
+        supportsTerminalPaste = false
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
         stopRenderGridLivenessWatchdog(listenerID: nil)

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -51,6 +51,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
+    private static let terminalPasteCapability = "terminal.paste.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
 
     /// How long the render-grid stream may stay silent (no event of any topic)
@@ -170,6 +171,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// for older Macs that lack the handler, so the UI can hide rename/pin rather
     /// than offer actions that would fail with `method_not_found`.
     public private(set) var supportsWorkspaceActions: Bool = false
+    /// Whether the connected Mac advertises the `terminal.paste.v1` capability
+    /// (the bracketed-paste `terminal.paste` RPC). `false` until host status is
+    /// read, and for older Macs that lack the handler, so multi-character commits
+    /// (dictation, autocorrect, keyboard/clipboard paste) fall back to per-key
+    /// `terminal.input` instead of being dropped with `method_not_found`.
+    public private(set) var supportsTerminalPaste: Bool = false
     public var terminalInputText: String
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
@@ -1448,10 +1455,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         })
         guard let workspace = workspaceCandidate else { return }
         guard remoteClient != nil else { return }
+        let terminalID = MobileTerminalPreview.ID(rawValue: surfaceID)
+        // Fall back to per-key input when the paired Mac is too old to advertise
+        // the bracketed-paste RPC, so a new client + old host drops nothing.
+        // `terminal.input` expects CR for Return, so normalize newlines.
+        guard supportsTerminalPaste else {
+            let normalized = text.replacingOccurrences(of: "\n", with: "\r")
+            await submitTerminalRawInput(normalized, workspaceID: workspace.id, terminalID: terminalID)
+            return
+        }
         await sendRemoteTerminalPasteText(
             text,
             workspaceID: workspace.id,
-            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+            terminalID: terminalID
         )
     }
 
@@ -2177,9 +2193,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let payload = try? MobileHostStatusResponse.decode(data) else {
                 terminalOutputTransport = fallback
                 supportsWorkspaceActions = false
+                supportsTerminalPaste = false
                 return fallback
             }
             supportsWorkspaceActions = payload.capabilities.contains(Self.workspaceActionsCapability)
+            supportsTerminalPaste = payload.capabilities.contains(Self.terminalPasteCapability)
             let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
                 payload.terminalFidelity == "render_grid" ? .renderGrid : .rawBytes
             terminalOutputTransport = transport
@@ -2188,6 +2206,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             terminalOutputTransport = fallback
             supportsWorkspaceActions = false
+            supportsTerminalPaste = false
             MobileDebugLog.anchormux("sync.transport=raw_bytes reason=status_failed")
             return fallback
         }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -110,6 +110,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             }
         }
 
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
+            // A committed block of text (dictation, autocorrect, keyboard
+            // clipboard insert). Send it through the Mac's bracketed-paste RPC so
+            // newlines stay part of one paste instead of fragmenting into Returns.
+            Task { @MainActor [weak store] in
+                await store?.submitTerminalPasteText(text, surfaceID: self.surfaceID)
+            }
+        }
+
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
             // Report our natural grid to the Mac and pin our render to the
             // effective grid it returns (the smallest across every attached

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -74,8 +74,15 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
-    /// Default: fall back to per-character input so a conformer that does not
-    /// implement the bracketed-paste path still delivers the text.
+    /// Default bracketed-paste handler that falls back to per-character input.
+    ///
+    /// A conformer that does not implement the bracketed-paste path still
+    /// delivers the text: newlines are normalized to CR (matching the
+    /// per-keystroke input path) and the bytes are forwarded through
+    /// ``ghosttySurfaceView(_:didProduceInput:)``.
+    /// - Parameters:
+    ///   - surfaceView: The surface view that produced the committed block.
+    ///   - text: The committed block of pasted/dictated text.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
         let normalized = text.replacingOccurrences(of: "\n", with: "\r")
         ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -60,6 +60,13 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
+    /// Forward a committed block of text (system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text) that should reach the
+    /// remote terminal as a bracketed paste rather than per-character input. The
+    /// host sends it via the `terminal.paste` RPC so embedded newlines do not
+    /// fragment into separate Returns. Defaults to the raw-input path so existing
+    /// conformers keep working. Optional.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String)
 }
 
 public extension GhosttySurfaceViewDelegate {
@@ -67,6 +74,12 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    /// Default: fall back to per-character input so a conformer that does not
+    /// implement the bracketed-paste path still delivers the text.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
+        let normalized = text.replacingOccurrences(of: "\n", with: "\r")
+        ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))
+    }
 }
 
 @MainActor
@@ -804,6 +817,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             TerminalInputDebugLog.log("surface.onEscape data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
+        }
+        inputProxy.onPasteText = { [weak self] text in
+            guard let self else { return }
+            self.resetCursorBlink()
+            // Multi-character commits (dictation, autocorrect, keyboard clipboard
+            // insert) go through the bracketed-paste RPC so embedded newlines are
+            // not split into separate Returns by the remote terminal.
+            TerminalInputDebugLog.log("surface.onPasteText text=\(TerminalInputDebugLog.textSummary(text))")
+            self.delegate?.ghosttySurfaceView(self, didPasteText: text)
         }
         inputProxy.onPasteImage = { [weak self] data, format in
             guard let self else { return }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -663,11 +663,13 @@ final class TerminalInputTextView: UITextView {
 
     /// Read the system clipboard for the Paste button. An image is forwarded via
     /// ``onPasteImage`` (the host uploads it to the Mac as `terminal.paste_image`
-    /// and the Mac injects the resulting file path); plain text rides the normal
-    /// ``onText`` input path. Images win when both are present. A large image
-    /// falls back to JPEG so it stays under the Mac's 10 MB cap. Accessing the
-    /// pasteboard contents here is what shows iOS's one-shot paste banner, which
-    /// is the expected confirmation for an explicit Paste tap.
+    /// and the Mac injects the resulting file path); plain text rides the
+    /// bracketed-paste ``onPasteText`` path so multi-line clipboard text lands as
+    /// one paste instead of executing line-by-line. Images win when both are
+    /// present. A large image falls back to JPEG so it stays under the Mac's
+    /// 10 MB cap. Accessing the pasteboard contents here is what shows iOS's
+    /// one-shot paste banner, which is the expected confirmation for an explicit
+    /// Paste tap.
     private func handlePasteAction() {
         let pasteboard = UIPasteboard.general
         if pasteboard.hasImages, let image = pasteboard.image {
@@ -686,7 +688,15 @@ final class TerminalInputTextView: UITextView {
             }
         }
         if pasteboard.hasStrings, let string = pasteboard.string, !string.isEmpty {
-            onText?(string)
+            // An explicit Paste is always pasted content, so it goes through the
+            // bracketed-paste sink (which falls back to per-key input on a host
+            // that does not support it). The host gates the fallback on the
+            // `terminal.paste.v1` capability.
+            if onPasteText != nil {
+                onPasteText?(string)
+            } else {
+                onText?(string)
+            }
         }
     }
 

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -6,6 +6,14 @@ final class TerminalInputTextView: UITextView {
     var onText: ((String) -> Void)?
     var onBackspace: (() -> Void)?
     var onEscapeSequence: ((Data) -> Void)?
+    /// Invoked for a committed *block* of text (more than one character) that no
+    /// modifier transforms: system dictation, autocorrect/predictive-bar
+    /// replacements, and clipboard text inserted by the keyboard all arrive this
+    /// way. The host routes the block through a bracketed-paste RPC so the remote
+    /// terminal receives it as a single paste rather than per-character input,
+    /// which avoids CR-fragmenting multi-line text and lets TUIs treat it as
+    /// pasted content. Single characters and Return still ride ``onText``.
+    var onPasteText: ((String) -> Void)?
     /// Invoked when the Paste accessory button reads an image off the system
     /// clipboard. The host forwards the bytes (+ a lowercase format hint) to the
     /// Mac, which injects the resulting file path into the terminal. Clipboard
@@ -43,6 +51,25 @@ final class TerminalInputTextView: UITextView {
     private static let directInsertMirrorTextLimit = 128
 
     override var canBecomeFirstResponder: Bool { true }
+
+    /// Always report that there is text to delete.
+    ///
+    /// This is the load-bearing piece (borrowed from iSH's `TerminalView`) that
+    /// makes the system software keyboard's *hold-to-repeat* backspace work. The
+    /// keyboard's auto-repeat timer keeps firing ``deleteBackward()`` only while
+    /// the first responder reports `hasText == true`; the moment it reads
+    /// `false` the repeat stops. Because this view keeps a perpetually-empty
+    /// document (every committed keystroke is forwarded to the Mac and the local
+    /// buffer is cleared), the inherited `UITextView.hasText` returned `false`,
+    /// so holding backspace deleted exactly one character. Forcing `true` here
+    /// lets the keyboard repeat indefinitely, just like a normal text field. It
+    /// is always safe to send a DEL byte to the remote terminal, so there is no
+    /// "nothing to delete" state to honor.
+    ///
+    /// Internal byte-routing must therefore *not* key off `hasText` (it is now a
+    /// constant); ``deleteBackward()`` and the modifier guards key off
+    /// ``markedTextRange`` (IME composition) instead.
+    override var hasText: Bool { true }
 
     override var keyCommands: [UIKeyCommand]? {
         guard markedTextRange == nil else { return nil }
@@ -359,7 +386,13 @@ final class TerminalInputTextView: UITextView {
     }
 
     override func deleteBackward() {
-        if commandAccessoryArmed, markedTextRange == nil, !hasText {
+        // Routing keys off `markedTextRange` (IME composition in progress), NOT
+        // `hasText`: `hasText` is now a forced constant `true` so the software
+        // keyboard auto-repeats backspace, so it can no longer mean "the local
+        // document is empty". While composing, the delete edits the marked text
+        // locally (`super.deleteBackward()`); otherwise it is a real backspace
+        // that must reach the Mac.
+        if commandAccessoryArmed, markedTextRange == nil {
             if !commandAccessorySticky {
                 setCommandAccessoryArmed(false)
             }
@@ -367,7 +400,7 @@ final class TerminalInputTextView: UITextView {
             onEscapeSequence?(Data([0x15]))
             return
         }
-        if alternateAccessoryArmed, markedTextRange == nil, !hasText {
+        if alternateAccessoryArmed, markedTextRange == nil {
             if !alternateAccessorySticky {
                 setAlternateAccessoryArmed(false)
             }
@@ -379,19 +412,36 @@ final class TerminalInputTextView: UITextView {
             }
             return
         }
-        if controlAccessoryArmed, markedTextRange == nil, !hasText {
+        if controlAccessoryArmed, markedTextRange == nil {
             if !controlAccessorySticky {
                 setControlAccessoryArmed(false)
             }
             onBackspace?()
             return
         }
-        if markedTextRange != nil || hasText {
+        // While composing (marked text present), let UITextView edit the marked
+        // string locally so the IME candidate updates; the committed result
+        // still flows to the Mac via the normal insert/textChange path.
+        if markedTextRange != nil {
             super.deleteBackward()
             return
         }
         onBackspace?()
     }
+
+    // MARK: Dictation
+    //
+    // Unlike iSH's `TerminalView` (a raw `UIView` that hand-rolls `UITextInput`
+    // and therefore must provide `insertDictationResultPlaceholder` /
+    // `removeDictationResultPlaceholder`), this view is a `UITextView`, which
+    // already conforms to `UITextInput` and supplies those placeholder methods
+    // as framework witnesses that are not exposed for override. So we inherit
+    // iSH's dictation plumbing for free: when the user taps the keyboard mic,
+    // UIKit drives its own placeholder against this view's text storage and then
+    // delivers the recognized text through the normal `insertText(_:)` /
+    // ``textViewDidChange(_:)`` path, where ``emitCommittedText(_:source:)``
+    // routes the multi-character block through the bracketed-paste sink
+    // (``onPasteText``). There is nothing to override here.
 
     func simulateTextChangeForTesting(_ text: String, isComposing: Bool) {
         self.text = text
@@ -764,9 +814,28 @@ final class TerminalInputTextView: UITextView {
             if !shiftAccessorySticky {
                 setShiftAccessoryArmed(false)
             }
-            onText?(committedText.uppercased())
+            emitUnmodifiedText(committedText.uppercased())
         } else {
-            onText?(committedText)
+            emitUnmodifiedText(committedText)
+        }
+    }
+
+    /// Route a committed block with no active modifier to either the per-key
+    /// input path or the bracketed-paste path.
+    ///
+    /// Single characters and Return keep riding ``onText`` so byte semantics
+    /// (CR for Return, control bytes, the existing per-keystroke flow) are
+    /// unchanged. A multi-character block — system dictation, an
+    /// autocorrect/predictive replacement, or keyboard-inserted clipboard text —
+    /// is sent through ``onPasteText`` so it reaches the remote terminal as one
+    /// bracketed paste instead of fragmenting on embedded newlines.
+    private func emitUnmodifiedText(_ text: String) {
+        switch TerminalCommitRouter.route(for: text) {
+        case .paste where onPasteText != nil:
+            onPasteText?(text)
+        case .paste, .input:
+            // No paste sink wired (or a single character): per-character input.
+            onText?(text)
         }
     }
 

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRoute.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRoute.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// How a committed block of terminal text (no active modifier) should reach the
+/// remote terminal.
+///
+/// The soft keyboard delivers committed text two ways that need different
+/// transports: a single typed character (or Return) is per-key input, while a
+/// multi-character block (system dictation, an autocorrect/predictive
+/// replacement, or keyboard-inserted clipboard text) should arrive as one
+/// *bracketed paste* so embedded newlines do not fragment into separate
+/// Returns. ``TerminalCommitRouter`` picks between them.
+public enum TerminalCommitRoute: Equatable, Sendable {
+    /// Send as ordinary per-character input (preserves CR-for-Return and control
+    /// byte semantics).
+    case input
+    /// Send as a single bracketed paste (multi-character block).
+    case paste
+}

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRouter.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRouter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure transform deciding whether a committed, unmodified block of text should
+/// be sent as per-character input or as a bracketed paste.
+///
+/// Extracted from the iOS input view so the input-vs-paste policy is testable
+/// without a `UITextView`. The view calls ``route(for:)`` for the no-modifier
+/// commit path; any active Ctrl/Alt/Cmd/Shift modifier is resolved before this
+/// (those always use the per-key input/escape paths).
+///
+/// ```swift
+/// switch TerminalCommitRouter.route(for: text) {
+/// case .input: onText?(text)
+/// case .paste: onPasteText?(text)
+/// }
+/// ```
+public struct TerminalCommitRouter {
+    private init() {}
+
+    /// Classifies a committed block by character count.
+    ///
+    /// A block of more than one character (counted by `Character`, so an emoji
+    /// or other grapheme cluster is one) is treated as a paste; anything else
+    /// stays per-character input. The text is not transformed here.
+    /// - Parameter text: The committed block (already modifier-resolved).
+    /// - Returns: ``TerminalCommitRoute/paste`` for a multi-character block,
+    ///   otherwise ``TerminalCommitRoute/input``.
+    public static func route(for text: String) -> TerminalCommitRoute {
+        text.count > 1 ? .paste : .input
+    }
+}

--- a/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalCommitRouterTests.swift
+++ b/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalCommitRouterTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import CmuxMobileTerminalKit
+
+@Suite("TerminalCommitRouter input-vs-paste classification")
+struct TerminalCommitRouterTests {
+    @Test("a single character is per-character input")
+    func singleCharacterIsInput() {
+        #expect(TerminalCommitRouter.route(for: "a") == .input)
+    }
+
+    @Test("Return (a single character) stays input so CR semantics are preserved")
+    func returnIsInput() {
+        #expect(TerminalCommitRouter.route(for: "\n") == .input)
+    }
+
+    @Test("the empty string routes to input (no-op send)")
+    func emptyIsInput() {
+        #expect(TerminalCommitRouter.route(for: "") == .input)
+    }
+
+    @Test("a multi-character word is a paste")
+    func wordIsPaste() {
+        #expect(TerminalCommitRouter.route(for: "hello") == .paste)
+    }
+
+    @Test("a dictated multi-line block is a paste so it is not CR-fragmented")
+    func multilineBlockIsPaste() {
+        #expect(TerminalCommitRouter.route(for: "line one\nline two") == .paste)
+    }
+
+    @Test("a single emoji grapheme cluster is one character, so input")
+    func singleEmojiIsInput() {
+        // A flag emoji is multiple scalars but one Character, so it must not be
+        // mis-classified as a multi-character paste.
+        #expect(TerminalCommitRouter.route(for: "🇺🇸") == .input)
+    }
+
+    @Test("two emoji are a paste")
+    func twoEmojiArePaste() {
+        #expect(TerminalCommitRouter.route(for: "🇺🇸🇯🇵") == .paste)
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -300,6 +300,7 @@ final class MobileHostService {
     nonisolated static let mobileHostCapabilities: [String] = [
         "events.v1",
         "terminal.bytes.v1",
+        "terminal.paste.v1",
         "terminal.render_grid.v1",
         "terminal.replay.v1",
         "terminal.viewport.v1",
@@ -1264,6 +1265,7 @@ final class MobileHostService {
         case "mobile.terminal.create", "terminal.create":
             return nil
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1755,6 +1755,8 @@ class TerminalController {
             return v2Result(id: id, self.v2MobileTerminalCreate(params: params))
         case "mobile.terminal.input", "terminal.input":
             return v2Result(id: id, self.v2MobileTerminalInput(params: params))
+        case "mobile.terminal.paste", "terminal.paste":
+            return v2Result(id: id, self.v2MobileTerminalPaste(params: params))
         case "mobile.terminal.replay", "terminal.replay":
             return v2Result(id: id, self.v2MobileTerminalReplay(params: params))
         case "mobile.terminal.viewport", "terminal.viewport":
@@ -2294,10 +2296,12 @@ class TerminalController {
             "mobile.workspace.list",
             "mobile.terminal.create",
             "mobile.terminal.input",
+            "mobile.terminal.paste",
             "mobile.terminal.replay",
             "mobile.terminal.viewport",
             "terminal.create",
             "terminal.input",
+            "terminal.paste",
             "terminal.replay",
             "terminal.viewport",
             "auth.login",
@@ -20674,6 +20678,8 @@ class TerminalController {
             result = v2MobileTerminalCreate(params: request.params)
         case "mobile.terminal.input", "terminal.input":
             result = v2MobileTerminalInput(params: request.params)
+        case "mobile.terminal.paste", "terminal.paste":
+            result = v2MobileTerminalPaste(params: request.params)
         case "mobile.terminal.paste_image", "terminal.paste_image":
             result = v2MobileTerminalPasteImage(params: request.params)
         case "mobile.terminal.replay", "terminal.replay":
@@ -21332,6 +21338,62 @@ class TerminalController {
             "workspace_id": resolved.workspace.id.uuidString,
             "surface_id": terminalPanel.id.uuidString,
             "queued": sendResult == .queued,
+        ]
+        if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
+            payload["terminal_seq"] = seq
+        }
+        return .ok(payload)
+    }
+
+    /// Handle `terminal.paste`: a paired client (the iOS app) forwards a
+    /// committed block of text (system dictation, an autocorrect replacement, or
+    /// keyboard-inserted clipboard text) that should land as a *bracketed paste*.
+    ///
+    /// Unlike ``v2MobileTerminalInput(params:)`` (which routes through
+    /// `sendInputResult`, splitting control bytes and Returns into per-key
+    /// events), this routes through ``GhosttySurfaceView/sendText(_:)`` →
+    /// `ghostty_surface_text`, the same path a local clipboard paste uses. That
+    /// triggers bracketed-paste framing when the program enabled it, so embedded
+    /// newlines stay part of one paste instead of executing line-by-line.
+    private func v2MobileTerminalPaste(params: [String: Any]) -> V2CallResult {
+        guard let text = v2RawString(params, "text"), !text.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing text", data: nil)
+        }
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        if let error = mobileTerminalAliasValidationError(params: params) {
+            return error
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
+
+        // `sendText` returns false only when the surface is cold and cannot
+        // accept (or queue) the paste; a live surface always accepts. It does
+        // not distinguish queued vs sent, so report queued=false on success.
+        let accepted = terminalPanel.surface.sendText(text)
+        guard accepted else {
+            return .err(
+                code: "input_queue_full",
+                message: Self.terminalInputQueueFullMessage,
+                data: ["surface_id": surfaceId.uuidString]
+            )
+        }
+        terminalPanel.surface.forceRefresh(reason: "mobileHost.terminalPaste")
+        #if DEBUG
+        cmuxDebugLog(
+            "mobile.terminal.paste workspace=\(resolved.workspace.id.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) chars=\(text.count)"
+        )
+        #endif
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspace.id.uuidString,
+            "surface_id": terminalPanel.id.uuidString,
+            "queued": false,
         ]
         if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
             payload["terminal_seq"] = seq


### PR DESCRIPTION
Makes the iOS terminal input view behave like a real text input so the system software keyboard drives backspace auto-repeat and dictation natively, the way [iSH](https://github.com/ish-app/ish)'s terminal does, without local-echo drift. Keystrokes still forward to the Mac (the iOS terminal is display-only); the change is the input-view conformance, not a live local document.

## The iSH technique

In iSH's `app/TerminalView.m`, `hasText` returns `YES` unconditionally with the comment "it's always ok to send a delete". The software keyboard's auto-repeat timer keeps firing `deleteBackward` only while the first responder reports `hasText == true`; the moment it reads `false` the repeat stops. iSH never returns `false`, so holding backspace repeats indefinitely like a normal text field. `deleteBackward` just sends `\x7f`.

## The cmux delta that defeated it

`TerminalInputTextView` (a `UITextView` subclass) keeps a perpetually-empty local document, because every committed keystroke is forwarded to the Mac and the buffer is cleared. So the inherited `UITextView.hasText` returned `false`, and holding backspace deleted exactly one character. Worse, the existing `deleteBackward` used `!hasText` to mean "document empty", so naively forcing `hasText = true` would have broken backspace entirely.

## What changed

- **Backspace auto-repeat:** override `hasText` -> `true`. Decouple `deleteBackward` routing from `hasText` (now a constant) by keying off `markedTextRange` (IME composition) instead, so plain backspace and the Ctrl/Alt/Cmd+Backspace ladders still reach the Mac.
- **Dictation / multi-char blocks:** committed blocks longer than one character (dictation, autocorrect/predictive, keyboard clipboard insert) route through a new bracketed-paste path so embedded newlines are not CR-fragmented into separate Returns. Single chars and Return stay on per-key `terminal.input`.
- **`terminal.paste` text RPC:** Mac side routes to `sendText` -> `ghostty_surface_text` (the bracketed-paste path, distinct from `terminal.input`'s per-key parser). Wired through every gate: `TerminalController` dispatch + `v2MobileTerminalPaste` handler, `MobileHostService` ticket auth, advertised capability (`terminal.paste.v1`), v2 capabilities, and the iOS RPC client allowlist + `MobileShellComposite.submitTerminalPasteText`.
- **Old-host compatibility:** iOS consumes `terminal.paste.v1` from `mobile.host.status` and falls back to per-key `terminal.input` (CR-normalized) when a new client pairs with a Mac that lacks the handler, so nothing is dropped with `method_not_found`. The flag is cleared on every reconnect.
- **Shared paste entrypoint:** the visible accessory Paste button now routes clipboard text through the same bracketed-paste sink, so multi-line clipboard text no longer fragments.
- Extracted a pure `TerminalCommitRouter` (input-vs-paste) into `CmuxMobileTerminalKit` with unit tests (7 new, all green; package suite 79/79).

## Dictation: iSH's placeholder stubs do not transfer (and don't need to)

iSH hand-rolls `insertDictationResultPlaceholder` / `removeDictationResultPlaceholder` only because its `TerminalView` is a raw `UIView` manually conforming to `UITextInput`. cmux's view is a `UITextView`, which already conforms to `UITextInput` and supplies those methods as framework witnesses that are **not exposed for override** (the compiler rejects `override` on them: "method does not override any method from its superclass"). So we inherit iSH's placeholder plumbing for free: recognized dictation text arrives via `insertText`/`textViewDidChange` and routes through the bracketed-paste sink. This is the faithful technique on this view type, not a retreat to app-owned buttons.

## Verification

- iOS simulator build (iPhone 17 Pro, Debug): **BUILD SUCCEEDED**.
- `CmuxMobileTerminalKit` `swift test`: **79/79 passed** (incl. new `TerminalCommitRouter` suite).
- autoreview (Codex, branch vs origin/main): **clean, patch correct (0.86)**.
- Backspace auto-repeat and dictation are device-only dogfood items (no speech in / no key-hold on the simulator).

## Dogfood checklist

PREV: holding the keyboard backspace deleted one character; tapping the keyboard mic did nothing.
NOW: holding the keyboard backspace auto-repeats; tapping the mic dictates into the terminal as a bracketed paste.

1. Pair the iOS app to a Mac running this build, open a terminal, type some text.
2. Press and hold the software keyboard backspace -> characters delete continuously while held (not one-per-tap).
3. Tap the keyboard mic, say a short phrase, stop -> the recognized text appears in the terminal.
4. Dictate or paste a multi-line phrase -> it lands as one paste (does not execute line-by-line). (Final line-vs-block behavior is terminal/shell dependent; verify against a shell prompt.)
5. Old-host check: against a Mac without `terminal.paste.v1`, dictation/paste still delivers via per-key input (nothing dropped).

If the mic still produces nothing on device, the suspect is the buffer-clearing in `handleTextChange` churning against UITextView's internal dictation placeholder (not missing stubs); the documented fallback is a raw-UIView + UITextInput rewrite, to be done only if device dogfood proves the UITextView path can't carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429057&installation_id=133855650&pr_number=5573&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5573&signature=8826c039d036cc7004156d2778b91bbf25e8f0137486e4dc53d9db2f570b788e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mobile terminal input and new Mac RPC path that feeds live PTY sessions; mitigated by capability gating and per-key fallback on older hosts.
> 
> **Overview**
> Improves iOS soft-keyboard terminal input so **hold-to-repeat backspace** works and **dictation, autocorrect, and multi-line clipboard text** reach the remote session as one paste instead of fragmented keystrokes.
> 
> **Backspace repeat:** `TerminalInputTextView` now always reports `hasText == true` (iSH-style) so the system keyboard keeps firing `deleteBackward`. Routing no longer treats an empty local buffer as “nothing to delete”; it keys off `markedTextRange` for IME composition and modifier accessories instead.
> 
> **Bracketed paste path:** Commits longer than one character (via `TerminalCommitRouter`) go through a new `onPasteText` → `submitTerminalPasteText` → **`terminal.paste`** RPC. The Mac handler injects through `sendText` / `ghostty_surface_text` (bracketed paste), not per-key `terminal.input`. The accessory **Paste** button’s plain text uses the same sink.
> 
> **Capability & compatibility:** Mac advertises **`terminal.paste.v1`**; iOS sets `supportsTerminalPaste` from `mobile.host.status` and clears it on reconnect. Older hosts fall back to CR-normalized `terminal.input` so nothing is dropped with `method_not_found`. RPC auth/ticket coverage includes `terminal.paste` alongside other terminal methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a9d8ad115b2f53ce314a983f865a66b40a860a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native hold-to-repeat backspace and system dictation to the iOS terminal. Multi-character commits (dictation, autocorrect, clipboard insert) now send as a single bracketed paste to the Mac, avoiding per-line execution.

- **New Features**
  - Backspace auto-repeat: override `hasText` to always be true; route `deleteBackward` using `markedTextRange` so modifiers still work.
  - Bracketed paste path for committed blocks; single chars and Return stay on per-key input.
  - New `terminal.paste` text RPC wired end-to-end (controller handler, `MobileHostService` capability/auth, RPC allowlist, and `MobileShellComposite.submitTerminalPasteText`).
  - Host capability `terminal.paste.v1` detected; falls back to `terminal.input` with CR normalization on older hosts; flag cleared on reconnects.
  - Accessory Paste button now uses the same bracketed-paste path for multi-line text.
  - Extracted `TerminalCommitRouter` in `CmuxMobileTerminalKit` with tests to decide input vs paste.

<sup>Written for commit 0a9d8ad115b2f53ce314a983f865a66b40a860a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal paste support for multi-character text input, sending pasted content as a single bracketed-paste unit to reduce fragmentation
  * Intelligent fallback to per-character input when the remote host doesn't advertise paste capability
  * Host capability advertisement now includes paste support signaling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->