### PR TITLE
Fix: image paste/drop upload over sshpass-wrapped SSH sessions (#1660)

### DIFF
--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -13,6 +13,7 @@ struct DetectedSSHSession: Equatable {
     let forwardAgent: Bool
     let compressionEnabled: Bool
     let sshOptions: [String]
+    var password: String? = nil
 
     func uploadDroppedFiles(
         _ fileURLs: [URL],
@@ -101,9 +102,13 @@ struct DetectedSSHSession: Equatable {
                 }
 
                 let remotePath = WorkspaceRemoteSessionController.remoteDropPath(for: normalizedLocalURL)
-                let result = try Self.runProcess(
+                let (scpExecutable, scpArgs) = wrappedCommand(
                     executable: "/usr/bin/scp",
-                    arguments: scpArguments(localPath: normalizedLocalURL.path, remotePath: remotePath),
+                    arguments: scpArguments(localPath: normalizedLocalURL.path, remotePath: remotePath)
+                )
+                let result = try Self.runProcess(
+                    executable: scpExecutable,
+                    arguments: scpArgs,
                     timeout: 45,
                     operation: operation
                 )
@@ -132,9 +137,11 @@ struct DetectedSSHSession: Equatable {
             "-o", "ConnectTimeout=6",
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
-            "-o", "BatchMode=yes",
             "-o", "ControlMaster=no",
         ]
+        if password == nil {
+            args += ["-o", "BatchMode=yes"]
+        }
 
         if useIPv4 {
             args.append("-4")
@@ -181,9 +188,11 @@ struct DetectedSSHSession: Equatable {
             "-o", "ConnectTimeout=6",
             "-o", "ServerAliveInterval=20",
             "-o", "ServerAliveCountMax=2",
-            "-o", "BatchMode=yes",
             "-o", "ControlMaster=no",
         ]
+        if password == nil {
+            args += ["-o", "BatchMode=yes"]
+        }
 
         if useIPv4 {
             args.append("-4")
@@ -224,13 +233,30 @@ struct DetectedSSHSession: Equatable {
         return args
     }
 
+    private func wrappedCommand(executable: String, arguments: [String]) -> (String, [String]) {
+        guard let password, !password.isEmpty,
+              let sshpass = Self.sshpassExecutablePath() else {
+            return (executable, arguments)
+        }
+        return (sshpass, ["-p", password, executable] + arguments)
+    }
+
+    private static func sshpassExecutablePath() -> String? {
+        let candidates = ["/opt/homebrew/bin/sshpass", "/usr/local/bin/sshpass", "/usr/bin/sshpass"]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
     private func cleanupUploadedRemotePaths(_ remotePaths: [String]) {
         guard !remotePaths.isEmpty else { return }
         let cleanupScript = "rm -f -- " + remotePaths.map(Self.shellSingleQuoted).joined(separator: " ")
         let cleanupCommand = "sh -c \(Self.shellSingleQuoted(cleanupScript))"
-        _ = try? Self.runProcess(
+        let (sshExecutable, sshArgs) = wrappedCommand(
             executable: "/usr/bin/ssh",
-            arguments: sshArguments(command: cleanupCommand),
+            arguments: sshArguments(command: cleanupCommand)
+        )
+        _ = try? Self.runProcess(
+            executable: sshExecutable,
+            arguments: sshArgs,
             timeout: 8
         )
     }
@@ -428,8 +454,14 @@ enum TerminalSSHSessionDetector {
             }
 
         for candidate in candidates {
+            guard let arguments = argumentsByPID[candidate.pid] else { continue }
+            if RemoteShellSessionParsing.normalizedExecutableName(candidate.executableName) == "sshpass" {
+                if let session = parseSshpassCommandLine(arguments) {
+                    return session
+                }
+                continue
+            }
             guard let transport = RemoteShellTransport(executableName: candidate.executableName),
-                  let arguments = argumentsByPID[candidate.pid],
                   let session = parseCommandLine(arguments, for: transport) else {
                 continue
             }
@@ -437,6 +469,45 @@ enum TerminalSSHSessionDetector {
         }
 
         return nil
+    }
+
+    // Sesiones lanzadas via `sshpass -p<pass> ssh ...`: el ssh real corre en un pty
+    // interno de sshpass, asi que en el TTY del pane solo se ve `sshpass`. Parseamos su
+    // linea de comando para extraer la sesion ssh embebida + el password.
+    static func parseSshpassCommandLine(_ arguments: [String]) -> DetectedSSHSession? {
+        guard !arguments.isEmpty else { return nil }
+        var index = 0
+        if RemoteShellSessionParsing.normalizedExecutableName(arguments[0]) == "sshpass" {
+            index = 1
+        }
+        var password: String?
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument.hasPrefix("-p") {
+                if argument.count > 2 {
+                    password = String(argument.dropFirst(2))
+                } else {
+                    index += 1
+                    if index < arguments.count { password = arguments[index] }
+                }
+                index += 1
+            } else if argument == "-f" || argument == "-d" || argument == "-P" {
+                index += 2
+            } else if argument == "-e" || argument == "-v" {
+                index += 1
+            } else if argument.hasPrefix("-") {
+                index += 1
+            } else {
+                break
+            }
+        }
+        guard index < arguments.count else { return nil }
+        let sshArguments = Array(arguments[index...])
+        guard var session = parseSSHCommandLine(sshArguments) else { return nil }
+        if let password, !password.isEmpty {
+            session.password = password
+        }
+        return session
     }
 
     private static let psPath = "/bin/ps"
@@ -454,10 +525,15 @@ enum TerminalSSHSessionDetector {
 
     private static func isForegroundRemoteShellProcess(_ process: ProcessSnapshot, ttyName: String) -> Bool {
         normalizeTTYName(process.tty) == normalizeTTYName(ttyName) &&
-            RemoteShellTransport(executableName: process.executableName) != nil &&
+            isRemoteShellExecutable(process.executableName) &&
             process.pgid > 0 &&
             process.tpgid > 0 &&
             process.pgid == process.tpgid
+    }
+
+    private static func isRemoteShellExecutable(_ executableName: String) -> Bool {
+        if RemoteShellTransport(executableName: executableName) != nil { return true }
+        return RemoteShellSessionParsing.normalizedExecutableName(executableName) == "sshpass"
     }
 
     private static func processSnapshots(forTTY ttyName: String) -> [ProcessSnapshot] {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -6831,3 +6831,27 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         )
     }
 }
+
+final class SshpassImagePasteDetectionTests: XCTestCase {
+    func testSshpassSeparatePassword() {
+        let s = TerminalSSHSessionDetector.parseSshpassCommandLine(
+            ["sshpass", "-p", "secretPass123", "ssh", "-o", "StrictHostKeyChecking=no", "root@187.77.175.242"])
+        XCTAssertNotNil(s, "debe detectar sesion sshpass")
+        XCTAssertEqual(s?.destination, "root@187.77.175.242")
+        XCTAssertEqual(s?.password, "secretPass123")
+    }
+    func testSshpassInlinePassword() {
+        let s = TerminalSSHSessionDetector.parseSshpassCommandLine(
+            ["sshpass", "-pInlinePass", "ssh", "ec2-user@1.2.3.4"])
+        XCTAssertEqual(s?.destination, "ec2-user@1.2.3.4")
+        XCTAssertEqual(s?.password, "InlinePass")
+    }
+    func testSshpassWithIdentityAndPort() {
+        let s = TerminalSSHSessionDetector.parseSshpassCommandLine(
+            ["sshpass", "-p", "pw", "ssh", "-i", "/k.pem", "-p", "2222", "user@host.example"])
+        XCTAssertEqual(s?.destination, "user@host.example")
+        XCTAssertEqual(s?.password, "pw")
+        XCTAssertEqual(s?.identityFile, "/k.pem")
+        XCTAssertEqual(s?.port, 2222)
+    }
+}


### PR DESCRIPTION
## Problem
When an SSH session is started via `sshpass -p<password> ssh ...` (very common for password-auth hosts), pasting/dropping an image inserts the local `/var/folders/.../clipboard-*.png` path instead of uploading it to the remote — so remote Claude Code / Codex can't read it.

Root cause: with `sshpass`, the real `ssh` runs inside sshpass's internal pty, so only `sshpass` is visible on the pane TTY. `TerminalSSHSessionDetector` only recognized `ssh`/`et`, so the session resolved to `.local`. Additionally those hosts use password auth, which the scp path (`BatchMode=yes`) can't satisfy.

## Fix
- Recognize `sshpass` as a foreground remote-shell process.
- Parse the embedded ssh command line (host, identity, port, options) and capture the password (`-p<pass>` / `-p <pass>`).
- Use `sshpass -p<password>` for the scp upload / ssh cleanup and skip `BatchMode=yes` when a password is present.
- Unit tests for `parseSshpassCommandLine` (separate password, inline password, identity+port).

Addresses the password/sshpass case of #1660.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783467296&installation_id=133855650&pr_number=5586&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5586&signature=eb65f47b2a128e993cfb5eb277e8486ba338521277925dafc836d2dc0b146d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image paste/drop uploads for SSH sessions launched via `sshpass`, so images are uploaded to the remote instead of inserting a local clipboard path. This addresses the password-auth scenario in #1660.

- **Bug Fixes**
  - Detects `sshpass` as the foreground process and parses the embedded `ssh` command (host, port, identity).
  - Extracts the password from `-p <pass>` or `-p<pass>` and wraps `scp`/`ssh` cleanup with `sshpass -p`.
  - Skips `-o BatchMode=yes` when a password is present to allow password-based uploads.
  - Adds unit tests for separate/inline password and identity+port cases.

<sup>Written for commit e1433852ae5cd9159c4bba847ec992a5af2ffa0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for password-based SSH and SCP connections using sshpass
  * Enhanced SSH session detection to automatically recognize and extract credentials from sshpass invocations
  * Improved remote file operations to utilize password authentication when available

* **Tests**
  * Added test coverage for sshpass command-line parsing validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->