### PR TITLE
iOS: tellable incrementing version (1.0.x + dev tag/SHA) instead of frozen 1.0

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -134,6 +134,20 @@ struct MobileSettingsView: View {
                     }
                     .accessibilityIdentifier("MobileSettingsNotifications")
                 }
+
+                Section(L10n.string("mobile.settings.about", defaultValue: "About")) {
+                    LabeledContent {
+                        Text(AppVersionInfo.current().displayString)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    } label: {
+                        Label(
+                            L10n.string("mobile.settings.version", defaultValue: "Version"),
+                            systemImage: "info.circle"
+                        )
+                    }
+                    .accessibilityIdentifier("MobileSettingsVersionRow")
+                }
             }
             .onAppear { notificationsEnabled = pushCoordinator.isEnabled }
             .navigationTitle(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))

--- a/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/AppVersionInfo.swift
+++ b/Packages/CmuxMobileSupport/Sources/CmuxMobileSupport/AppVersionInfo.swift
@@ -1,0 +1,99 @@
+public import Foundation
+
+/// The running build's user-tellable version, assembled from the app bundle's
+/// `Info.plist` so the in-app About row reports exactly which build a device is
+/// running.
+///
+/// A release/TestFlight build reports a clean marketing version with its build
+/// number, e.g. `1.0.0 (20260607031606)`. A DEBUG dogfood build additionally
+/// appends the `--tag` and the short git SHA injected by `ios/scripts/reload.sh`
+/// (the `CMUXDevTag` / `CMUXGitSHA` Info.plist keys), e.g.
+/// `1.0.0 (123) · grid · a1b2c3d`, so two dev reloads are never indistinguishable.
+///
+/// The type is a pure value derived from a dictionary, so it is testable without
+/// launching the app: pass a fixture dictionary and an explicit `isDevBuild`.
+///
+/// ```swift
+/// let info = AppVersionInfo(
+///     infoDictionary: ["CFBundleShortVersionString": "1.0.0", "CFBundleVersion": "123"],
+///     isDevBuild: false
+/// )
+/// info.displayString // "1.0.0 (123)"
+/// ```
+public struct AppVersionInfo: Sendable, Equatable {
+    /// The human marketing version (`CFBundleShortVersionString`), e.g. `1.0.0`.
+    public let marketingVersion: String
+
+    /// The monotonic build identifier (`CFBundleVersion`); empty when absent.
+    public let buildNumber: String
+
+    /// The dev `--tag` (`CMUXDevTag`); empty for release/TestFlight builds.
+    public let devTag: String
+
+    /// The short git SHA (`CMUXGitSHA`); empty for release/TestFlight builds.
+    ///
+    /// A trailing `+` (stamped by the reload script) marks an uncommitted tree.
+    public let gitSHA: String
+
+    /// Whether this is a development build, controlling whether the dev tag and
+    /// SHA are appended to ``displayString``.
+    public let isDevBuild: Bool
+
+    /// Build a version info from an app bundle's info dictionary.
+    ///
+    /// - Parameters:
+    ///   - infoDictionary: Typically `Bundle.main.infoDictionary`. Missing keys
+    ///     degrade gracefully (marketing version falls back to `0.0.0`, the rest
+    ///     to empty).
+    ///   - isDevBuild: Whether the running build is a development build. The
+    ///     caller passes the real `#if DEBUG` value; tests pass it explicitly so
+    ///     both code paths are exercisable.
+    public init(infoDictionary: [String: Any]?, isDevBuild: Bool) {
+        func trimmedString(_ key: String) -> String {
+            guard let value = infoDictionary?[key] as? String else { return "" }
+            // Unexpanded build-setting placeholders (e.g. "$(CMUX_GIT_SHA)" when
+            // a key was never overridden) are not user-meaningful; treat them as
+            // empty so a release build shows nothing rather than a raw macro.
+            if value.hasPrefix("$(") { return "" }
+            return value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let marketing = trimmedString("CFBundleShortVersionString")
+        self.marketingVersion = marketing.isEmpty ? "0.0.0" : marketing
+        self.buildNumber = trimmedString("CFBundleVersion")
+        self.devTag = trimmedString("CMUXDevTag")
+        self.gitSHA = trimmedString("CMUXGitSHA")
+        self.isDevBuild = isDevBuild
+    }
+
+    /// The full user-tellable version string for the About row.
+    ///
+    /// Release: `"1.0.0 (123)"` (or just `"1.0.0"` when there is no build
+    /// number). Dev: the same, plus ` · <tag> · <sha>` for whichever of the dev
+    /// tag and SHA are present.
+    public var displayString: String {
+        var base = marketingVersion
+        if !buildNumber.isEmpty {
+            base += " (\(buildNumber))"
+        }
+        guard isDevBuild else { return base }
+        var suffixes: [String] = []
+        if !devTag.isEmpty { suffixes.append(devTag) }
+        if !gitSHA.isEmpty { suffixes.append(gitSHA) }
+        guard !suffixes.isEmpty else { return base }
+        return ([base] + suffixes).joined(separator: " · ")
+    }
+
+    /// The running app's version info, read from `Bundle.main`.
+    ///
+    /// `isDevBuild` is resolved from `#if DEBUG` at the call site, so a release
+    /// build never appends dev metadata even if the keys somehow carried values.
+    public static func current() -> AppVersionInfo {
+        #if DEBUG
+        let isDev = true
+        #else
+        let isDev = false
+        #endif
+        return AppVersionInfo(infoDictionary: Bundle.main.infoDictionary, isDevBuild: isDev)
+    }
+}

--- a/Packages/CmuxMobileSupport/Tests/CmuxMobileSupportTests/AppVersionInfoTests.swift
+++ b/Packages/CmuxMobileSupport/Tests/CmuxMobileSupportTests/AppVersionInfoTests.swift
@@ -1,0 +1,114 @@
+import Testing
+@testable import CmuxMobileSupport
+
+@Suite struct AppVersionInfoTests {
+    @Test func releaseShowsCleanVersionWithBuildNumber() {
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "20260607031606",
+                "CMUXDevTag": "",
+                "CMUXGitSHA": "",
+            ],
+            isDevBuild: false
+        )
+        #expect(info.displayString == "1.0.0 (20260607031606)")
+    }
+
+    @Test func releaseIgnoresDevMetadataEvenIfPresent() {
+        // A release build must never leak a tag/SHA, even if the keys carry
+        // values: isDevBuild gates the suffix, not just empty strings.
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "123",
+                "CMUXDevTag": "grid",
+                "CMUXGitSHA": "a1b2c3d",
+            ],
+            isDevBuild: false
+        )
+        #expect(info.displayString == "1.0.0 (123)")
+    }
+
+    @Test func devAppendsTagAndSHA() {
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "123",
+                "CMUXDevTag": "grid",
+                "CMUXGitSHA": "a1b2c3d",
+            ],
+            isDevBuild: true
+        )
+        #expect(info.displayString == "1.0.0 (123) · grid · a1b2c3d")
+    }
+
+    @Test func devWithDirtyTreeMarkerIsPreserved() {
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "123",
+                "CMUXDevTag": "grid",
+                "CMUXGitSHA": "a1b2c3d+",
+            ],
+            isDevBuild: true
+        )
+        #expect(info.displayString == "1.0.0 (123) · grid · a1b2c3d+")
+    }
+
+    @Test func devWithOnlyTagOmitsSHASeparator() {
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "123",
+                "CMUXDevTag": "grid",
+                "CMUXGitSHA": "",
+            ],
+            isDevBuild: true
+        )
+        #expect(info.displayString == "1.0.0 (123) · grid")
+    }
+
+    @Test func devWithNoTagOrSHAFallsBackToBase() {
+        // A dev build run outside reload.sh (no overrides) still renders cleanly.
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "1",
+                "CMUXDevTag": "",
+                "CMUXGitSHA": "",
+            ],
+            isDevBuild: true
+        )
+        #expect(info.displayString == "1.0.0 (1)")
+    }
+
+    @Test func unexpandedBuildSettingPlaceholdersAreTreatedAsEmpty() {
+        // If the keys were never overridden, Info.plist substitution leaves the
+        // raw "$(CMUX_GIT_SHA)" macro; it must not surface to the user.
+        let info = AppVersionInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.0.0",
+                "CFBundleVersion": "123",
+                "CMUXDevTag": "$(CMUX_DEV_TAG)",
+                "CMUXGitSHA": "$(CMUX_GIT_SHA)",
+            ],
+            isDevBuild: true
+        )
+        #expect(info.displayString == "1.0.0 (123)")
+    }
+
+    @Test func missingBuildNumberOmitsParentheses() {
+        let info = AppVersionInfo(
+            infoDictionary: ["CFBundleShortVersionString": "1.0.0"],
+            isDevBuild: false
+        )
+        #expect(info.displayString == "1.0.0")
+    }
+
+    @Test func missingMarketingVersionFallsBack() {
+        let info = AppVersionInfo(infoDictionary: nil, isDevBuild: false)
+        #expect(info.marketingVersion == "0.0.0")
+        #expect(info.displayString == "0.0.0")
+    }
+}

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -12,6 +12,10 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CMUXDevTag</key>
+	<string>$(CMUX_DEV_TAG)</string>
+	<key>CMUXGitSHA</key>
+	<string>$(CMUX_GIT_SHA)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -9,8 +9,20 @@
 PRODUCT_NAME = cmux
 PRODUCT_DISPLAY_NAME = cmux
 PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
-MARKETING_VERSION = 1.0
+// User-visible version (CFBundleShortVersionString). Semver X.Y.Z, bumped on
+// release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
+// tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
+// (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
+MARKETING_VERSION = 1.0.0
 CURRENT_PROJECT_VERSION = 1
+
+// Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood
+// build is tellable. Empty by default, so release/TestFlight builds show a clean
+// "1.0.0". ios/scripts/reload.sh overrides these on the xcodebuild command line
+// with the short git SHA and the --tag, and Config/Info.plist maps them to the
+// CMUXGitSHA / CMUXDevTag Info.plist keys that AppVersionInfo reads.
+CMUX_GIT_SHA =
+CMUX_DEV_TAG =
 
 // ==========================================
 // Platform Configuration

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1429,6 +1429,23 @@
         }
       }
     },
+    "mobile.settings.about": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        }
+      }
+    },
     "mobile.settings.display": {
       "extractionState": "manual",
       "localizations": {
@@ -1459,6 +1476,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Macを切り替え"
+          }
+        }
+      }
+    },
+    "mobile.settings.version": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バージョン"
           }
         }
       }

--- a/ios/scripts/bump-ios-version.sh
+++ b/ios/scripts/bump-ios-version.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bump the iOS app's MARKETING_VERSION (CFBundleShortVersionString) in
+# ios/Config/Shared.xcconfig. This is the user-visible, tellable version testers
+# report. It is bumped MANUALLY on release (semver, human-meaningful) — unlike
+# CFBundleVersion (the monotonic build id), which ios/scripts/upload-testflight.sh
+# stamps per upload as a UTC timestamp. Keeping the marketing bump manual avoids
+# a CI commit-back loop on every merge; the patch number moves only when you cut
+# a build worth reporting.
+#
+# Usage:
+#   ios/scripts/bump-ios-version.sh           # Bump patch (1.0.0 -> 1.0.1, default)
+#   ios/scripts/bump-ios-version.sh patch     # Bump patch (1.0.0 -> 1.0.1)
+#   ios/scripts/bump-ios-version.sh minor     # Bump minor (1.0.0 -> 1.1.0)
+#   ios/scripts/bump-ios-version.sh major     # Bump major (1.0.0 -> 2.0.0)
+#   ios/scripts/bump-ios-version.sh 1.2.3     # Set a specific version
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+XCCONFIG="$IOS_DIR/Config/Shared.xcconfig"
+
+if [[ ! -f "$XCCONFIG" ]]; then
+  echo "Error: $XCCONFIG not found." >&2
+  exit 1
+fi
+
+CURRENT_MARKETING="$(grep -m1 '^MARKETING_VERSION = ' "$XCCONFIG" | sed 's/^MARKETING_VERSION = //')"
+if [[ -z "$CURRENT_MARKETING" ]]; then
+  echo "Error: could not read MARKETING_VERSION from $XCCONFIG" >&2
+  exit 1
+fi
+
+echo "Current: MARKETING_VERSION=$CURRENT_MARKETING"
+
+# Normalize to X.Y.Z (tolerate a bare "1.0" by treating the missing patch as 0).
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_MARKETING"
+MAJOR="${MAJOR:-0}"
+MINOR="${MINOR:-0}"
+PATCH="${PATCH:-0}"
+
+if [[ $# -eq 0 ]] || [[ "$1" == "patch" ]]; then
+  NEW_MARKETING="$MAJOR.$MINOR.$((PATCH + 1))"
+elif [[ "$1" == "minor" ]]; then
+  NEW_MARKETING="$MAJOR.$((MINOR + 1)).0"
+elif [[ "$1" == "major" ]]; then
+  NEW_MARKETING="$((MAJOR + 1)).0.0"
+elif [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  NEW_MARKETING="$1"
+else
+  echo "Usage: $0 [version|patch|minor|major]" >&2
+  echo "  version: specific version like 1.2.3" >&2
+  echo "  patch: bump patch version (default)" >&2
+  echo "  minor: bump minor version" >&2
+  echo "  major: bump major version" >&2
+  exit 1
+fi
+
+echo "New:     MARKETING_VERSION=$NEW_MARKETING"
+
+sed -i '' "s/^MARKETING_VERSION = $CURRENT_MARKETING\$/MARKETING_VERSION = $NEW_MARKETING/" "$XCCONFIG"
+
+UPDATED_MARKETING="$(grep -m1 '^MARKETING_VERSION = ' "$XCCONFIG" | sed 's/^MARKETING_VERSION = //')"
+if [[ "$UPDATED_MARKETING" != "$NEW_MARKETING" ]]; then
+  echo "Error: version update failed!" >&2
+  exit 1
+fi
+
+echo "Updated $XCCONFIG successfully."

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -140,6 +140,19 @@ BUNDLE_ID="dev.cmux.ios.$TAG_SLUG"
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-ios-$TAG_SLUG"
 DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
 
+# Dev-build identity baked into the app's Info.plist (CMUXGitSHA / CMUXDevTag),
+# surfaced in-app under Settings > About so a dogfood build is tellable. The
+# short SHA marks "+" when the working tree is dirty. Use `git status --porcelain`
+# (not `git diff HEAD`) so an UNTRACKED new source file also flips the marker:
+# SwiftPM/Xcode compile untracked files under Sources, so a build that contains
+# uncommitted local work must never read as a clean committed SHA. These default
+# empty in Shared.xcconfig, so a TestFlight/release build shows a clean "1.0.0"
+# while a reload shows "1.0.0 (123) · <tag> · <sha>".
+GIT_SHA="$(git -C "$IOS_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+if [[ -n "$GIT_SHA" && -n "$(git -C "$IOS_DIR" status --porcelain 2>/dev/null)" ]]; then
+  GIT_SHA="$GIT_SHA+"
+fi
+
 LOCAL_ASC_CONFIG="$IOS_DIR/Config/AppStoreConnect.local.plist"
 if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
   ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
@@ -393,6 +406,8 @@ reload_simulator() {
     -derivedDataPath "$DERIVED_DATA" \
     PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME" \
+    CMUX_GIT_SHA="$GIT_SHA" \
+    CMUX_DEV_TAG="$TAG" \
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist \
     CODE_SIGNING_ALLOWED=NO \
     SWIFT_OPTIMIZATION_LEVEL=-O \
@@ -492,6 +507,8 @@ reload_device() {
   build_args+=(
     PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME"
+    CMUX_GIT_SHA="$GIT_SHA"
+    CMUX_DEV_TAG="$TAG"
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist
     CODE_SIGNING_ALLOWED=YES
     CODE_SIGN_STYLE=Automatic


### PR DESCRIPTION
## Problem

The iOS app's `MARKETING_VERSION` was hardcoded to `1.0` in `ios/Config/Shared.xcconfig` and never bumped, so every iOS build (TestFlight releases AND dev dogfood builds) showed `1.0`. `CFBundleVersion` is a date/build id, so neither real users nor the dev could easily tell which version/build a phone was running. The version wasn't displayed in the app at all (only sent as an analytics super-property).

## What changed

- **Release/TestFlight version increments.** Bump `MARKETING_VERSION` `1.0` → `1.0.0` (`CFBundleShortVersionString`). This is the authoritative source for both Debug and Release, verified with `xcodebuild -showBuildSettings` (the pbxproj does not override it; `Debug.xcconfig` and `Release.xcconfig` both `#include Shared.xcconfig`). TestFlight already inherits it because `ios/scripts/upload-testflight.sh` never passes `MARKETING_VERSION`, so this alone makes release builds report a meaningful version.
- **Manual patch-bump script.** New `ios/scripts/bump-ios-version.sh` (`patch` default, also `minor`/`major`/`X.Y.Z`) bumps the version on release, mirroring the macOS `bump-version.sh` model. Kept manual on purpose: a per-merge auto-bump would force CI to commit back to the repo. `CFBundleVersion` stays the per-upload monotonic UTC timestamp that `upload-testflight.sh` already stamps, so App Store's strictly-increasing-build-number requirement is unaffected.
- **Dev builds are tellable.** New empty-default Info.plist keys `CMUXDevTag` / `CMUXGitSHA` (sourced from `CMUX_DEV_TAG` / `CMUX_GIT_SHA` build settings). `ios/scripts/reload.sh` overrides them with the `--tag` and the short git SHA (trailing `+` when the working tree is dirty, including untracked files). Empty on release, so release shows a clean `1.0.0`.
- **In-app display.** `AppVersionInfo` (in `CmuxMobileSupport`) is a pure, testable value type that assembles the display string from the bundle's info dictionary plus an injected `isDevBuild`. Shown in `MobileSettingsView` under a new **About → Version** row (selectable text). 10 unit tests cover release vs dev, dirty marker, missing keys, and unexpanded-macro fallback.

## What the version shows now

- **TestFlight/release build:** `1.0.0 (20260607031606)` — clean semver + the monotonic build number. Bump the patch with `ios/scripts/bump-ios-version.sh` per release.
- **Dev/dogfood build:** `1.0.0 (1) · grid · a1b2c3d` — semver + build number + `--tag` + short git SHA, so two dev builds are never indistinguishable.

The patch increments only when you run `ios/scripts/bump-ios-version.sh` on release (manual, no CI churn). The build number keeps auto-incrementing per TestFlight upload.

## Tradeoff

The `MARKETING_VERSION` bump is manual, not fully automated. A fully-automated per-merge bump would require CI to commit the version back to the repo on every iOS-affecting merge (churn + race-prone with the existing TestFlight workflow). The documented `bump-ios-version.sh` path is the deliberate, low-risk choice; the build number (`CFBundleVersion`) is already auto-monotonic per upload, so uploads never collide regardless.

## Verification

Build-metadata change — verified by inspecting the built Info.plist, no full iOS dogfood required. Simulator build via `ios/scripts/reload.sh --tag iosver` succeeded; built `cmux.app/Info.plist` shows `CFBundleShortVersionString=1.0.0`, `CMUXDevTag=iosver`, `CMUXGitSHA=7135f32c5f+`. All 25 `CmuxMobileSupport` tests pass. Autoreview clean (`patch is correct`), cmux-policy clean.

Localization: `mobile.settings.about` and `mobile.settings.version` added to `ios/cmux/Resources/Localizable.xcstrings` with en + ja. The version value string is not localizable text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783472802&installation_id=133855650&pr_number=5592&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5592&signature=2d45db410db25b0fc31dedaef954f101716baa34c0243c404e46d85d8d50cb87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build metadata and settings UI only; release builds explicitly hide dev tag/SHA via `#if DEBUG`, with tests covering edge cases.
> 
> **Overview**
> Replaces the frozen iOS `MARKETING_VERSION` (`1.0` → `1.0.0`) with a semver users and testers can report, and surfaces that identity in the app.
> 
> **In-app:** New **About → Version** row in `MobileSettingsView` shows a selectable string from `AppVersionInfo`, which reads `CFBundleShortVersionString`, `CFBundleVersion`, and optional dev keys from the bundle.
> 
> **Release:** `ios/scripts/bump-ios-version.sh` manually bumps semver in `Shared.xcconfig` on release (patch/minor/major or explicit `X.Y.Z`). TestFlight’s per-upload `CFBundleVersion` behavior is unchanged.
> 
> **Dev dogfood:** `Info.plist` adds `CMUXDevTag` / `CMUXGitSHA` (from `CMUX_DEV_TAG` / `CMUX_GIT_SHA`, empty by default). `reload.sh` passes the `--tag` and short git SHA (with `+` when the tree is dirty, including untracked files). **DEBUG** builds append ` · tag · sha` to the About string; release builds stay clean even if those keys are set.
> 
> Unit tests cover formatting, release vs dev gating, placeholders, and missing keys. Localized **About** / **Version** labels (en + ja).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc8f1346fb4ba2f2e73bd1d673ac2cfacd6aaf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the iOS app version tellable. Release/TestFlight builds now show semver + build number, and dev builds add a tag and short git SHA. The version also appears in-app.

- **New Features**
  - Bump `MARKETING_VERSION` from 1.0 → 1.0.0 (`CFBundleShortVersionString`) for Debug and Release.
  - Add `ios/scripts/bump-ios-version.sh` to manually bump semver on release; `CFBundleVersion` stays the auto UTC timestamp.
  - Dev builds stamp `CMUXDevTag` and `CMUXGitSHA` via `ios/scripts/reload.sh` (adds “+” when dirty); release/TestFlight render a clean string and ignore dev metadata.
  - Show About → Version in `MobileSettingsView` using `AppVersionInfo` from `CmuxMobileSupport` (selectable text). Tests cover release/dev formatting.

- **Migration**
  - On releases, run `ios/scripts/bump-ios-version.sh` (defaults to patch).
  - No change to TestFlight; the build number still auto-increments per upload.
  - For dev builds, use `ios/scripts/reload.sh --tag <name>` to stamp the tag and SHA.

<sup>Written for commit 5fc8f1346fb4ba2f2e73bd1d673ac2cfacd6aaf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an "About" section to Settings that displays the app version and build metadata with localized labels and accessibility identifiers.

* **Tests**
  * Adds tests covering version formatting, placeholder handling, dev-build metadata, and fallback behavior.

* **Chores**
  * Updates project versioning configuration and adds/updates scripts to manage and embed version and build identifiers during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->