### PR TITLE
Turnkey dev builds P3: /dev-cli environment profiles (composer/notif/browser/groups/...)

### DIFF
--- a/scripts/dev-profiles/README.md
+++ b/scripts/dev-profiles/README.md
@@ -1,0 +1,110 @@
+# dev-profiles
+
+Data-driven environment presets for the turnkey dev-build flow (P3). A profile
+provisions a realistic test environment in a **tagged** dev cmux instance so a
+given feature has live state to test against, picked by what you're testing.
+
+Profiles are replayed by `scripts/dev-setup.sh --profile <name>` after the app
+is built, launched, and paired. Every step runs through
+`scripts/cmux-debug-cli.sh`, which refuses without `CMUX_TAG` and targets
+`/tmp/cmux-debug-<slug>.sock` only, never the user's stable app. Profiles are
+dev-only tooling and must contain no secrets.
+
+## Usage
+
+```bash
+# Build + launch + pair, then seed a live agent for composer testing:
+scripts/dev-setup.sh --tag grid --profile composer
+
+# Compose several presets (applied in order):
+scripts/dev-setup.sh --tag grid --profile composer,browser
+
+# List the available profiles:
+scripts/dev-profiles/replay-cli.mjs --list
+
+# Dry-run: print the resolved `cmux` arg vectors without touching a socket:
+scripts/dev-profiles/replay-cli.mjs --dry-run --cwd "$PWD" --profile groups
+
+# Apply directly to an already-running tagged build (no rebuild):
+scripts/dev-profiles/replay-cli.mjs --tag grid --profile notif --cwd "$PWD"
+```
+
+An unknown profile name fails fast (before any build) and lists the available
+profiles.
+
+## Adding a profile = adding a file
+
+Drop a `<name>.json` file in this directory. No code change is needed; the name
+becomes available automatically. Format:
+
+```json
+{
+  "description": "Human summary of what this preset provisions.",
+  "steps": [
+    {
+      "args": ["workspace", "create", "--name", "Composer",
+               "--cwd", "${cwd}", "--command", "claude", "--json"],
+      "capture": { "ws": "workspace_id" }
+    },
+    {
+      "args": ["send", "--workspace", "${ws}", "echo hi\\n"]
+    }
+  ]
+}
+```
+
+- **`steps`** (required): an ordered list. Each step is one `cmux` invocation.
+- **`args`** (required): the exact `cmux` argument vector for the step, with the
+  leading `cmux` omitted. These are passed verbatim to `cmux-debug-cli.sh`.
+- **`${name}`** placeholders are substituted from earlier `capture`s plus the
+  built-in `${cwd}` (the directory dev-setup ran in, i.e. the repo worktree).
+- **`capture`** (optional): maps a local variable name to a dotted JSON path
+  read out of that step's stdout. The step must pass `--json`. Later steps
+  reference the value as `${name}`. Use this to chain "create a thing, then act
+  on the thing" (e.g. capture `workspace_id`, then `send` to it). Captured
+  values are cmux refs/ids, never secrets.
+
+Only use `cmux` verbs that actually exist (see
+`skills/cmux-workspace/references/commands.md` and the `cmux-groups` skill).
+Prefer the canonical noun forms (`cmux workspace create`,
+`cmux workspace group create`) which honor `--json`. Use `--focus false` on
+creation steps so replay does not yank the dev window around.
+
+To get a stable id across windows, capture from a `--id-format uuids` step
+(`group.id` is a UUID then; the default `ref` form is positional, e.g.
+`workspace_group:1`).
+
+## Shipped profiles
+
+| Profile | What it provisions |
+| --- | --- |
+| `composer` | A workspace at the repo cwd with a live `claude` agent in its first surface, so composer / dictation / paste flows have something to type into. |
+| `notif` | A dedicated workspace with a notification posted to it and an attention flash triggered, for testing notification mirror / dismiss-sync. |
+| `browser` | A workspace with a browser pane open to `https://example.com` (always reachable, no local server needed). |
+| `groups` | A named sidebar group (anchor) with two extra member workspaces, for testing workspace groups and groups-on-mobile. |
+| `multi-mac` | **Partial.** Seeds the *current* Mac with two clearly-named workspaces. The host switcher lists Macs the phone has actually paired with (iOS-side state) and no socket verb can fabricate a second Mac, so seeding the *switch itself* requires pairing a second real Mac. See note below. |
+
+### multi-mac gap
+
+The multi-Mac host switcher renders the set of Macs a phone has paired with,
+which lives in iOS-side `MobilePairedMacStore` state, not in any Mac socket.
+There is no debug-CLI verb to inject a fake paired Mac, so this profile can only
+seed the local Mac with realistic content. To exercise the actual switch, run
+`scripts/dev-setup.sh --tag <other>` on a second physical Mac and pair the phone
+to both.
+
+## How it works
+
+- `replay.mjs` — the engine. `resolveSteps(profile, context)` is a pure,
+  I/O-free function (parse + substitute + JSON-path capture) that the unit test
+  and `--dry-run` both use. `ProfileReplayer` wraps it with execution: it shells
+  out to `cmux-debug-cli.sh` with `CMUX_TAG` set, so the tagged-socket safety
+  contract is enforced by the helper, not re-implemented.
+- `replay-cli.mjs` — the thin CLI `dev-setup.sh` calls (`--list`, `--dry-run`,
+  `--tag`, comma-list `--profile`).
+- `replay.test.mjs` — `node --test` coverage of the construction half (no live
+  socket required).
+
+```bash
+node --test scripts/dev-profiles/replay.test.mjs
+```

--- a/scripts/dev-profiles/README.md
+++ b/scripts/dev-profiles/README.md
@@ -42,7 +42,7 @@ becomes available automatically. Format:
   "description": "Human summary of what this preset provisions.",
   "steps": [
     {
-      "args": ["workspace", "create", "--name", "Composer",
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "Composer",
                "--cwd", "${cwd}", "--command", "claude", "--json"],
       "capture": { "ws": "workspace_id" }
     },
@@ -70,9 +70,13 @@ Prefer the canonical noun forms (`cmux workspace create`,
 `cmux workspace group create`) which honor `--json`. Use `--focus false` on
 creation steps so replay does not yank the dev window around.
 
-To get a stable id across windows, capture from a `--id-format uuids` step
-(`group.id` is a UUID then; the default `ref` form is positional, e.g.
-`workspace_group:1`).
+The capture key name depends on the id format, because cmux renames id fields
+in `--json` output: with the default `refs` format a created workspace prints
+`workspace_ref` (a positional `workspace:N`), but with `--id-format uuids` it
+prints `workspace_id` (a stable UUID). The shipped profiles prepend
+`--id-format uuids` to creation steps and capture `workspace_id` / `group.id`
+so the captured value is a UUID that stays valid regardless of window numbering.
+Captured UUIDs are accepted anywhere a `--workspace` / group id is expected.
 
 ## Shipped profiles
 

--- a/scripts/dev-profiles/browser.json
+++ b/scripts/dev-profiles/browser.json
@@ -1,0 +1,12 @@
+{
+  "description": "A workspace with a browser pane open to example.com (a stable, always-reachable page), so the in-app browser surface can be exercised without a local dev server. --id-format uuids makes the captured workspace_id a stable UUID.",
+  "steps": [
+    {
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "Browser", "--cwd", "${cwd}", "--json"],
+      "capture": { "ws": "workspace_id" }
+    },
+    {
+      "args": ["new-pane", "--workspace", "${ws}", "--type", "browser", "--direction", "right", "--url", "https://example.com", "--focus", "false"]
+    }
+  ]
+}

--- a/scripts/dev-profiles/composer.json
+++ b/scripts/dev-profiles/composer.json
@@ -1,0 +1,9 @@
+{
+  "description": "A workspace at the repo cwd with a live Claude agent in its first surface, so composer/dictation/paste flows have something to type into. --id-format uuids makes the captured workspace_id a stable UUID.",
+  "steps": [
+    {
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "Composer", "--cwd", "${cwd}", "--command", "claude", "--json"],
+      "capture": { "ws": "workspace_id" }
+    }
+  ]
+}

--- a/scripts/dev-profiles/groups.json
+++ b/scripts/dev-profiles/groups.json
@@ -1,0 +1,15 @@
+{
+  "description": "A named sidebar group (anchor) with two extra member workspaces created inside it, so workspace groups (and groups-on-mobile) have real grouped state to render. Uses --id-format uuids so the captured group id is stable regardless of window numbering.",
+  "steps": [
+    {
+      "args": ["--id-format", "uuids", "workspace", "group", "create", "--name", "Dev Group", "--cwd", "${cwd}", "--json"],
+      "capture": { "group": "group.id" }
+    },
+    {
+      "args": ["--id-format", "uuids", "workspace", "group", "new-workspace", "${group}", "--json"]
+    },
+    {
+      "args": ["--id-format", "uuids", "workspace", "group", "new-workspace", "${group}", "--json"]
+    }
+  ]
+}

--- a/scripts/dev-profiles/multi-mac.json
+++ b/scripts/dev-profiles/multi-mac.json
@@ -1,0 +1,13 @@
+{
+  "description": "Partial seed for the multi-Mac host switcher. The switcher lists Macs the phone has actually paired with (iOS-side MobilePairedMacStore state), which no socket verb can fabricate, so a second Mac cannot be seeded from here. This profile seeds the CURRENT Mac with a couple of clearly-named workspaces so it shows realistic content when selected in the switcher; pair a second real Mac (run dev-setup.sh --tag <other> on another machine and pair the phone to both) to exercise the switch itself. See README.md.",
+  "steps": [
+    {
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "This Mac - A", "--cwd", "${cwd}", "--json"],
+      "capture": { "wsA": "workspace_id" }
+    },
+    {
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "This Mac - B", "--cwd", "${cwd}", "--json"],
+      "capture": { "wsB": "workspace_id" }
+    }
+  ]
+}

--- a/scripts/dev-profiles/notif.json
+++ b/scripts/dev-profiles/notif.json
@@ -1,0 +1,15 @@
+{
+  "description": "A dedicated workspace with a notification already posted to it and an attention flash triggered, so notification mirror/dismiss-sync (Mac <-> phone) has real state to exercise. --id-format uuids makes the captured workspace_id a stable UUID.",
+  "steps": [
+    {
+      "args": ["--id-format", "uuids", "workspace", "create", "--name", "Notif", "--cwd", "${cwd}", "--json"],
+      "capture": { "ws": "workspace_id" }
+    },
+    {
+      "args": ["notify", "--workspace", "${ws}", "--title", "Dev notification", "--body", "Seeded by the notif dev profile"]
+    },
+    {
+      "args": ["trigger-flash", "--workspace", "${ws}"]
+    }
+  ]
+}

--- a/scripts/dev-profiles/replay-cli.mjs
+++ b/scripts/dev-profiles/replay-cli.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// CLI wrapper around the dev-profile replay engine.
+//
+// Usage:
+//   replay-cli.mjs --tag <tag> --profile <name[,name2,...]> [--cwd <dir>] [--dry-run]
+//   replay-cli.mjs --list
+//
+// `dev-setup.sh --profile <name>` calls this after the app is built/launched/
+// paired. Everything routes through `scripts/cmux-debug-cli.sh` (sibling
+// `../cmux-debug-cli.sh`), which targets the TAGGED socket only.
+//
+// --dry-run prints the resolved `cmux` argument vectors for each profile
+// without touching a socket. It is the same construction path the unit test
+// exercises, so a green dry run proves the parsing + substitution plumbing.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  listProfiles,
+  loadProfile,
+  ProfileReplayer,
+  resolveSteps,
+} from "./replay.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEBUG_CLI = path.join(SCRIPT_DIR, "..", "cmux-debug-cli.sh");
+
+function parseArgs(argv) {
+  const opts = { tag: "", profiles: [], cwd: process.cwd(), dryRun: false, list: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    switch (a) {
+      case "--tag":
+        opts.tag = argv[(i += 1)] ?? "";
+        break;
+      case "--profile":
+        opts.profiles.push(
+          ...(argv[(i += 1)] ?? "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+        );
+        break;
+      case "--cwd":
+        opts.cwd = argv[(i += 1)] ?? process.cwd();
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--list":
+        opts.list = true;
+        break;
+      default:
+        throw new Error(`unknown arg: ${a}`);
+    }
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.list) {
+    for (const name of listProfiles(SCRIPT_DIR)) {
+      process.stdout.write(`${name}\n`);
+    }
+    return;
+  }
+
+  if (opts.profiles.length === 0) {
+    throw new Error("at least one --profile <name> is required");
+  }
+  // Validate every requested profile up front so an unknown name fails before
+  // any side effects, listing the available profiles.
+  const profiles = opts.profiles.map((name) => ({
+    name,
+    profile: loadProfile(SCRIPT_DIR, name),
+  }));
+
+  const context = { cwd: opts.cwd };
+
+  if (opts.dryRun) {
+    for (const { name, profile } of profiles) {
+      process.stdout.write(`# profile: ${name}\n`);
+      for (const { argv } of resolveSteps(profile, context)) {
+        process.stdout.write(`cmux ${argv.join(" ")}\n`);
+      }
+    }
+    return;
+  }
+
+  if (!opts.tag) {
+    throw new Error("--tag is required to replay a profile (omit for --dry-run)");
+  }
+
+  for (const { name, profile } of profiles) {
+    process.stderr.write(`==> applying profile "${name}" against tag "${opts.tag}"\n`);
+    const replayer = new ProfileReplayer({
+      tag: opts.tag,
+      cliPath: DEBUG_CLI,
+      context,
+      log: (m) => process.stderr.write(`${m}\n`),
+    });
+    replayer.run(profile);
+  }
+  process.stderr.write(`==> profiles applied: ${opts.profiles.join(", ")}\n`);
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`dev-profile replay error: ${err.message}\n`);
+  process.exit(1);
+}

--- a/scripts/dev-profiles/replay.mjs
+++ b/scripts/dev-profiles/replay.mjs
@@ -1,0 +1,286 @@
+// Replay engine for cmux dev environment profiles (P3 of turnkey dev builds).
+//
+// A profile is a JSON file under scripts/dev-profiles/<name>.json: an ordered
+// list of debug-CLI steps that provision a realistic test environment against a
+// TAGGED dev cmux instance. Every step is replayed through
+// `scripts/cmux-debug-cli.sh`, which refuses without `CMUX_TAG` and targets
+// `/tmp/cmux-debug-<slug>.sock` (never the user's stable app).
+//
+// Profile format (one file per profile, JSON):
+//
+//   {
+//     "description": "human summary (optional)",
+//     "steps": [
+//       { "args": ["workspace", "create", "--name", "Composer",
+//                  "--cwd", "${cwd}", "--command", "claude", "--json"],
+//         "capture": { "ws": "workspace_id" } },
+//       { "args": ["send", "--workspace", "${ws}", "echo hi\\n"] }
+//     ]
+//   }
+//
+// - `args` is the exact `cmux` argument vector for that step (no leading `cmux`).
+// - `${name}` placeholders are substituted from earlier captures and the small
+//   built-in variable set (currently `${cwd}` = the directory dev-setup ran in,
+//   overridable via the `cwd` context value).
+// - `capture` maps a local variable name -> a dotted JSON path read from that
+//   step's stdout (the step must pass `--json`). Later steps reference it as
+//   `${name}`. Captured values are cmux refs/ids, never secrets.
+//
+// The construction half (`resolveSteps`) is a pure function of (profile, context)
+// with no I/O, so it is unit-testable without a live socket
+// (`node --test scripts/dev-profiles/replay.test.mjs`). `ProfileReplayer`
+// wraps it with execution against the tagged CLI.
+//
+// Adding a profile = adding a JSON file. See scripts/dev-profiles/README.md.
+
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const PLACEHOLDER_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+/**
+ * Substitute `${name}` placeholders in a single argument string.
+ *
+ * @param {string} arg A raw argument from a step's `args` vector.
+ * @param {Record<string, string>} vars Known variable name -> value.
+ * @returns {string} The argument with every placeholder replaced.
+ * @throws {Error} When a referenced variable is undefined.
+ */
+export function substituteArg(arg, vars) {
+  return arg.replace(PLACEHOLDER_RE, (_match, name) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, name)) {
+      throw new Error(
+        `profile step references undefined variable \${${name}} ` +
+          `(known: ${Object.keys(vars).join(", ") || "none"})`,
+      );
+    }
+    return vars[name];
+  });
+}
+
+/**
+ * Read a dotted path (e.g. `group.id`) out of a parsed JSON object.
+ *
+ * @param {unknown} obj The parsed JSON value.
+ * @param {string} dottedPath A `.`-separated path.
+ * @returns {unknown} The value at that path, or `undefined` if any hop misses.
+ */
+export function readJSONPath(obj, dottedPath) {
+  return dottedPath.split(".").reduce((acc, key) => {
+    if (acc && typeof acc === "object" && key in acc) {
+      return acc[key];
+    }
+    return undefined;
+  }, obj);
+}
+
+/**
+ * Validate a profile object's shape, returning its normalized steps.
+ *
+ * @param {unknown} profile A parsed profile JSON value.
+ * @param {string} [label] A name used in error messages.
+ * @returns {Array<{args: string[], capture?: Record<string, string>}>}
+ * @throws {Error} When the profile is malformed.
+ */
+export function validateProfile(profile, label = "profile") {
+  if (!profile || typeof profile !== "object" || Array.isArray(profile)) {
+    throw new Error(`${label}: expected a JSON object`);
+  }
+  const steps = profile.steps;
+  if (!Array.isArray(steps) || steps.length === 0) {
+    throw new Error(`${label}: "steps" must be a non-empty array`);
+  }
+  steps.forEach((step, i) => {
+    if (!step || typeof step !== "object" || Array.isArray(step)) {
+      throw new Error(`${label}: step ${i} must be an object`);
+    }
+    if (!Array.isArray(step.args) || step.args.length === 0) {
+      throw new Error(`${label}: step ${i} needs a non-empty "args" array`);
+    }
+    if (!step.args.every((a) => typeof a === "string")) {
+      throw new Error(`${label}: step ${i} "args" must be all strings`);
+    }
+    if (step.capture !== undefined) {
+      if (
+        !step.capture ||
+        typeof step.capture !== "object" ||
+        Array.isArray(step.capture)
+      ) {
+        throw new Error(`${label}: step ${i} "capture" must be an object`);
+      }
+      for (const [k, v] of Object.entries(step.capture)) {
+        if (typeof v !== "string") {
+          throw new Error(
+            `${label}: step ${i} capture "${k}" must map to a string JSON path`,
+          );
+        }
+      }
+      if (!step.args.includes("--json")) {
+        throw new Error(
+          `${label}: step ${i} declares "capture" but its args omit "--json"; ` +
+            `capture reads the step's JSON stdout`,
+        );
+      }
+    }
+  });
+  return steps;
+}
+
+/**
+ * Resolve a profile into the concrete `cmux` argument vectors that would run,
+ * given a set of starting context variables (e.g. `${cwd}`).
+ *
+ * This is the pure, I/O-free half of the engine. It substitutes every
+ * placeholder it can from the context, but it cannot fill captured variables
+ * (those depend on live step output). For `--dry-run` and for unit tests, pass
+ * the captures you expect via `context` to see the fully-resolved vectors;
+ * otherwise unresolved captures surface as a thrown error naming the variable.
+ *
+ * @param {{steps: Array<object>}} profile A parsed, validated profile.
+ * @param {Record<string, string>} [context] Starting variables.
+ * @returns {Array<{argv: string[], capture?: Record<string, string>}>}
+ *   One entry per step with its substituted argument vector.
+ */
+export function resolveSteps(profile, context = {}) {
+  const steps = validateProfile(profile);
+  const vars = { ...context };
+  return steps.map((step) => {
+    const argv = step.args.map((a) => substituteArg(a, vars));
+    // Pre-declare captured names so a later-resolving dry run still substitutes
+    // the placeholder (with the literal capture token) instead of throwing.
+    if (step.capture) {
+      for (const name of Object.keys(step.capture)) {
+        if (!(name in vars)) {
+          vars[name] = `<captured:${name}>`;
+        }
+      }
+    }
+    return { argv, capture: step.capture };
+  });
+}
+
+/**
+ * Discover the available profile names (filenames without `.json`) in a dir.
+ *
+ * @param {string} dir The `scripts/dev-profiles` directory.
+ * @returns {string[]} Sorted profile names.
+ */
+export function listProfiles(dir) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(/\.json$/, ""))
+    .sort();
+}
+
+/**
+ * Load and validate a profile by name from a directory.
+ *
+ * @param {string} dir The `scripts/dev-profiles` directory.
+ * @param {string} name The profile name (no extension).
+ * @returns {{steps: Array<object>, description?: string}}
+ * @throws {Error} When the file is missing or malformed (lists alternatives).
+ */
+export function loadProfile(dir, name) {
+  const file = path.join(dir, `${name}.json`);
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    const available = listProfiles(dir);
+    throw new Error(
+      `unknown profile "${name}". Available: ${available.join(", ") || "(none)"}`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`profile "${name}" is not valid JSON: ${err.message}`);
+  }
+  validateProfile(parsed, `profile "${name}"`);
+  return parsed;
+}
+
+/**
+ * Executes resolved profile steps against a tagged dev cmux socket.
+ *
+ * Each step shells out to `scripts/cmux-debug-cli.sh` with `CMUX_TAG` set, so
+ * the safety contract (refuse without a tag, target the tagged socket only) is
+ * enforced by the helper, not re-implemented here.
+ */
+export class ProfileReplayer {
+  /**
+   * @param {object} opts
+   * @param {string} opts.tag The `CMUX_TAG` value (tagged dev build).
+   * @param {string} opts.cliPath Absolute path to `scripts/cmux-debug-cli.sh`.
+   * @param {Record<string, string>} [opts.context] Starting variables.
+   * @param {(msg: string) => void} [opts.log] Progress logger (stderr).
+   */
+  constructor({ tag, cliPath, context = {}, log = () => {} }) {
+    this.tag = tag;
+    this.cliPath = cliPath;
+    this.vars = { ...context };
+    this.log = log;
+  }
+
+  /**
+   * Replay one already-substituted step, applying its captures to `this.vars`.
+   *
+   * @param {{argv: string[], capture?: Record<string, string>}} step
+   * @returns {{stdout: string}}
+   * @throws {Error} When the CLI call fails or a capture path is absent.
+   */
+  runStep(step) {
+    const display = step.argv.join(" ");
+    this.log(`  cmux ${display}`);
+    const res = spawnSync(this.cliPath, step.argv, {
+      encoding: "utf8",
+      env: { ...process.env, CMUX_TAG: this.tag, CMUX_QUIET: "1" },
+    });
+    if (res.error) {
+      throw new Error(`failed to spawn debug CLI: ${res.error.message}`);
+    }
+    if (res.status !== 0) {
+      const detail = (res.stderr || res.stdout || "").trim();
+      throw new Error(`step failed (exit ${res.status}): cmux ${display}\n${detail}`);
+    }
+    const stdout = res.stdout || "";
+    if (step.capture) {
+      let parsed;
+      try {
+        parsed = JSON.parse(stdout);
+      } catch {
+        throw new Error(
+          `step declared captures but stdout was not JSON: cmux ${display}`,
+        );
+      }
+      for (const [name, jsonPath] of Object.entries(step.capture)) {
+        const value = readJSONPath(parsed, jsonPath);
+        if (value === undefined || value === null) {
+          throw new Error(
+            `capture "${name}" path "${jsonPath}" not found in output of: cmux ${display}`,
+          );
+        }
+        this.vars[name] = String(value);
+      }
+    }
+    return { stdout };
+  }
+
+  /**
+   * Resolve + replay every step of a profile in order.
+   *
+   * Substitution happens per-step so captures from earlier steps are visible
+   * to later ones.
+   *
+   * @param {{steps: Array<object>}} profile A validated profile.
+   */
+  run(profile) {
+    const steps = validateProfile(profile);
+    for (const step of steps) {
+      const argv = step.args.map((a) => substituteArg(a, this.vars));
+      this.runStep({ argv, capture: step.capture });
+    }
+  }
+}

--- a/scripts/dev-profiles/replay.test.mjs
+++ b/scripts/dev-profiles/replay.test.mjs
@@ -1,0 +1,149 @@
+// Unit tests for the dev-profile replay engine.
+//
+// Covers the pure construction half (parse + substitute + resolve + JSON-path
+// capture) with no live socket, plus a smoke test that every shipped profile
+// file parses and resolves. Run with:
+//
+//   node --test scripts/dev-profiles/replay.test.mjs
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import {
+  listProfiles,
+  loadProfile,
+  readJSONPath,
+  resolveSteps,
+  substituteArg,
+  validateProfile,
+} from "./replay.mjs";
+
+const PROFILES_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+test("substituteArg replaces a known variable", () => {
+  assert.equal(substituteArg("${cwd}/x", { cwd: "/repo" }), "/repo/x");
+});
+
+test("substituteArg replaces multiple variables in one arg", () => {
+  assert.equal(
+    substituteArg("${a}-${b}", { a: "1", b: "2" }),
+    "1-2",
+  );
+});
+
+test("substituteArg leaves a plain arg untouched", () => {
+  assert.equal(substituteArg("workspace", {}), "workspace");
+});
+
+test("substituteArg throws on an undefined variable", () => {
+  assert.throws(() => substituteArg("${missing}", {}), /undefined variable.*missing/);
+});
+
+test("readJSONPath reads a nested dotted path", () => {
+  assert.equal(readJSONPath({ group: { id: "G1" } }, "group.id"), "G1");
+});
+
+test("readJSONPath returns undefined for a missing path", () => {
+  assert.equal(readJSONPath({ a: 1 }, "a.b.c"), undefined);
+});
+
+test("validateProfile rejects a profile with no steps", () => {
+  assert.throws(() => validateProfile({ steps: [] }), /non-empty array/);
+});
+
+test("validateProfile rejects a step with empty args", () => {
+  assert.throws(() => validateProfile({ steps: [{ args: [] }] }), /non-empty "args"/);
+});
+
+test("validateProfile rejects capture without --json", () => {
+  assert.throws(
+    () =>
+      validateProfile({
+        steps: [{ args: ["workspace", "create"], capture: { ws: "workspace_id" } }],
+      }),
+    /omit "--json"/,
+  );
+});
+
+test("resolveSteps substitutes context variables into arg vectors", () => {
+  const profile = {
+    steps: [
+      {
+        args: ["workspace", "create", "--cwd", "${cwd}", "--json"],
+        capture: { ws: "workspace_id" },
+      },
+    ],
+  };
+  const resolved = resolveSteps(profile, { cwd: "/home/dev/repo" });
+  assert.deepEqual(resolved[0].argv, [
+    "workspace",
+    "create",
+    "--cwd",
+    "/home/dev/repo",
+    "--json",
+  ]);
+  assert.deepEqual(resolved[0].capture, { ws: "workspace_id" });
+});
+
+test("resolveSteps threads a captured variable into a later step (dry-run token)", () => {
+  const profile = {
+    steps: [
+      { args: ["workspace", "create", "--json"], capture: { ws: "workspace_id" } },
+      { args: ["send", "--workspace", "${ws}", "echo hi\\n"] },
+    ],
+  };
+  const resolved = resolveSteps(profile, {});
+  // The capture is unknown at construction time, so it resolves to a visible
+  // placeholder token rather than throwing.
+  assert.deepEqual(resolved[1].argv, [
+    "send",
+    "--workspace",
+    "<captured:ws>",
+    "echo hi\\n",
+  ]);
+});
+
+test("resolveSteps substitutes an explicitly-provided capture value", () => {
+  const profile = {
+    steps: [
+      { args: ["workspace", "create", "--json"], capture: { ws: "workspace_id" } },
+      { args: ["send", "--workspace", "${ws}", "x"] },
+    ],
+  };
+  const resolved = resolveSteps(profile, { ws: "workspace:7" });
+  assert.deepEqual(resolved[1].argv, ["send", "--workspace", "workspace:7", "x"]);
+});
+
+test("every shipped profile parses and resolves", () => {
+  const names = listProfiles(PROFILES_DIR);
+  assert.ok(names.length >= 5, `expected >=5 profiles, found ${names.join(",")}`);
+  for (const name of names) {
+    const profile = loadProfile(PROFILES_DIR, name);
+    const resolved = resolveSteps(profile, { cwd: "/tmp/repo" });
+    assert.ok(resolved.length >= 1, `${name} resolved to zero steps`);
+    for (const { argv } of resolved) {
+      assert.ok(
+        argv.every((a) => !a.includes("${")),
+        `${name} left an unresolved placeholder: ${argv.join(" ")}`,
+      );
+    }
+  }
+});
+
+test("loadProfile lists alternatives for an unknown name", () => {
+  assert.throws(
+    () => loadProfile(PROFILES_DIR, "does-not-exist"),
+    /unknown profile.*Available:.*composer/,
+  );
+});
+
+test("the composer profile starts an agent in a captured workspace", () => {
+  const profile = loadProfile(PROFILES_DIR, "composer");
+  const resolved = resolveSteps(profile, { cwd: "/repo" });
+  const first = resolved[0];
+  assert.ok(first.argv.includes("--command"));
+  assert.ok(first.argv.includes("claude"));
+  assert.deepEqual(first.capture, { ws: "workspace_id" });
+});

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -228,6 +228,34 @@ build_and_launch_ios() {
   CMUX_DOGFOOD_ATTACH_URL="$attach_url" "$REPO_ROOT/scripts/mobile-dev-launch.sh" "${launch_args[@]}"
 }
 
+# --- apply environment profile(s) (P3) --------------------------------------
+# Profiles provision a realistic test environment against the TAGGED Mac socket
+# via scripts/cmux-debug-cli.sh. The replay engine spawns the debug CLI, which
+# refuses without CMUX_TAG and never touches the stable app.
+#
+# This must run BEFORE build_and_launch_ios: the simulator launch path
+# (mobile-dev-launch.sh -> `simctl launch --console-pty`) attaches to the app
+# console and blocks until the app exits, so anything after it would never run.
+# Profiles only need the Mac socket anyway, and seeding before the phone attaches
+# means the phone sees the seeded workspaces/groups immediately. For --surface
+# ios the tagged Mac app must already be running.
+apply_profile() {
+  echo "==> applying profile(s) '$PROFILE' against $SOCKET_PATH"
+  # The Mac app needs its socket bound before the debug CLI can connect. Poll
+  # the socket file (the real readiness signal), bounded so a never-launching
+  # app fails clearly instead of hanging.
+  local _attempt
+  for _attempt in $(seq 1 40); do
+    [[ -S "$SOCKET_PATH" ]] && break
+    sleep 0.25
+  done
+  if [[ ! -S "$SOCKET_PATH" ]]; then
+    echo "error: tagged socket $SOCKET_PATH never appeared; is the Mac dev app for tag '$TAG' running?" >&2
+    exit 1
+  fi
+  node "$PROFILE_REPLAY" --tag "$TAG" --profile "$PROFILE" --cwd "$REPO_ROOT"
+}
+
 # --- orchestrate ------------------------------------------------------------
 ATTACH_URL=""
 
@@ -253,35 +281,15 @@ if [[ "$NO_PAIR" -eq 0 && ( "$SURFACE" == "ios" || "$SURFACE" == "both" ) ]]; th
   fi
 fi
 
-if [[ "$SURFACE" == "ios" || "$SURFACE" == "both" ]]; then
-  build_and_launch_ios "$ATTACH_URL"
-fi
-
-# --- apply environment profile(s) (P3) --------------------------------------
-# Profiles provision a realistic test environment against the TAGGED Mac socket
-# via scripts/cmux-debug-cli.sh. Run last, once the app(s) are up, so the
-# workspaces/panes/groups they create are visible immediately. The replay engine
-# spawns the debug CLI, which refuses without CMUX_TAG and never touches the
-# stable app. For --surface ios, the tagged Mac app must already be running.
-apply_profile() {
-  echo "==> applying profile(s) '$PROFILE' against $SOCKET_PATH"
-  # The Mac app needs its socket bound before the debug CLI can connect. Poll
-  # the socket file (the real readiness signal), bounded so a never-launching
-  # app fails clearly instead of hanging.
-  local _attempt
-  for _attempt in $(seq 1 40); do
-    [[ -S "$SOCKET_PATH" ]] && break
-    sleep 0.25
-  done
-  if [[ ! -S "$SOCKET_PATH" ]]; then
-    echo "error: tagged socket $SOCKET_PATH never appeared; is the Mac dev app for tag '$TAG' running?" >&2
-    exit 1
-  fi
-  node "$PROFILE_REPLAY" --tag "$TAG" --profile "$PROFILE" --cwd "$REPO_ROOT"
-}
-
+# Apply environment profile(s) BEFORE the (blocking) iOS launch. Profiles target
+# the Mac socket, so they only need the Mac app up; seeding here means the phone
+# sees the seeded state the moment it attaches.
 if [[ -n "$PROFILE" ]]; then
   apply_profile
+fi
+
+if [[ "$SURFACE" == "ios" || "$SURFACE" == "both" ]]; then
+  build_and_launch_ios "$ATTACH_URL"
 fi
 
 echo "==> dev-setup complete (tag: $TAG, surface: $SURFACE)"

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -30,7 +30,11 @@
 # Flags:
 #   --tag <t>           required; tags the macOS + iOS dev builds.
 #   --surface <s>       mac | ios | both   (default both)
-#   --profile <name>    reserved for P3 (env presets); currently a no-op + warn.
+#   --profile <name>    apply an environment preset after the app is up. Replays
+#                       scripts/dev-profiles/<name>.json against the tagged debug
+#                       socket (composer, notif, browser, groups, multi-mac, ...).
+#                       Accepts a comma-list to compose (e.g. composer,browser).
+#                       Run `scripts/dev-profiles/replay-cli.mjs --list` for names.
 #   --no-pair           skip enabling the host + minting + auto-pair.
 #   --simulator <name>  iOS simulator name (default "iPhone 17").
 #   --device            target a connected iPhone instead of the simulator.
@@ -74,10 +78,6 @@ case "$SURFACE" in
   *) echo "error: --surface must be mac|ios|both (got '$SURFACE')" >&2; exit 2 ;;
 esac
 
-if [[ -n "$PROFILE" ]]; then
-  echo "warning: --profile '$PROFILE' is reserved for P3 (env presets) and is currently a no-op." >&2
-fi
-
 if [[ "$AGENT" -eq 1 && ( "$SURFACE" == "mac" || "$SURFACE" == "both" ) ]]; then
   echo "warning: --agent only changes the iOS sign-in account. The macOS app picks its" >&2
   echo "         account from ~/.secrets via DebugDogfoodCredentialResolver (dogfood-first)," >&2
@@ -86,6 +86,20 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROFILE_REPLAY="$SCRIPT_DIR/dev-profiles/replay-cli.mjs"
+
+# --- profiles: validate up front (P3) ---------------------------------------
+# Fail fast on an unknown profile name BEFORE any heavy build/launch work, so a
+# typo doesn't cost a full build. --dry-run validates parse + resolution without
+# touching a socket; it lists the available profiles on an unknown name.
+if [[ -n "$PROFILE" ]]; then
+  if ! node "$PROFILE_REPLAY" --dry-run --profile "$PROFILE" >/dev/null; then
+    echo "error: invalid --profile '$PROFILE'." >&2
+    echo "available profiles:" >&2
+    node "$PROFILE_REPLAY" --list | sed 's/^/  /' >&2
+    exit 2
+  fi
+fi
 
 # --- credentials: validate only, do NOT export into this process -------------
 # The macOS app reads dogfood creds from disk (DebugDogfoodCredentialResolver),
@@ -241,6 +255,33 @@ fi
 
 if [[ "$SURFACE" == "ios" || "$SURFACE" == "both" ]]; then
   build_and_launch_ios "$ATTACH_URL"
+fi
+
+# --- apply environment profile(s) (P3) --------------------------------------
+# Profiles provision a realistic test environment against the TAGGED Mac socket
+# via scripts/cmux-debug-cli.sh. Run last, once the app(s) are up, so the
+# workspaces/panes/groups they create are visible immediately. The replay engine
+# spawns the debug CLI, which refuses without CMUX_TAG and never touches the
+# stable app. For --surface ios, the tagged Mac app must already be running.
+apply_profile() {
+  echo "==> applying profile(s) '$PROFILE' against $SOCKET_PATH"
+  # The Mac app needs its socket bound before the debug CLI can connect. Poll
+  # the socket file (the real readiness signal), bounded so a never-launching
+  # app fails clearly instead of hanging.
+  local _attempt
+  for _attempt in $(seq 1 40); do
+    [[ -S "$SOCKET_PATH" ]] && break
+    sleep 0.25
+  done
+  if [[ ! -S "$SOCKET_PATH" ]]; then
+    echo "error: tagged socket $SOCKET_PATH never appeared; is the Mac dev app for tag '$TAG' running?" >&2
+    exit 1
+  fi
+  node "$PROFILE_REPLAY" --tag "$TAG" --profile "$PROFILE" --cwd "$REPO_ROOT"
+}
+
+if [[ -n "$PROFILE" ]]; then
+  apply_profile
 fi
 
 echo "==> dev-setup complete (tag: $TAG, surface: $SURFACE)"


### PR DESCRIPTION
Fills in the P2 `--profile` no-op hook with real, data-driven environment presets. A profile provisions a realistic test environment in a **tagged** dev cmux instance, picked by what's being tested, so a feature (composer, notifications, browser, groups, multi-mac) has live state to test against.

Sequence: P1 (macOS DEBUG auto-sign-in, https://github.com/manaflow-ai/cmux/pull/5582, merged) → P2 (phone auto-pair + `scripts/dev-setup.sh`, https://github.com/manaflow-ai/cmux/pull/5584) → **this**. Stacked on the P2 branch; review/merge P2 first.

## Profile format (adding a profile = adding a file)

A profile is a JSON file under `scripts/dev-profiles/<name>.json`: an ordered list of debug-CLI steps. Every step is replayed through `scripts/cmux-debug-cli.sh`, which refuses without `CMUX_TAG` and targets `/tmp/cmux-debug-<slug>.sock` only, never the user's stable app. No code change is needed to add one. Documented in `scripts/dev-profiles/README.md`.

```json
{
  "description": "...",
  "steps": [
    { "args": ["--id-format", "uuids", "workspace", "create", "--cwd", "${cwd}", "--command", "claude", "--json"],
      "capture": { "ws": "workspace_id" } },
    { "args": ["send", "--workspace", "${ws}", "echo hi\\n"] }
  ]
}
```

`${cwd}` plus any captured variable are substituted into later steps. `capture` reads a dotted JSON path out of a step's `--json` output and threads it forward, which is what lets a profile "create a thing, then act on the thing" (groups and browser both act on a freshly-created workspace/group id). Steps prepend `--id-format uuids` so the captured id is a stable UUID (the default `refs` format renames the key to `workspace_ref` and is positional). Profiles carry no secrets.

## Engine

- `replay.mjs`: `resolveSteps(profile, context)` is a pure, I/O-free construction function (parse + substitute + JSON-path capture) reused by `--dry-run` and the unit test. `ProfileReplayer` wraps it with execution via `cmux-debug-cli.sh`, so the tagged-socket safety contract is enforced by the helper, not re-implemented.
- `replay-cli.mjs`: thin CLI `dev-setup.sh` calls (`--list`, `--dry-run`, `--tag`, comma-list `--profile`).
- `replay.test.mjs`: 15 `node --test` cases over the construction half (no socket needed).

## Shipped profiles

- **composer** — workspace at the repo cwd with a live `claude` agent in its first surface (composer/dictation/paste flows have something to type into).
- **notif** — a workspace with a notification posted to it + an attention flash triggered (notification mirror / dismiss-sync).
- **browser** — a workspace with a browser pane open to `https://example.com` (always reachable, no local server).
- **groups** — a named sidebar group (anchor) with two extra member workspaces (workspace groups / groups-on-mobile).
- **multi-mac** — *partial.* Seeds the current Mac with two clearly-named workspaces. The host switcher lists Macs the phone has actually paired with (iOS-side `MobilePairedMacStore` state); no socket verb can fabricate a second Mac, so exercising the switch itself needs a second real Mac (run `dev-setup.sh --tag <other>` on another machine and pair the phone to both). Documented in the README and the profile description.

All verbs were verified against `CLI/cmux.swift` (the authoritative catalog) and the `cmux-groups` skill before use. **Verb gap:** the only gap hit is the multi-mac one above (no debug verb seeds a paired Mac); every other profile uses verbs that exist.

## dev-setup.sh wiring

`--profile <name>` now: validates up front (fails fast listing the available profiles on a typo, before any build), then after the Mac app is up replays each step against `CMUX_TAG=<tag> scripts/cmux-debug-cli.sh ...`. Accepts a comma-list to compose (`--profile composer,browser`).

```bash
scripts/dev-setup.sh --tag grid --profile composer
scripts/dev-setup.sh --tag grid --profile composer,browser
scripts/dev-profiles/replay-cli.mjs --list
scripts/dev-profiles/replay-cli.mjs --dry-run --cwd "$PWD" --profile groups
```

Profiles are applied after the Mac app is up but **before** the iOS launch, because the simulator launch path (`simctl launch --console-pty`) blocks until the app exits; an autoreview round caught that the original "apply last" placement would never run on the default `--surface both`. Profiles target the Mac socket anyway, and seeding before the phone attaches means the phone sees the seeded state immediately.

## Verification

- `node --test scripts/dev-profiles/replay.test.mjs`: 15 pass (parse, substitution, JSON-path capture, every shipped profile resolves with no leftover `${...}`, unknown-name lists alternatives).
- `--dry-run` prints the resolved `cmux` arg-vectors for all 5 profiles with no live socket.
- Replay plumbing proven end-to-end against a live tagged socket (a throwaway `cmd2` build): a read-only probe (`ping` + `workspace list --json` capturing `window_ref`), then a self-cleaning mutation+capture+chain (create workspace → capture UUID → rename via `${ws}` → close), then the real `groups` profile (create group → capture `group.id` → add two members), each cleaned up afterward, leaving the socket's original state. No junk; the stable app was never touched.
- `shellcheck -x scripts/dev-setup.sh`: clean. `node --check` on all three `.mjs`: clean.
- Fast-fail on unknown `--profile` (exit 2, lists available) and valid-profile pass-through verified without a build.

This completes the turnkey directive: auto-sign-in (P1) + auto-pair (P2) + realistic environment profiles (P3).

## Autoreview

Converged on P3 files: the one P3-specific finding (profiles placed after the blocking iOS launch) is fixed. The single remaining autoreview finding is **pre-existing P2 code** (`scripts/dev-setup.sh:157`: ambient `CMUX_UITEST_STACK_PASSWORD`/`CMUX_DOGFOOD_STACK_PASSWORD` already exported by the caller is inherited by the long-lived macOS GUI via `reload.sh --launch`), untouched by this diff and tracked on https://github.com/manaflow-ai/cmux/pull/5584. P3's replay path only spawns short-lived `cmux-debug-cli.sh` calls, so it neither introduces nor worsens that vector.

## Localization

N/A: scripts + JSON profile data + Markdown docs, zero app-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only scripts and JSON presets that mutate tagged debug sockets only; no production app or auth paths touched.
> 
> **Overview**
> Implements **P3 environment profiles** for turnkey dev builds: `--profile` on `dev-setup.sh` is no longer a no-op and replays JSON-defined `cmux` step sequences against the **tagged** debug socket only (via `cmux-debug-cli.sh`).
> 
> Adds `scripts/dev-profiles/` with a replay engine (`replay.mjs`: `${cwd}` / capture substitution, JSON-path capture, `ProfileReplayer`), CLI (`replay-cli.mjs`: `--list`, `--dry-run`, comma-separated profiles), unit tests, README, and five presets (`composer`, `notif`, `browser`, `groups`, partial `multi-mac`). New profiles are drop-in `<name>.json` files with no code changes.
> 
> **`dev-setup.sh`** validates profile names up front with `--dry-run` (fail before build), polls for the tagged socket, then applies profiles **after** the Mac app is up but **before** the blocking iOS `simctl` launch so `--surface both` still runs seeding and the phone sees state on attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a9b3a220d68eef2ecad19214a016ed162029ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783465903&installation_id=133855650&pr_number=5585&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5585&signature=1aaac024a688d3dc2d33de09a68372473e747bcfaadd5f6866055a3a395bb7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns `--profile` into real, data‑driven environment presets for tagged dev builds, so features can be tested against realistic state quickly and safely. Ships a small replay engine, CLI, and ready-made profiles (composer, notif, browser, groups, partial multi‑mac).

- **New Features**
  - JSON profiles in `scripts/dev-profiles/*.json` with `${cwd}` and JSON‑path capture to chain steps.
  - `scripts/dev-profiles/replay.mjs` engine and `scripts/dev-profiles/replay-cli.mjs` (`--list`, `--dry-run`, comma-list `--profile`), executed via `scripts/cmux-debug-cli.sh` with `CMUX_TAG` to hit only the tagged socket.
  - `scripts/dev-setup.sh` validates profile names up front and applies profiles; supports composition (e.g. `composer,browser`). Unit tests in `scripts/dev-profiles/replay.test.mjs`.

- **Bug Fixes**
  - Apply profiles before the blocking iOS launch so `--surface both` runs profiles reliably.
  - Correct README example to use `workspace_id` with `--id-format uuids`.

<sup>Written for commit 51a9b3a220d68eef2ecad19214a016ed162029ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development profiles now fully functional: five new presets (`browser`, `composer`, `groups`, `multi-mac`, `notif`) available for seeding dev environments.
  * `--profile` flag in dev-setup is now operational for applying environment configurations.

* **Documentation**
  * Added comprehensive guide for using and creating custom development profiles.

* **Tests**
  * Added test suite validating profile configuration and replay logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->