### PR TITLE
macOS: closing the sign-in window no longer closes the workspace behind it

### DIFF
--- a/Sources/Mobile/Pairing/MobilePairingWindowController.swift
+++ b/Sources/Mobile/Pairing/MobilePairingWindowController.swift
@@ -44,6 +44,9 @@ final class MobilePairingWindowController {
         window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
         window.styleMask = [.titled, .closable, .miniaturizable]
         window.isReleasedWhenClosed = false
+        // On-demand window: never let AppKit state restoration reopen it
+        // uninvited on the next launch.
+        window.isRestorable = false
         window.setContentSize(NSSize(width: 460, height: 640))
         window.center()
         self.window = window

--- a/Sources/Mobile/Pairing/MobilePairingWindowController.swift
+++ b/Sources/Mobile/Pairing/MobilePairingWindowController.swift
@@ -12,7 +12,10 @@ final class MobilePairingWindowController {
     /// singletons (see the task-manager and debug windows).
     static let shared = MobilePairingWindowController()
 
-    private static let windowIdentifier = "cmux.mobilePairingWindow"
+    /// The pairing window's stable `NSWindow.identifier`. Exposed so the
+    /// app's close-shortcut routing can treat this as an auxiliary window
+    /// (Cmd-W closes the pairing window itself, never the workspace behind it).
+    static let windowIdentifier = "cmux.mobilePairingWindow"
 
     private var window: NSWindow?
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1418,6 +1418,10 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.startupAppearanceDebug",
     "cmux.bonsplitTabBarDebug",
     "cmux.titlebarLayoutDebug",
+    // The iOS pairing window hosts a standalone "Sign In" / pairing flow. Cmd-W
+    // (and menu Close) must dismiss this window itself, never the workspace
+    // behind it. https://github.com/manaflow-ai/cmux/issues/3617
+    MobilePairingWindowController.windowIdentifier,
 ]
 
 /// Returns whether the given window should handle the standard close shortcut

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 		0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */; };
 		325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */; };
 		A2538FE83AE79539E3BF9248 /* MobilePairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */; };
+		D3F1000000000000000000A2 /* MobilePairingWindowCloseRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F1000000000000000000A1 /* MobilePairingWindowCloseRoutingTests.swift */; };
 		18A8E29E9BD87E184983527C /* MobilePairingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */; };
 		9916B44C7A9914E172D112D4 /* MobileRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */; };
 		AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */; };
@@ -1141,6 +1142,7 @@
 		04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingModel.swift"; sourceTree = "<group>"; };
 		B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingQRImageView.swift"; sourceTree = "<group>"; };
 		F9BC53FA4991A6EBFB930EDF /* MobilePairingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingView.swift"; sourceTree = "<group>"; };
+		D3F1000000000000000000A1 /* MobilePairingWindowCloseRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePairingWindowCloseRoutingTests.swift; sourceTree = "<group>"; };
 		5AE701F43A0B49F08835191C /* MobilePairingWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Pairing/MobilePairingWindowController.swift"; sourceTree = "<group>"; };
 		7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileRouteResolver.swift; sourceTree = "<group>"; };
 		4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileTerminalByteTee.swift; sourceTree = "<group>"; };
@@ -2068,6 +2070,7 @@
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
+				D3F1000000000000000000A1 /* MobilePairingWindowCloseRoutingTests.swift */,
 				A9E030000000000000000001 /* AgentSessionSocketSurfaceTests.swift */,
 				A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */,
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
@@ -3201,6 +3204,7 @@
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */,
+				D3F1000000000000000000A2 /* MobilePairingWindowCloseRoutingTests.swift in Sources */,
 				F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */,
 				734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 				4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */,

--- a/cmuxTests/MobilePairingWindowCloseRoutingTests.swift
+++ b/cmuxTests/MobilePairingWindowCloseRoutingTests.swift
@@ -1,0 +1,56 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+/// Regression coverage for the close-shortcut routing of the iOS pairing
+/// ("Sign In") window.
+///
+/// The pairing window hosts a standalone sign-in / pairing flow. Pressing Cmd-W
+/// (or choosing menu Close) while it is key must dismiss the pairing window
+/// itself, never the workspace window behind it. The routing decision lives in
+/// ``cmuxWindowShouldOwnCloseShortcut(_:)``: it returns `true` for auxiliary
+/// windows (whose own `performClose:` runs) and `false` for the main workspace
+/// window (where Cmd-W falls through to panel/workspace close). Before the fix
+/// the pairing window's identifier was missing from the auxiliary set, so the
+/// shortcut closed the workspace behind it.
+@MainActor
+@Suite struct MobilePairingWindowCloseRoutingTests {
+    private func makeWindow(identifier: String?) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: true
+        )
+        if let identifier {
+            window.identifier = NSUserInterfaceItemIdentifier(identifier)
+        }
+        return window
+    }
+
+    @Test func pairingWindowOwnsItsCloseShortcut() {
+        let window = makeWindow(identifier: MobilePairingWindowController.windowIdentifier)
+        #expect(cmuxWindowShouldOwnCloseShortcut(window) == true)
+    }
+
+    @Test func mainWorkspaceWindowDoesNotOwnCloseShortcut() {
+        // The main workspace window must NOT own the shortcut, so Cmd-W keeps
+        // routing to panel/workspace close instead of closing the whole window.
+        let window = makeWindow(identifier: "cmux.mainWindow")
+        #expect(cmuxWindowShouldOwnCloseShortcut(window) == false)
+    }
+
+    @Test func windowWithoutIdentifierDoesNotOwnCloseShortcut() {
+        let window = makeWindow(identifier: nil)
+        #expect(cmuxWindowShouldOwnCloseShortcut(window) == false)
+    }
+
+    @Test func nilWindowDoesNotOwnCloseShortcut() {
+        #expect(cmuxWindowShouldOwnCloseShortcut(nil) == false)
+    }
+}


### PR DESCRIPTION
On a signed-out launch the iOS pairing window presents a standalone "Sign In" prompt ("Sign in with your cmux account to pair your iPhone."). Pressing Cmd-W (or menu Close) while that window was key destroyed the workspace window behind it instead of dismissing the sign-in window, and when it was the last workspace it quit the app.

Root cause: Cmd-W and menu Close route through `closePanelOrWindow()` in `Sources/cmuxApp.swift`, which only lets a window own its close shortcut when `cmuxWindowShouldOwnCloseShortcut` returns true, i.e. the window's identifier is in `cmuxAuxiliaryWindowIdentifiers`. The pairing window's identifier `cmux.mobilePairingWindow` was missing from that set, so the shortcut fell through to `activeTabManager.closeCurrentPanelWithConfirmation()` and closed the workspace. Settings, About, Task Manager, etc. are already in the set, which is why they close correctly.

Fix: add the pairing window to the auxiliary set (referencing `MobilePairingWindowController.windowIdentifier` so the two strings can't drift), so Cmd-W and menu Close dismiss the pairing window itself and leave the workspace intact. The red close button already only closed the pairing window (it calls `performClose:` directly, bypassing the shortcut router), so all three close entrypoints are now consistent. Also mark the on-demand pairing window non-restorable so AppKit state restoration can't reopen it uninvited on the next launch (which is why it appeared "on launch" in the first place).

Regression test (`cmuxTests/MobilePairingWindowCloseRoutingTests.swift`) asserts the routing decision directly: the pairing identifier owns its close shortcut (true), while the main workspace window / bare / nil windows do not (false). Two-commit red/green: commit 1 adds the failing test, commit 2 adds the fix.

Verification: app target and `cmux-unit` test target both build clean (`build-for-testing` → TEST BUILD SUCCEEDED). Reproduced the bug live on a tagged signed-out build (Cmd-W on the pairing window quit the app), and confirmed Settings (an existing auxiliary window) Cmd-W closes only itself and leaves the workspace intact, which is the exact mechanism this fix grants the pairing window.

https://github.com/manaflow-ai/cmux/issues/3617

## Dogfood checklist

PREV: launch signed-out, open the pairing/"Sign In" window (Settings → Mobile → Pair a Device, or command palette "mobile connect"), press Cmd-W → the workspace behind it closed (and quit the app if it was the last workspace).

NOW: same steps → Cmd-W (and menu File → Close) dismiss only the pairing window; the workspace stays open. The red close button behaves the same. The pairing window no longer reopens uninvited on the next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783459872&installation_id=133855650&pr_number=5581&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5581&signature=1fcb0ece4b3ad3889ff8effdc1525a29369aafbc9294d48d8ec123ce6d307e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized window-close routing and restoration flags for the pairing window, with unit tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **Cmd-W / File → Close** on the iOS pairing (“Sign In”) window so it dismisses **only that auxiliary window**, not the workspace behind it (issue #3617).
> 
> The pairing window’s identifier is registered in `cmuxAuxiliaryWindowIdentifiers` via `MobilePairingWindowController.windowIdentifier` (public so the string can’t drift from the window). `cmuxWindowShouldOwnCloseShortcut` then routes close shortcuts to `performClose:` on the pairing window instead of `closeCurrentPanelWithConfirmation()` on the workspace.
> 
> The pairing window is also marked **`isRestorable = false`** so AppKit won’t reopen it on the next launch without user action.
> 
> Adds **`MobilePairingWindowCloseRoutingTests`** to lock in the auxiliary vs main-workspace routing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96d6285b169ac40be030bde71c7ee12d0e82d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS bug where Cmd-W or File → Close on the iOS pairing “Sign In” window closed the workspace (and sometimes quit the app). These shortcuts now dismiss only the pairing window; the workspace stays open.

- **Bug Fixes**
  - Added the pairing window to the auxiliary close routing (using `MobilePairingWindowController.windowIdentifier`) so it owns Cmd-W/File → Close.
  - Marked the pairing window non-restorable to prevent it from reopening on next launch.
  - Added regression tests to verify routing: pairing window owns the close shortcut; main/bare/nil windows do not.

<sup>Written for commit f96d6285b169ac40be030bde71c7ee12d0e82d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The iOS pairing/sign-in window now properly responds to the close shortcut and dismisses correctly. The window will no longer automatically reopen when the application restarts, providing improved window management behavior.

* **Tests**
  * Added comprehensive test coverage for close-shortcut routing to ensure the pairing window behaves correctly in various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->