### PR TITLE
Codex: don't displace a live different session's resume binding (no-TTY slice)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1181,12 +1181,80 @@ private final class ClaudeHookSessionStore {
         }
     }
 
+    /// Whether the given surface is still owned by a *different*, older, live agent session — the one
+    /// whose resume binding the caller must not displace.
+    ///
+    /// "Live" means the recorded PID still has a running process, regardless of `runtimeStatus`: a
+    /// session paused on an approval prompt (`needsInput`), idle at the prompt (`idle`), or in an
+    /// `error` state is still resumable (unlike `hasRunningSession`, which only counts `.running`).
+    /// "Owner" means it started before the current session (`olderThan`): the original occupant wins,
+    /// and a later, misrouted session does not in turn block the owner's own resume updates.
+    func hasLiveProcessSessionOnSurface(
+        workspaceId: String,
+        surfaceId: String,
+        excludingSessionId: String?,
+        olderThan currentSessionStartedAt: TimeInterval?
+    ) throws -> Bool {
+        guard let normalizedWorkspace = normalizeOptional(workspaceId),
+              let normalizedSurface = normalizeOptional(surfaceId) else {
+            return false
+        }
+        let excluded = normalizeOptional(excludingSessionId)
+        return try withLockedState { state in
+            for sessionId in Array(state.sessions.keys) {
+                guard let record = state.sessions[sessionId] else { continue }
+                guard normalizeOptional(record.workspaceId) == normalizedWorkspace,
+                      normalizeOptional(record.surfaceId) == normalizedSurface,
+                      record.sessionId != excluded,
+                      let pid = record.pid,
+                      Self.processExists(pid) else {
+                    continue
+                }
+                // Ownership tiebreaker: only yield to a session that started before the current one.
+                // The original surface owner started first; a misrouted newcomer is younger and must
+                // not, in turn, suppress the owner's own later resume updates (symmetric blocking).
+                if let currentSessionStartedAt, record.startedAt >= currentSessionStartedAt {
+                    continue
+                }
+                // Defend against PID reuse: a crashed agent's record can linger with a PID later
+                // recycled by an unrelated long-lived process, which `kill(pid, 0)` would report as
+                // live and wrongly suppress a fresh session's binding (breaking resume-latest
+                // takeover). Only treat the PID as the original agent when its process did not start
+                // after the session's last recorded activity — a recycled PID belongs to a process
+                // that started later than the crashed agent's last hook event, whereas a genuine
+                // (including freshly-resumed) agent updates the record at/after it starts. If the
+                // start time is unreadable, do not suppress the fresh binding.
+                if let started = Self.processStartTime(pid),
+                   started <= record.updatedAt + Self.pidOwnershipSlackSeconds {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+
     private static func processExists(_ pid: Int?) -> Bool {
         guard let pid, pid > 0 else { return false }
         if kill(pid_t(pid), 0) == 0 {
             return true
         }
         return errno == EPERM
+    }
+
+    /// Slack (seconds) allowed between a session's last recorded activity and its process start time
+    /// before the PID is treated as recycled. A genuine agent's process starts at or before its own
+    /// hook updates the record, so this only needs to absorb clock skew, not real lifetime.
+    private static let pidOwnershipSlackSeconds: TimeInterval = 5
+
+    /// Best-effort wall-clock start time (seconds since epoch) of `pid`, or nil if unreadable.
+    private static func processStartTime(_ pid: Int) -> TimeInterval? {
+        guard pid > 0 else { return nil }
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.size
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, Int32(pid)]
+        guard sysctl(&mib, 4, &info, &size, nil, 0) == 0, size > 0 else { return nil }
+        let started = info.kp_proc.p_un.__p_starttime
+        return TimeInterval(started.tv_sec) + TimeInterval(started.tv_usec) / 1_000_000
     }
 
     /// Returns true when an event belongs to the workspace's active Claude session.
@@ -28006,6 +28074,46 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 requireLiveProcess: true
             )) == true
         }
+        func liveDifferentSessionOwnsSurface(workspaceId: String, surfaceId: String) -> Bool {
+            // Live PID regardless of runtimeStatus (a session paused on an approval prompt is still
+            // live), validated against PID reuse, and scoped to a session older than this one so a
+            // misrouted newcomer does not symmetrically block the original owner's resume updates.
+            let currentStartedAt = (try? store.lookup(sessionId: sessionId))?.startedAt
+            return (try? store.hasLiveProcessSessionOnSurface(
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                excludingSessionId: sessionId,
+                olderThan: currentStartedAt
+            )) == true
+        }
+        // Publish this session's surface resume binding UNLESS a *different* agent session is still
+        // live on the same surface. That only happens when PID/TTY ground truth is unavailable
+        // (remote/SSH) and a leaked CMUX_SURFACE_ID routes this hook onto the live session's pane —
+        // the slice https://github.com/manaflow-ai/cmux/issues/5333's PID/TTY override punts on.
+        // Overwriting the live session's binding would orphan the running thread across reload, so
+        // preserve it. A stopped/dead prior session does not count (`requireLiveProcess`), so normal
+        // resume-latest takeover of a finished session is unaffected.
+        func publishResumeBindingUnlessLiveSurfaceOwner(
+            workspaceId: String,
+            surfaceId: String,
+            cwd: String?,
+            launchCommand: AgentHookLaunchCommandRecord?
+        ) {
+            if liveDifferentSessionOwnsSurface(workspaceId: workspaceId, surfaceId: surfaceId) {
+                telemetry.breadcrumb("\(def.name)-hook.preserve-live-surface-binding")
+                return
+            }
+            publishAgentSurfaceResumeBinding(
+                client: client,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                kind: def.name,
+                displayName: def.displayName,
+                sessionId: sessionId,
+                cwd: cwd,
+                launchCommand: launchCommand
+            )
+        }
         func setIdleStatusUnlessAnotherSessionIsRunning(workspaceId: String, surfaceId: String) {
             if hasOtherRunningSession(workspaceId: workspaceId) {
 #if DEBUG
@@ -28236,13 +28344,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     telemetry.breadcrumb("\(def.name)-hook.session-start.nested-suppressed")
                 } else {
                     try? store.clearNotificationEmission(sessionId: sessionId)
-                    publishAgentSurfaceResumeBinding(
-                        client: client,
+                    publishResumeBindingUnlessLiveSurfaceOwner(
                         workspaceId: workspaceId,
                         surfaceId: surfaceId,
-                        kind: def.name,
-                        displayName: def.displayName,
-                        sessionId: sessionId,
                         cwd: hookCwd ?? mapped?.cwd,
                         launchCommand: launchCommand
                     )
@@ -28352,13 +28456,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     updateRuntimeStatus: true
                 )
                 try? store.clearNotificationEmission(sessionId: sessionId)
-                publishAgentSurfaceResumeBinding(
-                    client: client,
+                publishResumeBindingUnlessLiveSurfaceOwner(
                     workspaceId: workspaceId,
                     surfaceId: surfaceId,
-                    kind: def.name,
-                    displayName: def.displayName,
-                    sessionId: sessionId,
                     cwd: hookCwd ?? mapped?.cwd,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )
@@ -28592,13 +28692,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                                   updateLastNotificationStatus: true,
                                   runtimeStatus: (antigravityHasActiveBackgroundWork && stopNotificationStatus == .idle) ? .running : runtimeStatus(for: stopNotificationStatus),
                                   updateRuntimeStatus: true)
-                publishAgentSurfaceResumeBinding(
-                    client: client,
+                publishResumeBindingUnlessLiveSurfaceOwner(
                     workspaceId: workspaceId,
                     surfaceId: surfaceId,
-                    kind: def.name,
-                    displayName: def.displayName,
-                    sessionId: sessionId,
                     cwd: cwd,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )
@@ -28749,13 +28845,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     agentLifecycle: .running,
                     runtimeStatus: .running
                 )
-                publishAgentSurfaceResumeBinding(
-                    client: client,
+                publishResumeBindingUnlessLiveSurfaceOwner(
                     workspaceId: workspaceId,
                     surfaceId: surfaceId,
-                    kind: def.name,
-                    displayName: def.displayName,
-                    sessionId: sessionId,
                     cwd: hookCwd ?? mapped?.cwd,
                     launchCommand: launchCommand ?? mapped?.launchCommand
                 )

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3517,6 +3517,473 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    /// Characterization: resume-latest is intentionally PRESERVED for a stopped/finished prior
+    /// session. When the session previously on a surface has exited (dead pid), a fresh codex
+    /// session-start SHOULD publish its own resume binding and take over the surface. This is the
+    /// common single-terminal case (the prior process is gone before the next starts), and the
+    /// live-binding guard must not change it. Stays GREEN before and after the fix.
+    func testCodexSessionStartPublishesWhenPriorSessionOnSurfaceIsStopped() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-stopped")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-stopped-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionA = "codex-stopped-session-aaaa"   // finished prior thread on the surface
+        let sessionB = "codex-stopped-session-bbbb"   // fresh codex taking over the surface
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        // A definitely-exited pid: the prior session is finished, so it must NOT block takeover
+        // (`hasRunningSession(requireLiveProcess:)` self-heals a dead-pid record).
+        let deadHelper = Process()
+        deadHelper.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try deadHelper.run()
+        deadHelper.waitUntilExit()
+        let deadPID = Int(deadHelper.processIdentifier)
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let now = Date().timeIntervalSince1970
+        let seededStore: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionA: [
+                    "sessionId": sessionA,
+                    "workspaceId": workspaceId,
+                    "surfaceId": surfaceId,
+                    "cwd": root.path,
+                    "pid": deadPID,
+                    "runtimeStatus": "running",
+                    "startedAt": now,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seededStore, options: [.prettyPrinted])
+            .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else { return "OK" }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "debug.terminals":
+                return self.v2Response(id: id, ok: true, result: ["terminals": []])
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["ok": true])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = "/usr/local/bin/codex"
+        environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(["/usr/local/bin/codex"])
+        environment.removeValue(forKey: "CMUX_CLI_TTY_NAME")
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "session-start"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionB)","cwd":"\#(root.path)","hook_event_name":"SessionStart"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let resumeSets = state.snapshot().compactMap { command -> [String: Any]? in
+            guard let payload = self.jsonObject(command),
+                  payload["method"] as? String == "surface.resume.set" else { return nil }
+            return payload["params"] as? [String: Any]
+        }
+        let publishedByB = resumeSets.contains {
+            ($0["checkpoint_id"] as? String) == sessionB && ($0["surface_id"] as? String) == surfaceId
+        }
+        XCTAssertTrue(
+            publishedByB,
+            """
+            a fresh codex session-start must take over a surface whose prior session has exited \
+            (resume-latest preserved); the live-binding guard must not block this. \
+            resumeSets=\(resumeSets)
+            """
+        )
+    }
+
+    /// Regression (the uncontested live-clobber defect): a fresh codex session-start must NOT displace
+    /// the resume binding of a DIFFERENT session that is still LIVE on the same surface.
+    ///
+    /// In the common single-terminal flow this cannot happen — the prior process is dead before a new
+    /// one starts in the same TTY, and `hasRunningSession(requireLiveProcess:)` self-heals the stale
+    /// record. It bites in the remote/SSH slice that #5333's PID/TTY override explicitly punts on:
+    /// when no controlling TTY is available, a leaked `CMUX_SURFACE_ID` routes a fresh session onto a
+    /// genuinely-live session's pane. Overwriting that live session's binding orphans the running
+    /// thread across reload. This models exactly that slice: A is seeded live + running, no TTY truth
+    /// is available, and the env surface id points at A's pane.
+    ///
+    /// RED before the fix (the hook publishes B's binding unconditionally), GREEN after.
+    func testCodexSessionStartDoesNotDisplaceLiveDifferentSessionWithoutTTYTruth() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-live")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-live-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"   // A's pane; leaked into B's env
+        let sessionA = "codex-live-session-aaaa"   // still running on the surface
+        let sessionB = "codex-live-session-bbbb"   // a fresh codex misrouted onto A's pane
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        // A genuinely-live process so the surface still has a live agent (`processExists(pid)`).
+        let liveHelper = Process()
+        liveHelper.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        liveHelper.arguments = ["600"]
+        try liveHelper.run()
+        let livePID = Int(liveHelper.processIdentifier)
+
+        defer {
+            liveHelper.terminate()
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        // Seed A as live + running, bound to the surface.
+        let now = Date().timeIntervalSince1970
+        let seededStore: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionA: [
+                    "sessionId": sessionA,
+                    "workspaceId": workspaceId,
+                    "surfaceId": surfaceId,
+                    "cwd": root.path,
+                    "pid": livePID,
+                    "runtimeStatus": "running",
+                    "startedAt": now - 60,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seededStore, options: [.prettyPrinted])
+            .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else { return "OK" }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "debug.terminals":
+                // No controlling TTY is known, so there is no PID/TTY ground truth to override the
+                // leaked env surface (the remote/SSH slice #5333 punts on).
+                return self.v2Response(id: id, ok: true, result: ["terminals": []])
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["ok": true])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId   // leaked: points at A's live pane
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = "/usr/local/bin/codex"
+        environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(["/usr/local/bin/codex"])
+        // No controlling TTY: ensure the PID/TTY override has nothing to work with.
+        environment.removeValue(forKey: "CMUX_CLI_TTY_NAME")
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "session-start"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionB)","cwd":"\#(root.path)","hook_event_name":"SessionStart"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let resumeSets = state.snapshot().compactMap { command -> [String: Any]? in
+            guard let payload = self.jsonObject(command),
+                  payload["method"] as? String == "surface.resume.set" else { return nil }
+            return payload["params"] as? [String: Any]
+        }
+        let displacedByB = resumeSets.contains { ($0["checkpoint_id"] as? String) == sessionB }
+        XCTAssertFalse(
+            displacedByB,
+            """
+            a fresh codex session-start must not displace a LIVE different session's resume binding \
+            (remote/no-TTY slice). session B published a binding for surface \(surfaceId), orphaning \
+            the still-running session A. resumeSets=\(resumeSets)
+            """
+        )
+    }
+
+    /// Regression for the same live-clobber defect when the live prior session is paused on an
+    /// approval prompt. A waiting agent is persisted as `runtimeStatus == needsInput`, not `running`,
+    /// while its process and resume binding are still valid. The guard must key off the live PID, not
+    /// the runtime status, or it would still orphan a session that is merely waiting for input.
+    ///
+    /// RED if the guard only checks `runtimeStatus == .running`; GREEN once it checks a live PID.
+    func testCodexSessionStartDoesNotDisplaceLiveNeedsInputSessionWithoutTTYTruth() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-needsinput")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-needsinput-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"   // A's pane; leaked into B's env
+        let sessionA = "codex-ni-session-aaaa"   // live, paused on an approval prompt
+        let sessionB = "codex-ni-session-bbbb"   // a fresh codex misrouted onto A's pane
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        // A genuinely-live process: the agent is alive but waiting for input, not running a turn.
+        let liveHelper = Process()
+        liveHelper.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        liveHelper.arguments = ["600"]
+        try liveHelper.run()
+        let livePID = Int(liveHelper.processIdentifier)
+
+        defer {
+            liveHelper.terminate()
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        // Seed A as live but in needsInput (paused on an approval prompt), bound to the surface.
+        let now = Date().timeIntervalSince1970
+        let seededStore: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionA: [
+                    "sessionId": sessionA,
+                    "workspaceId": workspaceId,
+                    "surfaceId": surfaceId,
+                    "cwd": root.path,
+                    "pid": livePID,
+                    "runtimeStatus": "needsInput",
+                    "startedAt": now - 60,
+                    "updatedAt": now,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seededStore, options: [.prettyPrinted])
+            .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else { return "OK" }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "debug.terminals":
+                return self.v2Response(id: id, ok: true, result: ["terminals": []])
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["ok": true])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId   // leaked: points at A's live pane
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = "/usr/local/bin/codex"
+        environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(["/usr/local/bin/codex"])
+        environment.removeValue(forKey: "CMUX_CLI_TTY_NAME")
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "session-start"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionB)","cwd":"\#(root.path)","hook_event_name":"SessionStart"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let resumeSets = state.snapshot().compactMap { command -> [String: Any]? in
+            guard let payload = self.jsonObject(command),
+                  payload["method"] as? String == "surface.resume.set" else { return nil }
+            return payload["params"] as? [String: Any]
+        }
+        let displacedByB = resumeSets.contains { ($0["checkpoint_id"] as? String) == sessionB }
+        XCTAssertFalse(
+            displacedByB,
+            """
+            a fresh codex session-start must not displace a LIVE different session that is waiting \
+            for input (needsInput). session B published a binding for surface \(surfaceId), orphaning \
+            the still-live session A. resumeSets=\(resumeSets)
+            """
+        )
+    }
+
+    /// Resume-latest must still work when a prior session's record lingers with a PID that has been
+    /// recycled by an unrelated live process (e.g. the agent crashed without a session-end). A bare
+    /// `kill(pid, 0)` would treat the recycled PID as the live agent and wrongly suppress the fresh
+    /// session's binding. The guard compares the process start time to the record's last activity, so
+    /// a process that started long after the record is not mistaken for the original agent.
+    ///
+    /// RED if the guard keys off PID existence alone; GREEN once it validates the process start time.
+    func testCodexSessionStartTakesOverWhenPriorRecordPidWasRecycled() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-reuse")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-reuse-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionA = "codex-reuse-session-aaaa"   // finished long ago; its PID was recycled
+        let sessionB = "codex-reuse-session-bbbb"   // fresh codex taking over the surface
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        // A live, unrelated process standing in for the recycled PID: it started "now", but the
+        // seeded session's last activity is an hour ago, so it cannot be the original agent.
+        let recycler = Process()
+        recycler.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        recycler.arguments = ["600"]
+        try recycler.run()
+        let recycledPID = Int(recycler.processIdentifier)
+
+        defer {
+            recycler.terminate()
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let staleActivity = Date().timeIntervalSince1970 - 3600
+        let seededStore: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                sessionA: [
+                    "sessionId": sessionA,
+                    "workspaceId": workspaceId,
+                    "surfaceId": surfaceId,
+                    "cwd": root.path,
+                    "pid": recycledPID,
+                    "runtimeStatus": "running",
+                    "startedAt": staleActivity,
+                    "updatedAt": staleActivity,
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seededStore, options: [.prettyPrinted])
+            .write(to: root.appendingPathComponent("codex-hook-sessions.json"), options: .atomic)
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else { return "OK" }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+            case "debug.terminals":
+                return self.v2Response(id: id, ok: true, result: ["terminals": []])
+            case "surface.resume.set":
+                return self.v2Response(id: id, ok: true, result: ["ok": true])
+            case "feed.push":
+                return self.v2Response(id: id, ok: true, result: [:])
+            default:
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = root.path
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = "/usr/local/bin/codex"
+        environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(["/usr/local/bin/codex"])
+        environment.removeValue(forKey: "CMUX_CLI_TTY_NAME")
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "session-start"],
+            environment: environment,
+            standardInput: #"{"session_id":"\#(sessionB)","cwd":"\#(root.path)","hook_event_name":"SessionStart"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        let resumeSets = state.snapshot().compactMap { command -> [String: Any]? in
+            guard let payload = self.jsonObject(command),
+                  payload["method"] as? String == "surface.resume.set" else { return nil }
+            return payload["params"] as? [String: Any]
+        }
+        let publishedByB = resumeSets.contains {
+            ($0["checkpoint_id"] as? String) == sessionB && ($0["surface_id"] as? String) == surfaceId
+        }
+        XCTAssertTrue(
+            publishedByB,
+            """
+            a recycled PID on a stale session record must not be mistaken for a live agent: the fresh \
+            session must still publish its resume binding (resume-latest takeover). resumeSets=\(resumeSets)
+            """
+        )
+    }
+
     /// G3 stale-env variant (https://github.com/manaflow-ai/cmux/issues/5333): when the ambient
     /// CMUX_SURFACE_ID is stale/invalid (the surface was closed, or belongs to another workspace) it no
     /// longer resolves to an accessible surface. That must NOT abort hook routing — the agent's own


### PR DESCRIPTION
Guards the codex/generic resume-binding publish so a fresh session cannot overwrite a **different, still-live** session's resume binding on the same surface.

### The bug
The codex/generic agent hook published `surface.resume.set` unconditionally on every session-start / prompt-submit / stop (`CLI/cmux.swift`), unlike the claude path which gates it behind `shouldPromoteActiveSession`. Combined with the app-side last-writer-wins write (`Workspace.setSurfaceResumeBinding`), a fresh session routed onto a surface a *different live* session occupies overwrites that session's binding and orphans the running thread across reload.

### Where it bites (and where it doesn't)
Only in the remote/SSH slice that https://github.com/manaflow-ai/cmux/issues/5333's PID/TTY override explicitly punts on: no controlling TTY, so a leaked `CMUX_SURFACE_ID` misroutes the hook onto the live session's pane. In the common single-terminal flow this cannot happen (the prior process is dead before the next starts, and `hasRunningSession(requireLiveProcess:)` self-heals the stale record), so single-terminal behavior is unchanged.

### Fix
Route all four generic-hook publish sites through one local helper that skips the publish when a different session is live on the surface (`requireLiveProcess: true`). A stopped/dead prior session does not count, so normal resume-latest takeover of a finished session is preserved.

### Scope
This does **not** fix the broader incident where a *completed* thread is displaced by a later throwaway session with no way back (the single-terminal case): that is the no-per-surface-history product gap tracked in https://github.com/manaflow-ai/cmux/issues/5617.

### Verification
CI's `tests` job masks the red regression test (separate gap, https://github.com/manaflow-ai/cmux/issues/5641), so red→green is shown via a mock-socket repro driving the real built CLI:

```
unfixed CLI:  LIVE prior -> B clobbers (True, bug)   STOPPED prior -> B publishes (True)   => FAIL
fixed CLI:    LIVE prior -> no displace (False)       STOPPED prior -> B publishes (True)   => PASS
```

Two app-host hook tests added (`CLIGenericHookPersistenceTests`): the live-clobber regression (red without the fix) and a stopped-session-takeover characterization (stays green).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when resume bindings are written for multi-session / remote routing edge cases; wrong guard logic could block legitimate takeover or still allow clobbering, but scope is hook publish paths with targeted tests.
> 
> **Overview**
> Generic codex/agent hooks no longer call `surface.resume.set` unconditionally. They go through **`publishResumeBindingUnlessLiveSurfaceOwner`**, which skips publishing when another **older** session on the same workspace/surface still has a **live PID** (any `runtimeStatus`, including `needsInput`), so a misrouted fresh session cannot clobber the incumbent’s resume binding in the no-TTY / leaked `CMUX_SURFACE_ID` case.
> 
> **`hasLiveProcessSessionOnSurface`** implements that check: `startedAt` tie-breaking so only the original owner blocks a newcomer, plus **`processStartTime`** (sysctl) vs `updatedAt` so a stale record with a **recycled PID** does not block normal resume-latest takeover when the prior agent is actually gone.
> 
> Four hook paths (session-start, prompt-submit, stop, etc.) are switched from direct `publishAgentSurfaceResumeBinding` to the guarded helper. **`CLIGenericHookPersistenceTests`** adds coverage for stopped-prior takeover, live-prior no-clobber, `needsInput` live prior, and PID reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5290f35332a7e88c2abdabf1cc85e9c14873db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing resume bindings when another active agent session owns the same surface, preventing unintended takeover or disruption.
  * Improve robustness against recycled process identifiers so live sessions aren’t mistaken for inactive ones.

* **Tests**
  * Added regression tests for session-start behavior covering live, stopped, and process-reuse scenarios to prevent resume-binding regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->