### PR TITLE
iOS: DEBUG dogfood floating pane + checklist push (feedback P2)

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DogfoodFeedbackModel.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DogfoodFeedbackModel.swift
@@ -1,0 +1,177 @@
+#if DEBUG
+public import CmuxMobileShellModel
+public import Foundation
+import Observation
+
+/// Drives the floating, hideable DEV dogfood pane (P2 of the Mac↔phone feedback
+/// loop): holds the agent-pushed "what to check" checklist, the dogfooder's
+/// per-item multiple-choice answers, the shared freeform note, and the
+/// expand/submit UI state, and runs the "Capture & Send" submit.
+///
+/// `@MainActor @Observable`, built once in the app composition root and injected
+/// into the floating-pane window and the shell. DEBUG-only; it does not exist in
+/// release builds.
+///
+/// The model is the single source of truth for the pane. Pane rows read value
+/// snapshots (``DogfoodChecklistItem`` + the current selection) and call back
+/// through ``selectAnswer(itemID:choice:)``, never holding a reference to the
+/// model — so the snapshot-boundary rule for `ForEach` subtrees holds.
+///
+/// The actual transport (export the diagnostic log, gather the terminal text,
+/// build + send the `dogfood.feedback.submit` request) is injected as a
+/// ``DogfoodFeedbackSubmitting`` seam so the model is testable without a live
+/// connection and never reaches across modules for the surface/diagnostic
+/// accessors.
+@MainActor
+@Observable
+public final class DogfoodFeedbackModel {
+    /// The current checklist pushed by the agent. Empty until the first push or
+    /// fetch; the pane shows just the freeform note in that case.
+    public private(set) var checklist: DogfoodChecklist = .empty
+
+    /// The current selection per item id (the raw choice value), built up as the
+    /// dogfooder answers. Absent ids are unanswered.
+    public private(set) var selections: [String: String] = [:]
+
+    /// The shared freeform note across all questions.
+    public var note: String = ""
+
+    /// Whether the pane is expanded into the full overlay (vs. collapsed to the
+    /// draggable bug pill).
+    public var isExpanded: Bool = false
+
+    /// True while a "Capture & Send" submit is in flight (disables the button).
+    public private(set) var isSubmitting: Bool = false
+
+    /// The outcome of the most recent submit, for a transient pane banner. `nil`
+    /// until the first submit completes.
+    public private(set) var lastSubmitSucceeded: Bool?
+
+    private let submitter: any DogfoodFeedbackSubmitting
+
+    /// Creates the model.
+    /// - Parameter submitter: The seam that captures and sends a feedback bundle.
+    public init(submitter: any DogfoodFeedbackSubmitting) {
+        self.submitter = submitter
+    }
+
+    /// Replace the checklist with a freshly pushed/fetched one.
+    ///
+    /// A selection is preserved only when the new checklist still has an item with
+    /// that id *and* that item still offers the selected choice. This drops an
+    /// answer whose item disappeared (so it can't ride along on the next submit)
+    /// and also one whose item kept its id but changed its choices (so the pane
+    /// can't submit a stale choice that the dogfooder can no longer see or pick).
+    /// - Parameter checklist: The new checklist from the agent.
+    public func applyChecklist(_ checklist: DogfoodChecklist) {
+        self.checklist = checklist
+        // Build the valid-choice map without trapping on duplicate ids: an agent
+        // can push a malformed checklist with repeated ids, and the contract is
+        // that a bad payload is ignored, not a crash. A later duplicate id just
+        // unions its choices onto the earlier one's valid set.
+        var validChoicesByID: [String: Set<String>] = [:]
+        for item in checklist.items {
+            validChoicesByID[item.id, default: []].formUnion(item.choices)
+        }
+        selections = selections.filter { id, choice in
+            validChoicesByID[id]?.contains(choice) ?? false
+        }
+    }
+
+    /// Decode and apply a checklist from a raw `dogfood.checklist` event payload
+    /// or `dogfood.checklist.fetch` result. A malformed payload is ignored so a
+    /// bad push can't crash or blank the pane.
+    /// - Parameter payloadJSON: The raw JSON bytes, if any.
+    public func applyChecklistPayload(_ payloadJSON: Data?) {
+        guard let payloadJSON,
+              let decoded = try? DogfoodChecklist.decode(payloadJSON) else { return }
+        applyChecklist(decoded)
+    }
+
+    /// Record the dogfooder's selection for one item. Selecting the already
+    /// selected choice clears it (so a question can be un-answered back to
+    /// skipped).
+    /// - Parameters:
+    ///   - itemID: The answered item's stable id.
+    ///   - choice: The chosen raw choice value.
+    public func selectAnswer(itemID: String, choice: String) {
+        if selections[itemID] == choice {
+            selections.removeValue(forKey: itemID)
+        } else {
+            selections[itemID] = choice
+        }
+    }
+
+    /// The current selection for an item, or `nil` if unanswered.
+    /// - Parameter itemID: The item's stable id.
+    /// - Returns: The selected raw choice value, or `nil`.
+    public func selection(for itemID: String) -> String? {
+        selections[itemID]
+    }
+
+    /// Toggle the pane between the pill and the expanded overlay.
+    public func toggleExpanded() {
+        isExpanded.toggle()
+    }
+
+    /// The freeform note is capped at this character count in ``answersPayload``
+    /// so a pasted multi-MiB note cannot bloat the submitted answers JSON (it
+    /// also rides in the submit's separately capped `text` field). Matches the
+    /// shell + Mac feedback text caps.
+    public static let maxNoteChars = 16_384
+
+    /// The answers payload for the current selections, in checklist order, with
+    /// unanswered items omitted, plus the (capped) freeform note.
+    ///
+    /// Built in checklist order (not dictionary order) so the bundle is
+    /// deterministic and reads top-to-bottom like the pane. The note is capped
+    /// here so the MC answers are never dropped just because the note is large.
+    public var answersPayload: DogfoodFeedbackAnswers {
+        let ordered = checklist.items.compactMap { item -> DogfoodFeedbackAnswer? in
+            guard let choice = selections[item.id] else { return nil }
+            return DogfoodFeedbackAnswer(id: item.id, choice: choice)
+        }
+        return DogfoodFeedbackAnswers(answers: ordered, note: String(note.prefix(Self.maxNoteChars)))
+    }
+
+    /// Capture a chrome screenshot + terminal text + diagnostics + the current
+    /// answers and send them to the paired Mac's `dogfood.feedback.submit` sink.
+    ///
+    /// Sets ``isSubmitting`` for the duration and records ``lastSubmitSucceeded``.
+    /// On success it clears only the answers + note that were actually submitted
+    /// and have not changed since: the `submit` await is a reentrancy point, so a
+    /// dogfooder may re-answer an item, type more note text, or a new checklist
+    /// may arrive while the request is in flight; those in-flight edits must
+    /// survive rather than be wiped by the success path. The checklist stays so
+    /// the next capture starts clean. Fire-and-forget from the UI.
+    public func captureAndSend() async {
+        guard !isSubmitting else { return }
+        isSubmitting = true
+        let payload = answersPayload
+        // Snapshot exactly what was submitted, so the success-path clear only
+        // touches state that is still the submitted value. Merge without trapping
+        // on duplicate ids: `applyChecklist` tolerates a malformed checklist with
+        // repeated ids, and `answersPayload` emits one answer per row, so a
+        // duplicate id could otherwise trap here on Capture & Send.
+        let submittedSelections = Dictionary(
+            payload.answers.map { ($0.id, $0.choice) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let submittedNote = note
+        let ok = await submitter.submit(answers: payload)
+        isSubmitting = false
+        lastSubmitSucceeded = ok
+        guard ok else { return }
+        // Clear each submitted answer only if it is still the submitted choice
+        // (an in-flight re-answer is preserved).
+        for (id, choice) in submittedSelections where selections[id] == choice {
+            selections.removeValue(forKey: id)
+        }
+        // Clear the note only if it was not edited while the request was in
+        // flight.
+        if note == submittedNote {
+            note = ""
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DogfoodFeedbackSubmitting.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DogfoodFeedbackSubmitting.swift
@@ -1,0 +1,24 @@
+#if DEBUG
+public import CmuxMobileShellModel
+
+/// The seam ``DogfoodFeedbackModel`` uses to capture and send a feedback bundle.
+///
+/// The concrete implementation lives in the UI layer, where the chrome
+/// screenshot (`drawHierarchy`), the visible terminal text
+/// (`GhosttySurfaceView.visibleTerminalSnapshot()`), and the debug-log snapshot
+/// (`MobileDebugLog`) are reachable; it gathers those, attaches the supplied
+/// multiple-choice answers + note, and forwards to the shell's
+/// `dogfood.feedback.submit` path. Injecting it keeps the model testable with a
+/// fake submitter and avoids the model reaching across modules for UIKit/terminal
+/// accessors.
+///
+/// DEBUG-only; absent in release builds.
+@MainActor
+public protocol DogfoodFeedbackSubmitting: AnyObject {
+    /// Capture the current screen + terminal + diagnostics, attach the answers,
+    /// and submit to the paired Mac.
+    /// - Parameter answers: The multiple-choice answers + freeform note.
+    /// - Returns: `true` when the Mac acknowledged the bundle.
+    func submit(answers: DogfoodFeedbackAnswers) async -> Bool
+}
+#endif

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -239,6 +239,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
     private var terminalEventListenerTask: Task<Void, Never>?
     private var terminalEventListenerID: UUID?
+    #if DEBUG
+    /// The floating DEV dogfood pane's model. Injected from the composition root
+    /// so the dedicated ``dogfood.checklist`` subscription can feed it
+    /// agent-pushed checklists. `weak` because the pane window owns the model's
+    /// lifetime, not the shell. DEBUG-only.
+    private weak var dogfoodFeedbackModel: DogfoodFeedbackModel?
+    /// The dedicated, durable ``dogfood.checklist`` subscription task. Kept
+    /// separate from ``terminalEventListenerTask`` so the render-grid liveness
+    /// watchdog's ~9s re-subscribe never tears it down (it does not carry the
+    /// checklist topic). DEBUG-only.
+    private var dogfoodChecklistListenerTask: Task<Void, Never>?
+    #endif
     // Liveness watchdog for the render-grid push subscription. The `for await`
     // listener loop blocks indefinitely if the underlying connection half-dies
     // (network blip, Mac stops pushing, background/foreground cycle): the
@@ -578,12 +590,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ///   - text: An optional freeform note from the dogfooder.
     ///   - debugLogText: The string debug-log snapshot (from `MobileDebugLog`).
     ///   - terminalText: The visible terminal text (from `GhosttySurfaceView`).
+    ///   - answersJSON: The P2 multiple-choice answers as canonical JSON
+    ///     (``CmuxMobileShellModel/DogfoodFeedbackAnswers``), or `nil` for the P1
+    ///     freeform-only path. An old (P1-only) Mac ignores the extra key.
+    ///   - screenshotPNG: The P2 chrome screenshot PNG (the terminal renders
+    ///     blank in a UIView snapshot, which is why the terminal *text* is sent
+    ///     too), or `nil`. Sent base64; an old Mac ignores the extra key.
     /// - Returns: `true` when the Mac acknowledged the bundle.
     @discardableResult
     public func submitDogfoodFeedback(
         text: String,
         debugLogText: String,
-        terminalText: String
+        terminalText: String,
+        answersJSON: Data? = nil,
+        screenshotPNG: Data? = nil
     ) async -> Bool {
         guard let client = remoteClient else { return false }
         let diagnosticBlob = await diagnosticLog?.export() ?? Data()
@@ -602,7 +622,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     terminalText: terminalText,
                     buildStamp: buildStamp,
                     clientID: clientID,
-                    diagnosticBlob: diagnosticBlob
+                    diagnosticBlob: diagnosticBlob,
+                    answersJSON: answersJSON,
+                    screenshotPNG: screenshotPNG
                 )
             }.value
         } catch {
@@ -626,20 +648,36 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     nonisolated private static let dogfoodFeedbackMaxTextChars = 16_384
     nonisolated private static let dogfoodFeedbackMaxTerminalChars = 262_144
     nonisolated private static let dogfoodFeedbackMaxDebugLogChars = 1_048_576
+    /// Drop the answers JSON past this size before attaching it, mirroring the
+    /// Mac sink's `answers_json` cap. The freeform note rides inside the answers
+    /// payload, so without this a pasted multi-MiB note would serialize and ship
+    /// uncapped (the separate `text` field is capped, but the same note is here
+    /// too). 64 KiB matches the Mac's `dogfoodFeedbackMaxAnswersChars`.
+    nonisolated private static let dogfoodFeedbackMaxAnswersBytes = 65_536
+    /// Drop a screenshot larger than this before encoding it, mirroring the Mac
+    /// sink's blob byte cap so a huge PNG can't be base64'd into a multi-MiB
+    /// request on the phone. A dropped screenshot still ships the rest of the
+    /// bundle (text + terminal + answers + diagnostics).
+    nonisolated private static let dogfoodFeedbackMaxScreenshotBytes = 6_291_456 // 6 MiB
 
     /// Combine the structured + string diagnostics into one self-contained blob,
-    /// base64-encode it, and build the RPC request — all off the main actor.
+    /// base64-encode it, attach the optional P2 answers + screenshot, and build
+    /// the RPC request — all off the main actor.
     ///
     /// The string debug log rides inside the same diagnostic file as the compact
     /// structured rows (rows, a divider, then the human-readable log) so the Mac
-    /// bundle is self-contained. Inputs are size-capped first.
+    /// bundle is self-contained. Inputs are size-capped first. The P2 fields are
+    /// added only when present, so a P1 freeform-only submit produces the exact
+    /// same params it did before (and an old Mac ignores the new keys).
     nonisolated private static func buildDogfoodFeedbackRequest(
         text: String,
         debugLogText: String,
         terminalText: String,
         buildStamp: String,
         clientID: String,
-        diagnosticBlob: Data
+        diagnosticBlob: Data,
+        answersJSON: Data?,
+        screenshotPNG: Data?
     ) throws -> Data {
         let cappedText = String(text.prefix(dogfoodFeedbackMaxTextChars))
         let cappedTerminal = String(terminalText.prefix(dogfoodFeedbackMaxTerminalChars))
@@ -649,16 +687,234 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             combined.append(Data("\n----- mobile debug log -----\n".utf8))
             combined.append(Data(cappedDebugLog.utf8))
         }
-        return try MobileCoreRPCClient.requestData(
+        var params: [String: Any] = [
+            "text": cappedText,
+            "terminal_text": cappedTerminal,
+            "build_stamp": buildStamp,
+            "diagnostic_blob_base64": combined.base64EncodedString(),
+            "client_id": clientID,
+        ]
+        // Attach the answers JSON, keeping it under the Mac-side cap WITHOUT ever
+        // dropping the structured MC answers (the dogfooder's actual responses).
+        // The freeform note is the only unbounded contributor here, so if the
+        // encoded payload is over the byte cap, re-encode with a shrunk note that
+        // leaves room for the MC rows. The note also ships in the capped `text`
+        // field, so trimming it here loses nothing the bundle does not already
+        // carry. The model already byte-caps the note, so this is a backstop for
+        // a pathologically large agent-pushed checklist.
+        if let answersString = Self.cappedAnswersJSONString(
+            answersJSON,
+            maxBytes: dogfoodFeedbackMaxAnswersBytes
+        ) {
+            params["answers_json"] = answersString
+        }
+        // Attach the screenshot only if the *whole request frame* still fits the
+        // mobile transport's frame limit. The screenshot is the largest and most
+        // droppable field, and the diagnostic blob + terminal text + answers can
+        // already consume much of the budget, so a screenshot that passes its own
+        // byte cap could still push the frame over `defaultMaximumFrameByteCount`
+        // and make the transport throw `frameTooLarge` — failing the whole submit
+        // instead of just dropping the screenshot. So: build the request without
+        // the screenshot first, then re-add it only when the larger request still
+        // fits (with header + margin). This keeps the rest of the bundle shipping
+        // even when the screenshot has to be dropped.
+        let requestWithoutScreenshot = try MobileCoreRPCClient.requestData(
             method: "dogfood.feedback.submit",
-            params: [
-                "text": cappedText,
-                "terminal_text": cappedTerminal,
-                "build_stamp": buildStamp,
-                "diagnostic_blob_base64": combined.base64EncodedString(),
-                "client_id": clientID,
-            ]
+            params: params
         )
+        guard let screenshotPNG, screenshotPNG.count <= dogfoodFeedbackMaxScreenshotBytes else {
+            return requestWithoutScreenshot
+        }
+        let screenshotBase64 = screenshotPNG.base64EncodedString()
+        params["screenshot_png_base64"] = screenshotBase64
+        let requestWithScreenshot = try MobileCoreRPCClient.requestData(
+            method: "dogfood.feedback.submit",
+            params: params
+        )
+        let frameBudget = MobileSyncFrameCodec.defaultMaximumFrameByteCount - MobileSyncFrameCodec.headerByteCount
+        if requestWithScreenshot.count <= frameBudget {
+            return requestWithScreenshot
+        }
+        // The screenshot would overflow the frame; ship the rest without it.
+        return requestWithoutScreenshot
+    }
+
+    /// Return the answers JSON as a UTF-8 string capped under `maxBytes`, dropping
+    /// the freeform note (not the structured MC answers) when needed.
+    ///
+    /// The MC answers are the dogfooder's actual responses and must never be lost
+    /// silently, so when the encoded payload is over the cap this re-encodes the
+    /// same answers with an empty note (the note also rides in the capped `text`
+    /// field). Returns `nil` when there is no answers payload, the payload cannot
+    /// be decoded, or even the note-free encoding is still over the cap (a
+    /// pathologically large agent checklist — the structured rows themselves are
+    /// bounded by the Mac's checklist size cap, so this is a defensive backstop).
+    ///
+    /// `internal` (not `private`) so the byte-cap-preserves-answers behavior is
+    /// testable without a live transport.
+    nonisolated static func cappedAnswersJSONString(_ answersJSON: Data?, maxBytes: Int) -> String? {
+        guard let answersJSON else { return nil }
+        if answersJSON.count <= maxBytes {
+            return String(data: answersJSON, encoding: .utf8)
+        }
+        // Over the cap: the note is the only unbounded field. Re-encode keeping
+        // the MC answers but dropping the note.
+        guard let decoded = try? DogfoodFeedbackAnswers.decode(answersJSON) else { return nil }
+        let noteFree = DogfoodFeedbackAnswers(answers: decoded.answers, note: "")
+        guard let reEncoded = try? noteFree.encode(), reEncoded.count <= maxBytes else { return nil }
+        return String(data: reEncoded, encoding: .utf8)
+    }
+
+    // MARK: - Dogfood checklist (P2)
+
+    /// The event topic the Mac pushes agent checklists on.
+    nonisolated private static let dogfoodChecklistTopic = "dogfood.checklist"
+    /// The capability the Mac advertises when it can push/serve checklists. A
+    /// P1-only Mac omits it, so the phone skips the subscribe + fetch and never
+    /// eats a `method_not_found`.
+    nonisolated private static let dogfoodChecklistCapability = "dogfood.checklist"
+
+    /// Inject the floating pane's model so the dedicated checklist subscription
+    /// can feed it. Called once from the composition root after both are built.
+    /// - Parameter model: The DEV dogfood pane model.
+    public func setDogfoodFeedbackModel(_ model: DogfoodFeedbackModel) {
+        dogfoodFeedbackModel = model
+    }
+
+    private var dogfoodChecklistStreamID: String {
+        "ios-dogfood-checklist-\(clientID)"
+    }
+
+    /// Start the dedicated, durable ``dogfood.checklist`` subscription for the
+    /// active connection, then pull the current checklist once so a checklist the
+    /// agent pushed *before* this device subscribed is not missed (the
+    /// subscribe-after-push race).
+    ///
+    /// This is intentionally separate from ``startTerminalRefreshPolling()``: the
+    /// terminal stream is re-subscribed every ~9s by the render-grid liveness
+    /// watchdog, which would repeatedly drop a topic piggybacked on it. A
+    /// dedicated stream_id + listener coexists with the terminal stream (both the
+    /// client session and the Mac host demux subscriptions by topic / stream_id).
+    private func startDogfoodChecklistSubscription() {
+        guard let client = remoteClient else { return }
+        guard runtime?.supportsServerPushEvents ?? true else { return }
+        guard dogfoodChecklistListenerTask == nil else { return }
+        let topics: Set<String> = [Self.dogfoodChecklistTopic]
+        dogfoodChecklistListenerTask = Task { @MainActor [weak self] in
+            defer { self?.dogfoodChecklistListenerTask = nil }
+            guard let self else { return }
+            // Gate on the Mac advertising the capability so a P1-only Mac is a
+            // no-op (no subscribe, no fetch). The capability check reuses the
+            // host status the terminal path already resolves.
+            guard await self.macAdvertisesDogfoodChecklist(client: client) else { return }
+            let stream = await client.subscribe(to: topics)
+            let subscribed = await self.requestDogfoodChecklistSubscription(client: client)
+            guard subscribed else { return }
+            // Close the subscribe-after-push race: pull the current checklist now.
+            await self.fetchDogfoodChecklist(client: client)
+            for await event in stream {
+                guard !Task.isCancelled else { return }
+                guard self.remoteClient === client else { return }
+                if event.topic == Self.dogfoodChecklistTopic {
+                    self.dogfoodFeedbackModel?.applyChecklistPayload(event.payloadJSON)
+                }
+            }
+        }
+    }
+
+    private func stopDogfoodChecklistSubscription() {
+        dogfoodChecklistListenerTask?.cancel()
+        dogfoodChecklistListenerTask = nil
+    }
+
+    /// Whether the connected Mac advertises the dogfood-checklist capability.
+    private func macAdvertisesDogfoodChecklist(client: MobileCoreRPCClient) async -> Bool {
+        do {
+            let data = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(method: "mobile.host.status", params: [:]),
+                timeoutNanoseconds: Self.terminalOutputCapabilityTimeoutNanoseconds
+            )
+            guard let payload = try? MobileHostStatusResponse.decode(data) else { return false }
+            return payload.capabilities.contains(Self.dogfoodChecklistCapability)
+        } catch {
+            return false
+        }
+    }
+
+    /// Register the dedicated checklist subscription with the Mac host. Uses a
+    /// distinct stream_id so it coexists with the terminal subscription.
+    private func requestDogfoodChecklistSubscription(client: MobileCoreRPCClient) async -> Bool {
+        do {
+            let requestData = try MobileCoreRPCClient.requestData(
+                method: "mobile.events.subscribe",
+                params: [
+                    "stream_id": dogfoodChecklistStreamID,
+                    "topics": [Self.dogfoodChecklistTopic],
+                ]
+            )
+            let responseData = try await client.sendRequest(requestData)
+            let response = try? MobileEventSubscribeResponse.decode(responseData)
+            return !(response?.streamID ?? "").isEmpty
+        } catch {
+            mobileShellLog.error("dogfood checklist subscribe failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
+    /// Pull the current checklist via `dogfood.checklist.fetch` and feed it to the
+    /// pane model. Best-effort: a missing/old Mac or an unparseable result is a
+    /// no-op (the subscription still delivers future pushes). A result that
+    /// explicitly reports no checklist (`{"checklist": null}`) clears the pane —
+    /// this is the reconnect/missed-clear recovery path, so a phone that still
+    /// shows a since-cleared checklist gets cleared on the next fetch.
+    private func fetchDogfoodChecklist(client: MobileCoreRPCClient) async {
+        do {
+            let data = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(method: "dogfood.checklist.fetch", params: [:])
+            )
+            switch Self.dogfoodChecklistFetchResult(from: data) {
+            case .present(let payload):
+                dogfoodFeedbackModel?.applyChecklistPayload(payload)
+            case .cleared:
+                dogfoodFeedbackModel?.applyChecklist(.empty)
+            case .unparseable:
+                break
+            }
+        } catch {
+            mobileShellLog.error("dogfood checklist fetch failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// The three outcomes of parsing a `dogfood.checklist.fetch` result.
+    private enum DogfoodChecklistFetchResult {
+        /// A checklist object was present; carries its re-serialized JSON.
+        case present(Data)
+        /// The Mac explicitly reported no checklist (`{"checklist": null}`).
+        case cleared
+        /// The result could not be parsed; the caller should leave state as-is.
+        case unparseable
+    }
+
+    /// Classify a `dogfood.checklist.fetch` result.
+    ///
+    /// ``MobileCoreRPCClient/sendRequest(_:timeoutNanoseconds:)`` already unwraps
+    /// the JSON-RPC envelope and returns only the `result` object, so the data
+    /// here is `{"checklist": {...}}` (a checklist) or `{"checklist": null}` (no
+    /// checklist), not a nested `{"result": …}`. A present `checklist` object is
+    /// re-serialized for the typed decoder; an explicit `null` (or absent key on
+    /// a well-formed result) is a `cleared` signal; anything else is
+    /// `unparseable`.
+    nonisolated private static func dogfoodChecklistFetchResult(from data: Data) -> DogfoodChecklistFetchResult {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .unparseable
+        }
+        if let checklist = root["checklist"] as? [String: Any],
+           let reSerialized = try? JSONSerialization.data(withJSONObject: checklist) {
+            return .present(reSerialized)
+        }
+        // A well-formed result whose `checklist` is null/absent means the Mac has
+        // no checklist set: clear the pane.
+        return .cleared
     }
     #endif
 
@@ -2273,6 +2529,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func startTerminalRefreshPolling() {
         guard let client = remoteClient else { return }
         guard runtime?.supportsServerPushEvents ?? true else { return }
+        #if DEBUG
+        // Arm the dedicated, durable dogfood-checklist subscription alongside the
+        // terminal stream (its own task + stream_id, so the render-grid liveness
+        // watchdog's re-subscribe never drops it). Idempotent.
+        startDogfoodChecklistSubscription()
+        #endif
         guard terminalEventListenerTask == nil else { return }
         let listenerID = UUID()
         terminalEventListenerID = listenerID
@@ -2834,6 +3096,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalEventListenerTask = nil
         terminalEventListenerID = nil
         stopRenderGridLivenessWatchdog(listenerID: nil)
+        #if DEBUG
+        stopDogfoodChecklistSubscription()
+        #endif
     }
 
     private func setSelectedWorkspaceID(_ id: MobileWorkspacePreview.ID?) {

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DogfoodAnswersCapTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DogfoodAnswersCapTests.swift
@@ -1,0 +1,48 @@
+#if DEBUG
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for the answers-JSON byte cap used when building a dogfood
+/// feedback submit: an oversized note must never silently discard the structured
+/// multiple-choice answers (the dogfooder's actual responses).
+@Suite struct DogfoodAnswersCapTests {
+    @Test func smallAnswersPassThroughUnchanged() throws {
+        let answers = DogfoodFeedbackAnswers(
+            answers: [DogfoodFeedbackAnswer(id: "a", choice: "pass")],
+            note: "ok"
+        )
+        let json = try answers.encode()
+        let capped = MobileShellComposite.cappedAnswersJSONString(json, maxBytes: 65_536)
+        #expect(capped == String(data: json, encoding: .utf8))
+    }
+
+    @Test func oversizedNoteIsDroppedButMCAnswersSurvive() throws {
+        // A huge note pushes the encoded payload over the cap; the structured MC
+        // answers must survive (note dropped, not the answers).
+        let bigNote = String(repeating: "x", count: 200_000)
+        let answers = DogfoodFeedbackAnswers(
+            answers: [
+                DogfoodFeedbackAnswer(id: "a", choice: "pass"),
+                DogfoodFeedbackAnswer(id: "b", choice: "fail"),
+            ],
+            note: bigNote
+        )
+        let json = try answers.encode()
+        let cappedString = try #require(
+            MobileShellComposite.cappedAnswersJSONString(json, maxBytes: 4_096)
+        )
+        let cappedData = try #require(cappedString.data(using: .utf8))
+        #expect(cappedData.count <= 4_096)
+        let decoded = try DogfoodFeedbackAnswers.decode(cappedData)
+        // The MC answers are preserved; only the note was dropped.
+        #expect(decoded.answers.map(\.id) == ["a", "b"])
+        #expect(decoded.note.isEmpty)
+    }
+
+    @Test func nilAnswersReturnNil() {
+        #expect(MobileShellComposite.cappedAnswersJSONString(nil, maxBytes: 65_536) == nil)
+    }
+}
+#endif

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DogfoodFeedbackModelTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DogfoodFeedbackModelTests.swift
@@ -1,0 +1,231 @@
+#if DEBUG
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``DogfoodFeedbackModel`` (the floating DEV dogfood pane
+/// model) with a fake submitter so the model is exercised without a live
+/// connection: checklist application, answer selection, the ordered answers
+/// payload, and the capture/submit reset behavior.
+@MainActor
+@Suite struct DogfoodFeedbackModelTests {
+    /// Records the answers a capture submits and returns a scripted result.
+    private final class FakeSubmitter: DogfoodFeedbackSubmitting {
+        var result = true
+        private(set) var submitted: [DogfoodFeedbackAnswers] = []
+        func submit(answers: DogfoodFeedbackAnswers) async -> Bool {
+            submitted.append(answers)
+            return result
+        }
+    }
+
+    private func makeChecklist() -> DogfoodChecklist {
+        DogfoodChecklist(
+            title: "Pane",
+            items: [
+                DogfoodChecklistItem(id: "a", prompt: "Pass/fail?", kind: .passFail),
+                DogfoodChecklistItem(id: "b", prompt: "Choice?", kind: .choice(["x", "y"])),
+            ]
+        )
+    }
+
+    @Test func appliesAChecklistAndStartsUnanswered() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        #expect(model.checklist.items.count == 2)
+        #expect(model.selection(for: "a") == nil)
+        #expect(model.selection(for: "b") == nil)
+    }
+
+    @Test func selectingAndReselectingTogglesTheAnswer() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "a", choice: "pass")
+        #expect(model.selection(for: "a") == "pass")
+        // Reselecting the same choice clears it (un-answer back to skipped).
+        model.selectAnswer(itemID: "a", choice: "pass")
+        #expect(model.selection(for: "a") == nil)
+        // Selecting a different choice replaces it.
+        model.selectAnswer(itemID: "a", choice: "fail")
+        model.selectAnswer(itemID: "a", choice: "pass")
+        #expect(model.selection(for: "a") == "pass")
+    }
+
+    @Test func answersPayloadIsInChecklistOrderAndOmitsUnanswered() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        // Answer the second item first; payload must still read in checklist order
+        // (b is index 1) and omit the unanswered first item.
+        model.selectAnswer(itemID: "b", choice: "y")
+        model.note = "note text"
+        let payload = model.answersPayload
+        #expect(payload.answers.map(\.id) == ["b"])
+        #expect(payload.answers.first?.choice == "y")
+        #expect(payload.note == "note text")
+
+        model.selectAnswer(itemID: "a", choice: "pass")
+        #expect(model.answersPayload.answers.map(\.id) == ["a", "b"])
+    }
+
+    @Test func applyingANewChecklistDropsStaleSelectionsButKeepsLiveOnes() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "a", choice: "pass")
+        model.selectAnswer(itemID: "b", choice: "x")
+        // Re-push a checklist that keeps "a" but drops "b" and adds "c".
+        model.applyChecklist(DogfoodChecklist(items: [
+            DogfoodChecklistItem(id: "a", prompt: "Pass/fail?", kind: .passFail),
+            DogfoodChecklistItem(id: "c", prompt: "New", kind: .passFail),
+        ]))
+        #expect(model.selection(for: "a") == "pass")
+        #expect(model.selection(for: "b") == nil)
+        #expect(model.selection(for: "c") == nil)
+    }
+
+    @Test func rePushDropsAnswerWhoseChoiceIsNoLongerValid() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "b", choice: "x")
+        #expect(model.selection(for: "b") == "x")
+        // Re-push keeps id "b" but changes its choices so "x" is gone. The stale
+        // selection must be dropped so it can't be submitted invisibly.
+        model.applyChecklist(DogfoodChecklist(items: [
+            DogfoodChecklistItem(id: "b", prompt: "Choice?", kind: .choice(["p", "q"])),
+        ]))
+        #expect(model.selection(for: "b") == nil)
+        #expect(model.answersPayload.answers.isEmpty)
+    }
+
+    @Test func applyingAMalformedPayloadIsANoOp() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(makeChecklist())
+        model.applyChecklistPayload(Data("not json".utf8))
+        model.applyChecklistPayload(nil)
+        // Unchanged.
+        #expect(model.checklist.items.count == 2)
+    }
+
+    @Test func captureSendsTheAnswersAndClearsOnSuccess() async {
+        let submitter = FakeSubmitter()
+        let model = DogfoodFeedbackModel(submitter: submitter)
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "a", choice: "pass")
+        model.note = "looks good"
+        await model.captureAndSend()
+        #expect(submitter.submitted.count == 1)
+        #expect(submitter.submitted.first?.answers.map(\.id) == ["a"])
+        #expect(submitter.submitted.first?.note == "looks good")
+        #expect(model.lastSubmitSucceeded == true)
+        // Success clears answers + note; the checklist stays for the next capture.
+        #expect(model.selection(for: "a") == nil)
+        #expect(model.note.isEmpty)
+        #expect(model.checklist.items.count == 2)
+    }
+
+    @Test func applyingAChecklistWithDuplicateIDsDoesNotCrash() {
+        // An agent can push a malformed checklist with repeated ids; the contract
+        // is to ignore bad payloads, not trap on a duplicate-key dictionary build.
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(DogfoodChecklist(items: [
+            DogfoodChecklistItem(id: "dup", prompt: "First", kind: .choice(["a"])),
+            DogfoodChecklistItem(id: "dup", prompt: "Second", kind: .choice(["b"])),
+        ]))
+        // The unioned valid set keeps a selection that matches either item's choices.
+        model.selectAnswer(itemID: "dup", choice: "a")
+        #expect(model.selection(for: "dup") == "a")
+    }
+
+    @Test func captureDoesNotCrashOnDuplicateChecklistIDs() async {
+        // answersPayload emits one answer per row, so duplicate ids must not trap
+        // when the success-path snapshot is built on Capture & Send.
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.applyChecklist(DogfoodChecklist(items: [
+            DogfoodChecklistItem(id: "dup", prompt: "First", kind: .choice(["a"])),
+            DogfoodChecklistItem(id: "dup", prompt: "Second", kind: .choice(["a"])),
+        ]))
+        model.selectAnswer(itemID: "dup", choice: "a")
+        await model.captureAndSend()
+        #expect(model.lastSubmitSucceeded == true)
+    }
+
+    /// Mutates the model during the submit await so the in-flight-edit path runs.
+    private final class MutatingSubmitter: DogfoodFeedbackSubmitting {
+        var onSubmit: (() -> Void)?
+        func submit(answers: DogfoodFeedbackAnswers) async -> Bool {
+            onSubmit?()
+            return true
+        }
+    }
+
+    @Test func captureKeepsInFlightEditsOnSuccess() async {
+        let submitter = MutatingSubmitter()
+        let model = DogfoodFeedbackModel(submitter: submitter)
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "a", choice: "pass")
+        model.note = "original"
+        // While the submit is in flight, the dogfooder re-answers "a" and edits
+        // the note. The success clear must preserve both.
+        submitter.onSubmit = {
+            model.selectAnswer(itemID: "a", choice: "fail")
+            model.note = "edited mid-flight"
+        }
+        await model.captureAndSend()
+        #expect(model.selection(for: "a") == "fail")
+        #expect(model.note == "edited mid-flight")
+    }
+
+    @Test func captureKeepsAnswersOnFailure() async {
+        let submitter = FakeSubmitter()
+        submitter.result = false
+        let model = DogfoodFeedbackModel(submitter: submitter)
+        model.applyChecklist(makeChecklist())
+        model.selectAnswer(itemID: "a", choice: "fail")
+        model.note = "broken"
+        await model.captureAndSend()
+        #expect(model.lastSubmitSucceeded == false)
+        // A failed submit keeps the answers so the dogfooder can retry.
+        #expect(model.selection(for: "a") == "fail")
+        #expect(model.note == "broken")
+    }
+
+    @Test func answersPayloadCapsAVeryLargeNote() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        model.note = String(repeating: "x", count: DogfoodFeedbackModel.maxNoteChars + 5_000)
+        #expect(model.answersPayload.note.count == DogfoodFeedbackModel.maxNoteChars)
+    }
+
+    @Test func bothClearRoutesAgreeAndDropSelections() {
+        // The Mac clears two ways: the event push sends `{"items":[]}` (decoded by
+        // applyChecklistPayload) and the fetch-clear path calls applyChecklist(.empty).
+        // Both must leave the same empty, selection-free model state so a live
+        // reconnect after a clear does not strand a stale checklist/answer.
+        let pushModel = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        pushModel.applyChecklist(makeChecklist())
+        pushModel.selectAnswer(itemID: "a", choice: "pass")
+        pushModel.applyChecklistPayload(Data(#"{"items":[]}"#.utf8))
+
+        let fetchModel = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        fetchModel.applyChecklist(makeChecklist())
+        fetchModel.selectAnswer(itemID: "a", choice: "pass")
+        fetchModel.applyChecklist(.empty)
+
+        #expect(pushModel.checklist == fetchModel.checklist)
+        #expect(pushModel.checklist.isEmpty)
+        #expect(fetchModel.checklist.isEmpty)
+        #expect(pushModel.selection(for: "a") == nil)
+        #expect(fetchModel.selection(for: "a") == nil)
+        #expect(pushModel.answersPayload.answers.isEmpty)
+        #expect(fetchModel.answersPayload.answers.isEmpty)
+    }
+
+    @Test func toggleExpandedFlipsTheState() {
+        let model = DogfoodFeedbackModel(submitter: FakeSubmitter())
+        #expect(!model.isExpanded)
+        model.toggleExpanded()
+        #expect(model.isExpanded)
+        model.toggleExpanded()
+        #expect(!model.isExpanded)
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklist.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklist.swift
@@ -1,0 +1,82 @@
+public import Foundation
+
+/// A "what to check" checklist the agent pushes to the floating dogfood pane.
+///
+/// The Mac stores the checklist as opaque validated JSON (set via the
+/// `dogfood_checklist_set` debug-socket command) and pushes it to the phone over
+/// the `dogfood.checklist` event topic; the phone also pulls the current
+/// checklist on open via `dogfood.checklist.fetch` to close the
+/// subscribe-after-push race. Decoding the typed schema lives on the phone (this
+/// type), so the Mac never needs to redeploy as the schema evolves.
+///
+/// Each ``DogfoodChecklistItem`` renders as one multiple-choice question; a
+/// single shared freeform note rides alongside all of them in the submitted
+/// bundle.
+///
+/// ```swift
+/// let json = Data(#"{"title":"Pane test","items":[{"id":"i1","prompt":"Drag works?","kind":"pass_fail"}]}"#.utf8)
+/// let checklist = try DogfoodChecklist.decode(json)
+/// ```
+public struct DogfoodChecklist: Codable, Equatable, Sendable {
+    /// An optional title shown above the questions (e.g. the feature under test).
+    public let title: String?
+    /// The ordered checklist items, each rendered as a multiple-choice question.
+    public let items: [DogfoodChecklistItem]
+
+    /// Creates a checklist.
+    /// - Parameters:
+    ///   - title: An optional heading describing what the dogfooder is checking.
+    ///   - items: The ordered questions.
+    public init(title: String? = nil, items: [DogfoodChecklistItem]) {
+        self.title = title
+        self.items = items
+    }
+
+    /// An empty checklist (no title, no items). The pane shows its freeform note
+    /// only and the agent has not pushed anything yet.
+    public static let empty = DogfoodChecklist(title: nil, items: [])
+
+    /// Whether the checklist carries no questions.
+    public var isEmpty: Bool { items.isEmpty }
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case items
+    }
+
+    /// Decodes a checklist, defaulting a missing `items` array to empty so a
+    /// clear payload (`{}`) decodes to an empty checklist rather than failing —
+    /// the pane then shows the empty state instead of keeping a stale checklist.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        items = (try container.decodeIfPresent([DogfoodChecklistItem].self, forKey: .items)) ?? []
+    }
+
+    /// Encodes the checklist. A `nil` title is omitted; `items` is always written
+    /// (empty array for a cleared checklist).
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encode(items, forKey: .items)
+    }
+
+    /// Decode a checklist from raw JSON (the `dogfood.checklist` event payload or
+    /// the `dogfood.checklist.fetch` result).
+    /// - Parameter data: The raw JSON bytes.
+    /// - Returns: The decoded checklist.
+    /// - Throws: A `DecodingError` if the JSON does not match the schema.
+    public static func decode(_ data: Data) throws -> DogfoodChecklist {
+        try JSONDecoder().decode(DogfoodChecklist.self, from: data)
+    }
+
+    /// Encode the checklist to canonical JSON (sorted keys), used when the agent
+    /// drives the pane or a test asserts a round-trip.
+    /// - Returns: The encoded JSON bytes.
+    /// - Throws: An `EncodingError` if encoding fails.
+    public func encode() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(self)
+    }
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklistItem.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklistItem.swift
@@ -1,0 +1,90 @@
+public import Foundation
+
+/// One question in a ``DogfoodChecklist``, rendered as a multiple-choice prompt.
+///
+/// The ``id`` is the stable key the submitted ``DogfoodFeedbackAnswer`` maps back
+/// to, so it must be unique within a checklist and stable across pushes. The
+/// ``kind`` selects how the pane renders the choices.
+///
+/// The wire form flattens the kind: a `kind` discriminator string plus, for a
+/// custom choice set, a sibling `choices` array on the item:
+///
+/// ```json
+/// {"id": "i1", "prompt": "Works?", "kind": "pass_fail"}
+/// {"id": "i2", "prompt": "Which one?", "kind": "choice", "choices": ["a", "b"]}
+/// ```
+public struct DogfoodChecklistItem: Codable, Equatable, Identifiable, Sendable {
+    /// A stable identifier unique within the checklist; answers map back to it.
+    public let id: String
+    /// The question text shown to the dogfooder.
+    public let prompt: String
+    /// How the question is answered (pass/fail or a custom choice set).
+    public let kind: DogfoodChecklistItemKind
+
+    /// Creates a checklist item.
+    /// - Parameters:
+    ///   - id: A stable identifier unique within the checklist.
+    ///   - prompt: The question text.
+    ///   - kind: How the question is answered. Defaults to ``DogfoodChecklistItemKind/passFail``.
+    public init(id: String, prompt: String, kind: DogfoodChecklistItemKind = .passFail) {
+        self.id = id
+        self.prompt = prompt
+        self.kind = kind
+    }
+
+    /// The selectable choices for this item, in display order.
+    ///
+    /// For ``DogfoodChecklistItemKind/passFail`` this is the fixed
+    /// pass/fail/skip set; for ``DogfoodChecklistItemKind/choice(_:)`` it is the
+    /// item's own choice list.
+    public var choices: [String] {
+        switch kind {
+        case .passFail:
+            return DogfoodChecklistItemKind.passFailChoices
+        case let .choice(options):
+            return options
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case prompt
+        case kind
+        case choices
+    }
+
+    /// Decodes an item, flattening the `kind` discriminator and optional sibling
+    /// `choices` array into a ``DogfoodChecklistItemKind``. An unknown or missing
+    /// `kind` decodes as ``DogfoodChecklistItemKind/passFail`` so an evolving
+    /// agent-pushed schema never hard-fails the whole checklist on one item.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        prompt = try container.decode(String.self, forKey: .prompt)
+        let kindWire = (try container.decodeIfPresent(String.self, forKey: .kind))
+            ?? DogfoodChecklistItemKind.passFailWireValue
+        if kindWire == DogfoodChecklistItemKind.choiceWireValue {
+            let options = (try container.decodeIfPresent([String].self, forKey: .choices)) ?? []
+            // A choice item with no choices is meaningless; fall back to pass/fail
+            // so the question is still answerable rather than rendering a dead row.
+            kind = options.isEmpty ? .passFail : .choice(options)
+        } else {
+            kind = .passFail
+        }
+    }
+
+    /// Encodes an item back to the flattened wire form (`kind` discriminator plus
+    /// a sibling `choices` array for a custom choice set).
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(prompt, forKey: .prompt)
+        switch kind {
+        case .passFail:
+            try container.encode(DogfoodChecklistItemKind.passFailWireValue, forKey: .kind)
+        case let .choice(options):
+            try container.encode(DogfoodChecklistItemKind.choiceWireValue, forKey: .kind)
+            try container.encode(options, forKey: .choices)
+        }
+    }
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklistItemKind.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodChecklistItemKind.swift
@@ -1,0 +1,27 @@
+public import Foundation
+
+/// How a ``DogfoodChecklistItem`` is answered.
+///
+/// Encodes in the JSON wire form as a `kind` discriminator plus, for
+/// ``choice``, a sibling `choices` array on the item:
+///
+/// ```json
+/// {"id": "i1", "prompt": "Works?", "kind": "pass_fail"}
+/// {"id": "i2", "prompt": "Which one?", "kind": "choice", "choices": ["a", "b"]}
+/// ```
+public enum DogfoodChecklistItemKind: Equatable, Sendable {
+    /// A fixed pass / fail / skip segmented control.
+    case passFail
+    /// A custom set of mutually exclusive choices supplied by the agent.
+    case choice([String])
+
+    /// The fixed choice labels for ``passFail``, in display order. These are the
+    /// raw answer values stored in a ``DogfoodFeedbackAnswer``; the pane may
+    /// localize the visible label, but the stored value is one of these.
+    public static let passFailChoices = ["pass", "fail", "skip"]
+
+    /// The wire discriminator string for ``passFail``.
+    static let passFailWireValue = "pass_fail"
+    /// The wire discriminator string for ``choice``.
+    static let choiceWireValue = "choice"
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodFeedbackAnswer.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodFeedbackAnswer.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+/// One dogfooder answer to a ``DogfoodChecklistItem``, carried in the submitted
+/// feedback bundle.
+///
+/// The ``id`` matches the answered item's ``DogfoodChecklistItem/id``; ``choice``
+/// is the selected raw choice value (one of the item's
+/// ``DogfoodChecklistItem/choices``). An item the dogfooder left unanswered is
+/// represented by omitting it from the bundle's answer list, so the Mac sink can
+/// tell answered from skipped.
+public struct DogfoodFeedbackAnswer: Codable, Equatable, Sendable, Identifiable {
+    /// The answered item's stable identifier.
+    public let id: String
+    /// The selected raw choice value (one of the item's choices).
+    public let choice: String
+
+    /// Creates an answer.
+    /// - Parameters:
+    ///   - id: The answered item's stable identifier.
+    ///   - choice: The selected raw choice value.
+    public init(id: String, choice: String) {
+        self.id = id
+        self.choice = choice
+    }
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodFeedbackAnswers.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DogfoodFeedbackAnswers.swift
@@ -1,0 +1,50 @@
+public import Foundation
+
+/// The multiple-choice answers plus the shared freeform note the dogfood pane
+/// submits alongside the screenshot and diagnostics.
+///
+/// This is the additive payload the phone adds to the existing
+/// `dogfood.feedback.submit` RPC; the Mac sink writes it into `bundle.json` as
+/// the `answers` object. An old (P1-only) Mac that does not know this field
+/// simply ignores it, so a new phone degrades gracefully.
+///
+/// ```swift
+/// let answers = DogfoodFeedbackAnswers(
+///     answers: [DogfoodFeedbackAnswer(id: "i1", choice: "pass")],
+///     note: "looked good"
+/// )
+/// let json = try answers.encode()
+/// ```
+public struct DogfoodFeedbackAnswers: Codable, Equatable, Sendable {
+    /// The answered items, in checklist order. Unanswered items are omitted.
+    public let answers: [DogfoodFeedbackAnswer]
+    /// The shared freeform note (empty when the dogfooder typed nothing).
+    public let note: String
+
+    /// Creates an answers payload.
+    /// - Parameters:
+    ///   - answers: The answered items (unanswered ones omitted).
+    ///   - note: The shared freeform note.
+    public init(answers: [DogfoodFeedbackAnswer], note: String) {
+        self.answers = answers
+        self.note = note
+    }
+
+    /// Decode an answers payload from raw JSON (the bundle's `answers` object).
+    /// - Parameter data: The raw JSON bytes.
+    /// - Returns: The decoded payload.
+    /// - Throws: A `DecodingError` if the JSON does not match the schema.
+    public static func decode(_ data: Data) throws -> DogfoodFeedbackAnswers {
+        try JSONDecoder().decode(DogfoodFeedbackAnswers.self, from: data)
+    }
+
+    /// Encode the payload to canonical JSON (sorted keys) for the submit RPC and
+    /// round-trip tests.
+    /// - Returns: The encoded JSON bytes.
+    /// - Throws: An `EncodingError` if encoding fails.
+    public func encode() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(self)
+    }
+}

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DogfoodChecklistTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DogfoodChecklistTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellModel
+
+/// Behavior tests for the dogfood checklist + answer DTOs: the JSON the agent
+/// pushes via `dogfood_checklist_set` must decode into the typed model, and the
+/// answers the pane submits must round-trip through JSON.
+@Suite struct DogfoodChecklistTests {
+    @Test func decodesPassFailAndChoiceItemsFromAgentJSON() throws {
+        let json = Data(#"""
+        {
+          "title": "Floating pane test",
+          "items": [
+            {"id": "drag", "prompt": "Does the pill drag?", "kind": "pass_fail"},
+            {"id": "edge", "prompt": "Which edge?", "kind": "choice", "choices": ["left", "right"]}
+          ]
+        }
+        """#.utf8)
+
+        let checklist = try DogfoodChecklist.decode(json)
+
+        #expect(checklist.title == "Floating pane test")
+        #expect(checklist.items.count == 2)
+        #expect(checklist.items[0].id == "drag")
+        #expect(checklist.items[0].kind == .passFail)
+        #expect(checklist.items[0].choices == DogfoodChecklistItemKind.passFailChoices)
+        #expect(checklist.items[1].kind == .choice(["left", "right"]))
+        #expect(checklist.items[1].choices == ["left", "right"])
+    }
+
+    @Test func defaultsMissingKindToPassFail() throws {
+        let json = Data(#"{"items":[{"id":"x","prompt":"No kind?"}]}"#.utf8)
+        let checklist = try DogfoodChecklist.decode(json)
+        #expect(checklist.title == nil)
+        #expect(checklist.items.first?.kind == .passFail)
+    }
+
+    @Test func emptyChoiceListFallsBackToPassFail() throws {
+        // A `choice` item with no usable choices is meaningless; it must stay
+        // answerable rather than render a dead row.
+        let json = Data(#"{"items":[{"id":"x","prompt":"Bad","kind":"choice","choices":[]}]}"#.utf8)
+        let checklist = try DogfoodChecklist.decode(json)
+        #expect(checklist.items.first?.kind == .passFail)
+    }
+
+    @Test func unknownKindFallsBackToPassFail() throws {
+        let json = Data(#"{"items":[{"id":"x","prompt":"Future","kind":"slider"}]}"#.utf8)
+        let checklist = try DogfoodChecklist.decode(json)
+        #expect(checklist.items.first?.kind == .passFail)
+    }
+
+    @Test func checklistRoundTripsThroughEncodeDecode() throws {
+        let checklist = DogfoodChecklist(
+            title: "Round trip",
+            items: [
+                DogfoodChecklistItem(id: "a", prompt: "Pass/fail", kind: .passFail),
+                DogfoodChecklistItem(id: "b", prompt: "Choice", kind: .choice(["one", "two", "three"])),
+            ]
+        )
+        let decoded = try DogfoodChecklist.decode(checklist.encode())
+        #expect(decoded == checklist)
+    }
+
+    @Test func clearPayloadsDecodeToAnEmptyChecklist() throws {
+        // The Mac's clear path pushes `{"items":[]}`, and an agent may send `{}`.
+        // Both must decode to an empty checklist (not throw) so the pane clears.
+        #expect(try DogfoodChecklist.decode(Data("{}".utf8)).isEmpty)
+        #expect(try DogfoodChecklist.decode(Data(#"{"items":[]}"#.utf8)).isEmpty)
+    }
+
+    @Test func emptyChecklistIsEmpty() {
+        #expect(DogfoodChecklist.empty.isEmpty)
+        #expect(DogfoodChecklist(items: []).isEmpty)
+        #expect(!DogfoodChecklist(items: [DogfoodChecklistItem(id: "x", prompt: "y")]).isEmpty)
+    }
+
+    @Test func answersRoundTripWithNote() throws {
+        let answers = DogfoodFeedbackAnswers(
+            answers: [
+                DogfoodFeedbackAnswer(id: "drag", choice: "pass"),
+                DogfoodFeedbackAnswer(id: "edge", choice: "left"),
+            ],
+            note: "looked good overall"
+        )
+        let decoded = try DogfoodFeedbackAnswers.decode(answers.encode())
+        #expect(decoded == answers)
+        #expect(decoded.note == "looked good overall")
+    }
+
+    @Test func unansweredItemsAreOmittedFromAnswers() throws {
+        // The pane built a checklist with three items but the dogfooder only
+        // answered one; the omitted ids must simply be absent so the Mac can tell
+        // answered from skipped.
+        let answers = DogfoodFeedbackAnswers(
+            answers: [DogfoodFeedbackAnswer(id: "i2", choice: "fail")],
+            note: ""
+        )
+        let decoded = try DogfoodFeedbackAnswers.decode(answers.encode())
+        #expect(decoded.answers.map(\.id) == ["i2"])
+        #expect(decoded.note.isEmpty)
+    }
+
+    @Test func answersEncodeWithStableSortedKeys() throws {
+        // Sorted-keys output keeps the bundle's `answers` JSON deterministic.
+        let answers = DogfoodFeedbackAnswers(
+            answers: [DogfoodFeedbackAnswer(id: "z", choice: "skip")],
+            note: "n"
+        )
+        let string = String(decoding: try answers.encode(), as: UTF8.self)
+        #expect(string == #"{"answers":[{"choice":"skip","id":"z"}],"note":"n"}"#)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileAppView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileAppView.swift
@@ -8,12 +8,29 @@ import AppKit
 
 public struct CMUXMobileAppView: View {
     @State private var store: CMUXMobileShellStore
+    #if os(iOS) && DEBUG
+    /// The floating DEV dogfood pane model, built once next to the store and
+    /// wired into it so the dedicated `dogfood.checklist` subscription feeds it.
+    /// DEBUG-only; absent in release builds.
+    @State private var dogfoodFeedbackModel: DogfoodFeedbackModel
+    #endif
 
     public init(store: CMUXMobileShellStore = .preview()) {
         _store = State(initialValue: store)
+        #if os(iOS) && DEBUG
+        let model = DogfoodFeedbackModel(submitter: DogfoodFeedbackUISubmitter(store: store))
+        store.setDogfoodFeedbackModel(model)
+        _dogfoodFeedbackModel = State(initialValue: model)
+        #endif
     }
 
     public var body: some View {
         CMUXMobileRootView(store: store)
+            #if os(iOS) && DEBUG
+            // Install the passthrough overlay window that floats the dogfood pane
+            // above the terminal. The 0-size installer resolves the window scene
+            // once it connects and retains the overlay window.
+            .background(DogfoodPaneInstaller(model: dogfoodFeedbackModel))
+            #endif
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodChecklistRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodChecklistRow.swift
@@ -1,0 +1,46 @@
+#if os(iOS) && DEBUG
+import CmuxMobileShellModel
+import SwiftUI
+
+/// One checklist question in the dogfood pane, rendered as a prompt plus a
+/// segmented set of choice buttons.
+///
+/// Snapshot-boundary clean: it holds only value snapshots (the ``item`` and the
+/// current ``selection``) plus a `select` closure, never a reference to
+/// ``DogfoodFeedbackModel``. So an unrelated change in the model (a different
+/// item's answer, the freeform note) cannot invalidate every row in the
+/// enclosing `ForEach`. DEV-only; strings are not localized.
+struct DogfoodChecklistRow: View {
+    let item: DogfoodChecklistItem
+    let selection: String?
+    let select: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(item.prompt)
+                .font(.subheadline.weight(.medium))
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 6) {
+                ForEach(item.choices, id: \.self) { choice in
+                    Button {
+                        select(choice)
+                    } label: {
+                        Text(choice)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(1)
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .fill(selection == choice ? Color.accentColor : Color.secondary.opacity(0.15))
+                            )
+                            .foregroundStyle(selection == choice ? Color.white : Color.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("DogfoodPaneChoice-\(item.id)-\(choice)")
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodChecklistSection.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodChecklistSection.swift
@@ -1,0 +1,44 @@
+#if os(iOS) && DEBUG
+import CmuxMobileShellModel
+import SwiftUI
+
+/// The scrollable list of checklist questions in the dogfood pane.
+///
+/// Snapshot-boundary clean: it holds only value snapshots (the immutable
+/// ``items`` and the current ``selections`` map) plus a `select` closure, never a
+/// reference to ``DogfoodFeedbackModel``. Pulling this out of
+/// ``DogfoodPaneOverlayView`` means a freeform-note keystroke (a write to
+/// `model.note`) does not invalidate the checklist rows, only the note editor —
+/// the orthogonal-`@Observable`-change thrash the snapshot-boundary rule exists
+/// to prevent.
+///
+/// DEV-only; strings are not localized.
+struct DogfoodChecklistSection: View {
+    let items: [DogfoodChecklistItem]
+    let selections: [String: String]
+    let select: (String, String) -> Void
+
+    var body: some View {
+        if items.isEmpty {
+            Text("No checklist pushed yet. The agent can push one with the dogfood_checklist_set debug command.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    ForEach(items) { item in
+                        DogfoodChecklistRow(
+                            item: item,
+                            selection: selections[item.id],
+                            select: { choice in select(item.id, choice) }
+                        )
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+            .frame(maxHeight: 240)
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodFeedbackUISubmitter.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodFeedbackUISubmitter.swift
@@ -1,0 +1,81 @@
+#if os(iOS) && DEBUG
+import CmuxMobileDiagnostics
+import CmuxMobileShell
+import CmuxMobileShellModel
+import CmuxMobileTerminal
+import UIKit
+
+/// The UI-layer ``DogfoodFeedbackSubmitting`` implementation: gathers a chrome
+/// screenshot, the visible terminal text, and the debug-log snapshot, attaches
+/// the multiple-choice answers + note, and forwards to the shell's
+/// `dogfood.feedback.submit` path.
+///
+/// It lives here (not in ``CmuxMobileShell``) because the capture primitives are
+/// only reachable from the UI/terminal modules: `drawHierarchy(in:)` over the
+/// app window, `GhosttySurfaceView.visibleTerminalSnapshot()`, and
+/// ``MobileDebugLog``. The terminal renders blank in a UIView snapshot (it is a
+/// Metal/IOSurface layer), which is exactly why the terminal *text* is sent
+/// alongside the screenshot.
+///
+/// DEV-only; absent in release builds.
+@MainActor
+final class DogfoodFeedbackUISubmitter: DogfoodFeedbackSubmitting {
+    private let store: CMUXMobileShellStore
+
+    /// Creates the submitter.
+    /// - Parameter store: The shell store whose `submitDogfoodFeedback` carries
+    ///   the bundle to the paired Mac.
+    init(store: CMUXMobileShellStore) {
+        self.store = store
+    }
+
+    func submit(answers: DogfoodFeedbackAnswers) async -> Bool {
+        // Snapshot the chrome window + visible terminal text on the main actor
+        // first (UIKit + the bounded terminal read both want main), then hand the
+        // rest to the store, which builds + sends off-main.
+        let screenshot = Self.captureChromeScreenshotPNG()
+        let terminalText = GhosttySurfaceView.visibleTerminalSnapshot()
+        let (_, debugLogText) = await MobileDebugLog.shared.sink.snapshotWithCount()
+        let answersJSON = try? answers.encode()
+        return await store.submitDogfoodFeedback(
+            text: answers.note,
+            debugLogText: debugLogText,
+            terminalText: terminalText,
+            answersJSON: answersJSON,
+            screenshotPNG: screenshot
+        )
+    }
+
+    /// Render a PNG of the app's content window (chrome only; the terminal is a
+    /// Metal layer and renders blank, which is why the terminal text rides along).
+    ///
+    /// Uses `drawHierarchy(in:afterScreenUpdates:)` on the app's key window,
+    /// explicitly skipping the dogfood overlay window (so the pill/pane do not
+    /// appear in the shot). `ImageRenderer` would render a SwiftUI view we hand
+    /// it, not the live UIKit hierarchy, so it is the wrong tool here. Returns
+    /// `nil` if no suitable app window is found or the render fails.
+    private static func captureChromeScreenshotPNG() -> Data? {
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive })
+            ?? UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first
+        else { return nil }
+        // The app's content window is the first non-overlay window in the scene.
+        // The dogfood overlay is a `DogfoodPaneWindow`, excluded here so the shot
+        // is the app, not the pane.
+        let appWindows = scene.windows.filter { !($0 is DogfoodPaneWindow) }
+        guard let window = appWindows.first(where: { $0.isKeyWindow }) ?? appWindows.first else {
+            return nil
+        }
+        let bounds = window.bounds
+        guard bounds.width > 0, bounds.height > 0 else { return nil }
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = true
+        let renderer = UIGraphicsImageRenderer(bounds: bounds, format: format)
+        let image = renderer.image { _ in
+            window.drawHierarchy(in: bounds, afterScreenUpdates: false)
+        }
+        return image.pngData()
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneInstaller.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneInstaller.swift
@@ -1,0 +1,73 @@
+#if os(iOS) && DEBUG
+import CmuxMobileShell
+import SwiftUI
+import UIKit
+
+/// A zero-size SwiftUI host that installs the floating dogfood pane window onto
+/// the current `UIWindowScene` once it is connected.
+///
+/// Mounted in the root view's background. It resolves the scene in
+/// `didMoveToWindow` (the scene is not connected at app launch, so resolving it
+/// eagerly would fail), then builds and retains a ``DogfoodPaneWindowController``
+/// — which puts the passthrough overlay window above the app. Retaining the
+/// controller in the coordinator keeps the window alive.
+///
+/// DEBUG-only; absent in release builds.
+struct DogfoodPaneInstaller: UIViewRepresentable {
+    let model: DogfoodFeedbackModel
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(model: model)
+    }
+
+    func makeUIView(context: Context) -> SceneResolvingView {
+        let view = SceneResolvingView()
+        view.onResolveScene = { [coordinator = context.coordinator] scene in
+            coordinator.installIfNeeded(scene: scene)
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: SceneResolvingView, context: Context) {}
+
+    /// Retains the overlay window controller across SwiftUI view updates.
+    @MainActor
+    final class Coordinator {
+        private let model: DogfoodFeedbackModel
+        private var controller: DogfoodPaneWindowController?
+
+        init(model: DogfoodFeedbackModel) {
+            self.model = model
+        }
+
+        func installIfNeeded(scene: UIWindowScene) {
+            guard controller == nil else { return }
+            controller = DogfoodPaneWindowController(scene: scene, model: model)
+        }
+    }
+
+    /// A 0-size `UIView` that reports its window scene as soon as it is added to a
+    /// window, so the overlay window can be created against the connected scene.
+    final class SceneResolvingView: UIView {
+        var onResolveScene: ((UIWindowScene) -> Void)?
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isUserInteractionEnabled = false
+            isHidden = true
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) is not supported")
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            if let scene = window?.windowScene {
+                onResolveScene?(scene)
+            }
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneOverlayView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneOverlayView.swift
@@ -1,0 +1,206 @@
+#if os(iOS) && DEBUG
+import CmuxMobileShell
+import SwiftUI
+
+/// The floating, hideable DEV dogfood pane: a draggable "bug" pill that expands
+/// into an overlay card showing the agent-pushed checklist (each item a
+/// multiple-choice question), a shared freeform note, and a Capture & Send
+/// button.
+///
+/// Hosted in its own passthrough `UIWindow` (see ``DogfoodPaneWindowController``)
+/// so it floats over the terminal regardless of the SwiftUI view tree. The whole
+/// view is the only hittable content in that window; the rest is transparent and
+/// passes touches through to the app.
+///
+/// DEV-only; not shipped, so its strings are not localized.
+struct DogfoodPaneOverlayView: View {
+    @Bindable var model: DogfoodFeedbackModel
+
+    /// The pill's free-drag offset from its default bottom-trailing anchor.
+    @State private var dragOffset: CGSize = .zero
+    @State private var accumulatedOffset: CGSize = CGSize(width: -16, height: -120)
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .bottomTrailing) {
+                // Transparent backdrop: hit-tests off so taps fall through to the
+                // app window beneath this overlay window.
+                Color.clear
+                    .allowsHitTesting(false)
+
+                if model.isExpanded {
+                    expandedCard
+                        .frame(maxWidth: min(360, proxy.size.width - 24))
+                        .padding(12)
+                        .transition(.scale(scale: 0.92).combined(with: .opacity))
+                } else {
+                    pill
+                        .offset(currentOffset(in: proxy.size))
+                        .gesture(dragGesture(in: proxy.size))
+                }
+            }
+            .animation(.snappy(duration: 0.18), value: model.isExpanded)
+        }
+        .ignoresSafeArea()
+    }
+
+    // MARK: - Pill
+
+    private var pill: some View {
+        Button {
+            model.toggleExpanded()
+        } label: {
+            Image(systemName: "ladybug.fill")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(Circle().fill(Color.pink.opacity(0.9)))
+                .overlay(Circle().stroke(.white.opacity(0.5), lineWidth: 1))
+                .shadow(radius: 4, y: 2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("DogfoodPanePill")
+    }
+
+    /// The pill's hit-target size; also the basis for keeping it on-screen.
+    private static let pillSize: CGFloat = 44
+    /// Minimum on-screen inset so the pill never sits flush against an edge.
+    private static let pillEdgeMargin: CGFloat = 8
+
+    private func currentOffset(in size: CGSize) -> CGSize {
+        clampedOffset(
+            CGSize(
+                width: accumulatedOffset.width + dragOffset.width,
+                height: accumulatedOffset.height + dragOffset.height
+            ),
+            in: size
+        )
+    }
+
+    /// Clamp an offset (relative to the bottom-trailing anchor) so the pill stays
+    /// at least partially within the scene. The pill is the only affordance that
+    /// reopens the overlay, so a long drag must not strand it off-screen with no
+    /// hittable control left. Negative width moves left, negative height moves up.
+    private func clampedOffset(_ offset: CGSize, in size: CGSize) -> CGSize {
+        let minWidth = -max(0, size.width - Self.pillSize - Self.pillEdgeMargin)
+        let minHeight = -max(0, size.height - Self.pillSize - Self.pillEdgeMargin)
+        return CGSize(
+            width: min(-Self.pillEdgeMargin, max(minWidth, offset.width)),
+            height: min(-Self.pillEdgeMargin, max(minHeight, offset.height))
+        )
+    }
+
+    private func dragGesture(in size: CGSize) -> some Gesture {
+        DragGesture()
+            .onChanged { value in
+                dragOffset = value.translation
+            }
+            .onEnded { value in
+                // Persist the clamped offset so the pill cannot be lost off-screen.
+                accumulatedOffset = clampedOffset(
+                    CGSize(
+                        width: accumulatedOffset.width + value.translation.width,
+                        height: accumulatedOffset.height + value.translation.height
+                    ),
+                    in: size
+                )
+                dragOffset = .zero
+            }
+    }
+
+    // MARK: - Expanded card
+
+    private var expandedCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            // Value-snapshot section so a note keystroke does not invalidate the
+            // checklist rows (snapshot-boundary rule).
+            DogfoodChecklistSection(
+                items: model.checklist.items,
+                selections: model.selections,
+                select: { itemID, choice in model.selectAnswer(itemID: itemID, choice: choice) }
+            )
+            noteSection
+            footer
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.ultraThinMaterial)
+                .shadow(radius: 12, y: 4)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.white.opacity(0.12), lineWidth: 1)
+        )
+    }
+
+    private var header: some View {
+        HStack {
+            Label(model.checklist.title ?? "Dogfood", systemImage: "ladybug.fill")
+                .font(.headline)
+                .lineLimit(1)
+            Spacer()
+            Button {
+                model.toggleExpanded()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("DogfoodPaneCollapse")
+        }
+    }
+
+    private var noteSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Note")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            TextEditor(text: $model.note)
+                .font(.callout)
+                .frame(height: 64)
+                .scrollContentBackground(.hidden)
+                .padding(6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.secondary.opacity(0.12))
+                )
+                .accessibilityIdentifier("DogfoodPaneNote")
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            if let succeeded = model.lastSubmitSucceeded {
+                Label(
+                    succeeded ? "Sent" : "Failed",
+                    systemImage: succeeded ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(succeeded ? Color.green : Color.orange)
+            }
+            Spacer()
+            Button {
+                Task { await model.captureAndSend() }
+            } label: {
+                HStack(spacing: 6) {
+                    if model.isSubmitting {
+                        ProgressView().controlSize(.small)
+                    }
+                    Text(model.isSubmitting ? "Sending…" : "Capture & Send")
+                        .font(.subheadline.weight(.semibold))
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(RoundedRectangle(cornerRadius: 9).fill(Color.accentColor))
+                .foregroundStyle(.white)
+            }
+            .buttonStyle(.plain)
+            .disabled(model.isSubmitting)
+            .accessibilityIdentifier("DogfoodPaneCaptureSend")
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneWindow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneWindow.swift
@@ -1,0 +1,29 @@
+#if os(iOS) && DEBUG
+import UIKit
+
+/// The dedicated `UIWindow` that hosts the floating DEV dogfood pane above the
+/// app's scene, so the pill/overlay floats over the terminal regardless of the
+/// SwiftUI view tree.
+///
+/// It is a passthrough window: a touch that resolves to the transparent root
+/// (anywhere outside the pill or expanded pane) returns `nil` from `hitTest` so
+/// the touch falls through to the app window underneath. Only the actual pane
+/// controls are hittable. Without this, a full-screen overlay window would eat
+/// every terminal touch.
+///
+/// DEBUG-only; absent in release builds.
+final class DogfoodPaneWindow: UIWindow {
+    /// Hit-tests so only the pane's own subviews are interactive; everything else
+    /// passes through to the window below.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hit = super.hitTest(point, with: event) else { return nil }
+        // A hit that lands on the hosting controller's root view (the transparent
+        // SwiftUI container itself, not one of the pane's interactive subviews)
+        // is "empty space": let it fall through to the app window.
+        if hit == rootViewController?.view {
+            return nil
+        }
+        return hit
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneWindowController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DogfoodPaneWindowController.swift
@@ -1,0 +1,44 @@
+#if os(iOS) && DEBUG
+import CmuxMobileShell
+import SwiftUI
+import UIKit
+
+/// Owns the floating dogfood pane's ``DogfoodPaneWindow`` for one `UIWindowScene`.
+///
+/// Built lazily when the host representable first resolves its window scene (the
+/// scene is not connected at launch), retained by the representable's coordinator
+/// so the window is not deallocated. The window sits one level above the app's
+/// normal windows and hosts the ``DogfoodPaneOverlayView`` bound to the injected
+/// ``DogfoodFeedbackModel``.
+///
+/// DEBUG-only; absent in release builds.
+@MainActor
+final class DogfoodPaneWindowController {
+    private let window: DogfoodPaneWindow
+
+    /// Creates and shows the overlay window for a scene.
+    /// - Parameters:
+    ///   - scene: The window scene to float above.
+    ///   - model: The pane model the overlay binds to.
+    init(scene: UIWindowScene, model: DogfoodFeedbackModel) {
+        let window = DogfoodPaneWindow(windowScene: scene)
+        // One level above `.normal` so it floats over the app content but below
+        // system alerts. It is a passthrough window, so it never blocks the app.
+        window.windowLevel = .normal + 1
+        window.backgroundColor = .clear
+        window.isOpaque = false
+        let host = UIHostingController(rootView: DogfoodPaneOverlayView(model: model))
+        host.view.backgroundColor = .clear
+        window.rootViewController = host
+        window.isHidden = false
+        self.window = window
+    }
+
+    /// Tear the window down (scene disconnect). Detaching the root controller and
+    /// hiding the window drops it from the scene.
+    func teardown() {
+        window.isHidden = true
+        window.rootViewController = nil
+    }
+}
+#endif

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -311,7 +311,12 @@ final class MobileHostService {
             "workspace.actions.v1",
         ]
         #if DEBUG
-        capabilities.append("dogfood.v1")
+        // `dogfood.v1` is the P1 umbrella (the `dogfood.feedback.submit` sink).
+        // `dogfood.checklist`/`dogfood.feedback` are the P2 verbs the floating
+        // pane gates on: a P1-only Mac advertises only `dogfood.v1`, so a newer
+        // phone skips the checklist subscribe + fetch and never eats a
+        // `method_not_found`.
+        capabilities.append(contentsOf: ["dogfood.v1", "dogfood.checklist", "dogfood.feedback"])
         #endif
         return capabilities
     }
@@ -337,6 +342,16 @@ final class MobileHostService {
     private var readinessTimeoutTask: Task<Void, Never>?
     #if DEBUG
     private var debugAcceptedStackAuthToken: String?
+    /// The current DEV dogfood checklist as opaque validated JSON (a top-level
+    /// object), set by the `dogfood_checklist_set` debug-socket command and
+    /// served to the phone via `dogfood.checklist.fetch`. The Mac never models
+    /// the schema (the phone owns the typed decode), so it stays
+    /// schema-agnostic. `nil` until the agent pushes one.
+    private var dogfoodChecklistJSON: [String: Any]?
+    /// Reject a checklist larger than this on `dogfood_checklist_set` so a hostile
+    /// or runaway client can't push a giant blob the Mac then re-serializes per
+    /// fetch.
+    nonisolated static let dogfoodChecklistMaxBytes = 65_536
     #endif
 
     private init() {}
@@ -355,6 +370,63 @@ final class MobileHostService {
         guard auth.isAuthenticated else { return nil }
         return auth.currentUser?.id
     }
+
+    #if DEBUG
+    /// The topic the DEV dogfood checklist is pushed/served on.
+    nonisolated static let dogfoodChecklistTopic = "dogfood.checklist"
+
+    /// Set the current DEV dogfood checklist from raw JSON pushed by the agent
+    /// (the `dogfood_checklist_set` debug-socket command), then push it to every
+    /// subscribed phone over the `dogfood.checklist` event topic.
+    ///
+    /// The JSON is validated as a top-level object and size-capped, but its
+    /// schema is otherwise opaque to the Mac (the phone owns the typed decode).
+    /// - Parameter rawJSON: The checklist JSON bytes.
+    /// - Returns: `true` when stored + pushed; `false` when the JSON is
+    ///   oversized, not parseable, or not a top-level object.
+    @discardableResult
+    func setDogfoodChecklist(rawJSON: Data) -> Bool {
+        guard rawJSON.count <= Self.dogfoodChecklistMaxBytes else { return false }
+        guard let object = try? JSONSerialization.jsonObject(with: rawJSON) as? [String: Any] else {
+            return false
+        }
+        dogfoodChecklistJSON = object
+        // Push to any subscribed phone. A checklist set before a device subscribes
+        // is not lost: the phone pulls via `dogfood.checklist.fetch` on connect.
+        //
+        // Auth posture (intended): the checklist push shares the SAME same-account
+        // gate as every other event topic. `mobile.events.subscribe` is itself
+        // authorization-required (only `mobile.host.status` is exempt in
+        // `requiresAuthorization`), so no unauthenticated or cross-account client
+        // ever receives this. The scoped-attach-ticket allowance for subscribe
+        // governs workspace scope, not account identity, and the checklist is
+        // agent-authored test text with no workspace scope — strictly less
+        // sensitive than the `terminal.render_grid` / `workspace.updated` live
+        // terminal content already delivered on this same channel to those
+        // clients. The more-restrictive `dogfood.checklist.fetch` gate is
+        // incidental (every RPC defaults to authorization-required), not a
+        // stronger intended gate that the push undercuts. DEBUG-only regardless.
+        emitEvent(topic: Self.dogfoodChecklistTopic, payload: object)
+        return true
+    }
+
+    /// Clear the current DEV dogfood checklist and push an empty checklist to
+    /// every subscribed phone so the pane shows its empty state instead of a
+    /// stale checklist. `dogfood.checklist.fetch` then reports no checklist.
+    func clearDogfoodChecklist() {
+        dogfoodChecklistJSON = nil
+        // Push an explicit empty checklist (an object with an empty `items`
+        // array) so a subscribed phone applies the cleared state immediately;
+        // the typed decoder reads a missing/empty `items` as an empty checklist.
+        emitEvent(topic: Self.dogfoodChecklistTopic, payload: ["items": [Any]()])
+    }
+
+    /// The current checklist JSON object, or `nil` if none is set. Served by the
+    /// `dogfood.checklist.fetch` RPC.
+    func currentDogfoodChecklist() -> [String: Any]? {
+        dogfoodChecklistJSON
+    }
+    #endif
 
     /// Fan out a server-pushed event to every connection subscribed to `topic`.
     /// Safe to call from any actor/queue.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1631,6 +1631,9 @@ class TerminalController {
 
         case "screenshot":
             return captureScreenshot(args)
+
+        case "dogfood_checklist_set":
+            return setDogfoodChecklist(args)
 #endif
 
         case "help":
@@ -16054,6 +16057,7 @@ class TerminalController {
           flash_count <id|idx>            - Read flash count for a panel
           reset_flash_counts              - Reset flash counters
           screenshot [label]              - Capture window screenshot
+          dogfood_checklist_set <json>    - Push a DEV dogfood checklist to paired phones (test-only)
           set_shortcut <name> <combo|clear> - Set a keyboard shortcut (test-only)
           simulate_shortcut <combo>       - Simulate a keyDown shortcut (test-only)
           simulate_type <text>            - Insert text into the current first responder (test-only)
@@ -17986,6 +17990,34 @@ class TerminalController {
 
         // Return OK with screenshot ID and path for easy reference
         return "OK \(screenshotId) \(outputPath.path)"
+    }
+
+    /// DEV-only `dogfood_checklist_set <json>`: store the agent's "what to check"
+    /// checklist on ``MobileHostService`` and push it to every subscribed phone.
+    ///
+    /// The agent drives this via
+    /// `CMUX_TAG=<tag> scripts/cmux-debug-cli.sh dogfood_checklist_set '<json>'`
+    /// where `<json>` is a top-level object, for example:
+    /// `{"title":"Pane test","items":[{"id":"drag","prompt":"Drag works?","kind":"pass_fail"}]}`.
+    /// Pass an empty body, `clear`, `null`, or `{}` to clear the checklist (the
+    /// phone is pushed an empty checklist and shows its empty state). The Mac
+    /// treats a non-empty checklist as opaque (the phone owns the typed decode),
+    /// validating only that it is a size-capped top-level object.
+    private func setDogfoodChecklist(_ args: String) -> String {
+        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Explicit clear forms: empty, the `clear` keyword, or a JSON null.
+        if trimmed.isEmpty || trimmed.lowercased() == "clear" || trimmed == "null" {
+            v2MainSync { MobileHostService.shared.clearDogfoodChecklist() }
+            return "OK dogfood checklist cleared"
+        }
+        guard let data = trimmed.data(using: .utf8) else {
+            return "ERROR: checklist is not valid UTF-8"
+        }
+        let ok = v2MainSync { MobileHostService.shared.setDogfoodChecklist(rawJSON: data) }
+        guard ok else {
+            return "ERROR: checklist must be a top-level JSON object under \(MobileHostService.dogfoodChecklistMaxBytes) bytes"
+        }
+        return "OK dogfood checklist set (\(data.count) bytes)"
     }
 
     private func captureCompositedWindowPNGData(_ window: NSWindow) -> Data? {
@@ -20689,6 +20721,8 @@ class TerminalController {
 #if DEBUG
         case "dogfood.feedback.submit":
             result = await v2MobileDogfoodFeedbackSubmit(params: request.params)
+        case "dogfood.checklist.fetch":
+            result = v2MobileDogfoodChecklistFetch()
 #endif
         default:
             result = .err(code: "method_not_found", message: "Unknown mobile method", data: [
@@ -20710,24 +20744,34 @@ class TerminalController {
     nonisolated private static let dogfoodFeedbackMaxBuildStampChars = 512
     nonisolated private static let dogfoodFeedbackMaxBlobBase64Chars = 8_388_608 // ~6 MiB decoded
     nonisolated private static let dogfoodFeedbackMaxBlobBytes = 6_291_456 // 6 MiB
+    /// P2 additive caps: the multiple-choice answers JSON (capped by character
+    /// count before parse) and the chrome screenshot PNG (rejected past its
+    /// base64 cap so it is never decoded; a decoded PNG past the byte cap is
+    /// dropped without failing the rest of the bundle).
+    nonisolated private static let dogfoodFeedbackMaxAnswersChars = 65_536
+    nonisolated private static let dogfoodFeedbackMaxScreenshotBase64Chars = 8_388_608 // ~6 MiB decoded
+    nonisolated private static let dogfoodFeedbackMaxScreenshotBytes = 6_291_456 // 6 MiB
     /// Keep at most this many bundle directories; older ones are pruned after
     /// each write so a retrying client can't grow the cache without bound.
     nonisolated private static let dogfoodFeedbackMaxRetainedBundles = 50
 
-    /// DEV-only dogfood feedback sink (P1 of the Mac↔phone feedback loop).
+    /// DEV-only dogfood feedback sink (P1 + P2 of the Mac↔phone feedback loop).
     ///
-    /// Decodes `{ text, terminal_text, build_stamp, diagnostic_blob_base64 }`,
-    /// writes a self-contained bundle directory under
+    /// Decodes `{ text, terminal_text, build_stamp, diagnostic_blob_base64 }`
+    /// plus the P2-additive `{ answers_json, screenshot_png_base64 }`, writes a
+    /// self-contained bundle directory under
     /// `~/.cache/cmux-dogfood-feedback/<ISO8601>_<shortid>/` (a `bundle.json`
-    /// manifest plus the decoded `diagnostic.log`), and returns the bundle path.
-    /// Gated behind `#if DEBUG` and the same-account Stack-auth authorization the
-    /// rest of the mobile data plane enforces, so it never exists in a release
-    /// build and never accepts an unauthenticated caller.
+    /// manifest, the decoded `diagnostic.log`, and `screenshot.png` when present),
+    /// and returns the bundle path. Gated behind `#if DEBUG` and the same-account
+    /// Stack-auth authorization the rest of the mobile data plane enforces, so it
+    /// never exists in a release build and never accepts an unauthenticated
+    /// caller.
     ///
     /// Field sizes are capped on the main actor *before* any large allocation,
     /// invalid/oversized base64 is rejected without decoding, and the decode +
     /// filesystem writes run off the main actor so a large payload cannot block
-    /// the Mac UI.
+    /// the Mac UI. The P2 fields are optional, so a P1 phone's request is handled
+    /// exactly as before.
     private func v2MobileDogfoodFeedbackSubmit(params: [String: Any]) async -> V2CallResult {
         // Cheap main-actor validation first: cap each field by character count
         // before allocating anything large, and reject an oversized base64 blob
@@ -20743,9 +20787,24 @@ class TerminalController {
                 data: nil
             )
         }
+        // P2 answers: a capped JSON string, validated as a top-level object off
+        // the request hot path but cheap enough to parse here. An invalid/missing
+        // answers blob is simply dropped (P1 compatibility), never an error.
+        let answersJSONString = String((v2RawString(params, "answers_json") ?? "").prefix(Self.dogfoodFeedbackMaxAnswersChars))
+        // P2 screenshot: reject an oversized base64 PNG outright (never decoded);
+        // an absent one is the P1 path. Dropping it must not fail the bundle.
+        let screenshotBase64 = v2RawString(params, "screenshot_png_base64") ?? ""
+        guard screenshotBase64.count <= Self.dogfoodFeedbackMaxScreenshotBase64Chars else {
+            return .err(
+                code: "invalid_params",
+                message: "screenshot_png_base64 exceeds size limit",
+                data: nil
+            )
+        }
 
         let maxBlobBytes = Self.dogfoodFeedbackMaxBlobBytes
-        // Off-main: decode the blob and write the bundle. A `Task.detached`
+        let maxScreenshotBytes = Self.dogfoodFeedbackMaxScreenshotBytes
+        // Off-main: decode the blobs and write the bundle. A `Task.detached`
         // keeps the (potentially multi-MiB) decode + synchronous file I/O off the
         // main actor so it never stalls the Mac UI. Returns a Sendable result.
         let outcome = await Task.detached(priority: .utility) { () -> DogfoodFeedbackWriteOutcome in
@@ -20753,11 +20812,19 @@ class TerminalController {
             guard decoded.count <= maxBlobBytes else {
                 return .rejected(reason: "diagnostic blob exceeds size limit")
             }
+            // A decoded screenshot past the byte cap (or undecodable) is dropped,
+            // not fatal: the rest of the bundle still ships.
+            var screenshot = screenshotBase64.isEmpty ? nil : Data(base64Encoded: screenshotBase64)
+            if let s = screenshot, s.count > maxScreenshotBytes {
+                screenshot = nil
+            }
             return Self.writeDogfoodFeedbackBundle(
                 text: text,
                 terminalText: terminalText,
                 buildStamp: buildStamp,
-                diagnosticData: decoded
+                diagnosticData: decoded,
+                answersJSONString: answersJSONString.isEmpty ? nil : answersJSONString,
+                screenshotData: screenshot
             )
         }.value
 
@@ -20779,6 +20846,18 @@ class TerminalController {
         }
     }
 
+    /// DEV-only `dogfood.checklist.fetch`: return the current agent-pushed
+    /// checklist so the phone can pull it on open (closing the subscribe-after-push
+    /// race). Returns `{ checklist: {...} }` when one is set, or `{ checklist:
+    /// null }` when none has been pushed. Auth-gated like the rest of the mobile
+    /// data plane (`requiresAuthorization` defaults to `true`).
+    private func v2MobileDogfoodChecklistFetch() -> V2CallResult {
+        if let checklist = MobileHostService.shared.currentDogfoodChecklist() {
+            return .ok(["checklist": checklist])
+        }
+        return .ok(["checklist": NSNull()])
+    }
+
     /// The result of writing a dogfood feedback bundle off the main actor.
     private enum DogfoodFeedbackWriteOutcome: Sendable {
         case written(bundlePath: String, byteCount: Int)
@@ -20789,11 +20868,21 @@ class TerminalController {
     /// Persist a validated dogfood feedback bundle to disk. Runs off the main
     /// actor (called from a detached task), so its synchronous file I/O never
     /// blocks the Mac UI. All inputs are already size-capped by the caller.
+    ///
+    /// - Parameters:
+    ///   - answersJSONString: The P2 multiple-choice answers as a JSON string,
+    ///     parsed into the manifest's `answers` object; `nil` for the P1 path or
+    ///     when unparseable.
+    ///   - screenshotData: The P2 chrome screenshot PNG written as
+    ///     `screenshot.png` and referenced from the manifest; `nil` when absent
+    ///     or dropped past the size cap.
     nonisolated private static func writeDogfoodFeedbackBundle(
         text: String,
         terminalText: String,
         buildStamp: String,
-        diagnosticData: Data
+        diagnosticData: Data,
+        answersJSONString: String? = nil,
+        screenshotData: Data? = nil
     ) -> DogfoodFeedbackWriteOutcome {
         let fileManager = FileManager.default
         let root = fileManager.homeDirectoryForCurrentUser
@@ -20829,7 +20918,7 @@ class TerminalController {
             let diagnosticURL = bundleDir.appendingPathComponent("diagnostic.log")
             try diagnosticData.write(to: diagnosticURL)
             try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: diagnosticURL.path)
-            let manifest: [String: Any] = [
+            var manifest: [String: Any] = [
                 "schema": "cmux.dogfood.feedback.v1",
                 "received_at": formatter.string(from: Date()),
                 "text": text,
@@ -20838,6 +20927,24 @@ class TerminalController {
                 "diagnostic_log_file": "diagnostic.log",
                 "diagnostic_log_bytes": diagnosticData.count,
             ]
+            // P2: parse the answers JSON into the manifest as a nested object so a
+            // reader can map answers back to checklist item ids. A non-object or
+            // unparseable answers blob is omitted rather than failing the bundle.
+            if let answersJSONString,
+               let answersData = answersJSONString.data(using: .utf8),
+               let answersObject = try? JSONSerialization.jsonObject(with: answersData) as? [String: Any] {
+                manifest["answers"] = answersObject
+            }
+            // P2: write the chrome screenshot alongside the manifest and reference
+            // it. The terminal renders blank in a UIView snapshot, which is why
+            // the terminal *text* is also in `terminal_text`.
+            if let screenshotData {
+                let screenshotURL = bundleDir.appendingPathComponent("screenshot.png")
+                try screenshotData.write(to: screenshotURL)
+                try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: screenshotURL.path)
+                manifest["screenshot_file"] = "screenshot.png"
+                manifest["screenshot_bytes"] = screenshotData.count
+            }
             let manifestData = try JSONSerialization.data(
                 withJSONObject: manifest,
                 options: [.prettyPrinted, .sortedKeys]


### PR DESCRIPTION
Builds P2 of the Mac↔phone dogfood feedback loop on top of P1 (https://github.com/manaflow-ai/cmux/pull/5574). Everything here is `#if DEBUG`-gated and does not exist in release builds.

## What this adds

**Floating, hideable iOS pane.** A draggable bug pill that expands into a card, hosted in its own passthrough `UIWindow` above the app scene, so it floats over the terminal regardless of the SwiftUI view tree. A `@MainActor @Observable DogfoodFeedbackModel` (built once in `AppCompositionRoot` via `CMUXMobileAppView`, wired into the shell) holds the agent-pushed checklist, the per-item multiple-choice answers, a shared freeform note, and capture/submit state. Each checklist item renders as a pass/fail or custom-choice question. Snapshot-boundary clean: the checklist section + rows take value snapshots + closures, never a store ref, so a note keystroke does not invalidate the rows.

**Checklist push (Mac→phone), so the agent can tell the pane what to dogfood:**
- `dogfood_checklist_set <json>` debug-socket command stores an opaque validated checklist on `MobileHostService` and emits the `dogfood.checklist` event. Pass empty/`clear`/`null`/`{}` to clear.
- `dogfood.checklist.fetch` RPC serves the current checklist so the pane pulls it on open (closes the subscribe-after-push race). Auth-gated by default (`requiresAuthorization`).
- iOS subscribes to `dogfood.checklist` on a **dedicated durable task + stream_id**, kept separate from the terminal stream so the render-grid liveness watchdog's ~9s re-subscribe never drops it.
- Mac advertises `dogfood.checklist` / `dogfood.feedback` capabilities alongside the P1 `dogfood.v1` umbrella; the phone gates the subscribe + fetch on `dogfood.checklist` so a P1-only Mac is a no-op (no `method_not_found`).

**Capture & Send.** Assembles a chrome screenshot via `drawHierarchy` over the app window (excluding the overlay window), paired with the verbatim `GhosttySurfaceView.visibleTerminalSnapshot()` terminal text (the terminal is a Metal/IOSurface layer and renders blank in a UIView snapshot, which is why the text rides along), the diagnostic log, the MC answers, and the note. `submitDogfoodFeedback` is extended additively (`answers_json` + `screenshot_png_base64`, both optional) so the P1 call site is unchanged and an old Mac degrades gracefully. The Mac sink writes `screenshot.png` + an `answers` object into `bundle.json`.

## How to drive it (agent)

Push a checklist to paired phones:
```bash
CMUX_TAG=<tag> scripts/cmux-debug-cli.sh dogfood_checklist_set '{"title":"Pane test","items":[{"id":"drag","prompt":"Does the pill drag?","kind":"pass_fail"},{"id":"edge","prompt":"Which edge feels best?","kind":"choice","choices":["left","right"]}]}'
```
- `kind: "pass_fail"` → fixed pass/fail/skip segmented control.
- `kind: "choice"` + `choices: [...]` → custom mutually-exclusive options.
- `id` is the stable key answers map back to (unique per checklist).
- Clear with `dogfood_checklist_set clear` (or empty/`null`/`{}`).

## Submit payload (additive over P1)

`dogfood.feedback.submit` params now also carry, when present:
- `answers_json`: canonical JSON of `{"answers":[{"id":"drag","choice":"pass"}],"note":"freeform"}` (unanswered items omitted). Capped client-side; the note is dropped (not the MC answers) if over the cap, since the note also ships in `text`.
- `screenshot_png_base64`: the chrome screenshot, attached only if the whole request still fits the 8 MiB transport frame (else dropped, rest of bundle ships).

The Mac sink writes `screenshot.png` alongside `bundle.json` and adds `answers`, `screenshot_file`, `screenshot_bytes` to the manifest.

## Tests

`CmuxMobileShellModel`: checklist/answer DTO round-trips, kind discriminator, clear-payload decode. `CmuxMobileShell`: pane model selection/ordering/capture-reset, in-flight-edit preservation, duplicate-id safety, answers byte-cap preserving MC answers, both-clear-routes agreement.

## Review notes

- DEV-only throughout; not shipped, so DEBUG-minimal strings are not localized (matches the P1 "Send to agent" precedent).
- Autoreview (Codex) run to convergence over several rounds; one final P3 finding consciously rejected with an inline-documented invariant: the `dogfood.checklist` push shares the **same** same-account auth gate as every other event topic (`mobile.events.subscribe` is `requiresAuthorization`; the scoped-ticket allowance governs workspace scope, not account identity). The checklist is agent-authored test text with no workspace scope, strictly less sensitive than the `terminal.render_grid` / `workspace.updated` live terminal content already on that channel. The more-restrictive `fetch` gate is incidental (every RPC defaults to auth-required), not a stronger intended gate.

Ready to roll into the dog build. The Mac dog build needs this branch's new debug-socket command (`dogfood_checklist_set`) for the agent to push checklists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783478858&installation_id=133855650&pr_number=5597&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5597&signature=cede8f6a3640d8fa12964c11e15bfa44fb0e03afd379ee42496e32659826ba23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile RPC/event plumbing and large payload encoding with size caps; DEBUG-only but expands the dogfood data plane and bundle persistence on paired devices.
> 
> **Overview**
> **P2 of the DEBUG Mac↔phone dogfood loop:** a floating iOS dogfood pane plus agent-driven checklists and richer feedback bundles, all behind `#if DEBUG`.
> 
> On **iOS**, adds a draggable bug pill / expandable overlay in a passthrough `UIWindow`, driven by `DogfoodFeedbackModel` (checklist, MC answers, note, Capture & Send). The shell gains a **separate durable** `dogfood.checklist` subscription (not tied to the terminal stream’s liveness re-subscribe), capability gating, and `dogfood.checklist.fetch` on connect. `submitDogfoodFeedback` is extended additively with optional `answers_json` and `screenshot_png_base64`, with client-side caps (note trimming must not drop MC answers; screenshot dropped if the RPC frame would overflow).
> 
> On **Mac (DEBUG)**, adds `dogfood_checklist_set` / clear, in-memory checklist storage, `dogfood.checklist` event push, `dogfood.checklist.fetch`, and P2 fields on the feedback sink (`answers` in `bundle.json`, `screenshot.png`). New shared model types decode agent JSON and encode submitted answers.
> 
> Tests cover DTO round-trips, pane model behavior, and answers byte-cap logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a9859dc9a7d9b970694b92ff965f96eab0e32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DEBUG‑only floating iOS feedback pane with an agent‑pushed checklist, plus screenshot and multiple‑choice answers in feedback submissions. Improves reliability with a dedicated `dogfood.checklist` stream separate from terminal events.

- **New Features**
  - iOS: Draggable “bug” pill that expands into a pane hosted in a passthrough `UIWindow` over the app; `DogfoodFeedbackModel` tracks checklist, selections, note, and submit state.
  - Mac→phone checklist: `dogfood_checklist_set <json>` stores validated JSON on `MobileHostService` and pushes `dogfood.checklist`; `dogfood.checklist.fetch` lets the phone pull on open; gated by advertised `dogfood.checklist` capability; durable subscription on its own `stream_id`.
  - Capture & Send: `submitDogfoodFeedback` now accepts optional `answers_json` and `screenshot_png_base64` (with size caps and frame‑budget guard); Mac writes `screenshot.png` and an `answers` object to `bundle.json`. P1 clients remain compatible.
  - Tests: DTO round‑trips, answers‑cap preserves MC answers, model behavior (selection, ordering, in‑flight edit preservation).

- **Migration**
  - DEV‑only; no release impact.
  - To use, run a Mac dog build that includes `dogfood_checklist_set`, push a JSON checklist, and the phone will auto‑subscribe and fetch the current checklist.

<sup>Written for commit f8a9859dc9a7d9b970694b92ff965f96eab0e32b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DEBUG-only floating feedback pane for internal testers to respond to checklist questions, provide freeform notes, and submit feedback with optional screenshot capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->