### PR TITLE
Show sidebar command-two shortcut hint

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15804,7 +15804,6 @@ struct TabItemView: View, Equatable {
                     }
                 }
         )
-        .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .overlay(alignment: .topTrailing) {
             if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
                 ShortcutHintPill(
@@ -15822,6 +15821,7 @@ struct TabItemView: View, Equatable {
                 .shortcutHintTransition()
             }
         }
+        .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .contentShape(Rectangle())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15018,18 +15018,8 @@ enum SidebarWorkspaceShortcutHintMetrics {
 enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 
-    static func slotWidth(
-        closeButtonWidth: CGFloat,
-        shortcutHintLabel: String?,
-        shortcutHintXOffset: Double
-    ) -> CGFloat {
-        max(
-            closeButtonWidth,
-            SidebarWorkspaceShortcutHintMetrics.slotWidth(
-                label: shortcutHintLabel,
-                debugXOffset: shortcutHintXOffset
-            )
-        )
+    static func slotWidth(closeButtonWidth: CGFloat, shortcutHintLabel _: String?) -> CGFloat {
+        closeButtonWidth
     }
 }
 
@@ -15497,8 +15487,7 @@ struct TabItemView: View, Equatable {
         )
         let trailingAccessorySlotWidth = SidebarTrailingAccessoryWidthPolicy.slotWidth(
             closeButtonWidth: scaledCloseButtonWidth,
-            shortcutHintLabel: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil,
-            shortcutHintXOffset: sidebarShortcutHintXOffset
+            shortcutHintLabel: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil
         )
 
         VStack(alignment: .leading, spacing: 4) {
@@ -15530,49 +15519,29 @@ struct TabItemView: View, Equatable {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
 
-                // The trailing accessory slot hosts either the close button or
-                // the shortcut hint so hover and modifier transitions keep a
-                // stable, visible target.
-                if canCloseWorkspace || showsWorkspaceShortcutHint {
-                    ZStack(alignment: .topTrailing) {
-                        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-                            ShortcutHintPill(
-                                text: workspaceShortcutLabel,
-                                fontSize: scaledFontSize(10),
-                                emphasis: shortcutHintEmphasis
-                            )
-                            .offset(
-                                x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
-                                y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
-                            )
-                            .shortcutHintTransition()
-                        }
-
-                        if canCloseWorkspace {
-                            Button(action: {
-                                #if DEBUG
-                                cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                                #endif
-                                tabManager.closeWorkspaceWithConfirmation(tab)
-                            }) {
-                                Image(systemName: "xmark")
-                                    .font(.system(size: scaledFontSize(9), weight: .medium))
-                                    .foregroundColor(activeSecondaryColor(0.7))
-                                    .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                            .safeHelp(closeButtonTooltip)
-                            .opacity(showCloseButton ? 1 : 0)
-                            .allowsHitTesting(showCloseButton)
-                            .accessibilityHidden(!showCloseButton)
-                        }
+                // The close button is a sibling that always reserves its width
+                // when the workspace is closable, so the title wraps/truncates
+                // before this corner instead of flowing under the hover x. Its
+                // visibility toggles via opacity so hover never re-lays-out the
+                // row. (Matches the group-header plus-button pattern.)
+                if canCloseWorkspace {
+                    Button(action: {
+                        #if DEBUG
+                        cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                        #endif
+                        tabManager.closeWorkspaceWithConfirmation(tab)
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: scaledFontSize(9), weight: .medium))
+                            .foregroundColor(activeSecondaryColor(0.7))
+                            .frame(width: trailingAccessorySlotWidth, height: scaledCloseButtonHitSize, alignment: .center)
+                            .contentShape(Rectangle())
                     }
-                    .frame(
-                        width: trailingAccessorySlotWidth,
-                        height: max(scaledCloseButtonHitSize, scaledFontSize(18)),
-                        alignment: .topTrailing
-                    )
+                    .buttonStyle(.plain)
+                    .safeHelp(closeButtonTooltip)
+                    .opacity(showCloseButton ? 1 : 0)
+                    .allowsHitTesting(showCloseButton)
+                    .accessibilityHidden(!showCloseButton)
                 }
             }
 
@@ -15836,6 +15805,23 @@ struct TabItemView: View, Equatable {
                 }
         )
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
+        .overlay(alignment: .topTrailing) {
+            if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
+                ShortcutHintPill(
+                    text: workspaceShortcutLabel,
+                    fontSize: scaledFontSize(10),
+                    emphasis: shortcutHintEmphasis
+                )
+                .offset(
+                    x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
+                    y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
+                )
+                .padding(.top, 6)
+                .padding(.trailing, 16)
+                .allowsHitTesting(false)
+                .shortcutHintTransition()
+            }
+        }
         .padding(.horizontal, 6)
         .background { rowHeightProbe }
         .contentShape(Rectangle())

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15816,7 +15816,7 @@ struct TabItemView: View, Equatable {
                     y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
                 )
                 .padding(.top, 6)
-                .padding(.trailing, 16)
+                .padding(.trailing, 10)
                 .allowsHitTesting(false)
                 .shortcutHintTransition()
             }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15017,6 +15017,20 @@ enum SidebarWorkspaceShortcutHintMetrics {
 
 enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
+
+    static func slotWidth(
+        closeButtonWidth: CGFloat,
+        shortcutHintLabel: String?,
+        shortcutHintXOffset: Double
+    ) -> CGFloat {
+        max(
+            closeButtonWidth,
+            SidebarWorkspaceShortcutHintMetrics.slotWidth(
+                label: shortcutHintLabel,
+                debugXOffset: shortcutHintXOffset
+            )
+        )
+    }
 }
 
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
@@ -15481,6 +15495,11 @@ struct TabItemView: View, Equatable {
             SidebarTrailingAccessoryWidthPolicy.closeButtonWidth,
             scaledCloseButtonHitSize
         )
+        let trailingAccessorySlotWidth = SidebarTrailingAccessoryWidthPolicy.slotWidth(
+            closeButtonWidth: scaledCloseButtonWidth,
+            shortcutHintLabel: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil,
+            shortcutHintXOffset: sidebarShortcutHintXOffset
+        )
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 8) {
@@ -15511,29 +15530,49 @@ struct TabItemView: View, Equatable {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .layoutPriority(1)
 
-                // The close button is a sibling that always reserves its width
-                // when the workspace is closable, so the title wraps/truncates
-                // before this corner instead of flowing under the hover x. Its
-                // visibility toggles via opacity so hover never re-lays-out the
-                // row. (Matches the group-header plus-button pattern.)
-                if canCloseWorkspace {
-                    Button(action: {
-                        #if DEBUG
-                        cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                        #endif
-                        tabManager.closeWorkspaceWithConfirmation(tab)
-                    }) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: scaledFontSize(9), weight: .medium))
-                            .foregroundColor(activeSecondaryColor(0.7))
-                            .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
-                            .contentShape(Rectangle())
+                // The trailing accessory slot hosts either the close button or
+                // the shortcut hint so hover and modifier transitions keep a
+                // stable, visible target.
+                if canCloseWorkspace || showsWorkspaceShortcutHint {
+                    ZStack(alignment: .topTrailing) {
+                        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
+                            ShortcutHintPill(
+                                text: workspaceShortcutLabel,
+                                fontSize: scaledFontSize(10),
+                                emphasis: shortcutHintEmphasis
+                            )
+                            .offset(
+                                x: ShortcutHintDebugSettings.clamped(sidebarShortcutHintXOffset),
+                                y: ShortcutHintDebugSettings.clamped(sidebarShortcutHintYOffset)
+                            )
+                            .shortcutHintTransition()
+                        }
+
+                        if canCloseWorkspace {
+                            Button(action: {
+                                #if DEBUG
+                                cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+                                #endif
+                                tabManager.closeWorkspaceWithConfirmation(tab)
+                            }) {
+                                Image(systemName: "xmark")
+                                    .font(.system(size: scaledFontSize(9), weight: .medium))
+                                    .foregroundColor(activeSecondaryColor(0.7))
+                                    .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .safeHelp(closeButtonTooltip)
+                            .opacity(showCloseButton ? 1 : 0)
+                            .allowsHitTesting(showCloseButton)
+                            .accessibilityHidden(!showCloseButton)
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .safeHelp(closeButtonTooltip)
-                    .opacity(showCloseButton ? 1 : 0)
-                    .allowsHitTesting(showCloseButton)
-                    .accessibilityHidden(!showCloseButton)
+                    .frame(
+                        width: trailingAccessorySlotWidth,
+                        height: max(scaledCloseButtonHitSize, scaledFontSize(18)),
+                        alignment: .topTrailing
+                    )
                 }
             }
 
@@ -15795,13 +15834,6 @@ struct TabItemView: View, Equatable {
                             .offset(x: -1)
                     }
                 }
-        )
-        .sidebarShortcutHintOverlay(
-            text: showsWorkspaceShortcutHint ? workspaceShortcutLabel : nil,
-            emphasis: shortcutHintEmphasis,
-            offsetX: sidebarShortcutHintXOffset,
-            offsetY: sidebarShortcutHintYOffset,
-            fontSize: scaledFontSize(10)
         )
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, 6)

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -7153,16 +7153,14 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
         XCTAssertGreaterThan(widened, base)
     }
 
-    func testTrailingAccessorySlotWidensForCommandTwoHint() {
+    func testTrailingAccessorySlotDoesNotWidenForCommandTwoHint() {
         let closeButtonWidth: CGFloat = 16
         let slotWidth = SidebarTrailingAccessoryWidthPolicy.slotWidth(
             closeButtonWidth: closeButtonWidth,
-            shortcutHintLabel: "⌘2",
-            shortcutHintXOffset: 0
+            shortcutHintLabel: "⌘2"
         )
 
-        XCTAssertGreaterThan(slotWidth, closeButtonWidth)
-        XCTAssertGreaterThanOrEqual(slotWidth, SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘2"))
+        XCTAssertEqual(slotWidth, closeButtonWidth)
     }
 }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -7152,6 +7152,18 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
         let widened = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 10)
         XCTAssertGreaterThan(widened, base)
     }
+
+    func testTrailingAccessorySlotWidensForCommandTwoHint() {
+        let closeButtonWidth: CGFloat = 16
+        let slotWidth = SidebarTrailingAccessoryWidthPolicy.slotWidth(
+            closeButtonWidth: closeButtonWidth,
+            shortcutHintLabel: "⌘2",
+            shortcutHintXOffset: 0
+        )
+
+        XCTAssertGreaterThan(slotWidth, closeButtonWidth)
+        XCTAssertGreaterThanOrEqual(slotWidth, SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘2"))
+    }
 }
 
 final class ExtensionWorktreePrototypeTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Render workspace shortcut hints in the row trailing accessory slot so the `⌘2` pill is not hidden by close-button/hover state.
- Add regression coverage that the trailing accessory slot widens for the `⌘2` hint.

## Testing
- `git diff --check HEAD`
- `./scripts/reload-cloud.sh --tag cmd2`

## Issues
- Related: user screenshot report in chat, holding Command does not show the sidebar `⌘2` hint

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783457581&installation_id=133855650&pr_number=5580&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5580&signature=ff6236286df3e1cd37dc17c2bd2fa2891d5b0b0b0de0048a2d6b506b75f3ee2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI sidebar layout and overlay behavior with a regression test; no auth, data, or API changes.
> 
> **Overview**
> Fixes sidebar workspace shortcut hints (e.g. **⌘2**) not showing reliably when holding Command by **not** reserving extra trailing width for the hint and drawing it on top of the row instead.
> 
> Adds **`SidebarTrailingAccessoryWidthPolicy.slotWidth`**, which always matches the close-button width (the hint label is ignored for layout). The close button’s frame uses that slot width so the row doesn’t shift when a hint appears. The previous **`sidebarShortcutHintOverlay`** helper is replaced with a **top-trailing** overlay that renders **`ShortcutHintPill`** with clamped debug offsets, padding, no hit testing, and the existing shortcut-hint transition/visibility animation.
> 
> Adds a unit test that the trailing accessory slot stays **16pt** when the hint label is **⌘2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18adc0d24152eee0b0d20c4b054e8bbd5f48f8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sidebar workspace shortcut hint (e.g., ⌘2) at the row’s top-right with a smooth visibility animation, without shifting text. The close button slot stays fixed; the hint overlays above it and is nudged right for better spacing.

- **Bug Fixes**
  - Render the shortcut hint as a top-trailing overlay with clamped offsets, a small right padding, and the restored show/hide transition.
  - Keep the trailing accessory slot width equal to the close button width to avoid layout shifts.
  - Add a regression test asserting the slot does not widen for the ⌘2 hint.

<sup>Written for commit 18adc0d24152eee0b0d20c4b054e8bbd5f48f8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined sidebar trailing accessory sizing to match the close button width. Workspace shortcut hints now render as a positioned, non-interactive overlay with clamped offsets, top/trailing padding, and a smooth visibility transition.

* **Tests**
  * Added a unit test confirming the trailing accessory slot width does not expand for the "⌘2" shortcut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->