### PR TITLE
Agent chat view P1: shared Conversation model + Claude/Codex parsers + macOS chat view

### DIFF
--- a/Packages/CmuxAgentConversation/Package.swift
+++ b/Packages/CmuxAgentConversation/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxAgentConversation",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "CmuxAgentConversation",
+            targets: ["CmuxAgentConversation"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxAgentConversation",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxAgentConversationTests",
+            dependencies: [
+                "CmuxAgentConversation",
+            ],
+            resources: [
+                .copy("Fixtures"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/AgentKind.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/AgentKind.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The coding agent that produced a transcript.
+///
+/// Used to pick the matching ``AgentTranscriptParsing`` implementation and to
+/// label a ``Conversation`` in the UI. New agents are added as cases; the
+/// ``AgentKind/unknown`` case keeps the model total when a transcript comes
+/// from a source this build does not recognize.
+public enum AgentKind: String, Codable, Hashable, Sendable {
+    /// Anthropic's Claude Code CLI (`~/.claude/projects/<dir>/<uuid>.jsonl`).
+    case claudeCode
+
+    /// OpenAI's Codex CLI (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`).
+    case codex
+
+    /// An agent whose transcript format this build does not understand.
+    case unknown
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/AgentTranscriptParsing.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/AgentTranscriptParsing.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Parses an agent session transcript (split into lines) into a ``Conversation``.
+///
+/// Each agent ships one conforming struct (``ClaudeCodeTranscriptParser``,
+/// ``CodexTranscriptParser``). Parsers are pure and value-typed: the caller
+/// owns reading the file (chunked IO, size caps) and hands over already-split
+/// lines, keeping this package free of any filesystem dependency.
+///
+/// Construct the parser at the call site for the kind you have:
+///
+/// ```swift
+/// let parser: any AgentTranscriptParsing = ClaudeCodeTranscriptParser()
+/// let conversation = parser.parse(lines: lines)
+/// ```
+public protocol AgentTranscriptParsing: Sendable {
+    /// The agent kind this parser produces.
+    var agentKind: AgentKind { get }
+
+    /// Parses the transcript lines into a structured conversation.
+    ///
+    /// Implementations tolerate unknown or malformed lines by skipping them
+    /// rather than failing, so a partially understood transcript still renders.
+    ///
+    /// - Parameter lines: The transcript's lines, one JSON object per line.
+    /// - Returns: The parsed conversation.
+    func parse(lines: [String]) -> Conversation
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ClaudeCodeTranscriptParser.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ClaudeCodeTranscriptParser.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// Parses Claude Code transcripts (`~/.claude/projects/<dir>/<uuid>.jsonl`).
+///
+/// Each line is one JSON object with a top-level `type`. Conversation turns are
+/// `user`, `assistant`, and `system`; `summary`, `queue-operation`,
+/// `attachment`, `mode`, `last-prompt`, and any other type are skipped. The
+/// turn's content lives in `message.content`, which is either a plain string or
+/// an array of typed blocks (`text`, `tool_use`, `tool_result`, `thinking`,
+/// `image`). A `tool_result` block appears inside a `user` line and is emitted
+/// as a ``MessageRole/toolResult`` message correlated by `tool_use_id`; the
+/// call and result are kept as separate messages, not merged.
+///
+/// ```swift
+/// let conversation = ClaudeCodeTranscriptParser().parse(lines: lines)
+/// ```
+public struct ClaudeCodeTranscriptParser: AgentTranscriptParsing {
+    /// Always ``AgentKind/claudeCode``.
+    public let agentKind: AgentKind = .claudeCode
+
+    /// Shared per-line JSON/timestamp decoding.
+    private let decoder = TranscriptLineDecoder()
+
+    /// Creates a Claude Code transcript parser.
+    public init() {}
+
+    /// Parses Claude Code transcript lines into a conversation.
+    ///
+    /// - Parameter lines: The `.jsonl` transcript lines.
+    /// - Returns: The parsed conversation. Unknown line types are skipped.
+    public func parse(lines: [String]) -> Conversation {
+        var messages: [Message] = []
+        var sessionId = ""
+        var index = 0
+
+        for line in lines {
+            guard let object = decoder.object(from: line) else { continue }
+            if sessionId.isEmpty, let id = object["sessionId"] as? String {
+                sessionId = id
+            }
+            guard let type = object["type"] as? String else { continue }
+            let timestamp = decoder.date(from: object["timestamp"])
+
+            switch type {
+            case "user":
+                appendUserMessages(from: object, timestamp: timestamp, index: &index, into: &messages)
+            case "assistant":
+                appendAssistantMessages(from: object, timestamp: timestamp, index: &index, into: &messages)
+            default:
+                // summary, system, queue-operation, attachment, mode,
+                // last-prompt, and any future type are not conversation turns.
+                continue
+            }
+        }
+
+        return Conversation(
+            id: sessionId,
+            agentKind: .claudeCode,
+            sessionId: sessionId,
+            messages: messages,
+            seq: UInt64(messages.count)
+        )
+    }
+
+    /// Appends the user-line content as one or more messages. A user line is
+    /// either a plain prompt or a carrier for one or more `tool_result` blocks.
+    private func appendUserMessages(
+        from object: [String: Any],
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        guard let message = object["message"] as? [String: Any] else { return }
+        let content = message["content"]
+
+        if let text = content as? String {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            messages.append(makeMessage(role: .user, blocks: [.text(text)], timestamp: timestamp, index: &index))
+            return
+        }
+
+        guard let blockArray = content as? [[String: Any]] else { return }
+        var promptBlocks: [ContentBlock] = []
+        for raw in blockArray {
+            guard let blockType = raw["type"] as? String else { continue }
+            switch blockType {
+            case "tool_result":
+                // Flush any accumulated prompt text before the result so order
+                // is preserved, then emit the result as its own message.
+                flush(&promptBlocks, role: .user, timestamp: timestamp, index: &index, into: &messages)
+                if let result = toolResult(from: raw) {
+                    messages.append(
+                        makeMessage(
+                            role: .toolResult,
+                            blocks: [.toolResult(result)],
+                            timestamp: timestamp,
+                            toolCallID: result.toolUseID,
+                            index: &index
+                        )
+                    )
+                }
+            case "text":
+                if let text = raw["text"] as? String { promptBlocks.append(.text(text)) }
+            case "image":
+                if let image = imageRef(from: raw) { promptBlocks.append(.image(image)) }
+            default:
+                continue
+            }
+        }
+        flush(&promptBlocks, role: .user, timestamp: timestamp, index: &index, into: &messages)
+    }
+
+    /// Appends the assistant-line content. Reasoning is split into its own
+    /// ``MessageRole/reasoning`` message so the UI can present it distinctly.
+    private func appendAssistantMessages(
+        from object: [String: Any],
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        guard let message = object["message"] as? [String: Any],
+              let blockArray = message["content"] as? [[String: Any]] else { return }
+
+        var assistantBlocks: [ContentBlock] = []
+        for raw in blockArray {
+            guard let blockType = raw["type"] as? String else { continue }
+            switch blockType {
+            case "text":
+                if let text = raw["text"] as? String, !text.isEmpty {
+                    assistantBlocks.append(.text(text))
+                }
+            case "tool_use":
+                if let use = toolUse(from: raw) { assistantBlocks.append(.toolUse(use)) }
+            case "thinking":
+                let thinking = (raw["thinking"] as? String) ?? ""
+                guard !thinking.isEmpty else { continue }
+                // Flush assistant blocks first so reasoning keeps its position.
+                flush(&assistantBlocks, role: .assistant, timestamp: timestamp, index: &index, into: &messages)
+                messages.append(
+                    makeMessage(role: .reasoning, blocks: [.reasoning(thinking)], timestamp: timestamp, index: &index)
+                )
+            case "image":
+                if let image = imageRef(from: raw) { assistantBlocks.append(.image(image)) }
+            default:
+                continue
+            }
+        }
+        flush(&assistantBlocks, role: .assistant, timestamp: timestamp, index: &index, into: &messages)
+    }
+
+    /// Builds a ``ToolUse`` from a Claude `tool_use` block.
+    private func toolUse(from raw: [String: Any]) -> ToolUse? {
+        guard let id = raw["id"] as? String, let name = raw["name"] as? String else { return nil }
+        let input = raw["input"]
+        let inputJSON = decoder.jsonString(from: input) ?? "{}"
+        return ToolUse(id: id, name: name, inputJSON: inputJSON, inputSummary: summary(forInput: input))
+    }
+
+    /// Builds a ``ToolResult`` from a Claude `tool_result` block. Its `content`
+    /// is either a string or an array of inner blocks (`text`, `image`).
+    private func toolResult(from raw: [String: Any]) -> ToolResult? {
+        guard let toolUseID = raw["tool_use_id"] as? String else { return nil }
+        let isError = (raw["is_error"] as? Bool) ?? false
+        let content = raw["content"]
+        var blocks: [ContentBlock] = []
+        if let text = content as? String {
+            blocks.append(.text(text))
+        } else if let innerArray = content as? [[String: Any]] {
+            for inner in innerArray {
+                switch inner["type"] as? String {
+                case "text":
+                    if let text = inner["text"] as? String { blocks.append(.text(text)) }
+                case "image":
+                    if let image = imageRef(from: inner) { blocks.append(.image(image)) }
+                default:
+                    continue
+                }
+            }
+        }
+        return ToolResult(toolUseID: toolUseID, blocks: blocks, isError: isError)
+    }
+
+    /// Builds an ``ImageRef`` from a Claude `image` block. The base64 payload is
+    /// referenced (by its byte count and media type) rather than inlined.
+    private func imageRef(from raw: [String: Any]) -> ImageRef? {
+        let source = raw["source"] as? [String: Any]
+        let mediaType = source?["media_type"] as? String
+        let data = source?["data"] as? String
+        let byteCount = data.map { $0.utf8.count }
+        let id = (source?["file_id"] as? String) ?? UUID().uuidString
+        return ImageRef(id: id, mediaType: mediaType, byteCount: byteCount)
+    }
+
+    /// Emits the accumulated blocks as one message (if any) and clears them.
+    private func flush(
+        _ blocks: inout [ContentBlock],
+        role: MessageRole,
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        guard !blocks.isEmpty else { return }
+        messages.append(makeMessage(role: role, blocks: blocks, timestamp: timestamp, index: &index))
+        blocks = []
+    }
+
+    /// Builds a message with a stable sequential id and advances the counter.
+    private func makeMessage(
+        role: MessageRole,
+        blocks: [ContentBlock],
+        timestamp: Date?,
+        toolCallID: String? = nil,
+        index: inout Int
+    ) -> Message {
+        defer { index += 1 }
+        return Message(
+            id: "claude-\(index)",
+            role: role,
+            blocks: blocks,
+            timestamp: timestamp,
+            toolCallID: toolCallID
+        )
+    }
+
+    /// A short one-line summary for a tool input: prefers a `command` or
+    /// `file_path` field, else the first scalar value.
+    private func summary(forInput input: Any?) -> String? {
+        guard let dict = input as? [String: Any] else { return nil }
+        for key in ["command", "file_path", "path", "pattern", "query", "url"] {
+            if let value = dict[key] as? String, !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/CodexTranscriptParser.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/CodexTranscriptParser.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+/// Parses Codex transcripts (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`).
+///
+/// Each line is one JSON object with a top-level `type`. Only `response_item`
+/// lines carry conversation content (`session_meta` supplies the session id;
+/// `turn_context`, `event_msg`, and `token_count` are dropped). Within a
+/// `response_item`, `payload.type` selects the shape:
+///
+/// - `message` → `{role, content[]}` with `input_text`/`output_text` blocks.
+/// - `reasoning` → `{summary, content}` reasoning text.
+/// - `function_call` → `{call_id, name, arguments}` (a ``ToolUse``).
+/// - `function_call_output` → `{call_id, output}` (a ``ToolResult``).
+///
+/// `event_msg` `user_message`/`agent_message` lines are intentionally dropped
+/// because they duplicate the text already present in the `response_item`
+/// `message` lines. Envelope `developer`/`user` messages (`<permissions>`,
+/// `<environment_context>`, `# AGENTS.md`, …) are stripped so only real prompts
+/// surface.
+///
+/// ```swift
+/// let conversation = CodexTranscriptParser().parse(lines: lines)
+/// ```
+public struct CodexTranscriptParser: AgentTranscriptParsing {
+    /// Always ``AgentKind/codex``.
+    public let agentKind: AgentKind = .codex
+
+    /// Shared per-line JSON/timestamp decoding.
+    private let decoder = TranscriptLineDecoder()
+
+    /// Creates a Codex transcript parser.
+    public init() {}
+
+    /// Parses Codex rollout lines into a conversation.
+    ///
+    /// - Parameter lines: The rollout `.jsonl` lines.
+    /// - Returns: The parsed conversation. `event_msg`/`token_count` noise and
+    ///   unknown payload types are skipped.
+    public func parse(lines: [String]) -> Conversation {
+        var messages: [Message] = []
+        var sessionId = ""
+        var index = 0
+
+        for line in lines {
+            guard let object = decoder.object(from: line) else { continue }
+            guard let type = object["type"] as? String else { continue }
+            let timestamp = decoder.date(from: object["timestamp"])
+
+            switch type {
+            case "session_meta":
+                if sessionId.isEmpty,
+                   let payload = object["payload"] as? [String: Any],
+                   let id = payload["id"] as? String {
+                    sessionId = id
+                }
+            case "response_item":
+                guard let payload = object["payload"] as? [String: Any] else { continue }
+                appendResponseItem(payload, timestamp: timestamp, index: &index, into: &messages)
+            default:
+                // turn_context, event_msg (user_message/agent_message/
+                // token_count/task_started), and any future type are dropped.
+                continue
+            }
+        }
+
+        return Conversation(
+            id: sessionId,
+            agentKind: .codex,
+            sessionId: sessionId,
+            messages: messages,
+            seq: UInt64(messages.count)
+        )
+    }
+
+    /// Dispatches one `response_item` payload by its `type`.
+    private func appendResponseItem(
+        _ payload: [String: Any],
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        switch payload["type"] as? String {
+        case "message":
+            appendMessage(payload, timestamp: timestamp, index: &index, into: &messages)
+        case "reasoning":
+            appendReasoning(payload, timestamp: timestamp, index: &index, into: &messages)
+        case "function_call":
+            if let use = toolUse(from: payload) {
+                messages.append(
+                    makeMessage(role: .assistant, blocks: [.toolUse(use)], timestamp: timestamp, index: &index)
+                )
+            }
+        case "function_call_output":
+            if let result = toolResult(from: payload) {
+                messages.append(
+                    makeMessage(
+                        role: .toolResult,
+                        blocks: [.toolResult(result)],
+                        timestamp: timestamp,
+                        toolCallID: result.toolUseID,
+                        index: &index
+                    )
+                )
+            }
+        default:
+            // tool_search_call, web_search_call, and other item types are not
+            // part of the rendered conversation.
+            return
+        }
+    }
+
+    /// Appends a `message` payload. `developer` messages map to
+    /// ``MessageRole/system``; envelope text is stripped from user prompts.
+    private func appendMessage(
+        _ payload: [String: Any],
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        guard let rawRole = payload["role"] as? String else { return }
+
+        // `content` is usually an array of typed blocks, but Codex can also
+        // store it as a plain string; handle both so a string-form turn is not
+        // dropped (the parser also drops the `event_msg` fallback for it).
+        let text: String
+        if let blocks = payload["content"] as? [[String: Any]] {
+            text = joinedText(from: blocks)
+        } else if let string = payload["content"] as? String {
+            text = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            return
+        }
+        guard !text.isEmpty else { return }
+
+        let role: MessageRole
+        switch rawRole {
+        case "assistant":
+            role = .assistant
+        case "developer", "system":
+            role = .system
+        default:
+            role = .user
+        }
+
+        // Strip envelope/system wrappers (`<permissions>`, `<environment_context>`,
+        // `# AGENTS.md`, …) for every role; these are implementation noise, not
+        // conversation. A message that is only an envelope is dropped.
+        guard let real = realUserMessage(text) else { return }
+        messages.append(makeMessage(role: role, blocks: [.text(real)], timestamp: timestamp, index: &index))
+    }
+
+    /// Appends a `reasoning` payload built from its `summary` and/or `content`
+    /// text blocks. Encrypted-only reasoning (no readable text) is skipped.
+    private func appendReasoning(
+        _ payload: [String: Any],
+        timestamp: Date?,
+        index: inout Int,
+        into messages: inout [Message]
+    ) {
+        var pieces: [String] = []
+        if let summary = payload["summary"] as? [[String: Any]] {
+            let text = joinedText(from: summary)
+            if !text.isEmpty { pieces.append(text) }
+        }
+        if let content = payload["content"] as? [[String: Any]] {
+            let text = joinedText(from: content)
+            if !text.isEmpty { pieces.append(text) }
+        }
+        let combined = pieces.joined(separator: "\n\n")
+        guard !combined.isEmpty else { return }
+        messages.append(makeMessage(role: .reasoning, blocks: [.reasoning(combined)], timestamp: timestamp, index: &index))
+    }
+
+    /// Builds a ``ToolUse`` from a Codex `function_call` payload. `arguments` is
+    /// already a JSON string in the transcript.
+    private func toolUse(from payload: [String: Any]) -> ToolUse? {
+        guard let id = payload["call_id"] as? String, let name = payload["name"] as? String else { return nil }
+        let arguments = (payload["arguments"] as? String) ?? "{}"
+        return ToolUse(id: id, name: name, inputJSON: arguments, inputSummary: summary(forArguments: arguments))
+    }
+
+    /// Builds a ``ToolResult`` from a Codex `function_call_output` payload.
+    private func toolResult(from payload: [String: Any]) -> ToolResult? {
+        guard let id = payload["call_id"] as? String else { return nil }
+        let output = stringOutput(from: payload["output"])
+        return ToolResult(toolUseID: id, blocks: [.text(output)], isError: false)
+    }
+
+    /// Concatenates the `text` fields of `input_text`/`output_text`/`text`
+    /// content blocks in order.
+    private func joinedText(from content: [[String: Any]]) -> String {
+        content.compactMap { block -> String? in
+            switch block["type"] as? String {
+            case "input_text", "output_text", "text", "summary_text":
+                return block["text"] as? String
+            default:
+                return nil
+            }
+        }
+        .joined()
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Codex `function_call_output.output` is usually a string but can be an
+    /// object `{output, metadata}`; this returns the displayable text.
+    private func stringOutput(from value: Any?) -> String {
+        if let string = value as? String { return string }
+        if let dict = value as? [String: Any], let nested = dict["output"] as? String { return nested }
+        return decoder.jsonString(from: value) ?? ""
+    }
+
+    /// A short one-line summary of a `function_call` arguments JSON string:
+    /// prefers a `cmd`/`command`/`path` field.
+    private func summary(forArguments arguments: String) -> String? {
+        guard let data = arguments.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        for key in ["cmd", "command", "file_path", "path", "query"] {
+            if let value = dict[key] as? String, !value.isEmpty { return value }
+            if let array = dict[key] as? [String], !array.isEmpty { return array.joined(separator: " ") }
+        }
+        return nil
+    }
+
+    /// Returns a real user prompt, or `nil` for envelope/system wrappers
+    /// (`<environment_context>`, `<user_instructions>`, `<permissions>`,
+    /// `AGENTS.md` preamble). Ported from the app's `realCodexUserMessage`.
+    private func realUserMessage(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let envelopePrefixes = [
+            "<environment_context",
+            "<user_instructions",
+            "<permissions",
+            "<system",
+            "# AGENTS.md",
+        ]
+        for prefix in envelopePrefixes where trimmed.hasPrefix(prefix) {
+            return nil
+        }
+        return trimmed
+    }
+
+    /// Builds a message with a stable sequential id and advances the counter.
+    private func makeMessage(
+        role: MessageRole,
+        blocks: [ContentBlock],
+        timestamp: Date?,
+        toolCallID: String? = nil,
+        index: inout Int
+    ) -> Message {
+        defer { index += 1 }
+        return Message(
+            id: "codex-\(index)",
+            role: role,
+            blocks: blocks,
+            timestamp: timestamp,
+            toolCallID: toolCallID
+        )
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ContentBlock.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ContentBlock.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// One piece of content inside a ``Message`` or ``ToolResult``.
+///
+/// A message's content is an ordered list of blocks so interleaved text, tool
+/// calls, reasoning, and images keep their original sequence. The enum is
+/// `indirect` because ``ContentBlock/toolResult(_:)`` carries a ``ToolResult``
+/// whose own blocks are `ContentBlock`s (a tool result can contain text and
+/// images).
+public indirect enum ContentBlock: Codable, Hashable, Sendable {
+    /// Plain text.
+    case text(String)
+
+    /// A request by the agent to invoke a tool.
+    case toolUse(ToolUse)
+
+    /// The result of a tool invocation, correlated to its call by id.
+    case toolResult(ToolResult)
+
+    /// A referenced image attachment (see ``ImageRef``).
+    case image(ImageRef)
+
+    /// Agent reasoning / thinking text.
+    case reasoning(String)
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/Conversation.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/Conversation.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// A parsed, structured view of one agent session transcript.
+///
+/// This is the shared model both macOS and iOS render. It is a pure value type
+/// (`Sendable` + `Codable`) so it can be parsed off the main actor, cached, and
+/// later streamed across a transport without any UI or IO dependency.
+///
+/// ```swift
+/// let parser = ClaudeCodeTranscriptParser()
+/// let conversation = parser.parse(lines: jsonlLines)
+/// for message in conversation.messages where message.role == .assistant {
+///     // render assistant turns
+/// }
+/// ```
+public struct Conversation: Codable, Hashable, Sendable, Identifiable {
+    /// A stable identifier for the conversation (the agent session id is used).
+    public let id: String
+
+    /// The agent that produced the transcript.
+    public let agentKind: AgentKind
+
+    /// The agent's own session identifier.
+    public let sessionId: String
+
+    /// The conversation's messages in transcript order.
+    public let messages: [Message]
+
+    /// A monotonically increasing version stamp.
+    ///
+    /// For a one-shot file read this is simply the message count; a future
+    /// live-tailing source bumps it so consumers can detect and order updates.
+    public let seq: UInt64
+
+    /// Creates a conversation.
+    ///
+    /// - Parameters:
+    ///   - id: A stable identifier for the conversation.
+    ///   - agentKind: The agent that produced the transcript.
+    ///   - sessionId: The agent's own session identifier.
+    ///   - messages: The conversation's messages in transcript order.
+    ///   - seq: A monotonically increasing version stamp.
+    public init(
+        id: String,
+        agentKind: AgentKind,
+        sessionId: String,
+        messages: [Message],
+        seq: UInt64
+    ) {
+        self.id = id
+        self.agentKind = agentKind
+        self.sessionId = sessionId
+        self.messages = messages
+        self.seq = seq
+    }
+
+    /// An empty conversation for the given session, used as a render placeholder
+    /// before any transcript content is available.
+    ///
+    /// - Parameters:
+    ///   - agentKind: The agent the placeholder represents.
+    ///   - sessionId: The session the placeholder represents.
+    /// - Returns: A conversation with no messages and `seq` 0.
+    public static func empty(agentKind: AgentKind, sessionId: String) -> Conversation {
+        Conversation(
+            id: sessionId,
+            agentKind: agentKind,
+            sessionId: sessionId,
+            messages: [],
+            seq: 0
+        )
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ConversationEvent.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ConversationEvent.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// An update emitted by a ``ConversationSource``.
+///
+/// P1 only ever emits a single ``ConversationEvent/snapshot(_:)``. The
+/// incremental cases exist so a later live-tailing or mobile-stream source can
+/// push deltas without changing the consumer's event shape.
+public enum ConversationEvent: Sendable {
+    /// A full replacement of the current conversation state.
+    case snapshot(Conversation)
+
+    /// New or changed messages, tagged with the producing conversation's `seq`
+    /// so consumers can order and merge them.
+    case upsert([Message], seq: UInt64)
+
+    /// The underlying transcript was truncated or rewritten from the start;
+    /// consumers should discard prior state and await a fresh snapshot.
+    case truncated
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ConversationSource.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ConversationSource.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A source of conversation state and updates.
+///
+/// A view model subscribes to ``ConversationSource/events`` and projects each
+/// emission for rendering, and can pull the current state on demand via
+/// ``ConversationSource/snapshot()``. P1 implements this as a one-shot local
+/// file read that yields a single ``ConversationEvent/snapshot(_:)`` and
+/// finishes; P3 adds a live-tailing implementation behind the same protocol.
+public protocol ConversationSource: Sendable {
+    /// The stream of conversation updates. The first element is the initial
+    /// snapshot; the stream finishes when no further updates will arrive.
+    var events: AsyncStream<ConversationEvent> { get }
+
+    /// Returns the current conversation state.
+    ///
+    /// - Returns: The latest parsed conversation.
+    func snapshot() async -> Conversation
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ImageRef.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ImageRef.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A reference to an image attachment in a transcript, stored by id rather than
+/// inline.
+///
+/// Transcripts can embed large base64 image payloads. The model deliberately
+/// keeps only a lightweight reference (id, media type, byte count) so a
+/// ``Conversation`` stays cheap to hold and diff; the bytes are fetched lazily
+/// by a later loader when an image actually needs to render.
+public struct ImageRef: Codable, Hashable, Sendable, Identifiable {
+    /// A stable identifier for the image within its conversation.
+    public let id: String
+
+    /// The image's MIME media type (e.g. `image/png`), or `nil` if unknown.
+    public let mediaType: String?
+
+    /// The size of the referenced image in bytes, or `nil` if unknown.
+    public let byteCount: Int?
+
+    /// Creates an image reference.
+    ///
+    /// - Parameters:
+    ///   - id: A stable identifier for the image within its conversation.
+    ///   - mediaType: The image's MIME media type, if known.
+    ///   - byteCount: The image's size in bytes, if known.
+    public init(id: String, mediaType: String? = nil, byteCount: Int? = nil) {
+        self.id = id
+        self.mediaType = mediaType
+        self.byteCount = byteCount
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/Message.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/Message.swift
@@ -1,0 +1,47 @@
+public import Foundation
+
+/// One turn in an agent ``Conversation``: a role plus ordered content blocks.
+///
+/// A message maps to one transcript line for most roles. Tool calls and tool
+/// results stay as separate messages (linked by ``Message/toolCallID``) rather
+/// than being merged, so the model is a faithful, append-only projection of the
+/// transcript and a view layer owns call/result pairing.
+public struct Message: Codable, Hashable, Sendable, Identifiable {
+    /// A stable identifier for this message within its conversation.
+    public let id: String
+
+    /// Who authored this message and how to render it.
+    public let role: MessageRole
+
+    /// The ordered content of the message.
+    public let blocks: [ContentBlock]
+
+    /// When the message was recorded, if the transcript carried a timestamp.
+    public let timestamp: Date?
+
+    /// For ``MessageRole/toolResult`` messages, the id of the call this result
+    /// answers; otherwise `nil`.
+    public let toolCallID: String?
+
+    /// Creates a message.
+    ///
+    /// - Parameters:
+    ///   - id: A stable identifier for the message within its conversation.
+    ///   - role: Who authored the message.
+    ///   - blocks: The ordered content blocks.
+    ///   - timestamp: When the message was recorded, if known.
+    ///   - toolCallID: For tool-result messages, the call id being answered.
+    public init(
+        id: String,
+        role: MessageRole,
+        blocks: [ContentBlock],
+        timestamp: Date? = nil,
+        toolCallID: String? = nil
+    ) {
+        self.id = id
+        self.role = role
+        self.blocks = blocks
+        self.timestamp = timestamp
+        self.toolCallID = toolCallID
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/MessageRole.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/MessageRole.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// The author/category of a ``Message`` in an agent conversation.
+///
+/// Roles are normalized across agents: Claude Code and Codex use different raw
+/// strings (`assistant` vs `output_text`-bearing `message`, `tool_result`
+/// inside a `user` line vs `function_call_output`), but both map onto this
+/// shared set so one view can render either transcript.
+public enum MessageRole: String, Codable, Hashable, Sendable {
+    /// A human prompt.
+    case user
+
+    /// Agent-authored output (text and/or tool calls).
+    case assistant
+
+    /// The result returned to the agent from a tool it invoked. Correlated to
+    /// its call by ``Message/toolCallID``.
+    case toolResult
+
+    /// A system/envelope message (instructions, environment context).
+    case system
+
+    /// Agent reasoning / thinking content surfaced as its own message.
+    case reasoning
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ToolResult.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ToolResult.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// The result returned to the agent from a tool it invoked.
+///
+/// Stored separately from the originating ``ToolUse`` and linked by
+/// ``ToolResult/toolUseID``. Keeping the two as distinct nodes (rather than
+/// pre-merging them) lets a view projection pair them, while a parser that only
+/// ever sees the result still produces a faithful node.
+public struct ToolResult: Codable, Hashable, Sendable {
+    /// The id of the ``ToolUse`` this result answers (Claude `tool_use_id`,
+    /// Codex `call_id`).
+    public let toolUseID: String
+
+    /// The result content. Usually a single ``ContentBlock/text(_:)``, but tool
+    /// results can also carry images or multiple blocks.
+    public let blocks: [ContentBlock]
+
+    /// Whether the tool reported an error (Claude `is_error`). Codex does not
+    /// flag errors structurally, so this is `false` for Codex results.
+    public let isError: Bool
+
+    /// Creates a tool-result node.
+    ///
+    /// - Parameters:
+    ///   - toolUseID: The id of the ``ToolUse`` this result answers.
+    ///   - blocks: The result content blocks.
+    ///   - isError: Whether the tool reported an error.
+    public init(toolUseID: String, blocks: [ContentBlock], isError: Bool = false) {
+        self.toolUseID = toolUseID
+        self.blocks = blocks
+        self.isError = isError
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ToolUse.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/ToolUse.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// A request by the agent to invoke a tool, captured verbatim from the transcript.
+///
+/// The call is stored separately from its result: ``ToolResult`` references
+/// this value by ``ToolUse/id``. Pairing call and result into a single row is a
+/// view-projection concern, not a model concern, so the model preserves both
+/// nodes and the correlating id.
+public struct ToolUse: Codable, Hashable, Sendable, Identifiable {
+    /// The agent-assigned call id (Claude `tool_use.id`, Codex `call_id`).
+    /// ``ToolResult/toolUseID`` points back to this value.
+    public let id: String
+
+    /// The tool's name (e.g. `Bash`, `Read`, `exec_command`).
+    public let name: String
+
+    /// The raw JSON arguments the agent passed, as a string. Kept unparsed so
+    /// the model stays schema-agnostic; the UI can pretty-print on demand.
+    public let inputJSON: String
+
+    /// A short, human-readable one-line summary of the call (e.g. the shell
+    /// command), or `nil` when no concise summary is available.
+    public let inputSummary: String?
+
+    /// Creates a tool-use node.
+    ///
+    /// - Parameters:
+    ///   - id: The agent-assigned call id used to correlate the result.
+    ///   - name: The tool's name.
+    ///   - inputJSON: The raw JSON arguments as a string.
+    ///   - inputSummary: An optional concise one-line summary of the input.
+    public init(id: String, name: String, inputJSON: String, inputSummary: String? = nil) {
+        self.id = id
+        self.name = name
+        self.inputJSON = inputJSON
+        self.inputSummary = inputSummary
+    }
+}

--- a/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/TranscriptLineDecoder.swift
+++ b/Packages/CmuxAgentConversation/Sources/CmuxAgentConversation/TranscriptLineDecoder.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Shared JSONL decoding helpers used by the transcript parsers.
+///
+/// A small value type (rather than free functions or a namespace enum) that
+/// both ``ClaudeCodeTranscriptParser`` and ``CodexTranscriptParser`` construct
+/// and hold, so per-line JSON decoding, re-serialization, and ISO8601 timestamp
+/// parsing live in one place without crossing the "no free functions" rule.
+struct TranscriptLineDecoder: Sendable {
+    /// Creates a decoder.
+    init() {}
+
+    /// Parses one JSONL line into a dictionary, returning `nil` on any error or
+    /// for a blank line.
+    func object(from line: String) -> [String: Any]? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    /// Re-serializes a JSON value to a compact, key-sorted string. Strings pass
+    /// through unchanged; values that are not valid JSON return `nil`.
+    func jsonString(from value: Any?) -> String? {
+        if let string = value as? String { return string }
+        guard let value, JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Parses an ISO8601 timestamp string (with or without fractional seconds),
+    /// or `nil` when the value is missing or unparseable.
+    ///
+    /// Formatters are constructed per call: `ISO8601DateFormatter` is not
+    /// `Sendable`, so it cannot be a shared `static let` under Swift 6, and a
+    /// transcript holds at most a few thousand lines so the cost is negligible.
+    func date(from value: Any?) -> Date? {
+        guard let string = value as? String, !string.isEmpty else { return nil }
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = fractional.date(from: string) { return parsed }
+        return ISO8601DateFormatter().date(from: string)
+    }
+}

--- a/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/ClaudeCodeTranscriptParserTests.swift
+++ b/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/ClaudeCodeTranscriptParserTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentConversation
+
+/// Behavioral tests for ``ClaudeCodeTranscriptParser`` against a crafted
+/// transcript fixture covering a user prompt, an assistant reasoning + text +
+/// tool_use turn, a tool_result, an unknown line type, and malformed JSON.
+@Suite struct ClaudeCodeTranscriptParserTests {
+    /// Loads a fixture `.jsonl` from the test bundle and splits it into lines.
+    private func fixtureLines(_ name: String) throws -> [String] {
+        let url = try #require(
+            Bundle.module.url(forResource: name, withExtension: "jsonl", subdirectory: "Fixtures")
+        )
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        return contents.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    }
+
+    @Test func parsesStructureAndSessionId() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+
+        #expect(conversation.agentKind == .claudeCode)
+        #expect(conversation.sessionId == "sess-claude-1")
+        #expect(conversation.seq == UInt64(conversation.messages.count))
+
+        // user prompt, reasoning, assistant text+tool_use, tool_result, final assistant text.
+        let roles = conversation.messages.map(\.role)
+        #expect(roles == [.user, .reasoning, .assistant, .toolResult, .assistant])
+    }
+
+    @Test func userPromptText() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+        let first = try #require(conversation.messages.first)
+        #expect(first.role == .user)
+        #expect(first.blocks == [.text("List the files in the repo.")])
+    }
+
+    @Test func assistantToolUseIsCaptured() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+        let assistant = try #require(conversation.messages.first { $0.role == .assistant && $0.blocks.contains { if case .toolUse = $0 { true } else { false } } })
+
+        let toolUse = try #require(assistant.blocks.compactMap { block -> ToolUse? in
+            if case let .toolUse(use) = block { return use }
+            return nil
+        }.first)
+        #expect(toolUse.id == "toolu_01")
+        #expect(toolUse.name == "Bash")
+        #expect(toolUse.inputSummary == "ls")
+        #expect(toolUse.inputJSON.contains("\"command\":\"ls\""))
+    }
+
+    @Test func reasoningSplitIntoOwnMessage() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+        let reasoning = try #require(conversation.messages.first { $0.role == .reasoning })
+        #expect(reasoning.blocks == [.reasoning("I should run ls.")])
+    }
+
+    @Test func toolResultPairsToCallById() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+        let result = try #require(conversation.messages.first { $0.role == .toolResult })
+
+        // The call id is preserved on the message AND inside the result node,
+        // so a view projection can pair call to result without pre-merging.
+        #expect(result.toolCallID == "toolu_01")
+        let toolResult = try #require(result.blocks.compactMap { block -> ToolResult? in
+            if case let .toolResult(value) = block { return value }
+            return nil
+        }.first)
+        #expect(toolResult.toolUseID == "toolu_01")
+        #expect(toolResult.isError == false)
+        #expect(toolResult.blocks == [.text("README.md\nPackage.swift")])
+
+        // Call comes before result in transcript order.
+        let callIndex = try #require(conversation.messages.firstIndex { $0.blocks.contains { if case .toolUse = $0 { true } else { false } } })
+        let resultIndex = try #require(conversation.messages.firstIndex { $0.role == .toolResult })
+        #expect(callIndex < resultIndex)
+    }
+
+    @Test func unknownTypesAndMalformedLinesAreSkipped() throws {
+        let conversation = ClaudeCodeTranscriptParser().parse(lines: try fixtureLines("claude-sample"))
+        // The fixture contains a `summary`, an unknown future type, and an
+        // invalid-JSON line; none of them produce messages.
+        #expect(conversation.messages.count == 5)
+        #expect(conversation.messages.allSatisfy { !$0.blocks.isEmpty })
+    }
+}

--- a/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/CodexTranscriptParserTests.swift
+++ b/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/CodexTranscriptParserTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentConversation
+
+/// Behavioral tests for ``CodexTranscriptParser`` against a crafted rollout
+/// fixture covering session_meta, a developer envelope, a user prompt,
+/// reasoning, an assistant message, a function_call + function_call_output pair,
+/// dropped `event_msg` duplicates, and dropped `token_count` noise.
+@Suite struct CodexTranscriptParserTests {
+    /// Loads a fixture `.jsonl` from the test bundle and splits it into lines.
+    private func fixtureLines(_ name: String) throws -> [String] {
+        let url = try #require(
+            Bundle.module.url(forResource: name, withExtension: "jsonl", subdirectory: "Fixtures")
+        )
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        return contents.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    }
+
+    @Test func parsesStructureAndSessionId() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+
+        #expect(conversation.agentKind == .codex)
+        #expect(conversation.sessionId == "sess-codex-1")
+        #expect(conversation.seq == UInt64(conversation.messages.count))
+
+        // developer permissions envelope is stripped; user prompt, reasoning,
+        // assistant text, function_call, function_call_output, final assistant
+        // text remain.
+        let roles = conversation.messages.map(\.role)
+        #expect(roles == [.user, .reasoning, .assistant, .assistant, .toolResult, .assistant])
+    }
+
+    @Test func eventMsgDuplicatesAreDropped() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+        // The fixture's `user_message` and `agent_message` event_msg lines
+        // duplicate the response_item message text. They must not appear as
+        // extra messages: exactly one user prompt and the agent text comes from
+        // the response_item, not the event_msg.
+        let userMessages = conversation.messages.filter { $0.role == .user }
+        #expect(userMessages.count == 1)
+        #expect(userMessages.first?.blocks == [.text("List the files in the repo.")])
+
+        let assistantTexts = conversation.messages
+            .filter { $0.role == .assistant }
+            .compactMap { message -> String? in
+                guard case let .text(text) = message.blocks.first else { return nil }
+                return text
+            }
+        #expect(assistantTexts == ["Listing files now.", "There are two files."])
+    }
+
+    @Test func functionCallAndOutputPairById() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+
+        let call = try #require(conversation.messages.compactMap { message -> ToolUse? in
+            for block in message.blocks {
+                if case let .toolUse(use) = block { return use }
+            }
+            return nil
+        }.first)
+        #expect(call.id == "call_01")
+        #expect(call.name == "exec_command")
+        #expect(call.inputSummary == "ls")
+
+        let result = try #require(conversation.messages.first { $0.role == .toolResult })
+        #expect(result.toolCallID == "call_01")
+        let toolResult = try #require(result.blocks.compactMap { block -> ToolResult? in
+            if case let .toolResult(value) = block { return value }
+            return nil
+        }.first)
+        #expect(toolResult.toolUseID == call.id)
+        #expect(toolResult.blocks == [.text("README.md\nPackage.swift")])
+    }
+
+    @Test func reasoningCaptured() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+        let reasoning = try #require(conversation.messages.first { $0.role == .reasoning })
+        #expect(reasoning.blocks == [.reasoning("I'll run ls.")])
+    }
+
+    @Test func developerEnvelopeIsStripped() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+        // The `<permissions instructions>` developer envelope is implementation
+        // noise and must not appear as a conversation row.
+        #expect(conversation.messages.allSatisfy { $0.role != .system })
+        #expect(conversation.messages.allSatisfy { message in
+            message.blocks.allSatisfy { block in
+                if case let .text(text) = block { return !text.contains("permissions") }
+                return true
+            }
+        })
+    }
+
+    @Test func nonEnvelopeSystemMessageMappedToSystem() {
+        // A developer/system message that is NOT an envelope wrapper still
+        // surfaces as a `.system` row.
+        let lines = [
+            #"{"type":"session_meta","payload":{"id":"s3"}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"system","content":[{"type":"input_text","text":"You are now in plan mode."}]}}"#,
+        ]
+        let conversation = CodexTranscriptParser().parse(lines: lines)
+        #expect(conversation.messages.count == 1)
+        #expect(conversation.messages.first?.role == .system)
+        #expect(conversation.messages.first?.blocks == [.text("You are now in plan mode.")])
+    }
+
+    @Test func unknownPayloadTypesAreSkipped() throws {
+        let conversation = CodexTranscriptParser().parse(lines: try fixtureLines("codex-sample"))
+        // `tool_search_call`, `turn_context`, and `token_count` produce nothing;
+        // the developer permissions envelope is stripped. 6 messages remain.
+        #expect(conversation.messages.count == 6)
+    }
+
+    @Test func stringFormMessageContentIsKept() {
+        // A `response_item` message whose `content` is a plain string (not an
+        // array of blocks) must still produce a turn — the parser drops the
+        // duplicating `event_msg` fallback, so losing this would lose the turn.
+        let lines = [
+            #"{"type":"session_meta","payload":{"id":"s2"}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"assistant","content":"Plain string answer."}}"#,
+        ]
+        let conversation = CodexTranscriptParser().parse(lines: lines)
+        #expect(conversation.messages.count == 1)
+        #expect(conversation.messages.first?.role == .assistant)
+        #expect(conversation.messages.first?.blocks == [.text("Plain string answer.")])
+    }
+}

--- a/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/Fixtures/claude-sample.jsonl
+++ b/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/Fixtures/claude-sample.jsonl
@@ -1,0 +1,9 @@
+{"type":"queue-operation","operation":"enqueue","timestamp":"2026-06-02T11:54:43.242Z","sessionId":"sess-claude-1","content":"/start"}
+{"parentUuid":null,"type":"user","message":{"role":"user","content":"List the files in the repo."},"uuid":"u1","timestamp":"2026-06-02T11:54:43.294Z","cwd":"/tmp/demo","sessionId":"sess-claude-1"}
+{"parentUuid":"u1","type":"assistant","message":{"model":"claude-opus-4-8","role":"assistant","content":[{"type":"thinking","thinking":"I should run ls.","signature":"abc"}]},"uuid":"a1","timestamp":"2026-06-02T11:54:45.000Z","sessionId":"sess-claude-1"}
+{"parentUuid":"a1","type":"assistant","message":{"model":"claude-opus-4-8","role":"assistant","content":[{"type":"text","text":"I'll list the files."},{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"ls","description":"List files"}}]},"uuid":"a2","timestamp":"2026-06-02T11:54:46.000Z","sessionId":"sess-claude-1"}
+{"parentUuid":"a2","type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01","type":"tool_result","content":"README.md\nPackage.swift"}]},"uuid":"u2","timestamp":"2026-06-02T11:54:47.000Z","sessionId":"sess-claude-1"}
+{"type":"summary","summary":"Listed files","leafUuid":"u2"}
+{"type":"some-future-unknown-type","payload":{"whatever":true},"sessionId":"sess-claude-1"}
+{"parentUuid":"u2","type":"assistant","message":{"model":"claude-opus-4-8","role":"assistant","content":[{"type":"text","text":"There are two files."}]},"uuid":"a3","timestamp":"2026-06-02T11:54:48.000Z","sessionId":"sess-claude-1"}
+this is not valid json and must be skipped

--- a/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/Fixtures/codex-sample.jsonl
+++ b/Packages/CmuxAgentConversation/Tests/CmuxAgentConversationTests/Fixtures/codex-sample.jsonl
@@ -1,0 +1,14 @@
+{"timestamp":"2026-06-06T08:33:48.664Z","type":"session_meta","payload":{"id":"sess-codex-1","timestamp":"2026-06-06T08:33:27.138Z","cwd":"/tmp/demo","cli_version":"0.137.0"}}
+{"timestamp":"2026-06-06T08:33:48.667Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}
+{"timestamp":"2026-06-06T08:33:48.668Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<permissions instructions>\nDanger full access.\n</permissions instructions>"}]}}
+{"timestamp":"2026-06-06T08:33:48.668Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/tmp/demo","model":"gpt-5.5"}}
+{"timestamp":"2026-06-06T08:33:58.716Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"List the files in the repo."}]}}
+{"timestamp":"2026-06-06T08:33:58.719Z","type":"event_msg","payload":{"type":"user_message","message":"List the files in the repo."}}
+{"timestamp":"2026-06-06T08:34:11.016Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"I'll run ls."}],"encrypted_content":"xxx"}}
+{"timestamp":"2026-06-06T08:34:11.611Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Listing files now."}]}}
+{"timestamp":"2026-06-06T08:34:11.609Z","type":"event_msg","payload":{"type":"agent_message","message":"Listing files now."}}
+{"timestamp":"2026-06-06T08:34:12.523Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/tmp/demo\"}","call_id":"call_01"}}
+{"timestamp":"2026-06-06T08:34:21.925Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_01","output":"README.md\nPackage.swift"}}
+{"timestamp":"2026-06-06T08:34:22.029Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":22178}}}}
+{"timestamp":"2026-06-06T08:34:58.563Z","type":"response_item","payload":{"type":"tool_search_call","call_id":"call_02","status":"completed"}}
+{"timestamp":"2026-06-06T08:35:30.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"There are two files."}]}}

--- a/Packages/CmuxAgentConversationUI/Package.swift
+++ b/Packages/CmuxAgentConversationUI/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxAgentConversationUI",
+    defaultLocalization: "en",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "CmuxAgentConversationUI",
+            targets: ["CmuxAgentConversationUI"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxAgentConversation"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxAgentConversationUI",
+            dependencies: [
+                .product(name: "CmuxAgentConversation", package: "CmuxAgentConversation"),
+            ],
+            resources: [
+                .process("Resources/Localizable.xcstrings"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/AgentChatView.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/AgentChatView.swift
@@ -1,0 +1,112 @@
+public import CmuxAgentConversation
+public import SwiftUI
+import Foundation
+
+/// The entry view for the structured agent chat.
+///
+/// Owns a ``ConversationViewModel`` as `@State`, builds the ``ChatRowActions``
+/// closure bundle once above the `LazyVStack` boundary, and renders the
+/// projected ``MessageRowSnapshot`` rows. The rows below the boundary receive
+/// only value snapshots and those stable closures, never the model.
+///
+/// ```swift
+/// AgentChatView(source: LocalTranscriptConversationSource(...))
+/// ```
+public struct AgentChatView: View {
+    /// The view model, seeded from the injected source.
+    @State private var model: ConversationViewModel
+
+    /// Creates a chat view bound to a conversation source.
+    ///
+    /// - Parameter source: The source whose conversation to render.
+    public init(source: any ConversationSource) {
+        _model = State(initialValue: ConversationViewModel(source: source))
+    }
+
+    public var body: some View {
+        // Build the closure bundle here, above the list boundary, capturing the
+        // model once so no row holds a model reference.
+        let actions = ChatRowActions(
+            isToolCallExpanded: { model.isToolCallExpanded($0) },
+            toggleToolCall: { model.toggleToolCall($0) },
+            copyText: { Self.copyToPasteboard($0) }
+        )
+
+        Group {
+            if model.rows.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(model.rows) { row in
+                            rowView(row, actions: actions)
+                        }
+                    }
+                    .padding(12)
+                }
+            }
+        }
+        .task {
+            await model.run()
+        }
+    }
+
+    /// Renders one projected row by its kind.
+    @ViewBuilder
+    private func rowView(_ row: MessageRowSnapshot, actions: ChatRowActions) -> some View {
+        switch row.kind {
+        case let .message(bubble):
+            ChatMessageRowView(snapshot: bubble, actions: actions)
+                .equatable()
+        case let .toolCall(toolCall):
+            ToolCallRowView(
+                snapshot: toolCall,
+                isExpanded: model.isToolCallExpanded(toolCall.callID),
+                actions: actions
+            )
+            .equatable()
+        }
+    }
+
+    /// The placeholder shown before any content is available or when the
+    /// transcript has no renderable messages.
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(
+                model.hasLoaded
+                    ? String(
+                        localized: "agentChat.empty.noMessages",
+                        defaultValue: "No conversation found for this terminal.",
+                        bundle: .module
+                    )
+                    : String(
+                        localized: "agentChat.empty.loading",
+                        defaultValue: "Loading conversation…",
+                        bundle: .module
+                    )
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Copies text to the platform pasteboard.
+    private static func copyToPasteboard(_ text: String) {
+        #if canImport(AppKit)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #elseif canImport(UIKit)
+        UIPasteboard.general.string = text
+        #endif
+    }
+}
+
+#if canImport(AppKit)
+private import AppKit
+#elseif canImport(UIKit)
+private import UIKit
+#endif

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ChatMessageRowView.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ChatMessageRowView.swift
@@ -1,0 +1,102 @@
+import CmuxAgentConversation
+public import SwiftUI
+import Foundation
+
+/// Renders one plain message bubble (user / assistant / reasoning / system).
+///
+/// `Equatable` so SwiftUI can skip re-evaluating its body when the snapshot is
+/// unchanged. It holds only a ``MessageBubbleSnapshot`` value and a
+/// ``ChatRowActions`` closure bundle, never a store reference, satisfying the
+/// snapshot-boundary rule. `actions` is excluded from `==` because the closures
+/// are stable above the list boundary.
+public struct ChatMessageRowView: View, Equatable {
+    /// The value to render.
+    let snapshot: MessageBubbleSnapshot
+
+    /// Closures for row interactions (copy).
+    let actions: ChatRowActions
+
+    /// Creates a message-bubble row.
+    ///
+    /// - Parameters:
+    ///   - snapshot: The value to render.
+    ///   - actions: Closures for row interactions.
+    public init(snapshot: MessageBubbleSnapshot, actions: ChatRowActions) {
+        self.snapshot = snapshot
+        self.actions = actions
+    }
+
+    /// Compares only the value snapshot; closures are stable and excluded.
+    nonisolated public static func == (lhs: ChatMessageRowView, rhs: ChatMessageRowView) -> Bool {
+        lhs.snapshot == rhs.snapshot
+    }
+
+    public var body: some View {
+        HStack {
+            if snapshot.role == .user { Spacer(minLength: 48) }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(roleLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                if !snapshot.text.isEmpty {
+                    Text(snapshot.text)
+                        .font(snapshot.role == .reasoning ? .callout.italic() : .callout)
+                        .foregroundStyle(snapshot.role == .reasoning ? .secondary : .primary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                if snapshot.imageCount > 0 {
+                    Text(imageNote)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(10)
+            .background(bubbleBackground, in: RoundedRectangle(cornerRadius: 10))
+            .contextMenu {
+                Button(String(localized: "agentChat.copy", defaultValue: "Copy", bundle: .module)) {
+                    actions.copyText(snapshot.text)
+                }
+                .disabled(snapshot.text.isEmpty)
+            }
+            if snapshot.role != .user { Spacer(minLength: 48) }
+        }
+    }
+
+    /// The localized role label shown above the bubble.
+    private var roleLabel: String {
+        switch snapshot.role {
+        case .user:
+            return String(localized: "agentChat.role.user", defaultValue: "You", bundle: .module)
+        case .assistant:
+            return String(localized: "agentChat.role.assistant", defaultValue: "Agent", bundle: .module)
+        case .reasoning:
+            return String(localized: "agentChat.role.reasoning", defaultValue: "Reasoning", bundle: .module)
+        case .system:
+            return String(localized: "agentChat.role.system", defaultValue: "System", bundle: .module)
+        case .toolResult:
+            return String(localized: "agentChat.role.toolResult", defaultValue: "Tool result", bundle: .module)
+        }
+    }
+
+    /// A localized note for image-only content (P1 does not load image bytes).
+    private var imageNote: String {
+        String(
+            localized: "agentChat.imageAttachment",
+            defaultValue: "Image attachment",
+            bundle: .module
+        )
+    }
+
+    /// The bubble background, tinted for user vs others.
+    private var bubbleBackground: Color {
+        switch snapshot.role {
+        case .user:
+            return Color.accentColor.opacity(0.15)
+        case .system:
+            return Color.secondary.opacity(0.08)
+        default:
+            return Color.secondary.opacity(0.12)
+        }
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ChatRowActions.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ChatRowActions.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A value-typed bundle of closures handed to chat rows in place of a store
+/// reference.
+///
+/// Rows below the `LazyVStack` boundary must not hold an `@Observable` /
+/// `ObservableObject` reference (see the repo's snapshot-boundary rule), so
+/// every capability a row needs is a closure captured above the boundary. The
+/// closures are stable, so excluding them from a row's `Equatable` check keeps
+/// the layout cache from thrashing on unrelated model changes.
+@MainActor
+public struct ChatRowActions {
+    /// Whether the tool-call row with the given call id is currently expanded.
+    public let isToolCallExpanded: (String) -> Bool
+
+    /// Toggles the expanded/collapsed state of a tool-call row by call id.
+    public let toggleToolCall: (String) -> Void
+
+    /// Copies the given text to the pasteboard.
+    public let copyText: (String) -> Void
+
+    /// Creates a chat-row action bundle.
+    ///
+    /// - Parameters:
+    ///   - isToolCallExpanded: Returns whether a tool-call row is expanded.
+    ///   - toggleToolCall: Toggles a tool-call row's expansion by call id.
+    ///   - copyText: Copies text to the pasteboard.
+    public init(
+        isToolCallExpanded: @escaping (String) -> Bool,
+        toggleToolCall: @escaping (String) -> Void,
+        copyText: @escaping (String) -> Void
+    ) {
+        self.isToolCallExpanded = isToolCallExpanded
+        self.toggleToolCall = toggleToolCall
+        self.copyText = copyText
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ConversationViewModel.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ConversationViewModel.swift
@@ -1,0 +1,235 @@
+public import CmuxAgentConversation
+public import Observation
+
+/// The `@Observable` view model behind ``AgentChatView``.
+///
+/// It subscribes to a ``CmuxAgentConversation/ConversationSource``, holds the
+/// current ``CmuxAgentConversation/Conversation``, and projects it into an array
+/// of value-typed ``MessageRowSnapshot`` (pairing each tool call with its result
+/// by id). Rows render only those snapshots plus a ``ChatRowActions`` closure
+/// bundle, never this model — that is the snapshot-boundary contract.
+///
+/// ```swift
+/// let model = ConversationViewModel(source: source)
+/// await model.start()
+/// ```
+@Observable
+@MainActor
+public final class ConversationViewModel {
+    /// The current parsed conversation.
+    public private(set) var conversation: Conversation
+
+    /// The projected rows to render, in conversation order.
+    public private(set) var rows: [MessageRowSnapshot] = []
+
+    /// Whether the initial load has completed.
+    public private(set) var hasLoaded: Bool = false
+
+    /// The source of conversation state and updates.
+    private let source: any ConversationSource
+
+    /// Call ids of tool-call rows the user has expanded.
+    private var expandedToolCalls: Set<String> = []
+
+    /// Creates a view model bound to a conversation source.
+    ///
+    /// - Parameter source: The source to render. Its first event seeds the view.
+    public init(source: any ConversationSource) {
+        self.source = source
+        self.conversation = Conversation.empty(agentKind: .unknown, sessionId: "")
+    }
+
+    /// Subscribes to the source and projects each emission until the stream
+    /// finishes or the calling task is cancelled.
+    ///
+    /// Drive this from a SwiftUI `.task { await model.run() }` so the
+    /// subscription's lifetime is bound to the view: when the view disappears
+    /// SwiftUI cancels the task, which ends the `for await` loop. There is no
+    /// separate stored `Task`, so nothing can outlive the view.
+    public func run() async {
+        for await event in source.events {
+            if Task.isCancelled { return }
+            apply(event)
+        }
+    }
+
+    /// Whether the tool-call row for the given call id is expanded.
+    ///
+    /// - Parameter callID: The call id to query.
+    /// - Returns: `true` if the row is currently expanded.
+    public func isToolCallExpanded(_ callID: String) -> Bool {
+        expandedToolCalls.contains(callID)
+    }
+
+    /// Toggles the expanded/collapsed state of a tool-call row.
+    ///
+    /// - Parameter callID: The call id whose row to toggle.
+    public func toggleToolCall(_ callID: String) {
+        if expandedToolCalls.contains(callID) {
+            expandedToolCalls.remove(callID)
+        } else {
+            expandedToolCalls.insert(callID)
+        }
+    }
+
+    /// Applies one source event to the model state and re-projects rows.
+    private func apply(_ event: ConversationEvent) {
+        switch event {
+        case let .snapshot(conversation):
+            self.conversation = conversation
+            self.rows = Self.project(conversation)
+            self.hasLoaded = true
+        case let .upsert(messages, seq):
+            self.conversation = Self.merge(conversation, messages: messages, seq: seq)
+            self.rows = Self.project(conversation)
+            self.hasLoaded = true
+        case .truncated:
+            self.conversation = Conversation.empty(
+                agentKind: conversation.agentKind,
+                sessionId: conversation.sessionId
+            )
+            self.rows = []
+        }
+    }
+
+    /// Merges upserted messages into a conversation by id (append-or-replace),
+    /// preserving order and taking the newer `seq`.
+    private static func merge(
+        _ base: Conversation,
+        messages: [Message],
+        seq: UInt64
+    ) -> Conversation {
+        var merged = base.messages
+        var indexByID = Dictionary(uniqueKeysWithValues: merged.enumerated().map { ($1.id, $0) })
+        for message in messages {
+            if let existing = indexByID[message.id] {
+                merged[existing] = message
+            } else {
+                indexByID[message.id] = merged.count
+                merged.append(message)
+            }
+        }
+        return Conversation(
+            id: base.id,
+            agentKind: base.agentKind,
+            sessionId: base.sessionId,
+            messages: merged,
+            seq: max(base.seq, seq)
+        )
+    }
+
+    /// Projects a conversation into render rows, pairing each tool call with the
+    /// result that shares its id.
+    ///
+    /// Results are matched to calls and folded into the call's row, so a
+    /// standalone tool-result message never produces a second row. A result with
+    /// no preceding call (rare/malformed) still renders as its own bubble so no
+    /// content is dropped.
+    private static func project(_ conversation: Conversation) -> [MessageRowSnapshot] {
+        // Index results by call id so a call can absorb its output.
+        var resultsByCallID: [String: ToolResult] = [:]
+        for message in conversation.messages {
+            for block in message.blocks {
+                if case let .toolResult(result) = block {
+                    resultsByCallID[result.toolUseID] = result
+                }
+            }
+        }
+
+        var rows: [MessageRowSnapshot] = []
+        var consumedResultCallIDs: Set<String> = []
+
+        for message in conversation.messages {
+            for (blockIndex, block) in message.blocks.enumerated() {
+                let rowID = "\(message.id)-\(blockIndex)"
+                switch block {
+                case let .text(text):
+                    rows.append(bubbleRow(id: rowID, role: message.role, text: text))
+                case let .reasoning(text):
+                    rows.append(bubbleRow(id: rowID, role: .reasoning, text: text))
+                case let .toolUse(use):
+                    let result = resultsByCallID[use.id]
+                    if result != nil { consumedResultCallIDs.insert(use.id) }
+                    rows.append(toolCallRow(id: rowID, use: use, result: result))
+                case let .toolResult(result):
+                    // Already folded into its call's row; skip the duplicate.
+                    guard !consumedResultCallIDs.contains(result.toolUseID) else { continue }
+                    rows.append(orphanResultRow(id: rowID, result: result))
+                    consumedResultCallIDs.insert(result.toolUseID)
+                case let .image(image):
+                    rows.append(
+                        bubbleRow(
+                            id: rowID,
+                            role: message.role,
+                            text: "",
+                            imageCount: 1,
+                            imageMediaType: image.mediaType
+                        )
+                    )
+                }
+            }
+        }
+        return rows
+    }
+
+    /// Builds a message-bubble row.
+    private static func bubbleRow(
+        id: String,
+        role: MessageRole,
+        text: String,
+        imageCount: Int = 0,
+        imageMediaType: String? = nil
+    ) -> MessageRowSnapshot {
+        MessageRowSnapshot(
+            id: id,
+            kind: .message(MessageBubbleSnapshot(role: role, text: text, imageCount: imageCount))
+        )
+    }
+
+    /// Builds a tool-call row from a call and its optional result.
+    private static func toolCallRow(
+        id: String,
+        use: ToolUse,
+        result: ToolResult?
+    ) -> MessageRowSnapshot {
+        MessageRowSnapshot(
+            id: id,
+            kind: .toolCall(
+                ToolCallSnapshot(
+                    callID: use.id,
+                    name: use.name,
+                    inputSummary: use.inputSummary,
+                    inputJSON: use.inputJSON,
+                    resultText: result.map(Self.flatten),
+                    isError: result?.isError ?? false
+                )
+            )
+        )
+    }
+
+    /// Builds a row for a result with no matching call.
+    private static func orphanResultRow(id: String, result: ToolResult) -> MessageRowSnapshot {
+        MessageRowSnapshot(
+            id: id,
+            kind: .toolCall(
+                ToolCallSnapshot(
+                    callID: result.toolUseID,
+                    name: result.toolUseID,
+                    inputSummary: nil,
+                    inputJSON: "",
+                    resultText: Self.flatten(result),
+                    isError: result.isError
+                )
+            )
+        )
+    }
+
+    /// Flattens a tool result's blocks into displayable text.
+    private static func flatten(_ result: ToolResult) -> String {
+        result.blocks.compactMap { block -> String? in
+            if case let .text(text) = block { return text }
+            return nil
+        }
+        .joined(separator: "\n")
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/MessageBubbleSnapshot.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/MessageBubbleSnapshot.swift
@@ -1,0 +1,29 @@
+public import CmuxAgentConversation
+
+/// An immutable value describing a plain message bubble.
+///
+/// Carries the already-flattened display text and the role so the row view does
+/// no model traversal of its own. Images are noted as a count for P1 (the bytes
+/// are referenced, not loaded); P3 renders them.
+public struct MessageBubbleSnapshot: Hashable, Sendable {
+    /// The author/category that selects styling and alignment.
+    public let role: MessageRole
+
+    /// The flattened text content of the message.
+    public let text: String
+
+    /// The number of referenced images in the message (rendered as a note in P1).
+    public let imageCount: Int
+
+    /// Creates a message-bubble snapshot.
+    ///
+    /// - Parameters:
+    ///   - role: The author/category.
+    ///   - text: The flattened text content.
+    ///   - imageCount: The number of referenced images.
+    public init(role: MessageRole, text: String, imageCount: Int) {
+        self.role = role
+        self.text = text
+        self.imageCount = imageCount
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/MessageRowSnapshot.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/MessageRowSnapshot.swift
@@ -1,0 +1,35 @@
+/// An immutable, value-typed description of one rendered chat row.
+///
+/// The view model projects a ``Conversation`` into an array of these so the row
+/// views receive only values plus closures, never a store reference. This is
+/// the snapshot-boundary contract that keeps an orthogonal model change from
+/// invalidating every row in a `LazyVStack` (see the repo's snapshot-boundary
+/// rule). A tool call and its paired result collapse into a single
+/// ``MessageRowSnapshot/Kind/toolCall(_:)`` row; everything else is a
+/// ``MessageRowSnapshot/Kind/message(_:)`` bubble.
+public struct MessageRowSnapshot: Identifiable, Hashable, Sendable {
+    /// What a row renders.
+    public enum Kind: Hashable, Sendable {
+        /// A plain message bubble (user / assistant text, reasoning, system).
+        case message(MessageBubbleSnapshot)
+
+        /// A tool call paired with its result (if the result has arrived).
+        case toolCall(ToolCallSnapshot)
+    }
+
+    /// A stable identity for the row, used as the `ForEach` id.
+    public let id: String
+
+    /// The content this row renders.
+    public let kind: Kind
+
+    /// Creates a row snapshot.
+    ///
+    /// - Parameters:
+    ///   - id: A stable identity for the row.
+    ///   - kind: The content this row renders.
+    public init(id: String, kind: Kind) {
+        self.id = id
+        self.kind = kind
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/Resources/Localizable.xcstrings
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/Resources/Localizable.xcstrings
@@ -1,0 +1,230 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "agentChat.copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
+          }
+        }
+      }
+    },
+    "agentChat.empty.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading conversation…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会話を読み込んでいます…"
+          }
+        }
+      }
+    },
+    "agentChat.empty.noMessages" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No conversation found for this terminal."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このターミナルの会話が見つかりません。"
+          }
+        }
+      }
+    },
+    "agentChat.imageAttachment" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image attachment"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像の添付"
+          }
+        }
+      }
+    },
+    "agentChat.role.assistant" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェント"
+          }
+        }
+      }
+    },
+    "agentChat.role.reasoning" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reasoning"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推論"
+          }
+        }
+      }
+    },
+    "agentChat.role.system" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
+          }
+        }
+      }
+    },
+    "agentChat.role.toolResult" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tool result"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ツールの結果"
+          }
+        }
+      }
+    },
+    "agentChat.role.user" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あなた"
+          }
+        }
+      }
+    },
+    "agentChat.tool.copyResult" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy result"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果をコピー"
+          }
+        }
+      }
+    },
+    "agentChat.tool.emptyResult" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(no output)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(出力なし)"
+          }
+        }
+      }
+    },
+    "agentChat.tool.input" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Input"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "入力"
+          }
+        }
+      }
+    },
+    "agentChat.tool.pending" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "running…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行中…"
+          }
+        }
+      }
+    },
+    "agentChat.tool.result" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Result"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ToolCallRowView.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ToolCallRowView.swift
@@ -1,0 +1,131 @@
+public import SwiftUI
+import Foundation
+
+/// Renders a tool call paired with its result as a collapsible row.
+///
+/// Collapsed, it shows the tool name and a one-line input summary. Expanded, it
+/// shows the raw JSON input and the result text. `Equatable` so the body is
+/// skipped when neither the snapshot nor the expanded flag changes; both inputs
+/// are values, never a store reference (snapshot-boundary rule). `actions` is
+/// excluded from `==` because the closures are stable.
+public struct ToolCallRowView: View, Equatable {
+    /// The call + result value to render.
+    let snapshot: ToolCallSnapshot
+
+    /// Whether the row is currently expanded (a value, projected by the model).
+    let isExpanded: Bool
+
+    /// Closures for row interactions (toggle, copy).
+    let actions: ChatRowActions
+
+    /// Creates a tool-call row.
+    ///
+    /// - Parameters:
+    ///   - snapshot: The call + result value to render.
+    ///   - isExpanded: Whether the row is currently expanded.
+    ///   - actions: Closures for row interactions.
+    public init(snapshot: ToolCallSnapshot, isExpanded: Bool, actions: ChatRowActions) {
+        self.snapshot = snapshot
+        self.isExpanded = isExpanded
+        self.actions = actions
+    }
+
+    /// Compares the value snapshot and expanded flag; closures are excluded.
+    nonisolated public static func == (lhs: ToolCallRowView, rhs: ToolCallRowView) -> Bool {
+        lhs.snapshot == rhs.snapshot && lhs.isExpanded == rhs.isExpanded
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                actions.toggleToolCall(snapshot.callID)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: snapshot.isError ? "wrench.and.screwdriver.fill" : "wrench.and.screwdriver")
+                        .font(.caption)
+                        .foregroundStyle(snapshot.isError ? Color.red : Color.secondary)
+                    Text(snapshot.name)
+                        .font(.caption.weight(.semibold))
+                    if let summary = snapshot.inputSummary, !summary.isEmpty {
+                        Text(summary)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer(minLength: 0)
+                    if snapshot.resultText == nil {
+                        Text(pendingLabel)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                expandedContent
+            }
+        }
+        .padding(10)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(snapshot.isError ? Color.red.opacity(0.4) : Color.secondary.opacity(0.2))
+        )
+    }
+
+    /// The expanded body: raw input JSON and the result text.
+    @ViewBuilder
+    private var expandedContent: some View {
+        if !snapshot.inputJSON.isEmpty {
+            Text(inputLabel)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(snapshot.inputJSON)
+                .font(.caption.monospaced())
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        if let resultText = snapshot.resultText {
+            Text(resultLabel)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(snapshot.isError ? Color.red : Color.secondary)
+            Text(resultText.isEmpty ? emptyResultLabel : resultText)
+                .font(.caption.monospaced())
+                .foregroundStyle(snapshot.isError ? Color.red : Color.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(copyResultLabel) {
+                actions.copyText(resultText)
+            }
+            .font(.caption)
+            .buttonStyle(.plain)
+            .foregroundStyle(.tint)
+            .disabled(resultText.isEmpty)
+        }
+    }
+
+    private var pendingLabel: String {
+        String(localized: "agentChat.tool.pending", defaultValue: "running…", bundle: .module)
+    }
+
+    private var inputLabel: String {
+        String(localized: "agentChat.tool.input", defaultValue: "Input", bundle: .module)
+    }
+
+    private var resultLabel: String {
+        String(localized: "agentChat.tool.result", defaultValue: "Result", bundle: .module)
+    }
+
+    private var emptyResultLabel: String {
+        String(localized: "agentChat.tool.emptyResult", defaultValue: "(no output)", bundle: .module)
+    }
+
+    private var copyResultLabel: String {
+        String(localized: "agentChat.tool.copyResult", defaultValue: "Copy result", bundle: .module)
+    }
+}

--- a/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ToolCallSnapshot.swift
+++ b/Packages/CmuxAgentConversationUI/Sources/CmuxAgentConversationUI/ToolCallSnapshot.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// An immutable value describing a tool call paired with its result.
+///
+/// The view model pairs a ``CmuxAgentConversation/ToolUse`` with the
+/// ``CmuxAgentConversation/ToolResult`` that shares its id, so the row can show
+/// the call and (when present) its output as one collapsible unit. `resultText`
+/// is `nil` while a call is still pending (no result line yet).
+public struct ToolCallSnapshot: Hashable, Sendable {
+    /// The correlating call id (`tool_use_id` / `call_id`).
+    public let callID: String
+
+    /// The tool's name (e.g. `Bash`, `exec_command`).
+    public let name: String
+
+    /// A short one-line summary of the input (e.g. the shell command), if any.
+    public let inputSummary: String?
+
+    /// The raw JSON input, shown when the row is expanded.
+    public let inputJSON: String
+
+    /// The flattened result text, or `nil` if the result has not arrived.
+    public let resultText: String?
+
+    /// Whether the tool reported an error.
+    public let isError: Bool
+
+    /// Creates a tool-call snapshot.
+    ///
+    /// - Parameters:
+    ///   - callID: The correlating call id.
+    ///   - name: The tool's name.
+    ///   - inputSummary: A short one-line summary of the input, if any.
+    ///   - inputJSON: The raw JSON input.
+    ///   - resultText: The flattened result text, or `nil` if pending.
+    ///   - isError: Whether the tool reported an error.
+    public init(
+        callID: String,
+        name: String,
+        inputSummary: String?,
+        inputJSON: String,
+        resultText: String?,
+        isError: Bool
+    ) {
+        self.callID = callID
+        self.name = name
+        self.inputSummary = inputSummary
+        self.inputJSON = inputJSON
+        self.resultText = resultText
+        self.isError = isError
+    }
+}

--- a/Sources/AgentChat/AgentChatPresenter.swift
+++ b/Sources/AgentChat/AgentChatPresenter.swift
@@ -1,0 +1,67 @@
+import AppKit
+import CmuxAgentConversation
+import Foundation
+
+/// The shared action path for opening the agent chat view for a panel.
+///
+/// All entry points (menu item, future shortcut/command palette) call
+/// ``AgentChatPresenter/presentForFocusedPanel()`` so the resolve-and-open flow
+/// lives in one place. Resolution reads the restorable-session index and globs
+/// the filesystem, so it runs off-main; the window is shown back on the main
+/// actor.
+@MainActor
+struct AgentChatPresenter {
+    /// The resolver used to map a panel to its transcript file.
+    private let resolver: AgentChatTranscriptResolver
+
+    /// Creates a presenter.
+    ///
+    /// - Parameter resolver: The transcript resolver to use.
+    init(resolver: AgentChatTranscriptResolver = AgentChatTranscriptResolver()) {
+        self.resolver = resolver
+    }
+
+    /// Resolves the focused panel's agent and presents its chat, or shows an
+    /// alert when the focused panel has no recognizable agent session.
+    func presentForFocusedPanel() {
+        guard let manager = AppDelegate.shared?.activeTabManagerForCommands(),
+              let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            presentNoSessionAlert()
+            return
+        }
+        let workspaceId = workspace.id
+        let resolver = resolver
+
+        Task {
+            // Loading the index and globbing the filesystem is IO; keep it off
+            // the main actor, then present on the main actor.
+            let resolution = await Task.detached(priority: .userInitiated) {
+                let index = RestorableAgentSessionIndex.load()
+                return resolver.resolve(index: index, workspaceId: workspaceId, panelId: panelId)
+            }.value
+
+            guard let resolution else {
+                presentNoSessionAlert()
+                return
+            }
+            AgentChatWindowController.shared.present(for: resolution)
+        }
+    }
+
+    /// Shows an alert explaining that the focused panel has no agent session.
+    private func presentNoSessionAlert() {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "agentChat.noSession.title",
+            defaultValue: "No agent conversation"
+        )
+        alert.informativeText = String(
+            localized: "agentChat.noSession.message",
+            defaultValue: "Focus a terminal running Claude Code or Codex, then try View Chat again."
+        )
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "agentChat.noSession.ok", defaultValue: "OK"))
+        alert.runModal()
+    }
+}

--- a/Sources/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/AgentChat/AgentChatTranscriptResolver.swift
@@ -1,0 +1,232 @@
+import CMUXAgentLaunch
+import CmuxAgentConversation
+import Foundation
+
+/// Resolves a focused panel to the agent transcript file it should render.
+///
+/// Reuses the existing restorable-session index (`RestorableAgentSessionIndex`)
+/// to get a panel's `(kind, sessionId, workingDirectory)`, then locates the
+/// transcript with the same conventions the resume path uses: for Claude Code,
+/// the `~/.claude/projects/<encode(cwd)>/<sessionId>.jsonl` file (with a
+/// fallback scan across project dirs); for Codex, a glob of `<sessionId>` under
+/// `~/.codex/sessions`.
+struct AgentChatTranscriptResolver {
+    /// The agent home directory (defaults to the real home).
+    private let homeDirectory: String
+
+    /// The filesystem used for lookups (injectable for tests).
+    private let fileManager: FileManager
+
+    /// Creates a resolver.
+    ///
+    /// - Parameters:
+    ///   - homeDirectory: The home directory holding `~/.claude` and `~/.codex`.
+    ///   - fileManager: The filesystem to query.
+    init(
+        homeDirectory: String = NSHomeDirectory(),
+        fileManager: FileManager = .default
+    ) {
+        self.homeDirectory = homeDirectory
+        self.fileManager = fileManager
+    }
+
+    /// The agent kind plus the resolved transcript URL for a panel.
+    struct Resolution {
+        /// The normalized agent kind for the chat model.
+        let agentKind: AgentKind
+        /// The agent session id.
+        let sessionId: String
+        /// The located transcript file, or `nil` if none was found.
+        let transcriptURL: URL?
+    }
+
+    /// Resolves a panel's transcript from the restorable-session index.
+    ///
+    /// - Parameters:
+    ///   - index: The loaded restorable-session index.
+    ///   - workspaceId: The panel's workspace id.
+    ///   - panelId: The panel id.
+    /// - Returns: The resolution, or `nil` when the panel has no known agent
+    ///   session or the agent kind is not a transcript-backed kind P1 supports.
+    func resolve(
+        index: RestorableAgentSessionIndex,
+        workspaceId: UUID,
+        panelId: UUID
+    ) -> Resolution? {
+        guard let snapshot = index.snapshot(workspaceId: workspaceId, panelId: panelId) else {
+            return nil
+        }
+        let sessionId = snapshot.sessionId
+        guard !sessionId.isEmpty else { return nil }
+        let cwd = snapshot.workingDirectory
+
+        switch snapshot.kind {
+        case .claude:
+            let configuredRoot = snapshot.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]
+            return Resolution(
+                agentKind: .claudeCode,
+                sessionId: sessionId,
+                transcriptURL: claudeTranscriptURL(
+                    sessionId: sessionId,
+                    cwd: cwd,
+                    configuredRoot: configuredRoot
+                )
+            )
+        case .codex:
+            let codexHome = snapshot.launchCommand?.environment?["CODEX_HOME"]
+            return Resolution(
+                agentKind: .codex,
+                sessionId: sessionId,
+                transcriptURL: codexTranscriptURL(sessionId: sessionId, codexHome: codexHome)
+            )
+        default:
+            // Other agents are not transcript-backed in the P1 parsers.
+            return nil
+        }
+    }
+
+    /// Locates a Claude transcript across the same config roots the resume path
+    /// honors: a launch-time `CLAUDE_CONFIG_DIR` (highest priority), `~/.claude`,
+    /// and any `~/.codex-accounts/claude/*` account root. Within each root it
+    /// prefers the encoded-cwd project dir, then scans all project dirs for
+    /// `<sessionId>.jsonl`.
+    private func claudeTranscriptURL(sessionId: String, cwd: String?, configuredRoot: String?) -> URL? {
+        let fileName = "\(sessionId).jsonl"
+        for configRoot in claudeConfigRoots(configuredRoot: configuredRoot) {
+            let projectsRoot = (configRoot as NSString).appendingPathComponent("projects")
+
+            if let cwd {
+                // Single-source the encoding with the resume path.
+                let dirName = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd)
+                let path = (projectsRoot as NSString)
+                    .appendingPathComponent(dirName)
+                    .appending("/")
+                    .appending(fileName)
+                if regularFileExists(path) { return URL(fileURLWithPath: path) }
+            }
+
+            guard let projectDirs = try? fileManager.contentsOfDirectory(atPath: projectsRoot) else {
+                continue
+            }
+            for dir in projectDirs {
+                let path = (projectsRoot as NSString)
+                    .appendingPathComponent(dir)
+                    .appending("/")
+                    .appending(fileName)
+                if regularFileExists(path) { return URL(fileURLWithPath: path) }
+            }
+        }
+        return nil
+    }
+
+    /// The ordered Claude config roots to search, mirroring the restore/resume
+    /// path's `RestorableAgentSessionIndex.ClaudeTranscriptLookupCache.configRoots`
+    /// exactly so a session the resume path can find is found here too.
+    ///
+    /// When a launch-time `CLAUDE_CONFIG_DIR` is set, that preferred-path root is
+    /// the *only* root (the same single-root behavior the resume path uses).
+    /// Otherwise the order is: each `~/.codex-accounts/claude/*` multi-account
+    /// root (sorted), then `~/.claude`, then the legacy
+    /// `~/.subrouter/codex/claude` preferred path.
+    private func claudeConfigRoots(configuredRoot: String?) -> [String] {
+        if let configuredRoot, !configuredRoot.isEmpty {
+            return [
+                ClaudeConfigDirectoryPath.preferredPath(
+                    configuredRoot,
+                    fileManager: fileManager,
+                    homeDirectory: homeDirectory
+                ),
+            ]
+        }
+
+        var roots: [String] = []
+        var seen: Set<String> = []
+        func append(_ path: String) {
+            let standardized = (path as NSString).standardizingPath
+            guard !standardized.isEmpty, seen.insert(standardized).inserted else { return }
+            roots.append(standardized)
+        }
+
+        let accountRoot = (homeDirectory as NSString).appendingPathComponent(".codex-accounts/claude")
+        if let accountDirs = try? fileManager.contentsOfDirectory(atPath: accountRoot) {
+            for accountDir in accountDirs.sorted() {
+                append((accountRoot as NSString).appendingPathComponent(accountDir))
+            }
+        }
+        append((homeDirectory as NSString).appendingPathComponent(".claude"))
+        append(
+            ClaudeConfigDirectoryPath.preferredPath(
+                (homeDirectory as NSString).appendingPathComponent(".subrouter/codex/claude"),
+                fileManager: fileManager,
+                homeDirectory: homeDirectory
+            )
+        )
+        return roots
+    }
+
+    /// Locates a Codex rollout under the `sessions` tree of the captured
+    /// `CODEX_HOME` (when set), then the default `~/.codex`. Codex stores
+    /// rollouts under `$CODEX_HOME/sessions`, matching the resume path's
+    /// preserved env var.
+    ///
+    /// The tree is partitioned `YYYY/MM/DD/rollout-<ISO>-<sessionId>.jsonl`.
+    /// Rather than recursively enumerating the whole history on every menu
+    /// click, this walks the date directories newest-first and returns the
+    /// first exact-suffix match, so the cost is bounded to the most recent days.
+    private func codexTranscriptURL(sessionId: String, codexHome: String?) -> URL? {
+        // The id is the exact suffix; matching the suffix (not a substring)
+        // avoids binding to another rollout whose id merely contains this one.
+        let suffix = "-\(sessionId).jsonl"
+
+        // Check each `YYYY/MM/DD` directory newest-first and return as soon as a
+        // match is found, so a session in the newest day never walks the whole
+        // history. Directory names are zero-padded, so lexicographic-descending
+        // order is chronological-descending.
+        func children(_ path: String) -> [String] {
+            ((try? fileManager.contentsOfDirectory(atPath: path)) ?? []).sorted(by: >)
+        }
+        func match(inDay dayDir: String) -> URL? {
+            guard let names = try? fileManager.contentsOfDirectory(atPath: dayDir) else { return nil }
+            guard let name = names.filter({ $0.hasSuffix(suffix) }).sorted().last else { return nil }
+            return URL(fileURLWithPath: (dayDir as NSString).appendingPathComponent(name))
+        }
+
+        for sessionsRoot in codexSessionsRoots(codexHome: codexHome) {
+            for year in children(sessionsRoot) {
+                let yearPath = (sessionsRoot as NSString).appendingPathComponent(year)
+                for month in children(yearPath) {
+                    let monthPath = (yearPath as NSString).appendingPathComponent(month)
+                    for day in children(monthPath) {
+                        if let url = match(inDay: (monthPath as NSString).appendingPathComponent(day)) {
+                            return url
+                        }
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    /// The ordered Codex `sessions` roots to search: the captured `CODEX_HOME`
+    /// first (when set), then the default `~/.codex`.
+    private func codexSessionsRoots(codexHome: String?) -> [String] {
+        var roots: [String] = []
+        var seen: Set<String> = []
+        func append(_ home: String) {
+            let expanded = (home as NSString).expandingTildeInPath
+            let sessions = ((expanded as NSString).appendingPathComponent("sessions") as NSString)
+                .standardizingPath
+            guard !sessions.isEmpty, seen.insert(sessions).inserted else { return }
+            roots.append(sessions)
+        }
+        if let codexHome, !codexHome.isEmpty { append(codexHome) }
+        append((homeDirectory as NSString).appendingPathComponent(".codex"))
+        return roots
+    }
+
+    /// Whether a regular (non-directory) file exists at the path.
+    private func regularFileExists(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        return fileManager.fileExists(atPath: path, isDirectory: &isDir) && !isDir.boolValue
+    }
+}

--- a/Sources/AgentChat/AgentChatWindowController.swift
+++ b/Sources/AgentChat/AgentChatWindowController.swift
@@ -1,0 +1,77 @@
+import AppKit
+import CmuxAgentConversation
+import CmuxAgentConversationUI
+import SwiftUI
+
+/// Hosts ``AgentChatView`` in a standalone window for the focused panel's agent.
+///
+/// P1 entry point: resolves the focused panel to its transcript, builds a
+/// ``LocalTranscriptConversationSource``, and shows the parsed conversation.
+/// Re-running ``present(for:)`` swaps in a fresh source so the window always
+/// reflects the panel the user invoked it from.
+@MainActor
+final class AgentChatWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = AgentChatWindowController()
+
+    /// The hosting controller whose root view is swapped per presentation.
+    private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
+
+    /// Monotonic presentation counter folded into the view identity so each
+    /// View Chat invocation rebuilds the view and re-reads the transcript, even
+    /// when the same panel is reopened after its transcript has grown.
+    private var presentationGeneration: UInt64 = 0
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 720),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.agentChat")
+        window.title = String(localized: "agentChat.windowTitle", defaultValue: "Agent Chat")
+        window.center()
+        window.contentViewController = hostingController
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Presents the chat for the given resolution, building a fresh source.
+    ///
+    /// - Parameter resolution: The resolved agent kind, session id, and
+    ///   transcript URL for the focused panel.
+    func present(for resolution: AgentChatTranscriptResolver.Resolution) {
+        let source = LocalTranscriptConversationSource(
+            agentKind: resolution.agentKind,
+            sessionId: resolution.sessionId,
+            transcriptURL: resolution.transcriptURL
+        )
+        // `.id` ties the view's identity to this presentation so every View
+        // Chat invocation forces SwiftUI to rebuild `AgentChatView` (and its
+        // `@State` model), re-reading the transcript. The generation makes
+        // reopening the same panel re-read after its transcript has grown,
+        // while still discarding a previous panel's source.
+        presentationGeneration += 1
+        let identity = "\(presentationGeneration)|\(resolution.sessionId)"
+        hostingController.rootView = AnyView(AgentChatView(source: source).id(identity))
+        showWindow()
+    }
+
+    /// Brings the window to the front.
+    private func showWindow() {
+        guard let window else { return }
+        if !window.isVisible {
+            window.center()
+        }
+        NSApp.unhide(nil)
+        window.makeKeyAndOrderFront(nil)
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+    }
+}

--- a/Sources/AgentChat/LocalTranscriptConversationSource.swift
+++ b/Sources/AgentChat/LocalTranscriptConversationSource.swift
@@ -1,0 +1,121 @@
+import CmuxAgentConversation
+import Foundation
+
+/// A ``ConversationSource`` that reads and parses one agent transcript from the
+/// local filesystem.
+///
+/// P1 is a one-shot read: ``events`` yields a single ``ConversationEvent/snapshot(_:)``
+/// and finishes (no live tailing — that is P3). The transcript path is resolved
+/// from a panel's restorable-session snapshot (`kind` + `sessionId` +
+/// `workingDirectory`) using the same Claude project-dir encoding and Codex
+/// session glob the resume path already relies on.
+///
+/// The chunked, size-capped file read lives here (not in the pure
+/// `CmuxAgentConversation` package) so the model layer stays free of IO.
+final class LocalTranscriptConversationSource: ConversationSource {
+    /// Caps how much of a transcript is read so a runaway file can't stall the
+    /// UI. Generous enough for any realistic agent session.
+    private static let maxBytes = 32 * 1024 * 1024
+
+    /// The agent kind, used to select the parser.
+    private let agentKind: AgentKind
+
+    /// The resolved transcript file URL, or `nil` if none was found.
+    private let transcriptURL: URL?
+
+    /// The agent session id (used to seed an empty conversation if no file).
+    private let sessionId: String
+
+    /// Creates a source for a panel's resolved transcript.
+    ///
+    /// - Parameters:
+    ///   - agentKind: The agent kind selecting the parser.
+    ///   - sessionId: The agent session id.
+    ///   - transcriptURL: The resolved transcript file, if one was found.
+    init(agentKind: AgentKind, sessionId: String, transcriptURL: URL?) {
+        self.agentKind = agentKind
+        self.sessionId = sessionId
+        self.transcriptURL = transcriptURL
+    }
+
+    var events: AsyncStream<ConversationEvent> {
+        AsyncStream { continuation in
+            let task = Task.detached(priority: .userInitiated) { [agentKind, sessionId, transcriptURL] in
+                let conversation = Self.readAndParse(
+                    agentKind: agentKind,
+                    sessionId: sessionId,
+                    transcriptURL: transcriptURL
+                )
+                continuation.yield(.snapshot(conversation))
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func snapshot() async -> Conversation {
+        await Task.detached(priority: .userInitiated) { [agentKind, sessionId, transcriptURL] in
+            Self.readAndParse(agentKind: agentKind, sessionId: sessionId, transcriptURL: transcriptURL)
+        }.value
+    }
+
+    /// Reads the transcript file (chunked, size-capped) and parses it.
+    private static func readAndParse(
+        agentKind: AgentKind,
+        sessionId: String,
+        transcriptURL: URL?
+    ) -> Conversation {
+        guard let transcriptURL else {
+            return Conversation.empty(agentKind: agentKind, sessionId: sessionId)
+        }
+        let lines = readLines(url: transcriptURL, maxBytes: maxBytes)
+        let parser = makeParser(for: agentKind)
+        return parser.parse(lines: lines)
+    }
+
+    /// Constructs the parser for the given kind.
+    private static func makeParser(for agentKind: AgentKind) -> any AgentTranscriptParsing {
+        switch agentKind {
+        case .codex:
+            return CodexTranscriptParser()
+        case .claudeCode, .unknown:
+            return ClaudeCodeTranscriptParser()
+        }
+    }
+
+    /// Reads a `.jsonl` file into lines using a chunked newline reader with an
+    /// oversized-line guard, ported from the app's `forEachJSONLine` loop so the
+    /// parser package needs no filesystem dependency.
+    private static func readLines(url: URL, maxBytes: Int) -> [String] {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return [] }
+        defer { try? handle.close() }
+
+        var lines: [String] = []
+        var leftover = Data()
+        var totalRead = 0
+        let chunkSize = 64 * 1024
+        // Skip a single line longer than this so one pathological line (e.g. a
+        // huge embedded blob) can't blow up memory; matches the app's guard.
+        let maxLineBytes = 8 * 1024 * 1024
+
+        while totalRead < maxBytes {
+            let chunk = (try? handle.read(upToCount: chunkSize)) ?? Data()
+            if chunk.isEmpty { break }
+            totalRead += chunk.count
+            leftover.append(chunk)
+            while let newline = leftover.firstIndex(of: 0x0a) {
+                let lineData = leftover.subdata(in: leftover.startIndex..<newline)
+                leftover.removeSubrange(leftover.startIndex...newline)
+                if lineData.isEmpty || lineData.count > maxLineBytes { continue }
+                if let line = String(data: lineData, encoding: .utf8) {
+                    lines.append(line)
+                }
+            }
+        }
+        if !leftover.isEmpty, leftover.count <= maxLineBytes,
+           let line = String(data: leftover, encoding: .utf8) {
+            lines.append(line)
+        }
+        return lines
+    }
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -848,6 +848,9 @@ struct cmuxApp: App {
             Button(String(localized: "menu.window.taskManager", defaultValue: "Task Manager...")) {
                 TaskManagerWindowController.shared.show()
             }
+            Button(String(localized: "menu.window.viewChat", defaultValue: "View Chat...")) {
+                AgentChatPresenter().presentForFocusedPanel()
+            }
         }
         helpCommands
         historyCommands
@@ -1408,6 +1411,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.splitButtonLayoutDebug",
     "cmux.tabBarBackdropLab",
     "cmux.taskManager",
+    "cmux.agentChat",
     "cmux.aboutTitlebarDebug",
     "cmux.debugWindowControls",
     "cmux.browserImportHintDebug",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		A9E020000000000000000006 /* agent-session-react in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000006 /* agent-session-react */; };
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
+		A6E710010000000000000002 /* AgentChatPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710010000000000000001 /* AgentChatPresenter.swift */; };
+		A6E710020000000000000002 /* AgentChatTranscriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710020000000000000001 /* AgentChatTranscriptResolver.swift */; };
+		A6E710030000000000000002 /* AgentChatWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710030000000000000001 /* AgentChatWindowController.swift */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
 		A9F200000000000000000002 /* AgentExecutableResolverError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000002 /* AgentExecutableResolverError.swift */; };
 		A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000005 /* AgentExecutableResolverTests.swift */; };
@@ -132,6 +135,10 @@
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
 		B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000030A1B2C3D4E5F60719 /* cmux_open.swift */; };
 		A5001654 /* CmuxActionTrust.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001655 /* CmuxActionTrust.swift */; };
+		A6E700010000000000000001 /* CmuxAgentConversation in Frameworks */ = {isa = PBXBuildFile; productRef = A6E700010000000000000003 /* CmuxAgentConversation */; };
+		A6E700010000000000000002 /* CmuxAgentConversation in Frameworks */ = {isa = PBXBuildFile; productRef = A6E700010000000000000003 /* CmuxAgentConversation */; };
+		A6E700020000000000000001 /* CmuxAgentConversationUI in Frameworks */ = {isa = PBXBuildFile; productRef = A6E700020000000000000003 /* CmuxAgentConversationUI */; };
+		A6E700020000000000000002 /* CmuxAgentConversationUI in Frameworks */ = {isa = PBXBuildFile; productRef = A6E700020000000000000003 /* CmuxAgentConversationUI */; };
 		A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00005A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
@@ -384,6 +391,7 @@
 		A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */; };
 		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
+		A6E710040000000000000002 /* LocalTranscriptConversationSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710040000000000000001 /* LocalTranscriptConversationSource.swift */; };
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
 		2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000001 /* MainWindowFocusController.swift */; };
 		B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000006 /* MainWindowFocusTypes.swift */; };
@@ -770,6 +778,9 @@
 /* Begin PBXFileReference section */
 		A9E010000000000000000006 /* agent-session-react */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-react"; sourceTree = "<group>"; };
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
+		A6E710010000000000000001 /* AgentChatPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatPresenter.swift; sourceTree = "<group>"; };
+		A6E710020000000000000001 /* AgentChatTranscriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatTranscriptResolver.swift; sourceTree = "<group>"; };
+		A6E710030000000000000001 /* AgentChatWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatWindowController.swift; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
 		A9F100000000000000000002 /* AgentExecutableResolverError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolverError.swift; sourceTree = "<group>"; };
 		A9E010000000000000000005 /* AgentExecutableResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolverTests.swift; sourceTree = "<group>"; };
@@ -1108,6 +1119,7 @@
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		A6E710040000000000000001 /* LocalTranscriptConversationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/LocalTranscriptConversationSource.swift; sourceTree = "<group>"; };
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
 		2F0C05000000000000000001 /* MainWindowFocusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusController.swift; sourceTree = "<group>"; };
 		B37A00000000000000000006 /* MainWindowFocusTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusTypes.swift; sourceTree = "<group>"; };
@@ -1418,6 +1430,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A6E700010000000000000001 /* CmuxAgentConversation in Frameworks */,
+				A6E700020000000000000001 /* CmuxAgentConversationUI in Frameworks */,
 				A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				F53000A0A1B2C3D4E5F60718 /* CMUXAgentVault in Frameworks */,
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
@@ -1465,6 +1479,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A6E700010000000000000002 /* CmuxAgentConversation in Frameworks */,
+				A6E700020000000000000002 /* CmuxAgentConversationUI in Frameworks */,
 				A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 				C8000314C8000314C8000314 /* CmuxFileWatch in Frameworks */,
 				CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */,
@@ -1668,6 +1684,10 @@
 				C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */,
 				9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */,
 				D36A00010000000000000002 /* AgentHibernationController.swift */,
+				A6E710010000000000000001 /* AgentChatPresenter.swift */,
+				A6E710020000000000000001 /* AgentChatTranscriptResolver.swift */,
+				A6E710030000000000000001 /* AgentChatWindowController.swift */,
+				A6E710040000000000000001 /* LocalTranscriptConversationSource.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */,
@@ -2276,6 +2296,8 @@
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				A6E700010000000000000003 /* CmuxAgentConversation */,
+				A6E700020000000000000003 /* CmuxAgentConversationUI */,
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
@@ -2313,6 +2335,8 @@
 				A5001251 /* Sentry */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				A6E700010000000000000003 /* CmuxAgentConversation */,
+				A6E700020000000000000003 /* CmuxAgentConversationUI */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
 				C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */,
@@ -2437,6 +2461,8 @@
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
+				A6E700010000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversation" */,
+				A6E700020000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversationUI" */,
 				C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */,
 				C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */,
 				C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */,
@@ -2619,6 +2645,9 @@
 			buildActionMask = 2147483647;
 			files = (
 
+				A6E710010000000000000002 /* AgentChatPresenter.swift in Sources */,
+				A6E710020000000000000002 /* AgentChatTranscriptResolver.swift in Sources */,
+				A6E710030000000000000002 /* AgentChatWindowController.swift in Sources */,
 				A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */,
 				A9F200000000000000000002 /* AgentExecutableResolverError.swift in Sources */,
 				C0DEF0C10000000000000001 /* AgentForkSupport.swift in Sources */,
@@ -2818,6 +2847,7 @@
 				A5F10013A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore+Template.swift in Sources */,
 				A5F10011A1B2C3D4E5F60719 /* KeyboardShortcutSettingsFileStore.swift in Sources */,
 				C1713004C1713004C1713004 /* KeyboardShortcutSettingsLookup.swift in Sources */,
+				A6E710040000000000000002 /* LocalTranscriptConversationSource.swift in Sources */,
 				53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */,
 				2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */,
 				B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */,
@@ -3704,6 +3734,14 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSocketControl;
 		};
+		A6E700010000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversation" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxAgentConversation;
+		};
+		A6E700020000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversationUI" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxAgentConversationUI;
+		};
 		A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXAgentLaunch;
@@ -3890,6 +3928,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
 			productName = CmuxSocketControl;
+		};
+		A6E700010000000000000003 /* CmuxAgentConversation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A6E700010000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversation" */;
+			productName = CmuxAgentConversation;
+		};
+		A6E700020000000000000003 /* CmuxAgentConversationUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A6E700020000000000000004 /* XCLocalSwiftPackageReference "CmuxAgentConversationUI" */;
+			productName = CmuxAgentConversationUI;
 		};
 		C52830000000000000000004 /* CmuxTerminalCopyMode */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
P1 of the agent chat feature: a structured GUI view of a terminal's agent conversation, parsed from the agent's session transcript files. Desktop-only, local file read; this proves the parse + render path. The mobile stream (P2) and live tailing + rich tool rendering (P3) are not built here.

## What's in P1

**`Packages/CmuxAgentConversation` (Core, pure Sendable+Codable, no AppKit/SwiftUI/IO).** The shared model both macOS and iOS will render: `Conversation` / `Message` / `MessageRole` / `ContentBlock` / `ToolUse` / `ToolResult` / `ImageRef` (image referenced by id, never inline base64). `AgentTranscriptParsing` protocol with two struct impls constructed at the call site:
- `ClaudeCodeTranscriptParser` parses `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. Handles `message.content` as String or block array (`text`/`tool_use`/`tool_result`/`thinking`/`image`); `tool_result` lives in a `user` line and is correlated to its call by `tool_use_id` and kept as a separate `.toolResult` message (call and result are NOT pre-merged; pairing happens in a view projection). Unknown top-level types (`summary`, `queue-operation`, `attachment`, `mode`, …) and malformed lines are skipped.
- `CodexTranscriptParser` parses `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. Uses `response_item` (`message`/`reasoning`/`function_call`/`function_call_output`, paired by `call_id`), drops `event_msg` (`user_message`/`agent_message` duplicate the response_item text) and `token_count` noise, strips envelope wrappers (`<permissions>`, `<environment_context>`, `# AGENTS.md`) from every role, and handles string-form `content`.

`ConversationEvent` / `ConversationSource` exist as the streaming seam for later phases; P1 only emits one `.snapshot`. Swift Testing tests run via `swift test` against crafted Claude + Codex JSONL fixtures: block structure, call↔result pairing by id, Codex `event_msg` dedup, envelope stripping, string-content handling, unknown-type tolerance (14 tests, all green).

**`Packages/CmuxAgentConversationUI` (UI, depends only on Core, builds on macOS + iOS).** `AgentChatView` (entry), `@Observable @MainActor ConversationViewModel` that subscribes to the source and projects value-typed `MessageRowSnapshot` rows (pairing each tool call with its result by id), `Equatable ChatMessageRowView` / `ToolCallRowView` (collapsible), `ChatRowActions` closure bundle. Rows receive only value snapshots + closures, never a store reference (snapshot-boundary rule; pattern mirrors `IndexSectionActions`). The subscription is driven from the SwiftUI `.task` so its lifetime is bound to the view. Ships its own en+ja localization catalog.

**App wiring (`Sources/AgentChat/`).** `LocalTranscriptConversationSource` does the chunked, size-capped file read (the IO deliberately kept out of Core) and parses it. `AgentChatTranscriptResolver` maps a focused panel to its transcript by reusing `RestorableAgentSessionIndex.snapshot(workspaceId:panelId:)` for `(kind, sessionId, workingDirectory)`, then: for Claude, mirrors the resume path's exact config-root order (`CLAUDE_CONFIG_DIR` via `ClaudeConfigDirectoryPath.preferredPath` as the sole root when set; else `~/.codex-accounts/claude/*` → `~/.claude` → legacy `~/.subrouter/codex/claude`) with the shared `encodeClaudeProjectDir`; for Codex, walks `$CODEX_HOME/sessions` (falling back to `~/.codex/sessions`) newest-first by date partition and exact-suffix-matches `-<sessionId>.jsonl`, short-circuiting on the first match. `AgentChatPresenter` is the shared action path; `AgentChatWindowController` hosts the view (re-presentation re-reads via a presentation-generation `.id`). A "View Chat..." Window menu item invokes it.

## Panel → transcript mapping

Focused panel → `RestorableAgentSessionIndex` snapshot → `(kind, sessionId, workingDirectory, launchCommand.environment)` → resolver locates the on-disk `.jsonl` → `LocalTranscriptConversationSource` reads + parses → `Conversation` → `AgentChatView` renders. No cwd-encoding or config-root logic is reimplemented; it reuses the verified resume-path constructs.

## What P2 / P3 still need

- **P2 (mobile stream):** the model + UI packages are already shared and iOS-buildable; P2 implements a `ConversationSource` backed by the mobile render-grid/RPC stream so the phone renders the same `Conversation` without local file access.
- **P3 (live tailing + rich tool rendering):** a file-watching `ConversationSource` that emits `.upsert`/`.truncated` as the transcript grows (the event shape already exists), plus richer per-tool rendering (diffs, structured Bash/Read output, image bytes loaded from `ImageRef`). A known P3 limitation: the Codex resolver globs the filesystem; reading the exact `rollout_path` from Codex's session index would remove the walk entirely.

## Project wiring note

Both packages are wired into `cmux.xcodeproj` for the `cmux` and `cmux-cli` targets, mirroring `CmuxSocketControl` exactly. `cmuxTests` intentionally does NOT link them: like ~30 other app-internal packages (including `CmuxSocketControl` itself), `cmuxTests` links a package only when a `cmuxTests` file references its symbols, and the behavior tests for this feature live in the package's own `swift test` target. If a future `cmuxTests` file imports the conversation packages, that wiring would be added then. The CI `tests` job is the authoritative gate for this.

## Dogfood

Needs a tagged macOS dogfood: open a terminal running Claude Code or Codex, invoke **Window → View Chat...**, confirm the conversation renders with user/assistant turns, reasoning, and collapsible tool calls paired with their results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783432456&installation_id=133855650&pr_number=5576&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5576&signature=e27c00eb2b056b0f600a158b72d61c45784d84e671dfd2a56b2067da138d7777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface area (filesystem resolution, transcript parsing correctness, new window flow) but mostly additive with bounded IO and package-level tests; wrong transcript mapping could show empty or misleading chat for a panel.
> 
> **Overview**
> **P1 agent chat** adds a structured GUI for Claude Code and Codex sessions by parsing local JSONL transcripts and rendering them in a dedicated macOS window.
> 
> Two new Swift packages split **model** from **UI**: `CmuxAgentConversation` defines `Conversation` / `Message` / tool nodes and pure parsers (`ClaudeCodeTranscriptParser`, `CodexTranscriptParser`) with tolerant JSONL handling, call↔result correlation by id, Codex envelope stripping, and duplicate `event_msg` drops. `CmuxAgentConversationUI` provides `AgentChatView`, an `@Observable` view model that projects value-typed row snapshots (pairing tool calls with results), and equatable bubble / collapsible tool rows behind the snapshot-boundary pattern. `ConversationSource` / `ConversationEvent` are introduced for a one-shot snapshot in P1 and future live/mobile streams.
> 
> The app wires **Window → View Chat...** via `AgentChatPresenter`, `AgentChatTranscriptResolver` (reusing `RestorableAgentSessionIndex` and resume-path Claude/Codex file conventions), `LocalTranscriptConversationSource` (chunked, capped file read off the main actor), and `AgentChatWindowController`. Package tests cover fixtures for both agents; Xcode links the packages into `cmux` / `cmux-cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb23b32026edb4a97a8781cfda5edbb448f3806f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P1 of the agent chat: parse Claude Code and Codex JSONL transcripts into a shared `Conversation` model and show a structured chat view on macOS via Window → View Chat.... Tool calls are paired with results and reasoning is displayed; desktop-only with a one-shot local file read.

- **New Features**
  - Core `CmuxAgentConversation`: `Conversation`, `Message`, `ContentBlock`, `ToolUse`, `ToolResult`, `ImageRef`, plus `ConversationSource`/`ConversationEvent`. Parsers `ClaudeCodeTranscriptParser` and `CodexTranscriptParser` pair calls/results by id, skip unknown lines, drop Codex `event_msg` duplicates, strip envelope messages, handle string-form content, and tolerate malformed lines.
  - UI `CmuxAgentConversationUI`: `AgentChatView` with `ConversationViewModel` projecting `MessageRowSnapshot` and `ToolCallSnapshot`; `ChatMessageRowView` and collapsible `ToolCallRowView`; en+ja localization.
  - macOS wiring: `LocalTranscriptConversationSource` (chunked, size-capped read), `AgentChatTranscriptResolver` (maps focused panel to Claude/Codex transcript using resume-path rules), `AgentChatPresenter`, `AgentChatWindowController`; adds “View Chat...” to the Window menu.
  - Tests: Swift Testing fixtures for Claude + Codex validate block structure, id pairing, envelope stripping, deduplication, string-content handling, and unknown-type tolerance.

<sup>Written for commit bb23b32026edb4a97a8781cfda5edbb448f3806f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "View Chat..." menu to open agent conversations in a dedicated window
  * Support for structured conversations from Claude Code and Codex (messages, reasoning, tool calls/results)
  * Interactive UI to expand/collapse tool calls, copy content, and view image attachments
  * Localized UI strings for English and Japanese

* **Tests**
  * Added end-to-end parser tests and JSONL fixtures validating parsing and pairing of tool calls/results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->