### PR TITLE
iOS: make Mac→iPhone push actually deliver on dev builds

### DIFF
--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -55,6 +55,16 @@
 	<string>Scan cmux pairing QR codes from your Mac terminal.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Connect to your Mac on the local network for cmux mobile pairing and terminal sync.</string>
+	<!-- NSAllowsLocalNetworking permits cleartext HTTP only to private/loopback
+	     addresses (RFC 1918 + .local). Dev tagged builds (LocalConfig.plist
+	     ApiBaseURL) point the web API at the Mac's LAN IP over http for
+	     dogfooding device-token registration + push. Production talks HTTPS to
+	     cmux.com, which is unaffected by this exception. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -55,11 +55,15 @@
 	<string>Scan cmux pairing QR codes from your Mac terminal.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Connect to your Mac on the local network for cmux mobile pairing and terminal sync.</string>
-	<!-- NSAllowsLocalNetworking permits cleartext HTTP only to private/loopback
-	     addresses (RFC 1918 + .local). Dev tagged builds (LocalConfig.plist
-	     ApiBaseURL) point the web API at the Mac's LAN IP over http for
-	     dogfooding device-token registration + push. Production talks HTTPS to
-	     cmux.com, which is unaffected by this exception. -->
+	<!-- NSAllowsLocalNetworking only PERMITS cleartext HTTP to private/loopback
+	     addresses (RFC 1918 + .local); it never forces it. Dev tagged builds
+	     (LocalConfig.plist ApiBaseURL) point the web API at the Mac's LAN IP over
+	     http for dogfooding device-token registration + push. In Release the
+	     LocalConfig override is empty, so every request is HTTPS to cmux.com and
+	     this exception is inert (no cleartext LAN requests are ever made).
+	     Per-config Debug-only scoping is a follow-up; a string-substituted
+	     `$(VAR)` value is NOT used because Info.plist expansion yields a
+	     `<string>`, not the `<true/>` Boolean ATS requires. -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/ios/cmux-ios.xcodeproj/project.pbxproj
+++ b/ios/cmux-ios.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8B8A10022DF5000000A66F90 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8B8A10192DF5000000A66F90 /* Assets.xcassets */; };
 		8B8A10032DF5000000A66F90 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8B8A101A2DF5000000A66F90 /* InfoPlist.xcstrings */; };
 		8B8A10042DF5000000A66F90 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8B8A101B2DF5000000A66F90 /* Localizable.xcstrings */; };
+		8BCFCFA10000000000000002 /* LocalConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8BCFCFA10000000000000001 /* LocalConfig.plist */; };
 		8B8A10052DF5000000A66F90 /* cmuxUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8A101C2DF5000000A66F90 /* cmuxUITests.swift */; };
 		8B41F6832DEDD23B001A66F9 /* cmuxFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6822DEDD23B001A66F9 /* cmuxFeature */; };
 		8B41F6852DEDD25C001A66F9 /* cmuxFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6842DEDD25C001A66F9 /* cmuxFeature */; };
@@ -47,6 +48,7 @@
 		8B8A10192DF5000000A66F90 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8B8A101A2DF5000000A66F90 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		8B8A101B2DF5000000A66F90 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		8BCFCFA10000000000000001 /* LocalConfig.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = LocalConfig.plist; sourceTree = "<group>"; };
 		8B8A101C2DF5000000A66F90 /* cmuxUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmuxUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -126,6 +128,7 @@
 			children = (
 				8B8A101A2DF5000000A66F90 /* InfoPlist.xcstrings */,
 				8B8A101B2DF5000000A66F90 /* Localizable.xcstrings */,
+				8BCFCFA10000000000000001 /* LocalConfig.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -237,6 +240,7 @@
 				8B8A10022DF5000000A66F90 /* Assets.xcassets in Resources */,
 				8B8A10032DF5000000A66F90 /* InfoPlist.xcstrings in Resources */,
 				8B8A10042DF5000000A66F90 /* Localizable.xcstrings in Resources */,
+				8BCFCFA10000000000000002 /* LocalConfig.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/cmux/Resources/LocalConfig.plist
+++ b/ios/cmux/Resources/LocalConfig.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  Local build-time config overrides read by MobileAuthComposition.
+
+  This default is intentionally EMPTY: a tracked, no-override file so production,
+  TestFlight, and CI builds resolve the normal environment defaults (AuthConfig
+  uses cmux.dev / cmux.com). Recognized keys: ApiBaseURL,
+  STACK_PROJECT_ID_DEV/PROD, STACK_PUBLISHABLE_CLIENT_KEY_DEV/PROD.
+
+  `ios/scripts/reload.sh` overwrites this with a dev `ApiBaseURL` (the Mac's LAN
+  origin) before a tagged dev build so a physical iPhone can reach the Mac's web
+  API for device-token registration + push, then restores this default after the
+  build so the dev origin never lands in git.
+-->
+<dict/>
+</plist>

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -16,6 +16,13 @@ Device signing uses the local Xcode account, or App Store Connect API
 credentials from ASC_API_KEY_ID, ASC_API_ISSUER_ID, ASC_API_KEY_PATH, or
 ios/Config/AppStoreConnect.local.plist. Set IOS_DEVELOPMENT_TEAM or pass
 --team when the project cannot infer a team.
+
+Pass --api-base-url <url> (or set CMUX_DEV_API_BASE_URL) to bake a phone-reachable
+web API origin into the dev build via LocalConfig.plist. Needed for device-token
+registration + phone push on a physical iPhone, since the default dev origin is
+http://localhost:3000, which the phone cannot reach. Use the Mac's LAN IP running
+`bun dev` bound to 0.0.0.0, e.g. http://10.0.0.102:3777. The tracked empty
+LocalConfig.plist is restored after the build so the dev origin never lands in git.
 EOF
 }
 
@@ -44,6 +51,13 @@ SIMULATOR_NAME="${IOS_SIMULATOR_NAME:-iPhone 17}"
 DEVICE_ID="${IOS_DEVICE_ID:-}"
 DEVICE_NAME="${IOS_DEVICE_NAME:-}"
 DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-}"
+# Web API origin baked into the dev build via LocalConfig.plist (ApiBaseURL).
+# Dev DEBUG builds otherwise default to http://localhost:3000, which a physical
+# iPhone cannot reach, so device-token registration + phone push silently no-op.
+# Pass --api-base-url to point the dev build at a phone-reachable origin (the
+# Mac's LAN IP running `bun dev`), or set CMUX_DEV_API_BASE_URL. Empty leaves the
+# tracked empty LocalConfig.plist in place (no override → normal defaults).
+API_BASE_URL="${CMUX_DEV_API_BASE_URL:-}"
 LAUNCH=1
 RELOAD_SIMULATOR=1
 RELOAD_DEVICE=0
@@ -86,6 +100,11 @@ while [[ $# -gt 0 ]]; do
     --team)
       require_option_value "$1" "${2:-}"
       DEVELOPMENT_TEAM="${2:-}"
+      shift 2
+      ;;
+    --api-base-url)
+      require_option_value "$1" "${2:-}"
+      API_BASE_URL="${2:-}"
       shift 2
       ;;
     --no-provisioning-updates)
@@ -158,6 +177,33 @@ if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
   ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
   ASC_API_ISSUER_ID="${ASC_API_ISSUER_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_ISSUER_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
   ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_PATH' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
+fi
+
+# LocalConfig.plist is bundled into the app and read by MobileAuthComposition for
+# build-time overrides. The tracked default is empty so prod/CI/TestFlight use the
+# normal cmux.dev defaults. For a dev build we write the dev ApiBaseURL here BEFORE
+# xcodebuild (so the Resources phase signs it into the bundle), then restore the
+# tracked default after the build so the dev origin never lands in git.
+LOCAL_CONFIG_PLIST="$IOS_DIR/cmux/Resources/LocalConfig.plist"
+LOCAL_CONFIG_DIRTIED=0
+
+restore_local_config() {
+  if [[ "$LOCAL_CONFIG_DIRTIED" -eq 1 ]]; then
+    git -C "$IOS_DIR" checkout -- "cmux/Resources/LocalConfig.plist" 2>/dev/null \
+      || git -C "$IOS_DIR/.." checkout -- "ios/cmux/Resources/LocalConfig.plist" 2>/dev/null || true
+    LOCAL_CONFIG_DIRTIED=0
+  fi
+}
+# Always restore on exit (success, failure, or interrupt) so a half-finished dev
+# build never leaves the dev origin in the working tree.
+trap restore_local_config EXIT INT TERM
+
+if [[ -n "$API_BASE_URL" ]]; then
+  echo "==> Baking dev ApiBaseURL into LocalConfig.plist: $API_BASE_URL"
+  /usr/libexec/PlistBuddy -c "Clear dict" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :ApiBaseURL string $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 \
+    || /usr/libexec/PlistBuddy -c "Set :ApiBaseURL $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1
+  LOCAL_CONFIG_DIRTIED=1
 fi
 
 XCODE_AUTH_ARGS=()

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -200,10 +200,23 @@ trap restore_local_config EXIT INT TERM
 
 if [[ -n "$API_BASE_URL" ]]; then
   echo "==> Baking dev ApiBaseURL into LocalConfig.plist: $API_BASE_URL"
-  /usr/libexec/PlistBuddy -c "Clear dict" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 || true
-  /usr/libexec/PlistBuddy -c "Add :ApiBaseURL string $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 \
-    || /usr/libexec/PlistBuddy -c "Set :ApiBaseURL $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1
+  # Mark dirty BEFORE touching the file: `Clear dict` rewrites the plist and
+  # strips the tracked comment, so the file is already modified even if the
+  # following Add/Set fails. Setting the flag first guarantees the EXIT trap
+  # restores the tracked default no matter where a failure lands.
   LOCAL_CONFIG_DIRTIED=1
+  if ! { /usr/libexec/PlistBuddy -c "Clear dict" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 \
+    && { /usr/libexec/PlistBuddy -c "Add :ApiBaseURL string $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1 \
+      || /usr/libexec/PlistBuddy -c "Set :ApiBaseURL $API_BASE_URL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1; }; }; then
+    echo "error: failed to write ApiBaseURL into $LOCAL_CONFIG_PLIST" >&2
+    exit 1
+  fi
+  # Confirm the override actually landed so a silent PlistBuddy no-op can't ship a
+  # build that still points at localhost.
+  if ! /usr/libexec/PlistBuddy -c "Print :ApiBaseURL" "$LOCAL_CONFIG_PLIST" >/dev/null 2>&1; then
+    echo "error: ApiBaseURL not present in $LOCAL_CONFIG_PLIST after write" >&2
+    exit 1
+  fi
 fi
 
 XCODE_AUTH_ARGS=()

--- a/web/scripts/dev-local.sh
+++ b/web/scripts/dev-local.sh
@@ -142,13 +142,7 @@ cmux web dev
   CMUX_WEB_EXTRA_SECRET_ENV_FILE=${CMUX_WEB_EXTRA_SECRET_ENV_FILE:-}
 EOF
 
-# Bind 0.0.0.0 so a physical iPhone on the same LAN can reach this dev web API
-# (device-token registration + phone push dogfood go to the Mac's LAN IP). Next
-# still serves localhost for the Mac app; this only widens the listen interface,
-# not the routes. Set CMUX_DEV_HOSTNAME to override (e.g. 127.0.0.1 to keep it
-# loopback-only).
-CMUX_DEV_HOSTNAME="${CMUX_DEV_HOSTNAME:-0.0.0.0}"
-next dev --hostname "$CMUX_DEV_HOSTNAME" --port "$CMUX_PORT" &
+next dev --port "$CMUX_PORT" &
 next_pid=$!
 
 set +e

--- a/web/scripts/dev-local.sh
+++ b/web/scripts/dev-local.sh
@@ -142,7 +142,13 @@ cmux web dev
   CMUX_WEB_EXTRA_SECRET_ENV_FILE=${CMUX_WEB_EXTRA_SECRET_ENV_FILE:-}
 EOF
 
-next dev --port "$CMUX_PORT" &
+# Bind 0.0.0.0 so a physical iPhone on the same LAN can reach this dev web API
+# (device-token registration + phone push dogfood go to the Mac's LAN IP). Next
+# still serves localhost for the Mac app; this only widens the listen interface,
+# not the routes. Set CMUX_DEV_HOSTNAME to override (e.g. 127.0.0.1 to keep it
+# loopback-only).
+CMUX_DEV_HOSTNAME="${CMUX_DEV_HOSTNAME:-0.0.0.0}"
+next dev --hostname "$CMUX_DEV_HOSTNAME" --port "$CMUX_PORT" &
 next_pid=$!
 
 set +e


### PR DESCRIPTION
## Root gap

The APNs pipeline (Mac `PhonePushClient` → web `/api/notifications/push` → APNs → registered device token) was fully built across #5215 / #5258 / the iOS refactor, but it never delivered end-to-end. The break was not missing code, it was configuration:

A dev iOS build resolves `apiBaseURL` to `http://localhost:3000` (`AuthConfig` DEBUG default), with no override wired into `ios/scripts/reload.sh`. So a physical iPhone POSTs its APNs device token to its OWN localhost (`/api/device-tokens` never reaches the Mac's web API), the token is never stored, and the Mac's push has nowhere to land. Sign-in still works because it goes straight to Stack, which masks the failure. Even pointed at the Mac's LAN IP, default iOS ATS blocks cleartext http to a private address, so the registration POST silently fails again.

Push provisioning was verified before touching code: a signed `dev.cmux.ios.*` build's embedded provisioning profile carries `aps-environment=development` + `usernotifications.time-sensitive`, so Xcode auto-provisions Push for dev tags (the ASC `bundleIdCapabilities` total of 0 is a red herring for XC-managed App IDs).

## Fix (dev path)

- `ios/Config/Info.plist`: `NSAllowsLocalNetworking` so the dev build can register its token over http to the Mac's private LAN IP. Production still talks HTTPS to cmux.com, unaffected.
- `ios/cmux/Resources/LocalConfig.plist`: new tracked EMPTY dict, read by `MobileAuthComposition` for the `ApiBaseURL` override. Empty means prod / CI / TestFlight keep the normal `cmux.dev` default (no behavior change), wired into the app Resources phase in the pbxproj.
- `ios/scripts/reload.sh`: `--api-base-url` / `CMUX_DEV_API_BASE_URL` writes the dev `ApiBaseURL` into `LocalConfig.plist` before xcodebuild (signed into the bundle), then restores the tracked empty default via a trap so the dev origin never lands in git.
- `web/scripts/dev-local.sh`: `next dev --hostname 0.0.0.0` (override via `CMUX_DEV_HOSTNAME`) so the phone can reach the Mac's dev web API on the LAN.

Opt-in gates stay default-OFF for privacy. Both toggles already exist and are discoverable (Mac Settings → Notifications "Forward to iPhone", iOS Settings "Notify Me About Agents").

## Coordination with #5568

This is the delivery foundation #5568 (cross-device dismiss-sync) builds on. No overlap: #5568 adds `cmux.notificationId` / `apns-collapse-id` / dismiss RPCs on top of an already-delivering pipe; this PR makes the pipe deliver on dev builds. No conflicting files.

## Follow-up (separate PR, prod path)

- Per-config `aps-environment=production` for Release/beta (TestFlight ships a sandbox token today vs the production-host mapping in `routePolicy.ts`).
- iOS prod `apiBaseURL` `cmux.dev` → `cmux.com` (canonical domain the Mac already uses; cmux.dev 301-redirects). Verify both by capturing a real beta token, not blind-flipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783480120&installation_id=133855650&pr_number=5603&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5603&signature=012ebe6b60340cb86bdf17a8c69dee2f1ebeabdc5416a57f97365c2761cdf812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ATS now permits cleartext to local/private networks app-wide (intended inert when no LAN API override); reload.sh temporarily mutates a tracked plist and relies on git checkout on exit.
> 
> **Overview**
> Enables **end-to-end Mac→iPhone push on physical dev builds** by letting the app reach the Mac’s web API on the LAN for APNs device-token registration, without changing production defaults when overrides are absent.
> 
> **`Info.plist`** adds **`NSAppTransportSecurity` / `NSAllowsLocalNetworking`** so cleartext HTTP to private/LAN hosts is allowed when a dev build points `ApiBaseURL` at the Mac; Release with an empty `LocalConfig` stays HTTPS-only.
> 
> A tracked empty **`LocalConfig.plist`** is added and bundled (Xcode project Resources) for optional **`ApiBaseURL`** overrides read by **`MobileAuthComposition`**.
> 
> **`ios/scripts/reload.sh`** gains **`--api-base-url`** / **`CMUX_DEV_API_BASE_URL`**: writes `ApiBaseURL` into `LocalConfig.plist` before `xcodebuild`, verifies the write, and restores the tracked empty plist on exit via a trap so the LAN origin is not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e563d3c7dd2b061aaacab41ec636401c2e18d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mac→iPhone push on dev builds by letting the phone register its APNs token to the Mac’s web API over the LAN. Adds a dev-only API base URL override; production behavior is unchanged.

- **Bug Fixes**
  - iOS `Info.plist`: add `NSAppTransportSecurity.NSAllowsLocalNetworking` to allow HTTP to private/LAN hosts for dev token registration; Release stays HTTPS-only.
  - Add tracked empty `LocalConfig.plist`; bundled in app Resources; app reads an optional `ApiBaseURL` override when present.
  - `ios/scripts/reload.sh`: new `--api-base-url` / `CMUX_DEV_API_BASE_URL` writes `ApiBaseURL` into `LocalConfig.plist` before build, then restores the tracked empty file; hardened to mark the file dirty before edits, fail on write errors, and verify the value was set.

<sup>Written for commit 51e563d3c7dd2b061aaacab41ec636401c2e18d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * iOS development builds now support custom API endpoint configuration via CLI option or environment variable, enabling connection to local development servers
  * Web development server now supports configurable listen address via environment variable for custom network binding

* **Chores**
  * Enabled local network connectivity support for iOS app to establish cleartext HTTP connections to private/local targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->