### PR TITLE
Fix sidebar Shift-click range anchor after no-op drag

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -16279,23 +16279,32 @@ struct TabItemView: View, Equatable {
     }
 
     private func updateSelection() {
-        #if DEBUG
-        let mods = NSEvent.modifierFlags
-        var modStr = ""
-        if mods.contains(.command) { modStr += "cmd " }
-        if mods.contains(.shift) { modStr += "shift " }
-        if mods.contains(.option) { modStr += "opt " }
-        if mods.contains(.control) { modStr += "ctrl " }
-        cmuxDebugLog("sidebar.select workspace=\(tab.id.uuidString.prefix(5)) modifiers=\(modStr.isEmpty ? "none" : modStr.trimmingCharacters(in: .whitespaces))")
-        #endif
         let modifiers = NSEvent.modifierFlags
         let isCommand = modifiers.contains(.command)
         let isShift = modifiers.contains(.shift)
         let wasSelected = tabManager.selectedTabId == tab.id
+        #if DEBUG
+        var modStr = ""
+        if modifiers.contains(.command) { modStr += "cmd " }
+        if modifiers.contains(.shift) { modStr += "shift " }
+        if modifiers.contains(.option) { modStr += "opt " }
+        if modifiers.contains(.control) { modStr += "ctrl " }
+        cmuxDebugLog("sidebar.select workspace=\(tab.id.uuidString.prefix(5)) modifiers=\(modStr.isEmpty ? "none" : modStr.trimmingCharacters(in: .whitespaces))")
+        #endif
 
-        if isShift, let lastIndex = lastSidebarSelectionIndex {
-            let lower = min(lastIndex, index)
-            let upper = max(lastIndex, index)
+        let workspaceIds = tabManager.tabs.map(\.id)
+        let shiftAnchorIndex = isShift
+            ? SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
+                existingAnchorIndex: lastSidebarSelectionIndex,
+                selectedWorkspaceIds: selectedTabIds,
+                focusedWorkspaceId: tabManager.selectedTabId,
+                liveWorkspaceIds: workspaceIds
+            )
+            : nil
+
+        if isShift, let anchorIndex = shiftAnchorIndex {
+            let lower = min(anchorIndex, index)
+            let upper = max(anchorIndex, index)
             // Filter out workspaces hidden inside collapsed groups so a
             // Shift-click range never silently includes rows the user
             // can't see (e.g. clicking a collapsed group's anchor and
@@ -16332,7 +16341,11 @@ struct TabItemView: View, Equatable {
             selectedTabIds = [tab.id]
         }
 
-        lastSidebarSelectionIndex = index
+        lastSidebarSelectionIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
+            isShiftClick: isShift,
+            resolvedShiftAnchorIndex: shiftAnchorIndex,
+            clickedIndex: index
+        )
         tabManager.selectTab(tab)
         if wasSelected, !isCommand, !isShift {
             tabManager.dismissNotificationOnDirectInteraction(
@@ -17633,6 +17646,64 @@ enum SidebarWorkspaceSelectionSyncPolicy {
         }
         return liveWorkspaceIds.firstIndex { selectedWorkspaceIds.contains($0) }
     }
+
+    static func anchorWorkspaceId(
+        existingAnchorIndex: Int?,
+        liveWorkspaceIds: [UUID]
+    ) -> UUID? {
+        guard let existingAnchorIndex,
+              liveWorkspaceIds.indices.contains(existingAnchorIndex) else {
+            return nil
+        }
+        return liveWorkspaceIds[existingAnchorIndex]
+    }
+
+    static func shiftClickAnchorIndex(
+        existingAnchorIndex: Int?,
+        selectedWorkspaceIds: Set<UUID>,
+        focusedWorkspaceId: UUID?,
+        liveWorkspaceIds: [UUID]
+    ) -> Int? {
+        if let existingAnchorIndex,
+           liveWorkspaceIds.indices.contains(existingAnchorIndex) {
+            return existingAnchorIndex
+        }
+        if selectedWorkspaceIds.count == 1,
+           let selectedWorkspaceId = selectedWorkspaceIds.first,
+           let selectedIndex = liveWorkspaceIds.firstIndex(of: selectedWorkspaceId) {
+            return selectedIndex
+        }
+        if let focusedWorkspaceId {
+            return liveWorkspaceIds.firstIndex(of: focusedWorkspaceId)
+        }
+        return nil
+    }
+
+    static func anchorIndexAfterWorkspaceClick(
+        isShiftClick: Bool,
+        resolvedShiftAnchorIndex: Int?,
+        clickedIndex: Int
+    ) -> Int {
+        isShiftClick ? (resolvedShiftAnchorIndex ?? clickedIndex) : clickedIndex
+    }
+
+    static func anchorIndexAfterWorkspaceReorder(
+        preferredAnchorWorkspaceId: UUID?,
+        selectedWorkspaceIds: Set<UUID>,
+        focusedWorkspaceId: UUID?,
+        liveWorkspaceIds: [UUID]
+    ) -> Int? {
+        if let preferredAnchorWorkspaceId,
+           selectedWorkspaceIds.contains(preferredAnchorWorkspaceId),
+           let anchorIndex = liveWorkspaceIds.firstIndex(of: preferredAnchorWorkspaceId) {
+            return anchorIndex
+        }
+        return anchorIndex(
+            preferredWorkspaceId: focusedWorkspaceId,
+            selectedWorkspaceIds: selectedWorkspaceIds,
+            liveWorkspaceIds: liveWorkspaceIds
+        )
+    }
 }
 
 @MainActor
@@ -17869,7 +17940,6 @@ struct SidebarTabDropDelegate: DropDelegate {
 #if DEBUG
             cmuxDebugLog("sidebar.drop.noop from=\(fromIndex) to=\(targetIndex)")
 #endif
-            syncSidebarSelection()
             return true
         }
 
@@ -17877,13 +17947,20 @@ struct SidebarTabDropDelegate: DropDelegate {
         cmuxDebugLog("sidebar.drop.commit tab=\(draggedTabId.uuidString.prefix(5)) from=\(fromIndex) to=\(targetIndex)")
 #endif
         let selectionBeforeReorder = selectedTabIds
+        let anchorWorkspaceIdBeforeReorder = SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
+            existingAnchorIndex: lastSidebarSelectionIndex,
+            liveWorkspaceIds: tabManager.tabs.map(\.id)
+        )
         let didReorder = tabManager.reorderSidebarWorkspace(
             tabId: draggedTabId,
             toIndex: targetIndex,
             isDragOperation: true,
             usesTopLevelRows: usesTopLevelRows
         )
-        syncSidebarSelection(preserving: selectionBeforeReorder)
+        syncSidebarSelection(
+            preserving: selectionBeforeReorder,
+            preferredAnchorWorkspaceId: anchorWorkspaceIdBeforeReorder
+        )
         return didReorder
     }
 
@@ -18048,7 +18125,10 @@ struct SidebarTabDropDelegate: DropDelegate {
         }
     }
 
-    private func syncSidebarSelection(preserving previousSelectionIds: Set<UUID>) {
+    private func syncSidebarSelection(
+        preserving previousSelectionIds: Set<UUID>,
+        preferredAnchorWorkspaceId: UUID?
+    ) {
         let liveWorkspaceIds = tabManager.tabs.map(\.id)
         let nextSelectionIds = SidebarWorkspaceSelectionSyncPolicy.reconciledSelection(
             previousSelectionIds: previousSelectionIds,
@@ -18056,9 +18136,10 @@ struct SidebarTabDropDelegate: DropDelegate {
             fallbackSelectedWorkspaceId: tabManager.selectedTabId
         )
         selectedTabIds = nextSelectionIds
-        lastSidebarSelectionIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndex(
-            preferredWorkspaceId: tabManager.selectedTabId,
+        lastSidebarSelectionIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
+            preferredAnchorWorkspaceId: preferredAnchorWorkspaceId,
             selectedWorkspaceIds: nextSelectionIds,
+            focusedWorkspaceId: tabManager.selectedTabId,
             liveWorkspaceIds: liveWorkspaceIds
         )
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 		C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */; };
 		C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */; };
 		D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */; };
+		C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */; };
 		988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */; };
 		62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 		A5001226 /* SocketControlMode+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlMode+Display.swift */; };
@@ -1280,6 +1281,7 @@
 		C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupingMetrics.swift; sourceTree = "<group>"; };
 		C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItem.swift; sourceTree = "<group>"; };
 		D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTracker.swift; sourceTree = "<group>"; };
+		C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSelectionAnchorPolicyTests.swift; sourceTree = "<group>"; };
 		D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift; sourceTree = "<group>"; };
 		F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSnapshotRefreshPolicyTests.swift; sourceTree = "<group>"; };
 		A5001225 /* SocketControlMode+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SocketControlMode+Display.swift"; sourceTree = "<group>"; };
@@ -2131,6 +2133,7 @@
 				D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */,
 				D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */,
 				D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */,
+				C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */,
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 				71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */,
 				EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */,
@@ -3246,6 +3249,7 @@
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,
 				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
+				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 				62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
 				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceSelectionAnchorPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSelectionAnchorPolicyTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Sidebar workspace selection anchor policy")
+struct SidebarWorkspaceSelectionAnchorPolicyTests {
+    @MainActor
+    @Test
+    func anchorWorkspaceIdReadsTheExistingAnchorIdentity() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        #expect(
+            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
+                existingAnchorIndex: 1,
+                liveWorkspaceIds: [first, second, third]
+            ) == second
+        )
+        #expect(
+            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
+                existingAnchorIndex: 3,
+                liveWorkspaceIds: [first, second, third]
+            ) == nil
+        )
+    }
+
+    @MainActor
+    @Test
+    func reorderKeepsRangeAnchorByWorkspaceIdentityInsteadOfFocus() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        let fourth = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
+            preferredAnchorWorkspaceId: first,
+            selectedWorkspaceIds: [first, second, third],
+            focusedWorkspaceId: third,
+            liveWorkspaceIds: [second, third, first, fourth]
+        )
+
+        #expect(anchorIndex == 2)
+    }
+
+    @MainActor
+    @Test
+    func reorderFallsBackToFocusedWorkspaceWhenRangeAnchorIsNoLongerSelected() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
+            preferredAnchorWorkspaceId: first,
+            selectedWorkspaceIds: [second, third],
+            focusedWorkspaceId: third,
+            liveWorkspaceIds: [second, third, first]
+        )
+
+        #expect(anchorIndex == 1)
+    }
+
+    @MainActor
+    @Test
+    func shiftClickAnchorFallsBackToSingleSidebarSelection() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
+            existingAnchorIndex: nil,
+            selectedWorkspaceIds: [first],
+            focusedWorkspaceId: second,
+            liveWorkspaceIds: [first, second, third]
+        )
+
+        #expect(anchorIndex == 0)
+    }
+
+    @MainActor
+    @Test
+    func shiftClickKeepsExistingAnchorWhileFocusMoves() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
+            existingAnchorIndex: 0,
+            selectedWorkspaceIds: [first, second],
+            focusedWorkspaceId: second,
+            liveWorkspaceIds: [first, second, third]
+        )
+        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
+            isShiftClick: true,
+            resolvedShiftAnchorIndex: anchorIndex,
+            clickedIndex: 2
+        )
+
+        #expect(anchorIndex == 0)
+        #expect(nextAnchorIndex == 0)
+    }
+
+    @MainActor
+    @Test
+    func nonShiftClickMovesSidebarSelectionAnchor() {
+        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
+            isShiftClick: false,
+            resolvedShiftAnchorIndex: 0,
+            clickedIndex: 2
+        )
+
+        #expect(nextAnchorIndex == 2)
+    }
+}

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Testing
 import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -3852,9 +3853,11 @@ final class SidebarWorkspaceAuxiliaryDetailVisibilityTests: XCTestCase {
 }
 
 
-final class SidebarWorkspaceSelectionSyncPolicyTests: XCTestCase {
+@Suite
+struct SidebarWorkspaceSelectionSyncPolicyTests {
     @MainActor
-    func testReconciledSelectionPreservesMultiSelectionAfterReorder() {
+    @Test
+    func reconciledSelectionPreservesMultiSelectionAfterReorder() {
         let first = UUID()
         let second = UUID()
         let third = UUID()
@@ -3867,19 +3870,19 @@ final class SidebarWorkspaceSelectionSyncPolicyTests: XCTestCase {
             fallbackSelectedWorkspaceId: second
         )
 
-        XCTAssertEqual(result, previousSelection)
-        XCTAssertEqual(
+        #expect(result == previousSelection)
+        #expect(
             SidebarWorkspaceSelectionSyncPolicy.anchorIndex(
                 preferredWorkspaceId: second,
                 selectedWorkspaceIds: result,
                 liveWorkspaceIds: [first, third, fourth, second]
-            ),
-            3
+            ) == 3
         )
     }
 
     @MainActor
-    func testReconciledSelectionFallsBackToActiveWorkspaceWhenPreviousSelectionIsGone() {
+    @Test
+    func reconciledSelectionFallsBackToActiveWorkspaceWhenPreviousSelectionIsGone() {
         let first = UUID()
         let second = UUID()
         let removed = UUID()
@@ -3890,7 +3893,115 @@ final class SidebarWorkspaceSelectionSyncPolicyTests: XCTestCase {
             fallbackSelectedWorkspaceId: second
         )
 
-        XCTAssertEqual(result, [second])
+        #expect(result == Set([second]))
+    }
+
+    @MainActor
+    @Test
+    func anchorWorkspaceIdReadsTheExistingAnchorIdentity() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        #expect(
+            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
+                existingAnchorIndex: 1,
+                liveWorkspaceIds: [first, second, third]
+            ) == second
+        )
+        #expect(
+            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
+                existingAnchorIndex: 3,
+                liveWorkspaceIds: [first, second, third]
+            ) == nil
+        )
+    }
+
+    @MainActor
+    @Test
+    func reorderKeepsRangeAnchorByWorkspaceIdentityInsteadOfFocus() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        let fourth = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
+            preferredAnchorWorkspaceId: first,
+            selectedWorkspaceIds: [first, second, third],
+            focusedWorkspaceId: third,
+            liveWorkspaceIds: [second, third, first, fourth]
+        )
+
+        #expect(anchorIndex == 2)
+    }
+
+    @MainActor
+    @Test
+    func reorderFallsBackToFocusedWorkspaceWhenRangeAnchorIsNoLongerSelected() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
+            preferredAnchorWorkspaceId: first,
+            selectedWorkspaceIds: [second, third],
+            focusedWorkspaceId: third,
+            liveWorkspaceIds: [second, third, first]
+        )
+
+        #expect(anchorIndex == 1)
+    }
+
+    @MainActor
+    @Test
+    func shiftClickAnchorFallsBackToSingleSidebarSelection() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
+            existingAnchorIndex: nil,
+            selectedWorkspaceIds: [first],
+            focusedWorkspaceId: second,
+            liveWorkspaceIds: [first, second, third]
+        )
+
+        #expect(anchorIndex == 0)
+    }
+
+    @MainActor
+    @Test
+    func shiftClickKeepsExistingAnchorWhileFocusMoves() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+
+        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
+            existingAnchorIndex: 0,
+            selectedWorkspaceIds: [first, second],
+            focusedWorkspaceId: second,
+            liveWorkspaceIds: [first, second, third]
+        )
+        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
+            isShiftClick: true,
+            resolvedShiftAnchorIndex: anchorIndex,
+            clickedIndex: 2
+        )
+
+        #expect(anchorIndex == 0)
+        #expect(nextAnchorIndex == 0)
+    }
+
+    @MainActor
+    @Test
+    func nonShiftClickMovesSidebarSelectionAnchor() {
+        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
+            isShiftClick: false,
+            resolvedShiftAnchorIndex: 0,
+            clickedIndex: 2
+        )
+
+        #expect(nextAnchorIndex == 2)
     }
 }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Testing
 import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
@@ -3853,11 +3852,9 @@ final class SidebarWorkspaceAuxiliaryDetailVisibilityTests: XCTestCase {
 }
 
 
-@Suite
-struct SidebarWorkspaceSelectionSyncPolicyTests {
+final class SidebarWorkspaceSelectionSyncPolicyTests: XCTestCase {
     @MainActor
-    @Test
-    func reconciledSelectionPreservesMultiSelectionAfterReorder() {
+    func testReconciledSelectionPreservesMultiSelectionAfterReorder() {
         let first = UUID()
         let second = UUID()
         let third = UUID()
@@ -3870,19 +3867,19 @@ struct SidebarWorkspaceSelectionSyncPolicyTests {
             fallbackSelectedWorkspaceId: second
         )
 
-        #expect(result == previousSelection)
-        #expect(
+        XCTAssertEqual(result, previousSelection)
+        XCTAssertEqual(
             SidebarWorkspaceSelectionSyncPolicy.anchorIndex(
                 preferredWorkspaceId: second,
                 selectedWorkspaceIds: result,
                 liveWorkspaceIds: [first, third, fourth, second]
-            ) == 3
+            ),
+            3
         )
     }
 
     @MainActor
-    @Test
-    func reconciledSelectionFallsBackToActiveWorkspaceWhenPreviousSelectionIsGone() {
+    func testReconciledSelectionFallsBackToActiveWorkspaceWhenPreviousSelectionIsGone() {
         let first = UUID()
         let second = UUID()
         let removed = UUID()
@@ -3893,115 +3890,7 @@ struct SidebarWorkspaceSelectionSyncPolicyTests {
             fallbackSelectedWorkspaceId: second
         )
 
-        #expect(result == Set([second]))
-    }
-
-    @MainActor
-    @Test
-    func anchorWorkspaceIdReadsTheExistingAnchorIdentity() {
-        let first = UUID()
-        let second = UUID()
-        let third = UUID()
-
-        #expect(
-            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
-                existingAnchorIndex: 1,
-                liveWorkspaceIds: [first, second, third]
-            ) == second
-        )
-        #expect(
-            SidebarWorkspaceSelectionSyncPolicy.anchorWorkspaceId(
-                existingAnchorIndex: 3,
-                liveWorkspaceIds: [first, second, third]
-            ) == nil
-        )
-    }
-
-    @MainActor
-    @Test
-    func reorderKeepsRangeAnchorByWorkspaceIdentityInsteadOfFocus() {
-        let first = UUID()
-        let second = UUID()
-        let third = UUID()
-        let fourth = UUID()
-
-        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
-            preferredAnchorWorkspaceId: first,
-            selectedWorkspaceIds: [first, second, third],
-            focusedWorkspaceId: third,
-            liveWorkspaceIds: [second, third, first, fourth]
-        )
-
-        #expect(anchorIndex == 2)
-    }
-
-    @MainActor
-    @Test
-    func reorderFallsBackToFocusedWorkspaceWhenRangeAnchorIsNoLongerSelected() {
-        let first = UUID()
-        let second = UUID()
-        let third = UUID()
-
-        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceReorder(
-            preferredAnchorWorkspaceId: first,
-            selectedWorkspaceIds: [second, third],
-            focusedWorkspaceId: third,
-            liveWorkspaceIds: [second, third, first]
-        )
-
-        #expect(anchorIndex == 1)
-    }
-
-    @MainActor
-    @Test
-    func shiftClickAnchorFallsBackToSingleSidebarSelection() {
-        let first = UUID()
-        let second = UUID()
-        let third = UUID()
-
-        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
-            existingAnchorIndex: nil,
-            selectedWorkspaceIds: [first],
-            focusedWorkspaceId: second,
-            liveWorkspaceIds: [first, second, third]
-        )
-
-        #expect(anchorIndex == 0)
-    }
-
-    @MainActor
-    @Test
-    func shiftClickKeepsExistingAnchorWhileFocusMoves() {
-        let first = UUID()
-        let second = UUID()
-        let third = UUID()
-
-        let anchorIndex = SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex(
-            existingAnchorIndex: 0,
-            selectedWorkspaceIds: [first, second],
-            focusedWorkspaceId: second,
-            liveWorkspaceIds: [first, second, third]
-        )
-        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
-            isShiftClick: true,
-            resolvedShiftAnchorIndex: anchorIndex,
-            clickedIndex: 2
-        )
-
-        #expect(anchorIndex == 0)
-        #expect(nextAnchorIndex == 0)
-    }
-
-    @MainActor
-    @Test
-    func nonShiftClickMovesSidebarSelectionAnchor() {
-        let nextAnchorIndex = SidebarWorkspaceSelectionSyncPolicy.anchorIndexAfterWorkspaceClick(
-            isShiftClick: false,
-            resolvedShiftAnchorIndex: 0,
-            clickedIndex: 2
-        )
-
-        #expect(nextAnchorIndex == 2)
+        XCTAssertEqual(result, [second])
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the intermittent sidebar Shift-click range selection bug where repeatedly Shift-selecting the next workspace could collapse or slide the selection after a tiny accidental drag.

The log-backed failure path was:

- Shift-click selected the next workspace.
- SwiftUI also started an `.onDrag` for the adjacent row.
- `SidebarTabDropDelegate.performDrop` saw `fromIndex == targetIndex` and treated the no-op drop as a selection repair.
- That reset `lastSidebarSelectionIndex` to the focused workspace, so the next Shift-click used the wrong anchor.

## Changes

- No-op sidebar drops now return without mutating sidebar selection or range anchor.
- Real sidebar reorders preserve the Shift-click anchor by workspace identity, then derive the new anchor index after the reorder.
- Shift-click resolves a stable anchor from the explicit anchor, single sidebar selection, or focused workspace, and keeps that anchor while focus moves.
- Adds focused Swift Testing regression coverage for no-op/real reorder anchor handling and Shift-click anchor resolution.

## Verification

- `git diff --check origin/main...HEAD`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-shsel2-unit -only-testing:cmuxTests/SidebarWorkspaceSelectionSyncPolicyTests -only-testing:cmuxTests/SidebarWorkspaceSelectionAnchorPolicyTests test`
  - `** TEST SUCCEEDED **`
  - 2 XCTest tests and 6 Swift Testing tests passed
- `$autoreview`: clean, including cmux policy
- Tagged dogfood build: [shsel2](http://127.0.0.1:17320/shsel2)

## Dogfood

Open [shsel2](http://127.0.0.1:17320/shsel2). The tagged instance is pre-seeded with five workspaces: `workspace:1` selected, then `Shift Row 2` through `Shift Row 5`.

Starting from `workspace:1`, repeatedly Shift-click one row lower: row 2, row 3, row 4, row 5. Before this fix, the range could intermittently collapse or slide to only the last pair when a small accidental row drag/no-op drop happened while holding Shift. Expected behavior: the range stays anchored at `workspace:1` and expands downward, even if a tiny accidental no-op drag occurs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar selection/drag-drop UI logic with dedicated unit tests; no auth, data, or network changes.
> 
> **Overview**
> Fixes sidebar **Shift-click range selection** when a tiny accidental drag triggers a no-op drop that used to reset the range anchor to the focused row.
> 
> **No-op drops** (`fromIndex == targetIndex`) now return without calling `syncSidebarSelection`, so `lastSidebarSelectionIndex` is not overwritten by focus.
> 
> **Shift-click** resolves the range anchor via `SidebarWorkspaceSelectionSyncPolicy.shiftClickAnchorIndex` (existing anchor index, single selected workspace, or focused workspace) and updates the anchor with `anchorIndexAfterWorkspaceClick` so the anchor stays fixed while focus moves down the list.
> 
> **Real reorders** snapshot the anchor workspace ID before the move and restore it with `anchorIndexAfterWorkspaceReorder` instead of always anchoring on the focused tab after `syncSidebarSelection(preserving:)`.
> 
> Adds **`SidebarWorkspaceSelectionAnchorPolicyTests`** for anchor identity, reorder, and shift-click behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4dab155c251fd192b30c6bcbefc59b9d7df1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sidebar workspace selection behavior during shift-clicks and when reordering workspaces via drag-and-drop.

* **Tests**
  * Added comprehensive test suite for workspace selection anchor logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->