### PR TITLE
Fix SSH PTY typing lag

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10420,6 +10420,7 @@ struct CMUXCLI {
         let lowered = trimmed.lowercased()
         if lowered.contains("missing required capability") ||
             lowered.contains("pty.session") ||
+            lowered.contains("pty.write.notification") ||
             lowered.contains("method_not_found") {
             return "remote daemon does not support persistent SSH PTY sessions; reconnect the remote workspace to update cmux"
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2474,7 +2474,13 @@ protocol WorkspaceRemotePTYBridgeRPCClient: AnyObject {
         onEvent: @escaping (WorkspaceRemotePTYBridgeEvent) -> Void
     ) throws -> WorkspaceRemotePTYBridgeAttachment
 
-    func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws
+    func writePTY(
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        data: Data,
+        completion: @escaping (Error?) -> Void
+    )
     func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String)
 }
 
@@ -2482,7 +2488,8 @@ nonisolated func remoteDaemonMissingRequiredCapabilitiesMessage(_ missingCapabil
     let missing = Set(missingCapabilities)
     if missing.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYSessionCapability) ||
         missing.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYSessionTokenCapability) ||
-        missing.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYPersistentDaemonCapability) {
+        missing.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYPersistentDaemonCapability) ||
+        missing.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYWriteNotificationCapability) {
         return String(
             localized: "remoteDaemon.error.missingPersistentPTYCapability",
             defaultValue: "remote daemon does not support persistent SSH PTY sessions; reconnect the remote workspace to update cmux"
@@ -2502,6 +2509,7 @@ private final class WorkspaceRemoteDaemonRPCClient {
     static let requiredPTYSessionCapability = "pty.session"
     static let requiredPTYSessionTokenCapability = "pty.session.token"
     static let requiredPTYPersistentDaemonCapability = "pty.session.persistent_daemon"
+    static let requiredPTYWriteNotificationCapability = "pty.write.notification"
 
     enum StreamEvent {
         case data(Data)
@@ -2642,6 +2650,7 @@ private final class WorkspaceRemoteDaemonRPCClient {
         if configuration.preserveAfterTerminalExit {
             capabilities.append(requiredPTYSessionCapability)
             capabilities.append(requiredPTYSessionTokenCapability)
+            capabilities.append(requiredPTYWriteNotificationCapability)
         }
         if configuration.persistentDaemonSlot != nil {
             capabilities.append(requiredPTYPersistentDaemonCapability)
@@ -3053,17 +3062,27 @@ private final class WorkspaceRemoteDaemonRPCClient {
         }
     }
 
-    func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws {
-        _ = try call(
-            method: "pty.write",
-            params: [
-                "session_id": sessionID,
-                "attachment_id": attachmentID,
-                "client_attachment_token": attachmentToken,
-                "data_base64": data.base64EncodedString(),
-            ],
-            timeout: 8.0
-        )
+    func writePTY(
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        data: Data,
+        completion: @escaping (Error?) -> Void
+    ) {
+        do {
+            try notify(
+                method: "pty.write",
+                params: [
+                    "session_id": sessionID,
+                    "attachment_id": attachmentID,
+                    "client_attachment_token": attachmentToken,
+                    "data_base64": data.base64EncodedString(),
+                ]
+            )
+            completion(nil)
+        } catch {
+            completion(error)
+        }
     }
 
     func resizePTY(sessionID: String, attachmentID: String, attachmentToken: String, cols: Int, rows: Int) throws {
@@ -3182,6 +3201,24 @@ private final class WorkspaceRemoteDaemonRPCClient {
         throw NSError(domain: "cmux.remote.daemon.rpc", code: 14, userInfo: [
             NSLocalizedDescriptionKey: "\(method) failed (\(code)): \(message)",
         ])
+    }
+
+    private func notify(method: String, params: [String: Any]) throws {
+        let payload: Data
+        do {
+            payload = try Self.encodeJSON([
+                "method": method,
+                "params": params,
+            ])
+        } catch {
+            throw NSError(domain: "cmux.remote.daemon.rpc", code: 10, userInfo: [
+                NSLocalizedDescriptionKey: "failed to encode daemon RPC notification \(method): \(error.localizedDescription)",
+            ])
+        }
+
+        try writeQueue.sync {
+            try writePayload(payload)
+        }
     }
 
     private func writePayload(_ payload: Data) throws {
@@ -5791,19 +5828,15 @@ final class WorkspaceRemotePTYBridgeServer {
                     }
                     return
                 }
-                var writeError: Error?
-                do {
-                    try self.rpcClient.writePTY(
-                        sessionID: currentSessionID,
-                        attachmentID: remoteAttachment.attachmentID,
-                        attachmentToken: remoteAttachment.token,
-                        data: data
-                    )
-                } catch {
-                    writeError = error
-                }
-                self.queue.async {
-                    self.handleInputWriteFinished(bytes: data.count, error: writeError)
+                self.rpcClient.writePTY(
+                    sessionID: currentSessionID,
+                    attachmentID: remoteAttachment.attachmentID,
+                    attachmentToken: remoteAttachment.token,
+                    data: data
+                ) { [weak self] writeError in
+                    self?.queue.async {
+                        self?.handleInputWriteFinished(bytes: data.count, error: writeError)
+                    }
                 }
             }
         }
@@ -6021,7 +6054,9 @@ final class WorkspaceRemotePTYBridgeServer {
         private static func userFacingBridgeErrorMessage(_ error: Error) -> String {
             let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
             let lowered = message.lowercased()
-            if lowered.contains("missing required capability") || lowered.contains("pty.session") {
+            if lowered.contains("missing required capability") ||
+                lowered.contains("pty.session") ||
+                lowered.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYWriteNotificationCapability) {
                 return String(
                     localized: "remoteDaemon.error.missingPersistentPTYCapability",
                     defaultValue: "remote daemon does not support persistent SSH PTY sessions; reconnect the remote workspace to update cmux"
@@ -7519,7 +7554,8 @@ final class WorkspaceRemoteSessionController {
     private var bakedDaemonPreflightRequiredCapabilities: [String] {
         requiredDaemonCapabilities.filter {
             $0 != WorkspaceRemoteDaemonRPCClient.requiredPTYSessionCapability &&
-                $0 != WorkspaceRemoteDaemonRPCClient.requiredPTYSessionTokenCapability
+                $0 != WorkspaceRemoteDaemonRPCClient.requiredPTYSessionTokenCapability &&
+                $0 != WorkspaceRemoteDaemonRPCClient.requiredPTYWriteNotificationCapability
         }
     }
 
@@ -7532,7 +7568,8 @@ final class WorkspaceRemoteSessionController {
         let lowered = message.lowercased()
         if lowered.contains("missing required capability") ||
             lowered.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYSessionCapability) ||
-            lowered.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYSessionTokenCapability) {
+            lowered.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYSessionTokenCapability) ||
+            lowered.contains(WorkspaceRemoteDaemonRPCClient.requiredPTYWriteNotificationCapability) {
             return remoteDaemonMissingRequiredCapabilitiesMessage([
                 WorkspaceRemoteDaemonRPCClient.requiredPTYSessionCapability,
             ])

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -920,12 +920,19 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         )
         XCTAssertFalse(message.contains("pty.session"))
 
+        let notificationMessage = remoteDaemonMissingRequiredCapabilitiesMessage([
+            "pty.write.notification",
+        ])
+        XCTAssertEqual(notificationMessage, message)
+        XCTAssertFalse(notificationMessage.contains("pty.write.notification"))
+
         let rawError = NSError(domain: "cmux.remote.daemon", code: 43, userInfo: [
-            NSLocalizedDescriptionKey: "remote daemon missing required capability pty.session,pty.session.token",
+            NSLocalizedDescriptionKey: "remote daemon missing required capability pty.write.notification",
         ])
         let bootstrapMessage = WorkspaceRemoteSessionController.userFacingRemoteDaemonBootstrapErrorMessage(rawError)
         XCTAssertEqual(bootstrapMessage, message)
         XCTAssertFalse(bootstrapMessage.contains("pty.session"))
+        XCTAssertFalse(bootstrapMessage.contains("pty.write.notification"))
     }
 
     @MainActor
@@ -3279,7 +3286,15 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             return WorkspaceRemotePTYBridgeAttachment(attachmentID: attachmentID, token: "immediate-token")
         }
 
-        func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws {}
+        func writePTY(
+            sessionID: String,
+            attachmentID: String,
+            attachmentToken: String,
+            data: Data,
+            completion: @escaping (Error?) -> Void
+        ) {
+            completion(nil)
+        }
         func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
     }
 
@@ -3301,7 +3316,15 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             return WorkspaceRemotePTYBridgeAttachment(attachmentID: attachmentID, token: "immediate-output-token")
         }
 
-        func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws {}
+        func writePTY(
+            sessionID: String,
+            attachmentID: String,
+            attachmentToken: String,
+            data: Data,
+            completion: @escaping (Error?) -> Void
+        ) {
+            completion(nil)
+        }
         func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
     }
 
@@ -3327,7 +3350,15 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             return WorkspaceRemotePTYBridgeAttachment(attachmentID: attachmentID, token: "flood-token")
         }
 
-        func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws {}
+        func writePTY(
+            sessionID: String,
+            attachmentID: String,
+            attachmentToken: String,
+            data: Data,
+            completion: @escaping (Error?) -> Void
+        ) {
+            completion(nil)
+        }
 
         func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {
             detachSemaphore.signal()
@@ -3370,8 +3401,15 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             return WorkspaceRemotePTYBridgeAttachment(attachmentID: attachmentID, token: "delayed-token")
         }
 
-        func writePTY(sessionID: String, attachmentID: String, attachmentToken: String, data: Data) throws {
+        func writePTY(
+            sessionID: String,
+            attachmentID: String,
+            attachmentToken: String,
+            data: Data,
+            completion: @escaping (Error?) -> Void
+        ) {
             guard String(data: data, encoding: .utf8)?.contains("after-half-close-input") == true else {
+                completion(nil)
                 return
             }
 
@@ -3392,10 +3430,66 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                 emitEvent?(.data(Data("after-half-close-output\n".utf8)))
                 emitEvent?(.exit)
             }
+            completion(nil)
         }
 
         func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {
             detachSemaphore.signal()
+        }
+    }
+
+    private final class DeferredWriteCompletionPTYBridgeRPC: WorkspaceRemotePTYBridgeRPCClient {
+        private let lock = NSLock()
+        private var completions: [(Error?) -> Void] = []
+
+        let firstWrite = DispatchSemaphore(value: 0)
+        let secondWrite = DispatchSemaphore(value: 0)
+
+        func attachBridgePTY(
+            sessionID: String,
+            attachmentID: String,
+            cols: Int,
+            rows: Int,
+            command: String?,
+            requireExisting: Bool,
+            queue: DispatchQueue,
+            onEvent: @escaping (WorkspaceRemotePTYBridgeEvent) -> Void
+        ) throws -> WorkspaceRemotePTYBridgeAttachment {
+            return WorkspaceRemotePTYBridgeAttachment(attachmentID: attachmentID, token: "deferred-token")
+        }
+
+        func writePTY(
+            sessionID: String,
+            attachmentID: String,
+            attachmentToken: String,
+            data: Data,
+            completion: @escaping (Error?) -> Void
+        ) {
+            let writeCount: Int
+            lock.lock()
+            completions.append(completion)
+            writeCount = completions.count
+            lock.unlock()
+
+            if writeCount == 1 {
+                firstWrite.signal()
+            } else if writeCount == 2 {
+                secondWrite.signal()
+            }
+        }
+
+        func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
+
+        func completeWrites() {
+            let pending: [(Error?) -> Void]
+            lock.lock()
+            pending = completions
+            completions.removeAll()
+            lock.unlock()
+
+            for completion in pending {
+                completion(nil)
+            }
         }
     }
 
@@ -5305,6 +5399,47 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         )
         XCTAssertEqual(firstJSON["type"] as? String, "ready", responseText)
         XCTAssertTrue(responseText.contains("early-output"), responseText)
+    }
+
+    func testPTYBridgeForwardsInputWithoutWaitingForWriteCompletion() throws {
+        let rpcClient = DeferredWriteCompletionPTYBridgeRPC()
+        let server = WorkspaceRemotePTYBridgeServer(
+            rpcClient: rpcClient,
+            sessionID: "session-input-completion",
+            attachmentID: "attachment-input-completion",
+            command: nil,
+            requireExisting: false
+        ) {}
+        let endpoint = try server.start()
+        let fd = try connectLoopbackTCP(port: endpoint.port)
+        defer {
+            rpcClient.completeWrites()
+            Darwin.close(fd)
+            server.stop()
+        }
+
+        let handshakeData = try JSONSerialization.data(withJSONObject: [
+            "token": endpoint.token,
+            "cols": 80,
+            "rows": 24,
+        ], options: [])
+        guard let handshake = String(data: handshakeData, encoding: .utf8) else {
+            return XCTFail("Failed to encode bridge handshake")
+        }
+        XCTAssertTrue(writeAll(handshake + "\n", to: fd))
+
+        let readyLine = try readLine(from: fd, timeout: 2)
+        XCTAssertTrue(readyLine.contains("\"ready\""), readyLine)
+
+        XCTAssertTrue(writeAll("a", to: fd))
+        XCTAssertEqual(rpcClient.firstWrite.wait(timeout: .now() + 2), .success)
+        XCTAssertTrue(writeAll("b", to: fd))
+        XCTAssertEqual(
+            rpcClient.secondWrite.wait(timeout: .now() + 1.0),
+            .success,
+            "Bridge input forwarding should not wait for the prior pty.write response"
+        )
+        rpcClient.completeWrites()
     }
 
     func testPTYBridgeStopRetainsServerUntilCleanupRuns() throws {

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -32,8 +32,31 @@ var version = "dev"
 
 type rpcRequest struct {
 	ID     any            `json:"id"`
+	HasID  bool           `json:"-"`
 	Method string         `json:"method"`
 	Params map[string]any `json:"params"`
+}
+
+func (r *rpcRequest) UnmarshalJSON(data []byte) error {
+	type rpcRequestWire struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params map[string]any  `json:"params"`
+	}
+	var wire rpcRequestWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	r.HasID = len(wire.ID) > 0
+	r.ID = nil
+	if r.HasID && string(wire.ID) != "null" {
+		if err := json.Unmarshal(wire.ID, &r.ID); err != nil {
+			return err
+		}
+	}
+	r.Method = wire.Method
+	r.Params = wire.Params
+	return nil
 }
 
 type rpcError struct {
@@ -292,8 +315,7 @@ func runRPCServer(stdin io.Reader, stdout io.Writer, ptyHub *wsPTYHub, ownsPTYHu
 			continue
 		}
 
-		resp := server.handleRequest(req)
-		if err := writer.writeResponse(resp); err != nil {
+		if err := server.handleRequestAndWriteResponse(req); err != nil {
 			return err
 		}
 	}
@@ -1109,8 +1131,7 @@ func runRPCServerWithReader(reader *bufio.Reader, writer *stdioFrameWriter, ptyH
 			continue
 		}
 
-		resp := server.handleRequest(req)
-		if err := writer.writeResponse(resp); err != nil {
+		if err := server.handleRequestAndWriteResponse(req); err != nil {
 			return err
 		}
 	}
@@ -1290,6 +1311,7 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 					"pty.session",
 					"pty.session.token",
 					"pty.session.persistent_daemon",
+					"pty.write.notification",
 				},
 			},
 		}
@@ -1343,6 +1365,48 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 			},
 		}
 	}
+}
+
+func (s *rpcServer) handleRequestAndWriteResponse(req rpcRequest) error {
+	resp := s.handleRequest(req)
+	if !rpcRequestExpectsResponse(req) {
+		return s.handleNotificationResponse(req, resp)
+	}
+	return s.frameWriter.writeResponse(resp)
+}
+
+func rpcRequestExpectsResponse(req rpcRequest) bool {
+	return !rpcRequestIsPTYWriteNotification(req)
+}
+
+func rpcRequestIsPTYWriteNotification(req rpcRequest) bool {
+	return !req.HasID && req.Method == "pty.write"
+}
+
+func (s *rpcServer) handleNotificationResponse(req rpcRequest, resp rpcResponse) error {
+	if !rpcRequestIsPTYWriteNotification(req) || resp.OK || s.frameWriter == nil {
+		return nil
+	}
+	sessionID, attachmentID, attachmentToken, badResp := parsePTYAttachmentIdentity(req, "pty.write")
+	if badResp != nil || strings.TrimSpace(attachmentToken) == "" {
+		return nil
+	}
+	detail := "PTY write failed"
+	if resp.Error != nil && strings.TrimSpace(resp.Error.Message) != "" {
+		detail = strings.TrimSpace(resp.Error.Message)
+	}
+	err := s.frameWriter.writeEvent(rpcEvent{
+		Event:           "pty.error",
+		SessionID:       sessionID,
+		AttachmentID:    attachmentID,
+		AttachmentToken: attachmentToken,
+		Error:           detail,
+		Message:         detail,
+	})
+	if resp.Error != nil && resp.Error.Code == "pty_input_queue_full" && s.ptyHub != nil {
+		s.ptyHub.detachByID(sessionID, attachmentID, attachmentToken)
+	}
+	return err
 }
 
 func (s *rpcServer) handleProxyOpen(req rpcRequest) rpcResponse {

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -1376,6 +1376,8 @@ func (s *rpcServer) handleRequestAndWriteResponse(req rpcRequest) error {
 }
 
 func rpcRequestExpectsResponse(req rpcRequest) bool {
+	// Only pty.write currently uses JSON-RPC notification semantics; all
+	// other id-less requests still get a response for compatibility.
 	return !rpcRequestIsPTYWriteNotification(req)
 }
 
@@ -1384,7 +1386,21 @@ func rpcRequestIsPTYWriteNotification(req rpcRequest) bool {
 }
 
 func (s *rpcServer) handleNotificationResponse(req rpcRequest, resp rpcResponse) error {
-	if !rpcRequestIsPTYWriteNotification(req) || resp.OK || s.frameWriter == nil {
+	if !rpcRequestIsPTYWriteNotification(req) || resp.OK {
+		return nil
+	}
+	if s.frameWriter == nil {
+		detail := "unknown error"
+		if resp.Error != nil {
+			detail = strings.TrimSpace(resp.Error.Code)
+			if message := strings.TrimSpace(resp.Error.Message); message != "" {
+				if detail != "" {
+					detail += ": "
+				}
+				detail += message
+			}
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "cmuxd-remote: pty.write notification failed without response writer: %s\n", detail)
 		return nil
 	}
 	sessionID, attachmentID, attachmentToken, badResp := parsePTYAttachmentIdentity(req, "pty.write")

--- a/daemon/remote/cmd/cmuxd-remote/main_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/main_test.go
@@ -341,6 +341,16 @@ func TestRunStdioHelloAndPing(t *testing.T) {
 	if !sawPersistentPTYCapability {
 		t.Fatalf("hello should advertise pty.session.persistent_daemon: %v", firstResult)
 	}
+	var sawPTYWriteNotificationCapability bool
+	for _, capability := range capabilities {
+		if capability == "pty.write.notification" {
+			sawPTYWriteNotificationCapability = true
+			break
+		}
+	}
+	if !sawPTYWriteNotificationCapability {
+		t.Fatalf("hello should advertise pty.write.notification: %v", firstResult)
+	}
 
 	var second map[string]any
 	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
@@ -348,6 +358,105 @@ func TestRunStdioHelloAndPing(t *testing.T) {
 	}
 	if ok, _ := second["ok"].(bool); !ok {
 		t.Fatalf("second response should be ok=true: %v", second)
+	}
+}
+
+func TestRunStdioPTYWriteNotificationDoesNotEmitResponse(t *testing.T) {
+	input := strings.NewReader(
+		`{"method":"pty.write","params":{"session_id":"missing","attachment_id":"missing","client_attachment_token":"token","data_base64":"YQ=="}}` + "\n" +
+			`{"id":2,"method":"ping","params":{}}` + "\n",
+	)
+	var out bytes.Buffer
+	code := run([]string{"serve", "--stdio"}, input, &out, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("run serve exit code = %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d frame lines, want pty.error event plus ping response: %q", len(lines), out.String())
+	}
+
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("failed to decode pty.write error event: %v", err)
+	}
+	if _, hasID := event["id"]; hasID {
+		t.Fatalf("pty.write notification should not emit an RPC response id: %v", event)
+	}
+	if got := event["event"]; got != "pty.error" {
+		t.Fatalf("first frame = %v, want pty.error event; payload=%v", got, event)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &response); err != nil {
+		t.Fatalf("failed to decode ping response: %v", err)
+	}
+	if got := response["id"]; got != float64(2) {
+		t.Fatalf("response id = %v, want ping id 2; payload=%v", got, response)
+	}
+	if ok, _ := response["ok"].(bool); !ok {
+		t.Fatalf("ping response should be ok=true after pty.write notification: %v", response)
+	}
+}
+
+func TestRunStdioNoIDNonPTYRequestStillEmitsResponse(t *testing.T) {
+	input := strings.NewReader(`{"method":"ping","params":{}}` + "\n")
+	var out bytes.Buffer
+	code := run([]string{"serve", "--stdio"}, input, &out, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("run serve exit code = %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("got %d response lines, want ping response: %q", len(lines), out.String())
+	}
+	var response map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &response); err != nil {
+		t.Fatalf("failed to decode ping response: %v", err)
+	}
+	if ok, _ := response["ok"].(bool); !ok {
+		t.Fatalf("no-id ping should still emit an ok response: %v", response)
+	}
+}
+
+func TestRunStdioNullIDPTYWriteStillEmitsResponse(t *testing.T) {
+	input := strings.NewReader(
+		`{"id":null,"method":"pty.write","params":{"session_id":"missing","attachment_id":"missing","client_attachment_token":"token","data_base64":"YQ=="}}` + "\n" +
+			`{"id":2,"method":"ping","params":{}}` + "\n",
+	)
+	var out bytes.Buffer
+	code := run([]string{"serve", "--stdio"}, input, &out, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatalf("run serve exit code = %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d frame lines, want pty.write response plus ping response: %q", len(lines), out.String())
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &response); err != nil {
+		t.Fatalf("failed to decode pty.write response: %v", err)
+	}
+	if eventName, _ := response["event"].(string); eventName != "" {
+		t.Fatalf("id:null pty.write should emit an RPC response, got event: %v", response)
+	}
+	if ok, _ := response["ok"].(bool); ok {
+		t.Fatalf("missing pty.write target should fail: %v", response)
+	}
+
+	var ping map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &ping); err != nil {
+		t.Fatalf("failed to decode ping response: %v", err)
+	}
+	if got := ping["id"]; got != float64(2) {
+		t.Fatalf("response id = %v, want ping id 2; payload=%v", got, ping)
+	}
+	if ok, _ := ping["ok"].(bool); !ok {
+		t.Fatalf("ping response should be ok=true after id:null pty.write: %v", ping)
 	}
 }
 
@@ -711,6 +820,42 @@ func TestPersistentDaemonAcceptsRotatedTokenFile(t *testing.T) {
 	}
 	conn, _, _ := openPersistentTestClient(t, socketPath, "new-token")
 	_ = conn.Close()
+}
+
+func TestPersistentDaemonPTYWriteNotificationDoesNotEmitResponse(t *testing.T) {
+	socketPath, stop := startPersistentDaemonForTest(t, "good-token")
+	defer stop()
+
+	conn, reader, writer := openPersistentTestClient(t, socketPath, "good-token")
+	defer conn.Close()
+
+	writePersistentTestFrame(t, writer, map[string]any{
+		"method": "pty.write",
+		"params": map[string]any{
+			"session_id":              "missing",
+			"attachment_id":           "missing",
+			"client_attachment_token": "token",
+			"data_base64":             base64.StdEncoding.EncodeToString([]byte("a")),
+		},
+	})
+	event := readPersistentTestFrame(t, conn, reader)
+	if _, hasID := event["id"]; hasID {
+		t.Fatalf("pty.write notification should not emit an RPC response id: %v", event)
+	}
+	if got := event["event"]; got != "pty.error" {
+		t.Fatalf("first frame = %v, want pty.error event; payload=%v", got, event)
+	}
+	ping := persistentTestRPCCall(t, conn, reader, writer, rpcRequest{
+		ID:     2,
+		Method: "ping",
+		Params: map[string]any{},
+	})
+	if got := ping["id"]; got != float64(2) {
+		t.Fatalf("response id = %v, want ping id 2; payload=%v", got, ping)
+	}
+	if ok, _ := ping["ok"].(bool); !ok {
+		t.Fatalf("ping response should be ok=true after pty.write notification: %v", ping)
+	}
 }
 
 func TestAuthenticatePersistentDaemonClientReadDeadline(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -501,8 +501,7 @@ func handleWebSocketRPC(w http.ResponseWriter, r *http.Request, cfg wsPTYServerC
 			continue
 		}
 
-		resp := server.handleRequest(req)
-		if err := server.frameWriter.writeResponse(resp); err != nil {
+		if err := server.handleRequestAndWriteResponse(req); err != nil {
 			_ = conn.Close(websocket.StatusInternalError, "write failed")
 			return
 		}

--- a/daemon/remote/cmd/cmuxd-remote/ws_rpc_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_rpc_test.go
@@ -141,6 +141,60 @@ func TestWebSocketRPCHelloAndProxyRoundTrip(t *testing.T) {
 	t.Fatalf("timed out waiting for proxy stream events, output=%q", output.String())
 }
 
+func TestWebSocketRPCPTYWriteNotificationDoesNotEmitResponse(t *testing.T) {
+	leasePath := t.TempDir() + "/rpc-lease.json"
+	server := httptest.NewServer(newWebSocketPTYHandler(wsPTYServerConfig{
+		PTYAuthLeaseFile: t.TempDir() + "/pty-lease.json",
+		RPCAuthLeaseFile: leasePath,
+		Shell:            "/bin/sh",
+	}, nil))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	writeTestLease(t, leasePath, "rpc-token", "sess-rpc-notify", false, time.Now().Add(time.Minute))
+	conn := dialRPC(t, ctx, server.URL)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	sendRPCAuth(t, ctx, conn, "rpc-token", "sess-rpc-notify")
+	ready := readWSRPCFrame(t, ctx, conn)
+	if ready["type"] != "ready" {
+		t.Fatalf("expected ready frame, got %v", ready)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"method": "pty.write",
+		"params": map[string]any{
+			"session_id":              "missing",
+			"attachment_id":           "missing",
+			"client_attachment_token": "token",
+			"data_base64":             base64.StdEncoding.EncodeToString([]byte("a")),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal notification: %v", err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText, payload); err != nil {
+		t.Fatalf("write notification: %v", err)
+	}
+	event := readWSRPCFrame(t, ctx, conn)
+	if _, hasID := event["id"]; hasID {
+		t.Fatalf("pty.write notification should not emit an RPC response id: %v", event)
+	}
+	if got := event["event"]; got != "pty.error" {
+		t.Fatalf("first frame = %v, want pty.error event; payload=%v", got, event)
+	}
+
+	ping := rpcCall(t, ctx, conn, rpcRequest{
+		ID:     2,
+		Method: "ping",
+		Params: map[string]any{},
+	})
+	if ping["ok"] != true {
+		t.Fatalf("ping failed after pty.write notification: %v", ping)
+	}
+}
+
 func dialRPC(t *testing.T, ctx context.Context, serverURL string) *websocket.Conn {
 	t.Helper()
 	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") + "/rpc"


### PR DESCRIPTION
## Summary

- Fixes SSH/tmux typing lag by removing the per-key remote RPC round trip from `pty.write`.
- Sends remote PTY input as a fire-and-forget notification after the local bridge accepts it, gated by the new `pty.write.notification` remote daemon capability.
- Keeps request/response behavior for normal RPCs and explicit `id: null`, and emits async `pty.error` for failed notification writes.
- Supersedes #5431 with a smaller root-cause branch after review feedback and dogfooding.

## Testing

- Dogfooded the tagged dev build in a real remote SSH session and confirmed lag is fixed.
- Verified debug logs before/after: previous per-key bridge latency was roughly network RTT; fixed build reports local write return around sub-millisecond for the same path.
- `git diff --cached --check`
- `(cd daemon/remote && go test ./cmd/cmuxd-remote)`
- `CMUX_SKIP_ZIG_BUILD=1 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace cmux.xcworkspace -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sshlag-notify-tests -only-testing:cmuxTests/CLINotifyProcessIntegrationTests/testPTYBridgeForwardsInputWithoutWaitingForWriteCompletion -only-testing:cmuxTests/WorkspaceRemoteConnectionTests/testRemoteDaemonCapabilityErrorsUseUserFacingMessage -only-testing:cmuxTests/WorkspaceRemoteConnectionTests/testSkipBootstrapPersistentPTYDoesNotFailBakedCapabilityPreflight`
- `./scripts/lint-pbxproj-test-wiring.sh`

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A; manually dogfooded in a real SSH session.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PTY write operations now use notification-based asynchronous handling for better responsiveness.
  * New capability requirement: `pty.write.notification` in capability negotiation.

* **Bug Fixes**
  * Improved error messages and handling when required PTY write capabilities are unavailable.

* **Tests**
  * Expanded test coverage for PTY write notifications, including new test cases for notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->