### PR TITLE
iOS: DEBUG dogfood feedback round-trip + structured diagnostic log (P1)

### DIFF
--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEvent.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEvent.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// One structured diagnostic event recorded on a hot path.
+///
+/// The value is deliberately tiny and free of any allocated string: a
+/// ``DiagnosticEventCode``, a monotonic ``tNanos`` timestamp, and a handful of
+/// optional integer fields. Recording one is a struct copy onto an
+/// `AsyncStream` continuation with no formatting work, so it is cheap enough for
+/// the input and render seams that the string-based ``MobileDebugLog`` is too
+/// heavy for. Formatting into text happens only later, in
+/// ``DiagnosticLog/export()``.
+///
+/// ```swift
+/// log.record(DiagnosticEvent(.inputSeqBehind, surface: 7, a: localSeq, b: remoteSeq))
+/// ```
+public struct DiagnosticEvent: Sendable, Codable, Equatable {
+    /// What kind of event this is.
+    public var code: DiagnosticEventCode
+
+    /// A monotonic timestamp, in nanoseconds, from a continuous clock.
+    ///
+    /// Sourced from `DispatchTime.now().uptimeNanoseconds` by the convenience
+    /// initializer so two events are strictly orderable without depending on
+    /// wall-clock skew. ``DiagnosticLog/export()`` writes one wall-clock anchor
+    /// in its header so a reader can convert these back to absolute time.
+    public var tNanos: UInt64
+
+    /// An optional surface identifier the event relates to.
+    public var surface: UInt32?
+
+    /// An optional millisecond magnitude (e.g. silence duration, lag).
+    public var ms: UInt32?
+
+    /// First optional integer payload slot; meaning is per ``code``.
+    public var a: Int?
+
+    /// Second optional integer payload slot; meaning is per ``code``.
+    public var b: Int?
+
+    /// Third optional integer payload slot; meaning is per ``code``.
+    public var c: Int?
+
+    /// Creates an event with an explicit timestamp.
+    ///
+    /// - Parameters:
+    ///   - code: The event kind.
+    ///   - tNanos: A monotonic nanosecond timestamp.
+    ///   - surface: An optional surface identifier.
+    ///   - ms: An optional millisecond magnitude.
+    ///   - a: First optional integer payload slot.
+    ///   - b: Second optional integer payload slot.
+    ///   - c: Third optional integer payload slot.
+    public init(
+        code: DiagnosticEventCode,
+        tNanos: UInt64,
+        surface: UInt32? = nil,
+        ms: UInt32? = nil,
+        a: Int? = nil,
+        b: Int? = nil,
+        c: Int? = nil
+    ) {
+        self.code = code
+        self.tNanos = tNanos
+        self.surface = surface
+        self.ms = ms
+        self.a = a
+        self.b = b
+        self.c = c
+    }
+
+    /// Creates an event stamped with the current monotonic time.
+    ///
+    /// Uses `DispatchTime.now().uptimeNanoseconds`, which is monotonic within a
+    /// process run and cheap to read. This is the initializer hot-path call
+    /// sites use; it does no allocation and no string work.
+    ///
+    /// - Parameters:
+    ///   - code: The event kind.
+    ///   - surface: An optional surface identifier.
+    ///   - ms: An optional millisecond magnitude.
+    ///   - a: First optional integer payload slot.
+    ///   - b: Second optional integer payload slot.
+    ///   - c: Third optional integer payload slot.
+    public init(
+        _ code: DiagnosticEventCode,
+        surface: UInt32? = nil,
+        ms: UInt32? = nil,
+        a: Int? = nil,
+        b: Int? = nil,
+        c: Int? = nil
+    ) {
+        self.init(
+            code: code,
+            tNanos: DispatchTime.now().uptimeNanoseconds,
+            surface: surface,
+            ms: ms,
+            a: a,
+            b: b,
+            c: c
+        )
+    }
+}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A compact, stable identifier for one kind of diagnostic event.
+///
+/// The raw value is a small ``UInt16`` so a ``DiagnosticEvent`` stays tiny and
+/// an exported log row is a few bytes instead of an interpolated string. New
+/// cases append a fresh raw value and never renumber an existing one, so a blob
+/// exported by an older build still decodes against a newer reader.
+///
+/// The cases cover the round-trip seams a dogfooder cares about: connection and
+/// pairing outcome, render-grid liveness (silent re-subscribe / stream ended),
+/// the input-sequence and byte-gap stalls that surface as "my keystrokes lag",
+/// and a generic ``error`` bucket.
+public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
+    /// A connection attempt to a paired Mac started.
+    case connect = 1
+    /// Pairing / attach completed successfully.
+    case pairOk = 2
+    /// Pairing / attach failed.
+    case pairFail = 3
+    /// The render-grid stream lagged behind (a bounded render-lag counter tick).
+    ///
+    /// Reserved for the render hot path in `GhosttySurfaceView` (the existing
+    /// `oq.render.LAG` site). It is part of the export vocabulary now, but not
+    /// emitted from the shell: instrumenting the per-frame render seam is a
+    /// deeper injection deferred past P1, and the spec caps render-path
+    /// instrumentation at a single bounded counter.
+    case renderGridLag = 4
+    /// The liveness watchdog forced a re-subscribe after a silent stream.
+    case livenessResubscribe = 5
+    /// The render-grid push stream ended and fell back to polling.
+    case streamEnded = 6
+    /// The local input sequence fell behind the remote-applied sequence.
+    case inputSeqBehind = 7
+    /// A gap was detected in the delivered terminal byte stream.
+    case byteGap = 8
+    /// A generic error at an instrumented seam.
+    case error = 9
+}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
@@ -1,0 +1,230 @@
+public import Foundation
+
+/// A fixed-capacity ring of recent ``DiagnosticEvent`` values with a lock-free
+/// hot-path recorder.
+///
+/// The recorder seam is the point of the design: ``record(_:)`` is
+/// `nonisolated` and does nothing but `continuation.yield(event)` on an
+/// `AsyncStream<DiagnosticEvent>.Continuation` created with
+/// `.bufferingNewest(capacity)`. There is no per-event `Task { await … }` hop
+/// (the cost the string-based `MobileDebugLog.append` pays), no lock, and no
+/// actor hop on the caller's thread, so it is safe to call from the input and
+/// render seams. A single internal consumer `Task` drains the stream into the
+/// ring (the only mutable state, held by an inner `actor`), evicting the oldest
+/// events past ``capacity``.
+///
+/// ``export()`` drains the ring into a compact blob: a one-line header carrying
+/// a wall-clock anchor and the build stamp, then one short row per event
+/// (`tNanos,code,surface,ms,a,b,c`, omitting absent fields). The blob is small
+/// by construction (bounded by ``capacity`` rows of integers).
+///
+/// Inject one instance from the app composition root; do not add a `.shared`
+/// singleton.
+///
+/// ```swift
+/// let log = DiagnosticLog()
+/// log.record(DiagnosticEvent(.connect))
+/// let blob = await log.export()
+/// ```
+public final class DiagnosticLog: Sendable {
+    /// The maximum number of retained events. Oldest are dropped past this.
+    public let capacity: Int
+
+    /// The build-identity stamp written into the export header. Exposed so a
+    /// caller can also carry it as a top-level field when submitting a bundle.
+    public let buildStamp: String
+
+    /// The continuation the hot path yields onto. `.bufferingNewest(capacity)`
+    /// drops the oldest pending event if the consumer falls behind, so a burst
+    /// can never block the recorder or grow unboundedly.
+    private let continuation: AsyncStream<DiagnosticEvent>.Continuation
+
+    /// The inner actor owning the ring buffer and the wall-clock anchor.
+    private let store: Store
+
+    /// The drain task. Held so it is cancelled when the log is deinitialized.
+    private let drainTask: Task<Void, Never>
+
+    /// Creates a diagnostic log.
+    ///
+    /// - Parameters:
+    ///   - capacity: Maximum retained events; oldest drop past this. Defaults to
+    ///     `4096`.
+    ///   - buildStamp: A short string identifying the running build, written
+    ///     into the export header. Defaults to empty.
+    ///   - anchorWallNanos: Wall-clock time at construction, in nanoseconds since
+    ///     the Unix epoch, paired with ``anchorMonotonicNanos`` so export can map
+    ///     monotonic event timestamps back to absolute time. Injected for tests;
+    ///     defaults to the current time.
+    ///   - anchorMonotonicNanos: The monotonic clock reading captured at the same
+    ///     instant as ``anchorWallNanos``. Injected for tests; defaults to
+    ///     `DispatchTime.now().uptimeNanoseconds`.
+    public init(
+        capacity: Int = 4096,
+        buildStamp: String = "",
+        anchorWallNanos: UInt64 = UInt64(max(0, Date().timeIntervalSince1970 * 1_000_000_000)),
+        anchorMonotonicNanos: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) {
+        self.capacity = capacity
+        self.buildStamp = buildStamp
+        let store = Store(
+            capacity: capacity,
+            buildStamp: buildStamp,
+            anchorWallNanos: anchorWallNanos,
+            anchorMonotonicNanos: anchorMonotonicNanos
+        )
+        self.store = store
+        let (stream, continuation) = AsyncStream<DiagnosticEvent>.makeStream(
+            bufferingPolicy: .bufferingNewest(capacity)
+        )
+        self.continuation = continuation
+        self.drainTask = Task {
+            for await event in stream {
+                await store.append(event)
+            }
+        }
+    }
+
+    deinit {
+        continuation.finish()
+        drainTask.cancel()
+    }
+
+    /// Record one event. Lock-free, non-blocking, safe from any thread.
+    ///
+    /// This is the hot-path API. It only yields the value onto the buffered
+    /// stream; the actual ring write happens on the internal drain task. A burst
+    /// past the consumer's pace drops the oldest pending events (per
+    /// `.bufferingNewest`), never the caller.
+    ///
+    /// - Parameter event: The event to record.
+    public nonisolated func record(_ event: DiagnosticEvent) {
+        continuation.yield(event)
+    }
+
+    /// Snapshot the currently-drained ring and format a compact export blob.
+    ///
+    /// Reads whatever the drain task has already moved into the ring; it does not
+    /// force a flush of events still in flight on the stream (the AsyncStream +
+    /// drain design is eventually consistent, which is fine for a human-timed
+    /// submit). The result is small by construction (bounded by ``capacity``
+    /// integer rows). Tests that need an exact post-record snapshot await
+    /// ``processedCount()`` first.
+    ///
+    /// - Returns: The UTF-8 encoded compact blob.
+    public func export() async -> Data {
+        await store.export()
+    }
+
+    /// The current number of retained events.
+    public func count() async -> Int {
+        await store.count()
+    }
+
+    /// The total number of events the drain task has processed since creation.
+    ///
+    /// Unlike ``count()`` this never decreases (ring eviction does not lower it),
+    /// so it is a stable barrier: after recording `n` events a caller can await
+    /// this reaching `n` to know every recorded event has reached the ring,
+    /// regardless of capacity. Used by tests to make the async drain
+    /// deterministic without sleeping.
+    public func processedCount() async -> Int {
+        await store.processedCount()
+    }
+
+    /// The inner actor that owns the ring and renders the export blob.
+    ///
+    /// The ring is a fixed-size pre-allocated `[DiagnosticEvent?]` indexed by a
+    /// `head` cursor and a saturating `filled` count, so both append and
+    /// eviction are O(1): a new event overwrites the slot at `head` and advances
+    /// the cursor (no `Array.removeFirst`, which would be O(capacity) per event
+    /// once full and would starve the drain task during the exact lag bursts this
+    /// log captures).
+    private actor Store {
+        private var slots: [DiagnosticEvent?]
+        private var head = 0
+        private var filled = 0
+        private var totalProcessed = 0
+        private let capacity: Int
+        private let buildStamp: String
+        private let anchorWallNanos: UInt64
+        private let anchorMonotonicNanos: UInt64
+
+        init(
+            capacity: Int,
+            buildStamp: String,
+            anchorWallNanos: UInt64,
+            anchorMonotonicNanos: UInt64
+        ) {
+            // A zero/negative capacity would make a 0-length ring; clamp to 1 so
+            // append always has a slot.
+            let clamped = max(1, capacity)
+            self.capacity = clamped
+            self.buildStamp = buildStamp
+            self.anchorWallNanos = anchorWallNanos
+            self.anchorMonotonicNanos = anchorMonotonicNanos
+            self.slots = Array(repeating: nil, count: clamped)
+        }
+
+        func append(_ event: DiagnosticEvent) {
+            slots[head] = event
+            head = (head + 1) % capacity
+            if filled < capacity {
+                filled += 1
+            }
+            totalProcessed += 1
+        }
+
+        func count() -> Int {
+            filled
+        }
+
+        func processedCount() -> Int {
+            totalProcessed
+        }
+
+        /// The retained events in chronological order (oldest first).
+        ///
+        /// When the ring is full the oldest event sits at `head` (the next write
+        /// target); when not yet full the oldest is at index 0. Walking `filled`
+        /// slots from `start` yields them in record order.
+        private func orderedEvents() -> [DiagnosticEvent] {
+            let start = filled < capacity ? 0 : head
+            var result: [DiagnosticEvent] = []
+            result.reserveCapacity(filled)
+            for offset in 0..<filled {
+                if let event = slots[(start + offset) % capacity] {
+                    result.append(event)
+                }
+            }
+            return result
+        }
+
+        func export() -> Data {
+            var out = "cmuxdiag v1"
+            out += " anchorWallNs=\(anchorWallNanos)"
+            out += " anchorMonoNs=\(anchorMonotonicNanos)"
+            out += " count=\(filled)"
+            if !buildStamp.isEmpty {
+                out += " build=\(buildStamp)"
+            }
+            out += "\n"
+            for event in orderedEvents() {
+                out += "\(event.tNanos),\(event.code.rawValue)"
+                out += ",\(Self.field(event.surface))"
+                out += ",\(Self.field(event.ms))"
+                out += ",\(Self.field(event.a))"
+                out += ",\(Self.field(event.b))"
+                out += ",\(Self.field(event.c))"
+                out += "\n"
+            }
+            return Data(out.utf8)
+        }
+
+        /// Render an optional integer field: empty when absent, decimal when set.
+        private static func field(_ value: (some BinaryInteger)?) -> String {
+            guard let value else { return "" }
+            return String(value)
+        }
+    }
+}

--- a/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+@Suite struct DiagnosticLogTests {
+    /// Await the log's drain task until its ring reports `expected` events, so a
+    /// test can assert on a deterministic post-drain state without sleeping. The
+    /// drain task runs on the cooperative pool; `Task.yield()` lets it advance.
+    /// Bounded so a regression that never drains fails instead of hanging.
+    /// Await the drain task processing at least `expected` total events, so a
+    /// test can assert on a deterministic post-drain state without sleeping.
+    /// ``DiagnosticLog/processedCount()`` only grows (eviction does not lower
+    /// it), so it is a stable barrier even when the ring is at capacity. The
+    /// drain task runs on the cooperative pool; `Task.yield()` lets it advance.
+    /// Bounded so a regression that never drains fails instead of hanging.
+    private func waitForProcessed(_ log: DiagnosticLog, _ expected: Int) async {
+        for _ in 0..<1_000_000 {
+            if await log.processedCount() >= expected { return }
+            await Task.yield()
+        }
+    }
+
+    /// Record one event and await it draining into the ring, so the next record
+    /// never overflows the stream buffer. Draining each event before recording
+    /// the next means what survives is governed only by the ring's eviction
+    /// (deterministic) and never by `.bufferingNewest`'s pending-drop policy
+    /// (timing-dependent).
+    private func recordAndDrain(
+        _ log: DiagnosticLog,
+        _ event: DiagnosticEvent,
+        processedAfter: Int
+    ) async {
+        log.record(event)
+        await waitForProcessed(log, processedAfter)
+    }
+
+    @Test func recordThenExportRoundTrips() async {
+        let log = DiagnosticLog(
+            capacity: 16,
+            buildStamp: "cmux DEV test",
+            anchorWallNanos: 1_700_000_000_000_000_000,
+            anchorMonotonicNanos: 500
+        )
+        log.record(DiagnosticEvent(code: .connect, tNanos: 1_000))
+        log.record(DiagnosticEvent(code: .pairOk, tNanos: 2_000, ms: 250))
+        log.record(DiagnosticEvent(code: .inputSeqBehind, tNanos: 3_000, surface: 7, a: 10, b: 20))
+        await waitForProcessed(log, 3)
+
+        let blob = await log.export()
+        let text = String(decoding: blob, as: UTF8.self)
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        // Header: version, anchors, count, build stamp.
+        #expect(lines[0].hasPrefix("cmuxdiag v1"))
+        #expect(lines[0].contains("anchorWallNs=1700000000000000000"))
+        #expect(lines[0].contains("anchorMonoNs=500"))
+        #expect(lines[0].contains("count=3"))
+        #expect(lines[0].contains("build=cmux DEV test"))
+
+        // One compact row per event: tNanos,code,surface,ms,a,b,c (absent = empty).
+        #expect(lines[1] == "1000,1,,,,,")
+        #expect(lines[2] == "2000,2,,250,,,")
+        #expect(lines[3] == "3000,7,7,,10,20,")
+    }
+
+    @Test func ringEvictionDropsOldest() async {
+        let log = DiagnosticLog(capacity: 3)
+        // Drain each event before recording the next so eviction is governed
+        // purely by the ring (not by the stream's bufferingNewest drop policy).
+        for i in 0..<6 {
+            await recordAndDrain(
+                log,
+                DiagnosticEvent(code: .connect, tNanos: UInt64(i)),
+                processedAfter: i + 1
+            )
+        }
+        #expect(await log.count() == 3)
+
+        let text = String(decoding: await log.export(), as: UTF8.self)
+        let rows = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .dropFirst()
+            .filter { !$0.isEmpty }
+            .map(String.init)
+        #expect(rows.count == 3)
+        // Oldest (tNanos 0,1,2) evicted; newest (3,4,5) retained, in order.
+        #expect(rows[0].hasPrefix("3,"))
+        #expect(rows[1].hasPrefix("4,"))
+        #expect(rows[2].hasPrefix("5,"))
+    }
+
+    @Test func recordIsNonBlockingUnderBurst() async {
+        // A burst far larger than capacity must not block the recorder: every
+        // `record` returns synchronously (no await), and the ring stays bounded
+        // by capacity once the drain settles. `.bufferingNewest` drops the
+        // oldest *pending* events, so the final ring is bounded, not exact.
+        let capacity = 64
+        let log = DiagnosticLog(capacity: capacity)
+        let burst = 50_000
+        for i in 0..<burst {
+            log.record(DiagnosticEvent(code: .renderGridLag, tNanos: UInt64(i), ms: 1))
+        }
+        // The recorder never suspended; we reach here immediately. Let the drain
+        // settle and confirm the ring never exceeds capacity.
+        await waitForProcessed(log, 1)
+        let count = await log.count()
+        #expect(count >= 1)
+        #expect(count <= capacity)
+    }
+
+    @Test func circularBufferWrapsAndPreservesChronologicalOrder() async {
+        // Drive the O(1) ring past several full wrap cycles and confirm export
+        // still yields exactly the newest `capacity` events in record order,
+        // proving the head/offset arithmetic is correct across the wrap boundary.
+        let capacity = 4
+        let log = DiagnosticLog(capacity: capacity)
+        let total = 13 // 3 full cycles + 1, so head wraps and lands mid-array
+        for i in 0..<total {
+            await recordAndDrain(
+                log,
+                DiagnosticEvent(code: .connect, tNanos: UInt64(i)),
+                processedAfter: i + 1
+            )
+        }
+        #expect(await log.count() == capacity)
+
+        let text = String(decoding: await log.export(), as: UTF8.self)
+        let rows = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .dropFirst()
+            .filter { !$0.isEmpty }
+            .map(String.init)
+        #expect(rows.count == capacity)
+        // Newest `capacity` events are tNanos 9,10,11,12, in order.
+        #expect(rows[0].hasPrefix("9,"))
+        #expect(rows[1].hasPrefix("10,"))
+        #expect(rows[2].hasPrefix("11,"))
+        #expect(rows[3].hasPrefix("12,"))
+    }
+
+    @Test func exportOnEmptyLogHasHeaderOnly() async {
+        let log = DiagnosticLog(capacity: 8)
+        let text = String(decoding: await log.export(), as: UTF8.self)
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0].hasPrefix("cmuxdiag v1"))
+        #expect(lines[0].contains("count=0"))
+        // No build stamp segment when empty default was used.
+        #expect(!lines[0].contains("build="))
+        // Nothing after the header but the trailing newline split.
+        #expect(lines.filter { !$0.isEmpty }.count == 1)
+    }
+}

--- a/Packages/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLog.swift
+++ b/Packages/CmuxMobileDiagnostics/Sources/CmuxMobileDiagnostics/MobileDebugLog.swift
@@ -45,7 +45,11 @@ public struct MobileDebugLog: Sendable {
     /// the executable's build timestamp (changes on every rebuild). All dev
     /// builds share `CFBundleVersion = 1`, so the exec mtime is the only signal
     /// that distinguishes one reload from the next.
-    static let buildStamp: String = {
+    ///
+    /// Public so the composition root can stamp the same identity into a
+    /// ``DiagnosticLog`` export header, keeping one build-identity source of
+    /// truth across both the string log and the structured log.
+    public static let buildStamp: String = {
         var parts: [String] = []
         if let name = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String {
             parts.append(name)

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -218,6 +218,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// reading it again would report the first successful pair as `is_first_pair:
     /// false` and break the first-pair funnel.
     private var pairingAttemptIsFirstPair = false
+
+    /// The structured diagnostic log, injected from the app composition root.
+    ///
+    /// Recording is lock-free and `nonisolated`, so the connect/pair, liveness,
+    /// and seq/byte-gap seams below dual-emit a compact ``DiagnosticEvent``
+    /// alongside their existing ``MobileDebugLog/anchormux(_:)`` string line.
+    /// `nil` in previews/tests that do not exercise the round-trip. Exposed
+    /// `public` so the DEV feedback-submit affordance can ``DiagnosticLog/export()``
+    /// it.
+    public let diagnosticLog: DiagnosticLog?
     private var remoteClient: MobileCoreRPCClient? {
         didSet {
             if remoteClient == nil {
@@ -284,6 +294,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return selectedWorkspace.preferredTerminal
     }
 
+    /// A small stable numeric handle for a surface-id string, for the compact
+    /// ``DiagnosticEvent/surface`` field. Surface ids are strings (e.g.
+    /// `"workspace-1-terminal-2"`); this maps one to a `UInt32` so the structured
+    /// log can carry which surface an event relates to without storing a string.
+    /// Correlation only, not reversible.
+    private static func diagnosticSurfaceHandle(_ surfaceID: String) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for byte in surfaceID.utf8 {
+            hash = (hash ^ UInt32(byte)) &* 16_777_619
+        }
+        return hash
+    }
+
     public init(
         runtime: (any MobileSyncRuntime)? = nil,
         isSignedIn: Bool = false,
@@ -296,7 +319,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         identityProvider: (any MobileIdentityProviding)? = nil,
         reachability: any ReachabilityProviding = ReachabilityService(),
         pairingHintDefaults: UserDefaults = .standard,
-        analytics: any AnalyticsEmitting = NoopAnalytics()
+        analytics: any AnalyticsEmitting = NoopAnalytics(),
+        diagnosticLog: DiagnosticLog? = nil
     ) {
         self.runtime = runtime
         self.pairedMacStore = pairedMacStore
@@ -304,6 +328,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.reachability = reachability
         self.pairingHintDefaults = pairingHintDefaults
         self.analytics = analytics
+        self.diagnosticLog = diagnosticLog
         // Distinguish "key absent" (an install that predates the hint and may
         // already have a paired Mac in SQLite) from "key present and false" (we
         // determined there is no paired Mac). didSet is not called for these
@@ -537,6 +562,105 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
     }
+
+    #if DEBUG
+    /// DEV dogfood feedback round-trip (P1): export the structured diagnostic
+    /// log, package it with the supplied debug-log text, visible terminal text,
+    /// and an optional freeform note, and submit it to the paired Mac's
+    /// `dogfood.feedback.submit` sink.
+    ///
+    /// The structured log is exported here (the store owns ``diagnosticLog``);
+    /// the string snapshots are gathered by the caller on the UI layer, where the
+    /// `GhosttySurfaceView`/`MobileDebugLog` accessors live. Fire-and-forget; a
+    /// transport failure is logged and surfaced via the returned `Bool`.
+    ///
+    /// - Parameters:
+    ///   - text: An optional freeform note from the dogfooder.
+    ///   - debugLogText: The string debug-log snapshot (from `MobileDebugLog`).
+    ///   - terminalText: The visible terminal text (from `GhosttySurfaceView`).
+    /// - Returns: `true` when the Mac acknowledged the bundle.
+    @discardableResult
+    public func submitDogfoodFeedback(
+        text: String,
+        debugLogText: String,
+        terminalText: String
+    ) async -> Bool {
+        guard let client = remoteClient else { return false }
+        let diagnosticBlob = await diagnosticLog?.export() ?? Data()
+        let buildStamp = diagnosticLog?.buildStamp ?? ""
+        let clientID = clientID
+        // Cap inputs and build the (potentially multi-MiB) combined blob +
+        // base64 + JSON request OFF the main actor: the store is `@MainActor`, so
+        // doing the concat/encode here would block the UI on a large bundle. A
+        // detached task returns the finished request bytes (`Data` is `Sendable`).
+        let request: Data?
+        do {
+            request = try await Task.detached(priority: .utility) { () -> Data in
+                try Self.buildDogfoodFeedbackRequest(
+                    text: text,
+                    debugLogText: debugLogText,
+                    terminalText: terminalText,
+                    buildStamp: buildStamp,
+                    clientID: clientID,
+                    diagnosticBlob: diagnosticBlob
+                )
+            }.value
+        } catch {
+            mobileShellLog.error("dogfood feedback encode failed error=\(String(describing: error), privacy: .public)")
+            return false
+        }
+        guard let request else { return false }
+        do {
+            _ = try await client.sendRequest(request)
+            return true
+        } catch {
+            mobileShellLog.error("dogfood feedback submit failed error=\(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
+    /// Client-side caps mirroring the Mac sink, applied before any large
+    /// allocation so a huge debug log or note can't be encoded into a multi-MiB
+    /// request on the phone. `nonisolated` so the off-main request builder can
+    /// read them.
+    nonisolated private static let dogfoodFeedbackMaxTextChars = 16_384
+    nonisolated private static let dogfoodFeedbackMaxTerminalChars = 262_144
+    nonisolated private static let dogfoodFeedbackMaxDebugLogChars = 1_048_576
+
+    /// Combine the structured + string diagnostics into one self-contained blob,
+    /// base64-encode it, and build the RPC request — all off the main actor.
+    ///
+    /// The string debug log rides inside the same diagnostic file as the compact
+    /// structured rows (rows, a divider, then the human-readable log) so the Mac
+    /// bundle is self-contained. Inputs are size-capped first.
+    nonisolated private static func buildDogfoodFeedbackRequest(
+        text: String,
+        debugLogText: String,
+        terminalText: String,
+        buildStamp: String,
+        clientID: String,
+        diagnosticBlob: Data
+    ) throws -> Data {
+        let cappedText = String(text.prefix(dogfoodFeedbackMaxTextChars))
+        let cappedTerminal = String(terminalText.prefix(dogfoodFeedbackMaxTerminalChars))
+        let cappedDebugLog = String(debugLogText.prefix(dogfoodFeedbackMaxDebugLogChars))
+        var combined = diagnosticBlob
+        if !cappedDebugLog.isEmpty {
+            combined.append(Data("\n----- mobile debug log -----\n".utf8))
+            combined.append(Data(cappedDebugLog.utf8))
+        }
+        return try MobileCoreRPCClient.requestData(
+            method: "dogfood.feedback.submit",
+            params: [
+                "text": cappedText,
+                "terminal_text": cappedTerminal,
+                "build_stamp": buildStamp,
+                "diagnostic_blob_base64": combined.base64EncodedString(),
+                "client_id": clientID,
+            ]
+        )
+    }
+    #endif
 
     // MARK: - Network recovery
 
@@ -1443,6 +1567,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) async throws {
         let generation = UUID()
         connectionGeneration = generation
+        diagnosticLog?.record(DiagnosticEvent(.connect))
         cancelRemoteOperationTasks()
         rawTerminalInputBuffer.clear()
         let supportedKinds = runtime?.supportedRouteKinds ?? []
@@ -1509,6 +1634,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     syncSelectedTerminalForWorkspace()
                     connectionState = .connected
                     markMacConnectionHealthy()
+                    diagnosticLog?.record(DiagnosticEvent(.pairOk))
                     if workspaceListRequest.isScoped {
                         scheduleFullWorkspaceListRefreshIfAvailable(
                             client: client,
@@ -1528,6 +1654,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
 
         clearRemoteConnectionContext()
+        diagnosticLog?.record(DiagnosticEvent(.pairFail))
         throw lastError ?? MobileShellConnectionError.connectionClosed
     }
 
@@ -2180,6 +2307,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             ) ?? false
             guard subscribed else {
                 MobileDebugLog.anchormux("sync.subscribe_failed reason=start")
+                self?.diagnosticLog?.record(DiagnosticEvent(.error))
                 self?.markMacConnectionUnavailable()
                 return
             }
@@ -2219,6 +2347,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         mobileShellLog.info("terminal event stream ended, restarting")
         MobileDebugLog.anchormux("sync.stream_ended restarting (render-grid push stopped; falling back to poll)")
+        diagnosticLog?.record(DiagnosticEvent(.streamEnded))
         markMacConnectionReconnecting()
         terminalEventListenerTask = nil
         terminalEventListenerID = nil
@@ -2295,6 +2424,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard silent >= Self.renderGridLivenessSilenceThreshold else { return }
         let silentMs = Int(silent * 1000)
         MobileDebugLog.anchormux("sync.liveness re-subscribe silentMs=\(silentMs)")
+        diagnosticLog?.record(DiagnosticEvent(.livenessResubscribe, ms: UInt32(clamping: silentMs)))
         mobileShellLog.info("render-grid stream silent for \(silentMs, privacy: .public)ms, re-subscribing")
         // resyncTerminalOutput(restartEventStream: true) stops the wedged listener
         // (which cancels this watchdog via stopTerminalRefreshPolling) and starts a
@@ -2341,6 +2471,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             pendingTerminalByteEndSeqBySurfaceID[surfaceID] = max(remoteSeq, pendingSeq ?? 0)
             if let pendingSeq, localSeq < pendingSeq {
                 MobileDebugLog.anchormux("sync.input_seq_still_behind surface=\(surfaceID) local=\(localSeq) pending=\(pendingSeq) remote=\(remoteSeq)")
+                diagnosticLog?.record(DiagnosticEvent(
+                    .inputSeqBehind,
+                    surface: Self.diagnosticSurfaceHandle(surfaceID),
+                    a: Int(clamping: localSeq),
+                    b: Int(clamping: remoteSeq),
+                    c: Int(clamping: pendingSeq)
+                ))
                 mobileShellLog.info("terminal render-grid still behind after input surface=\(surfaceID, privacy: .public) localSeq=\(localSeq, privacy: .public) pendingSeq=\(pendingSeq, privacy: .public) remoteSeq=\(remoteSeq, privacy: .public)")
                 resyncTerminalOutput(
                     reason: "input_seq_still_behind",
@@ -2354,6 +2491,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         MobileDebugLog.anchormux("sync.input_seq_behind surface=\(surfaceID) local=\(localSeq) remote=\(remoteSeq)")
+        diagnosticLog?.record(DiagnosticEvent(
+            .inputSeqBehind,
+            surface: Self.diagnosticSurfaceHandle(surfaceID),
+            a: Int(clamping: localSeq),
+            b: Int(clamping: remoteSeq)
+        ))
         mobileShellLog.info("terminal output behind after input surface=\(surfaceID, privacy: .public) localSeq=\(localSeq, privacy: .public) remoteSeq=\(remoteSeq, privacy: .public)")
         resyncTerminalOutput(
             reason: "input_seq_behind",
@@ -2640,6 +2783,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] {
             if seq > deliveredSeq {
                 MobileDebugLog.anchormux("sync.byte_gap surface=\(surfaceID) delivered=\(deliveredSeq) next=\(seq)")
+                diagnosticLog?.record(DiagnosticEvent(
+                    .byteGap,
+                    surface: Self.diagnosticSurfaceHandle(surfaceID),
+                    a: Int(clamping: deliveredSeq),
+                    b: Int(clamping: seq)
+                ))
                 mobileShellLog.info("terminal byte gap surface=\(surfaceID, privacy: .public) deliveredSeq=\(deliveredSeq, privacy: .public) nextSeq=\(seq, privacy: .public)")
                 resyncTerminalOutput(
                     reason: "seq_gap",

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -22,6 +22,11 @@ struct WorkspaceDetailView: View {
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
     @State private var isTerminalPickerPresented = false
+    #if DEBUG && canImport(UIKit)
+    @State private var isFeedbackComposerPresented = false
+    @State private var feedbackText = ""
+    @State private var isSubmittingFeedback = false
+    #endif
 
     private var selectedTerminal: MobileTerminalPreview? {
         workspace.terminals.first { $0.id == store.selectedTerminalID } ?? workspace.terminals.first
@@ -105,6 +110,11 @@ struct WorkspaceDetailView: View {
             }
         #endif
         }
+        #if DEBUG && canImport(UIKit)
+        .sheet(isPresented: $isFeedbackComposerPresented) {
+            feedbackComposer
+        }
+        #endif
     }
 
     @ViewBuilder
@@ -200,6 +210,17 @@ struct WorkspaceDetailView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
             .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
+
+            Button(action: openFeedbackComposerFromMenu) {
+                // DEV-only debug tooling; not shipped, so not localized.
+                Label("Send to agent", systemImage: "paperplane")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .accessibilityIdentifier("MobileSendFeedbackMenuItem")
             #endif
         }
         .frame(minWidth: 240, maxWidth: 320, alignment: .leading)
@@ -216,6 +237,68 @@ struct WorkspaceDetailView: View {
             let count = await MobileDebugLog.shared.copyToPasteboard(prepending: terminalText)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             NSLog("cmux.terminal copied %d debug log lines + visible terminal to pasteboard", count)
+        }
+    }
+
+    private func openFeedbackComposerFromMenu() {
+        isTerminalPickerPresented = false
+        feedbackText = ""
+        isFeedbackComposerPresented = true
+    }
+
+    // DEV-only dogfood feedback composer; not shipped, so its strings are not
+    // localized. Lets the dogfooder type an optional note and ship the structured
+    // diagnostic log + debug log + visible terminal text to the paired Mac.
+    private var feedbackComposer: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Send a structured diagnostic bundle (events + debug log + visible terminal) to the paired Mac. Add an optional note.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                TextField("What happened? (optional)", text: $feedbackText, axis: .vertical)
+                    .lineLimit(3...8)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityIdentifier("MobileFeedbackComposerField")
+                Spacer()
+            }
+            .padding(16)
+            .navigationTitle("Send to agent")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { isFeedbackComposerPresented = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Send", action: submitFeedbackFromComposer)
+                        .disabled(isSubmittingFeedback)
+                        .accessibilityIdentifier("MobileFeedbackComposerSend")
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    private func submitFeedbackFromComposer() {
+        guard !isSubmittingFeedback else { return }
+        isSubmittingFeedback = true
+        let note = feedbackText
+        // `visibleTerminalSnapshot()` reads off the output queue with a bounded
+        // wait (never a main-thread `ghostty_surface_read_text`, which blanks the
+        // terminal). The debug-log snapshot is awaited from its actor.
+        let terminalText = GhosttySurfaceView.visibleTerminalSnapshot()
+        Task { @MainActor in
+            defer {
+                isSubmittingFeedback = false
+                isFeedbackComposerPresented = false
+            }
+            let (_, debugLogText) = await MobileDebugLog.shared.sink.snapshotWithCount()
+            let ok = await store.submitDogfoodFeedback(
+                text: note,
+                debugLogText: debugLogText,
+                terminalText: terminalText
+            )
+            UINotificationFeedbackGenerator().notificationOccurred(ok ? .success : .error)
+            NSLog("cmux.dogfood feedback submit ok=%@", ok ? "1" : "0")
         }
     }
     #endif

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -297,14 +297,24 @@ final class MobileHostService {
     /// cache, the live `publicHostStatusResult`, and `TerminalController`'s
     /// full status) reads this so the lists cannot drift; iOS gates features
     /// like rename/pin on the entries present here.
-    nonisolated static let mobileHostCapabilities: [String] = [
-        "events.v1",
-        "terminal.bytes.v1",
-        "terminal.render_grid.v1",
-        "terminal.replay.v1",
-        "terminal.viewport.v1",
-        "workspace.actions.v1",
-    ]
+    ///
+    /// In DEBUG builds this also advertises `dogfood.v1`, the DEV dogfood
+    /// feedback round-trip (`dogfood.feedback.submit`). It is absent from
+    /// release builds, so a release client never sees the verb advertised.
+    nonisolated static var mobileHostCapabilities: [String] {
+        var capabilities = [
+            "events.v1",
+            "terminal.bytes.v1",
+            "terminal.render_grid.v1",
+            "terminal.replay.v1",
+            "terminal.viewport.v1",
+            "workspace.actions.v1",
+        ]
+        #if DEBUG
+        capabilities.append("dogfood.v1")
+        #endif
+        return capabilities
+    }
 
     private let callbackQueue = DispatchQueue(label: "dev.cmux.mobile.host-listener")
     private let routeResolver = MobileRouteResolver()

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20686,6 +20686,10 @@ class TerminalController {
             result = v2MobileTerminalMouse(params: request.params)
         case "workspace.action":
             result = v2MobileWorkspaceAction(params: request.params)
+#if DEBUG
+        case "dogfood.feedback.submit":
+            result = await v2MobileDogfoodFeedbackSubmit(params: request.params)
+#endif
         default:
             result = .err(code: "method_not_found", message: "Unknown mobile method", data: [
                 "method": request.method
@@ -20693,6 +20697,183 @@ class TerminalController {
         }
         return mobileHostResult(result)
     }
+
+#if DEBUG
+    /// Hard caps for the DEV dogfood feedback sink. A debug client is the only
+    /// caller, but a malformed or hostile request must not be able to allocate
+    /// huge buffers, block the Mac UI, or grow the cache without bound. Strings
+    /// are capped by character count before any large allocation; the base64
+    /// blob is rejected outright past its cap (so it is never decoded), and a
+    /// decoded blob past the byte cap is dropped.
+    nonisolated private static let dogfoodFeedbackMaxTextChars = 16_384
+    nonisolated private static let dogfoodFeedbackMaxTerminalChars = 262_144
+    nonisolated private static let dogfoodFeedbackMaxBuildStampChars = 512
+    nonisolated private static let dogfoodFeedbackMaxBlobBase64Chars = 8_388_608 // ~6 MiB decoded
+    nonisolated private static let dogfoodFeedbackMaxBlobBytes = 6_291_456 // 6 MiB
+    /// Keep at most this many bundle directories; older ones are pruned after
+    /// each write so a retrying client can't grow the cache without bound.
+    nonisolated private static let dogfoodFeedbackMaxRetainedBundles = 50
+
+    /// DEV-only dogfood feedback sink (P1 of the Mac↔phone feedback loop).
+    ///
+    /// Decodes `{ text, terminal_text, build_stamp, diagnostic_blob_base64 }`,
+    /// writes a self-contained bundle directory under
+    /// `~/.cache/cmux-dogfood-feedback/<ISO8601>_<shortid>/` (a `bundle.json`
+    /// manifest plus the decoded `diagnostic.log`), and returns the bundle path.
+    /// Gated behind `#if DEBUG` and the same-account Stack-auth authorization the
+    /// rest of the mobile data plane enforces, so it never exists in a release
+    /// build and never accepts an unauthenticated caller.
+    ///
+    /// Field sizes are capped on the main actor *before* any large allocation,
+    /// invalid/oversized base64 is rejected without decoding, and the decode +
+    /// filesystem writes run off the main actor so a large payload cannot block
+    /// the Mac UI.
+    private func v2MobileDogfoodFeedbackSubmit(params: [String: Any]) async -> V2CallResult {
+        // Cheap main-actor validation first: cap each field by character count
+        // before allocating anything large, and reject an oversized base64 blob
+        // outright so it is never decoded into a giant Data.
+        let text = String((v2RawString(params, "text") ?? "").prefix(Self.dogfoodFeedbackMaxTextChars))
+        let terminalText = String((v2RawString(params, "terminal_text") ?? "").prefix(Self.dogfoodFeedbackMaxTerminalChars))
+        let buildStamp = String((v2RawString(params, "build_stamp") ?? "").prefix(Self.dogfoodFeedbackMaxBuildStampChars))
+        let diagnosticBlobBase64 = v2RawString(params, "diagnostic_blob_base64") ?? ""
+        guard diagnosticBlobBase64.count <= Self.dogfoodFeedbackMaxBlobBase64Chars else {
+            return .err(
+                code: "invalid_params",
+                message: "diagnostic_blob_base64 exceeds size limit",
+                data: nil
+            )
+        }
+
+        let maxBlobBytes = Self.dogfoodFeedbackMaxBlobBytes
+        // Off-main: decode the blob and write the bundle. A `Task.detached`
+        // keeps the (potentially multi-MiB) decode + synchronous file I/O off the
+        // main actor so it never stalls the Mac UI. Returns a Sendable result.
+        let outcome = await Task.detached(priority: .utility) { () -> DogfoodFeedbackWriteOutcome in
+            let decoded = Data(base64Encoded: diagnosticBlobBase64) ?? Data()
+            guard decoded.count <= maxBlobBytes else {
+                return .rejected(reason: "diagnostic blob exceeds size limit")
+            }
+            return Self.writeDogfoodFeedbackBundle(
+                text: text,
+                terminalText: terminalText,
+                buildStamp: buildStamp,
+                diagnosticData: decoded
+            )
+        }.value
+
+        switch outcome {
+        case let .written(bundlePath, byteCount):
+            return .ok([
+                "ok": true,
+                "bundle_path": bundlePath,
+                "diagnostic_log_bytes": byteCount,
+            ])
+        case let .rejected(reason):
+            return .err(code: "invalid_params", message: reason, data: nil)
+        case .failed:
+            return .err(
+                code: "internal_error",
+                message: "Failed to persist dogfood feedback bundle",
+                data: nil
+            )
+        }
+    }
+
+    /// The result of writing a dogfood feedback bundle off the main actor.
+    private enum DogfoodFeedbackWriteOutcome: Sendable {
+        case written(bundlePath: String, byteCount: Int)
+        case rejected(reason: String)
+        case failed
+    }
+
+    /// Persist a validated dogfood feedback bundle to disk. Runs off the main
+    /// actor (called from a detached task), so its synchronous file I/O never
+    /// blocks the Mac UI. All inputs are already size-capped by the caller.
+    nonisolated private static func writeDogfoodFeedbackBundle(
+        text: String,
+        terminalText: String,
+        buildStamp: String,
+        diagnosticData: Data
+    ) -> DogfoodFeedbackWriteOutcome {
+        let fileManager = FileManager.default
+        let root = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache", isDirectory: true)
+            .appendingPathComponent("cmux-dogfood-feedback", isDirectory: true)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        // Colons are legal in HFS+/APFS but awkward in shell globs; swap for `-`
+        // so the directory name is paste-safe.
+        let timestamp = formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+        let shortID = String(UUID().uuidString.prefix(8)).lowercased()
+        let bundleDir = root.appendingPathComponent("\(timestamp)_\(shortID)", isDirectory: true)
+
+        do {
+            // The bundle holds visible terminal text and debug logs, which can
+            // contain credentials or other private data. Create the root and
+            // bundle dirs owner-only (0700) so no other local user can traverse
+            // into them, and chmod the written files to 0600. The dir is created
+            // 0700 first, so even the brief window before the file chmod is not
+            // world-readable through a traversable parent.
+            let dirAttributes: [FileAttributeKey: Any] = [.posixPermissions: 0o700]
+            try fileManager.createDirectory(
+                at: root,
+                withIntermediateDirectories: true,
+                attributes: dirAttributes
+            )
+            try fileManager.createDirectory(
+                at: bundleDir,
+                withIntermediateDirectories: true,
+                attributes: dirAttributes
+            )
+            let diagnosticURL = bundleDir.appendingPathComponent("diagnostic.log")
+            try diagnosticData.write(to: diagnosticURL)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: diagnosticURL.path)
+            let manifest: [String: Any] = [
+                "schema": "cmux.dogfood.feedback.v1",
+                "received_at": formatter.string(from: Date()),
+                "text": text,
+                "terminal_text": terminalText,
+                "build_stamp": buildStamp,
+                "diagnostic_log_file": "diagnostic.log",
+                "diagnostic_log_bytes": diagnosticData.count,
+            ]
+            let manifestData = try JSONSerialization.data(
+                withJSONObject: manifest,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            let manifestURL = bundleDir.appendingPathComponent("bundle.json")
+            try manifestData.write(to: manifestURL)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: manifestURL.path)
+        } catch {
+            return .failed
+        }
+
+        pruneDogfoodFeedbackBundles(root: root, keep: dogfoodFeedbackMaxRetainedBundles)
+        return .written(bundlePath: bundleDir.path, byteCount: diagnosticData.count)
+    }
+
+    /// Keep only the newest `keep` bundle directories under `root`, deleting the
+    /// rest. The directory names start with an ISO8601 timestamp, so a
+    /// lexicographic sort is chronological. Best-effort: a failure to enumerate
+    /// or remove is ignored (it only affects cleanup, not the just-written
+    /// bundle). Runs off the main actor with its writer.
+    nonisolated private static func pruneDogfoodFeedbackBundles(root: URL, keep: Int) {
+        let fileManager = FileManager.default
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+        let directories = entries
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard directories.count > keep else { return }
+        for stale in directories.dropLast(keep) {
+            try? fileManager.removeItem(at: stale)
+        }
+    }
+#endif
 
     /// The `workspace.action` sub-actions the mobile data plane may invoke.
     ///

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -5,6 +5,10 @@ import Foundation
 import SwiftUI
 import cmuxFeature
 
+#if DEBUG
+import CmuxMobileDiagnostics
+#endif
+
 /// Holds the de-singletonized graph the `cmuxApp` builds once at launch.
 ///
 /// Owns the mobile runtime, the auth composition (coordinator + push
@@ -18,6 +22,15 @@ final class AppCompositionRoot {
     let reachability: any ReachabilityProviding
     let pushCoordinator: MobilePushCoordinator
     let analytics: MobileAnalyticsComposition
+
+    #if DEBUG
+    /// The structured diagnostic log, built once here and injected into the
+    /// shell store. DEBUG-only: it backs the DEV dogfood feedback round-trip and
+    /// is not present in release builds. Its export header is stamped with the
+    /// same build identity as the string debug log so a submitted bundle proves
+    /// which reload it came from.
+    let diagnosticLog: DiagnosticLog
+    #endif
 
     init(
         runtime: CMUXMobileRuntime,
@@ -35,6 +48,9 @@ final class AppCompositionRoot {
             registration: auth.pushRegistration,
             analytics: analytics.emitter
         )
+        #if DEBUG
+        self.diagnosticLog = DiagnosticLog(buildStamp: MobileDebugLog.buildStamp)
+        #endif
     }
 
     /// The most recent scene phase, so a `.active` transition is classified as a

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -52,20 +52,37 @@ struct cmuxApp: App {
 
     var body: some Scene {
         WindowGroup {
-            CMUXMobileRootScene(
-                runtime: Self.root.runtime,
-                auth: Self.root.auth,
-                reachability: Self.root.reachability,
-                analytics: Self.root.analytics.emitter,
-                pushCoordinator: Self.root.pushCoordinator
-            )
-            // `initial: true` so the cold-launch `.active` value (which `onChange`
-            // otherwise skips) drives the first `ios_session_started` +
-            // `ios_app_foregrounded`. Without it the whole session funnel stays
-            // empty until the first background-and-return.
-            .onChange(of: scenePhase, initial: true) { _, newPhase in
-                Self.root.handleScenePhase(newPhase)
-            }
+            rootScene
+                // `initial: true` so the cold-launch `.active` value (which
+                // `onChange` otherwise skips) drives the first
+                // `ios_session_started` + `ios_app_foregrounded`. Without it the
+                // whole session funnel stays empty until the first
+                // background-and-return.
+                .onChange(of: scenePhase, initial: true) { _, newPhase in
+                    Self.root.handleScenePhase(newPhase)
+                }
         }
+    }
+
+    @ViewBuilder
+    private var rootScene: some View {
+        #if DEBUG
+        CMUXMobileRootScene(
+            runtime: Self.root.runtime,
+            auth: Self.root.auth,
+            reachability: Self.root.reachability,
+            analytics: Self.root.analytics.emitter,
+            pushCoordinator: Self.root.pushCoordinator,
+            diagnosticLog: Self.root.diagnosticLog
+        )
+        #else
+        CMUXMobileRootScene(
+            runtime: Self.root.runtime,
+            auth: Self.root.auth,
+            reachability: Self.root.reachability,
+            analytics: Self.root.analytics.emitter,
+            pushCoordinator: Self.root.pushCoordinator
+        )
+        #endif
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -35,6 +35,12 @@ public struct CMUXMobileRootScene: View {
     private let pushCoordinator: MobilePushCoordinator
     #endif
     private let pairedMacStore: (any MobilePairedMacStoring)?
+    #if DEBUG
+    /// The structured diagnostic log injected into the shell store so the DEV
+    /// dogfood feedback round-trip can export it. DEBUG-only; `nil` when the app
+    /// composition root did not build one.
+    private let diagnosticLog: DiagnosticLog?
+    #endif
 
     #if os(iOS)
     /// Creates the root scene.
@@ -46,12 +52,15 @@ public struct CMUXMobileRootScene: View {
     ///   - analytics: The app-root analytics emitter, injected into the store.
     ///   - pushCoordinator: The app-root push coordinator (shared with the app
     ///     delegate) injected into the environment.
+    ///   - diagnosticLog: The structured diagnostic log (DEBUG builds only),
+    ///     injected into the shell store for the DEV feedback round-trip.
     public init(
         runtime: CMUXMobileRuntime,
         auth: MobileAuthComposition,
         reachability: any ReachabilityProviding,
         analytics: any AnalyticsEmitting,
-        pushCoordinator: MobilePushCoordinator
+        pushCoordinator: MobilePushCoordinator,
+        diagnosticLog: DiagnosticLog? = nil
     ) {
         self.runtime = runtime
         self.auth = auth
@@ -59,6 +68,9 @@ public struct CMUXMobileRootScene: View {
         self.analytics = analytics
         self.pushCoordinator = pushCoordinator
         self.pairedMacStore = Self.openPairedMacStore()
+        #if DEBUG
+        self.diagnosticLog = diagnosticLog
+        #endif
     }
     #else
     /// Creates the root scene (non-iOS: no push).
@@ -73,6 +85,9 @@ public struct CMUXMobileRootScene: View {
         self.reachability = reachability
         self.analytics = analytics
         self.pairedMacStore = Self.openPairedMacStore()
+        #if DEBUG
+        self.diagnosticLog = nil
+        #endif
     }
     #endif
 
@@ -112,6 +127,16 @@ public struct CMUXMobileRootScene: View {
     @MainActor
     private func makeStore() -> CMUXMobileShellStore {
         let identityProvider = AuthCoordinatorIdentityProvider(coordinator: auth.coordinator)
+        #if DEBUG
+        return CMUXMobileShellStore(
+            runtime: runtime,
+            pairedMacStore: pairedMacStore,
+            identityProvider: identityProvider,
+            reachability: reachability,
+            analytics: analytics,
+            diagnosticLog: diagnosticLog
+        )
+        #else
         return CMUXMobileShellStore(
             runtime: runtime,
             pairedMacStore: pairedMacStore,
@@ -119,5 +144,6 @@ public struct CMUXMobileRootScene: View {
             reachability: reachability,
             analytics: analytics
         )
+        #endif
     }
 }


### PR DESCRIPTION
P1 of the cmux DEBUG dogfood feedback loop: prove the Mac↔phone round-trip end to end. Scope is exactly four pieces, everything new `#if DEBUG`-gated. No floating pane, screenshot, or checklist-push (those are P2).

## What's here

**1. Structured diagnostic log (`Packages/CMUXMobileCore`, UIKit-free).** `DiagnosticEvent` (a tiny `Sendable & Codable` value: a `DiagnosticEventCode` `UInt16` enum, a monotonic `tNanos`, and a few optional Ints / `surface` / `ms`, no hot-path string interpolation) and `DiagnosticLog`. The recorder is a lock-free `nonisolated func record(_:)` that only `continuation.yield(event)` onto an `AsyncStream(.bufferingNewest(N))`; a single drain `Task` moves events into a fixed-capacity O(1) circular ring (no per-event `Task { await … }` hop). `export()` drains the ring into a compact blob (one wall-clock anchor + build stamp header, then `tNanos,code,surface,ms,a,b,c` rows). One instance is injected from `AppCompositionRoot` down through the root scene into `MobileShellComposite` (no new singleton; injection mirrors `MobileDebugLog`/`MobileDebugLogSink`).

**2. Dual-emit at the meaningful sync seams** that already carry `MobileDebugLog.anchormux(...)`: `connect`/`pairOk`/`pairFail`, render-grid liveness re-subscribe + stream-ended, input seq-behind (incl. the render-grid escalation), byte-gap, and a subscribe-failure `error`. The existing string logs are unchanged. The zoom/scroll/per-keystroke latency paths are deliberately not instrumented.

**3. Mac feedback-submit RPC.** A `#if DEBUG` `dogfood.feedback.submit` case in `mobileHostHandleRPC`, gated by the same same-account Stack-auth authorization as the rest of the mobile data plane, plus a `#if DEBUG` `dogfood.v1` capability in `mobileHostCapabilities`. It caps each field before decoding, rejects oversized/invalid base64, decodes and writes the bundle off the main actor (0700 dirs, 0600 files), and prunes to the newest 50 bundles.

**4. iOS send trigger.** The DEBUG "Copy Debug Logs" affordance gains a sibling "Send to agent" composer that gathers `DiagnosticLog.export()` + the `MobileDebugLog` snapshot + `GhosttySurfaceView.visibleTerminalSnapshot()` (reused verbatim, off-`outputQueue`, never a main-thread `read_text`) + an optional note, builds the request off the main actor with client-side caps, and calls the new RPC.

## Where the Mac writes feedback bundles (for the monitor)

`~/.cache/cmux-dogfood-feedback/<ISO8601>_<shortid>/` containing:
- `diagnostic.log` — the exported structured blob, followed by `----- mobile debug log -----` and the string debug log
- `bundle.json` — manifest with keys: `schema` (`cmux.dogfood.feedback.v1`), `received_at`, `text`, `terminal_text`, `build_stamp`, `diagnostic_log_file` (`diagnostic.log`), `diagnostic_log_bytes`

`dogfood.feedback.submit` params (snake_case): `text`, `terminal_text`, `build_stamp`, `diagnostic_blob_base64`, `client_id`. Response: `{ ok, bundle_path, diagnostic_log_bytes }`.

Note: params/manifest keys are snake_case, which diverges from the camelCase shown in the original spec.

## Verification

iOS simulator Debug build green, macOS app Debug build green (`-derivedDataPath`), 61 `CMUXMobileCore` tests pass (focused `DiagnosticLog` tests cover record→export round-trip, ring eviction dropping oldest, circular-buffer wrap ordering, and non-blocking record under a 50k burst). Not run locally: `xcodebuild test` (banned locally) and device builds.

## Conscious deferrals

- `DiagnosticLog` lives in `CMUXMobileCore` per the explicit P1 spec ("structured diagnostic log in `Packages/CMUXMobileCore`, UIKit-free, so macOS can reuse later"). The reusable value vocabulary (`DiagnosticEvent`/`DiagnosticEventCode`) is correctly value-typed in Core; a strict layering reading would put the concrete recorder in a diagnostics service package instead. Deferred since the spec directs it here, `CMUXMobileCore` predates the current package policy and already holds non-value types, and P1 is scope-locked.
- DEBUG-only UI strings ("Send to agent", composer) are unlocalized, matching the existing "Copy Debug Logs" DEV affordance precedent.
- The render hot-path `.renderGridLag` code is part of the export vocabulary but not yet emitted from the shell (deeper `GhosttySurfaceView` seam, deferred past P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429737&installation_id=133855650&pr_number=5574&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5574&signature=60e1ba10eb171c103ffdce91a53d8e8ed44822d5c06419c065a1db506ef7a943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile RPC/auth on the Mac host and accepts diagnostic payloads (terminal text may be sensitive), but everything is `#if DEBUG`, size-capped, and uses existing Stack-auth gating.
> 
> **Overview**
> Adds a **DEBUG-only dogfood feedback loop** so iOS can ship structured diagnostics to a paired Mac instead of only copying logs.
> 
> **Structured logging in `CMUXMobileCore`:** New `DiagnosticEvent` / `DiagnosticEventCode` and a ring-buffer `DiagnosticLog` with lock-free `record(_:)` (AsyncStream drain) and compact `export()` blobs. A single instance is wired from `AppCompositionRoot` through `CMUXMobileRootScene` into `MobileShellComposite`; `MobileDebugLog.buildStamp` is shared for export headers.
> 
> **Instrumentation:** Existing `MobileDebugLog.anchormux` seams now also emit matching `DiagnosticEvent`s (connect/pair outcomes, stream ended, liveness re-subscribe, input-seq-behind, byte-gap, subscribe error) without changing string logs.
> 
> **Mac side (`#if DEBUG`):** `dogfood.v1` capability and `dogfood.feedback.submit` RPC persist capped bundles under `~/.cache/cmux-dogfood-feedback/` (0700/0600, off-main decode/write, prune to 50).
> 
> **iOS UI:** DEBUG “Send to agent” composer gathers structured export + debug log + visible terminal + note; `submitDogfoodFeedback` builds the RPC off the main actor with client-side size caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae6deaf1efd9ec82307def2f3759848bde46be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DEBUG-only iOS dogfood feedback round-trip with a lightweight structured diagnostic log and a “Send to agent” action that uploads a capped bundle to the paired Mac for analysis. This meets the P1 spec for proving the Mac↔phone loop end to end without touching hot render/input paths.

- **New Features**
  - Introduced `DiagnosticLog` in `CMUXMobileCore`: lock-free `record(_:)`, fixed ring buffer, compact `export()` with wall-clock anchor and build stamp.
  - Injected a single `DiagnosticLog` from the iOS composition root (stamped via `MobileDebugLog.buildStamp`) down into `MobileShellComposite` (no singleton).
  - Dual-emitted `DiagnosticEvent`s at key sync seams (connect/pairOk/pairFail, liveness re-subscribe, stream ended, input seq-behind, byte gap) alongside existing string logs.
  - Added DEBUG UI in `CmuxMobileShellUI`: “Send to agent” composer next to “Copy Debug Logs”; sends `DiagnosticLog.export()` + `MobileDebugLog` snapshot + visible terminal text + optional note.
  - Added Mac DEBUG RPC `dogfood.feedback.submit` and `dogfood.v1` capability in `MobileHostService`; validates/caps inputs, writes `~/.cache/cmux-dogfood-feedback/<ISO8601>_<shortid>/` (`diagnostic.log` + `bundle.json`), prunes to newest 50.
  - Added focused tests for `DiagnosticLog` covering record→export, ring eviction, burst non-blocking behavior, and chronological ordering.

<sup>Written for commit 7ae6deaf1efd9ec82307def2f3759848bde46be7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic event tracking infrastructure for monitoring system behavior and performance.
  * Introduced structured feedback submission mechanism with diagnostic data capture (iOS DEBUG builds).

* **Tests**
  * Added comprehensive tests for diagnostic event logging, ring-buffer behavior, and export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->