### PR TITLE
auth: capture Sign in with Apple / OAuth failures instead of swallowing them

### DIFF
--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -65,6 +65,7 @@ public final class AuthCoordinator {
     private let launch: AuthLaunchOptions
     private let isOnline: @Sendable () async -> Bool
     private let onSignedIn: @Sendable () async -> Void
+    private let errorReporter: any AuthErrorReporting
 
     private var pendingNonce: String?
     private var debugCredentials: CMUXAuthAutoLoginCredentials?
@@ -86,6 +87,11 @@ public final class AuthCoordinator {
     ///   - onSignedIn: Hook run after a successful sign-in / session restore, for
     ///     side effects above this package (e.g. push token re-upload). Defaults
     ///     to a no-op.
+    ///   - errorReporter: Reporting seam for sign-in failures (macOS injects a
+    ///     Sentry-backed conformer). The underlying error is reported before it
+    ///     is wrapped into a display-safe ``AuthError``. Defaults to
+    ///     ``NoopAuthErrorReporting`` so tests and surfaces without a backend
+    ///     opt out.
     public init(
         client: any AuthClient,
         sessionCache: CMUXAuthSessionCache,
@@ -95,7 +101,8 @@ public final class AuthCoordinator {
         config: AuthConfig,
         launch: AuthLaunchOptions,
         isOnline: @escaping @Sendable () async -> Bool = { true },
-        onSignedIn: @escaping @Sendable () async -> Void = {}
+        onSignedIn: @escaping @Sendable () async -> Void = {},
+        errorReporter: any AuthErrorReporting = NoopAuthErrorReporting()
     ) {
         self.client = client
         self.sessionCache = sessionCache
@@ -106,6 +113,7 @@ public final class AuthCoordinator {
         self.launch = launch
         self.isOnline = isOnline
         self.onSignedIn = onSignedIn
+        self.errorReporter = errorReporter
         self.selectedTeamID = teamSelection.selectedTeamID
         primeSessionState()
     }
@@ -401,6 +409,17 @@ public final class AuthCoordinator {
             try await client.signInWithOAuth(provider: provider, anchor: anchor)
             try await completeSignIn()
         } catch {
+            // Capture the real, un-wrapped error before it collapses into the
+            // generic display message, so OAuth/Apple sign-in breaks (e.g. a
+            // Stack INVALID_APPLE_CREDENTIALS from the native Apple token
+            // exchange) stop being invisible. User cancellation is not a
+            // failure, so it is not reported.
+            if AuthError(displaySafe: error) != .cancelled {
+                errorReporter.report(
+                    error: error,
+                    context: AuthErrorContext(flow: "oauth", provider: provider)
+                )
+            }
             throw AuthError(displaySafe: error) ?? error
         }
     }

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -445,6 +445,17 @@ public final class AuthCoordinator {
         do {
             try await completeSignIn()
         } catch {
+            // The macOS hosted-browser flow (Sign in with Apple/Google via the
+            // web app) completes here, so capture its session-validation
+            // failures too; otherwise that primary macOS path stays invisible.
+            // The provider is not known at this seam (the browser ran the OAuth
+            // choice), so only the flow is reported.
+            if AuthError(displaySafe: error) != .cancelled {
+                errorReporter.report(
+                    error: error,
+                    context: AuthErrorContext(flow: "browser_oauth")
+                )
+            }
             throw AuthError(displaySafe: error) ?? error
         }
     }

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorContext.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorContext.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Structured, non-sensitive context attached to a captured auth failure.
+///
+/// The conforming reporter (which owns the backend SDK) is responsible for
+/// extracting any stable error code from the reported error itself; this
+/// context only carries the flow-level facts the coordinator knows.
+public struct AuthErrorContext: Sendable, Equatable {
+    /// The auth flow that failed (e.g. `"oauth"`, `"password"`, `"magic_link"`).
+    public let flow: String
+    /// The OAuth provider when ``flow`` is `"oauth"` (e.g. `"apple"`), else `nil`.
+    public let provider: String?
+
+    /// Creates an auth error context.
+    /// - Parameters:
+    ///   - flow: The failing auth flow.
+    ///   - provider: The OAuth provider, when applicable.
+    public init(flow: String, provider: String? = nil) {
+        self.flow = flow
+        self.provider = provider
+    }
+}

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorReporting.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorReporting.swift
@@ -25,37 +25,3 @@ public protocol AuthErrorReporting: Sendable {
     ///     non-sensitive strings safe to send to a telemetry backend.
     func report(error: any Error, context: AuthErrorContext)
 }
-
-/// Structured, non-sensitive context attached to a captured auth failure.
-///
-/// The conforming reporter (which owns the backend SDK) is responsible for
-/// extracting any stable error code from the reported error itself; this
-/// context only carries the flow-level facts the coordinator knows.
-public struct AuthErrorContext: Sendable, Equatable {
-    /// The auth flow that failed (e.g. `"oauth"`, `"password"`, `"magic_link"`).
-    public let flow: String
-    /// The OAuth provider when ``flow`` is `"oauth"` (e.g. `"apple"`), else `nil`.
-    public let provider: String?
-
-    /// Creates an auth error context.
-    /// - Parameters:
-    ///   - flow: The failing auth flow.
-    ///   - provider: The OAuth provider, when applicable.
-    public init(flow: String, provider: String? = nil) {
-        self.flow = flow
-        self.provider = provider
-    }
-}
-
-/// A no-op ``AuthErrorReporting`` used as the default and in tests.
-///
-/// Reporting auth failures is opt-in: an app that does not inject a real
-/// reporter (e.g. a unit-test host, or iOS before its diagnostics reporter is
-/// wired) silently drops the events rather than depending on a backend.
-public struct NoopAuthErrorReporting: AuthErrorReporting {
-    /// Creates a no-op reporter.
-    public init() {}
-
-    /// Discards the reported error.
-    public func report(error: any Error, context: AuthErrorContext) {}
-}

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorReporting.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/AuthErrorReporting.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// A reporting seam the ``AuthCoordinator`` calls when a sign-in flow fails,
+/// before the underlying error is wrapped into a display-safe ``AuthError``.
+///
+/// `CmuxAuthRuntime` is a shared, low-level package that links into both the
+/// macOS and iOS apps. iOS links no crash/error reporter and the package may
+/// not depend on a concrete telemetry SDK, so the real reporter is injected at
+/// each app's composition root: macOS passes a Sentry-backed conformer, iOS a
+/// diagnostics-log-backed one (or the ``NoopAuthErrorReporting`` default).
+///
+/// Without this seam, OAuth/Apple sign-in failures were swallowed into the
+/// generic "Something went wrong. Please try again." message and never reached
+/// any backend, leaving production auth breaks invisible.
+public protocol AuthErrorReporting: Sendable {
+    /// Report a sign-in failure with the underlying error and structured
+    /// context, for capture by the app's telemetry/diagnostics backend.
+    ///
+    /// - Parameters:
+    ///   - error: The real, un-wrapped error thrown by the auth backend (e.g.
+    ///     the Stack SDK `OAuthError` carrying an `INVALID_APPLE_CREDENTIALS`
+    ///     code), before it is mapped to a display-safe ``AuthError``.
+    ///   - context: Structured key/value context (e.g. the flow name and OAuth
+    ///     provider) attached to the captured event. Values are short,
+    ///     non-sensitive strings safe to send to a telemetry backend.
+    func report(error: any Error, context: AuthErrorContext)
+}
+
+/// Structured, non-sensitive context attached to a captured auth failure.
+///
+/// The conforming reporter (which owns the backend SDK) is responsible for
+/// extracting any stable error code from the reported error itself; this
+/// context only carries the flow-level facts the coordinator knows.
+public struct AuthErrorContext: Sendable, Equatable {
+    /// The auth flow that failed (e.g. `"oauth"`, `"password"`, `"magic_link"`).
+    public let flow: String
+    /// The OAuth provider when ``flow`` is `"oauth"` (e.g. `"apple"`), else `nil`.
+    public let provider: String?
+
+    /// Creates an auth error context.
+    /// - Parameters:
+    ///   - flow: The failing auth flow.
+    ///   - provider: The OAuth provider, when applicable.
+    public init(flow: String, provider: String? = nil) {
+        self.flow = flow
+        self.provider = provider
+    }
+}
+
+/// A no-op ``AuthErrorReporting`` used as the default and in tests.
+///
+/// Reporting auth failures is opt-in: an app that does not inject a real
+/// reporter (e.g. a unit-test host, or iOS before its diagnostics reporter is
+/// wired) silently drops the events rather than depending on a backend.
+public struct NoopAuthErrorReporting: AuthErrorReporting {
+    /// Creates a no-op reporter.
+    public init() {}
+
+    /// Discards the reported error.
+    public func report(error: any Error, context: AuthErrorContext) {}
+}

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/NoopAuthErrorReporting.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Diagnostics/NoopAuthErrorReporting.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A no-op ``AuthErrorReporting`` used as the default and in tests.
+///
+/// Reporting auth failures is opt-in: an app that does not inject a real
+/// reporter (e.g. a unit-test host, or iOS before its diagnostics reporter is
+/// wired) silently drops the events rather than depending on a backend.
+public struct NoopAuthErrorReporting: AuthErrorReporting {
+    /// Creates a no-op reporter.
+    public init() {}
+
+    /// Discards the reported error.
+    public func report(error: any Error, context: AuthErrorContext) {}
+}

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -353,4 +353,21 @@ import Testing
         #expect(coordinator.isAuthenticated == false)
         #expect(coordinator.isLoading == false)
     }
+
+    @Test func browserFlowCompletionFailureIsReported() async {
+        // The macOS hosted-browser sign-in (Apple/Google via the web app)
+        // completes through completeExternalSignIn(); a validation failure
+        // there must reach the reporter so the primary macOS path is visible.
+        let client = FakeAuthClient()
+        await client.setThrowOnCurrentUser(AuthError.serverError(500, "auth_failed"))
+        let reporter = FakeAuthErrorReporter()
+        let (coordinator, _) = makeCoordinator(client: client, errorReporter: reporter)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.completeExternalSignIn()
+        }
+
+        #expect(reporter.reports.count == 1)
+        #expect(reporter.reports.first?.context.flow == "browser_oauth")
+    }
 }

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -8,7 +8,8 @@ import Testing
     private func makeCoordinator(
         client: FakeAuthClient,
         launch: AuthLaunchOptions = .plain(),
-        isOnline: @escaping @Sendable () async -> Bool = { true }
+        isOnline: @escaping @Sendable () async -> Bool = { true },
+        errorReporter: any AuthErrorReporting = NoopAuthErrorReporting()
     ) -> (AuthCoordinator, FakeKeyValueStore) {
         let store = FakeKeyValueStore()
         let coordinator = AuthCoordinator(
@@ -19,7 +20,8 @@ import Testing
             anchor: FakeAnchor(),
             config: .test,
             launch: launch,
-            isOnline: isOnline
+            isOnline: isOnline,
+            errorReporter: errorReporter
         )
         return (coordinator, store)
     }
@@ -81,6 +83,34 @@ import Testing
 
         let providers = await client.oauthProviders
         #expect(providers == ["apple", "google"])
+    }
+
+    @Test func oauthFailureReportsUnderlyingErrorWithProvider() async {
+        let client = FakeAuthClient()
+        await client.setThrowOnOAuth(AuthError.serverError(400, "INVALID_APPLE_CREDENTIALS"))
+        let reporter = FakeAuthErrorReporter()
+        let (coordinator, _) = makeCoordinator(client: client, errorReporter: reporter)
+
+        await #expect(throws: (any Error).self) {
+            try await coordinator.signInWithApple()
+        }
+
+        #expect(reporter.reports.count == 1)
+        #expect(reporter.reports.first?.context.flow == "oauth")
+        #expect(reporter.reports.first?.context.provider == "apple")
+    }
+
+    @Test func oauthCancellationIsNotReported() async {
+        let client = FakeAuthClient()
+        await client.setThrowOnOAuth(AuthError.cancelled)
+        let reporter = FakeAuthErrorReporter()
+        let (coordinator, _) = makeCoordinator(client: client, errorReporter: reporter)
+
+        await #expect(throws: AuthError.cancelled) {
+            try await coordinator.signInWithApple()
+        }
+
+        #expect(reporter.reports.isEmpty)
     }
 
     @Test func signOutClearsStateAndRunsHook() async throws {

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
@@ -28,6 +28,7 @@ actor FakeAuthClient: AuthClient {
     var teams: [CMUXAuthTeam] = []
     var throwOnCurrentUser: (any Error)?
     var throwOnListTeams: (any Error)?
+    var throwOnOAuth: (any Error)?
     var nonce = "nonce-123"
     private(set) var signedInWithMagicLink = false
     private(set) var signedInWithCredential: (email: String, password: String)?
@@ -49,6 +50,7 @@ actor FakeAuthClient: AuthClient {
     func setThrowOnCurrentUser(_ error: (any Error)?) { throwOnCurrentUser = error }
     func setTeams(_ teams: [CMUXAuthTeam]) { self.teams = teams }
     func setThrowOnListTeams(_ error: (any Error)?) { throwOnListTeams = error }
+    func setThrowOnOAuth(_ error: (any Error)?) { throwOnOAuth = error }
 
     func accessToken() async -> String? { access }
     func refreshToken() async -> String? { refresh }
@@ -83,6 +85,7 @@ actor FakeAuthClient: AuthClient {
 
     func signInWithOAuth(provider: String, anchor: any AuthPresentationAnchoring) async throws {
         oauthProviders.append(provider)
+        if let throwOnOAuth { throw throwOnOAuth }
         access = "access"
     }
 
@@ -108,6 +111,18 @@ final class FakeAnchor: NSObject, AuthPresentationAnchoring {
 actor HookFlag {
     private(set) var fired = false
     func fire() { fired = true }
+}
+
+/// Records every ``AuthErrorReporting`` call so a test can assert that a failed
+/// sign-in was captured with the expected flow/provider (and was not captured
+/// on user cancellation).
+final class FakeAuthErrorReporter: AuthErrorReporting, @unchecked Sendable {
+    // Single-threaded test usage; the coordinator reports on the main actor.
+    private(set) var reports: [(error: any Error, context: AuthErrorContext)] = []
+
+    func report(error: any Error, context: AuthErrorContext) {
+        reports.append((error, context))
+    }
 }
 
 /// Captures a value observed inside an async hook, for ordering assertions.

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -329,6 +329,10 @@ struct SignInView: View {
 
     /// Maps a sign-in error to the `ios_sign_in_failed` `failure_reason` enum
     /// (enums only — never the error text or the user's email).
+    ///
+    /// Apple/OAuth backend codes get distinct reasons so a structural break
+    /// like an unregistered Apple bundle id (`INVALID_APPLE_CREDENTIALS`) is
+    /// visible in analytics instead of collapsing into a generic `oauth_error`.
     private static func signInFailureReason(_ error: Error) -> String {
         if let stackError = error as? StackAuthErrorProtocol {
             switch stackError.code {
@@ -338,6 +342,12 @@ struct SignInView: View {
                 return "code_expired"
             case "RATE_LIMIT":
                 return "rate_limit"
+            case "INVALID_APPLE_CREDENTIALS":
+                return "apple_credentials_invalid"
+            case "REDIRECT_URL_NOT_WHITELISTED":
+                return "redirect_not_whitelisted"
+            case "OAUTH_PROVIDER_ACCOUNT_ID_ALREADY_USED_FOR_SIGN_IN":
+                return "oauth_account_linked"
             default:
                 return "oauth_error"
             }

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -111,7 +111,8 @@ struct MacAuthComposition {
             ),
             anchor: anchor,
             config: config,
-            launch: launch
+            launch: launch,
+            errorReporter: SentryAuthErrorReporter()
         )
         self.coordinator = coordinator
         let callbackRouter = AuthCallbackRouter(

--- a/Sources/Auth/SentryAuthErrorReporter.swift
+++ b/Sources/Auth/SentryAuthErrorReporter.swift
@@ -1,0 +1,34 @@
+import CmuxAuthRuntime
+import Foundation
+import Sentry
+import StackAuth
+
+/// The macOS ``AuthErrorReporting`` conformer: captures a failed sign-in to
+/// Sentry with the auth flow, OAuth provider, and the underlying Stack error
+/// code (e.g. `INVALID_APPLE_CREDENTIALS`).
+///
+/// Constructed at the app composition root and injected into the
+/// ``AuthCoordinator``. Lives in the app target because `CmuxAuthRuntime` is a
+/// shared low-level package that may not depend on Sentry (and iOS links none).
+/// Honors the user's telemetry opt-out via `TelemetrySettings`.
+struct SentryAuthErrorReporter: AuthErrorReporting {
+    func report(error: any Error, context: AuthErrorContext) {
+        guard TelemetrySettings.enabledForCurrentLaunch else { return }
+        // Extract the backend code here (this layer imports StackAuth); the
+        // coordinator stays SDK-free behind the AuthClient seam.
+        let code = (error as? any StackAuthErrorProtocol)?.code
+        var data: [String: Any] = ["flow": context.flow]
+        if let provider = context.provider { data["provider"] = provider }
+        if let code { data["code"] = code }
+
+        _ = SentrySDK.capture(error: error) { scope in
+            scope.setLevel(.error)
+            scope.setTag(value: "auth", key: "category")
+            scope.setContext(value: data, key: "auth_sign_in")
+            if let code { scope.setTag(value: code, key: "auth_error_code") }
+            if let provider = context.provider {
+                scope.setTag(value: provider, key: "auth_provider")
+            }
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		C0DEF0C20000000000000001 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0C20000000000000002 /* SemanticVersion.swift */; };
 		A5001250 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 		B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
+		5175A001A0B1C2D3E4F5A001 /* SentryAuthErrorReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5175A002A0B1C2D3E4F5A002 /* SentryAuthErrorReporter.swift */; };
 		A5001601 /* SentryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001600 /* SentryHelper.swift */; };
 		FE003106 /* SessionAgentPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003006 /* SessionAgentPresentation.swift */; };
 		A9F200000000000000000008 /* SessionAgentSessionPanelSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000008 /* SessionAgentSessionPanelSnapshot.swift */; };
@@ -1217,6 +1218,7 @@
 		3865B0013865B0013865B001 /* SearchIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/SearchIndex.swift; sourceTree = "<group>"; };
 		3865B0043865B0043865B004 /* SearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchIndexTests.swift; sourceTree = "<group>"; };
 		C0DEF0C20000000000000002 /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
+		5175A002A0B1C2D3E4F5A002 /* SentryAuthErrorReporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SentryAuthErrorReporter.swift; sourceTree = "<group>"; };
 		A5001600 /* SentryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHelper.swift; sourceTree = "<group>"; };
 		FE003006 /* SessionAgentPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAgentPresentation.swift; sourceTree = "<group>"; };
 		A9F100000000000000000008 /* SessionAgentSessionPanelSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAgentSessionPanelSnapshot.swift; sourceTree = "<group>"; };
@@ -1527,6 +1529,7 @@
 				43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */,
 				DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */,
 				53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */,
+				5175A002A0B1C2D3E4F5A002 /* SentryAuthErrorReporter.swift */,
 				CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */,
 			);
 			name = Auth;
@@ -2897,6 +2900,7 @@
 				E8BA79E246754A8B99A0B823 /* ScreenIdentity.swift in Sources */,
 				3865A0013865A0013865A001 /* SearchIndex.swift in Sources */,
 				C0DEF0C20000000000000001 /* SemanticVersion.swift in Sources */,
+				5175A001A0B1C2D3E4F5A001 /* SentryAuthErrorReporter.swift in Sources */,
 				A5001601 /* SentryHelper.swift in Sources */,
 				FE003106 /* SessionAgentPresentation.swift in Sources */,
 				A9F200000000000000000008 /* SessionAgentSessionPanelSnapshot.swift in Sources */,


### PR DESCRIPTION
## Why

Sign in with Apple (and other OAuth) failures were collapsed into the generic "Something went wrong. Please try again." in `AuthCoordinator`'s OAuth catch and captured nowhere. A real auth break was invisible: no Sentry event on macOS, and on iOS the sign-in catch had no error capture at all.

This PR makes that failure path observable. It does not change the thrown error type, so the existing `AuthError(displaySafe:)` mapping and the iOS `SignInView` error rendering keep working (no regression).

## What

- **`AuthErrorReporting` seam** (injected, `NoopAuthErrorReporting` default) on `AuthCoordinator`. Both the native-OAuth catch and the macOS hosted-browser completion path (`completeExternalSignIn`) report the real, un-wrapped error with the flow + provider before it is mapped to a display-safe `AuthError`. User cancellation is not reported.
- **macOS Sentry reporter** (`SentryAuthErrorReporter`) wired at the composition root; it extracts the Stack error code (e.g. `INVALID_APPLE_CREDENTIALS`) and honors the telemetry opt-out. `CmuxAuthRuntime` stays SDK-free behind the `AuthClient` seam; iOS keeps the no-op.
- **iOS analytics enrichment:** the existing `ios_sign_in_failed` PostHog event now has distinct `failure_reason` values for `INVALID_APPLE_CREDENTIALS` and related OAuth codes, so a structural break is visible in analytics instead of collapsing into a generic `oauth_error`. Values are enum-like codes, never error text or the user's email.
- Tests: failed OAuth and failed browser-flow completion report with the right flow/provider; cancellation does not.

## Context: the SIWA break (config/architecture, reported separately, not fixed by this PR)

iOS SIWA uses **native** `ASAuthorizationController`; Stack validates the Apple identity token's `aud` (the app bundle id) against the project's registered `apple_bundle_ids`. Tagged dev builds use per-tag bundle ids (`dev.cmux.ios.<tag>`) that can never be pre-registered, so native SIWA on dev tagged builds is structurally broken and returns `INVALID_APPLE_CREDENTIALS`. The Apple client secret is valid (not expired) and TestFlight's bundle (`dev.cmux.app.beta`) is registered, so those axes are not the cause.

Note: the user-reported symptom was the *generic* message, but `INVALID_APPLE_CREDENTIALS` already maps to a specific message on iOS. The generic message only appears for an *unrecognized* error code, so the user's actual failure is likely a different, still-unidentified code. This PR's capture + PostHog enrichment is what will surface that real code on the next attempt.

## Verification

- iOS simulator build (at HEAD): BUILD SUCCEEDED.
- macOS tagged build (at HEAD): BUILD SUCCEEDED.
- `swift test` (CmuxAuthRuntime): 26/26 pass including the new reporter tests.
- Autoreview: clean (no actionable findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)