### PR TITLE
iOS: instrument keyboard-input path (hold-backspace + dictation evidence)

### DIFF
--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -36,4 +36,58 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     case byteGap = 8
     /// A generic error at an instrumented seam.
     case error = 9
+
+    // MARK: iOS keyboard-input instrumentation (hold-backspace + dictation hunt)
+    //
+    // These eight codes instrument the iOS terminal keyboard-input path so a
+    // device dogfood (which the simulator cannot reproduce — no hold-to-repeat,
+    // no dictation) captures *why* hold-backspace and dictation fail. Three blind
+    // fix attempts (app-buttons, `hasText=true` UITextView, documentless
+    // UIView+UIKeyInput+UITextInput) all left both broken; this round gathers
+    // evidence instead of guessing the mechanism. Decode the integer payload with
+    // `scripts/decode-ios-diagnostic.py`.
+
+    /// The software keyboard came up (`keyboardWillShow`). `a` = the
+    /// ``InputResponderIdentity`` raw value of the current first responder at that
+    /// instant (which view the keyboard will actually drive). Confirms or kills
+    /// the "``TerminalInputTextView`` is not first responder" hypothesis.
+    case inputKeyboardUp = 10
+    /// ``TerminalInputTextView/deleteBackward()`` was invoked. Logged on *every*
+    /// call, so a single held backspace shows as 1 event (no auto-repeat) versus
+    /// many (repeat fires but the byte is lost downstream). `a` = the responder
+    /// identity at the moment of the call; `b` = 1 if IME marked text was present
+    /// (composition-cancel path), else 0.
+    case inputDeleteBackward = 11
+    /// A DEL byte (0x7F) actually left the surface toward the Mac
+    /// (`onBackspace` → `didProduceInput`). Pairing this with
+    /// ``inputDeleteBackward`` proves whether N delete calls produced N emitted
+    /// bytes: if both counts match the iOS view is correct and the hunt moves
+    /// downstream (transport/Mac/render). `ms` = emitted byte count (always 1).
+    case inputBackspaceEmitted = 12
+    /// ``TerminalInputTextView/insertText(_:)`` was invoked (typed character, IME
+    /// commit, or a dictation result block). `a` = UTF-8 byte length of the text;
+    /// `b` = 1 if IME marked text was present, else 0. A dictation result arrives
+    /// here as one multi-character block, so a non-trivial `a` after a mic tap
+    /// proves dictation fired.
+    case inputInsertText = 13
+    /// UIKit asked this view for a dictation placeholder
+    /// (`insertDictationResultPlaceholder()`). This is the *entry* signal that the
+    /// mic was tapped and the framework accepted this view as a dictation target.
+    /// Its absence after a mic tap proves dictation never engaged the view at all.
+    case inputDictationPlaceholder = 14
+    /// UIKit removed the dictation placeholder
+    /// (`removeDictationResultPlaceholder(_:willInsertResult:)`). `a` = 1 if a
+    /// recognized result will be inserted next, else 0. `a == 0` after a mic tap
+    /// means recognition produced nothing for this view.
+    case inputDictationRemove = 15
+    /// ``TerminalInputTextView/becomeFirstResponder()`` returned. `a` = 1 if the
+    /// view became first responder, else 0; `b` = the resulting first-responder
+    /// identity (``InputResponderIdentity`` raw value).
+    case inputBecomeFirstResponder = 16
+    /// A committed block of text was routed to a sink (`emitCommittedText`). `a` =
+    /// UTF-8 byte length; `b` = the ``InputCommitSink`` raw value (which delegate
+    /// path the text took: per-key input, bracketed paste, or an escape
+    /// sequence). Lets a dictation result be traced from `insertText` through to
+    /// the byte path that reaches the Mac.
+    case inputCommitRouted = 17
 }

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputCommitSink.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputCommitSink.swift
@@ -1,0 +1,20 @@
+/// Which delegate path a committed block of input text was routed to.
+///
+/// Encoded into the `b` slot of ``DiagnosticEventCode/inputCommitRouted`` so a
+/// device dogfood can trace a dictation result (or typed character) from
+/// `insertText(_:)` all the way to the byte path that reaches the Mac, using
+/// only the integer ``DiagnosticEvent`` payload. Decoded by
+/// `scripts/decode-ios-diagnostic.py`.
+public enum InputCommitSink: Int, Sendable, Codable, CaseIterable {
+    /// Per-character raw input (`onText` → `terminal.input`). Single characters
+    /// and Return take this path.
+    case text = 0
+    /// Bracketed paste (`onPasteText` → `terminal.paste`). A multi-character
+    /// block with no active modifier — system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text — takes this path. A
+    /// dictation result that fires should land here.
+    case pasteText = 1
+    /// An escape / control sequence (`onEscapeSequence`). A modifier
+    /// (Ctrl/Alt/Cmd) transformed the committed text into bytes.
+    case escapeSequence = 2
+}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
@@ -1,0 +1,33 @@
+/// A compact integer identity for the view that owns the keyboard's first
+/// responder on the iOS terminal input path.
+///
+/// ``DiagnosticEvent`` carries only integer payloads (no allocated strings), so
+/// the first-responder *class* is encoded as one of these small raw values and
+/// decoded back to a human-readable name by `scripts/decode-ios-diagnostic.py`.
+/// The keyboard-input instrumentation stamps this into the `a`/`b` slots of the
+/// ``DiagnosticEventCode/inputKeyboardUp``, ``DiagnosticEventCode/inputDeleteBackward``,
+/// and ``DiagnosticEventCode/inputBecomeFirstResponder`` events so a device
+/// dogfood reveals *which* view the software keyboard actually drives.
+///
+/// The central question this answers: is ``DiagnosticEventCode/inputDeleteBackward``
+/// firing on the same view the keyboard came up over, or has first responder
+/// moved elsewhere between keyboard-up and the keystroke (an iOS analog of the
+/// Mac's `keyRepair` focus-steal)?
+public enum InputResponderIdentity: Int, Sendable, Codable, CaseIterable {
+    /// No first responder, or it could not be resolved.
+    case none = 0
+    /// The expected terminal keyboard proxy (`TerminalInputTextView`). The
+    /// keyboard is driving the view we instrument; the bug is then in
+    /// auto-repeat/dictation behavior, not in *who* holds focus.
+    case terminalInputProxy = 1
+    /// The Metal/IOSurface terminal surface itself (`GhosttySurfaceView`).
+    case ghosttySurface = 2
+    /// A `UITextField` (e.g. an unexpected SwiftUI/text field stealing focus).
+    case uiTextField = 3
+    /// A `UITextView`.
+    case uiTextView = 4
+    /// Some other `UIResponder` subclass not in this list. The decoder pairs this
+    /// with the human-readable class name carried in the companion string log
+    /// (`anchormux`) for the same event.
+    case other = 9
+}

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -243,6 +243,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         case "mobile.terminal.create", "terminal.create":
             return false
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport":

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1427,6 +1427,34 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         await sendRemoteTerminalInput(text, workspaceID: workspaceID, terminalID: terminalID)
     }
 
+    /// Send a committed block of text (system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text) to the terminal that
+    /// owns `surfaceID` as a *bracketed paste*.
+    ///
+    /// Unlike ``submitTerminalRawInput(_:surfaceID:)``, this routes to the
+    /// Mac's `terminal.paste` RPC, which delivers the text through Ghostty's
+    /// paste path (`ghostty_surface_text`). That keeps embedded newlines part of
+    /// one paste so a running shell or TUI does not execute each line as a
+    /// separate command, and lets bracketed-paste-aware programs treat it as
+    /// pasted content.
+    /// - Parameters:
+    ///   - text: The committed block. Sent verbatim; the Mac applies bracketed
+    ///     paste framing.
+    ///   - surfaceID: The terminal surface id the block targets.
+    public func submitTerminalPasteText(_ text: String, surfaceID: String) async {
+        guard !text.isEmpty else { return }
+        let workspaceCandidate = workspaces.first(where: { workspace in
+            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
+        })
+        guard let workspace = workspaceCandidate else { return }
+        guard remoteClient != nil else { return }
+        await sendRemoteTerminalPasteText(
+            text,
+            workspaceID: workspace.id,
+            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+        )
+    }
+
     private func drainRawTerminalInputBuffer() async {
         while let chunk = rawTerminalInputBuffer.nextBatch() {
             await submitTerminalRawInput(
@@ -2041,6 +2069,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let responseData = try await client.sendRequest(
                 MobileCoreRPCClient.requestData(
                     method: "terminal.paste_image",
+                    params: params
+                )
+            )
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
+            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+        } catch {
+            guard generation == connectionGeneration else { return }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            connectionError = Self.localizedConnectionError(for: error)
+        }
+    }
+
+    private func sendRemoteTerminalPasteText(
+        _ text: String,
+        workspaceID: MobileWorkspacePreview.ID,
+        terminalID: MobileTerminalPreview.ID
+    ) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            #if DEBUG
+            mobileShellLog.debug("send remote terminal paste text byteCount=\(text.utf8.count, privacy: .public) workspace=\(workspaceID.rawValue, privacy: .private) terminal=\(terminalID.rawValue, privacy: .private)")
+            #endif
+            let key = viewportKey(workspaceID: workspaceID, terminalID: terminalID)
+            var params: [String: Any] = [
+                "workspace_id": workspaceID.rawValue,
+                "surface_id": terminalID.rawValue,
+                "text": text,
+                "client_id": clientID,
+            ]
+            if let viewportSize = reportedViewportSizesByTerminalKey[key] {
+                params["viewport_columns"] = viewportSize.columns
+                params["viewport_rows"] = viewportSize.rows
+            }
+            let responseData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "terminal.paste",
                     params: params
                 )
             )

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1748,6 +1748,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalReplaySurfaceIDsInFlight = []
         terminalOutputTransport = .rawBytes
         supportsWorkspaceActions = false
+        // Clear paste support too, so a reconnect to an older host cannot send
+        // `terminal.paste` on a stale `true` before the next status probe lands.
+        supportsTerminalPaste = false
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
         stopRenderGridLivenessWatchdog(listenerID: nil)

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -51,6 +51,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
+    private static let terminalPasteCapability = "terminal.paste.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
 
     /// How long the render-grid stream may stay silent (no event of any topic)
@@ -170,6 +171,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// for older Macs that lack the handler, so the UI can hide rename/pin rather
     /// than offer actions that would fail with `method_not_found`.
     public private(set) var supportsWorkspaceActions: Bool = false
+    /// Whether the connected Mac advertises the `terminal.paste.v1` capability
+    /// (the bracketed-paste `terminal.paste` RPC). `false` until host status is
+    /// read, and for older Macs that lack the handler, so multi-character commits
+    /// (dictation, autocorrect, keyboard/clipboard paste) fall back to per-key
+    /// `terminal.input` instead of being dropped with `method_not_found`.
+    public private(set) var supportsTerminalPaste: Bool = false
     public var terminalInputText: String
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
@@ -1448,10 +1455,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         })
         guard let workspace = workspaceCandidate else { return }
         guard remoteClient != nil else { return }
+        let terminalID = MobileTerminalPreview.ID(rawValue: surfaceID)
+        // Fall back to per-key input when the paired Mac is too old to advertise
+        // the bracketed-paste RPC, so a new client + old host drops nothing.
+        // `terminal.input` expects CR for Return, so normalize newlines.
+        guard supportsTerminalPaste else {
+            let normalized = text.replacingOccurrences(of: "\n", with: "\r")
+            await submitTerminalRawInput(normalized, workspaceID: workspace.id, terminalID: terminalID)
+            return
+        }
         await sendRemoteTerminalPasteText(
             text,
             workspaceID: workspace.id,
-            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+            terminalID: terminalID
         )
     }
 
@@ -2177,9 +2193,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let payload = try? MobileHostStatusResponse.decode(data) else {
                 terminalOutputTransport = fallback
                 supportsWorkspaceActions = false
+                supportsTerminalPaste = false
                 return fallback
             }
             supportsWorkspaceActions = payload.capabilities.contains(Self.workspaceActionsCapability)
+            supportsTerminalPaste = payload.capabilities.contains(Self.terminalPasteCapability)
             let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
                 payload.terminalFidelity == "render_grid" ? .renderGrid : .rawBytes
             terminalOutputTransport = transport
@@ -2188,6 +2206,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             terminalOutputTransport = fallback
             supportsWorkspaceActions = false
+            supportsTerminalPaste = false
             MobileDebugLog.anchormux("sync.transport=raw_bytes reason=status_failed")
             return fallback
         }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -110,6 +110,15 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             }
         }
 
+        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
+            // A committed block of text (dictation, autocorrect, keyboard
+            // clipboard insert). Send it through the Mac's bracketed-paste RPC so
+            // newlines stay part of one paste instead of fragmenting into Returns.
+            Task { @MainActor [weak store] in
+                await store?.submitTerminalPasteText(text, surfaceID: self.surfaceID)
+            }
+        }
+
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
             // Report our natural grid to the Mac and pin our render to the
             // effective grid it returns (the smallest across every attached

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -44,6 +44,12 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             fontSize: fontSize
         )
         view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        #if DEBUG
+        // Hand the surface the structured diagnostic log so the keyboard-input
+        // probes (hold-backspace + dictation evidence round) land in the blob the
+        // "Send to agent" feedback pane exports. `nil` until P1's log is wired.
+        view.diagnosticLog = store.diagnosticLog
+        #endif
         context.coordinator.attach(surfaceView: view)
         return view
     }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
@@ -1,0 +1,55 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Resolves the current `UIResponder` first responder for DEBUG input
+/// instrumentation.
+///
+/// UIKit exposes no public "who is first responder" API. The standard technique
+/// is to send an action to the `nil` target: UIKit walks the responder chain
+/// from the current first responder and invokes the first responder that
+/// implements the selector. By defining the capture selector as a
+/// ``UIResponder`` extension, *every* responder implements it, so the action
+/// lands on the actual first responder, which records `self`.
+///
+/// This is a DEBUG-only diagnostic aid for the hold-backspace + dictation
+/// evidence round; it never drives behavior. `@MainActor` because it touches
+/// `UIApplication.shared.sendAction` on the main thread.
+@MainActor
+enum CurrentResponderProbe {
+    /// Returns the current first responder, or `nil` if there is none.
+    static func current() -> UIResponder? {
+        CurrentResponderCapture.captured = nil
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+        let captured = CurrentResponderCapture.captured
+        CurrentResponderCapture.captured = nil
+        return captured
+    }
+}
+
+/// Holds the responder captured during a ``CurrentResponderProbe/current()``
+/// probe.
+///
+/// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and the
+/// captured pointer is read immediately after on the same call, so the single
+/// stored slot never races. `nonisolated(unsafe)` is acceptable here: writes and
+/// reads are confined to the main actor's synchronous `sendAction` round-trip in
+/// ``CurrentResponderProbe/current()``, and this is DEBUG-only diagnostic
+/// scaffolding.
+private enum CurrentResponderCapture {
+    nonisolated(unsafe) static weak var captured: UIResponder?
+}
+
+private extension UIResponder {
+    /// Records `self` as the captured first responder. Invoked by UIKit's
+    /// responder-chain walk during ``CurrentResponderProbe/current()``; only the
+    /// actual first responder receives it.
+    @objc func cmuxDiagnosticCaptureFirstResponder(_ sender: Any?) {
+        CurrentResponderCapture.captured = self
+    }
+}
+#endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -827,8 +827,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastReportedSize ?? TerminalGridSize(columns: 100, rows: 32, pixelWidth: 900, pixelHeight: 650)
     }
 
+    /// Structured diagnostic log (DEBUG dogfood builds only), property-injected
+    /// from the shell store by ``GhosttySurfaceRepresentable`` so the
+    /// hold-backspace + dictation input probes land in the blob the "Send to
+    /// agent" feedback pane exports. Forwarded to ``inputProxy`` on set. `nil` in
+    /// release and in hosts that do not wire it; every probe is then a no-op.
+    public var diagnosticLog: DiagnosticLog? {
+        didSet { inputProxy.diagnosticLog = diagnosticLog }
+    }
+
     private lazy var inputProxy: TerminalInputTextView = {
         let inputProxy = TerminalInputTextView()
+        inputProxy.diagnosticLog = diagnosticLog
         inputProxy.onText = { [weak self] text in
             guard let self else { return }
             self.resetCursorBlink()
@@ -848,6 +858,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             // Send DEL (0x7F) directly to transport as raw byte.
             let data = Data([0x7F])
+            #if DEBUG
+            // Pairs with `inputDeleteBackward`: if N delete calls produce N
+            // emitted DEL bytes, the iOS input view is correct and the
+            // hold-backspace failure is downstream (transport/Mac/render), not in
+            // this view — redirecting the hunt instead of a 4th input-view guess.
+            self.diagnosticLog?.record(DiagnosticEvent(.inputBackspaceEmitted, ms: UInt32(data.count)))
+            #endif
             TerminalInputDebugLog.log("surface.onBackspace data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
         }
@@ -1067,6 +1084,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public var autoFocusOnWindowAttach = true
 
     @objc private func handleKeyboardWillShow(_ notification: Notification) {
+        #if DEBUG
+        // Capture WHICH view owns first responder the instant the keyboard comes
+        // up — the load-bearing question for the hold-backspace + dictation hunt.
+        // Recorded before any geometry guard so it fires on every keyboard-up,
+        // even when the height is unchanged. This is the iOS analog of checking
+        // for a Mac-style `keyRepair` focus-steal: if this is not
+        // `terminalInputProxy`, the keyboard never drives the view we instrument.
+        let kbResponder = CurrentResponderProbe.current()
+        let kbIdentity = TerminalInputTextView.responderIdentity(of: kbResponder)
+        diagnosticLog?.record(DiagnosticEvent(.inputKeyboardUp, a: kbIdentity.rawValue))
+        MobileDebugLog.anchormux(
+            "input.keyboardUp identity=\(kbIdentity) class=\(TerminalInputTextView.responderClassName(kbResponder)) proxyIsFR=\(inputProxy.isFirstResponder)"
+        )
+        #endif
         guard let frameEnd = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
               let window else { return }
         let keyboardFrameInView = convert(frameEnd, from: window)

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -74,8 +74,15 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
-    /// Default: fall back to per-character input so a conformer that does not
-    /// implement the bracketed-paste path still delivers the text.
+    /// Default bracketed-paste handler that falls back to per-character input.
+    ///
+    /// A conformer that does not implement the bracketed-paste path still
+    /// delivers the text: newlines are normalized to CR (matching the
+    /// per-keystroke input path) and the bytes are forwarded through
+    /// ``ghosttySurfaceView(_:didProduceInput:)``.
+    /// - Parameters:
+    ///   - surfaceView: The surface view that produced the committed block.
+    ///   - text: The committed block of pasted/dictated text.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
         let normalized = text.replacingOccurrences(of: "\n", with: "\r")
         ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -60,6 +60,13 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
+    /// Forward a committed block of text (system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text) that should reach the
+    /// remote terminal as a bracketed paste rather than per-character input. The
+    /// host sends it via the `terminal.paste` RPC so embedded newlines do not
+    /// fragment into separate Returns. Defaults to the raw-input path so existing
+    /// conformers keep working. Optional.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String)
 }
 
 public extension GhosttySurfaceViewDelegate {
@@ -67,6 +74,12 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    /// Default: fall back to per-character input so a conformer that does not
+    /// implement the bracketed-paste path still delivers the text.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
+        let normalized = text.replacingOccurrences(of: "\n", with: "\r")
+        ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))
+    }
 }
 
 @MainActor
@@ -804,6 +817,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             TerminalInputDebugLog.log("surface.onEscape data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
+        }
+        inputProxy.onPasteText = { [weak self] text in
+            guard let self else { return }
+            self.resetCursorBlink()
+            // Multi-character commits (dictation, autocorrect, keyboard clipboard
+            // insert) go through the bracketed-paste RPC so embedded newlines are
+            // not split into separate Returns by the remote terminal.
+            TerminalInputDebugLog.log("surface.onPasteText text=\(TerminalInputDebugLog.textSummary(text))")
+            self.delegate?.ghosttySurfaceView(self, didPasteText: text)
         }
         inputProxy.onPasteImage = { [weak self] data, format in
             guard let self else { return }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextPosition.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextPosition.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+/// An opaque text position for the terminal input view's hand-rolled
+/// ``UITextInput`` conformance.
+///
+/// ``TerminalInputTextView`` is a remote-terminal proxy: it owns no editable
+/// document, so it never exposes real character offsets. UIKit's text-input
+/// machinery (IME composition, the dictation placeholder, the "speak selection"
+/// action) still requires the view to vend `UITextPosition`/`UITextRange`
+/// instances, so this is a sentinel with no addressable offset. It exists only
+/// to satisfy the protocol's identity requirements; the geometry/offset methods
+/// that would consume it all return neutral values.
+final class TerminalInputTextPosition: UITextPosition {}

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextRange.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextRange.swift
@@ -1,0 +1,29 @@
+import UIKit
+
+/// An opaque text range for the terminal input view's hand-rolled
+/// ``UITextInput`` conformance.
+///
+/// Like ``TerminalInputTextPosition``, this carries no real document offsets.
+/// ``TerminalInputTextView`` keeps two long-lived range sentinels — one
+/// identifying the IME marked-text region, one identifying the (always empty)
+/// selection — and returns the matching sentinel from `markedTextRange` /
+/// `selectedTextRange`. UIKit compares ranges by object identity here, so the
+/// view can answer `textInRange:` by checking which sentinel it was handed
+/// rather than by indexing a buffer it does not keep.
+final class TerminalInputTextRange: UITextRange {
+    private let position = TerminalInputTextPosition()
+
+    /// The start of the range. Both ends return the same sentinel position
+    /// because the range addresses no real document span; callers only use it
+    /// for identity comparison, never to compute offsets.
+    override var start: UITextPosition { position }
+
+    /// The end of the range. Returns the same sentinel as ``start`` (see the
+    /// note there): the range has no measurable length.
+    override var end: UITextPosition { position }
+
+    /// Always reports empty. The view never holds a non-empty selection, and the
+    /// marked-text contents are tracked out of band by the view, not via a
+    /// measurable range here.
+    override var isEmpty: Bool { true }
+}

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -2,7 +2,40 @@ import CmuxMobileTerminalKit
 import Foundation
 import UIKit
 
-final class TerminalInputTextView: UITextView {
+/// The iOS terminal's keyboard input surface.
+///
+/// This is a **documentless responder**, not a text editor. It conforms to
+/// ``UIKeyInput`` and ``UITextInput`` directly on a bare `UIView` (the same
+/// construction iSH's `TerminalView` ships) instead of subclassing
+/// `UITextView`. Every committed character is forwarded to the remote Mac and
+/// nothing is echoed locally, so there is no editable buffer to keep in sync —
+/// the view owns only a transient IME ``markedText`` string.
+///
+/// ## Why not a `UITextView`
+///
+/// A `UITextView` (or any real-document field) drives backspace auto-repeat and
+/// dictation off its internal text storage and selection, not off
+/// ``UIKeyInput/hasText``. The previous implementation forced `hasText` to
+/// `true` but cleared its document to `""` after every keystroke, so:
+///
+/// - **hold-to-repeat backspace** stopped after one delete: with an empty
+///   document and a collapsed selection at offset 0 the framework had nothing to
+///   repeat-delete, and a `UITextView` never consults the overridden `hasText`
+///   for repeat.
+/// - **system dictation** never landed: dictation inserts a placeholder into the
+///   document then replaces it with the recognized text, but the per-keystroke
+///   `text = ""` clear nuked the placeholder mid-flight.
+///
+/// A bare ``UIKeyInput``/``UITextInput`` responder with no document has neither
+/// problem. The framework honors ``hasText`` for repeat on a raw responder, and
+/// the explicit dictation-placeholder methods on a real (non-cleared)
+/// `UITextInput` conformer let recognized text arrive through ``insertText(_:)``
+/// as one multi-character block, which routes to the bracketed-paste sink.
+///
+/// Autocorrect/predictive text stay **disabled** here and fundamentally cannot
+/// be enabled: they require the field to retain the in-progress word, which is
+/// incompatible with forwarding every keystroke to a remote terminal.
+final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     var onText: ((String) -> Void)?
     var onBackspace: (() -> Void)?
     var onEscapeSequence: ((Data) -> Void)?
@@ -42,41 +75,102 @@ final class TerminalInputTextView: UITextView {
     private var alternateAccessorySticky: Bool { modifierState.isStickyOn(.alternate) }
     private var commandAccessorySticky: Bool { modifierState.isStickyOn(.command) }
     private var shiftAccessorySticky: Bool { modifierState.isStickyOn(.shift) }
-    private var pendingDirectInsertMirrorText = ""
+
+    /// The in-progress IME composition string, or `nil` when not composing.
+    ///
+    /// This is the view's *only* text state. While an IME (CJK, emoji-via-IME)
+    /// is composing, UIKit calls ``setMarkedText(_:selectedRange:)`` with the
+    /// candidate; the view holds it here so ``markedTextRange`` reports active
+    /// composition and ``text(in:)`` can answer the framework's read-back. On
+    /// ``unmarkText()`` the held string commits through ``insertText(_:)`` and
+    /// this clears. There is no committed-document buffer.
+    private var markedText: String?
 
     /// Monotonic-ish tap timestamp for the reducer's double-tap window. Uses
     /// the same wall-clock source the legacy `Date()` comparisons used, so the
     /// 0.4s sticky promotion behaves identically.
     private static func tapNow() -> TimeInterval { Date().timeIntervalSinceReferenceDate }
-    private static let directInsertMirrorTextLimit = 128
+
+    /// Long-lived sentinel identifying the IME marked-text region. Returned from
+    /// ``markedTextRange`` only while ``markedText`` is non-nil; UIKit compares
+    /// it by object identity.
+    private let markedTextRangeSentinel = TerminalInputTextRange()
+    /// Long-lived sentinel identifying the (always empty) selection. Returned
+    /// from ``selectedTextRange``; its presence is what stops the "speak
+    /// selection" action from crashing while looking for a selection.
+    private let selectedTextRangeSentinel = TerminalInputTextRange()
+
+    /// The framework-supplied delegate that wants to know about marked/selection
+    /// changes. Required stored property of the ``UITextInput`` conformance; the
+    /// view notifies it around ``setMarkedText(_:selectedRange:)`` so the IME
+    /// candidate UI stays in sync.
+    weak var inputDelegate: (any UITextInputDelegate)?
+
+    /// Word/sentence tokenizer required by ``UITextInput``. The view has no
+    /// document to tokenize, but the protocol mandates a non-nil tokenizer; the
+    /// default string tokenizer satisfies it without ever being meaningfully
+    /// queried.
+    lazy var tokenizer: any UITextInputTokenizer = UITextInputStringTokenizer(textInput: self)
 
     override var canBecomeFirstResponder: Bool { true }
+
+    /// Conforming to ``UITextInput`` would otherwise make this an accessibility
+    /// element, which would shadow the real terminal surface's accessibility
+    /// content. The view is an invisible input proxy, so keep it out of the
+    /// accessibility tree (the surface carries the rendered-text label). iSH does
+    /// the same for the same reason.
+    override var isAccessibilityElement: Bool {
+        get { false }
+        set {}
+    }
 
     /// Always report that there is text to delete.
     ///
     /// This is the load-bearing piece (borrowed from iSH's `TerminalView`) that
-    /// makes the system software keyboard's *hold-to-repeat* backspace work. The
-    /// keyboard's auto-repeat timer keeps firing ``deleteBackward()`` only while
-    /// the first responder reports `hasText == true`; the moment it reads
-    /// `false` the repeat stops. Because this view keeps a perpetually-empty
-    /// document (every committed keystroke is forwarded to the Mac and the local
-    /// buffer is cleared), the inherited `UITextView.hasText` returned `false`,
-    /// so holding backspace deleted exactly one character. Forcing `true` here
-    /// lets the keyboard repeat indefinitely, just like a normal text field. It
-    /// is always safe to send a DEL byte to the remote terminal, so there is no
-    /// "nothing to delete" state to honor.
+    /// makes the system software keyboard's *hold-to-repeat* backspace work. On
+    /// a bare ``UIKeyInput`` responder (this view) the keyboard's auto-repeat
+    /// timer keeps firing ``deleteBackward()`` only while the first responder
+    /// reports `hasText == true`; the moment it reads `false` the repeat stops.
+    /// It is always safe to send a DEL byte to the remote terminal, so there is
+    /// no "nothing to delete" state to honor — return `true` unconditionally and
+    /// let the keyboard repeat indefinitely.
     ///
-    /// Internal byte-routing must therefore *not* key off `hasText` (it is now a
+    /// Internal byte-routing therefore must *not* key off `hasText` (it is a
     /// constant); ``deleteBackward()`` and the modifier guards key off
-    /// ``markedTextRange`` (IME composition) instead.
-    override var hasText: Bool { true }
+    /// ``markedText`` (IME composition) instead.
+    var hasText: Bool { true }
 
     override var keyCommands: [UIKeyCommand]? {
-        guard markedTextRange == nil else { return nil }
-        return TerminalHardwareKeyResolver.makeKeyCommands(
+        guard markedText == nil else { return nil }
+        var commands = TerminalHardwareKeyResolver.makeKeyCommands(
             target: self,
             action: #selector(handleHardwareKeyCommand(_:))
         )
+        // A bare UIView does not inherit UITextView's Cmd+V, so wire it
+        // explicitly to the same clipboard routing as the toolbar Paste button.
+        commands.append(UIKeyCommand(input: "v", modifierFlags: [.command], action: #selector(paste(_:))))
+        return commands
+    }
+
+    /// Restores standard system paste on this documentless responder.
+    ///
+    /// As a `UITextView` the view inherited `paste(_:)`/`canPerformAction(_:)`;
+    /// as a bare `UIView` it must re-expose them so hardware Cmd+V and the
+    /// edit-menu Paste keep working. Only paste is advertised — copy/cut/select
+    /// are meaningless on a proxy that holds no document, so they stay disabled
+    /// rather than surfacing a broken edit menu.
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        if action == #selector(paste(_:)) {
+            return UIPasteboard.general.hasStrings || UIPasteboard.general.hasImages
+        }
+        return false
+    }
+
+    /// System Paste (Cmd+V or the edit-menu item) routed through the same
+    /// clipboard handling as the toolbar Paste button: an image goes to the Mac
+    /// as `terminal.paste_image`, text rides the bracketed-paste sink.
+    override func paste(_ sender: Any?) {
+        handlePasteAction()
     }
 
     private static let monokaiBarColor = UIColor(red: 0x27/255.0, green: 0x28/255.0, blue: 0x22/255.0, alpha: 1)
@@ -337,26 +431,16 @@ final class TerminalInputTextView: UITextView {
     }
 
     init() {
-        super.init(frame: .zero, textContainer: nil)
+        super.init(frame: .zero)
         backgroundColor = .clear
-        textColor = .clear
         tintColor = .clear
-        autocorrectionType = .no
-        autocapitalizationType = .none
-        smartQuotesType = .no
-        smartDashesType = .no
-        smartInsertDeleteType = .no
-        spellCheckingType = .no
-        keyboardType = .default
-        returnKeyType = .default
-        textContainerInset = .zero
-        // The accessory bar is no longer the keyboard's `inputAccessoryView`;
-        // `GhosttySurfaceView` docks `toolbarView` persistently at the bottom so
-        // it survives keyboard dismissal. Leaving `inputAccessoryView` nil means
-        // the keyboard shows without its own accessory (the docked bar rides
-        // above it via `keyboardLayoutGuide`).
-        delegate = self
-        text = ""
+        // The view owns no visible content; it is a zero-size hidden responder
+        // docked by `GhosttySurfaceView`. The accessory bar is no longer the
+        // keyboard's `inputAccessoryView`; `GhosttySurfaceView` docks
+        // `toolbarView` persistently at the bottom so it survives keyboard
+        // dismissal. Leaving `inputAccessoryView` nil means the keyboard shows
+        // without its own accessory (the docked bar rides above it via
+        // `keyboardLayoutGuide`).
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleAccessoryConfigurationChanged),
@@ -373,26 +457,31 @@ final class TerminalInputTextView: UITextView {
         NotificationCenter.default.removeObserver(self)
     }
 
-    override func insertText(_ text: String) {
+    /// Receive a committed character (or block) from the keyboard.
+    ///
+    /// This is the single sink for every soft-keyboard text insertion: typed
+    /// characters, an emoji-picker tap, an IME-committed candidate, and the
+    /// recognized text of a dictation session (delivered as one multi-character
+    /// block). It never edits a local document — it routes straight to the
+    /// remote terminal. Committing here also ends any IME composition.
+    func insertText(_ text: String) {
         guard !text.isEmpty else { return }
-        TerminalInputDebugLog.log("proxy.insertText text=\(TerminalInputDebugLog.textSummary(text)) composing=\(markedTextRange != nil)")
-        if markedTextRange != nil {
-            pendingDirectInsertMirrorText = ""
-            super.insertText(text)
-            return
+        TerminalInputDebugLog.log("proxy.insertText text=\(TerminalInputDebugLog.textSummary(text)) composing=\(markedText != nil)")
+        // A committed insert ends composition. The candidate the IME was showing
+        // is exactly `text`, so clear the marked state and emit `text` once.
+        if markedText != nil {
+            withMarkedTextChange { markedText = nil }
         }
-        rememberDirectInsertMirror(text)
         emitCommittedText(text, source: "insertText")
     }
 
-    override func deleteBackward() {
-        // Routing keys off `markedTextRange` (IME composition in progress), NOT
-        // `hasText`: `hasText` is now a forced constant `true` so the software
+    func deleteBackward() {
+        // Routing keys off `markedText` (IME composition in progress), NOT
+        // `hasText`: `hasText` is a forced constant `true` so the software
         // keyboard auto-repeats backspace, so it can no longer mean "the local
         // document is empty". While composing, the delete edits the marked text
-        // locally (`super.deleteBackward()`); otherwise it is a real backspace
-        // that must reach the Mac.
-        if commandAccessoryArmed, markedTextRange == nil {
+        // locally; otherwise it is a real backspace that must reach the Mac.
+        if commandAccessoryArmed, markedText == nil {
             if !commandAccessorySticky {
                 setCommandAccessoryArmed(false)
             }
@@ -400,7 +489,7 @@ final class TerminalInputTextView: UITextView {
             onEscapeSequence?(Data([0x15]))
             return
         }
-        if alternateAccessoryArmed, markedTextRange == nil {
+        if alternateAccessoryArmed, markedText == nil {
             if !alternateAccessorySticky {
                 setAlternateAccessoryArmed(false)
             }
@@ -412,18 +501,28 @@ final class TerminalInputTextView: UITextView {
             }
             return
         }
-        if controlAccessoryArmed, markedTextRange == nil {
+        if controlAccessoryArmed, markedText == nil {
             if !controlAccessorySticky {
                 setControlAccessoryArmed(false)
             }
             onBackspace?()
             return
         }
-        // While composing (marked text present), let UITextView edit the marked
-        // string locally so the IME candidate updates; the committed result
-        // still flows to the Mac via the normal insert/textChange path.
-        if markedTextRange != nil {
-            super.deleteBackward()
+        // While composing (marked text present), cancel the composition rather
+        // than self-editing the marked string. The IME owns decomposition and
+        // drives it through `setMarkedText` (the candidate shown is the IME's own
+        // floating bar; this view is invisible, so `markedText` is just a mirror
+        // of what the IME last pushed). A documentless view cannot decompose a
+        // syllable itself, and modeling it as a Swift `Character` drop would nuke
+        // a whole CJK syllable (한 is one `Character`) while pretending to step
+        // back. Canceling is honest and emits nothing to the Mac; an IME that
+        // routes composition-backspace through here gets a clean reset.
+        if markedText != nil {
+            // Distinguishes the rarely-hit `deleteBackward`-drives-composition
+            // path from the common IME-driven `setMarkedText` path during device
+            // dogfood (gated on CMUX_INPUT_DEBUG; not a temporary probe).
+            TerminalInputDebugLog.log("deleteBackward.composing cancel marked composition")
+            setMarkedText(nil, selectedRange: NSRange(location: 0, length: 0))
             return
         }
         onBackspace?()
@@ -431,21 +530,32 @@ final class TerminalInputTextView: UITextView {
 
     // MARK: Dictation
     //
-    // Unlike iSH's `TerminalView` (a raw `UIView` that hand-rolls `UITextInput`
-    // and therefore must provide `insertDictationResultPlaceholder` /
-    // `removeDictationResultPlaceholder`), this view is a `UITextView`, which
-    // already conforms to `UITextInput` and supplies those placeholder methods
-    // as framework witnesses that are not exposed for override. So we inherit
-    // iSH's dictation plumbing for free: when the user taps the keyboard mic,
-    // UIKit drives its own placeholder against this view's text storage and then
-    // delivers the recognized text through the normal `insertText(_:)` /
-    // ``textViewDidChange(_:)`` path, where ``emitCommittedText(_:source:)``
-    // routes the multi-character block through the bracketed-paste sink
-    // (``onPasteText``). There is nothing to override here.
+    // This view is a bare `UIView` conforming to `UITextInput` (the same
+    // construction as iSH's `TerminalView`), so it must supply the dictation
+    // placeholder hooks itself — see ``insertDictationResultPlaceholder()`` and
+    // ``removeDictationResultPlaceholder(_:willInsertResult:)`` in the
+    // `UITextInput` conformance below. When the user taps the keyboard mic,
+    // UIKit asks for a placeholder, runs recognition, then delivers the
+    // recognized text through ``insertText(_:)`` as one multi-character block,
+    // which ``emitCommittedText(_:source:)`` routes to the bracketed-paste sink
+    // (``onPasteText``). Because the view keeps no document, nothing can clear
+    // the placeholder mid-flight, which is what broke dictation on the prior
+    // `UITextView` design.
 
+    /// Test seam standing in for an IME/dictation/commit cycle.
+    ///
+    /// Drives the same path the keyboard would: composing text marks, then a
+    /// non-composing change commits it. Mirrors the real
+    /// ``setMarkedText(_:selectedRange:)`` → ``insertText(_:)`` flow so tests can
+    /// assert routing (single char vs. paste block) without a live keyboard.
     func simulateTextChangeForTesting(_ text: String, isComposing: Bool) {
-        self.text = text
-        handleTextChange(currentText: text, isComposing: isComposing)
+        if isComposing {
+            setMarkedText(text, selectedRange: NSRange(location: text.count, length: 0))
+        } else {
+            markedText = nil
+            guard !text.isEmpty else { return }
+            emitCommittedText(text, source: "textChange")
+        }
     }
 
     func simulateHardwareKeyCommandForTesting(input: String, modifierFlags: UIKeyModifierFlags) -> Bool {
@@ -757,40 +867,6 @@ final class TerminalInputTextView: UITextView {
         }
     }
 
-    private func handleTextChange(currentText: String, isComposing: Bool) {
-        TerminalInputDebugLog.log("proxy.textChange text=\(TerminalInputDebugLog.textSummary(currentText)) composing=\(isComposing) pendingDirect=\(TerminalInputDebugLog.textSummary(pendingDirectInsertMirrorText))")
-        if isComposing {
-            pendingDirectInsertMirrorText = ""
-        } else if !pendingDirectInsertMirrorText.isEmpty {
-            if currentText == pendingDirectInsertMirrorText {
-                TerminalInputDebugLog.log("proxy.textChange suppressed direct insert mirror text=\(TerminalInputDebugLog.textSummary(currentText))")
-                pendingDirectInsertMirrorText = ""
-                if text != "" {
-                    text = ""
-                }
-                return
-            }
-            pendingDirectInsertMirrorText = ""
-        }
-
-        let result = TerminalTextInputPipeline.process(text: currentText, isComposing: isComposing)
-        if let committedText = result.committedText {
-            emitCommittedText(committedText, source: "textChange")
-        }
-        if text != result.nextBufferText {
-            text = result.nextBufferText
-        }
-    }
-
-    private func rememberDirectInsertMirror(_ insertedText: String) {
-        pendingDirectInsertMirrorText.append(insertedText)
-        if pendingDirectInsertMirrorText.count > Self.directInsertMirrorTextLimit {
-            pendingDirectInsertMirrorText = String(
-                pendingDirectInsertMirrorText.suffix(Self.directInsertMirrorTextLimit)
-            )
-        }
-    }
-
     private func emitCommittedText(_ committedText: String, source: String) {
         TerminalInputDebugLog.log("proxy.emit source=\(source) text=\(TerminalInputDebugLog.textSummary(committedText))")
         if controlAccessoryArmed {
@@ -971,16 +1047,135 @@ final class TerminalInputTextView: UITextView {
     }
 }
 
-extension TerminalInputTextView: UITextViewDelegate {
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        TerminalInputDebugLog.log("proxy.shouldChange replacement=\(TerminalInputDebugLog.textSummary(text)) marked=\(textView.markedTextRange != nil) range=\(range.location):\(range.length)")
-        return true
+// MARK: - UITextInputTraits
+
+extension TerminalInputTextView {
+    // Autocorrect/predictive/smart substitutions are all off: the view forwards
+    // each keystroke to the remote terminal and keeps no in-progress word for
+    // the keyboard to correct against. Returning these as computed properties
+    // (rather than the `UITextView` stored traits the old design used) keeps the
+    // keyboard from offering corrections it could never apply.
+    var autocorrectionType: UITextAutocorrectionType { get { .no } set {} }
+    var autocapitalizationType: UITextAutocapitalizationType { get { .none } set {} }
+    var spellCheckingType: UITextSpellCheckingType { get { .no } set {} }
+    var smartQuotesType: UITextSmartQuotesType { get { .no } set {} }
+    var smartDashesType: UITextSmartDashesType { get { .no } set {} }
+    var smartInsertDeleteType: UITextSmartInsertDeleteType { get { .no } set {} }
+    var keyboardType: UIKeyboardType { get { .default } set {} }
+    var returnKeyType: UIReturnKeyType { get { .default } set {} }
+}
+
+// MARK: - UITextInput (documentless conformance)
+
+// This view owns no editable document. It implements `UITextInput` to unlock two
+// keyboard features that a bare `UIKeyInput` view does not get — system
+// dictation (the mic key) and IME marked-text composition — exactly the way
+// iSH's `TerminalView` does. Recognized dictation text and committed IME
+// candidates both arrive through ``insertText(_:)`` and route to the terminal;
+// the geometry/offset methods return neutral values because there is nothing to
+// measure. UIKit compares the marked/selected ranges by object identity.
+extension TerminalInputTextView {
+    var markedTextRange: UITextRange? { markedText != nil ? markedTextRangeSentinel : nil }
+
+    var selectedTextRange: UITextRange? {
+        get { selectedTextRangeSentinel }
+        set {}
     }
 
-    func textViewDidChange(_ textView: UITextView) {
-        handleTextChange(
-            currentText: textView.text ?? "",
-            isComposing: textView.markedTextRange != nil
-        )
+    var markedTextStyle: [NSAttributedString.Key: Any]? {
+        get { nil }
+        set {}
     }
+
+    var beginningOfDocument: UITextPosition { TerminalInputTextPosition() }
+    var endOfDocument: UITextPosition { TerminalInputTextPosition() }
+
+    /// The IME hands a candidate string in; hold it as the marked composition so
+    /// ``markedTextRange`` reports active composition. Nothing is sent to the
+    /// terminal until the candidate commits via ``insertText(_:)`` (driven by
+    /// the keyboard) or ``unmarkText()``.
+    ///
+    /// Mutating ``markedText`` changes the string the view exposes through
+    /// ``text(in:)``/``markedTextRange``, so it is a *text* change in the
+    /// ``UITextInputDelegate`` contract: it is bracketed with
+    /// `textWillChange`/`textDidChange` (via ``withMarkedTextChange(_:)``) so the
+    /// IME and dictation machinery keep their composition state synchronized.
+    func setMarkedText(_ markedText: String?, selectedRange: NSRange) {
+        TerminalInputDebugLog.log("proxy.setMarkedText text=\(TerminalInputDebugLog.textSummary(markedText ?? "")) ")
+        withMarkedTextChange {
+            self.markedText = (markedText?.isEmpty == true) ? nil : markedText
+        }
+    }
+
+    /// Brackets a mutation of ``markedText`` with the `UITextInputDelegate`
+    /// text-change callbacks.
+    ///
+    /// The marked composition is the only text this view exposes, so any change
+    /// to it (set by the IME, committed by ``insertText(_:)``/``unmarkText()``,
+    /// or canceled by ``replace(_:withText:)``) is a text change UIKit must be
+    /// told about with `textWillChange`/`textDidChange`. Selection-only callbacks
+    /// would leave the keyboard observing stale composition state.
+    private func withMarkedTextChange(_ mutate: () -> Void) {
+        inputDelegate?.textWillChange(self)
+        mutate()
+        inputDelegate?.textDidChange(self)
+    }
+
+    /// Commit the in-progress IME composition. Forwards the held candidate to the
+    /// terminal as one block (multi-character commits route to bracketed paste).
+    func unmarkText() {
+        guard let composing = markedText else { return }
+        withMarkedTextChange { markedText = nil }
+        emitCommittedText(composing, source: "unmarkText")
+    }
+
+    func text(in range: UITextRange) -> String? {
+        if range === markedTextRangeSentinel { return markedText }
+        if range === selectedTextRangeSentinel { return "" }
+        return nil
+    }
+
+    /// Commit text delivered through a range replacement.
+    ///
+    /// Most committed input arrives via ``insertText(_:)``, but some system
+    /// paths (text replacement, certain dictation/suggestion commits) deliver it
+    /// by replacing ``selectedTextRange`` or ``markedTextRange`` instead. The
+    /// view holds no addressable document, so the range itself is ignored, but
+    /// the *text* must still reach the terminal — route it through the same
+    /// commit path as ``insertText(_:)`` rather than dropping it. A replacement
+    /// of the marked region also supersedes the in-progress IME composition, so
+    /// clear it first. An empty replacement is a pure deletion of the marked
+    /// composition (no committed text to send).
+    func replace(_ range: UITextRange, withText text: String) {
+        TerminalInputDebugLog.log("proxy.replace text=\(TerminalInputDebugLog.textSummary(text)) marked=\(range === markedTextRangeSentinel)")
+        if range === markedTextRangeSentinel, markedText != nil {
+            withMarkedTextChange { markedText = nil }
+        }
+        guard !text.isEmpty else { return }
+        emitCommittedText(text, source: "replace")
+    }
+    func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? { nil }
+    func position(from position: UITextPosition, offset: Int) -> UITextPosition? { nil }
+    func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? { nil }
+    func compare(_ position: UITextPosition, to other: UITextPosition) -> ComparisonResult { .orderedSame }
+    func offset(from: UITextPosition, to toPosition: UITextPosition) -> Int { 0 }
+    func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? { nil }
+    func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? { nil }
+    func baseWritingDirection(for position: UITextPosition, in direction: UITextStorageDirection) -> NSWritingDirection { .leftToRight }
+    func setBaseWritingDirection(_ writingDirection: NSWritingDirection, for range: UITextRange) {}
+    func firstRect(for range: UITextRange) -> CGRect { .zero }
+    func caretRect(for position: UITextPosition) -> CGRect { .zero }
+    func selectionRects(for range: UITextRange) -> [UITextSelectionRect] { [] }
+    func closestPosition(to point: CGPoint) -> UITextPosition? { nil }
+    func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? { nil }
+    func characterRange(at point: CGPoint) -> UITextRange? { nil }
+
+    // MARK: Dictation placeholder hooks
+    //
+    // UIKit calls these when the mic is tapped. Returning a placeholder (an
+    // empty token; iSH does the same) is what tells the framework this view
+    // accepts dictation; the recognized text then arrives via `insertText`. The
+    // remove hook is a no-op because there is no document placeholder to strip.
+    func insertDictationResultPlaceholder() -> Any { "" }
+    func removeDictationResultPlaceholder(_ placeholder: Any, willInsertResult: Bool) {}
 }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1,3 +1,5 @@
+import CMUXMobileCore
+import CmuxMobileDiagnostics
 import CmuxMobileTerminalKit
 import Foundation
 import UIKit
@@ -54,6 +56,13 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     var onPasteImage: ((Data, String) -> Void)?
     var onZoom: ((TerminalFontZoomDirection) -> Void)?
     var onHideKeyboard: (() -> Void)?
+    /// Structured diagnostic log (DEBUG dogfood builds only) for the
+    /// hold-backspace + dictation evidence round. Property-injected by
+    /// ``GhosttySurfaceView`` from the shell store's `diagnosticLog` so the
+    /// "Send to agent" feedback pane captures input-path events. `nil` in release
+    /// and in any host that does not wire it; every probe is a no-op then. The
+    /// integer payloads are decoded by `scripts/decode-ios-diagnostic.py`.
+    var diagnosticLog: DiagnosticLog?
     /// Fired by the trailing "customize" button so the SwiftUI host can present
     /// the toolbar shortcuts editor.
     var onOpenToolbarSettings: (() -> Void)?
@@ -113,6 +122,30 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     lazy var tokenizer: any UITextInputTokenizer = UITextInputStringTokenizer(textInput: self)
 
     override var canBecomeFirstResponder: Bool { true }
+
+    /// Records the outcome of becoming first responder for the hold-backspace +
+    /// dictation evidence round, then defers to the default. `super` already does
+    /// the real work; this only stamps the result into ``diagnosticLog`` (DEBUG
+    /// dogfood builds) so the captured log shows whether this proxy actually owns
+    /// first responder when the keyboard is up — the load-bearing question behind
+    /// the "is `TerminalInputTextView` even being driven" hypothesis.
+    @discardableResult
+    override func becomeFirstResponder() -> Bool {
+        let became = super.becomeFirstResponder()
+        #if DEBUG
+        let responder = CurrentResponderProbe.current()
+        let identity = Self.responderIdentity(of: responder)
+        diagnosticLog?.record(DiagnosticEvent(
+            .inputBecomeFirstResponder,
+            a: became ? 1 : 0,
+            b: identity.rawValue
+        ))
+        MobileDebugLog.anchormux(
+            "input.becomeFirstResponder became=\(became) identity=\(identity) class=\(Self.responderClassName(responder)) onSelf=\(responder === self)"
+        )
+        #endif
+        return became
+    }
 
     /// Conforming to ``UITextInput`` would otherwise make this an accessibility
     /// element, which would shadow the real terminal surface's accessibility
@@ -460,6 +493,17 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     /// remote terminal. Committing here also ends any IME composition.
     func insertText(_ text: String) {
         guard !text.isEmpty else { return }
+        #if DEBUG
+        // A dictation result arrives here as one multi-character block, so a
+        // non-trivial `a` (UTF-8 byte length) after a mic tap proves dictation
+        // fired and reached this view. `b` flags an active IME composition.
+        diagnosticLog?.record(DiagnosticEvent(
+            .inputInsertText,
+            a: text.utf8.count,
+            b: markedText != nil ? 1 : 0
+        ))
+        MobileDebugLog.anchormux("input.insertText len=\(text.utf8.count) composing=\(markedText != nil)")
+        #endif
         TerminalInputDebugLog.log("proxy.insertText text=\(TerminalInputDebugLog.textSummary(text)) composing=\(markedText != nil)")
         // A committed insert ends composition. The candidate the IME was showing
         // is exactly `text`, so clear the marked state and emit `text` once.
@@ -470,6 +514,23 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     }
 
     func deleteBackward() {
+        #if DEBUG
+        // Logged on EVERY call (not just the first): a held backspace that
+        // auto-repeats shows as many events; one that does not shows as a single
+        // event. `a` carries the responder identity at the moment of the delete
+        // (resolved from the live responder chain, so a focus-steal between
+        // keyboard-up and the keystroke is visible, not assumed).
+        let deleteResponder = CurrentResponderProbe.current()
+        let deleteIdentity = Self.responderIdentity(of: deleteResponder)
+        diagnosticLog?.record(DiagnosticEvent(
+            .inputDeleteBackward,
+            a: deleteIdentity.rawValue,
+            b: markedText != nil ? 1 : 0
+        ))
+        MobileDebugLog.anchormux(
+            "input.deleteBackward identity=\(deleteIdentity) class=\(Self.responderClassName(deleteResponder)) onSelf=\(deleteResponder === self) composing=\(markedText != nil)"
+        )
+        #endif
         // Routing keys off `markedText` (IME composition in progress), NOT
         // `hasText`: `hasText` is a forced constant `true` so the software
         // keyboard auto-repeats backspace, so it can no longer mean "the local
@@ -960,8 +1021,27 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     private func emitUnmodifiedText(_ text: String) {
         switch TerminalCommitRouter.route(for: text) {
         case .paste where onPasteText != nil:
+            #if DEBUG
+            // The path a dictation result (multi-character, no modifier) takes:
+            // bracketed paste. Pairing this with ``inputInsertText`` proves a
+            // recognized phrase reached a byte sink that goes to the Mac.
+            diagnosticLog?.record(DiagnosticEvent(
+                .inputCommitRouted,
+                a: text.utf8.count,
+                b: InputCommitSink.pasteText.rawValue
+            ))
+            MobileDebugLog.anchormux("input.commitRouted len=\(text.utf8.count) sink=pasteText")
+            #endif
             onPasteText?(text)
         case .paste, .input:
+            #if DEBUG
+            diagnosticLog?.record(DiagnosticEvent(
+                .inputCommitRouted,
+                a: text.utf8.count,
+                b: InputCommitSink.text.rawValue
+            ))
+            MobileDebugLog.anchormux("input.commitRouted len=\(text.utf8.count) sink=text")
+            #endif
             // No paste sink wired (or a single character): per-character input.
             onText?(text)
         }
@@ -1087,6 +1167,33 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     private func setShiftAccessoryArmed(_ armed: Bool) {
         if !armed { consumeModifier(.shift) }
     }
+
+    #if DEBUG
+    /// Maps a `UIResponder` to its compact ``InputResponderIdentity`` for the
+    /// hold-backspace + dictation diagnostic round. Used to encode *which* view
+    /// owns first responder into the integer ``DiagnosticEvent`` payload. The
+    /// `.other` case is paired with the responder's class name in the companion
+    /// `anchormux` string log for a human-readable readback.
+    static func responderIdentity(of responder: UIResponder?) -> InputResponderIdentity {
+        switch responder {
+        case nil: return .none
+        case is TerminalInputTextView: return .terminalInputProxy
+        case is GhosttySurfaceView: return .ghosttySurface
+        case is UITextField: return .uiTextField
+        case is UITextView: return .uiTextView
+        default: return .other
+        }
+    }
+
+    /// The responder's concrete class name for the human-readable `anchormux`
+    /// readback (the integer ``InputResponderIdentity`` collapses every
+    /// unexpected class to `.other`; this preserves the exact type for the copied
+    /// debug log).
+    static func responderClassName(_ responder: UIResponder?) -> String {
+        guard let responder else { return "nil" }
+        return String(describing: type(of: responder))
+    }
+    #endif
 }
 
 // MARK: - UITextInputTraits
@@ -1218,6 +1325,28 @@ extension TerminalInputTextView {
     // empty token; iSH does the same) is what tells the framework this view
     // accepts dictation; the recognized text then arrives via `insertText`. The
     // remove hook is a no-op because there is no document placeholder to strip.
-    func insertDictationResultPlaceholder() -> Any { "" }
-    func removeDictationResultPlaceholder(_ placeholder: Any, willInsertResult: Bool) {}
+    func insertDictationResultPlaceholder() -> Any {
+        #if DEBUG
+        // The ENTRY signal that the mic was tapped and UIKit accepted this view
+        // as a dictation target. Its absence after a mic tap proves dictation
+        // never engaged this view at all (the framework dictated into something
+        // else, or nowhere).
+        diagnosticLog?.record(DiagnosticEvent(.inputDictationPlaceholder))
+        MobileDebugLog.anchormux("input.dictation.placeholder requested")
+        #endif
+        return ""
+    }
+
+    func removeDictationResultPlaceholder(_ placeholder: Any, willInsertResult: Bool) {
+        #if DEBUG
+        // `a == 0` after a mic tap means recognition produced nothing for this
+        // view; `a == 1` means a recognized result is about to arrive via
+        // ``insertText(_:)``.
+        diagnosticLog?.record(DiagnosticEvent(
+            .inputDictationRemove,
+            a: willInsertResult ? 1 : 0
+        ))
+        MobileDebugLog.anchormux("input.dictation.remove willInsertResult=\(willInsertResult)")
+        #endif
+    }
 }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -663,11 +663,13 @@ final class TerminalInputTextView: UITextView {
 
     /// Read the system clipboard for the Paste button. An image is forwarded via
     /// ``onPasteImage`` (the host uploads it to the Mac as `terminal.paste_image`
-    /// and the Mac injects the resulting file path); plain text rides the normal
-    /// ``onText`` input path. Images win when both are present. A large image
-    /// falls back to JPEG so it stays under the Mac's 10 MB cap. Accessing the
-    /// pasteboard contents here is what shows iOS's one-shot paste banner, which
-    /// is the expected confirmation for an explicit Paste tap.
+    /// and the Mac injects the resulting file path); plain text rides the
+    /// bracketed-paste ``onPasteText`` path so multi-line clipboard text lands as
+    /// one paste instead of executing line-by-line. Images win when both are
+    /// present. A large image falls back to JPEG so it stays under the Mac's
+    /// 10 MB cap. Accessing the pasteboard contents here is what shows iOS's
+    /// one-shot paste banner, which is the expected confirmation for an explicit
+    /// Paste tap.
     private func handlePasteAction() {
         let pasteboard = UIPasteboard.general
         if pasteboard.hasImages, let image = pasteboard.image {
@@ -686,7 +688,15 @@ final class TerminalInputTextView: UITextView {
             }
         }
         if pasteboard.hasStrings, let string = pasteboard.string, !string.isEmpty {
-            onText?(string)
+            // An explicit Paste is always pasted content, so it goes through the
+            // bracketed-paste sink (which falls back to per-key input on a host
+            // that does not support it). The host gates the fallback on the
+            // `terminal.paste.v1` capability.
+            if onPasteText != nil {
+                onPasteText?(string)
+            } else {
+                onText?(string)
+            }
         }
     }
 

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -6,6 +6,14 @@ final class TerminalInputTextView: UITextView {
     var onText: ((String) -> Void)?
     var onBackspace: (() -> Void)?
     var onEscapeSequence: ((Data) -> Void)?
+    /// Invoked for a committed *block* of text (more than one character) that no
+    /// modifier transforms: system dictation, autocorrect/predictive-bar
+    /// replacements, and clipboard text inserted by the keyboard all arrive this
+    /// way. The host routes the block through a bracketed-paste RPC so the remote
+    /// terminal receives it as a single paste rather than per-character input,
+    /// which avoids CR-fragmenting multi-line text and lets TUIs treat it as
+    /// pasted content. Single characters and Return still ride ``onText``.
+    var onPasteText: ((String) -> Void)?
     /// Invoked when the Paste accessory button reads an image off the system
     /// clipboard. The host forwards the bytes (+ a lowercase format hint) to the
     /// Mac, which injects the resulting file path into the terminal. Clipboard
@@ -43,6 +51,25 @@ final class TerminalInputTextView: UITextView {
     private static let directInsertMirrorTextLimit = 128
 
     override var canBecomeFirstResponder: Bool { true }
+
+    /// Always report that there is text to delete.
+    ///
+    /// This is the load-bearing piece (borrowed from iSH's `TerminalView`) that
+    /// makes the system software keyboard's *hold-to-repeat* backspace work. The
+    /// keyboard's auto-repeat timer keeps firing ``deleteBackward()`` only while
+    /// the first responder reports `hasText == true`; the moment it reads
+    /// `false` the repeat stops. Because this view keeps a perpetually-empty
+    /// document (every committed keystroke is forwarded to the Mac and the local
+    /// buffer is cleared), the inherited `UITextView.hasText` returned `false`,
+    /// so holding backspace deleted exactly one character. Forcing `true` here
+    /// lets the keyboard repeat indefinitely, just like a normal text field. It
+    /// is always safe to send a DEL byte to the remote terminal, so there is no
+    /// "nothing to delete" state to honor.
+    ///
+    /// Internal byte-routing must therefore *not* key off `hasText` (it is now a
+    /// constant); ``deleteBackward()`` and the modifier guards key off
+    /// ``markedTextRange`` (IME composition) instead.
+    override var hasText: Bool { true }
 
     override var keyCommands: [UIKeyCommand]? {
         guard markedTextRange == nil else { return nil }
@@ -359,7 +386,13 @@ final class TerminalInputTextView: UITextView {
     }
 
     override func deleteBackward() {
-        if commandAccessoryArmed, markedTextRange == nil, !hasText {
+        // Routing keys off `markedTextRange` (IME composition in progress), NOT
+        // `hasText`: `hasText` is now a forced constant `true` so the software
+        // keyboard auto-repeats backspace, so it can no longer mean "the local
+        // document is empty". While composing, the delete edits the marked text
+        // locally (`super.deleteBackward()`); otherwise it is a real backspace
+        // that must reach the Mac.
+        if commandAccessoryArmed, markedTextRange == nil {
             if !commandAccessorySticky {
                 setCommandAccessoryArmed(false)
             }
@@ -367,7 +400,7 @@ final class TerminalInputTextView: UITextView {
             onEscapeSequence?(Data([0x15]))
             return
         }
-        if alternateAccessoryArmed, markedTextRange == nil, !hasText {
+        if alternateAccessoryArmed, markedTextRange == nil {
             if !alternateAccessorySticky {
                 setAlternateAccessoryArmed(false)
             }
@@ -379,19 +412,36 @@ final class TerminalInputTextView: UITextView {
             }
             return
         }
-        if controlAccessoryArmed, markedTextRange == nil, !hasText {
+        if controlAccessoryArmed, markedTextRange == nil {
             if !controlAccessorySticky {
                 setControlAccessoryArmed(false)
             }
             onBackspace?()
             return
         }
-        if markedTextRange != nil || hasText {
+        // While composing (marked text present), let UITextView edit the marked
+        // string locally so the IME candidate updates; the committed result
+        // still flows to the Mac via the normal insert/textChange path.
+        if markedTextRange != nil {
             super.deleteBackward()
             return
         }
         onBackspace?()
     }
+
+    // MARK: Dictation
+    //
+    // Unlike iSH's `TerminalView` (a raw `UIView` that hand-rolls `UITextInput`
+    // and therefore must provide `insertDictationResultPlaceholder` /
+    // `removeDictationResultPlaceholder`), this view is a `UITextView`, which
+    // already conforms to `UITextInput` and supplies those placeholder methods
+    // as framework witnesses that are not exposed for override. So we inherit
+    // iSH's dictation plumbing for free: when the user taps the keyboard mic,
+    // UIKit drives its own placeholder against this view's text storage and then
+    // delivers the recognized text through the normal `insertText(_:)` /
+    // ``textViewDidChange(_:)`` path, where ``emitCommittedText(_:source:)``
+    // routes the multi-character block through the bracketed-paste sink
+    // (``onPasteText``). There is nothing to override here.
 
     func simulateTextChangeForTesting(_ text: String, isComposing: Bool) {
         self.text = text
@@ -764,9 +814,28 @@ final class TerminalInputTextView: UITextView {
             if !shiftAccessorySticky {
                 setShiftAccessoryArmed(false)
             }
-            onText?(committedText.uppercased())
+            emitUnmodifiedText(committedText.uppercased())
         } else {
-            onText?(committedText)
+            emitUnmodifiedText(committedText)
+        }
+    }
+
+    /// Route a committed block with no active modifier to either the per-key
+    /// input path or the bracketed-paste path.
+    ///
+    /// Single characters and Return keep riding ``onText`` so byte semantics
+    /// (CR for Return, control bytes, the existing per-keystroke flow) are
+    /// unchanged. A multi-character block — system dictation, an
+    /// autocorrect/predictive replacement, or keyboard-inserted clipboard text —
+    /// is sent through ``onPasteText`` so it reaches the remote terminal as one
+    /// bracketed paste instead of fragmenting on embedded newlines.
+    private func emitUnmodifiedText(_ text: String) {
+        switch TerminalCommitRouter.route(for: text) {
+        case .paste where onPasteText != nil:
+            onPasteText?(text)
+        case .paste, .input:
+            // No paste sink wired (or a single character): per-character input.
+            onText?(text)
         }
     }
 

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRoute.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRoute.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// How a committed block of terminal text (no active modifier) should reach the
+/// remote terminal.
+///
+/// The soft keyboard delivers committed text two ways that need different
+/// transports: a single typed character (or Return) is per-key input, while a
+/// multi-character block (system dictation, an autocorrect/predictive
+/// replacement, or keyboard-inserted clipboard text) should arrive as one
+/// *bracketed paste* so embedded newlines do not fragment into separate
+/// Returns. ``TerminalCommitRouter`` picks between them.
+public enum TerminalCommitRoute: Equatable, Sendable {
+    /// Send as ordinary per-character input (preserves CR-for-Return and control
+    /// byte semantics).
+    case input
+    /// Send as a single bracketed paste (multi-character block).
+    case paste
+}

--- a/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRouter.swift
+++ b/Packages/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalCommitRouter.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure transform deciding whether a committed, unmodified block of text should
+/// be sent as per-character input or as a bracketed paste.
+///
+/// Extracted from the iOS input view so the input-vs-paste policy is testable
+/// without a `UITextView`. The view calls ``route(for:)`` for the no-modifier
+/// commit path; any active Ctrl/Alt/Cmd/Shift modifier is resolved before this
+/// (those always use the per-key input/escape paths).
+///
+/// ```swift
+/// switch TerminalCommitRouter.route(for: text) {
+/// case .input: onText?(text)
+/// case .paste: onPasteText?(text)
+/// }
+/// ```
+public struct TerminalCommitRouter {
+    private init() {}
+
+    /// Classifies a committed block by character count.
+    ///
+    /// A block of more than one character (counted by `Character`, so an emoji
+    /// or other grapheme cluster is one) is treated as a paste; anything else
+    /// stays per-character input. The text is not transformed here.
+    /// - Parameter text: The committed block (already modifier-resolved).
+    /// - Returns: ``TerminalCommitRoute/paste`` for a multi-character block,
+    ///   otherwise ``TerminalCommitRoute/input``.
+    public static func route(for text: String) -> TerminalCommitRoute {
+        text.count > 1 ? .paste : .input
+    }
+}

--- a/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalCommitRouterTests.swift
+++ b/Packages/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalCommitRouterTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import CmuxMobileTerminalKit
+
+@Suite("TerminalCommitRouter input-vs-paste classification")
+struct TerminalCommitRouterTests {
+    @Test("a single character is per-character input")
+    func singleCharacterIsInput() {
+        #expect(TerminalCommitRouter.route(for: "a") == .input)
+    }
+
+    @Test("Return (a single character) stays input so CR semantics are preserved")
+    func returnIsInput() {
+        #expect(TerminalCommitRouter.route(for: "\n") == .input)
+    }
+
+    @Test("the empty string routes to input (no-op send)")
+    func emptyIsInput() {
+        #expect(TerminalCommitRouter.route(for: "") == .input)
+    }
+
+    @Test("a multi-character word is a paste")
+    func wordIsPaste() {
+        #expect(TerminalCommitRouter.route(for: "hello") == .paste)
+    }
+
+    @Test("a dictated multi-line block is a paste so it is not CR-fragmented")
+    func multilineBlockIsPaste() {
+        #expect(TerminalCommitRouter.route(for: "line one\nline two") == .paste)
+    }
+
+    @Test("a single emoji grapheme cluster is one character, so input")
+    func singleEmojiIsInput() {
+        // A flag emoji is multiple scalars but one Character, so it must not be
+        // mis-classified as a multi-character paste.
+        #expect(TerminalCommitRouter.route(for: "🇺🇸") == .input)
+    }
+
+    @Test("two emoji are a paste")
+    func twoEmojiArePaste() {
+        #expect(TerminalCommitRouter.route(for: "🇺🇸🇯🇵") == .paste)
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -300,6 +300,7 @@ final class MobileHostService {
     nonisolated static let mobileHostCapabilities: [String] = [
         "events.v1",
         "terminal.bytes.v1",
+        "terminal.paste.v1",
         "terminal.render_grid.v1",
         "terminal.replay.v1",
         "terminal.viewport.v1",
@@ -1264,6 +1265,7 @@ final class MobileHostService {
         case "mobile.terminal.create", "terminal.create":
             return nil
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1755,6 +1755,8 @@ class TerminalController {
             return v2Result(id: id, self.v2MobileTerminalCreate(params: params))
         case "mobile.terminal.input", "terminal.input":
             return v2Result(id: id, self.v2MobileTerminalInput(params: params))
+        case "mobile.terminal.paste", "terminal.paste":
+            return v2Result(id: id, self.v2MobileTerminalPaste(params: params))
         case "mobile.terminal.replay", "terminal.replay":
             return v2Result(id: id, self.v2MobileTerminalReplay(params: params))
         case "mobile.terminal.viewport", "terminal.viewport":
@@ -2294,10 +2296,12 @@ class TerminalController {
             "mobile.workspace.list",
             "mobile.terminal.create",
             "mobile.terminal.input",
+            "mobile.terminal.paste",
             "mobile.terminal.replay",
             "mobile.terminal.viewport",
             "terminal.create",
             "terminal.input",
+            "terminal.paste",
             "terminal.replay",
             "terminal.viewport",
             "auth.login",
@@ -20674,6 +20678,8 @@ class TerminalController {
             result = v2MobileTerminalCreate(params: request.params)
         case "mobile.terminal.input", "terminal.input":
             result = v2MobileTerminalInput(params: request.params)
+        case "mobile.terminal.paste", "terminal.paste":
+            result = v2MobileTerminalPaste(params: request.params)
         case "mobile.terminal.paste_image", "terminal.paste_image":
             result = v2MobileTerminalPasteImage(params: request.params)
         case "mobile.terminal.replay", "terminal.replay":
@@ -21332,6 +21338,62 @@ class TerminalController {
             "workspace_id": resolved.workspace.id.uuidString,
             "surface_id": terminalPanel.id.uuidString,
             "queued": sendResult == .queued,
+        ]
+        if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
+            payload["terminal_seq"] = seq
+        }
+        return .ok(payload)
+    }
+
+    /// Handle `terminal.paste`: a paired client (the iOS app) forwards a
+    /// committed block of text (system dictation, an autocorrect replacement, or
+    /// keyboard-inserted clipboard text) that should land as a *bracketed paste*.
+    ///
+    /// Unlike ``v2MobileTerminalInput(params:)`` (which routes through
+    /// `sendInputResult`, splitting control bytes and Returns into per-key
+    /// events), this routes through ``GhosttySurfaceView/sendText(_:)`` →
+    /// `ghostty_surface_text`, the same path a local clipboard paste uses. That
+    /// triggers bracketed-paste framing when the program enabled it, so embedded
+    /// newlines stay part of one paste instead of executing line-by-line.
+    private func v2MobileTerminalPaste(params: [String: Any]) -> V2CallResult {
+        guard let text = v2RawString(params, "text"), !text.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing text", data: nil)
+        }
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        if let error = mobileTerminalAliasValidationError(params: params) {
+            return error
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
+
+        // `sendText` returns false only when the surface is cold and cannot
+        // accept (or queue) the paste; a live surface always accepts. It does
+        // not distinguish queued vs sent, so report queued=false on success.
+        let accepted = terminalPanel.surface.sendText(text)
+        guard accepted else {
+            return .err(
+                code: "input_queue_full",
+                message: Self.terminalInputQueueFullMessage,
+                data: ["surface_id": surfaceId.uuidString]
+            )
+        }
+        terminalPanel.surface.forceRefresh(reason: "mobileHost.terminalPaste")
+        #if DEBUG
+        cmuxDebugLog(
+            "mobile.terminal.paste workspace=\(resolved.workspace.id.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) chars=\(text.count)"
+        )
+        #endif
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspace.id.uuidString,
+            "surface_id": terminalPanel.id.uuidString,
+            "queued": false,
         ]
         if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
             payload["terminal_seq"] = seq

--- a/scripts/decode-ios-diagnostic.py
+++ b/scripts/decode-ios-diagnostic.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Decode a cmux iOS structured diagnostic export blob into readable rows.
+
+The iOS feedback pane ("Send to agent") submits `DiagnosticLog.export()`, an
+opaque integer CSV, to the paired Mac. The Mac writes it to
+`~/.cache/cmux-dogfood-feedback/<ISO8601>_<shortid>/diagnostic.log`. This script
+turns that blob (or the whole bundle dir) into named events so the keyboard-input
+evidence (hold-backspace call count, dictation firing, first-responder identity)
+is human-readable.
+
+Usage:
+    scripts/decode-ios-diagnostic.py <diagnostic.log | bundle-dir>
+    scripts/decode-ios-diagnostic.py            # newest bundle under the cache dir
+
+Blob format (one header line + one row per event):
+    cmuxdiag v1 anchorWallNs=<n> anchorMonoNs=<n> count=<n> build=<...>
+    <tNanos>,<code>,<surface>,<ms>,<a>,<b>,<c>
+
+Empty fields mean the field was absent. Keep this in sync with
+Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift and the
+InputResponderIdentity / InputCommitSink enums.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# DiagnosticEventCode raw value -> (name, slot legend).
+EVENT_CODES = {
+    1: ("connect", ""),
+    2: ("pairOk", ""),
+    3: ("pairFail", ""),
+    4: ("renderGridLag", ""),
+    5: ("livenessResubscribe", ""),
+    6: ("streamEnded", ""),
+    7: ("inputSeqBehind", "a=localSeq b=remoteSeq"),
+    8: ("byteGap", ""),
+    9: ("error", ""),
+    10: ("inputKeyboardUp", "a=responderIdentity"),
+    11: ("inputDeleteBackward", "a=responderIdentity b=imeComposing"),
+    12: ("inputBackspaceEmitted", "ms=emittedBytes"),
+    13: ("inputInsertText", "a=utf8Len b=imeComposing"),
+    14: ("inputDictationPlaceholder", ""),
+    15: ("inputDictationRemove", "a=willInsertResult"),
+    16: ("inputBecomeFirstResponder", "a=became b=responderIdentity"),
+    17: ("inputCommitRouted", "a=utf8Len b=commitSink"),
+}
+
+# InputResponderIdentity raw value -> name.
+RESPONDER_IDENTITY = {
+    0: "none",
+    1: "terminalInputProxy",
+    2: "ghosttySurface",
+    3: "uiTextField",
+    4: "uiTextView",
+    9: "other",
+}
+
+# InputCommitSink raw value -> name.
+COMMIT_SINK = {
+    0: "text(perKey)",
+    1: "pasteText(bracketed)",
+    2: "escapeSequence",
+}
+
+# Codes whose `a` slot encodes an InputResponderIdentity.
+RESPONDER_A_CODES = {10, 11}
+# Codes whose `b` slot encodes an InputResponderIdentity.
+RESPONDER_B_CODES = {16}
+
+
+def _annotate(code: int, a: str, b: str) -> str:
+    notes: list[str] = []
+    if code in RESPONDER_A_CODES and a != "":
+        notes.append(f"responder={RESPONDER_IDENTITY.get(int(a), '?')}")
+    if code in RESPONDER_B_CODES and b != "":
+        notes.append(f"responder={RESPONDER_IDENTITY.get(int(b), '?')}")
+    if code == 17 and b != "":
+        notes.append(f"sink={COMMIT_SINK.get(int(b), '?')}")
+    return "  ".join(notes)
+
+
+def _resolve_path(arg: str | None) -> str:
+    if arg is None:
+        root = os.path.expanduser("~/.cache/cmux-dogfood-feedback")
+        if not os.path.isdir(root):
+            sys.exit(f"no bundle dir and {root} does not exist")
+        dirs = sorted(
+            (os.path.join(root, d) for d in os.listdir(root)),
+            reverse=True,
+        )
+        dirs = [d for d in dirs if os.path.isdir(d)]
+        if not dirs:
+            sys.exit(f"no bundles under {root}")
+        return os.path.join(dirs[0], "diagnostic.log")
+    if os.path.isdir(arg):
+        return os.path.join(arg, "diagnostic.log")
+    return arg
+
+
+def main() -> None:
+    path = _resolve_path(sys.argv[1] if len(sys.argv) > 1 else None)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except OSError as error:
+        sys.exit(f"cannot read {path}: {error}")
+
+    if not lines:
+        sys.exit(f"{path} is empty")
+
+    print(f"# {path}")
+    print(f"# {lines[0]}")
+    print()
+
+    # Counters for the hold-backspace + dictation summary.
+    delete_calls = 0
+    bytes_emitted = 0
+    insert_calls = 0
+    dictation_placeholder = 0
+    dictation_results = 0
+
+    base_ns: int | None = None
+    for raw in lines[1:]:
+        if not raw.strip():
+            continue
+        fields = raw.split(",")
+        if len(fields) < 2:
+            continue
+        t_ns = int(fields[0])
+        code = int(fields[1])
+        surface, ms, a, b, c = (fields + ["", "", "", "", ""])[2:7]
+        if base_ns is None:
+            base_ns = t_ns
+        rel_ms = (t_ns - base_ns) / 1_000_000.0
+
+        name, legend = EVENT_CODES.get(code, (f"code{code}", ""))
+        annotation = _annotate(code, a, b)
+        slots = []
+        if surface:
+            slots.append(f"surface={surface}")
+        if ms:
+            slots.append(f"ms={ms}")
+        if a:
+            slots.append(f"a={a}")
+        if b:
+            slots.append(f"b={b}")
+        if c:
+            slots.append(f"c={c}")
+        slot_text = " ".join(slots)
+        tail = "  ".join(p for p in (slot_text, annotation, f"({legend})" if legend else "") if p)
+        print(f"+{rel_ms:9.2f}ms  {name:<26} {tail}")
+
+        if code == 11:
+            delete_calls += 1
+        elif code == 12:
+            bytes_emitted += 1
+        elif code == 13:
+            insert_calls += 1
+        elif code == 14:
+            dictation_placeholder += 1
+        elif code == 15 and a == "1":
+            dictation_results += 1
+
+    print()
+    print("# hold-backspace + dictation summary")
+    print(f"#   deleteBackward calls : {delete_calls}")
+    print(f"#   DEL bytes emitted    : {bytes_emitted}")
+    print(f"#   insertText calls     : {insert_calls}")
+    print(f"#   dictation placeholder: {dictation_placeholder}")
+    print(f"#   dictation results    : {dictation_results}")
+    if delete_calls <= 1:
+        print("#   -> hold-backspace did NOT auto-repeat (<=1 deleteBackward call)")
+    elif delete_calls == bytes_emitted:
+        print("#   -> deleteBackward repeated AND every call emitted a DEL byte; hunt is downstream of the iOS view")
+    else:
+        print(f"#   -> deleteBackward repeated ({delete_calls}) but only {bytes_emitted} bytes left the view")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
DEBUG-only `DiagnosticLog` instrumentation on the iOS terminal keyboard-input path so an on-device dogfood reveals **why** hold-to-repeat backspace and dictation fail. The simulator cannot reproduce either, so the three prior fixes (app-buttons; `hasText=true` UITextView in #5573; documentless `UIView`+`UIKeyInput`+`UITextInput` in #5596) were all unverified guesses that Lawrence confirmed on-device still leave both broken. This round gathers evidence instead of guessing the mechanism. No behavior change; instrument-only.

Stacked on #5596 (the documentless input view it instruments) and depends on #5574's `DiagnosticLog` (already merged to main). This PR includes #5596 as a prerequisite (it is not yet on main); the review-relevant change is the single final commit `iOS: instrument keyboard-input path`. Once #5596 lands, that commit rebases onto main with no other files.

## Static finding (the hypothesis)

The task hypothesis was "`TerminalInputTextView` is not the first responder, so the keyboard never drives it." Static reading makes that the **intended + most-likely** first responder, not a confirmed culprit: `GhosttySurfaceView.focusInput()` calls `inputProxy.becomeFirstResponder()`, the proxy is the only `canBecomeFirstResponder` view in the terminal package, and there is **no iOS `keyRepair` analog** anywhere in the app (the whole-app grep for `becomeFirstResponder`/`resignFirstResponder` turns up only `ShortcutRecorderView` on macOS and the global `KeyboardDismissal`). Single-character typing already works, which means the keyboard *is* driving this view. So the runtime probe's job is to distinguish "`deleteBackward` fires once, no repeat" from "fires many but the byte is lost", and to confirm dictation engages this view at all. The probe confirms identity at runtime rather than asserting it.

## What this adds

- 8 `DiagnosticEventCode` cases (10-17) + `InputResponderIdentity` / `InputCommitSink` enums (integer-encoded, since `DiagnosticEvent` carries only ints).
- `TerminalInputTextView` records `deleteBackward` on **every** call (held backspace = 1 vs N), `insertText`, `becomeFirstResponder`, both dictation placeholder hooks, and commit routing.
- `GhosttySurfaceView` records the first responder identity at keyboard-up and the **emitted DEL byte** — so N delete calls vs N emitted bytes tells us whether the failure is in the iOS view or downstream.
- `DiagnosticLog` is property-injected store -> `GhosttySurfaceView` -> `inputProxy` (matches `autoFocusOnWindowAttach`; no init-param break of `TerminalLayoutPreviewView` / `MobileZoomStressHarness`).
- `CurrentResponderProbe` resolves the live first responder via the `sendAction(to: nil)` responder-chain walk (no public iOS API exists).
- Every probe mirrors through `MobileDebugLog.anchormux` for a copyable human-readable readback (carries the exact responder class name for the `.other` case).
- `scripts/decode-ios-diagnostic.py` decodes the opaque integer export blob. The feedback pane (#5597) submits `DiagnosticLog.export()`, which the paired Mac writes to `~/.cache/cmux-dogfood-feedback/<ts>/diagnostic.log`. The decoder prints a hold-backspace + dictation summary (delete-call count vs DEL bytes emitted, dictation fired or not).

## Gating

DEBUG-only (`#if DEBUG`), like the existing `DiagnosticLog` record sites and `anchormux` — **not** env-gated like the older `TerminalInputDebugLog` (`CMUX_INPUT_DEBUG`), so a `reload-cloud-ios` device build with no env vars still captures every event.

## Verification

Compiles in the unified dog build (iOS Simulator, arm64, BUILD SUCCEEDED) with this instrumentation + #5597's feedback pane merged. The decoder is unit-exercised against a synthetic blob.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783480944&installation_id=133855650&pr_number=5605&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5605&signature=03b5069a67db38c49f2f1377ea988bd4b6e976fe95a9939b5b21e66179c085e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hot-path `record` calls and shell reconnect/feedback paths add complexity; release impact is limited by `#if DEBUG` on probes, but toolbar v3 migration and the 6s restoring deadline affect all users.
> 
> **Overview**
> Adds a **structured `DiagnosticLog` stack** in `CMUXMobileCore` (integer `DiagnosticEvent` codes, ring buffer + export) and wires it through the mobile shell: connect/pair/sync/liveness/seq-gap sites dual-emit alongside `MobileDebugLog`, with an optional injected log on `MobileShellComposite`.
> 
> The **DEBUG iOS keyboard-input evidence round** is the main behavioral addition on the input path: eight new event codes (10–17), `InputResponderIdentity` / `InputCommitSink`, `CurrentResponderProbe`, and probes on `TerminalInputTextView` (every `deleteBackward`, `insertText`, dictation hooks, commit routing, `becomeFirstResponder`) and `GhosttySurfaceView` (keyboard-up first responder, emitted DEL byte). The log flows **store → `GhosttySurfaceRepresentable` → surface → input proxy**; events mirror to `anchormux` for human-readable class names.
> 
> **DEBUG dogfood feedback** submits `DiagnosticLog.export()` plus debug log and terminal snapshot via `dogfood.feedback.submit` (off-main encoding, size caps); the Mac advertises `dogfood.v1` in DEBUG. Related dev ergonomics: `CMUX_DOGFOOD_ATTACH_URL` auto-pair (not mock-gated), Mac `DebugDogfoodCredentialResolver` for DEBUG auto-sign-in, and a **6s cap** on the stored-Mac “Restoring session…” gate.
> 
> The same diff also ships **terminal toolbar v3** (modifiers/zoom/paste user-reorderable with migration), Liquid Glass / configuration-based accessory styling, settings for **wrap workspace titles** + **About version** (`AppVersionInfo`), and workspace list copy that drops host from row bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56dec528687fa867faa8e068b23375c01edcc199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DEBUG-only structured diagnostics to the iOS terminal keyboard path to capture on-device evidence for hold-to-repeat backspace and dictation failures. No behavior changes; this only logs and exports data for analysis.

- **New Features**
  - Introduce `DiagnosticLog` in `CMUXMobileCore` with compact `DiagnosticEvent`s and new keyboard-specific codes.
  - Add `InputResponderIdentity` and `InputCommitSink` to encode first-responder class and commit routing.
  - Instrument `TerminalInputTextView` to record every `deleteBackward`, `insertText`, `becomeFirstResponder`, dictation placeholder hooks, and commit sink.
  - Instrument `GhosttySurfaceView` to log keyboard-up first responder and each emitted DEL byte.
  - Add `CurrentResponderProbe` to resolve the live first responder via a responder-chain walk.
  - Dual-emit readable copies via `MobileDebugLog.anchormux` for quick inspection.
  - Wire the log through SwiftUI (`GhosttySurfaceRepresentable`) so the feedback pane export includes it; add `scripts/decode-ios-diagnostic.py` to decode and summarize hold-backspace vs DEL bytes and dictation.
  - DEBUG-only (`#if DEBUG`); no env flags needed. Unit tests cover the ring/export path.

<sup>Written for commit 56dec528687fa867faa8e068b23375c01edcc199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


