### PR TITLE
iOS: make terminal picker a native Menu (tap + press-drag-release)

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -21,7 +21,6 @@ struct WorkspaceDetailView: View {
     let reportTerminalViewport: (MobileWorkspacePreview.ID, MobileTerminalPreview.ID, MobileTerminalViewportSize) -> Void
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
-    @State private var isTerminalPickerPresented = false
     #if DEBUG && canImport(UIKit)
     @State private var isFeedbackComposerPresented = false
     @State private var feedbackText = ""
@@ -132,10 +131,19 @@ struct WorkspaceDetailView: View {
         .accessibilityIdentifier("MobileTerminalNewWorkspaceButton")
     }
 
+    // The picker is a native SwiftUI `Menu`, which renders as the platform menu
+    // (a `UIMenu` on iOS). That gives the standard menu gesture for free: a
+    // single tap opens it, and a press-and-drag from the button onto an item
+    // followed by a release selects that item. The previous `Button` +
+    // `.popover` was two separate hit-test sessions (tap to present, then tap an
+    // item), so it never supported press-drag-release. Selection still routes
+    // through `selectTerminalFromPicker`, which dismisses the keyboard, so the
+    // chrome behavior is preserved; only keyboard-dismiss-on-open is dropped
+    // because `Menu` has no will-open hook (the menu simply floats over the live
+    // keyboard like any nav-bar menu).
     private var terminalPickerToolbarButton: some View {
-        Button {
-            dismissTerminalKeyboardForChrome()
-            isTerminalPickerPresented = true
+        Menu {
+            terminalPickerMenuContent
         } label: {
             Label(
                 selectedTerminal?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
@@ -146,19 +154,11 @@ struct WorkspaceDetailView: View {
         .foregroundStyle(TerminalPalette.foreground)
         .accessibilityIdentifier("MobileTerminalDropdown")
         .accessibilityValue(host)
-        .popover(isPresented: $isTerminalPickerPresented, arrowEdge: .top) {
-            terminalPickerContent
-        }
     }
 
-    private var terminalPickerContent: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals"))
-                .font(.headline)
-                .padding(.horizontal, 16)
-                .padding(.top, 14)
-                .padding(.bottom, 8)
-
+    @ViewBuilder
+    private var terminalPickerMenuContent: some View {
+        Section(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals")) {
             ForEach(workspace.terminals) { terminal in
                 Button {
                     selectTerminalFromPicker(terminal.id)
@@ -167,69 +167,42 @@ struct WorkspaceDetailView: View {
                         terminal.name,
                         systemImage: terminal.id == selectedTerminal?.id ? "checkmark.circle.fill" : "terminal"
                     )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
                 .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
             }
+        }
 
-            Divider()
-                .padding(.vertical, 4)
-
+        Section {
             Button(action: createWorkspaceFromTerminalPicker) {
                 Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus.square.on.square")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
             .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
 
             Button(action: createTerminalFromToolbar) {
                 Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
             .accessibilityIdentifier("MobileNewTerminalMenuItem")
+        }
 
-            #if DEBUG && canImport(UIKit)
+        #if DEBUG && canImport(UIKit)
+        Section {
             Button(action: copyDebugLogsFromMenu) {
                 // DEV-only debug tooling; not shipped, so not localized.
                 Label("Copy Debug Logs", systemImage: "doc.on.clipboard")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
             .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
 
             Button(action: openFeedbackComposerFromMenu) {
                 // DEV-only debug tooling; not shipped, so not localized.
                 Label("Send to agent", systemImage: "paperplane")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
             .accessibilityIdentifier("MobileSendFeedbackMenuItem")
-            #endif
         }
-        .frame(minWidth: 240, maxWidth: 320, alignment: .leading)
-        .presentationCompactAdaptation(.popover)
+        #endif
     }
 
     #if DEBUG && canImport(UIKit)
     private func copyDebugLogsFromMenu() {
-        isTerminalPickerPresented = false
         // Include "what the user sees" (the visible terminal text) above the
         // debug log so a pasted bug report shows the on-screen content too.
         let terminalText = GhosttySurfaceView.visibleTerminalSnapshot()
@@ -241,7 +214,6 @@ struct WorkspaceDetailView: View {
     }
 
     private func openFeedbackComposerFromMenu() {
-        isTerminalPickerPresented = false
         feedbackText = ""
         isFeedbackComposerPresented = true
     }
@@ -310,19 +282,16 @@ struct WorkspaceDetailView: View {
 
     private func createWorkspaceFromTerminalPicker() {
         dismissTerminalKeyboardForChrome()
-        isTerminalPickerPresented = false
         createWorkspace()
     }
 
     private func createTerminalFromToolbar() {
         dismissTerminalKeyboardForChrome()
-        isTerminalPickerPresented = false
         createTerminal()
     }
 
     private func selectTerminalFromPicker(_ terminalID: MobileTerminalPreview.ID) {
         dismissTerminalKeyboardForChrome()
-        isTerminalPickerPresented = false
         // Switching from the picker is chrome, not a typing intent, so the
         // newly-selected surface must not grab the keyboard on attach. The
         // store suppresses the target's autofocus (and is a no-op when it is

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -173,7 +173,7 @@ struct WorkspaceDetailView: View {
         }
 
         Section {
-            Button(action: createWorkspaceFromTerminalPicker) {
+            Button(action: createWorkspaceFromToolbar) {
                 Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus.square.on.square")
             }
             .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
@@ -276,11 +276,6 @@ struct WorkspaceDetailView: View {
     #endif
 
     private func createWorkspaceFromToolbar() {
-        dismissTerminalKeyboardForChrome()
-        createWorkspace()
-    }
-
-    private func createWorkspaceFromTerminalPicker() {
         dismissTerminalKeyboardForChrome()
         createWorkspace()
     }


### PR DESCRIPTION
## What

The top-right terminal picker on the iOS workspace detail screen (the `terminal` button that lists all terminals in the workspace) used a `Button` toggling a custom `.popover`. A `Button` + `.popover` is two separate hit-test sessions: you tap the button to present the popover, then tap an item. It never supported the standard iOS menu gesture, where you press-and-drag from the button straight onto an item and release to select it.

This replaces it with a native SwiftUI `Menu`. On iOS, `Menu` renders as a `UIMenu`, which gives both interaction modes for free: single tap to open then tap an item, and press-drag-release-to-select, exactly like any native nav-bar menu.

## Behavior preserved

- The menu lists all terminals in the workspace; selecting one switches to it via `selectTerminalFromChrome` (keyboard suppressed on attach, same as before).
- Selected terminal still shows a checkmark.
- "New Workspace", "New Terminal", and the DEBUG-only "Copy Debug Logs" / "Send to agent" entries are kept, grouped into `Section`s.
- All existing accessibility identifiers (`MobileTerminalDropdown`, `MobileTerminalMenuItem-*`, `MobileNewTerminalMenuItem`, `MobileNewWorkspaceMenuItem`) are kept on the same buttons.

## Only behavior change

`Menu` has no will-open hook, so the keyboard is no longer dismissed when the menu opens (the menu floats over the live keyboard like any nav-bar menu). The keyboard still clears on selection, since the action handlers call `dismissTerminalKeyboardForChrome()`.

## Verification

- Clean iOS simulator build of the `cmux-ios` workspace scheme (arm64 simulator, build-only, no device, no test, no launch): BUILD SUCCEEDED.
- iOS UI tests that drive the picker (`testTerminalDropdownSwitchesToAlternateScreenSnapshot`, `testWorkspaceToolbarCreatesWorkspaceAndTerminal`, `testTUITerminalUsesAvailableViewportAndResizes`) run on the `iOS simulator tests` workflow, which gates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783485204&installation_id=133855650&pr_number=5618&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5618&signature=7c44429e7ee9f1cc90fb3f8b0a8797d63dc9d23b3c7413d669240947a0748ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI toolbar change on iOS with preserved accessibility IDs and selection logic; minor keyboard-on-open behavior change only.
> 
> **Overview**
> Replaces the workspace toolbar **terminal picker** from a `Button` + custom `.popover` to a native SwiftUI **`Menu`** (iOS `UIMenu`), so users get standard **tap-to-open** and **press-drag-release** selection instead of two separate tap sessions.
> 
> The menu content is reorganized into **`Section`s** (terminals, new workspace/terminal actions, DEBUG tools) with less custom padding/layout; **accessibility identifiers** and selection via `selectTerminalFromPicker` / `selectTerminalFromChrome` are unchanged. **New Workspace** from the menu now uses `createWorkspaceFromToolbar` directly (duplicate picker-only helper removed).
> 
> **Only UX delta:** the keyboard is **no longer dismissed when the menu opens** (`Menu` has no will-open hook); it still dismisses when an item is chosen because actions call `dismissTerminalKeyboardForChrome()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c3d85f05333f66c244f4fe919a992909da756b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the terminal picker popover with a native SwiftUI `Menu` in the iOS workspace toolbar, enabling tap and press-drag-release selection and preserving existing items/accessibility IDs. The "New Workspace" action now uses `createWorkspaceFromToolbar`; the keyboard stays up on open and still dismisses on selection.

<sup>Written for commit 76240aa8cce5d04e982a787a2fdbb8fadc6e0126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Terminal picker in the workspace detail view now uses the native menu for improved accessibility and consistency.
  * Menu groups terminals, New Workspace, and New Terminal actions for a clearer flow.

* **Bug Fixes**
  * Keyboard reliably dismisses when launching or selecting terminals/workspaces from the menu.
  * Debug and feedback actions no longer interfere with terminal selection or picker behavior.

* **New Features**
  * Debug-only options (Copy Debug Logs, Send to agent) available in debug builds for easier testing and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->