### PR TITLE
iOS: reorderable built-in toolbar items (Ctrl/Option/Cmd/Esc/Tab) in toolbar settings

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalShortcutsSettingsView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalShortcutsSettingsView.swift
@@ -4,11 +4,11 @@ import CmuxMobileTerminal
 import CmuxMobileTerminalKit
 import SwiftUI
 
-/// Editor for the terminal input-accessory shortcut bar: toggle which shortcuts
-/// appear, drag to reorder them, and add/edit/delete custom actions. The
-/// modifier keys (⌃ ⌥ ⌘) and zoom controls are structural and not listed here.
-/// Backed by ``TerminalAccessoryConfiguration``, so edits apply to the live bar
-/// immediately.
+/// Editor for the terminal input-accessory shortcut bar: toggle which buttons
+/// appear, drag to reorder them, and add/edit/delete custom actions. Every bar
+/// button is listed, including the modifier keys (⌃ ⌥ ⌘), zoom, and paste, so
+/// their position is customizable too. Backed by ``TerminalAccessoryConfiguration``,
+/// so edits apply to the live bar immediately.
 struct TerminalShortcutsSettingsView: View {
     // TRANSITIONAL: TerminalAccessoryConfiguration.shared is also read by the
     // off-limits typing-latency render path (TerminalInputTextView); inverting it
@@ -33,7 +33,7 @@ struct TerminalShortcutsSettingsView: View {
                 } footer: {
                     Text(L10n.string(
                         "mobile.shortcuts.footer",
-                        defaultValue: "Choose which buttons appear on the terminal keyboard bar, and drag to reorder them. Swipe a custom action to edit or delete it. The modifier keys and zoom controls are always shown."
+                        defaultValue: "Choose which buttons appear on the terminal keyboard bar, and drag to reorder them. The modifier keys, zoom, and paste can be moved or hidden along with the shortcuts. Swipe a custom action to edit or delete it."
                     ))
                 }
 

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -475,11 +475,12 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     }
 
     /// The default on-bar arrangement of the configurable shortcuts: the
-    /// high-traffic agent and control keys first (Tab, ^C/^D, the Claude/Codex
-    /// launchers, the arrow keys, Clear), then the punctuation and navigation
-    /// keys. Curated independently of the enum's `rawValue` order so the default
-    /// bar can be arranged without perturbing the persisted identifiers, which are
-    /// the `rawValue`s.
+    /// high-traffic agent and control keys first (Tab then Esc, ^C/^D, the
+    /// Claude/Codex launchers, the arrow keys, Clear), then the punctuation and
+    /// navigation keys. Esc sits immediately to the right of Tab so the two most
+    /// common terminal keys are adjacent. Curated independently of the enum's
+    /// `rawValue` order so the default bar can be arranged without perturbing the
+    /// persisted identifiers, which are the `rawValue`s.
     ///
     /// Must stay a permutation of ``configurableActions``;
     /// ``TerminalAccessoryLayoutReducer`` defensively appends any omission, so a
@@ -487,11 +488,11 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     public static var defaultConfigurableOrder: [TerminalInputAccessoryAction] {
         [
             .tab,
+            .escape,
             .ctrlC, .ctrlD,
             .claude, .codex,
             .upArrow, .downArrow, .leftArrow, .rightArrow,
             .ctrlL,
-            .escape,
             .tilde, .dollar, .slash, .atSign, .pipe,
             .ctrlZ,
             .home, .end, .pageUp, .pageDown,

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -460,11 +460,20 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         }
     }
 
-    /// Whether the user can show/hide/reorder this action. The modifier keys
-    /// (⌃ ⌥ ⌘ ⇧) and zoom controls are structural and stay pinned, so only the
-    /// insertable shortcuts (those with an `output`) are configurable.
+    /// Whether the user can show/hide/reorder this action.
+    ///
+    /// Every button on the bar is configurable except ``shift``, which has armed
+    /// machinery but is intentionally not surfaced as a bar button. The leading
+    /// modifier keys (⌃ ⌥ ⌘), zoom controls, and paste used to be structurally
+    /// pinned; they are now part of the user-configurable region too, so their
+    /// position can be moved alongside the insertable shortcuts.
     public var isUserConfigurable: Bool {
-        output != nil && !isModifier
+        switch self {
+        case .shift:
+            return false
+        default:
+            return true
+        }
     }
 
     /// Every user-configurable action in canonical (enum) order. This is the full
@@ -474,19 +483,36 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         allCases.filter { $0.isUserConfigurable }
     }
 
-    /// The default on-bar arrangement of the configurable shortcuts: the
-    /// high-traffic agent and control keys first (Tab then Esc, ^C/^D, the
-    /// Claude/Codex launchers, the arrow keys, Clear), then the punctuation and
-    /// navigation keys. Esc sits immediately to the right of Tab so the two most
-    /// common terminal keys are adjacent. Curated independently of the enum's
-    /// `rawValue` order so the default bar can be arranged without perturbing the
-    /// persisted identifiers, which are the `rawValue`s.
+    /// The configurable actions that previously sat in the bar's fixed leading
+    /// region, in their shipped left-to-right order. They lead ``defaultConfigurableOrder``
+    /// on a fresh install, and the v1/v2→v3 migration force-enables and inserts
+    /// them at the front so an upgrading user's bar looks unchanged.
+    public static var defaultLeadingActions: [TerminalInputAccessoryAction] {
+        [.control, .alternate, .command, .paste]
+    }
+
+    /// The configurable actions that previously sat in the bar's fixed trailing
+    /// region (the zoom controls). They tail ``defaultConfigurableOrder`` on a
+    /// fresh install, and the migration force-enables and appends them so an
+    /// upgrading user's bar looks unchanged.
+    public static var defaultTrailingActions: [TerminalInputAccessoryAction] {
+        [.zoomOut, .zoomIn]
+    }
+
+    /// The default on-bar arrangement of the configurable shortcuts: the leading
+    /// modifier/paste controls, then the high-traffic agent and control keys (Tab,
+    /// Esc, ^C/^D, the Claude/Codex launchers, the arrow keys, Clear), then the
+    /// punctuation and navigation keys, then the trailing zoom controls. Esc sits
+    /// immediately to the right of Tab so the two most common terminal keys are
+    /// adjacent. Curated independently of the enum's `rawValue` order so the
+    /// default bar can be arranged without perturbing the persisted identifiers,
+    /// which are the `rawValue`s.
     ///
     /// Must stay a permutation of ``configurableActions``;
     /// ``TerminalAccessoryLayoutReducer`` defensively appends any omission, so a
     /// gap here can never drop an action from the bar.
     public static var defaultConfigurableOrder: [TerminalInputAccessoryAction] {
-        [
+        defaultLeadingActions + [
             .tab,
             .escape,
             .ctrlC, .ctrlD,
@@ -496,7 +522,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             .tilde, .dollar, .slash, .atSign, .pipe,
             .ctrlZ,
             .home, .end, .pageUp, .pageDown,
-        ]
+        ] + defaultTrailingActions
     }
 
     /// Human-readable name for the shortcuts settings editor (the bar itself
@@ -525,7 +551,12 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .pageUp: return String(localized: "terminal.shortcut.name.pageUp", defaultValue: "Page Up")
         case .pageDown: return String(localized: "terminal.shortcut.name.pageDown", defaultValue: "Page Down")
         case .paste: return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
-        case .control, .alternate, .command, .shift, .zoomIn, .zoomOut:
+        case .control: return String(localized: "terminal.shortcut.name.control", defaultValue: "Control")
+        case .alternate: return String(localized: "terminal.shortcut.name.alternate", defaultValue: "Option")
+        case .command: return String(localized: "terminal.shortcut.name.command", defaultValue: "Command")
+        case .zoomIn: return String(localized: "terminal.input_accessory.zoom_in", defaultValue: "Zoom In")
+        case .zoomOut: return String(localized: "terminal.input_accessory.zoom_out", defaultValue: "Zoom Out")
+        case .shift:
             return title
         }
     }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalAccessoryConfiguration.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalAccessoryConfiguration.swift
@@ -2,16 +2,15 @@ import CmuxMobileTerminalKit
 import Foundation
 import Observation
 
-/// User-editable configuration of the terminal input-accessory bar's
-/// configurable region: which shortcut buttons appear, in what order, and any
-/// user-defined ``CustomToolbarAction``s.
+/// User-editable configuration of the terminal input-accessory bar: which
+/// buttons appear, in what order, and any user-defined ``CustomToolbarAction``s.
 ///
-/// The bar has two regions. The leading region (the ⌃ ⌥ ⌘ ⇧ modifier keys and
-/// the zoom controls) is structural and always pinned at the front, so
-/// reconfiguring never disturbs the armed-modifier machinery and is not modeled
-/// here. The trailing region is configurable: the shipped built-in shortcuts
-/// (Esc, Tab, arrows, the agent launchers, …) plus any custom actions, ordered
-/// and toggled together and keyed by ``ToolbarItemID``.
+/// Every button on the bar is configurable: the modifier keys (⌃ ⌥ ⌘), the zoom
+/// controls, paste, the shipped insertable shortcuts (Esc, Tab, arrows, the agent
+/// launchers, …), and any custom actions, all ordered and toggled together and
+/// keyed by ``ToolbarItemID``. (The ⇧ key and the trailing "customize" control
+/// are the only structural exceptions; ⇧ is never surfaced as a bar button and
+/// the customize control is a fixed affordance, not an action.)
 ///
 /// This is the single source of truth for that region. It persists to
 /// `UserDefaults`, is `@Observable` for the SwiftUI editor, and posts
@@ -31,14 +30,23 @@ public final class TerminalAccessoryConfiguration {
     /// UIKit input-accessory bar can rebuild its configurable buttons.
     public static let didChangeNotification = Notification.Name("cmux.terminal.accessoryConfigurationDidChange")
 
-    // v2 schema, keyed by ``ToolbarItemID`` storage keys + JSON custom actions.
-    private static let orderDefaultsKey = "cmux.terminal.toolbar.order.v2"
-    private static let enabledDefaultsKey = "cmux.terminal.toolbar.enabled.v2"
+    // v3 schema, keyed by ``ToolbarItemID`` storage keys + JSON custom actions.
+    // v3 widened the configurable region to include the modifier/zoom/paste
+    // built-ins that v1/v2 pinned, so its enabled set is authoritative (it knows
+    // those built-ins are hideable); presence of these keys means "skip the
+    // force-enable widening migration".
+    private static let orderDefaultsKey = "cmux.terminal.toolbar.order.v3"
+    private static let enabledDefaultsKey = "cmux.terminal.toolbar.enabled.v3"
+    // Custom actions are schema-stable across v2 and v3, so the v2 key is reused.
     private static let customDefaultsKey = "cmux.terminal.toolbar.custom.v2"
+    // v2 schema (ToolbarItemID storage keys, configurable region = trailing
+    // shortcuts only), read once to forward-migrate an upgrading user.
+    private static let legacyV2OrderDefaultsKey = "cmux.terminal.toolbar.order.v2"
+    private static let legacyV2EnabledDefaultsKey = "cmux.terminal.toolbar.enabled.v2"
     // v1 schema (parallel [Int] arrays of built-in rawValues), read once to
     // forward-migrate an upgrading user's existing arrangement.
-    private static let legacyOrderDefaultsKey = "cmux.terminal.accessory.displayOrder.v1"
-    private static let legacyEnabledDefaultsKey = "cmux.terminal.accessory.enabled.v1"
+    private static let legacyV1OrderDefaultsKey = "cmux.terminal.accessory.displayOrder.v1"
+    private static let legacyV1EnabledDefaultsKey = "cmux.terminal.accessory.enabled.v1"
 
     /// The configurable items in the order the user has arranged them, as unified
     /// identifiers (built-ins and custom actions together).
@@ -58,26 +66,53 @@ public final class TerminalAccessoryConfiguration {
     @ObservationIgnored private var reducer: TerminalAccessoryLayoutReducer<ToolbarItemID>
     @ObservationIgnored private let migration = ToolbarLayoutMigration()
 
-    init(defaults: UserDefaults = .standard) {
+    /// Creates a configuration backed by `defaults`.
+    ///
+    /// - Parameter defaults: The `UserDefaults` store to read and persist the
+    ///   layout from. Defaults to `.standard` for the live ``shared`` instance;
+    ///   tests inject a suite-scoped store so they exercise migration and
+    ///   reorder/hide behavior without touching the user's real settings.
+    public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
 
         let loadedCustoms = Self.loadCustomActions(from: defaults)
         self.customActions = loadedCustoms
         self.reducer = Self.makeReducer(customActions: loadedCustoms)
 
-        // Prefer the v2 layout; fall back to migrating a v1 arrangement; else a
-        // first-launch default (everything shown in canonical order).
+        // Resolve the persisted layout across schema generations:
+        //   v3 present  → authoritative; load as-is (modifiers can stay hidden).
+        //   else v2 present → widen to v3 (force-enable the now-configurable
+        //                     modifier/zoom/paste built-ins at their old spots).
+        //   else v1 present → relabel v1→ids, then widen to v3 the same way.
+        //   else fresh install → empty saved + nil enabled ⇒ default layout,
+        //                        which already includes modifiers/zoom/paste.
         let savedOrder: [ToolbarItemID]
         let savedEnabled: [ToolbarItemID]?
-        if let v2Order = defaults.array(forKey: Self.orderDefaultsKey) as? [String] {
-            savedOrder = v2Order.compactMap(ToolbarItemID.init(storageKey:))
+        if let v3Order = defaults.array(forKey: Self.orderDefaultsKey) as? [String] {
+            savedOrder = v3Order.compactMap(ToolbarItemID.init(storageKey:))
             savedEnabled = (defaults.array(forKey: Self.enabledDefaultsKey) as? [String])?
                 .compactMap(ToolbarItemID.init(storageKey:))
-        } else if let v1Order = defaults.array(forKey: Self.legacyOrderDefaultsKey) as? [Int] {
-            savedOrder = migration.migratedOrder(legacy: v1Order)
-            savedEnabled = migration.migratedEnabled(
-                legacy: defaults.array(forKey: Self.legacyEnabledDefaultsKey) as? [Int]
+        } else if let v2Order = defaults.array(forKey: Self.legacyV2OrderDefaultsKey) as? [String] {
+            let widened = migration.widenedToV3(
+                order: v2Order.compactMap(ToolbarItemID.init(storageKey:)),
+                enabled: (defaults.array(forKey: Self.legacyV2EnabledDefaultsKey) as? [String])?
+                    .compactMap(ToolbarItemID.init(storageKey:)),
+                forcedLeading: Self.forcedLeadingRawValues,
+                forcedTrailing: Self.forcedTrailingRawValues
             )
+            savedOrder = widened.order
+            savedEnabled = widened.enabled
+        } else if let v1Order = defaults.array(forKey: Self.legacyV1OrderDefaultsKey) as? [Int] {
+            let widened = migration.widenedToV3(
+                order: migration.migratedOrder(legacy: v1Order),
+                enabled: migration.migratedEnabled(
+                    legacy: defaults.array(forKey: Self.legacyV1EnabledDefaultsKey) as? [Int]
+                ),
+                forcedLeading: Self.forcedLeadingRawValues,
+                forcedTrailing: Self.forcedTrailingRawValues
+            )
+            savedOrder = widened.order
+            savedEnabled = widened.enabled
         } else {
             savedOrder = []
             savedEnabled = nil
@@ -86,10 +121,17 @@ public final class TerminalAccessoryConfiguration {
         let layout = reducer.load(savedOrder: savedOrder, savedEnabled: savedEnabled)
         self.displayOrder = layout.order
         self.enabledSet = layout.enabled
-        // Persist the normalized (and possibly migrated) layout so the migration
-        // path runs at most once.
+        // Persist the normalized (and possibly migrated) layout under the v3 keys
+        // so the migration path runs at most once.
         persist()
     }
+
+    /// `rawValue`s of the built-ins that v1/v2 pinned at the front of the bar,
+    /// passed to the v3 widening migration so they are force-enabled and inserted
+    /// at the front for an upgrading user.
+    private static let forcedLeadingRawValues = TerminalInputAccessoryAction.defaultLeadingActions.map(\.rawValue)
+    /// `rawValue`s of the built-ins that v1/v2 pinned at the end of the bar (zoom).
+    private static let forcedTrailingRawValues = TerminalInputAccessoryAction.defaultTrailingActions.map(\.rawValue)
 
     // MARK: - Resolved items for the UI
 
@@ -100,8 +142,9 @@ public final class TerminalAccessoryConfiguration {
         displayOrder.compactMap(resolve)
     }
 
-    /// The shown items in display order — exactly what the toolbar's configurable
-    /// region renders, after the pinned modifier/zoom buttons.
+    /// The shown items in display order — exactly what the toolbar renders, ahead
+    /// of the fixed trailing "customize" control. ``TerminalInputTextView`` skips
+    /// the ⌘ item when the session is not driving a Mac remote.
     public var enabledItems: [ResolvedToolbarItem] {
         displayOrder.filter { enabledSet.contains($0) }.compactMap(resolve)
     }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -175,9 +175,6 @@ final class TerminalInputTextView: UITextView {
     var toolbarView: UIView { terminalAccessoryToolbar }
 
     private weak var accessoryStackView: UIStackView?
-    // Strong reference — command button is not always in the stack's arrangedSubviews,
-    // so nothing else retains it.
-    private var commandAccessoryButton: UIButton?
     private var isMacRemote = false
 
     func updateAccessoryLayoutInsets() {
@@ -196,60 +193,66 @@ final class TerminalInputTextView: UITextView {
         }
     }
 
-    /// The structural buttons pinned to the front of the bar, ahead of the
-    /// user-configurable shortcuts. Command is created but kept out of the
-    /// stack until ``applyModifierPresentation()`` inserts it for a Mac remote.
-    private static let pinnedLeadingActions: [TerminalInputAccessoryAction] = [
-        .control, .alternate, .command, .paste,
-    ]
-
-    /// The structural buttons pinned to the end of the bar, after the
-    /// user-configurable shortcuts. The zoom controls live here so the
-    /// high-traffic shortcuts sit directly after the modifier keys.
-    private static let pinnedTrailingActions: [TerminalInputAccessoryAction] = [
-        .zoomOut, .zoomIn,
-    ]
-
-    /// Build (or rebuild) the bar's buttons: the pinned modifier controls, the
-    /// user-configurable shortcuts in their saved order, then the pinned zoom
-    /// controls. Safe to call repeatedly; it clears the stack first.
+    /// Build (or rebuild) the bar's buttons in the user's configured order
+    /// (modifiers, zoom, paste, shortcuts, and custom actions all reorderable
+    /// together), followed by the fixed trailing "customize" control. The ⌘ item
+    /// is rendered only when driving a Mac remote. Safe to call repeatedly; it
+    /// clears the stack first.
     private func populateAccessoryActions() {
         guard let stack = accessoryStackView else { return }
         for view in stack.arrangedSubviews {
             stack.removeArrangedSubview(view)
             view.removeFromSuperview()
         }
-        commandAccessoryButton?.removeFromSuperview()
-        commandAccessoryButton = nil
 
-        // Pinned leading modifier controls, in fixed order.
-        for action in Self.pinnedLeadingActions {
-            let button = makeAccessoryButton(for: action)
-            // Command is Mac-only; kept out of the stack and inserted by
-            // applyModifierPresentation() when driving a Mac remote.
-            if action == .command {
-                commandAccessoryButton = button
-            } else {
-                stack.addArrangedSubview(button)
-            }
-        }
-        // The user-configurable region: built-in shortcuts and custom actions in
-        // the user's saved order.
+        // The user-configurable region: built-in shortcuts/modifiers/zoom/paste
+        // and custom actions, all in the user's saved order.
         for item in TerminalAccessoryConfiguration.shared.enabledItems {
             switch item {
             case let .builtin(action):
+                // ⌘ only makes sense against a Mac remote; skip it otherwise
+                // (it stays in the saved order, just unrendered, so flipping the
+                // remote re-shows it in place).
+                if action == .command && !isMacRemote { continue }
                 stack.addArrangedSubview(makeAccessoryButton(for: action))
             case let .custom(custom):
                 stack.addArrangedSubview(makeCustomAccessoryButton(for: custom))
             }
         }
-        // Pinned trailing zoom controls, after the configurable shortcuts (the
-        // redesigned bar moved zoom here from the leading region).
-        for action in Self.pinnedTrailingActions {
-            stack.addArrangedSubview(makeAccessoryButton(for: action))
-        }
         // The "customize" button pinned at the very end of the bar.
         stack.addArrangedSubview(makeToolbarSettingsButton())
+
+        // A modifier the user just hid (or ⌘ on a non-Mac remote) is no longer
+        // rendered, so it would otherwise stay armed/sticky with no visible
+        // button to turn it off and silently modify every keystroke. Clear any
+        // armed modifier whose button is not on the bar.
+        reconcileArmedModifierVisibility()
+    }
+
+    /// Disarm the active modifier if its bar button is no longer rendered, so a
+    /// hidden (or non-Mac-remote ⌘) modifier can never stay invisibly armed.
+    private func reconcileArmedModifierVisibility() {
+        guard let armed = modifierState.armedModifier,
+              let action = Self.accessoryAction(for: armed) else { return }
+        let renderedActions = (accessoryStackView?.arrangedSubviews ?? []).compactMap { view -> TerminalInputAccessoryAction? in
+            guard let button = view as? AccessoryActionButton,
+                  case let .builtin(builtinAction) = button.item else { return nil }
+            return builtinAction
+        }
+        guard !renderedActions.contains(action) else { return }
+        modifierState.disarmAll()
+        refreshAccessoryButtonStyles()
+    }
+
+    /// Maps a modifier-state modifier to its accessory-bar action, so the
+    /// rebuild can check whether its button is currently on the bar.
+    private static func accessoryAction(for modifier: TerminalInputModifier) -> TerminalInputAccessoryAction? {
+        switch modifier {
+        case .control: return .control
+        case .alternate: return .alternate
+        case .command: return .command
+        case .shift: return .shift
+        }
     }
 
     @objc private func handleAccessoryConfigurationChanged() {
@@ -265,35 +268,18 @@ final class TerminalInputTextView: UITextView {
     func updateModifierLabels(isMacRemote: Bool) {
         guard self.isMacRemote != isMacRemote else { return }
         self.isMacRemote = isMacRemote
+        // The ⌘ item is rendered only for a Mac remote and modifier titles depend
+        // on `isMacRemote`, so a full repopulate (rather than an in-place relabel)
+        // keeps the bar correct now that ⌘ can sit anywhere in the user's order.
+        populateAccessoryActions()
         applyModifierPresentation()
     }
 
-    /// Retitle the modifier buttons for the current remote and insert/remove the
-    /// command button. Split out of ``updateModifierLabels(isMacRemote:)`` so a
-    /// configuration-driven rebuild can re-apply it without toggling the flag.
+    /// Retitle the modifier buttons for the current remote and re-apply each
+    /// button's armed/sticky style. Split out of ``updateModifierLabels(isMacRemote:)``
+    /// so a configuration-driven rebuild can re-apply it without toggling the flag.
     private func applyModifierPresentation() {
         guard let stack = accessoryStackView else { return }
-        // Insert/remove the command button first (it is not always in
-        // arrangedSubviews) so the restyle pass below covers it when present.
-        if let cmdButton = commandAccessoryButton {
-            if isMacRemote {
-                if cmdButton.superview == nil {
-                    // Insert after alternate (ctrl, alt, cmd order).
-                    var insertIndex = stack.arrangedSubviews.count
-                    for (idx, view) in stack.arrangedSubviews.enumerated() {
-                        if let button = view as? AccessoryActionButton,
-                           case .builtin(.alternate) = button.item {
-                            insertIndex = idx + 1
-                            break
-                        }
-                    }
-                    stack.insertArrangedSubview(cmdButton, at: insertIndex)
-                }
-            } else if cmdButton.superview != nil {
-                stack.removeArrangedSubview(cmdButton)
-                cmdButton.removeFromSuperview()
-            }
-        }
         // Restyle every visible button for the current remote (built-in titles
         // depend on `isMacRemote`) and its armed/sticky state. Custom actions
         // never arm.

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -56,7 +56,7 @@ final class TerminalInputTextView: UITextView {
     private static let accessoryHorizontalInset: CGFloat = 16
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
     private static let accessoryButtonSymbolConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-    private static let accessoryButtonInsets = UIEdgeInsets(top: 5, left: 10, bottom: 5, right: 10)
+    private static let accessoryButtonContentInsets = NSDirectionalEdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10)
     private static let accessoryButtonCornerRadius: CGFloat = 6
     private static let accessoryButtonHeight: CGFloat = 28
     private static let accessoryButtonMinWidth: CGFloat = 44
@@ -273,17 +273,12 @@ final class TerminalInputTextView: UITextView {
     /// configuration-driven rebuild can re-apply it without toggling the flag.
     private func applyModifierPresentation() {
         guard let stack = accessoryStackView else { return }
-        for case let button as AccessoryActionButton in stack.arrangedSubviews {
-            guard case let .builtin(action) = button.item else { continue }
-            button.setTitle(action.title(isMacRemote: isMacRemote), for: .normal)
-        }
-        // Insert/remove the command button based on whether this is a Mac terminal.
-        // We manage it outside the normal loop because it's not always in arrangedSubviews.
+        // Insert/remove the command button first (it is not always in
+        // arrangedSubviews) so the restyle pass below covers it when present.
         if let cmdButton = commandAccessoryButton {
             if isMacRemote {
                 if cmdButton.superview == nil {
-                    // Insert after alternate (index 2 in original enum order: ctrl, alt, cmd)
-                    // Find the alt button's index in the current arrangedSubviews
+                    // Insert after alternate (ctrl, alt, cmd order).
                     var insertIndex = stack.arrangedSubviews.count
                     for (idx, view) in stack.arrangedSubviews.enumerated() {
                         if let button = view as? AccessoryActionButton,
@@ -294,12 +289,25 @@ final class TerminalInputTextView: UITextView {
                     }
                     stack.insertArrangedSubview(cmdButton, at: insertIndex)
                 }
-            } else {
-                if cmdButton.superview != nil {
-                    stack.removeArrangedSubview(cmdButton)
-                    cmdButton.removeFromSuperview()
-                }
+            } else if cmdButton.superview != nil {
+                stack.removeArrangedSubview(cmdButton)
+                cmdButton.removeFromSuperview()
             }
+        }
+        // Restyle every visible button for the current remote (built-in titles
+        // depend on `isMacRemote`) and its armed/sticky state. Custom actions
+        // never arm.
+        for case let button as AccessoryActionButton in stack.arrangedSubviews {
+            let armed: Bool
+            let sticky: Bool
+            if case let .builtin(action) = button.item {
+                armed = isAccessoryActionArmed(action)
+                sticky = isAccessoryActionSticky(action)
+            } else {
+                armed = false
+                sticky = false
+            }
+            applyAccessoryButtonStyle(button, item: button.item, armed: armed, sticky: sticky)
         }
         // Disarm command state if switching away from Mac remote (clears a
         // sticky lock too, matching the legacy unconditional setter).
@@ -479,16 +487,17 @@ final class TerminalInputTextView: UITextView {
         button.addTarget(self, action: #selector(handleAccessoryButton(_:)), for: .touchUpInside)
         button.accessibilityIdentifier = action.accessibilityIdentifier
         button.accessibilityLabel = action.accessibilityLabel
-        button.titleLabel?.font = Self.accessoryButtonFont
-
-        if let symbolName = action.symbolName {
-            button.setImage(UIImage(systemName: symbolName), for: .normal)
-            button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
+        applyAccessoryButtonStyle(button, item: .builtin(action), armed: false, sticky: false)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
+        if action.isModifier || action.symbolName != nil {
+            // Single-glyph modifiers (⌃⌥⌘⇧) and icon buttons (zoom) get a fixed
+            // width so they stay uniform — their glyph metrics differ, and a
+            // greater-than-or-equal min-width let some (e.g. the glass capsule)
+            // grow wider than others. Variable-text buttons keep growing.
+            button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         } else {
-            button.setTitle(action.title, for: .normal)
+            button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
         }
-
-        applyAccessoryButtonBaseStyle(button)
         return button
     }
 
@@ -498,26 +507,25 @@ final class TerminalInputTextView: UITextView {
         button.addTarget(self, action: #selector(handleAccessoryButton(_:)), for: .touchUpInside)
         button.accessibilityIdentifier = "terminal.inputAccessory.custom.\(custom.id.uuidString)"
         button.accessibilityLabel = custom.title
-        button.titleLabel?.font = Self.accessoryButtonFont
-
+        // Custom actions never arm; they always render in the resting style.
+        applyAccessoryButtonStyle(button, item: .custom(custom), armed: false, sticky: false)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
         if let symbolName = custom.symbolName,
            !symbolName.isEmpty,
            UIImage(systemName: symbolName) != nil {
-            button.setImage(UIImage(systemName: symbolName), for: .normal)
-            button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
-            button.accessibilityLabel = custom.title
+            // Icon-only custom actions match the fixed-width modifier/zoom keys.
+            button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         } else {
-            button.setTitle(custom.title, for: .normal)
+            // Text custom actions (e.g. "Claude") grow with their title.
+            button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
         }
-
-        applyAccessoryButtonBaseStyle(button)
         return button
     }
 
     /// The trailing button that opens the toolbar shortcuts editor. A plain
     /// `UIButton` (not an ``AccessoryActionButton``) so the armed-modifier
-    /// styling/relabel loops skip it, and styled to read as a control rather
-    /// than an insertable key.
+    /// styling/relabel loops skip it, and styled to read as a de-emphasized
+    /// control rather than an insertable key.
     private func makeToolbarSettingsButton() -> UIButton {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -527,22 +535,86 @@ final class TerminalInputTextView: UITextView {
             localized: "terminal.input_accessory.customize",
             defaultValue: "Customize Toolbar"
         )
-        button.setImage(UIImage(systemName: "slider.horizontal.3"), for: .normal)
-        button.setPreferredSymbolConfiguration(Self.accessoryButtonSymbolConfig, forImageIn: .normal)
-        applyAccessoryButtonBaseStyle(button)
-        button.backgroundColor = .clear
+        // Read as a control, not a glass key: no glass/fill background, a muted
+        // gray tint, and a flat content layout matching the other buttons.
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "slider.horizontal.3")
+        config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+        config.baseForegroundColor = UIColor(white: 0.7, alpha: 1)
+        config.contentInsets = Self.accessoryButtonContentInsets
+        button.configuration = config
         button.tintColor = UIColor(white: 0.7, alpha: 1)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
+        button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
         return button
     }
 
-    private func applyAccessoryButtonBaseStyle(_ button: UIButton) {
-        button.contentEdgeInsets = Self.accessoryButtonInsets
-        button.backgroundColor = Self.accessoryButtonNormalBackground
-        button.setTitleColor(.white, for: .normal)
-        button.tintColor = .white
-        button.layer.cornerRadius = Self.accessoryButtonCornerRadius
-        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
-        button.widthAnchor.constraint(greaterThanOrEqualToConstant: Self.accessoryButtonMinWidth).isActive = true
+    /// Build (or rebuild) a button's configuration for `item` and its current
+    /// armed/sticky state. On iOS 26 the bar uses real Liquid Glass
+    /// (`.glass()` resting, `.prominentGlass()` armed/sticky); earlier OSes keep
+    /// the flat gray/blue fill the bar shipped with. Built-in modifier titles
+    /// follow `isMacRemote`; custom actions render their saved title/icon and
+    /// never arm.
+    private func applyAccessoryButtonStyle(
+        _ button: UIButton,
+        item: ResolvedToolbarItem,
+        armed: Bool,
+        sticky: Bool
+    ) {
+        var config = Self.accessoryButtonConfiguration(armed: armed, sticky: sticky)
+        let symbolName: String?
+        let title: String
+        switch item {
+        case let .builtin(action):
+            symbolName = action.symbolName
+            title = action.title(isMacRemote: isMacRemote)
+        case let .custom(custom):
+            // Only honor a custom symbol when it resolves to a real SF Symbol.
+            if let name = custom.symbolName, !name.isEmpty, UIImage(systemName: name) != nil {
+                symbolName = name
+            } else {
+                symbolName = nil
+            }
+            title = custom.title
+        }
+        if let symbolName {
+            config.image = UIImage(systemName: symbolName)
+            config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+            config.attributedTitle = nil
+        } else {
+            var attributed = AttributedString(title)
+            attributed.font = Self.accessoryButtonFont
+            config.attributedTitle = attributed
+            config.image = nil
+        }
+        config.contentInsets = Self.accessoryButtonContentInsets
+        button.configuration = config
+    }
+
+    private static func accessoryButtonConfiguration(armed: Bool, sticky: Bool) -> UIButton.Configuration {
+        if #available(iOS 26.0, *) {
+            var config: UIButton.Configuration = (armed || sticky) ? .prominentGlass() : .glass()
+            config.baseForegroundColor = .white
+            if armed || sticky {
+                config.baseBackgroundColor = .systemBlue
+            }
+            return config
+        }
+        var config = UIButton.Configuration.plain()
+        var background = UIBackgroundConfiguration.clear()
+        if sticky {
+            background.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.85)
+            background.strokeColor = .white
+            background.strokeWidth = 2
+        } else if armed {
+            background.backgroundColor = .systemBlue
+        } else {
+            background.backgroundColor = accessoryButtonNormalBackground
+        }
+        background.cornerRadius = accessoryButtonCornerRadius
+        config.background = background
+        config.baseForegroundColor = .white
+        return config
     }
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
@@ -677,23 +749,7 @@ final class TerminalInputTextView: UITextView {
                 armed = false
                 sticky = false
             }
-            if sticky {
-                button.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.85)
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 2
-                button.layer.borderColor = UIColor.white.cgColor
-            } else if armed {
-                button.backgroundColor = .systemBlue
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 0
-            } else {
-                button.backgroundColor = Self.accessoryButtonNormalBackground
-                button.setTitleColor(.white, for: .normal)
-                button.tintColor = .white
-                button.layer.borderWidth = 0
-            }
+            applyAccessoryButtonStyle(button, item: button.item, armed: armed, sticky: sticky)
         }
     }
 

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/ToolbarLayoutMigration.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/ToolbarLayoutMigration.swift
@@ -1,11 +1,27 @@
-/// Forward-migration of the terminal accessory bar's persisted layout from the
-/// original v1 schema (parallel `[Int]` arrays of built-in `rawValue`s) to the
-/// unified v2 schema keyed by ``ToolbarItemID``.
+/// Forward-migration of the terminal accessory bar's persisted layout across the
+/// schema generations keyed by ``ToolbarItemID``.
 ///
-/// The v1 bar had no custom actions, so migration is a pure relabel: every
-/// stored `Int` becomes a ``ToolbarItemID/builtin(_:)``. Crucially this
-/// preserves the user's existing order and shown/hidden set exactly — a user who
-/// had reordered or hidden shortcuts sees the same bar after upgrading.
+/// Two upgrade boundaries are handled:
+///
+/// - **v1 → v2 relabel.** The v1 bar stored parallel `[Int]` arrays of built-in
+///   `rawValue`s and had no custom actions, so migration is a pure relabel: every
+///   stored `Int` becomes a ``ToolbarItemID/builtin(_:)``. This preserves the
+///   user's existing order and shown/hidden set exactly.
+/// - **v1/v2 → v3 widening.** v1 and v2 modeled only the *trailing* shortcut
+///   region as configurable; the leading modifier keys (⌃ ⌥ ⌘), the zoom
+///   controls, and paste were structurally pinned and therefore absent from the
+///   persisted order/enabled sets. v3 folds those built-ins into the same
+///   configurable region. A naive load would treat the now-configurable ids as
+///   "user hid them" and drop them from the bar, so
+///   ``widenedToV3(order:enabled:forcedLeading:forcedTrailing:)`` deliberately
+///   force-enables them and inserts them at their old fixed positions (leading
+///   ids prepended, trailing ids appended) so an upgrading user's bar looks
+///   unchanged.
+///
+/// The force-enable is intentionally confined to this upgrade boundary: once a
+/// config is on the v3 schema its enabled set is authoritative, so hiding a
+/// modifier persists. Callers detect "already on v3" by the presence of the v3
+/// storage keys and skip this migration entirely.
 public struct ToolbarLayoutMigration: Sendable {
     /// Creates a migration helper.
     public init() {}
@@ -25,5 +41,74 @@ public struct ToolbarLayoutMigration: Sendable {
     /// - Returns: The same set as ``ToolbarItemID/builtin(_:)`` values, or `nil`.
     public func migratedEnabled(legacy: [Int]?) -> [ToolbarItemID]? {
         legacy.map { $0.map { .builtin($0) } }
+    }
+
+    /// The persisted order/enabled produced by widening a v1/v2 layout to v3.
+    public struct WidenedLayout: Equatable, Sendable {
+        /// The configurable identifiers in display order, with the newly-configurable
+        /// built-ins inserted at their old fixed positions.
+        public let order: [ToolbarItemID]
+        /// The shown identifiers, with the newly-configurable built-ins force-enabled.
+        /// Never `nil`: a v3 config always has an authoritative enabled set.
+        public let enabled: [ToolbarItemID]
+
+        /// Creates a widened layout.
+        /// - Parameters:
+        ///   - order: The configurable identifiers in display order.
+        ///   - enabled: The shown identifiers.
+        public init(order: [ToolbarItemID], enabled: [ToolbarItemID]) {
+            self.order = order
+            self.enabled = enabled
+        }
+    }
+
+    /// Widens a v1/v2 layout to v3 by folding the previously-pinned built-ins into
+    /// the configurable region: they are prepended/appended to the saved order at
+    /// their old fixed positions and force-enabled, so the bar looks unchanged
+    /// after the upgrade.
+    ///
+    /// The transform is pure and identifier-agnostic: callers pass the raw
+    /// `rawValue`s of the built-ins that were pinned leading/trailing (the
+    /// `TerminalInputAccessoryAction` enum lives one layer up and is not visible
+    /// here). Any forced id already present in `order` keeps its saved position
+    /// rather than being duplicated, so a user who somehow already had one stays
+    /// stable.
+    ///
+    /// - Parameters:
+    ///   - order: The saved v1/v2 order (already relabeled to ``ToolbarItemID``),
+    ///     covering only the previously-configurable shortcuts.
+    ///   - enabled: The saved v1/v2 enabled set, or `nil` if the saved config
+    ///     never recorded one. `nil` is treated as "all saved ids shown".
+    ///   - forcedLeading: `rawValue`s of the built-ins that were pinned at the
+    ///     front, in left-to-right order.
+    ///   - forcedTrailing: `rawValue`s of the built-ins that were pinned at the
+    ///     end, in left-to-right order.
+    /// - Returns: The v3 order and force-enabled set.
+    public func widenedToV3(
+        order: [ToolbarItemID],
+        enabled: [ToolbarItemID]?,
+        forcedLeading: [Int],
+        forcedTrailing: [Int]
+    ) -> WidenedLayout {
+        let leading = forcedLeading.map(ToolbarItemID.builtin)
+        let trailing = forcedTrailing.map(ToolbarItemID.builtin)
+        let savedSet = Set(order)
+
+        // Insert each forced id only if the saved order didn't already carry it,
+        // preserving the saved arrangement for everything else.
+        let newLeading = leading.filter { !savedSet.contains($0) }
+        let newLeadingSet = Set(newLeading)
+        let newTrailing = trailing.filter { !savedSet.contains($0) && !newLeadingSet.contains($0) }
+        let widenedOrder = newLeading + order + newTrailing
+
+        // Force the forced ids on; keep the saved shown set for everything else.
+        // A nil saved enabled means "everything that was in the saved order".
+        let savedEnabled = enabled ?? order
+        var enabledSet = savedEnabled
+        var seen = Set(savedEnabled)
+        for id in newLeading + newTrailing where seen.insert(id).inserted {
+            enabledSet.append(id)
+        }
+        return WidenedLayout(order: widenedOrder, enabled: enabledSet)
     }
 }

--- a/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/ToolbarCustomizationTests.swift
+++ b/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/ToolbarCustomizationTests.swift
@@ -104,6 +104,141 @@ struct ToolbarLayoutMigrationTests {
     }
 }
 
+@Suite("ToolbarLayoutMigration v3 widening")
+struct ToolbarLayoutMigrationV3Tests {
+    private let migration = ToolbarLayoutMigration()
+    // Mirrors the real action rawValues: control=0, alternate=1, command=2 pinned
+    // leading; zoomOut=4, zoomIn=5 pinned trailing; tab=7, escape=6 are shortcuts.
+    private let forcedLeading = [0, 1, 2]
+    private let forcedTrailing = [4, 5]
+
+    @Test("forced built-ins are inserted at front/back and force-enabled")
+    func insertsAndEnablesForcedBuiltins() {
+        // A v2 user had only the trailing shortcuts (tab, escape) configured.
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .builtin(6)],
+            enabled: [.builtin(7), .builtin(6)],
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        #expect(widened.order == [
+            .builtin(0), .builtin(1), .builtin(2), // leading modifiers prepended
+            .builtin(7), .builtin(6),              // saved shortcuts unchanged
+            .builtin(4), .builtin(5),              // trailing zoom appended
+        ])
+        // Modifiers/zoom are force-shown alongside the user's existing shown set.
+        #expect(Set(widened.enabled) == Set([
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(7), .builtin(6),
+            .builtin(4), .builtin(5),
+        ]))
+    }
+
+    @Test("a partially-hidden shortcut set keeps its hidden item, modifiers still forced on")
+    func partialEnabledSubsetPreserved() {
+        // The user hid escape (6) but kept tab (7) shown.
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .builtin(6)],
+            enabled: [.builtin(7)],
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        // escape stays in the order but hidden; the forced modifiers/zoom are shown.
+        #expect(widened.order == [
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(7), .builtin(6),
+            .builtin(4), .builtin(5),
+        ])
+        #expect(Set(widened.enabled) == Set([
+            .builtin(7),                            // user's still-shown shortcut
+            .builtin(0), .builtin(1), .builtin(2),  // forced modifiers
+            .builtin(4), .builtin(5),               // forced zoom
+        ]))
+        #expect(!widened.enabled.contains(.builtin(6))) // escape stays hidden
+    }
+
+    @Test("nil saved enabled treats all saved-order ids as shown, plus forced built-ins")
+    func nilEnabledShowsSavedPlusForced() {
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .builtin(6)],
+            enabled: nil,
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        #expect(Set(widened.enabled) == Set([
+            .builtin(7), .builtin(6),
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(4), .builtin(5),
+        ]))
+    }
+
+    @Test("a forced id already present in the saved order keeps its position, no duplicate")
+    func forcedIdAlreadyPresentNotDuplicated() {
+        // command (2) somehow already sits in the middle of the saved order.
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .builtin(2), .builtin(6)],
+            enabled: [.builtin(7), .builtin(2), .builtin(6)],
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        // Only the missing leading ids (0, 1) prepend; command (2) stays put.
+        #expect(widened.order == [
+            .builtin(0), .builtin(1),
+            .builtin(7), .builtin(2), .builtin(6),
+            .builtin(4), .builtin(5),
+        ])
+        // No duplicate command in the enabled set.
+        #expect(widened.enabled.filter { $0 == .builtin(2) }.count == 1)
+    }
+
+    @Test("widened layout round-trips through the reducer without dropping forced built-ins")
+    func roundTripsThroughReducer() {
+        // The reducer's configurable universe now includes the forced built-ins.
+        let configurable = [0, 1, 2, 4, 5, 6, 7].map { ToolbarItemID.builtin($0) }
+        let reducer = TerminalAccessoryLayoutReducer(configurable: configurable)
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .builtin(6)],
+            enabled: [.builtin(7)],
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        let layout = reducer.load(savedOrder: widened.order, savedEnabled: widened.enabled)
+        // Forced modifiers/zoom present and shown; user's hidden escape stays hidden.
+        #expect(layout.visibleOrder == [
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(7),
+            .builtin(4), .builtin(5),
+        ])
+        #expect(layout.order.contains(.builtin(6)))
+        #expect(!layout.enabled.contains(.builtin(6)))
+    }
+
+    @Test("a saved custom action keeps its relative position with modifiers in front, zoom behind")
+    func customActionSurvivesWideningInPlace() {
+        let custom = UUID()
+        // A v2 user with one custom action between two shortcuts, all shown.
+        let widened = migration.widenedToV3(
+            order: [.builtin(7), .custom(custom), .builtin(6)],
+            enabled: [.builtin(7), .custom(custom), .builtin(6)],
+            forcedLeading: forcedLeading,
+            forcedTrailing: forcedTrailing
+        )
+        // The custom keeps its saved slot, untouched; modifiers prepend, zoom appends.
+        #expect(widened.order == [
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(7), .custom(custom), .builtin(6),
+            .builtin(4), .builtin(5),
+        ])
+        // The custom stays shown alongside the force-enabled modifiers/zoom.
+        #expect(widened.enabled.contains(.custom(custom)))
+        #expect(Set(widened.enabled) == Set([
+            .builtin(0), .builtin(1), .builtin(2),
+            .builtin(7), .custom(custom), .builtin(6),
+            .builtin(4), .builtin(5),
+        ]))
+    }
+}
+
 @Suite("CustomToolbarAction")
 struct CustomToolbarActionTests {
     @Test("text payload normalizes newlines to carriage returns")

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1503,13 +1503,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Choose which buttons appear on the terminal keyboard bar, and drag to reorder them. Swipe a custom action to edit or delete it. The modifier keys and zoom controls are always shown."
+            "value": "Choose which buttons appear on the terminal keyboard bar, and drag to reorder them. The modifier keys, zoom, and paste can be moved or hidden along with the shortcuts. Swipe a custom action to edit or delete it."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルのキーボードバーに表示するボタンを選び、ドラッグして並べ替えできます。カスタムアクションはスワイプで編集または削除できます。修飾キーとズームコントロールは常に表示されます。"
+            "value": "ターミナルのキーボードバーに表示するボタンを選び、ドラッグして並べ替えできます。修飾キー、ズーム、ペーストもショートカットと一緒に移動したり非表示にしたりできます。カスタムアクションはスワイプで編集または削除できます。"
           }
         }
       }
@@ -3431,6 +3431,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "クリア (Control-L)"
+          }
+        }
+      }
+    },
+    "terminal.shortcut.name.control": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Control"
+          }
+        }
+      }
+    },
+    "terminal.shortcut.name.alternate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Option"
+          }
+        }
+      }
+    },
+    "terminal.shortcut.name.command": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command"
           }
         }
       }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalAccessoryConfigurationTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalAccessoryConfigurationTests.swift
@@ -1,0 +1,202 @@
+import CmuxMobileTerminal
+import CmuxMobileTerminalKit
+import Foundation
+import Testing
+
+/// Behavioral tests for ``TerminalAccessoryConfiguration``: the source of truth
+/// for the reorderable terminal accessory bar. These verify the fresh-install
+/// default layout (modifiers leading, zoom trailing), reorder + hide/show
+/// round-trips, and the v1/v2 → v3 widening migration that folds the
+/// previously-pinned modifier/zoom/paste built-ins into the configurable region.
+///
+/// Each test injects a private `UserDefaults` suite so it never touches the live
+/// `.shared` settings.
+@MainActor
+@Suite("TerminalAccessoryConfiguration")
+struct TerminalAccessoryConfigurationTests {
+    /// A fresh suite-scoped defaults store, cleared so each test starts empty.
+    private func freshDefaults() -> UserDefaults {
+        let name = "cmux.toolbar.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    private func id(_ action: TerminalInputAccessoryAction) -> ToolbarItemID { action.itemID }
+
+    // MARK: - Gating test #1: fresh-install default order
+
+    @Test("fresh install puts modifiers at the front and zoom at the back, all shown")
+    func freshInstallDefaultOrder() throws {
+        let config = TerminalAccessoryConfiguration(defaults: freshDefaults())
+        let order = config.displayOrder
+
+        // Leading region: ⌃ ⌥ ⌘ then paste, in that order.
+        #expect(Array(order.prefix(4)) == [
+            id(.control), id(.alternate), id(.command), id(.paste),
+        ])
+        // Trailing region: the two zoom controls, in that order.
+        #expect(Array(order.suffix(2)) == [id(.zoomOut), id(.zoomIn)])
+        // Esc sits right after Tab in the redesigned default.
+        let tabIndex = try #require(order.firstIndex(of: id(.tab)))
+        #expect(order[tabIndex + 1] == id(.escape))
+        // Everything is shown on a fresh install, including the now-configurable
+        // modifiers/zoom/paste.
+        for action in TerminalInputAccessoryAction.configurableActions {
+            #expect(config.isEnabled(action.itemID))
+        }
+        // Shift is never surfaced as a bar button.
+        #expect(!order.contains(id(.shift)))
+    }
+
+    // MARK: - Reorder + hide/show round-trips
+
+    @Test("moving a modifier to the end persists across reload")
+    func reorderModifierPersists() throws {
+        let defaults = freshDefaults()
+        let config = TerminalAccessoryConfiguration(defaults: defaults)
+        let controlIndex = try #require(config.displayOrder.firstIndex(of: id(.control)))
+
+        // Move ⌃ to the end of the configurable region.
+        config.moveItems(from: IndexSet(integer: controlIndex), to: config.displayOrder.count)
+        #expect(config.displayOrder.last == id(.control))
+
+        // A fresh instance over the same defaults sees the moved order.
+        let reloaded = TerminalAccessoryConfiguration(defaults: defaults)
+        #expect(reloaded.displayOrder.last == id(.control))
+    }
+
+    @Test("hiding a modifier persists across reload and keeps it in the order")
+    func hideModifierPersists() {
+        let defaults = freshDefaults()
+        let config = TerminalAccessoryConfiguration(defaults: defaults)
+
+        config.setEnabled(id(.command), false)
+        #expect(!config.isEnabled(id(.command)))
+        #expect(config.displayOrder.contains(id(.command)))
+        #expect(!config.enabledItems.contains { $0.id == id(.command) })
+
+        // The hidden state survives a reload (v3 enabled set is authoritative).
+        let reloaded = TerminalAccessoryConfiguration(defaults: defaults)
+        #expect(!reloaded.isEnabled(id(.command)))
+        #expect(reloaded.displayOrder.contains(id(.command)))
+    }
+
+    // MARK: - Gating test #2: v2 → v3 widening migration
+
+    @Test("v2 config without modifiers gains them force-enabled at front/back")
+    func migratesV2ConfigForceEnablingModifiers() throws {
+        let defaults = freshDefaults()
+        // Seed a v2-era config: only the trailing shortcuts were configurable, the
+        // user kept Tab + Esc shown and reordered Esc before Tab.
+        defaults.set(
+            [id(.escape).storageKey, id(.tab).storageKey],
+            forKey: "cmux.terminal.toolbar.order.v2"
+        )
+        defaults.set(
+            [id(.escape).storageKey, id(.tab).storageKey],
+            forKey: "cmux.terminal.toolbar.enabled.v2"
+        )
+
+        let config = TerminalAccessoryConfiguration(defaults: defaults)
+
+        // The previously-pinned modifiers/zoom/paste are now present AND shown.
+        for action: TerminalInputAccessoryAction in [.control, .alternate, .command, .paste, .zoomOut, .zoomIn] {
+            #expect(config.displayOrder.contains(action.itemID))
+            #expect(config.isEnabled(action.itemID))
+        }
+        // Modifiers/paste fold in at the very front. (Zoom is force-enabled and
+        // inserted after the saved shortcuts by the migration, but the reducer's
+        // forward-compat pass then appends the other shortcuts the partial v2 seed
+        // omitted, so zoom is no longer the absolute tail here — only on a fresh
+        // install, asserted in `freshInstallDefaultOrder`.)
+        #expect(Array(config.displayOrder.prefix(4)) == [
+            id(.control), id(.alternate), id(.command), id(.paste),
+        ])
+        // Zoom lands after the user's saved shortcuts (Esc/Tab).
+        let escIndex = try #require(config.displayOrder.firstIndex(of: id(.escape)))
+        let tabIndex = try #require(config.displayOrder.firstIndex(of: id(.tab)))
+        let zoomOutIndex = try #require(config.displayOrder.firstIndex(of: id(.zoomOut)))
+        #expect(escIndex < tabIndex)
+        #expect(zoomOutIndex > tabIndex)
+    }
+
+    @Test("v2 migration preserves a hidden shortcut while still force-showing modifiers")
+    func migratesV2ConfigPreservingHiddenShortcut() {
+        let defaults = freshDefaults()
+        // The user had Tab + Esc in the order but hid Esc.
+        defaults.set(
+            [id(.tab).storageKey, id(.escape).storageKey],
+            forKey: "cmux.terminal.toolbar.order.v2"
+        )
+        defaults.set([id(.tab).storageKey], forKey: "cmux.terminal.toolbar.enabled.v2")
+
+        let config = TerminalAccessoryConfiguration(defaults: defaults)
+
+        // Esc stays hidden; the forced modifiers/zoom are shown.
+        #expect(!config.isEnabled(id(.escape)))
+        #expect(config.isEnabled(id(.tab)))
+        #expect(config.isEnabled(id(.control)))
+        #expect(config.isEnabled(id(.zoomIn)))
+    }
+
+    @Test("an upgraded config re-persists under the v3 keys so the migration runs once")
+    func migrationPersistsUnderV3Keys() {
+        let defaults = freshDefaults()
+        defaults.set([id(.tab).storageKey], forKey: "cmux.terminal.toolbar.order.v2")
+        defaults.set([id(.tab).storageKey], forKey: "cmux.terminal.toolbar.enabled.v2")
+
+        _ = TerminalAccessoryConfiguration(defaults: defaults)
+
+        // After init, v3 keys exist; a second load takes the v3 path (no second
+        // force-enable), so hiding a modifier then would persist.
+        let v3Order = defaults.array(forKey: "cmux.terminal.toolbar.order.v3") as? [String]
+        #expect(v3Order != nil)
+        #expect(v3Order?.contains(id(.control).storageKey) == true)
+
+        let reloaded = TerminalAccessoryConfiguration(defaults: defaults)
+        reloaded.setEnabled(id(.control), false)
+        let reloadedAgain = TerminalAccessoryConfiguration(defaults: defaults)
+        // The v3 path honored the hidden modifier rather than re-forcing it on.
+        #expect(!reloadedAgain.isEnabled(id(.control)))
+    }
+
+    @Test("v2 config carrying a custom action keeps the custom in place when modifiers fold in")
+    func migratesV2ConfigWithCustomAction() throws {
+        let defaults = freshDefaults()
+        let custom = CustomToolbarAction(title: "Claude", payload: .text("claude\n"))
+
+        // A v2 user with one custom action sitting between Tab and Esc, all shown.
+        let customData = try JSONEncoder().encode([custom])
+        defaults.set(customData, forKey: "cmux.terminal.toolbar.custom.v2")
+        defaults.set(
+            [id(.tab).storageKey, custom.itemID.storageKey, id(.escape).storageKey],
+            forKey: "cmux.terminal.toolbar.order.v2"
+        )
+        defaults.set(
+            [id(.tab).storageKey, custom.itemID.storageKey, id(.escape).storageKey],
+            forKey: "cmux.terminal.toolbar.enabled.v2"
+        )
+
+        let config = TerminalAccessoryConfiguration(defaults: defaults)
+
+        // The custom action survives migration in its saved slot, still shown.
+        #expect(config.customActions.contains { $0.id == custom.id })
+        #expect(config.isEnabled(custom.itemID))
+        let customIndex = try #require(config.displayOrder.firstIndex(of: custom.itemID))
+        let tabIndex = try #require(config.displayOrder.firstIndex(of: id(.tab)))
+        let escIndex = try #require(config.displayOrder.firstIndex(of: id(.escape)))
+        #expect(tabIndex < customIndex)
+        #expect(customIndex < escIndex)
+        // Modifiers fold in at the front and stay ahead of the custom; zoom is
+        // force-enabled and inserted after the saved shortcuts (the reducer then
+        // appends the omitted shortcuts, so zoom is not the absolute tail here).
+        let controlIndex = try #require(config.displayOrder.firstIndex(of: id(.control)))
+        #expect(controlIndex < customIndex)
+        #expect(config.isEnabled(id(.control)))
+        let zoomOutIndex = try #require(config.displayOrder.firstIndex(of: id(.zoomOut)))
+        #expect(zoomOutIndex > customIndex)
+        #expect(config.isEnabled(id(.zoomOut)))
+        #expect(config.isEnabled(id(.zoomIn)))
+    }
+}


### PR DESCRIPTION
## Summary

The terminal accessory bar's modifier keys (⌃ ⌥ ⌘), zoom controls, and paste were structurally pinned outside the configurable region, so only the insertable shortcuts and custom actions could be reordered or hidden in toolbar settings. This folds those built-ins into the same reorderable region, so every bar button can be dragged to any position or hidden, alongside custom actions. (⇧ stays off the bar as before, and the trailing "customize" control is a fixed affordance.)

Liquid Glass styling (#5536) applies to every item regardless of position.

## Stacking

Stacks on #5536 (`feat-ios-accessory-glass`). Review/merge sequence: **#5536 → this**. The PR base is set to `feat-ios-accessory-glass` so the diff is only this change. The "Esc right of Tab" default already landed on the base; this PR keeps it (and only adds the leading/trailing built-ins around it).

## How the data-driven toolbar + persistence works

PR #5510 made the bar data-driven: a unified `ToolbarItemID` (`.builtin(rawValue)` | `.custom(uuid)`), a pure `TerminalAccessoryLayoutReducer` (order/enable/move over opaque ids), and `TerminalAccessoryConfiguration` (`@Observable`, `UserDefaults`-backed, posts `didChangeNotification` so the UIKit bar rebuilds live). The settings list (`TerminalShortcutsSettingsView`) already lists `displayItems` and reorders via SwiftUI `onMove`. The only thing keeping modifiers/zoom/paste out was the `isUserConfigurable` predicate plus fixed `pinnedLeadingActions`/`pinnedTrailingActions` lists in the UIKit builder.

## Model + migration

- Widen `isUserConfigurable` to include every action except `shift`. Add `defaultLeadingActions` (`⌃ ⌥ ⌘`, paste) and `defaultTrailingActions` (zoom), and rebuild `defaultConfigurableOrder` so a fresh install renders modifiers/paste leading, zoom trailing.
- Bump the persisted schema to **v3** and add `ToolbarLayoutMigration.widenedToV3` (pure, in `CmuxMobileTerminalKit`). On a v1/v2 → v3 upgrade it **force-enables** the now-configurable built-ins and inserts them at their old fixed positions, so an upgrading user's bar looks unchanged. Force-enable is confined to the upgrade boundary: a v3 config's enabled set is authoritative, so hiding a modifier then persists. Init order: v3 (load as-is) → v2 (widen) → v1 (relabel + widen) → fresh.

## UIKit bar

- `populateAccessoryActions` renders the configurable region inline (no pinned lists). `⌘` stays in the saved order but only renders for a Mac remote; `updateModifierLabels` repopulates on the flip.
- After every rebuild, `reconcileArmedModifierVisibility` disarms any armed/sticky modifier whose button is no longer on the bar, so hiding an active modifier can't leave it invisibly modifying every keystroke.

## Tests

- `CmuxMobileTerminalKit` (`swift test`, 77 pass): v3 widening transform — inserts/force-enables forced built-ins, preserves a partially-hidden shortcut set, handles `nil` enabled, no duplicate when a forced id is already present, a custom action keeps its slot while modifiers fold in around it, and round-trips through the reducer.
- `cmuxFeatureTests` (simulator, CI): live `TerminalAccessoryConfiguration` — fresh-install default order (modifiers front, zoom back, Esc after Tab, all shown), reorder + hide round-trips across reload, v2 → v3 migration with a partial enabled subset, migration of a config carrying a custom action (the custom keeps its slot while modifiers/zoom fold in), and that the upgraded config re-persists under v3 keys so hiding a modifier survives.

## Verification

iOS simulator app builds clean (`ios/scripts/reload.sh --tag tbarord`). Kit tests pass locally; `cmuxFeatureTests` run in CI (local iOS test runs are disallowed).

## Localization

Footer (`mobile.shortcuts.footer`) updated en+ja. New settings labels for the modifiers use `terminal.shortcut.name.control/.alternate/.command` (added en+ja); zoom reuses the existing localized `terminal.input_accessory.zoom_in/zoom_out`; paste reuses `terminal.input_accessory.paste`. All resolve via `Bundle.main` (the app catalog), matching the package's existing `String(localized:)` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783457543&installation_id=133855650&pr_number=5579&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5579&signature=abec50615324ac4be536b1c20a4aae56e5f42485525d08a25114d71aa9648897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted toolbar layout (v3 migration), live UIKit bar rebuild, and armed-modifier state when users hide keys—user-facing input behavior with migration edge cases covered by tests.
> 
> **Overview**
> **Makes every iOS terminal keyboard-bar button reorderable and hideable**, including ⌃ ⌥ ⌘, paste, and zoom—not only insertable shortcuts and custom actions. The settings list and persisted layout now treat the whole bar as one region (⇧ and the trailing customize control stay fixed).
> 
> **Persistence** moves to **UserDefaults v3** with `ToolbarLayoutMigration.widenedToV3`: upgrading from v1/v2 force-enables and inserts previously pinned leading/trailing built-ins so the on-screen bar matches pre-upgrade, then v3 keys make hide/reorder authoritative.
> 
> **UIKit bar** drops separate pinned leading/trailing stacks; it renders `TerminalAccessoryConfiguration.enabledItems` in user order (⌘ still omitted unless Mac remote). **`reconcileArmedModifierVisibility`** disarms modifiers whose buttons are hidden or not rendered so sticky modifiers cannot affect typing invisibly. Accessory button styling is centralized via `UIButton.Configuration` (including Liquid Glass on iOS 26).
> 
> **Tests and copy**: v3 migration and configuration behavior tests; settings footer and modifier labels localized (en/ja).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ac973524ce86403b11646f38a7eba8017a33897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make every iOS terminal accessory bar button reorderable and hideable, including ⌃ ⌥ ⌘, Esc/Tab, Paste, and Zoom. Also adopts real iOS 26 Liquid Glass styling for buttons, with a solid-fill fallback on earlier iOS.

- **New Features**
  - Built-ins (⌃ ⌥ ⌘, Paste, Zoom) are configurable alongside shortcuts and custom actions; ⇧ stays off the bar.
  - Default layout: modifiers/paste leading, Esc right of Tab, zoom trailing. ⌘ stays in the saved order but only renders for Mac remotes; titles update on flip.
  - Liquid Glass on iOS 26 via UIButton.Configuration (.glass resting, .prominentGlass armed); flat gray/blue fallback on older iOS. Single styling path and fixed widths for glyph/icon buttons to keep them uniform.
  - Hidden modifiers are auto-disarmed so they can’t stay active without a visible button. The whole region renders inline; the trailing “customize” control is fixed.

- **Migration**
  - Schema bumped to v3 in `CmuxMobileTerminal`/`CmuxMobileTerminalKit`.
  - Upgrading from v1/v2 force-enables and inserts the now-configurable built-ins at their old leading/trailing spots (no duplicates), so the bar looks the same.
  - v3 keys persist the widened layout so the migration runs once; after that, the enabled set is authoritative and hiding a modifier persists.

<sup>Written for commit 1ac973524ce86403b11646f38a7eba8017a33897. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal shortcut buttons for modifier keys (Control, Option, Command), zoom controls, and paste are now customizable—they can be reordered or hidden from the toolbar.

* **Changes**
  * Default toolbar layout adjusted; Escape now appears immediately after Tab.

* **Improvements**
  * Enhanced handling of modifier key visibility when switching between connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->