### PR TITLE
feat: add global workspace status bar with settings toggle

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -172,6 +172,15 @@ public struct AppCatalogSection: SettingCatalogSection {
         userDefaultsKey: "workspaceTitlebarVisible"
     )
 
+    /// Visibility of the global workspace status bar — the bottom bar showing
+    /// the focused panel's Git branch, working directory, and workspace/tab
+    /// name. Defaults to `true`.
+    public let showWorkspaceStatusBar = DefaultsKey<Bool>(
+        id: "app.showWorkspaceStatusBar",
+        defaultValue: true,
+        userDefaultsKey: "showWorkspaceStatusBar"
+    )
+
     public let systemWideHotkeyEnabled = DefaultsKey<Bool>(
         id: "app.systemWideHotkeyEnabled",
         defaultValue: false,

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -56,6 +56,7 @@ public struct AppSection: View {
     @State private var hideCloseButton: DefaultsValueModel<Bool>
     @State private var renameSelects: DefaultsValueModel<Bool>
     @State private var paletteAllSurfaces: DefaultsValueModel<Bool>
+    @State private var showWorkspaceStatusBar: DefaultsValueModel<Bool>
 
     @State private var languageAtAppear: AppLanguage?
     @State private var telemetryAtAppear: Bool?
@@ -100,6 +101,7 @@ public struct AppSection: View {
         _hideCloseButton = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.hideTabCloseButton))
         _renameSelects = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.renameSelectsExistingName))
         _paletteAllSurfaces = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.commandPaletteSearchesAllSurfaces))
+        _showWorkspaceStatusBar = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.showWorkspaceStatusBar))
     }
 
     private static let columnWidth: CGFloat = 196
@@ -214,6 +216,22 @@ public struct AppSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsMinimalModeToggle")
+            }
+            SettingsCardDivider()
+
+            // Workspace Status Bar — the global bottom bar. A separate per-pane
+            // status bar (for worktrees) is configured elsewhere.
+            SettingsCardRow(
+                configurationReview: .json("app.showWorkspaceStatusBar"),
+                String(localized: "settings.app.showWorkspaceStatusBar", defaultValue: "Show Workspace Status Bar"),
+                subtitle: showWorkspaceStatusBar.current
+                    ? String(localized: "settings.app.showWorkspaceStatusBar.subtitleOn", defaultValue: "Show a bottom bar with the focused pane's Git branch, working directory, and workspace name.")
+                    : String(localized: "settings.app.showWorkspaceStatusBar.subtitleOff", defaultValue: "Hide the bottom workspace status bar.")
+            ) {
+                Toggle("", isOn: Binding(get: { showWorkspaceStatusBar.current }, set: { showWorkspaceStatusBar.set($0) }))
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityIdentifier("SettingsShowWorkspaceStatusBarToggle")
             }
             SettingsCardDivider()
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2280,6 +2280,7 @@ struct ContentView: View {
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarMaterial") private var sidebarMaterial = SidebarMaterialOption.sidebar.rawValue
     @AppStorage("sidebarState") private var sidebarStateSetting = SidebarStateOption.followWindow.rawValue
+    @AppStorage("showWorkspaceStatusBar") private var showWorkspaceStatusBar = true
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
 
@@ -2758,16 +2759,23 @@ struct ContentView: View {
     var body: some View {
         let appearance = windowAppearanceSnapshot
         var view = AnyView(
-            ZStack(alignment: .topLeading) {
-                WindowBackdropLayer(role: .windowRoot, snapshot: appearance)
-                    .ignoresSafeArea()
-                    .allowsHitTesting(false)
+            VStack(spacing: 0) {
+                ZStack(alignment: .topLeading) {
+                    WindowBackdropLayer(role: .windowRoot, snapshot: appearance)
+                        .ignoresSafeArea()
+                        .allowsHitTesting(false)
 
-                contentAndSidebarLayout(appearance: appearance)
+                    contentAndSidebarLayout(appearance: appearance)
 
-                if !isMinimalMode {
-                    workspaceTitlebarBand(appearance: appearance)
-                        .zIndex(100)
+                    if !isMinimalMode {
+                        workspaceTitlebarBand(appearance: appearance)
+                            .zIndex(100)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+                if !isMinimalMode, showWorkspaceStatusBar, let workspace = tabManager.selectedWorkspace {
+                    WorkspaceStatusBar(workspace: workspace, appearance: appearance)
                 }
             }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -9,6 +9,11 @@ enum WindowChromeMetrics {
     static let maximumTitlebarHeight: CGFloat = 72
     static let defaultTitlebarHeight: CGFloat = sharedChromeBarHeight
 
+    /// Height of the persistent bottom status bar (branch / directory / context).
+    /// Slightly shorter than the titlebar to read as a lighter strip, matching
+    /// the proportions of editor status bars such as VS Code / Cursor.
+    static let statusBarHeight: CGFloat = 22
+
     static func clampedTitlebarHeight(_ height: CGFloat) -> CGFloat {
         max(minimumTitlebarHeight, min(maximumTitlebarHeight, height))
     }

--- a/Sources/WorkspaceStatusBar.swift
+++ b/Sources/WorkspaceStatusBar.swift
@@ -1,0 +1,175 @@
+import AppKit
+import SwiftUI
+
+/// A persistent bottom status bar, in the spirit of VS Code / Cursor, that
+/// surfaces the focused panel's Git branch (with a dirty indicator), its
+/// working directory, and the active workspace + tab name.
+///
+/// The bar observes the selected ``Workspace`` directly. The workspace-level
+/// `gitBranch` and `currentDirectory` already track the *focused* panel (their
+/// values are promoted whenever focus moves between splits), so reading them
+/// gives focused-panel scope while staying reactive to `@Published` changes.
+///
+/// This view sits in the main window chrome — outside any `LazyVStack`/`List`
+/// row boundary — so observing the workspace here does not trip the
+/// row-invalidation pitfalls that apply to list subtrees.
+struct WorkspaceStatusBar: View {
+    /// The workspace whose focused panel drives the bar's contents.
+    @ObservedObject var workspace: Workspace
+    /// Window appearance snapshot used to match the terminal chrome colors.
+    let appearance: WindowAppearanceSnapshot
+
+    var body: some View {
+        HStack(spacing: 12) {
+            branchItem
+            directoryItem
+            Spacer(minLength: 8)
+            contextItem
+        }
+        .padding(.horizontal, 10)
+        .frame(height: WindowChromeMetrics.statusBarHeight)
+        .frame(maxWidth: .infinity)
+        .background(Color(nsColor: appearance.terminalBackgroundColor))
+        .overlay(alignment: .top) {
+            WindowChromeBorder(orientation: .horizontal, ignoresSafeArea: false)
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Items
+
+    @ViewBuilder
+    private var branchItem: some View {
+        if let branch = trimmedBranch {
+            HStack(spacing: 4) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(secondaryColor)
+                Text(branch)
+                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .foregroundColor(primaryColor)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if isDirty {
+                    Circle()
+                        .fill(secondaryColor)
+                        .frame(width: 5, height: 5)
+                        .accessibilityLabel(Text(String(
+                            localized: "statusBar.branch.dirty.accessibility",
+                            defaultValue: "Uncommitted changes"
+                        )))
+                }
+            }
+            .help(String(localized: "statusBar.branch.help", defaultValue: "Current Git branch"))
+            .accessibilityElement(children: .combine)
+        }
+    }
+
+    @ViewBuilder
+    private var directoryItem: some View {
+        if let directory = focusedDirectory {
+            Text(abbreviatedDirectory(directory))
+                .font(.system(size: 11, weight: .regular))
+                .foregroundColor(secondaryColor)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(directory)
+                .accessibilityLabel(Text(String(
+                    localized: "statusBar.directory.accessibility",
+                    defaultValue: "Working directory"
+                )))
+                .accessibilityValue(Text(directory))
+        }
+    }
+
+    @ViewBuilder
+    private var contextItem: some View {
+        if !contextText.isEmpty {
+            Text(contextText)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundColor(secondaryColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .accessibilityLabel(Text(String(
+                    localized: "statusBar.context.accessibility",
+                    defaultValue: "Workspace and tab"
+                )))
+                .accessibilityValue(Text(contextText))
+        }
+    }
+
+    // MARK: - Derived values (focused panel)
+
+    /// The focused panel id, used to enrich the workspace-level values with
+    /// per-panel directory and tab title.
+    private var focusedPanelId: UUID? {
+        workspace.focusedPanelId
+    }
+
+    /// The focused panel's branch name, trimmed; `nil` when not in a repo.
+    private var trimmedBranch: String? {
+        let branch = workspace.gitBranch?.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (branch?.isEmpty == false) ? branch : nil
+    }
+
+    /// Whether the focused panel's working tree has uncommitted changes.
+    private var isDirty: Bool {
+        workspace.gitBranch?.isDirty ?? false
+    }
+
+    /// The focused panel's working directory, preferring the per-panel value
+    /// and falling back to the workspace's current directory.
+    private var focusedDirectory: String? {
+        if let panelId = focusedPanelId,
+           let dir = workspace.panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !dir.isEmpty {
+            return dir
+        }
+        let dir = workspace.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        return dir.isEmpty ? nil : dir
+    }
+
+    /// The "workspace · tab" trailing context string. The tab title is omitted
+    /// when it is empty or identical to the workspace title.
+    private var contextText: String {
+        let title = workspace.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tab = focusedPanelId
+            .flatMap { workspace.panelTitles[$0] }?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if tab.isEmpty || tab == title {
+            return title
+        }
+        if title.isEmpty {
+            return tab
+        }
+        return "\(title) · \(tab)"
+    }
+
+    // MARK: - Formatting
+
+    /// Replaces the home-directory prefix with `~` for a compact path.
+    private func abbreviatedDirectory(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path == home {
+            return "~"
+        }
+        if path.hasPrefix(home + "/") {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    // MARK: - Colors (matched to terminal chrome)
+
+    private var isLightChrome: Bool {
+        appearance.terminalBackgroundColor.isLightColor
+    }
+
+    private var primaryColor: Color {
+        isLightChrome ? Color.black.opacity(0.78) : Color.white.opacity(0.82)
+    }
+
+    private var secondaryColor: Color {
+        isLightChrome ? Color.black.opacity(0.55) : Color.white.opacity(0.6)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -690,6 +690,7 @@
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
 		6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */; };
 		F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */; };
+		C0FFEE5784A2B100D1A5B0E1 /* WorkspaceStatusBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE5784A2B100D1A5B0E2 /* WorkspaceStatusBar.swift */; };
 		FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 		D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */; };
 		C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000004 /* WorkspaceSurfaceIdentifierClipboardText.swift */; };
@@ -1405,6 +1406,7 @@
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
 		71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSplitStartupCommandTests.swift; sourceTree = "<group>"; };
 		F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSSHFishShellTests.swift; sourceTree = "<group>"; };
+		C0FFEE5784A2B100D1A5B0E2 /* WorkspaceStatusBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStatusBar.swift; sourceTree = "<group>"; };
 		FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 		D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSurfaceConfig.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000004 /* WorkspaceSurfaceIdentifierClipboardText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSurfaceIdentifierClipboardText.swift; sourceTree = "<group>"; };
@@ -1988,6 +1990,7 @@
 				B7F9A601B7F9A601B7F9A601 /* RightSidebarChromeGeometryReporting.swift */,
 				B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */,
 				B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */,
+				C0FFEE5784A2B100D1A5B0E2 /* WorkspaceStatusBar.swift */,
 				B37A00000000000000000004 /* RightSidebarMode+Availability.swift */,
 				B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */,
 				FE003003 /* RightSidebarPanelView.swift */,
@@ -3014,6 +3017,7 @@
 				E30780000000000000000002 /* WorkspaceRemoteConfiguration.swift in Sources */,
 				E30770000000000000000002 /* WorkspaceRemoteSSHBatchCommandBuilder.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
+				C0FFEE5784A2B100D1A5B0E1 /* WorkspaceStatusBar.swift in Sources */,
 				D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */,
 				C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */,
 				E30750000000000000000002 /* WorkspaceTabColorResolution.swift in Sources */,


### PR DESCRIPTION
## What

Adds a persistent bottom **workspace status bar** (VS Code / Cursor style) to the main window, with a Settings toggle to show/hide it.

The bar shows, for the **focused** panel:
- **Git branch** with an `arrow.triangle.branch` icon and a small dirty-state dot
- **Working directory** (`~`-abbreviated)
- **Workspace · tab** name on the trailing edge

## How

- New view `Sources/WorkspaceStatusBar.swift` (its own file, fully doc-commented). It observes the selected `Workspace` and reads the already-tracked, focus-promoted `gitBranch` / `currentDirectory` / `panelTitles`, so it stays reactive with **no new git plumbing**. It lives in window chrome (outside any `LazyVStack`/`List` row boundary), so observing the workspace here is safe.
- `ContentView` wraps the window body in a `VStack` so the bar takes its own full-width strip and the terminal reflows above it (true editor status-bar layout, not a floating overlay that covers the last row). Hidden in minimal mode, matching the titlebar.
- Colors and the 1px top separator derive from the terminal chrome (`WindowChromeBorder`, `terminalBackgroundColor.isLightColor`) to match the existing titlebar.

## Settings toggle

- **Settings → App → "Show Workspace Status Bar"** (default **on**).
- Declared once as a `DefaultsKey<Bool>` in the central `AppCatalogSection` catalog, surfaced via the standard `SettingsCardRow` + `Toggle` pattern, and read in `ContentView` via `@AppStorage` so toggling updates the bar live and persists.

## Notes

- Localized **EN + JA** in `Resources/Localizable.xcstrings` (toggle label/subtitles + the bar's accessibility labels/tooltip).
- New source file wired into `project.pbxproj`, normalized, and validated with `scripts/check-pbxproj.sh`.
- A separate per-pane status bar (for worktrees) is intentionally out of scope here; a code comment notes the distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783431002&installation_id=133855650&pr_number=5575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5575&signature=a63ede70ad79997227f52a7cbbc4dbb4b3580fdb688e186e0a4d1b87576cfe35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent bottom workspace status bar with a Settings toggle. It shows the focused panel’s Git branch (with a dirty dot), working directory, and workspace/tab, and reflows the editor above it.

- **New Features**
  - Added `WorkspaceStatusBar` that reads the workspace’s `gitBranch`, `currentDirectory`, and `panelTitles` (no new Git plumbing).
  - Integrated into `ContentView` as a fixed bottom strip; hidden in minimal mode or when toggled off.
  - New Settings → App toggle “Show Workspace Status Bar” (default on), stored under `app.showWorkspaceStatusBar` and wired via `@AppStorage` for live updates.
  - Styling matches terminal chrome with a 1px top separator and `WindowChromeMetrics.statusBarHeight`.
  - EN/JA localization plus accessibility labels and tooltips.

<sup>Written for commit 6362b14421255bff6cf245293a2fc63da6e8cdad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace status bar at the bottom of the window displaying the active Git branch, repository status, and current working directory. The feature is enabled by default.
  * New setting allows toggling the workspace status bar visibility on or off for user preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->