### PR TITLE
macOS: DEBUG auto-sign-in for tagged DEV builds (dogfood account)

### DIFF
--- a/Sources/Auth/DebugDogfoodCredentialResolver.swift
+++ b/Sources/Auth/DebugDogfoodCredentialResolver.swift
@@ -1,0 +1,167 @@
+#if DEBUG
+import Foundation
+
+/// Resolves dogfood Stack credentials for the macOS DEBUG auto-sign-in path.
+///
+/// A tagged `cmux DEV` build is a separate bundle (separate keychain), so it
+/// starts signed out and shows the sign-in window. iOS already auto-signs-in on
+/// DEBUG launch by injecting `CMUX_UITEST_STACK_EMAIL` / `CMUX_UITEST_STACK_PASSWORD`
+/// into the app's environment (SIMCTL / devicectl), which the existing
+/// `CMUXAuthAutoLoginCredentials` path reads. The macOS app needs the same
+/// behavior, but a `cmux DEV` opened from Finder or the CMUX Tag Opener does
+/// **not** inherit a shell's environment, so an env-only approach never fires on
+/// those launches. This resolver adds a file-read fallback so the creds are
+/// found regardless of how the app was launched.
+///
+/// Resolution order is **dogfood account first, then agent account**, so the
+/// dog Mac comes up as the human dogfood account (`lawrence@manaflow.ai`) even
+/// when an agent's `CMUX_UITEST_*` creds are also present (the iOS dogfood flow
+/// commonly leaves those in the environment / `~/.secrets`). Within each
+/// account, env wins over `~/.secrets/cmuxterm-dev.env`, which wins over
+/// `~/.secrets/cmux.env`:
+///
+///   1. env `CMUX_DOGFOOD_STACK_EMAIL` / `CMUX_DOGFOOD_STACK_PASSWORD`
+///   2. file `~/.secrets/cmuxterm-dev.env` dogfood keys
+///   3. file `~/.secrets/cmux.env` dogfood keys
+///   4. env `CMUX_UITEST_STACK_EMAIL` / `CMUX_UITEST_STACK_PASSWORD`
+///   5. file `~/.secrets/cmuxterm-dev.env` uitest keys
+///   6. file `~/.secrets/cmux.env` uitest keys
+///
+/// The resolved pair is merged into the launch environment dict as the existing
+/// `CMUX_UITEST_STACK_*` keys, so the already-tested `CMUXAuthAutoLoginCredentials`
+/// + `AuthLaunchOptions.shouldStartAutoLogin` gate (`hasCredentials && !hasStoredTokens`)
+/// fires unchanged. This type holds no autoLogin logic of its own.
+///
+/// The whole type is compiled out of release builds (`#if DEBUG`), so it can
+/// never run in production. It takes its environment and a file-reader seam via
+/// `init`, so tests drive every precedence branch without touching the real
+/// filesystem or `~/.secrets`.
+struct DebugDogfoodCredentialResolver {
+    /// A resolved email/password pair, plus which source it came from (for
+    /// non-secret diagnostics; the password is never surfaced here).
+    struct ResolvedCredentials: Equatable {
+        let email: String
+        let password: String
+    }
+
+    /// The launch environment to read env-var credentials from.
+    private let environment: [String: String]
+    /// Ordered secret-file candidate paths (highest precedence first), already
+    /// expanded to absolute paths by the caller.
+    private let secretFilePaths: [String]
+    /// Reads the contents of a secret file at the given path, or `nil` when the
+    /// file is absent/unreadable. Injected so tests never read real files.
+    private let readFile: (String) -> String?
+
+    /// Creates a resolver.
+    ///
+    /// - Parameters:
+    ///   - environment: The launch environment (env-var credential source).
+    ///   - secretFilePaths: Ordered secret-file candidates, highest precedence
+    ///     first. Defaults to `~/.secrets/cmuxterm-dev.env` then
+    ///     `~/.secrets/cmux.env`, resolved from the environment's `HOME`.
+    ///   - readFile: Reads a file's UTF-8 contents, or `nil` if unreadable.
+    ///     Defaults to a `FileManager`-free `String(contentsOfFile:)` read.
+    init(
+        environment: [String: String],
+        secretFilePaths: [String]? = nil,
+        readFile: @escaping (String) -> String? = { path in
+            try? String(contentsOfFile: path, encoding: .utf8)
+        }
+    ) {
+        self.environment = environment
+        self.secretFilePaths = secretFilePaths ?? Self.defaultSecretFilePaths(environment: environment)
+        self.readFile = readFile
+    }
+
+    /// The default ordered secret-file candidates, resolved against `HOME`.
+    /// `cmuxterm-dev.env` (cmux-terminal-specific Stack creds) is preferred over
+    /// the broader `cmux.env`.
+    private static func defaultSecretFilePaths(environment: [String: String]) -> [String] {
+        guard let home = environment["HOME"], !home.isEmpty else { return [] }
+        let base = home as NSString
+        return [
+            base.appendingPathComponent(".secrets/cmuxterm-dev.env"),
+            base.appendingPathComponent(".secrets/cmux.env"),
+        ]
+    }
+
+    /// The credential-key pair an account uses in env vars and secret files.
+    private enum Account {
+        case dogfood
+        case uitest
+
+        var emailKey: String {
+            switch self {
+            case .dogfood: return "CMUX_DOGFOOD_STACK_EMAIL"
+            case .uitest: return "CMUX_UITEST_STACK_EMAIL"
+            }
+        }
+
+        var passwordKey: String {
+            switch self {
+            case .dogfood: return "CMUX_DOGFOOD_STACK_PASSWORD"
+            case .uitest: return "CMUX_UITEST_STACK_PASSWORD"
+            }
+        }
+    }
+
+    /// Resolve the highest-precedence credential pair, or `nil` when none is
+    /// available. See the type doc for the full precedence order.
+    func resolve() -> ResolvedCredentials? {
+        // Dogfood account wins over the agent (uitest) account everywhere, so
+        // resolve ALL dogfood sources before ANY uitest source.
+        for account in [Account.dogfood, .uitest] {
+            if let fromEnv = credentials(in: environment, for: account) {
+                return fromEnv
+            }
+            for path in secretFilePaths {
+                guard let contents = readFile(path) else { continue }
+                let parsed = Self.parseEnvFile(contents)
+                if let fromFile = credentials(in: parsed, for: account) {
+                    return fromFile
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Read a non-empty email/password pair for `account` out of a key/value map.
+    private func credentials(
+        in map: [String: String],
+        for account: Account
+    ) -> ResolvedCredentials? {
+        guard let email = map[account.emailKey], !email.isEmpty,
+              let password = map[account.passwordKey], !password.isEmpty
+        else {
+            return nil
+        }
+        return ResolvedCredentials(email: email, password: password)
+    }
+
+    /// Parse a `KEY=value` `.env` file into a dictionary, skipping comments and
+    /// blank lines and stripping a single layer of surrounding quotes. Mirrors
+    /// the tiny parser already used by `AuthEnvironment.devOverride`.
+    static func parseEnvFile(_ contents: String) -> [String: String] {
+        var result: [String: String] = [:]
+        for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#"), let eq = line.firstIndex(of: "=") else {
+                continue
+            }
+            let key = String(line[..<eq]).trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+            var value = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
+            if value.count >= 2 {
+                if value.hasPrefix("\""), value.hasSuffix("\"") {
+                    value = String(value.dropFirst().dropLast())
+                } else if value.hasPrefix("'"), value.hasSuffix("'") {
+                    value = String(value.dropFirst().dropLast())
+                }
+            }
+            result[key] = value
+        }
+        return result
+    }
+}
+#endif

--- a/Sources/Auth/DebugDogfoodCredentialResolver.swift
+++ b/Sources/Auth/DebugDogfoodCredentialResolver.swift
@@ -37,8 +37,11 @@ import Foundation
 /// `init`, so tests drive every precedence branch without touching the real
 /// filesystem or `~/.secrets`.
 struct DebugDogfoodCredentialResolver {
-    /// A resolved email/password pair, plus which source it came from (for
-    /// non-secret diagnostics; the password is never surfaced here).
+    /// A resolved email/password pair.
+    ///
+    /// Kept nested in this file under the file-organization carve-out for small,
+    /// closely-bound helpers: two stored fields plus synthesized `Equatable`, no
+    /// meaningful body, used only by this resolver and its tests.
     struct ResolvedCredentials: Equatable {
         let email: String
         let password: String
@@ -87,6 +90,10 @@ struct DebugDogfoodCredentialResolver {
     }
 
     /// The credential-key pair an account uses in env vars and secret files.
+    ///
+    /// Kept nested under the file-organization carve-out for small, closely-bound
+    /// helpers: a private two-case enum with two computed key strings, used only
+    /// inside this resolver.
     private enum Account {
         case dogfood
         case uitest

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -76,10 +76,23 @@ struct MacAuthComposition {
                 .absoluteString,
             apiBaseURL: AuthEnvironment.apiBaseURL.absoluteString
         )
+        // DEBUG-only: make a tagged `cmux DEV` build come up already signed in
+        // as the dogfood account, mirroring iOS. A tagged build is a separate
+        // bundle (separate keychain), so it starts signed out. iOS injects
+        // `CMUX_UITEST_STACK_*` into the launch environment; the Mac app needs
+        // the same, but a `cmux DEV` opened from Finder / the CMUX Tag Opener
+        // does not inherit a shell's environment, so the resolver also reads
+        // `~/.secrets/cmuxterm-dev.env` / `~/.secrets/cmux.env` directly. We
+        // only fill the two cred keys (never the whole file) into the launch
+        // environment when they are absent, so an explicit env injection (a UI
+        // test, `reload.sh --launch`) still wins, and the existing
+        // `CMUXAuthAutoLoginCredentials` + `shouldStartAutoLogin` gate fires
+        // unchanged. Compiled out of release builds.
+        let resolvedEnvironment = Self.environmentWithDogfoodAutoSignIn(environment)
         let launch = AuthLaunchOptions(
-            clearAuthRequested: environment["CMUX_UITEST_CLEAR_AUTH"] == "1",
+            clearAuthRequested: resolvedEnvironment["CMUX_UITEST_CLEAR_AUTH"] == "1",
             mockDataEnabled: false,
-            environment: environment,
+            environment: resolvedEnvironment,
             includesDevAuth: Self.includesDevAuth
         )
 
@@ -136,4 +149,66 @@ struct MacAuthComposition {
         false
         #endif
     }
+
+    #if DEBUG
+    /// Returns `environment` with the dogfood auto-sign-in credentials filled in
+    /// under the `CMUX_UITEST_STACK_*` keys (DEBUG only; the whole method is
+    /// compiled out of release, so the auto-sign-in path can never run in
+    /// production).
+    ///
+    /// Always consults ``DebugDogfoodCredentialResolver`` so the resolver's
+    /// dogfood-over-agent precedence is honored even when `CMUX_UITEST_STACK_*`
+    /// are already present in the environment: on the dog Mac an iOS dogfood
+    /// flow can leave the agent's `CMUX_UITEST_STACK_*` in the environment while
+    /// the human dogfood creds live only in `~/.secrets/cmuxterm-dev.env`, and
+    /// the build must come up as the human account. When only `CMUX_UITEST_STACK_*`
+    /// env creds exist (e.g. a CI UI test with no `~/.secrets` files), the
+    /// resolver returns that same pair, so the merge is a no-op.
+    ///
+    /// - Parameters:
+    ///   - environment: The launch environment.
+    ///   - secretFilePaths: Ordered secret-file candidates for the resolver.
+    ///     Defaults to `nil` so the resolver uses `~/.secrets/cmuxterm-dev.env`
+    ///     then `~/.secrets/cmux.env`. Injected by tests to exercise the
+    ///     dog-Mac precedence without touching real files.
+    ///   - readFile: File reader seam for the resolver. Defaults to a real read;
+    ///     injected by tests.
+    ///
+    /// `nonisolated`: a pure transformation over its arguments that touches no
+    /// main-actor state, so tests can call it from a nonisolated context.
+    nonisolated static func environmentWithDogfoodAutoSignIn(
+        _ environment: [String: String],
+        secretFilePaths: [String]? = nil,
+        readFile: ((String) -> String?)? = nil
+    ) -> [String: String] {
+        let resolver: DebugDogfoodCredentialResolver
+        if let readFile {
+            resolver = DebugDogfoodCredentialResolver(
+                environment: environment,
+                secretFilePaths: secretFilePaths,
+                readFile: readFile
+            )
+        } else {
+            resolver = DebugDogfoodCredentialResolver(
+                environment: environment,
+                secretFilePaths: secretFilePaths
+            )
+        }
+        guard let resolved = resolver.resolve() else {
+            return environment
+        }
+        var merged = environment
+        merged["CMUX_UITEST_STACK_EMAIL"] = resolved.email
+        merged["CMUX_UITEST_STACK_PASSWORD"] = resolved.password
+        return merged
+    }
+    #else
+    /// In release builds the dogfood auto-sign-in path does not exist; this is
+    /// the identity function so production never auto-signs-in.
+    nonisolated static func environmentWithDogfoodAutoSignIn(
+        _ environment: [String: String]
+    ) -> [String: String] {
+        environment
+    }
+    #endif
 }

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -82,12 +82,16 @@ struct MacAuthComposition {
         // `CMUX_UITEST_STACK_*` into the launch environment; the Mac app needs
         // the same, but a `cmux DEV` opened from Finder / the CMUX Tag Opener
         // does not inherit a shell's environment, so the resolver also reads
-        // `~/.secrets/cmuxterm-dev.env` / `~/.secrets/cmux.env` directly. We
-        // only fill the two cred keys (never the whole file) into the launch
-        // environment when they are absent, so an explicit env injection (a UI
-        // test, `reload.sh --launch`) still wins, and the existing
-        // `CMUXAuthAutoLoginCredentials` + `shouldStartAutoLogin` gate fires
-        // unchanged. Compiled out of release builds.
+        // `~/.secrets/cmuxterm-dev.env` / `~/.secrets/cmux.env` directly. The
+        // resolver runs unconditionally and applies dogfood-account-first
+        // precedence, so on the dog Mac the human dogfood file wins even when an
+        // agent's `CMUX_UITEST_STACK_*` are already in the environment; only the
+        // two resolved cred keys are filled in (never the whole file). When the
+        // only creds are `CMUX_UITEST_STACK_*` env (a CI UI test with no
+        // `~/.secrets` files), the resolver returns that same pair, so the merge
+        // is a no-op. The existing `CMUXAuthAutoLoginCredentials` +
+        // `shouldStartAutoLogin` gate then fires unchanged. Compiled out of
+        // release builds.
         let resolvedEnvironment = Self.environmentWithDogfoodAutoSignIn(environment)
         let launch = AuthLaunchOptions(
             clearAuthRequested: resolvedEnvironment["CMUX_UITEST_CLEAR_AUTH"] == "1",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -266,6 +266,8 @@
 		C3408A000000000000000005 /* ContentView+ViewCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */; };
 		A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 		C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */; };
+		DEBDADADADADADADAD000001 /* DebugDogfoodCredentialResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */; };
+		DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
 		A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001F000000000000000002 /* DetachedFolderDragIcon.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
@@ -991,6 +993,8 @@
 		C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+ViewCommandPalette.swift"; sourceTree = "<group>"; };
 		A5001012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewIdentifierCopyCommands.swift; sourceTree = "<group>"; };
+		DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolver.swift; sourceTree = "<group>"; };
+		DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolverTests.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
 		A5001F000000000000000002 /* DetachedFolderDragIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedFolderDragIcon.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
@@ -1521,6 +1525,7 @@
 			isa = PBXGroup;
 			children = (
 				43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */,
+				DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */,
 				53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
 			);
@@ -2058,6 +2063,7 @@
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
 				C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */,
 				C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */,
+				DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */,
 				C135190000000000000000A2 /* PreferredEditorSettingsTests.swift */,
 				C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */,
 				A11EAE000000000000000001 /* WorkspaceAppearanceConfigResolutionTests.swift */,
@@ -2746,6 +2752,7 @@
 				C3408A000000000000000005 /* ContentView+ViewCommandPalette.swift in Sources */,
 				A5001002 /* ContentView.swift in Sources */,
 				C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */,
+				DEBDADADADADADADAD000001 /* DebugDogfoodCredentialResolver.swift in Sources */,
 				A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */,
 				A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
@@ -3162,6 +3169,7 @@
 				A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
 				C0DEF4120000000000000001 /* CommandPaletteSettingsToggleTests.swift in Sources */,
 				C1713006C1713006C1713006 /* CommandPaletteShortcutCustomizationTests.swift in Sources */,
+				DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,
 				E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,

--- a/cmuxTests/DebugDogfoodCredentialResolverTests.swift
+++ b/cmuxTests/DebugDogfoodCredentialResolverTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+// The resolver only exists in DEBUG (it is the macOS dogfood auto-sign-in seam,
+// compiled out of release builds), so the whole suite is DEBUG-gated. In a
+// release test build there is nothing to test: the auto-sign-in path does not
+// exist, which is the production guarantee.
+#if DEBUG
+@Suite struct DebugDogfoodCredentialResolverTests {
+    /// Build a resolver whose only file source is `path` returning `contents`,
+    /// so a test never reads the real `~/.secrets` files.
+    private func makeResolver(
+        environment: [String: String],
+        files: [String: String] = [:]
+    ) -> DebugDogfoodCredentialResolver {
+        DebugDogfoodCredentialResolver(
+            environment: environment,
+            secretFilePaths: Array(files.keys),
+            readFile: { files[$0] }
+        )
+    }
+
+    @Test func noCredentialsAnywhereResolvesNil() {
+        let resolver = makeResolver(environment: ["HOME": "/Users/test"])
+        #expect(resolver.resolve() == nil)
+    }
+
+    @Test func dogfoodEnvCredentialsResolve() {
+        let resolver = makeResolver(environment: [
+            "CMUX_DOGFOOD_STACK_EMAIL": "lawrence@manaflow.ai",
+            "CMUX_DOGFOOD_STACK_PASSWORD": "dog-pw",
+        ])
+        #expect(
+            resolver.resolve()
+                == .init(email: "lawrence@manaflow.ai", password: "dog-pw")
+        )
+    }
+
+    @Test func uitestEnvCredentialsResolveWhenNoDogfood() {
+        let resolver = makeResolver(environment: [
+            "CMUX_UITEST_STACK_EMAIL": "agent-dev@manaflow.ai",
+            "CMUX_UITEST_STACK_PASSWORD": "agent-pw",
+        ])
+        #expect(
+            resolver.resolve()
+                == .init(email: "agent-dev@manaflow.ai", password: "agent-pw")
+        )
+    }
+
+    @Test func dogfoodAccountWinsOverUitestAccountAcrossSources() {
+        // The dog Mac case: the agent (uitest) creds are in the environment, but
+        // the human dogfood creds are only in a secret file. Dogfood must win so
+        // the dog Mac comes up as lawrence, not the agent account.
+        let resolver = makeResolver(
+            environment: [
+                "CMUX_UITEST_STACK_EMAIL": "agent-dev@manaflow.ai",
+                "CMUX_UITEST_STACK_PASSWORD": "agent-pw",
+            ],
+            files: [
+                "/secrets/cmuxterm-dev.env": """
+                CMUX_DOGFOOD_STACK_EMAIL=lawrence@manaflow.ai
+                CMUX_DOGFOOD_STACK_PASSWORD=dog-pw
+                """,
+            ]
+        )
+        #expect(
+            resolver.resolve()
+                == .init(email: "lawrence@manaflow.ai", password: "dog-pw")
+        )
+    }
+
+    @Test func envWinsOverFileWithinSameAccount() {
+        let resolver = makeResolver(
+            environment: [
+                "CMUX_DOGFOOD_STACK_EMAIL": "env@manaflow.ai",
+                "CMUX_DOGFOOD_STACK_PASSWORD": "env-pw",
+            ],
+            files: [
+                "/secrets/cmuxterm-dev.env": """
+                CMUX_DOGFOOD_STACK_EMAIL=file@manaflow.ai
+                CMUX_DOGFOOD_STACK_PASSWORD=file-pw
+                """,
+            ]
+        )
+        #expect(
+            resolver.resolve()
+                == .init(email: "env@manaflow.ai", password: "env-pw")
+        )
+    }
+
+    @Test func earlierFileWinsOverLaterFile() {
+        // cmuxterm-dev.env is listed before cmux.env, so it takes precedence.
+        let resolver = DebugDogfoodCredentialResolver(
+            environment: [:],
+            secretFilePaths: ["/secrets/cmuxterm-dev.env", "/secrets/cmux.env"],
+            readFile: { path in
+                switch path {
+                case "/secrets/cmuxterm-dev.env":
+                    return """
+                    CMUX_DOGFOOD_STACK_EMAIL=devfile@manaflow.ai
+                    CMUX_DOGFOOD_STACK_PASSWORD=dev-pw
+                    """
+                case "/secrets/cmux.env":
+                    return """
+                    CMUX_DOGFOOD_STACK_EMAIL=cmuxfile@manaflow.ai
+                    CMUX_DOGFOOD_STACK_PASSWORD=cmux-pw
+                    """
+                default:
+                    return nil
+                }
+            }
+        )
+        #expect(
+            resolver.resolve()
+                == .init(email: "devfile@manaflow.ai", password: "dev-pw")
+        )
+    }
+
+    @Test func fallsThroughToCmuxEnvFileWhenDevFileLacksCreds() {
+        let resolver = DebugDogfoodCredentialResolver(
+            environment: [:],
+            secretFilePaths: ["/secrets/cmuxterm-dev.env", "/secrets/cmux.env"],
+            readFile: { path in
+                switch path {
+                case "/secrets/cmuxterm-dev.env":
+                    return "# no stack creds here\nE2B_API_KEY=abc\n"
+                case "/secrets/cmux.env":
+                    return """
+                    CMUX_UITEST_STACK_EMAIL=agent@manaflow.ai
+                    CMUX_UITEST_STACK_PASSWORD=agent-pw
+                    """
+                default:
+                    return nil
+                }
+            }
+        )
+        #expect(
+            resolver.resolve()
+                == .init(email: "agent@manaflow.ai", password: "agent-pw")
+        )
+    }
+
+    @Test func partialCredentialPairIsIgnored() {
+        // Email without password must not yield a half-resolved credential.
+        let resolver = makeResolver(environment: [
+            "CMUX_DOGFOOD_STACK_EMAIL": "lawrence@manaflow.ai",
+        ])
+        #expect(resolver.resolve() == nil)
+    }
+
+    @Test func emptyCredentialValuesAreIgnored() {
+        let resolver = makeResolver(environment: [
+            "CMUX_DOGFOOD_STACK_EMAIL": "",
+            "CMUX_DOGFOOD_STACK_PASSWORD": "",
+        ])
+        #expect(resolver.resolve() == nil)
+    }
+
+    @Test func parsesQuotedAndCommentedEnvFile() {
+        let parsed = DebugDogfoodCredentialResolver.parseEnvFile(
+            """
+            # comment line
+            CMUX_DOGFOOD_STACK_EMAIL="lawrence@manaflow.ai"
+            CMUX_DOGFOOD_STACK_PASSWORD='secret value'
+
+            BLANK_AFTER=1
+            """
+        )
+        #expect(parsed["CMUX_DOGFOOD_STACK_EMAIL"] == "lawrence@manaflow.ai")
+        #expect(parsed["CMUX_DOGFOOD_STACK_PASSWORD"] == "secret value")
+        #expect(parsed["BLANK_AFTER"] == "1")
+    }
+}
+
+/// Integration coverage for the `MacAuthComposition` wrapper that feeds resolved
+/// creds into `AuthLaunchOptions`. The wrapper, not the resolver, is where a
+/// regression would re-introduce the "agent creds in env shadow the dogfood
+/// file" bug, so these tests drive the wrapper directly with injected file
+/// fakes.
+@Suite struct MacAuthCompositionDogfoodAutoSignInTests {
+    @Test func dogfoodFileWinsOverAgentEnvCredsOnDogMac() {
+        // Dog-Mac scenario: agent (uitest) creds in the environment, human
+        // dogfood creds only in the secret file. The build must come up as the
+        // human dogfood account, so the file creds win and overwrite the env
+        // uitest keys that AuthLaunchOptions reads.
+        let merged = MacAuthComposition.environmentWithDogfoodAutoSignIn(
+            [
+                "CMUX_UITEST_STACK_EMAIL": "agent-dev@manaflow.ai",
+                "CMUX_UITEST_STACK_PASSWORD": "agent-pw",
+            ],
+            secretFilePaths: ["/secrets/cmuxterm-dev.env"],
+            readFile: { _ in
+                """
+                CMUX_DOGFOOD_STACK_EMAIL=lawrence@manaflow.ai
+                CMUX_DOGFOOD_STACK_PASSWORD=dog-pw
+                """
+            }
+        )
+        #expect(merged["CMUX_UITEST_STACK_EMAIL"] == "lawrence@manaflow.ai")
+        #expect(merged["CMUX_UITEST_STACK_PASSWORD"] == "dog-pw")
+    }
+
+    @Test func leavesAgentEnvCredsWhenNoDogfoodFile() {
+        // CI UI-test scenario: only uitest env creds, no secret file. The
+        // resolver returns that same pair, so the merge is a no-op.
+        let merged = MacAuthComposition.environmentWithDogfoodAutoSignIn(
+            [
+                "CMUX_UITEST_STACK_EMAIL": "agent-dev@manaflow.ai",
+                "CMUX_UITEST_STACK_PASSWORD": "agent-pw",
+            ],
+            secretFilePaths: ["/secrets/cmuxterm-dev.env"],
+            readFile: { _ in nil }
+        )
+        #expect(merged["CMUX_UITEST_STACK_EMAIL"] == "agent-dev@manaflow.ai")
+        #expect(merged["CMUX_UITEST_STACK_PASSWORD"] == "agent-pw")
+    }
+
+    @Test func injectsNothingWhenNoCredentialsAvailable() {
+        let merged = MacAuthComposition.environmentWithDogfoodAutoSignIn(
+            ["HOME": "/Users/test"],
+            secretFilePaths: ["/secrets/cmuxterm-dev.env"],
+            readFile: { _ in nil }
+        )
+        #expect(merged["CMUX_UITEST_STACK_EMAIL"] == nil)
+        #expect(merged["CMUX_UITEST_STACK_PASSWORD"] == nil)
+    }
+}
+#endif

--- a/cmuxTests/DebugDogfoodCredentialResolverTests.swift
+++ b/cmuxTests/DebugDogfoodCredentialResolverTests.swift
@@ -13,16 +13,19 @@ import Testing
 // exist, which is the production guarantee.
 #if DEBUG
 @Suite struct DebugDogfoodCredentialResolverTests {
-    /// Build a resolver whose only file source is `path` returning `contents`,
-    /// so a test never reads the real `~/.secrets` files.
+    /// Build a resolver over an ordered list of `(path, contents)` secret-file
+    /// fakes, so a test never reads the real `~/.secrets` files and the file
+    /// precedence order is deterministic (a plain `[String: String]` would
+    /// iterate in undefined key order).
     private func makeResolver(
         environment: [String: String],
-        files: [String: String] = [:]
+        files: [(path: String, contents: String)] = []
     ) -> DebugDogfoodCredentialResolver {
-        DebugDogfoodCredentialResolver(
+        let table = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0.contents) })
+        return DebugDogfoodCredentialResolver(
             environment: environment,
-            secretFilePaths: Array(files.keys),
-            readFile: { files[$0] }
+            secretFilePaths: files.map(\.path),
+            readFile: { table[$0] }
         )
     }
 
@@ -63,10 +66,13 @@ import Testing
                 "CMUX_UITEST_STACK_PASSWORD": "agent-pw",
             ],
             files: [
-                "/secrets/cmuxterm-dev.env": """
-                CMUX_DOGFOOD_STACK_EMAIL=lawrence@manaflow.ai
-                CMUX_DOGFOOD_STACK_PASSWORD=dog-pw
-                """,
+                (
+                    "/secrets/cmuxterm-dev.env",
+                    """
+                    CMUX_DOGFOOD_STACK_EMAIL=lawrence@manaflow.ai
+                    CMUX_DOGFOOD_STACK_PASSWORD=dog-pw
+                    """
+                ),
             ]
         )
         #expect(
@@ -82,10 +88,13 @@ import Testing
                 "CMUX_DOGFOOD_STACK_PASSWORD": "env-pw",
             ],
             files: [
-                "/secrets/cmuxterm-dev.env": """
-                CMUX_DOGFOOD_STACK_EMAIL=file@manaflow.ai
-                CMUX_DOGFOOD_STACK_PASSWORD=file-pw
-                """,
+                (
+                    "/secrets/cmuxterm-dev.env",
+                    """
+                    CMUX_DOGFOOD_STACK_EMAIL=file@manaflow.ai
+                    CMUX_DOGFOOD_STACK_PASSWORD=file-pw
+                    """
+                ),
             ]
         )
         #expect(

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1045,6 +1045,13 @@ if [[ "$LAUNCH" -eq 1 ]]; then
     -u XDG_DATA_DIRS
   )
 
+  # DEBUG dogfood auto-sign-in needs no env injection here: the in-app resolver
+  # reads ~/.secrets/cmuxterm-dev.env (then ~/.secrets/cmux.env) directly on
+  # launch, which fires for every launch method including Finder / the CMUX Tag
+  # Opener that this script's TAG_LAUNCH_ENV never reaches. Exporting the Stack
+  # password into the long-lived GUI process environment would leak it to every
+  # child terminal/CLI it spawns, for zero added coverage, so we deliberately do
+  # not set CMUX_UITEST_STACK_* here.
   TAG_LAUNCH_ENV=(
     CMUX_TAG="${TAG_SLUG:-}"
     CMUX_BUNDLE_ID="$BUNDLE_ID"


### PR DESCRIPTION
A tagged `cmux DEV` build is a separate bundle with its own keychain, so it starts signed out and shows the sign-in window. iOS already auto-signs-in on DEBUG launch by injecting `CMUX_UITEST_STACK_*` into the app environment, which the existing `CMUXAuthAutoLoginCredentials` + `shouldStartAutoLogin` path reads. The macOS app had no equivalent. This adds it.

## What changed

- New `Sources/Auth/DebugDogfoodCredentialResolver.swift` (DEBUG-only, compiled out of release). Resolves dogfood Stack creds from env vars and `~/.secrets` files, dogfood account first.
- `Sources/Auth/MacAuthComposition.swift`: before building `AuthLaunchOptions`, always run the resolver and fill the resolved creds into the launch environment under the existing `CMUX_UITEST_STACK_*` keys. The already-tested `CMUXAuthAutoLoginCredentials` + `AuthLaunchOptions.shouldStartAutoLogin` gate (`hasCredentials && !hasStoredTokens`) fires unchanged. No parallel sign-in path.
- Unit + integration tests for resolver precedence and the composition wrapper.

## Why a file-read fallback

A `cmux DEV` opened from Finder or the CMUX Tag Opener does not inherit a shell's environment, so iOS's env-injection approach never fires on those launches. The resolver reads `~/.secrets/cmuxterm-dev.env` then `~/.secrets/cmux.env` directly, so auto-sign-in works regardless of how the app was launched. This is the load-bearing path for the cloud-built dog app launched via Tag Opener.

## Precedence

Dogfood account first (`CMUX_DOGFOOD_STACK_*` = the human dogfood account) over the agent account (`CMUX_UITEST_STACK_*`); within each account env wins over `cmuxterm-dev.env` wins over `cmux.env`. The composition wrapper always runs the resolver (no early-return when uitest env creds already exist), so on the dog Mac the human dogfood file wins over agent env creds left by an iOS dogfood flow. The password is never logged.

## Stack project

The Mac DEBUG build already targets the dev Stack project (`454ecd03-...`), same as iOS, which allows password sign-in without email verification. No change needed there.

## Deliberate deviation: no reload.sh password export

The task suggested also exporting the creds in `reload.sh --launch` as belt-and-suspenders. I did NOT do that: putting `CMUX_UITEST_STACK_PASSWORD` into the long-lived GUI process environment leaks it to every child terminal/CLI the app spawns (`env | grep CMUX` in any dev shell), for zero added coverage. The actual dog Mac is built with `reload-cloud.sh --tag dog` (no `--launch`) and launched via Tag Opener, which never sees `reload.sh`'s launch env; and even on a local `--launch`, `$HOME` survives the env scrub so the in-app file read fires anyway. So the file-read path fully covers it. reload.sh only gains a clarifying comment.

## Release safety

The entire resolver and the auto-sign-in wrapper branch are `#if DEBUG`; the release `environmentWithDogfoodAutoSignIn` is the identity function. The path can never run in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783460405&installation_id=133855650&pr_number=5582&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5582&signature=2e586f3129712fd781e7f53b10ef205a808b1803b01466ea969f9384fde4348a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth launch environment and reads local secret files in DEBUG only; release is a no-op, but DEBUG builds can auto-login with resolved passwords merged into process env.
> 
> **Overview**
> Adds **DEBUG-only auto sign-in** for macOS tagged `cmux DEV` builds so they can start signed in as the dogfood Stack account, matching iOS behavior without a new auth code path.
> 
> A new `DebugDogfoodCredentialResolver` loads credentials from launch env and `~/.secrets/cmuxterm-dev.env` / `~/.secrets/cmux.env`, with **dogfood keys before agent `CMUX_UITEST_STACK_*`** and env over file within each account. `MacAuthComposition` always runs `environmentWithDogfoodAutoSignIn` before `AuthLaunchOptions`, writing the resolved pair into `CMUX_UITEST_STACK_EMAIL` / `CMUX_UITEST_STACK_PASSWORD` so existing `CMUXAuthAutoLoginCredentials` and `shouldStartAutoLogin` behave unchanged. The resolver and merge logic are `#if DEBUG`; release uses an identity wrapper.
> 
> Tests cover precedence, env-file parsing, and composition merge (including dogfood file winning over agent env). `reload.sh` documents why Stack passwords are **not** exported into the GUI launch env (would leak to child shells); in-app file read covers Finder/Tag Opener launches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7d8edacc69ca717b70426dc4c2af8e074fb6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DEBUG-only auto sign-in for macOS DEV builds by resolving dogfood Stack credentials and injecting them into the existing auto-login path. Works for Finder and Tag Opener launches and is compiled out of release.

- New Features
  - Added `DebugDogfoodCredentialResolver` (DEBUG only) to read creds from env and `~/.secrets/cmuxterm-dev.env` then `~/.secrets/cmux.env`.
  - Precedence: dogfood `CMUX_DOGFOOD_STACK_*` over agent `CMUX_UITEST_STACK_*`; within each account env > `cmuxterm-dev.env` > `cmux.env`.
  - `MacAuthComposition` always resolves and fills `CMUX_UITEST_STACK_*` before building `AuthLaunchOptions`, reusing the existing `CMUXAuthAutoLoginCredentials` + `shouldStartAutoLogin` gate. Tests cover precedence and env merge. All gated by `#if DEBUG`.

- Bug Fixes
  - Fixed a stale `MacAuthComposition` comment to match dogfood-over-agent precedence.
  - Made resolver tests deterministic by using an ordered list for secret-file inputs.
  - Documented nested helper types in the resolver per the file-organization carve-out.

<sup>Written for commit 8b7d8edacc69ca717b70426dc4c2af8e074fb6f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS DEBUG builds now auto-populate test account credentials from environment variables or local secret files with documented precedence.

* **Tests**
  * Added DEBUG-only tests validating credential resolution, precedence rules, parsing behavior, and environment merge outcomes.

* **Chores**
  * Updated project build configuration and added launch-environment documentation explaining debug credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->