### PR TITLE
iOS: distinct sticky-lock cue for glass toolbar modifiers (double-tap lock vs one-shot arm)

### DIFF
--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryActionButton.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryActionButton.swift
@@ -13,6 +13,28 @@ final class AccessoryActionButton: UIButton {
     /// The configurable item this button triggers.
     let item: ResolvedToolbarItem
 
+    /// Whether this modifier is double-tap *sticky-locked* (vs. single-tap armed).
+    ///
+    /// A sticky-locked modifier stays applied to every keystroke until the user
+    /// taps it off, whereas an armed modifier is consumed by the next key. On
+    /// iOS 26 both states share the same prominent-glass blue fill, so the lock
+    /// needs its own visual cue: a white capsule border drawn on the button's
+    /// layer, *over* the glass, mirroring the 2pt white stroke the pre-26 flat
+    /// style already used for the locked state. The border is drawn at the layer
+    /// level (not via `UIButton.Configuration.background.strokeColor`) so it
+    /// composites on top of Liquid Glass regardless of how the glass material
+    /// renders its own background, and adds zero intrinsic width so it does not
+    /// fight the bar's min-width sizing.
+    var isStickyLocked = false {
+        didSet {
+            guard oldValue != isStickyLocked else { return }
+            updateStickyLockBorder()
+        }
+    }
+
+    /// Width of the sticky-lock capsule border, matching the pre-26 flat stroke.
+    private static let stickyLockBorderWidth: CGFloat = 2
+
     /// Creates a button bound to a resolved toolbar item.
     /// - Parameter item: The built-in or custom action the button represents.
     init(item: ResolvedToolbarItem) {
@@ -23,5 +45,29 @@ final class AccessoryActionButton: UIButton {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Keep the lock border a true capsule that hugs the glass pill as the
+        // button's bounds settle (height is fixed, but the corner radius is
+        // derived here so the border tracks any future sizing change).
+        updateStickyLockBorder()
+    }
+
+    /// Sync the layer-level white capsule border to ``isStickyLocked``.
+    ///
+    /// Always clears the border when not locked, so a button that transitions
+    /// locked → armed → resting never keeps a stale border.
+    private func updateStickyLockBorder() {
+        if isStickyLocked {
+            layer.cornerRadius = bounds.height / 2
+            layer.cornerCurve = .continuous
+            layer.borderColor = UIColor.white.cgColor
+            layer.borderWidth = Self.stickyLockBorderWidth
+        } else {
+            layer.borderWidth = 0
+            layer.borderColor = nil
+        }
     }
 }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -575,6 +575,20 @@ final class TerminalInputTextView: UITextView {
         }
         config.contentInsets = Self.accessoryButtonContentInsets
         button.configuration = config
+        if let actionButton = button as? AccessoryActionButton {
+            // On iOS 26 the armed and sticky states share the same
+            // prominent-glass blue fill, so the double-tap *lock* is
+            // distinguished by a white capsule border drawn over the glass (see
+            // ``AccessoryActionButton/isStickyLocked``). On earlier OSes the
+            // flat style already renders the locked white stroke through the
+            // background configuration, so the layer border stays off to avoid
+            // a doubled stroke.
+            if #available(iOS 26.0, *) {
+                actionButton.isStickyLocked = sticky
+            } else {
+                actionButton.isStickyLocked = false
+            }
+        }
     }
 
     private static func accessoryButtonConfiguration(armed: Bool, sticky: Bool) -> UIButton.Configuration {


### PR DESCRIPTION
On iOS 26 the Liquid Glass accessory bar (#5536 / #5579) made the one-shot-armed and double-tap sticky-locked modifier states render identically: both used `.prominentGlass()` with a `.systemBlue` tint, so you could not tell a locked modifier from an armed one. The pre-iOS-26 flat style had always distinguished the locked state with a 2pt white stroke; that cue was lost on the glass path. Reported in dogfood: double-tapping a modifier to sticky-lock it showed no visible difference.

This restores the locked cue as a white capsule border drawn on the button's layer, over the glass. `AccessoryActionButton` gains an `isStickyLocked` flag that syncs a layer-level border (`cornerRadius = bounds.height / 2`, `.continuous` curve, white, 2pt) from `didSet` and `layoutSubviews`. Drawing at the layer level (not via `UIButton.Configuration.background.strokeColor`) composites the border on top of Liquid Glass regardless of how the glass material renders its own background, so the cue reads clearly over glass. It mirrors the pre-26 white stroke, and adds zero intrinsic width so it does not fight the bar's min-width sizing. The border is set unconditionally from `sticky`, so a button going locked then armed then resting never keeps a stale border. It is applied only on iOS 26; the pre-26 flat path keeps its existing background-config stroke (no doubled border).

Three states now read distinctly:
- resting: plain `.glass()`
- one-shot-armed (single tap): `.prominentGlass()` + blue, no border
- sticky-locked (double tap): `.prominentGlass()` + blue + white capsule border

Dogfood: single-tap Ctrl shows the armed look (blue glass, no border); double-tap Ctrl shows the clearly-locked look (blue glass with a white capsule border around it). The simulator may not composite the glass material, so the locked-over-glass read is best confirmed on device.

Branching and merge sequencing: this is based off `feat-ios-toolbar-reorder-builtins` (#5579), which carries the glass styling being fixed. Merge #5579 first, then this. The in-flight button-min-width PR #5599 (`feat-ios-accessory-min-width`) edits the exact same two functions on the same line, so it overlaps and will conflict on merge: both touch `accessoryButtonConfiguration` and `applyAccessoryButtonStyle` in `TerminalInputTextView.swift`. The border cue here was deliberately chosen to add zero width so it composes with #5599's narrower buttons; sequence #5599 and this PR together and resolve the trivial overlap in `applyAccessoryButtonStyle`.

Verified: clean iOS simulator Debug build (`cmux-ios` scheme, isolated derivedDataPath). Not a device build, no `xcodebuild test`. Autoreview clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783480734&installation_id=133855650&pr_number=5604&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5604&signature=dbb020927972d67e3e1d11fcd2bde6fc8c554928a119708b339925ea4d372f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI-only styling in the mobile terminal accessory bar; no input or modifier state logic changes.
> 
> **Overview**
> On **iOS 26**, sticky-locked modifier keys (double-tap) were visually indistinguishable from one-shot armed keys because both used the same prominent Liquid Glass blue fill. This PR restores a **2pt white capsule border** on the button layer for the sticky-lock state only, matching the cue pre-26 flat styling already had via background stroke.
> 
> `AccessoryActionButton` gains **`isStickyLocked`**, which toggles the layer border in `didSet` and keeps the capsule aligned in **`layoutSubviews`**. **`applyAccessoryButtonStyle`** sets that flag from the existing `sticky` state on iOS 26+ and forces it off on earlier OS versions so the flat background stroke is not doubled.
> 
> Resting, armed, and sticky-locked modifiers should now read as three distinct states on glass toolbars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a82dcf714b424248c0374ae845009f89b41e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS 26 Liquid Glass toolbar so sticky‑locked modifiers show a clear white capsule border, making them distinct from one‑shot armed. Pre‑iOS‑26 styling stays the same.

- **Bug Fixes**
  - Added `isStickyLocked` to `AccessoryActionButton` to sync a 2pt white layer border (cornerRadius = height/2, continuous curve) and clear it when unlocked.
  - Border updates in `didSet` and `layoutSubviews`; applied only on iOS 26. Earlier iOS keeps the existing background stroke.
  - Visual states: resting (glass), armed (prominent glass + blue), locked (prominent glass + blue + white border).

- **Migration**
  - Merge `feat-ios-toolbar-reorder-builtins` first. Expect a small overlap with `feat-ios-accessory-min-width` in `applyAccessoryButtonStyle` and `accessoryButtonConfiguration`.

<sup>Written for commit d3a82dcf714b424248c0374ae845009f89b41e82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

