### PR TITLE
Turnkey dev builds P2: phone auto-pair + unified dev-setup entrypoint

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -270,15 +270,21 @@ struct CMUXMobileRootView: View {
     @discardableResult
     private func connectUITestAttachURLIfNeeded() -> Bool {
         #if DEBUG
-        // Auto-pair when CMUX_UITEST_ATTACH_URL is supplied at launch. Originally
-        // gated on mock data (the XCUITest harness), but the dev-launch tooling
-        // (scripts/mobile-dev-launch.sh) signs in for real (CMUX_UITEST_STACK_*
-        // with CMUX_UITEST_MOCK_DATA=0) and still wants to auto-attach, so this
-        // fires for any authenticated session once the attach URL is present.
-        // No-op unless that env var is set, so normal launches are unaffected.
+        // Auto-pair when an attach URL is supplied at launch. Two sources:
+        //   - CMUX_DOGFOOD_ATTACH_URL (UITestConfig.dogfoodAttachURL): NOT gated on
+        //     mock data, so it fires against the real backend. The dev-launch
+        //     tooling (scripts/mobile-dev-launch.sh, scripts/dev-setup.sh) signs in
+        //     for real (CMUX_UITEST_STACK_* with CMUX_UITEST_MOCK_DATA=0) and wants
+        //     the phone to auto-pair to the freshly built Mac dev app. With mock
+        //     off, UITestConfig.attachURL is always nil, so this dedicated accessor
+        //     is what un-breaks real-backend auto-pair.
+        //   - CMUX_UITEST_ATTACH_URL (UITestConfig.attachURL): gated on mock data,
+        //     kept intact for the XCUITest harness.
+        // No-op unless one of those env vars is set, so normal launches are
+        // unaffected.
         guard !didConsumeUITestAttachURL,
               isAuthenticated,
-              let attachURL = UITestConfig.attachURL else {
+              let attachURL = UITestConfig.dogfoodAttachURL ?? UITestConfig.attachURL else {
             return false
         }
         didConsumeUITestAttachURL = true

--- a/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -34,6 +34,37 @@ public struct UITestConfig {
         value(for: "CMUX_UITEST_ATTACH_URL")
     }
 
+    /// The dogfood attach URL to auto-open after sign-in, if injected.
+    ///
+    /// Unlike ``attachURL`` (which is gated on ``mockDataEnabled`` so it only
+    /// fires under the XCUITest mock harness), this reads `CMUX_DOGFOOD_ATTACH_URL`
+    /// *without* the mock gate. The dev-launch tooling
+    /// (`scripts/mobile-dev-launch.sh`, `scripts/dev-setup.sh`) signs in for real
+    /// against the live backend (`CMUX_UITEST_MOCK_DATA=0`) and wants the phone to
+    /// auto-pair to the freshly built Mac dev app. With the mock off, ``attachURL``
+    /// is always `nil`, so a dedicated, not-mock-gated accessor is required for the
+    /// real-backend auto-pair path to fire. DEBUG-only; always `nil` in release.
+    public static var dogfoodAttachURL: String? {
+        dogfoodAttachURL(from: ProcessInfo.processInfo.environment)
+    }
+
+    /// The dogfood attach URL for an explicit environment, not gated on mock data.
+    ///
+    /// - Parameter env: The environment dictionary to read.
+    /// - Returns: The trimmed value of `CMUX_DOGFOOD_ATTACH_URL` when present and
+    ///   non-empty; otherwise `nil`. Always `nil` in release builds.
+    public static func dogfoodAttachURL(from env: [String: String]) -> String? {
+        #if DEBUG
+        // BUG (commit 1): routed through the mock-gated reader, so it returns nil
+        // with CMUX_UITEST_MOCK_DATA=0 (the real-backend dev-launch path). Fixed
+        // in commit 2 by reading the env directly.
+        let value = value(for: "CMUX_DOGFOOD_ATTACH_URL", env: env)
+        return value
+        #else
+        return nil
+        #endif
+    }
+
     /// Whether the standalone terminal-layout preview is enabled.
     ///
     /// When `CMUX_UITEST_TERMINAL_PREVIEW=1`, the root view renders a standalone

--- a/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -55,11 +55,11 @@ public struct UITestConfig {
     ///   non-empty; otherwise `nil`. Always `nil` in release builds.
     public static func dogfoodAttachURL(from env: [String: String]) -> String? {
         #if DEBUG
-        // BUG (commit 1): routed through the mock-gated reader, so it returns nil
-        // with CMUX_UITEST_MOCK_DATA=0 (the real-backend dev-launch path). Fixed
-        // in commit 2 by reading the env directly.
-        let value = value(for: "CMUX_DOGFOOD_ATTACH_URL", env: env)
-        return value
+        // Read the env directly, NOT through the mock-gated value(for:), so the
+        // URL is returned with CMUX_UITEST_MOCK_DATA=0 (the real-backend
+        // dev-launch path) and iOS auto-pair actually fires.
+        let value = env["CMUX_DOGFOOD_ATTACH_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
         #else
         return nil
         #endif

--- a/Packages/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
+++ b/Packages/CmuxMobileSupport/Tests/CmuxMobileSupportTests/UITestConfigTests.swift
@@ -60,4 +60,55 @@ import Testing
         ]
         #expect(UITestConfig.value(for: "CMUX_UITEST_ADD_DEVICE_HOST", env: env) == nil)
     }
+
+    // MARK: - dogfoodAttachURL (NOT mock-gated)
+
+    /// The core P2 fix: the dogfood attach URL must be returned even when mock data
+    /// is off (the real-backend dev-launch path), so iOS auto-pair actually fires.
+    @Test func dogfoodAttachURLReturnedWithMockDisabled() {
+        let env = [
+            "CMUX_UITEST_MOCK_DATA": "0",
+            "CMUX_DOGFOOD_ATTACH_URL": "cmux-ios://attach?v=1&payload=abc",
+        ]
+        #if DEBUG
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == "cmux-ios://attach?v=1&payload=abc")
+        #else
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == nil)
+        #endif
+    }
+
+    /// Regression guard: with mock off, the legacy mock-gated `attachURL`
+    /// (`CMUX_UITEST_ATTACH_URL`) stays nil, which is exactly why the dedicated
+    /// dogfood accessor is required for the real-backend auto-pair path.
+    @Test func legacyAttachURLStaysNilWithMockDisabledButDogfoodDoesNot() {
+        let env = [
+            "CMUX_UITEST_MOCK_DATA": "0",
+            "CMUX_UITEST_ATTACH_URL": "cmux-ios://attach?v=1&payload=legacy",
+            "CMUX_DOGFOOD_ATTACH_URL": "cmux-ios://attach?v=1&payload=dogfood",
+        ]
+        #expect(UITestConfig.value(for: "CMUX_UITEST_ATTACH_URL", env: env) == nil)
+        #if DEBUG
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == "cmux-ios://attach?v=1&payload=dogfood")
+        #else
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == nil)
+        #endif
+    }
+
+    @Test func dogfoodAttachURLIsTrimmed() {
+        let env = ["CMUX_DOGFOOD_ATTACH_URL": "  cmux-ios://attach?v=1&payload=zzz  "]
+        #if DEBUG
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == "cmux-ios://attach?v=1&payload=zzz")
+        #else
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == nil)
+        #endif
+    }
+
+    @Test func dogfoodAttachURLIsNilWhenAbsent() {
+        #expect(UITestConfig.dogfoodAttachURL(from: [:]) == nil)
+    }
+
+    @Test func dogfoodAttachURLIsNilWhenBlank() {
+        let env = ["CMUX_DOGFOOD_ATTACH_URL": "   "]
+        #expect(UITestConfig.dogfoodAttachURL(from: env) == nil)
+    }
 }

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# Turnkey dev-build entrypoint: build + launch the macOS dev app auto-signed-in,
+# and (optionally) the iOS dev build auto-paired to it, with no QR scan and no
+# manual sign-in. Wraps the P1 macOS auto-sign-in path and the P2 iOS auto-pair.
+#
+# Everything here is DEBUG-only and targets the TAGGED app/socket/bundle id, so
+# it never touches the user's stable cmux instance.
+#
+# Flow (--surface both):
+#   1. Load dev sign-in creds (dogfood account wins; --agent forces agent).
+#   2. Enable the iOS pairing host on the tagged build (opt-in, default OFF):
+#        defaults write com.cmuxterm.app.debug.<tag-id> mobile.iOSPairingHost.enabled -bool true
+#      Written BEFORE the macOS launch so a single build binds the NWListener on
+#      first launch. NOTE: the first bind per bundle id triggers a one-time macOS
+#      "Local Network" permission prompt; click Allow.
+#   3. Build + launch the macOS dev app via reload.sh --tag <t> --launch. It
+#      auto-signs-in from ~/.secrets/cmuxterm-dev.env (DebugDogfoodCredentialResolver).
+#   4. Headlessly mint a short-TTL attach URL against the tagged socket via the
+#      local automation path (no Stack auth needed for the mint).
+#   5. Build + launch the iOS dev build, passing the URL as CMUX_DOGFOOD_ATTACH_URL
+#      so the phone auto-attaches.
+#
+# Usage:
+#   scripts/dev-setup.sh --tag grid                 # macOS + iOS, auto-pair
+#   scripts/dev-setup.sh --tag grid --surface mac   # macOS only
+#   scripts/dev-setup.sh --tag grid --surface ios   # iOS only (needs Mac listener up)
+#   scripts/dev-setup.sh --tag grid --no-pair       # build both, skip auto-pair
+#   scripts/dev-setup.sh --tag grid --agent         # sign in as the agent account
+#
+# Flags:
+#   --tag <t>           required; tags the macOS + iOS dev builds.
+#   --surface <s>       mac | ios | both   (default both)
+#   --profile <name>    reserved for P3 (env presets); currently a no-op + warn.
+#   --no-pair           skip enabling the host + minting + auto-pair.
+#   --simulator <name>  iOS simulator name (default "iPhone 17").
+#   --device            target a connected iPhone instead of the simulator.
+#   --agent             use the shared agent account for the iOS sign-in. NOTE:
+#                       this does NOT change the macOS account: the Mac app picks
+#                       its account from disk via DebugDogfoodCredentialResolver
+#                       (dogfood-first), which has no agent-force selector and
+#                       which we cannot override without env-leaking the password.
+#                       For a pure agent-account run, use --surface ios --agent.
+
+set -euo pipefail
+
+TAG=""
+SURFACE="both"            # mac | ios | both
+PROFILE=""
+NO_PAIR=0
+AGENT=0
+SIMULATOR_NAME="iPhone 17"
+IOS_TARGET="simulator"   # simulator | device
+TTL_SECONDS="600"
+
+usage() { sed -n '2,40p' "$0"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="${2:-}"; shift 2 ;;
+    --surface) SURFACE="${2:-}"; shift 2 ;;
+    --profile) PROFILE="${2:-}"; shift 2 ;;
+    --no-pair) NO_PAIR=1; shift ;;
+    --simulator) SIMULATOR_NAME="${2:-}"; shift 2 ;;
+    --device) IOS_TARGET="device"; shift ;;
+    --agent) AGENT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown arg $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$TAG" ]] || { echo "error: --tag is required" >&2; usage >&2; exit 2; }
+case "$SURFACE" in
+  mac|ios|both) ;;
+  *) echo "error: --surface must be mac|ios|both (got '$SURFACE')" >&2; exit 2 ;;
+esac
+
+if [[ -n "$PROFILE" ]]; then
+  echo "warning: --profile '$PROFILE' is reserved for P3 (env presets) and is currently a no-op." >&2
+fi
+
+if [[ "$AGENT" -eq 1 && ( "$SURFACE" == "mac" || "$SURFACE" == "both" ) ]]; then
+  echo "warning: --agent only changes the iOS sign-in account. The macOS app picks its" >&2
+  echo "         account from ~/.secrets via DebugDogfoodCredentialResolver (dogfood-first)," >&2
+  echo "         which has no agent-force selector. For a pure agent run use --surface ios --agent." >&2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- credentials: validate only, do NOT export into this process -------------
+# The macOS app reads dogfood creds from disk (DebugDogfoodCredentialResolver),
+# and mobile-dev-launch.sh loads its own creds for the iOS launch. So this script
+# must NOT export CMUX_UITEST_STACK_PASSWORD: reload.sh launches the long-lived
+# GUI process inheriting this environment (it only scrubs a denylist, and the
+# Stack vars are not on it), which would leak the password to every child
+# terminal/CLI the app spawns. Validate in a subshell to surface a clear early
+# error, but keep the password out of dev-setup.sh's environment.
+DEV_SECRETS_ARGS=()
+[[ "$AGENT" -eq 1 ]] && DEV_SECRETS_ARGS+=(--agent)
+# shellcheck source=scripts/lib/dev-secrets.sh
+if ! ( source "$SCRIPT_DIR/lib/dev-secrets.sh"; cmux_dev_secrets_load "${DEV_SECRETS_ARGS[@]}" ); then
+  exit 2
+fi
+
+# --- tag identity (must match reload.sh / cmux-debug-cli.sh exactly) ---------
+# slug -> socket path + DerivedData; tag-id -> bundle id.
+dev_setup__sanitize_path() {
+  local cleaned
+  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  [[ -n "$cleaned" ]] || cleaned="agent"
+  printf '%s' "$cleaned"
+}
+dev_setup__sanitize_bundle() {
+  local cleaned
+  cleaned="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g')"
+  [[ -n "$cleaned" ]] || cleaned="agent"
+  printf '%s' "$cleaned"
+}
+
+TAG_SLUG="$(dev_setup__sanitize_path "$TAG")"
+TAG_ID="$(dev_setup__sanitize_bundle "$TAG")"
+BUNDLE_ID="com.cmuxterm.app.debug.${TAG_ID}"
+SOCKET_PATH="/tmp/cmux-debug-${TAG_SLUG}.sock"
+
+# --- enable the iOS pairing host (must precede the macOS launch) -------------
+enable_pairing_host() {
+  echo "==> enabling iOS pairing host on $BUNDLE_ID (opt-in, default OFF)"
+  echo "    (first bind per bundle id triggers a one-time macOS Local Network prompt; click Allow)"
+  # The host listener is opt-in. createAttachTicket returns empty routes unless
+  # the NWListener is bound. MobileHostService.start() reads this default at app
+  # launch (applicationDidFinishLaunching), so it must be written BEFORE the
+  # macOS launch below. The tagged bundle id is targeted, never the stable app.
+  defaults write "$BUNDLE_ID" mobile.iOSPairingHost.enabled -bool true
+}
+
+# --- macOS build + launch (P1 auto-sign-in) ---------------------------------
+# Writing the pairing default first means a single reload.sh build binds the
+# listener on its first launch (no double build).
+build_and_launch_mac() {
+  echo "==> building + launching macOS dev app (tag: $TAG)"
+  # reload.sh --launch builds the tagged Debug app and opens it. The macOS app
+  # auto-signs-in from ~/.secrets/cmuxterm-dev.env via DebugDogfoodCredentialResolver.
+  "$REPO_ROOT/scripts/reload.sh" --tag "$TAG" --launch
+}
+
+# --- mint a short-TTL attach URL headlessly ---------------------------------
+# Echoes the URL on stdout. The URL is a bearer credential: callers must NOT
+# print it. Polls the mint RPC (real readiness signal) until routes are ready,
+# bounded so a never-binding listener fails instead of hanging.
+mint_attach_url() {
+  local payload _attempt
+  for _attempt in $(seq 1 20); do
+    if [[ ! -S "$SOCKET_PATH" ]]; then
+      sleep 0.5
+      continue
+    fi
+    # scope=mac mints a Mac-wide ticket; ttl bounded by the RPC (30..3600).
+    payload="$(CMUX_TAG="$TAG" "$REPO_ROOT/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.create \
+      "{\"ttl_seconds\":${TTL_SECONDS},\"scope\":\"mac\"}" 2>/dev/null || true)"
+    if [[ -n "$payload" ]]; then
+      local url
+      url="$(REPO_ROOT="$REPO_ROOT" PAYLOAD="$payload" node --input-type=module <<'NODE' 2>/dev/null || true
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const { buildAttachURL } = await import(
+  pathToFileURL(path.join(process.env.REPO_ROOT, "scripts", "lib", "attach-url.mjs")).href
+);
+const { attachURL } = buildAttachURL(JSON.parse(process.env.PAYLOAD));
+process.stdout.write(attachURL);
+NODE
+)"
+      if [[ -n "$url" ]]; then
+        printf '%s' "$url"
+        return 0
+      fi
+    fi
+    # Listener not bound yet (routes unavailable) or app still starting; retry.
+    sleep 0.5
+  done
+  return 1
+}
+
+# --- iOS build + launch (auto-pair via CMUX_DOGFOOD_ATTACH_URL) -------------
+build_and_launch_ios() {
+  local attach_url="${1:-}"
+  echo "==> building iOS dev app (tag: $TAG)"
+  # --no-launch: build + install only. mobile-dev-launch.sh below does the launch
+  # with the sign-in + auto-pair env, so a plain reload launch would be redundant
+  # (and would launch signed-out).
+  local ios_args=(--tag "$TAG" --no-launch)
+  if [[ "$IOS_TARGET" == "device" ]]; then
+    # --device-only skips the simulator build/boot entirely (--device would also
+    # reload the default simulator first and can fail before reaching the iPhone).
+    ios_args+=(--device-only)
+  else
+    # Build + install onto the SAME simulator mobile-dev-launch.sh launches on,
+    # so the requested sim has the freshly built app (reload defaults to iPhone 17).
+    ios_args+=(--simulator "$SIMULATOR_NAME")
+  fi
+  "$REPO_ROOT/ios/scripts/reload.sh" "${ios_args[@]}"
+
+  echo "==> launching iOS dev app${attach_url:+ (auto-pairing)}"
+  local launch_args=(--tag "$TAG")
+  if [[ "$AGENT" -eq 1 ]]; then
+    launch_args+=(--agent)
+  fi
+  if [[ "$IOS_TARGET" == "device" ]]; then
+    launch_args+=(--device)
+  else
+    launch_args+=(--simulator "$SIMULATOR_NAME")
+  fi
+  # Pass the URL via env (CMUX_DOGFOOD_ATTACH_URL), never on the command line, so
+  # it is not visible in `ps`. mobile-dev-launch.sh injects it into the app env.
+  CMUX_DOGFOOD_ATTACH_URL="$attach_url" "$REPO_ROOT/scripts/mobile-dev-launch.sh" "${launch_args[@]}"
+}
+
+# --- orchestrate ------------------------------------------------------------
+ATTACH_URL=""
+
+# Enable the pairing host BEFORE the macOS launch so a single build binds the
+# listener on first launch (the default is read in applicationDidFinishLaunching).
+if [[ "$NO_PAIR" -eq 0 && ( "$SURFACE" == "mac" || "$SURFACE" == "both" ) ]]; then
+  enable_pairing_host
+fi
+
+if [[ "$SURFACE" == "mac" || "$SURFACE" == "both" ]]; then
+  build_and_launch_mac
+fi
+
+# Mint the attach URL when iOS is in play and pairing is on. For --surface ios
+# the Mac dev app must already be running with the pairing host enabled.
+if [[ "$NO_PAIR" -eq 0 && ( "$SURFACE" == "ios" || "$SURFACE" == "both" ) ]]; then
+  echo "==> minting attach URL against $SOCKET_PATH"
+  if ATTACH_URL="$(mint_attach_url)"; then
+    echo "==> attach URL minted (TTL ${TTL_SECONDS}s); auto-pair armed"
+  else
+    ATTACH_URL=""
+    echo "warning: could not mint an attach URL (is the Mac dev app running with the pairing host enabled, and the Local Network prompt allowed?). iOS will launch signed-in only." >&2
+  fi
+fi
+
+if [[ "$SURFACE" == "ios" || "$SURFACE" == "both" ]]; then
+  build_and_launch_ios "$ATTACH_URL"
+fi
+
+echo "==> dev-setup complete (tag: $TAG, surface: $SURFACE)"

--- a/scripts/lib/attach-url.mjs
+++ b/scripts/lib/attach-url.mjs
@@ -1,0 +1,71 @@
+// Pure encoder for the cmux iOS attach deep link.
+//
+// Takes the raw payload returned by the `mobile.attach_ticket.create` RPC
+// (`{ ticket: { routes, version, ... }, ... }`), optionally filters the ticket
+// routes by id/kind, base64url-encodes the (filtered) ticket, and builds the
+// `cmux-ios://attach?v=<n>&payload=<b64>` URL the phone consumes.
+//
+// This is the single source of truth for the encode recipe, shared by
+// `scripts/mobile-attach-qr.sh` (QR/HTML rendering) and `scripts/dev-setup.sh`
+// (headless auto-pair mint). Keep it pure (no I/O) so it is unit-testable with
+// `node --test scripts/lib/attach-url.test.mjs`.
+
+/**
+ * Filter a ticket's routes by id and/or kind. Returns the matching subset.
+ *
+ * @param {Array<object>} routes Ticket routes.
+ * @param {{routeID?: string, routeKind?: string}} [filter]
+ * @returns {Array<object>} The matching routes (all routes when no filter).
+ * @throws {Error} When a filter is given but matches nothing.
+ */
+export function filterRoutes(routes, { routeID = "", routeKind = "" } = {}) {
+  const id = String(routeID || "").trim();
+  const kind = String(routeKind || "").trim();
+  let filtered = routes;
+  if (id) {
+    filtered = filtered.filter((route) => route.id === id);
+  }
+  if (kind) {
+    filtered = filtered.filter((route) => route.kind === kind);
+  }
+  if (filtered.length === 0) {
+    throw new Error(
+      `No matching route for route_id=${id || "(none)"} route_kind=${kind || "(none)"}`,
+    );
+  }
+  return filtered;
+}
+
+/**
+ * Build the `cmux-ios://attach` deep link from a raw attach-ticket payload.
+ *
+ * The returned `attachURL` is a bearer credential: it grants the holder the
+ * paired Mac's terminals for the ticket's TTL. Never log it.
+ *
+ * @param {object} payload The raw `mobile.attach_ticket.create` result.
+ * @param {{routeID?: string, routeKind?: string}} [filter]
+ * @returns {{attachURL: string, routes: Array<object>, payload: object}}
+ *   `payload` is a shallow clone with `ticket.routes`/`routes` narrowed to the
+ *   filtered set, so callers (e.g. the QR HTML renderer) can show the addresses.
+ * @throws {Error} When the payload has no ticket/routes, or the filter is empty.
+ */
+export function buildAttachURL(payload, filter = {}) {
+  if (!payload || !payload.ticket || !Array.isArray(payload.ticket.routes)) {
+    throw new Error(
+      "mobile.attach_ticket.create did not return a ticket with routes",
+    );
+  }
+
+  const routes = filterRoutes(payload.ticket.routes, filter);
+
+  const ticket = { ...payload.ticket, routes };
+  const result = { ...payload, ticket, routes };
+
+  const encodedPayload = Buffer.from(JSON.stringify(ticket)).toString(
+    "base64url",
+  );
+  const version = ticket.version || 1;
+  result.attach_url = `cmux-ios://attach?v=${version}&payload=${encodedPayload}`;
+
+  return { attachURL: result.attach_url, routes, payload: result };
+}

--- a/scripts/lib/attach-url.test.mjs
+++ b/scripts/lib/attach-url.test.mjs
@@ -1,0 +1,86 @@
+// Unit tests for the attach-url encoder.
+//   node --test scripts/lib/attach-url.test.mjs
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAttachURL, filterRoutes } from "./attach-url.mjs";
+
+function samplePayload() {
+  return {
+    ticket: {
+      version: 1,
+      workspaceID: "",
+      routes: [
+        { id: "ts", kind: "tailscale", endpoint: { type: "host_port", host: "100.1.2.3", port: 8080 } },
+        { id: "lo", kind: "loopback", endpoint: { type: "host_port", host: "127.0.0.1", port: 8080 } },
+      ],
+      authToken: "secret-token",
+    },
+    expires_at: "2026-06-07T00:00:00Z",
+  };
+}
+
+function decodePayload(url) {
+  const params = new URL(url).searchParams;
+  const b64 = params.get("payload");
+  return JSON.parse(Buffer.from(b64, "base64url").toString("utf8"));
+}
+
+test("builds a cmux-ios://attach URL with the version and base64url ticket", () => {
+  const { attachURL } = buildAttachURL(samplePayload());
+  assert.match(attachURL, /^cmux-ios:\/\/attach\?v=1&payload=/);
+  const decoded = decodePayload(attachURL);
+  assert.equal(decoded.version, 1);
+  assert.equal(decoded.authToken, "secret-token");
+  assert.equal(decoded.routes.length, 2);
+});
+
+test("round-trips the encoded ticket back to the original object", () => {
+  const payload = samplePayload();
+  const { attachURL } = buildAttachURL(payload);
+  const decoded = decodePayload(attachURL);
+  assert.deepEqual(decoded, payload.ticket);
+});
+
+test("filters routes by kind and narrows the encoded ticket", () => {
+  const { attachURL, routes } = buildAttachURL(samplePayload(), { routeKind: "tailscale" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].id, "ts");
+  const decoded = decodePayload(attachURL);
+  assert.equal(decoded.routes.length, 1);
+  assert.equal(decoded.routes[0].kind, "tailscale");
+});
+
+test("filters routes by id", () => {
+  const { routes } = buildAttachURL(samplePayload(), { routeID: "lo" });
+  assert.equal(routes.length, 1);
+  assert.equal(routes[0].id, "lo");
+});
+
+test("throws when no route matches the filter", () => {
+  assert.throws(() => buildAttachURL(samplePayload(), { routeKind: "nope" }), /No matching route/);
+});
+
+test("throws when the payload has no ticket routes", () => {
+  assert.throws(() => buildAttachURL({ ticket: {} }), /ticket with routes/);
+  assert.throws(() => buildAttachURL({}), /ticket with routes/);
+});
+
+test("defaults version to 1 when the ticket omits it", () => {
+  const payload = samplePayload();
+  delete payload.ticket.version;
+  const { attachURL } = buildAttachURL(payload);
+  assert.match(attachURL, /\?v=1&/);
+});
+
+test("filterRoutes returns all routes when no filter is given", () => {
+  const routes = samplePayload().ticket.routes;
+  assert.equal(filterRoutes(routes).length, 2);
+});
+
+test("does not mutate the caller's payload", () => {
+  const payload = samplePayload();
+  buildAttachURL(payload, { routeKind: "tailscale" });
+  assert.equal(payload.ticket.routes.length, 2);
+});

--- a/scripts/lib/dev-secrets.sh
+++ b/scripts/lib/dev-secrets.sh
@@ -1,0 +1,166 @@
+# shellcheck shell=bash
+# Sourceable helper that loads dogfood/agent Stack credentials for DEBUG dev
+# builds and exposes them as CMUX_UITEST_STACK_EMAIL / CMUX_UITEST_STACK_PASSWORD
+# (the env vars the app's existing DEBUG sign-in hook reads).
+#
+# Precedence MIRRORS the macOS DebugDogfoodCredentialResolver EXACTLY, so a
+# `dev-setup.sh --surface both` run signs the Mac and the phone in under the same
+# account. A complete email+password pair is resolved from ONE source (never
+# mixed across sources). Dogfood account first, then agent; within each account,
+# env wins over ~/.secrets/cmuxterm-dev.env, which wins over ~/.secrets/cmux.env:
+#   1. env  CMUX_DOGFOOD_STACK_EMAIL / CMUX_DOGFOOD_STACK_PASSWORD
+#   2. file ~/.secrets/cmuxterm-dev.env  dogfood keys (CMUX_DOGFOOD_STACK_*)
+#   3. file ~/.secrets/cmux.env          dogfood keys (CMUX_DOGFOOD_STACK_*)
+#   4. env  CMUX_UITEST_STACK_EMAIL / CMUX_UITEST_STACK_PASSWORD
+#   5. file ~/.secrets/cmuxterm-dev.env  uitest  keys (CMUX_UITEST_STACK_*)
+#   6. file ~/.secrets/cmux.env          uitest  keys (CMUX_UITEST_STACK_*)
+#
+# The dogfood account (a personal dogfood login) is preferred so dev builds sign
+# in as the human, not the shared agent.
+#
+# Usage:
+#   source "scripts/lib/dev-secrets.sh"
+#   cmux_dev_secrets_load            # default: dogfood-preferred
+#   cmux_dev_secrets_load --agent    # force the agent account only
+#
+# After a successful load, CMUX_UITEST_STACK_EMAIL / CMUX_UITEST_STACK_PASSWORD
+# are exported. The email is echoed (so the operator can see who they signed in
+# as); the password is NEVER printed.
+#
+# Returns non-zero (and prints guidance) when no usable credentials are found.
+
+# Read a single KEY=value out of a .env file without sourcing it (so we never
+# execute arbitrary secret-file contents). Mirrors DebugDogfoodCredentialResolver.
+# parseEnvFile: trims the line, skips blank/`#`-comment lines, trims the key and
+# value around the first `=`, and strips ONE layer of matching surrounding single
+# or double quotes. Prints the parsed value, or nothing.
+cmux_dev_secrets__read_key() {
+  local file="$1" key="$2" line lkey lval
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Trim leading/trailing whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == '#'* || "$line" != *'='* ]] && continue
+    lkey="${line%%=*}"
+    lval="${line#*=}"
+    # Trim key and value.
+    lkey="${lkey#"${lkey%%[![:space:]]*}"}"; lkey="${lkey%"${lkey##*[![:space:]]}"}"
+    lval="${lval#"${lval%%[![:space:]]*}"}"; lval="${lval%"${lval##*[![:space:]]}"}"
+    [[ "$lkey" == "$key" ]] || continue
+    # Strip one layer of matching surrounding quotes (len >= 2).
+    if [[ ${#lval} -ge 2 ]]; then
+      if [[ "$lval" == '"'*'"' || "$lval" == "'"*"'" ]]; then
+        lval="${lval:1:${#lval}-2}"
+      fi
+    fi
+    printf '%s' "$lval"
+    return 0
+  done < "$file"
+  return 0
+}
+
+# Load dev sign-in credentials into CMUX_UITEST_STACK_EMAIL / _PASSWORD.
+#
+#   cmux_dev_secrets_load [--agent]
+#
+# Without --agent, the full 6-step chain above runs (dogfood account preferred).
+# With --agent, only the agent (uitest) sources are used (env CMUX_UITEST_STACK_*,
+# then ~/.secrets/cmux.env uitest keys), for agent-driven flows that must not
+# borrow a human's dogfood login.
+# Try to resolve a COMPLETE (email + password) credential pair from one source,
+# so a partial higher-precedence source never combines with a lower one. Sets
+# the caller's `email`/`password` and returns 0 on a full pair, else 1.
+#
+#   cmux_dev_secrets__try_pair email_var pw_var <getter...>
+#
+# The getter is invoked as `<getter> EMAIL` and `<getter> PASSWORD`; it must echo
+# the value (or nothing). Both must be non-empty for the pair to be accepted.
+cmux_dev_secrets__try_pair() {
+  local email_var="$1" pw_var="$2"; shift 2
+  local e p
+  e="$("$@" EMAIL)"
+  p="$("$@" PASSWORD)"
+  if [[ -n "$e" && -n "$p" ]]; then
+    printf -v "$email_var" '%s' "$e"
+    printf -v "$pw_var" '%s' "$p"
+    return 0
+  fi
+  return 1
+}
+
+cmux_dev_secrets_load() {
+  local agent_only=0
+  case "${1:-}" in
+    --agent) agent_only=1 ;;
+  esac
+
+  local home_dir="${HOME:-}"
+  local dogfood_file="${home_dir}/.secrets/cmuxterm-dev.env"
+  local agent_file="${home_dir}/.secrets/cmux.env"
+
+  local email="" password=""
+
+  # Per-source getters. Each maps the abstract EMAIL/PASSWORD slot to one
+  # source's concrete keys, so a pair always comes from a single source.
+  # Invoked indirectly via "$@" in cmux_dev_secrets__try_pair.
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__env_dogfood() {       # step 1
+    case "$1" in EMAIL) printf '%s' "${CMUX_DOGFOOD_STACK_EMAIL:-}" ;; PASSWORD) printf '%s' "${CMUX_DOGFOOD_STACK_PASSWORD:-}" ;; esac
+  }
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__dev_file_dogfood() {  # step 2: cmuxterm-dev.env dogfood keys
+    case "$1" in EMAIL) cmux_dev_secrets__read_key "$dogfood_file" CMUX_DOGFOOD_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$dogfood_file" CMUX_DOGFOOD_STACK_PASSWORD ;; esac
+  }
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__agent_file_dogfood() {  # step 3: cmux.env dogfood keys
+    case "$1" in EMAIL) cmux_dev_secrets__read_key "$agent_file" CMUX_DOGFOOD_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$agent_file" CMUX_DOGFOOD_STACK_PASSWORD ;; esac
+  }
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__env_uitest() {        # step 4
+    case "$1" in EMAIL) printf '%s' "${CMUX_UITEST_STACK_EMAIL:-}" ;; PASSWORD) printf '%s' "${CMUX_UITEST_STACK_PASSWORD:-}" ;; esac
+  }
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__dev_file_uitest() {   # step 5: cmuxterm-dev.env uitest keys
+    case "$1" in EMAIL) cmux_dev_secrets__read_key "$dogfood_file" CMUX_UITEST_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$dogfood_file" CMUX_UITEST_STACK_PASSWORD ;; esac
+  }
+  # shellcheck disable=SC2329
+  cmux_dev_secrets__agent_file_uitest() { # step 6: cmux.env uitest keys
+    case "$1" in EMAIL) cmux_dev_secrets__read_key "$agent_file" CMUX_UITEST_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$agent_file" CMUX_UITEST_STACK_PASSWORD ;; esac
+  }
+
+  if [[ "$agent_only" -eq 1 ]]; then
+    # Agent flow: only the shared agent (uitest) sources (steps 4 and 6).
+    cmux_dev_secrets__try_pair email password cmux_dev_secrets__env_uitest \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__agent_file_uitest
+  else
+    # Full chain, identical to DebugDogfoodCredentialResolver steps 1..6.
+    cmux_dev_secrets__try_pair email password cmux_dev_secrets__env_dogfood \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__dev_file_dogfood \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__agent_file_dogfood \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__env_uitest \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__dev_file_uitest \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__agent_file_uitest
+  fi
+
+  if [[ -z "$email" || -z "$password" ]]; then
+    cat >&2 <<EOF
+error: no dev sign-in credentials found.
+
+Store a personal dogfood Stack account in ~/.secrets/cmuxterm-dev.env:
+
+  CMUX_DOGFOOD_STACK_EMAIL=you@example.com
+  CMUX_DOGFOOD_STACK_PASSWORD=<password>
+
+(falls back to the shared agent CMUX_UITEST_STACK_* in ~/.secrets/cmux.env;
+pass --agent to force the agent account.)
+EOF
+    return 2
+  fi
+
+  export CMUX_UITEST_STACK_EMAIL="$email"
+  export CMUX_UITEST_STACK_PASSWORD="$password"
+  # Email only; never echo the password.
+  echo "==> dev sign-in account: $CMUX_UITEST_STACK_EMAIL"
+  return 0
+}

--- a/scripts/mobile-attach-qr.sh
+++ b/scripts/mobile-attach-qr.sh
@@ -81,9 +81,13 @@ CMUX_TAG="$TAG" "$REPO_ROOT/scripts/cmux-debug-cli.sh" rpc mobile.attach_ticket.
 chmod 600 "$RAW_JSON_TMP"
 mv "$RAW_JSON_TMP" "$RAW_JSON"
 
-REPO_ROOT="$REPO_ROOT" RAW_JSON="$RAW_JSON" HTML_PATH="$HTML_PATH" ROUTE_ID="$ROUTE_ID" ROUTE_KIND="$ROUTE_KIND" node <<'NODE'
-const fs = require("fs");
-const path = require("path");
+REPO_ROOT="$REPO_ROOT" RAW_JSON="$RAW_JSON" HTML_PATH="$HTML_PATH" ROUTE_ID="$ROUTE_ID" ROUTE_KIND="$ROUTE_KIND" node --input-type=module <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
 
 const repoRoot = process.env.REPO_ROOT;
 const rawPath = process.env.RAW_JSON;
@@ -97,26 +101,15 @@ main().catch((error) => {
 });
 
 async function main() {
-const payload = JSON.parse(fs.readFileSync(rawPath, "utf8"));
-if (!payload.ticket || !Array.isArray(payload.ticket.routes)) {
-  throw new Error("mobile.attach_ticket.create did not return a ticket with routes");
-}
+const { buildAttachURL } = await import(
+  pathToFileURL(path.join(repoRoot, "scripts", "lib", "attach-url.mjs")).href
+);
 
-let routes = payload.ticket.routes;
-if (routeID) {
-  routes = routes.filter((route) => route.id === routeID);
-}
-if (routeKind) {
-  routes = routes.filter((route) => route.kind === routeKind);
-}
-if (routes.length === 0) {
-  throw new Error(`No matching route for route_id=${routeID || "(none)"} route_kind=${routeKind || "(none)"}`);
-}
-
-payload.ticket.routes = routes;
-payload.routes = routes;
-const encodedPayload = Buffer.from(JSON.stringify(payload.ticket)).toString("base64url");
-payload.attach_url = `cmux-ios://attach?v=${payload.ticket.version || 1}&payload=${encodedPayload}`;
+const rawPayload = JSON.parse(fs.readFileSync(rawPath, "utf8"));
+// Shared encode recipe: filter routes, base64url-encode the ticket, build the
+// cmux-ios://attach URL. Same module dev-setup.sh uses for headless minting.
+const { attachURL, routes, payload } = buildAttachURL(rawPayload, { routeID, routeKind });
+payload.attach_url = attachURL;
 
 let qrSVG = "";
 try {

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -1,25 +1,28 @@
 #!/usr/bin/env bash
 # Launch a tagged cmux iOS DEV build fully signed in (and optionally paired to a
-# running Mac), with NO human OAuth, so an agent can autonomously reproduce and
-# dogfood on the simulator or a device.
+# running Mac), with NO human OAuth, so a dev or agent can autonomously dogfood
+# on the simulator or a device.
 #
 # It reuses the app's existing DEBUG launch hooks:
 #   CMUX_UITEST_STACK_EMAIL / CMUX_UITEST_STACK_PASSWORD  -> real Stack sign-in
 #   CMUX_UITEST_MOCK_DATA=0                               -> real backend, not mock
-#   CMUX_UITEST_ATTACH_URL=<cmux-ios://attach...>         -> auto-pair after sign-in
+#   CMUX_DOGFOOD_ATTACH_URL=<cmux-ios://attach...>        -> auto-pair after sign-in
 # (sim env via SIMCTL_CHILD_*, device env via DEVICECTL_CHILD_*).
 #
-# Credentials come from the environment or ~/.secrets/cmux.env (preferred) /
-# ~/.secrets/cmuxterm-dev.env. Use a DEDICATED dev/agent Stack account, never a
-# real user's primary login.
+# Credentials are loaded by scripts/lib/dev-secrets.sh: the personal dogfood
+# account (~/.secrets/cmuxterm-dev.env) wins by default; --agent forces the
+# shared agent account (~/.secrets/cmux.env).
 #
 # Usage:
 #   scripts/mobile-dev-launch.sh --tag grid [--simulator "iPhone 17"] [--attach]
 #   scripts/mobile-dev-launch.sh --tag grid --device [--device-id <id>] [--attach]
+#   scripts/mobile-dev-launch.sh --tag grid --agent  [--attach]
 #
-#   --attach   also pair to the running Mac by minting a fresh attach ticket from
-#              the mobile-attach QR server (default :17321). Requires that server
-#              + the tagged Mac app to be running.
+#   --attach   also pair to the running Mac. Uses CMUX_DOGFOOD_ATTACH_URL when it
+#              is already set (as dev-setup.sh passes it), else mints a fresh
+#              ticket from the mobile-attach QR server (default :17321). Requires
+#              that server + the tagged Mac app to be running.
+#   --agent    sign in with the shared agent account instead of the dogfood one.
 
 set -euo pipefail
 
@@ -28,6 +31,7 @@ TARGET="simulator"          # simulator | device
 SIMULATOR_NAME="iPhone 17"
 DEVICE_ID=""
 ATTACH=0
+AGENT=0
 QR_PORT="${CMUX_QR_PORT:-17321}"
 
 usage() { sed -n '2,30p' "$0"; }
@@ -39,6 +43,7 @@ while [[ $# -gt 0 ]]; do
     --device) TARGET="device"; shift ;;
     --device-id) DEVICE_ID="${2:-}"; shift 2 ;;
     --attach) ATTACH=1; shift ;;
+    --agent) AGENT=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown arg $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -47,33 +52,15 @@ done
 [[ -n "$TAG" ]] || { echo "error: --tag is required" >&2; usage >&2; exit 2; }
 
 # --- credentials ------------------------------------------------------------
-load_secret_file() {
-  local f="$1"
-  [[ -f "$f" ]] || return 0
-  # Only pull the two keys we need; don't blanket-source arbitrary secrets.
-  while IFS= read -r line; do
-    case "$line" in
-      CMUX_UITEST_STACK_EMAIL=*) : "${CMUX_UITEST_STACK_EMAIL:=${line#*=}}" ;;
-      CMUX_UITEST_STACK_PASSWORD=*) : "${CMUX_UITEST_STACK_PASSWORD:=${line#*=}}" ;;
-    esac
-  done < "$f"
-}
-load_secret_file "$HOME/.secrets/cmux.env"
-load_secret_file "$HOME/.secrets/cmuxterm-dev.env"
-
-if [[ -z "${CMUX_UITEST_STACK_EMAIL:-}" || -z "${CMUX_UITEST_STACK_PASSWORD:-}" ]]; then
-  cat >&2 <<EOF
-error: no dev sign-in credentials found.
-
-Set a DEDICATED dev/agent Stack account (not your primary login) in
-~/.secrets/cmux.env:
-
-  CMUX_UITEST_STACK_EMAIL=agent-dev@manaflow.ai
-  CMUX_UITEST_STACK_PASSWORD=<password>
-
-(or export them in the environment before running this script).
-EOF
-  exit 2
+# Dogfood account wins over the agent account so iOS dev builds sign in as the
+# human dogfooder by default. Pass --agent for agent-driven flows.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/dev-secrets.sh
+source "$SCRIPT_DIR/lib/dev-secrets.sh"
+if [[ "$AGENT" -eq 1 ]]; then
+  cmux_dev_secrets_load --agent || exit $?
+else
+  cmux_dev_secrets_load || exit $?
 fi
 
 # --- bundle id (matches ios/scripts/reload.sh sanitize_tag) ------------------
@@ -81,9 +68,13 @@ slug="$(echo "$TAG" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^
 [[ -n "$slug" ]] || slug="dev"
 BUNDLE_ID="dev.cmux.ios.$slug"
 
-# --- optional fresh attach ticket -------------------------------------------
-ATTACH_URL=""
-if [[ "$ATTACH" -eq 1 ]]; then
+# --- attach ticket ----------------------------------------------------------
+# Prefer a pre-minted CMUX_DOGFOOD_ATTACH_URL (dev-setup.sh sets it directly,
+# so no QR server is needed). With --attach and no pre-set URL, mint a fresh one
+# from the mobile-attach QR server. Inject it as CMUX_DOGFOOD_ATTACH_URL, the
+# NOT-mock-gated env var the app reads with the real backend (CMUX_UITEST_MOCK_DATA=0).
+ATTACH_URL="${CMUX_DOGFOOD_ATTACH_URL:-}"
+if [[ -z "$ATTACH_URL" && "$ATTACH" -eq 1 ]]; then
   ATTACH_URL="$(curl -fsS -m 8 "http://127.0.0.1:${QR_PORT}/ticket.json" 2>/dev/null \
     | python3 -c 'import sys,json; print(json.load(sys.stdin).get("attach_url",""))' 2>/dev/null || true)"
   if [[ -z "$ATTACH_URL" ]]; then
@@ -91,6 +82,7 @@ if [[ "$ATTACH" -eq 1 ]]; then
   fi
 fi
 
+# Never print the attach URL (bearer credential); just whether auto-pair is on.
 echo "==> launching $BUNDLE_ID on $TARGET (signed in as $CMUX_UITEST_STACK_EMAIL${ATTACH_URL:+, auto-pairing})"
 
 if [[ "$TARGET" == "simulator" ]]; then
@@ -103,7 +95,7 @@ if [[ "$TARGET" == "simulator" ]]; then
   SIMCTL_CHILD_CMUX_UITEST_STACK_EMAIL="$CMUX_UITEST_STACK_EMAIL" \
   SIMCTL_CHILD_CMUX_UITEST_STACK_PASSWORD="$CMUX_UITEST_STACK_PASSWORD" \
   SIMCTL_CHILD_CMUX_UITEST_MOCK_DATA="0" \
-  SIMCTL_CHILD_CMUX_UITEST_ATTACH_URL="$ATTACH_URL" \
+  SIMCTL_CHILD_CMUX_DOGFOOD_ATTACH_URL="$ATTACH_URL" \
     xcrun simctl launch --console-pty "$SIM_UDID" "$BUNDLE_ID"
 else
   if [[ -z "$DEVICE_ID" ]]; then
@@ -111,17 +103,18 @@ else
       | awk '/iPhone/ && !/unavailable/ {for(i=1;i<=NF;i++) if($i ~ /^[0-9A-Fa-f-]{36}$/){print $i; exit}}')"
   fi
   [[ -n "$DEVICE_ID" ]] || { echo "error: no connected iPhone found (pass --device-id)" >&2; exit 1; }
-  ENV_JSON="$(CMUX_UITEST_STACK_EMAIL="$CMUX_UITEST_STACK_EMAIL" \
-              CMUX_UITEST_STACK_PASSWORD="$CMUX_UITEST_STACK_PASSWORD" \
-              ATTACH_URL="$ATTACH_URL" python3 -c '
-import json, os
-env = {
-  "CMUX_UITEST_STACK_EMAIL": os.environ["CMUX_UITEST_STACK_EMAIL"],
-  "CMUX_UITEST_STACK_PASSWORD": os.environ["CMUX_UITEST_STACK_PASSWORD"],
-  "CMUX_UITEST_MOCK_DATA": "0",
-}
-if os.environ.get("ATTACH_URL"): env["CMUX_UITEST_ATTACH_URL"] = os.environ["ATTACH_URL"]
-print(json.dumps(env))')"
-  xcrun devicectl device process launch --terminate-existing \
-    --device "$DEVICE_ID" --environment-variables "$ENV_JSON" "$BUNDLE_ID"
+  # Pass the password + attach URL via the DEVICECTL_CHILD_ prefix (calling-env
+  # injection), NOT --environment-variables, which would expose these bearer
+  # credentials in argv. devicectl strips DEVICECTL_CHILD_<NAME> from its own
+  # environment and forwards it to the app as <NAME>, mirroring the simulator's
+  # SIMCTL_CHILD_ path. This is documented in `devicectl device process launch
+  # --help` (518.31): "set them in the calling environment with a DEVICECTL_CHILD_
+  # prefix", and the -e note "Using the environment-variables flag will override
+  # the caller environment variables prefixed with DEVICECTL_CHILD_".
+  DEVICECTL_CHILD_CMUX_UITEST_STACK_EMAIL="$CMUX_UITEST_STACK_EMAIL" \
+  DEVICECTL_CHILD_CMUX_UITEST_STACK_PASSWORD="$CMUX_UITEST_STACK_PASSWORD" \
+  DEVICECTL_CHILD_CMUX_UITEST_MOCK_DATA="0" \
+  DEVICECTL_CHILD_CMUX_DOGFOOD_ATTACH_URL="$ATTACH_URL" \
+    xcrun devicectl device process launch --terminate-existing \
+      --device "$DEVICE_ID" "$BUNDLE_ID"
 fi


### PR DESCRIPTION
Builds on P1 (macOS DEBUG auto-sign-in, https://github.com/manaflow-ai/cmux/pull/5582, now merged). P2 makes the phone auto-attach to the dev Mac with no QR scan and adds one unified `dev-setup` entrypoint.

## The Swift fix (why real-backend auto-pair was broken)

The iOS auto-pair path (`connectUITestAttachURLIfNeeded` in `CMUXMobileRootView.swift`) read `UITestConfig.attachURL`, which routes through `UITestConfig.value(for:)`. That accessor early-returns `nil` unless `mockDataEnabled`. The dev launcher sets `CMUX_UITEST_MOCK_DATA=0` (real backend), so `attachURL` was always `nil` and auto-pair never fired, despite the code comment intending it to.

Fix: a dedicated, NOT-mock-gated `UITestConfig.dogfoodAttachURL` accessor reading `CMUX_DOGFOOD_ATTACH_URL` directly, consumed as `UITestConfig.dogfoodAttachURL ?? UITestConfig.attachURL`. The mock-gated `CMUX_UITEST_ATTACH_URL` path stays intact for XCUITests. All `#if DEBUG`; `nil` in release.

Landed as a red/green two-commit pair: commit 1 wires the accessor through the mock gate (tests fail with mock off, proving the bug), commit 2 un-gates it (green).

## dev-setup.sh

```
scripts/dev-setup.sh --tag grid                # macOS + iOS, phone auto-pairs
scripts/dev-setup.sh --tag grid --surface mac  # macOS only
```

It loads dev creds (dogfood account preferred), enables the opt-in iOS pairing host on the tagged build BEFORE the macOS launch (so a single build binds the listener), headlessly mints a short-TTL attach URL against the tagged socket via the local automation path (no Stack auth needed for the mint), and launches the iOS dev build passing the URL as `CMUX_DOGFOOD_ATTACH_URL`. Flags: `--surface mac|ios|both`, `--no-pair`, `--agent`, `--profile` (P3 hook, currently a warn).

## Supporting changes

- `scripts/lib/dev-secrets.sh` (new): sourceable cred loader whose precedence mirrors `DebugDogfoodCredentialResolver` exactly (steps 1-6), resolves email+password as a complete same-account pair (never mixes accounts), strips one layer of surrounding quotes like the Swift parser, never echoes the password.
- `scripts/lib/attach-url.mjs` (+ `node --test`, 9 cases): single source of truth for the route-filter + base64url + `cmux-ios://attach` encode recipe, factored out of `mobile-attach-qr.sh` (which now imports it).
- `scripts/mobile-dev-launch.sh`: defaults to the dogfood account (was the agent account); `--agent` opt-out; injects the NOT-mock-gated `CMUX_DOGFOOD_ATTACH_URL` (was the mock-gated var, nil with the real backend); device path uses `DEVICECTL_CHILD_*` env (no argv exposure of the bearer credential).

## Safety

Everything DEBUG-gated. Every debug-CLI call and `defaults write` targets the TAGGED socket/bundle id, never the stable app. dev-setup.sh validates creds in a subshell and never exports `CMUX_UITEST_STACK_PASSWORD` into its own env (the macOS app reads creds from disk, and reload.sh launches the long-lived GUI process inheriting that env). Attach ticket is short-TTL and never printed.

## One-time macOS Local Network TCC

The first time the pairing host binds its `NWListener` per bundle id, macOS shows a one-time "Local Network" permission prompt. Click Allow. After that the phone can connect on that tag.

## Verification

- iOS sim build clean (`xcodebuild -scheme cmux-ios ... build`).
- `swift test --package-path Packages/CmuxMobileSupport`: 16 pass (incl. 6 new dogfood-attach cases).
- `node --test scripts/lib/attach-url.test.mjs`: 9 pass.
- Shellcheck clean on all new/changed scripts.
- dev-secrets precedence + quote-strip + same-account pairing + password non-leak verified with synthetic secret dirs.
- The headless mint chain (enable host -> bind listener -> `mobile.attach_ticket.create` -> encode) is verified piecewise; the full mac->mint->phone round-trip needs a live Mac (and the one-time TCC Allow). The `--device` path is verified against `devicectl ... --help` (518.31) docs; live-device dogfood is inherently a live step.
- No macOS `xcodebuild` was needed: both Swift changes are additive/non-signature (new `dogfoodAttachURL` accessor; a `??` swap in an iOS-only view), so they cannot break a macOS target.

Localization audit: N/A (scripts + a DEBUG env accessor, zero user-facing app strings).

## Autoreview note (dismissed false positive)

A late autoreview round flagged `DEVICECTL_CHILD_` as "an unsupported simctl-only convention". This is refuted by `devicectl device process launch --help` (518.31): it documents "set them in the calling environment with a DEVICECTL_CHILD_ prefix", and the `-e` note states "Using the environment-variables flag will override the caller environment variables prefixed with DEVICECTL_CHILD_". The suggested alternative (`--environment-variables`) would reintroduce the argv bearer-token leak an earlier round correctly flagged; `DEVICECTL_CHILD_` is the only non-argv injection devicectl offers, so this is the right fix.

## Remaining

P3 (`--profile` env presets via the debug CLI) is the remaining piece; `--profile` is wired as a no-op hook here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783464017&installation_id=133855650&pr_number=5584&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5584&signature=5a5d3c98a2ee6ed60ea8502cc3441b43e58aac0464415c5dcb60823df16d8d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are DEBUG-only for Swift attach env handling and dev scripts targeting tagged bundle IDs; release builds and production auth paths are unchanged, with explicit care around not logging or argv-leaking bearer attach URLs and Stack passwords.
> 
> **Overview**
> Fixes **real-backend iOS auto-pair** by reading `CMUX_DOGFOOD_ATTACH_URL` through a new DEBUG-only `UITestConfig.dogfoodAttachURL` that bypasses the mock-data gate, while `connectUITestAttachURLIfNeeded` prefers that URL over the existing mock-gated `CMUX_UITEST_ATTACH_URL` for XCUITests. Unit tests cover the mock-off behavior.
> 
> Adds **`scripts/dev-setup.sh`** as a turnkey flow: validate creds without leaking passwords into the Mac GUI env, enable the tagged bundle’s iOS pairing host, build/launch tagged macOS + iOS dev apps, headlessly mint a short-TTL attach ticket via the debug socket, and pass the URL into `mobile-dev-launch.sh`.
> 
> Supporting script work: shared **`dev-secrets.sh`** (credential precedence aligned with `DebugDogfoodCredentialResolver`), **`attach-url.mjs`** (+ tests) as the single attach-URL encoder (also used by `mobile-attach-qr.sh`), and **`mobile-dev-launch.sh`** updates for dogfood-first sign-in, `--agent`, `CMUX_DOGFOOD_ATTACH_URL` injection, and `DEVICECTL_CHILD_*` on device to avoid argv exposure of secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a174abfa2f5f6e1dc6cb9e28e548704c13a80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds turnkey dev setup to auto-sign in on macOS and auto-pair the iOS dev app to the tagged Mac build without QR scans. Fixes a gating bug so auto-pair works against the real backend.

- **New Features**
  - Added scripts/dev-setup.sh to build/launch macOS and iOS for a tag, enable the pairing host, mint a short‑TTL attach URL, and auto-pair the phone; supports --surface mac|ios|both, --no-pair, --agent.
  - Added scripts/lib/dev-secrets.sh to load dev credentials with the same precedence as the Mac resolver (dogfood preferred, agent opt-in); never prints the password and keeps same-account pairs.
  - Added scripts/lib/attach-url.mjs (+ node --test) as the single encoder for cmux-ios://attach; mobile-attach-qr.sh now imports it.
  - Updated scripts/mobile-dev-launch.sh to default to the dogfood account, add --agent, pass CMUX_DOGFOOD_ATTACH_URL, and use DEVICECTL_CHILD_* for device env injection.

- **Bug Fixes**
  - iOS auto-pair now works with the real backend by reading a new, not-mock-gated UITestConfig.dogfoodAttachURL (CMUX_DOGFOOD_ATTACH_URL), falling back to the existing mock-gated attachURL for tests; unit tests added.

<sup>Written for commit 45a174abfa2f5f6e1dc6cb9e28e548704c13a80d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated development workflow for launching macOS and iOS dev apps with optional auto-pairing support

* **Chores**
  * Enhanced credential handling and attach URL generation for development environments
  * Refactored environment variable management for dev-app pairing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->