### PR TITLE
iOS image paste: deliver path via bracketed paste so Claude Code attaches [Image #N]

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7251,6 +7251,39 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return true
     }
 
+    /// Deliver `text` through Ghostty's paste path (`ghostty_surface_text`), the
+    /// same route a desktop clipboard paste or file drop takes.
+    ///
+    /// Unlike ``sendInputResult(_:)`` (which feeds bytes as typed text via
+    /// `ghostty_surface_text_input`, with bracketed paste *disabled*), this wraps
+    /// the bytes in a bracketed paste when the foreground program has enabled
+    /// bracketed paste mode (DECSET 2004). That framing is what lets prompt UIs
+    /// such as Claude Code recognize a pasted image file path and attach it as
+    /// `[Image #N]` instead of inserting the literal path string. It mirrors the
+    /// rich ``InputSendResult`` reporting of ``sendInputResult(_:)`` so callers
+    /// keep precise queue/availability error mapping.
+    @MainActor
+    @discardableResult
+    func sendTextResult(_ text: String) -> InputSendResult {
+        guard let data = text.data(using: .utf8), !data.isEmpty else { return .sent }
+        guard surface != nil else {
+            guard allowsRuntimeSurfaceCreation() else { return .surfaceUnavailable }
+            let queued = enqueuePendingSocketInput(.pasteText(data))
+            if queued {
+                recordAgentHibernationTerminalInput(workspaceId: tabId, panelId: id)
+                requestBackgroundSurfaceStartIfNeeded()
+            }
+            return queued ? .queued : .inputQueueFull
+        }
+        guard let liveSurface = liveSurfaceForSocketWrite(reason: "socket.sendText") else {
+            return .surfaceUnavailable
+        }
+        guard !ghostty_surface_process_exited(liveSurface) else { return .processExited }
+        recordAgentHibernationTerminalInput(workspaceId: tabId, panelId: id)
+        writeTextData(data, to: liveSurface)
+        return .sent
+    }
+
     @MainActor
     @discardableResult
     func sendKeyText(_ text: String) -> Bool {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -21522,9 +21522,15 @@ class TerminalController {
 
     /// Handle `terminal.paste_image`: a paired client (the iOS app) forwards an
     /// image it pasted as base64 bytes. We materialize it to a temp file on the
-    /// Mac and inject the shell-escaped path as terminal input, exactly the way a
-    /// local clipboard-image paste does, so the running TUI (e.g. Claude Code)
-    /// attaches the image from the path.
+    /// Mac and inject the shell-escaped path through Ghostty's paste path, exactly
+    /// the way a local clipboard-image paste or file drop does, so the running TUI
+    /// (e.g. Claude Code) recognizes the pasted image file path and attaches it as
+    /// `[Image #N]`.
+    ///
+    /// The delivery route matters: the path must arrive as a bracketed paste so
+    /// the prompt's paste handler runs its image-path detection. Feeding it as
+    /// typed text (the old `sendInputResult` route) skips bracketed paste, so the
+    /// path lands as a literal string and the image is never attached.
     private func v2MobileTerminalPasteImage(params: [String: Any]) -> V2CallResult {
         guard let base64 = v2RawString(params, "image_base64"),
               let imageData = Data(base64Encoded: base64), !imageData.isEmpty else {
@@ -21549,7 +21555,7 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Image payload was empty or exceeded the size limit", data: nil)
         }
 
-        let sendResult = terminalPanel.surface.sendInputResult(escapedPath)
+        let sendResult = terminalPanel.surface.sendTextResult(escapedPath)
         switch sendResult {
         case .sent:
             terminalPanel.surface.forceRefresh(reason: "mobileHost.terminalPasteImage")


### PR DESCRIPTION
## Problem

Pasting a phone-clipboard image into the iOS terminal injected the image's file path as a readable string, but Claude Code did **not** attach it as `[Image #N]`. It just looked like a pasted path.

## Root cause

The `terminal.paste_image` RPC (`TerminalController.v2MobileTerminalPasteImage`) writes the forwarded clipboard image to a temp file on the Mac, shell-escapes the path, then injected it with `sendInputResult` → `ghostty_surface_text_input`. Per Ghostty's own API docs, that call "is treated like typed text, not a paste ... bracketed paste mode is not used."

Claude Code only runs its pasted-image-path detection from its **bracketed-paste** handler (the text framed by `ESC[200~ … ESC[201~`). Its paste handler strips the bracketed-paste artifacts, splits the pasted text on path boundaries, unescapes shell escaping (so a shell-escaped path is accepted), matches `/\.(png|jpe?g|gif|webp)$/i`, reads the file, and attaches it as `[Image #N]`. When the path arrives as ordinary typed text (no bracketing), that handler never fires, so the path lands as a literal string and no image is attached. (Verified against the Claude Code binary's input layer: `handlePaste → X(Z)` path-detection vs the raw-key path, which only runs the detector for single key events over 800 chars.)

The escaping/format was never the problem; the **delivery route** was. The desktop drop/paste path already produces `[Image #N]` because it delivers through `ghostty_surface_complete_clipboard_request` (the paste path, which respects bracketed paste mode).

## Fix

Route the mobile image-paste injection through Ghostty's paste path (`ghostty_surface_text`), the same route a desktop clipboard paste or file drop takes. This wraps the bytes in a bracketed paste when the foreground program has enabled bracketed paste mode (DECSET 2004), so Claude Code's image-path detection runs.

- Adds `TerminalSurface.sendTextResult(_:)`, a paste-path twin of `sendInputResult` that preserves the rich `InputSendResult` queue/availability error mapping (and the cold-surface `.pasteText` enqueue path, which already flushes via the paste route).
- `v2MobileTerminalPasteImage` now calls `sendTextResult` instead of `sendInputResult`.

Non-Claude shells are unaffected: a single-line escaped path has no newline and no `ESC[201~`, so it passes Ghostty paste protection and pastes the path exactly as before.

The change is entirely Mac-side (the iOS app forwards the image bytes; the Mac does the injection). Stacks on / relates to the merged image-paste work (#5546).

## Testing

A meaningful automated test is not practical here: the bug is in the delivery primitive (`ghostty_surface_text` vs `ghostty_surface_text_input`), which is a C-API call on a live Ghostty surface, and the user-visible outcome (`[Image #N]`) requires Claude Code running with auth. Per the repo test-quality policy, no source-shape regression test was added. Verification is on-device dogfood.

**Dogfood (on device):** copy an image to the iPhone clipboard, open a cmux terminal running `claude`, paste the image. Previously: the prompt showed a literal file path. Now: the prompt shows `[Image #N]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783480098&installation_id=133855650&pr_number=5602&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5602&signature=40e4f306d15e3e706c11c536021f35ff431cfcf93d71f8c4339ad1941148c932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal input delivery for mobile image paste and adds a new paste-path API; scope is narrow (one RPC + surface helper) but affects how bytes reach the PTY.
> 
> **Overview**
> Fixes iOS-forwarded clipboard images not becoming `[Image #N]` in Claude Code by changing **how** the Mac injects the temp file path, not how the path is escaped.
> 
> Adds **`sendTextResult(_:)`** on the terminal surface as a paste-path counterpart to **`sendInputResult`**: it delivers UTF-8 through Ghostty’s paste API (`ghostty_surface_text` via `writeTextData`), so bracketed paste (DECSET 2004) applies when the foreground program has it enabled. It keeps the same **`InputSendResult`** semantics (queue when the surface is cold, surface/process errors, etc.), including enqueueing **`.pasteText`** for background surfaces.
> 
> **`v2MobileTerminalPasteImage`** now calls **`sendTextResult`** instead of **`sendInputResult`**, matching desktop clipboard paste / file drop so TUIs like Claude Code run paste-time image-path detection instead of treating the path as typed text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c626c22694645cd58c5e1686015e19ab0ed65141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS image paste so Claude Code attaches images as [Image #N] by sending the temp file path via Ghostty’s paste path (bracketed paste) instead of typed text. Other shells paste the escaped path unchanged.

- **Bug Fixes**
  - Added `TerminalSurface.sendTextResult(_:)` to deliver via `ghostty_surface_text` (uses bracketed paste when DECSET 2004 is enabled) while preserving `InputSendResult` semantics and queueing.
  - Switched `v2MobileTerminalPasteImage` to use `sendTextResult` rather than `sendInputResult`, matching desktop paste/drop behavior.

<sup>Written for commit c626c22694645cd58c5e1686015e19ab0ed65141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new text input API with enhanced delivery status reporting, distinguishing between successfully sent, queued, and failed delivery states.

* **Improvements**
  * Enhanced image paste operations with bracketed-paste protocol support for improved terminal application compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->