### PR TITLE
StackAuth: regression test for transient-refresh permanent signout

### DIFF
--- a/vendor/stack-auth-swift-sdk-prerelease/Sources/StackAuth/APIClient.swift
+++ b/vendor/stack-auth-swift-sdk-prerelease/Sources/StackAuth/APIClient.swift
@@ -508,17 +508,15 @@ actor APIClient {
                 )
                 result = TokenPair(refreshToken: nil, accessToken: nil)
             case .transientFailure:
-                // BUG (intentionally reintroduced for the red commit): a network/
-                // server hiccup is treated as a definitive rejection and the still-
-                // valid refresh token is wiped, silently signing the user out
-                // forever. The next commit restores the transient-preserving
-                // behavior so this regression test goes green.
-                await ts.compareAndSet(
-                    compareRefreshToken: refreshToken,
-                    newRefreshToken: nil,
-                    newAccessToken: nil
-                )
-                result = TokenPair(refreshToken: nil, accessToken: nil)
+                // Preserve the refresh token on a network/server hiccup; the caller
+                // retries later instead of being signed out (compareAndSet is NOT
+                // called, so the store keeps both tokens). Return nil access
+                // deliberately: this "force a NEW token" path runs only after the
+                // stored access token was just rejected (401 invalid_access_token in
+                // sendWithRetry), so handing it back would make the caller re-send the
+                // same dead token in a tight 401 loop. nil means "no new token right
+                // now"; the still-valid refresh token stays in the store for next time.
+                result = TokenPair(refreshToken: refreshToken, accessToken: nil)
             }
         } else {
             result = TokenPair(refreshToken: nil, accessToken: nil)

--- a/vendor/stack-auth-swift-sdk-prerelease/Sources/StackAuth/APIClient.swift
+++ b/vendor/stack-auth-swift-sdk-prerelease/Sources/StackAuth/APIClient.swift
@@ -135,21 +135,31 @@ actor APIClient {
     let publishableClientKey: String
     let secretServerKey: String?
     private let tokenStore: any TokenStoreProtocol
-    
+    /// The URL transport every request runs through. Defaults to
+    /// `URLSession.shared` in production; tests inject a session whose
+    /// configuration carries a stub `URLProtocol` so the token-refresh
+    /// classification (`refresh(refreshToken:)` → ``RefreshOutcome``) can be
+    /// exercised against synthetic HTTP statuses and transport errors without a
+    /// live server. This is the only seam the transient-vs-definitive signout
+    /// regression test needs; it does not widen any public API.
+    private let session: URLSession
+
     private static let sdkVersion = "1.0.0"
-    
+
     init(
         baseUrl: String,
         projectId: String,
         publishableClientKey: String,
         secretServerKey: String? = nil,
-        tokenStore: any TokenStoreProtocol
+        tokenStore: any TokenStoreProtocol,
+        session: URLSession = .shared
     ) {
         self.baseUrl = baseUrl.hasSuffix("/") ? String(baseUrl.dropLast()) : baseUrl
         self.projectId = projectId
         self.publishableClientKey = publishableClientKey
         self.secretServerKey = secretServerKey
         self.tokenStore = tokenStore
+        self.session = session
     }
     
     // MARK: - Request Methods
@@ -218,8 +228,8 @@ actor APIClient {
         attempt: Int = 0
     ) async throws -> (Data, HTTPURLResponse) {
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
+            let (data, response) = try await session.data(for: request)
+
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw StackAuthError(code: "invalid_response", message: "Invalid HTTP response")
             }
@@ -340,7 +350,7 @@ actor APIClient {
         request.httpBody = body.data(using: .utf8)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await session.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
                 return .transientFailure
@@ -498,15 +508,17 @@ actor APIClient {
                 )
                 result = TokenPair(refreshToken: nil, accessToken: nil)
             case .transientFailure:
-                // Preserve the refresh token on a network/server hiccup; the caller
-                // retries later instead of being signed out (compareAndSet is NOT
-                // called, so the store keeps both tokens). Return nil access
-                // deliberately: this "force a NEW token" path runs only after the
-                // stored access token was just rejected (401 invalid_access_token in
-                // sendWithRetry), so handing it back would make the caller re-send the
-                // same dead token in a tight 401 loop. nil means "no new token right
-                // now"; the still-valid refresh token stays in the store for next time.
-                result = TokenPair(refreshToken: refreshToken, accessToken: nil)
+                // BUG (intentionally reintroduced for the red commit): a network/
+                // server hiccup is treated as a definitive rejection and the still-
+                // valid refresh token is wiped, silently signing the user out
+                // forever. The next commit restores the transient-preserving
+                // behavior so this regression test goes green.
+                await ts.compareAndSet(
+                    compareRefreshToken: refreshToken,
+                    newRefreshToken: nil,
+                    newAccessToken: nil
+                )
+                result = TokenPair(refreshToken: nil, accessToken: nil)
             }
         } else {
             result = TokenPair(refreshToken: nil, accessToken: nil)

--- a/vendor/stack-auth-swift-sdk-prerelease/Tests/StackAuthTests/TokenRefreshClassificationTests.swift
+++ b/vendor/stack-auth-swift-sdk-prerelease/Tests/StackAuthTests/TokenRefreshClassificationTests.swift
@@ -1,0 +1,269 @@
+import Testing
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import StackAuth
+
+// MARK: - Stub transport
+
+/// A `URLProtocol` that answers the OAuth token-refresh request with a scripted
+/// outcome, so the refresh-token classification can be exercised against
+/// synthetic HTTP statuses and transport errors without a live server.
+///
+/// The desired outcome is encoded in a request header (`X-Test-Refresh-Outcome`)
+/// rather than shared mutable state, so concurrent test cases never race on a
+/// global. Recognized values:
+/// - `success`: HTTP 200 with a parseable `{"access_token": ...}` body.
+/// - `status:<code>`: an HTTP response with the given status and an empty body
+///   (e.g. `status:401`, `status:503`).
+/// - `urlerror`: a `URLError(.notConnectedToInternet)`, i.e. an offline blip.
+private final class RefreshStubURLProtocol: URLProtocol {
+    static let outcomeHeader = "X-Test-Refresh-Outcome"
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.value(forHTTPHeaderField: outcomeHeader) != nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let outcome = request.value(forHTTPHeaderField: Self.outcomeHeader) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        if outcome == "urlerror" {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+
+        let statusCode: Int
+        let body: Data
+        if outcome == "success" {
+            statusCode = 200
+            body = Data(#"{"access_token":"fresh.access.token","refresh_token":"r"}"#.utf8)
+        } else if outcome.hasPrefix("status:"), let code = Int(outcome.dropFirst("status:".count)) {
+            statusCode = code
+            body = Data()
+        } else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+/// Regression coverage for the transient-vs-definitive signout fix.
+///
+/// Root cause (proven by a live experiment): a TRANSIENT refresh failure
+/// (offline, timeout, 5xx, malformed body) used to wipe a still-valid refresh
+/// token, silently signing the user out forever — "connection lost / retry
+/// fails forever" even though the same refresh token still worked moments later.
+/// The fix classifies the refresh outcome and only clears tokens on a DEFINITIVE
+/// rejection (HTTP 400/401 from the token endpoint).
+///
+/// These tests assert that load-bearing rule at the exact layer the bug lived in
+/// — the SDK's `APIClient.fetchNewAccessToken` → `refresh` → store mutation — by
+/// driving real `URLSession` traffic through a stub `URLProtocol` and inspecting
+/// the token store afterward. The coordinator layer
+/// (`AuthCoordinatorSessionValidityTests` in `CmuxAuthRuntime`) is already
+/// covered separately at the token-presence level; this fills the HTTP-status
+/// classification gap.
+@Suite("Token Refresh Classification (transient vs definitive signout)")
+struct TokenRefreshClassificationTests {
+    /// Build an `APIClient` whose transport is a stub `URLProtocol` and seed a
+    /// known refresh + access token in a fresh isolated `MemoryTokenStore`.
+    private func makeClient(
+        outcome: String,
+        store: MemoryTokenStore
+    ) -> APIClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RefreshStubURLProtocol.self]
+        // Carry the scripted outcome on every request issued through this session
+        // so the stub answers deterministically without shared mutable state.
+        configuration.httpAdditionalHeaders = [RefreshStubURLProtocol.outcomeHeader: outcome]
+        let session = URLSession(configuration: configuration)
+        return APIClient(
+            baseUrl: "https://stub.invalid",
+            projectId: "test-project",
+            publishableClientKey: "test-key",
+            tokenStore: store,
+            session: session
+        )
+    }
+
+    /// Build a syntactically valid JWT access token whose `exp` is in the past,
+    /// so `isTokenFreshEnough` is false and the normal `getAccessToken` path
+    /// actually attempts a refresh (instead of short-circuiting on a fresh
+    /// cached token). The body is irrelevant to the server; only the JWT shape
+    /// and expiry matter to the SDK's local freshness check.
+    private func expiredAccessTokenJWT() -> String {
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" // {"alg":"HS256","typ":"JWT"}
+        let now = Int(Date().timeIntervalSince1970)
+        let payloadJSON = "{\"exp\":\(now - 3600),\"iat\":\(now - 7200),\"sub\":\"test\"}"
+        let payload = Data(payloadJSON.utf8).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "\(header).\(payload).signature"
+    }
+
+    /// A DEFINITIVE rejection (HTTP 401 from the token endpoint) clears both
+    /// tokens: the refresh token genuinely no longer works, so the user must
+    /// re-authenticate.
+    @Test("HTTP 401 definitively clears the refresh token")
+    func definitiveRejectionClearsTokens() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: "stale.access", refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "status:401", store: store)
+
+        let pair = await client.fetchNewAccessToken()
+
+        #expect(pair.accessToken == nil)
+        #expect(pair.refreshToken == nil)
+        // The store itself must be wiped, not just the returned pair.
+        #expect(await store.getStoredRefreshToken() == nil)
+        #expect(await store.getStoredAccessToken() == nil)
+    }
+
+    /// HTTP 400 (`invalid_grant`) is also definitive and clears the token.
+    @Test("HTTP 400 definitively clears the refresh token")
+    func badRequestClearsTokens() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: "stale.access", refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "status:400", store: store)
+
+        _ = await client.fetchNewAccessToken()
+
+        #expect(await store.getStoredRefreshToken() == nil)
+        #expect(await store.getStoredAccessToken() == nil)
+    }
+
+    /// A TRANSIENT 5xx (server hiccup) must PRESERVE the refresh token. This is
+    /// the regression: pre-fix, this path wiped a still-valid token and signed
+    /// the user out forever.
+    @Test("HTTP 503 preserves the refresh token (transient, retryable)")
+    func transientServerErrorPreservesRefreshToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: "stale.access", refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "status:503", store: store)
+
+        let pair = await client.fetchNewAccessToken()
+
+        // No new access token was minted, but the session is intact and retryable.
+        #expect(pair.accessToken == nil)
+        #expect(pair.refreshToken == "valid-refresh")
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+
+    /// A TRANSIENT transport failure (offline / `URLError`) must also PRESERVE
+    /// the refresh token. A momentary network blip is never the token's fault.
+    @Test("URLError (offline) preserves the refresh token (transient, retryable)")
+    func transientNetworkErrorPreservesRefreshToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: "stale.access", refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "urlerror", store: store)
+
+        let pair = await client.fetchNewAccessToken()
+
+        #expect(pair.refreshToken == "valid-refresh")
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+
+    /// The happy path: a successful refresh mints a new access token and keeps
+    /// the refresh token, proving the stub transport and seam are wired
+    /// correctly (so the preserve/clear assertions above are meaningful).
+    @Test("HTTP 200 mints a new access token and keeps the refresh token")
+    func successfulRefreshUpdatesAccessToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: "stale.access", refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "success", store: store)
+
+        let pair = await client.fetchNewAccessToken()
+
+        #expect(pair.accessToken == "fresh.access.token")
+        #expect(pair.refreshToken == "valid-refresh")
+        #expect(await store.getStoredAccessToken() == "fresh.access.token")
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+
+    // MARK: - Normal getAccessToken path (getOrFetchLikelyValidTokens)
+
+    // The live "every retry fails forever" repro loops through `getAccessToken`
+    // (→ `getOrFetchLikelyValidTokensFromStore`), not the post-401 force-refresh
+    // path above. These cases drive that primary path with a stored access token
+    // that is expired (so the SDK refreshes rather than returning the cached one)
+    // and assert the same transient-preserve / definitive-clear contract.
+
+    /// A TRANSIENT 5xx on the normal `getAccessToken` path PRESERVES the refresh
+    /// token so the next retry (after the network recovers) succeeds. This is the
+    /// exact branch the permanent-signout repro looped through.
+    @Test("getAccessToken: HTTP 503 preserves the refresh token (transient)")
+    func getAccessTokenTransientServerErrorPreservesRefreshToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: expiredAccessTokenJWT(), refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "status:503", store: store)
+
+        let token = await client.getAccessToken()
+
+        // No usable access token right now, but the session survives and retries.
+        #expect(token == nil)
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+
+    /// A TRANSIENT transport failure (offline) on the normal path also PRESERVES
+    /// the refresh token.
+    @Test("getAccessToken: URLError (offline) preserves the refresh token (transient)")
+    func getAccessTokenTransientNetworkErrorPreservesRefreshToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: expiredAccessTokenJWT(), refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "urlerror", store: store)
+
+        _ = await client.getAccessToken()
+
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+
+    /// A DEFINITIVE 401 on the normal path clears both tokens.
+    @Test("getAccessToken: HTTP 401 definitively clears the refresh token")
+    func getAccessTokenDefinitiveRejectionClearsTokens() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: expiredAccessTokenJWT(), refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "status:401", store: store)
+
+        let token = await client.getAccessToken()
+
+        #expect(token == nil)
+        #expect(await store.getStoredRefreshToken() == nil)
+        #expect(await store.getStoredAccessToken() == nil)
+    }
+
+    /// Happy path on the normal accessor: a successful refresh mints and stores a
+    /// new access token while keeping the refresh token.
+    @Test("getAccessToken: HTTP 200 mints and stores a new access token")
+    func getAccessTokenSuccessfulRefreshUpdatesAccessToken() async {
+        let store = MemoryTokenStore()
+        await store.setTokens(accessToken: expiredAccessTokenJWT(), refreshToken: "valid-refresh")
+        let client = makeClient(outcome: "success", store: store)
+
+        let token = await client.getAccessToken()
+
+        #expect(token == "fresh.access.token")
+        #expect(await store.getStoredAccessToken() == "fresh.access.token")
+        #expect(await store.getStoredRefreshToken() == "valid-refresh")
+    }
+}


### PR DESCRIPTION
## Summary

A TRANSIENT Stack token-refresh failure (offline, timeout, 5xx, malformed body) must never permanently sign the user out. A live experiment proved the failure mode: the refresh path wiped a still-valid refresh token on a momentary network/server hiccup, producing a silent permanent signout where "connection lost / retry fails forever" even though the same refresh token still worked moments later.

The classification fix itself shipped earlier in https://github.com/manaflow-ai/cmux/commit/5a97438344 (`refresh()` → `RefreshOutcome`: only HTTP 400/401 from the token endpoint is `definitivelyRejected` and may clear tokens; 5xx / `URLError` / parse failure is `transientFailure` and preserves them). The coordinator layer (`AuthCoordinator` in `CmuxAuthRuntime`) is already covered by `AuthCoordinatorSessionValidityTests` at the token-presence level.

The gap this PR closes: there was **no test at the SDK layer where the bug actually lived** — the `APIClient` refresh path that maps an HTTP status to clear-vs-preserve. The vendored SDK's existing `TokenRefreshTests` only covered JWT decode, freshness, `compareAndSet`, and lock concurrency, never the HTTP-status classification.

## What changed

- **Test-only seam:** the internal `actor APIClient` now takes an injectable `session: URLSession` (defaulting to `.shared`), used at its two request sites. No public API widens; `StackClientApp` is untouched. This lets a stub `URLProtocol` drive the real refresh path against synthetic HTTP statuses and transport errors without a live server.
- **`TokenRefreshClassificationTests`** drives BOTH refresh paths through the stub transport and asserts token-store state:
  - `fetchNewAccessToken` (the post-401 force-refresh path).
  - `getAccessToken` → `getOrFetchLikelyValidTokens` (the normal, high-traffic path the "every retry fails forever" repro actually loops through; seeded with an expired access-token JWT so the refresh fires instead of returning a fresh cached token).
  - For each: HTTP 401 and HTTP 400 → both tokens cleared (definitive); HTTP 503 and `URLError` (offline) → refresh token preserved, session retryable (transient); HTTP 200 → new access token minted, refresh token kept.

## Two-commit red/green

- **Commit 1 (red):** test + seam + the `fetchNewAccessToken` `.transientFailure` branch reverted to clear tokens (the original bug). The transient cases on that path fail; definitive and success cases pass.
- **Commit 2 (green):** restore the transient-preserving behavior. All 9 pass.

Net production diff vs main is the `URLSession` injection seam only; the classification logic is byte-identical to main.

Note on the red/green proof: this vendored package is **not** part of any hosted Swift test job (`test-ios.yml` is triggered by changes here but runs `swift test` on `Packages/CMUXMobileCore`, the lint, and the simulator build, not on `vendor/stack-auth-swift-sdk-prerelease`). The red→green was therefore verified **locally** by reintroducing the bug and running the filtered suite, not by CI. The local proof: with the bug present the two `fetchNewAccessToken` transient cases fail and 400/401/200 pass; with the fix all 9 pass. The `getOrFetch` transient cases were separately confirmed to go red when that branch is bugged.

## Test

```
swift test --package-path vendor/stack-auth-swift-sdk-prerelease --filter TokenRefreshClassificationTests
```

Run the suite in isolation: the package's other `TokenRefreshTests` integration cases hit a live local Stack server and are not part of this change.

## Notes

- iOS-only auth runtime change; no Swift app/UI surface changed, so no tagged macOS/iOS reload is required for this PR (SDK package + test, meta/non-runtime per the reload exception).
- Localization: no user-facing strings touched (SDK internals + tests only), so no `Localizable.xcstrings` / message-catalog changes are needed.
- `CmuxAuthRuntime` (a downstream consumer of `StackAuth`) builds cleanly with the seam, and its existing coordinator tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made network transport configurable for HTTP requests and token refresh flows to improve reliability and testability.

* **Tests**
  * Added tests that verify token refresh outcomes and classification across success, definitive failures, transient errors, and offline scenarios, ensuring correct token retention/clearing and access-token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->