### PR TITLE
iOS: distinguish never-paired vs offline vs reconnecting on disconnect

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -995,6 +995,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    /// Display name of the currently-active paired Mac, when one is loaded.
+    ///
+    /// Used by the disconnected screen to name the offline/asleep Mac. Falls back
+    /// to `connectedHostName` (set during the last live connection) when the
+    /// paired-Mac list has not been loaded yet, and is `nil` only when neither is
+    /// available so the view shows generic offline copy. Reading the active row's
+    /// `displayName` keeps it correct after a host switch.
+    public var activeMacDisplayName: String? {
+        if let active = pairedMacs.first(where: { $0.isActive }),
+           let name = active.displayName,
+           !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return name
+        }
+        let trimmed = connectedHostName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Reload ``pairedMacs`` from the store, scoped to the signed-in Stack user.
     ///
     /// A missing current Stack user id yields no pairings rather than falling

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -132,7 +132,10 @@ struct CMUXMobileRootView: View {
             }
         } else if store.connectionState != .connected {
             DisconnectedWorkspaceShellView(
+                state: disconnectedShellState,
+                macName: store.activeMacDisplayName,
                 showAddDevice: showAddDevice,
+                reconnect: store.retryMobileConnection,
                 signOut: signOut
             )
             .sheet(isPresented: $isShowingAddDeviceSheet) {
@@ -154,11 +157,42 @@ struct CMUXMobileRootView: View {
                 #endif
             }
             .onAppear {
-                showAddDevice()
+                // Auto-open the pairing sheet only when there is no Mac on record:
+                // a never-paired device should land straight in pairing. A
+                // known-but-offline Mac instead sees the offline screen with
+                // explicit Reconnect / Pair-another controls, so popping the sheet
+                // over it would be wrong. Load the paired Macs so the offline copy
+                // can name the unreachable Mac.
+                if disconnectedShellState == .neverPaired {
+                    showAddDevice()
+                } else {
+                    isShowingAddDeviceSheet = false
+                    Task { await store.loadPairedMacs() }
+                }
             }
         } else {
             WorkspaceShellView(store: store, signOut: signOut)
         }
+    }
+
+    /// The reason the disconnected screen is showing (never paired, known Mac
+    /// offline, or actively reconnecting), classified from the store's signals.
+    ///
+    /// In practice the primary reconnecting indicator is the full-screen
+    /// ``RestoringSessionView`` shown one branch up: a stored-Mac reconnect sets
+    /// ``CMUXMobileShellStore/isReconnectingStoredMac``, which routes there
+    /// (bounded by the store's reconnect deadline) before this branch renders. The
+    /// ``DisconnectedShellState/reconnecting`` case here covers the brief window
+    /// where a user-initiated retry has set ``isRecoveringConnection`` but the
+    /// stored-Mac reconnect has not yet flipped its flag, so the offline screen
+    /// shows a bounded reconnect indicator instead of a contradicting offline
+    /// message. The never-paired and offline cases are this view's main job.
+    private var disconnectedShellState: DisconnectedShellState {
+        DisconnectedShellPolicy.state(
+            hasKnownPairedMac: store.hasKnownPairedMac,
+            isReconnectingStoredMac: store.isReconnectingStoredMac,
+            isRecoveringConnection: store.isRecoveringConnection
+        )
     }
 
     private var isAuthenticated: Bool {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -1,4 +1,5 @@
 import CmuxMobileSupport
+import CmuxMobileWorkspace
 import SwiftUI
 #if os(iOS)
 @preconcurrency import UIKit
@@ -6,8 +7,20 @@ import SwiftUI
 import AppKit
 #endif
 
+/// The screen shown when the phone has no live connection to a Mac.
+///
+/// It communicates *why* there is no connection so the user knows what to do:
+/// guide a never-paired device to pairing, tell a known-but-unreachable Mac it
+/// is offline or asleep (with a reconnect control), and show a bounded indicator
+/// while a reconnect attempt is in flight. The state is classified upstream by
+/// ``DisconnectedShellPolicy`` so this view only renders.
 struct DisconnectedWorkspaceShellView: View {
+    /// Why we are disconnected (never paired, known-but-offline, reconnecting).
+    let state: DisconnectedShellState
+    /// Display name of the known Mac, when one is on record, for the offline copy.
+    let macName: String?
     let showAddDevice: () -> Void
+    let reconnect: () -> Void
     let signOut: () -> Void
 
     /// The Founders Edition page (Mac download + TestFlight enrollment) the
@@ -17,48 +30,130 @@ struct DisconnectedWorkspaceShellView: View {
 
     var body: some View {
         NavigationStack {
-            ContentUnavailableView {
-                Label(
-                    L10n.string("mobile.devices.emptyTitle", defaultValue: "No devices"),
-                    systemImage: "desktopcomputer.and.iphone"
-                )
-            } description: {
-                Text(L10n.string("mobile.devices.emptyDescription", defaultValue: "Add a Mac to start syncing terminal workspaces."))
-            } actions: {
-                Button(action: showAddDevice) {
-                    Text(L10n.string("mobile.addDevice.title", defaultValue: "Add device"))
+            content
+                .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
+                .mobileInlineNavigationTitle()
+                .toolbar {
+                    #if os(iOS)
+                    ToolbarItem(placement: .topBarLeading) {
+                        signOutButton
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        addDeviceToolbarButton
+                    }
+                    #else
+                    ToolbarItem {
+                        signOutButton
+                    }
+                    ToolbarItem {
+                        addDeviceToolbarButton
+                    }
+                    #endif
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.blue)
-                .accessibilityIdentifier("MobileShowAddDeviceButton")
-                Link(
-                    L10n.string("mobile.testflight.link", defaultValue: "Download via TestFlight"),
-                    destination: Self.testFlightURL
-                )
-                .font(.callout)
-                .accessibilityIdentifier("MobileTestFlightLink")
-            }
-            .navigationTitle(L10n.string("mobile.workspaces.title", defaultValue: "Workspaces"))
-            .mobileInlineNavigationTitle()
-            .toolbar {
-                #if os(iOS)
-                ToolbarItem(placement: .topBarLeading) {
-                    signOutButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    addDeviceToolbarButton
-                }
-                #else
-                ToolbarItem {
-                    signOutButton
-                }
-                ToolbarItem {
-                    addDeviceToolbarButton
-                }
-                #endif
-            }
-            .accessibilityIdentifier("MobileDisconnectedWorkspaceShell")
+                .accessibilityIdentifier("MobileDisconnectedWorkspaceShell")
         }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .neverPaired:
+            neverPairedContent
+        case .offline:
+            offlineContent
+        case .reconnecting:
+            reconnectingContent
+        }
+    }
+
+    /// No Mac on record: guide the user to pair one. There is nothing to
+    /// reconnect to, so this never shows a reconnect control or a spinner.
+    @ViewBuilder
+    private var neverPairedContent: some View {
+        ContentUnavailableView {
+            Label(
+                L10n.string("mobile.devices.emptyTitle", defaultValue: "No devices"),
+                systemImage: "desktopcomputer.and.iphone"
+            )
+        } description: {
+            Text(L10n.string("mobile.devices.emptyDescription", defaultValue: "Add a Mac to start syncing terminal workspaces."))
+        } actions: {
+            Button(action: showAddDevice) {
+                Text(L10n.string("mobile.addDevice.title", defaultValue: "Add device"))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+            .accessibilityIdentifier("MobileShowAddDeviceButton")
+            Link(
+                L10n.string("mobile.testflight.link", defaultValue: "Download via TestFlight"),
+                destination: Self.testFlightURL
+            )
+            .font(.callout)
+            .accessibilityIdentifier("MobileTestFlightLink")
+        }
+        .accessibilityIdentifier("MobileDisconnectedNeverPaired")
+    }
+
+    /// A known Mac is unreachable (offline, asleep, or its route went stale).
+    /// Name it when we can, and offer Reconnect so the user can retry without
+    /// waiting on the next automatic attempt.
+    @ViewBuilder
+    private var offlineContent: some View {
+        ContentUnavailableView {
+            Label(
+                L10n.string("mobile.disconnected.offlineTitle", defaultValue: "Mac is offline or asleep"),
+                systemImage: "desktopcomputer.trianglebadge.exclamationmark"
+            )
+        } description: {
+            Text(offlineDescription)
+        } actions: {
+            Button(action: reconnect) {
+                Text(L10n.string("mobile.disconnected.reconnect", defaultValue: "Reconnect"))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.blue)
+            .accessibilityIdentifier("MobileDisconnectedReconnectButton")
+            Button(action: showAddDevice) {
+                Text(L10n.string("mobile.disconnected.pairAnother", defaultValue: "Pair another Mac"))
+            }
+            .font(.callout)
+            .accessibilityIdentifier("MobileDisconnectedPairAnotherButton")
+        }
+        .accessibilityIdentifier("MobileDisconnectedOffline")
+    }
+
+    private var offlineDescription: String {
+        if let macName, !macName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return String(
+                format: L10n.string(
+                    "mobile.disconnected.offlineDescriptionNamed",
+                    defaultValue: "Can't reach %@. Open cmux on the Mac or wake the computer, then reconnect."
+                ),
+                macName
+            )
+        }
+        return L10n.string(
+            "mobile.disconnected.offlineDescription",
+            defaultValue: "Open cmux on the Mac or wake the computer, then reconnect."
+        )
+    }
+
+    /// A reconnect attempt is actively running: a bounded, indeterminate
+    /// indicator. The attempt resolves on its own (success flips to the
+    /// workspaces; failure falls through to the offline state), so this never
+    /// shows a manual control.
+    @ViewBuilder
+    private var reconnectingContent: some View {
+        ContentUnavailableView {
+            Label {
+                Text(L10n.string("mobile.disconnected.reconnectingTitle", defaultValue: "Reconnecting…"))
+            } icon: {
+                ProgressView()
+            }
+        } description: {
+            Text(L10n.string("mobile.disconnected.reconnectingDescription", defaultValue: "Trying to reach your Mac."))
+        }
+        .accessibilityIdentifier("MobileDisconnectedReconnecting")
     }
 
     private var signOutButton: some View {

--- a/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/DisconnectedShellPolicy.swift
+++ b/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/DisconnectedShellPolicy.swift
@@ -1,0 +1,39 @@
+/// Pure classifier mapping the mobile-shell store's connection-related state to
+/// the ``DisconnectedShellState`` the disconnected screen renders.
+///
+/// Kept as a pure function (no store, no UIKit) so the never-paired vs
+/// offline vs reconnecting decision is unit-testable without standing up the
+/// composite store, mirroring ``MobileRootAuthGate``.
+public struct DisconnectedShellPolicy {
+    private init() {}
+
+    /// Classify the disconnected screen's state from the store's signals.
+    ///
+    /// The disconnected screen is only mounted while `connectionState` is not
+    /// `.connected`, so this assumes a non-connected link and does not branch on
+    /// the connection state itself.
+    ///
+    /// - Parameters:
+    ///   - hasKnownPairedMac: The persisted hint that this device has paired a Mac
+    ///     before. `true` means there is a Mac to reconnect to; `false` means the
+    ///     device has never paired (or the last Mac was definitively forgotten).
+    ///   - isReconnectingStoredMac: Whether a stored Mac is actively mid-reconnect
+    ///     on launch.
+    ///   - isRecoveringConnection: Whether a user-initiated or network-triggered
+    ///     recovery attempt is actively in flight.
+    /// - Returns: ``DisconnectedShellState/reconnecting`` while an attempt is in
+    ///   flight; otherwise ``DisconnectedShellState/offline`` when a Mac is known,
+    ///   or ``DisconnectedShellState/neverPaired`` when none is.
+    public static func state(
+        hasKnownPairedMac: Bool,
+        isReconnectingStoredMac: Bool,
+        isRecoveringConnection: Bool
+    ) -> DisconnectedShellState {
+        // An in-flight attempt always wins: show the bounded reconnect indicator
+        // rather than an offline message that contradicts the live attempt.
+        if isReconnectingStoredMac || isRecoveringConnection {
+            return .reconnecting
+        }
+        return hasKnownPairedMac ? .offline : .neverPaired
+    }
+}

--- a/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/DisconnectedShellState.swift
+++ b/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/DisconnectedShellState.swift
@@ -1,0 +1,23 @@
+/// Why the mobile shell is showing the disconnected screen.
+///
+/// The disconnected screen renders only once the launch reconnect attempt has
+/// resolved without a live connection, but historically it could not say *why*.
+/// This three-way split lets the view show accurate copy and the right
+/// affordance: pairing guidance for a device that has never paired a Mac, an
+/// offline/asleep message with a reconnect control for a known Mac that is
+/// currently unreachable, and a bounded reconnect indicator while an attempt is
+/// actively in flight.
+///
+/// Classified by ``DisconnectedShellPolicy``.
+public enum DisconnectedShellState: Equatable, Sendable {
+    /// No Mac is on record for this device: there is nothing to reconnect to, so
+    /// the user is guided to pair a Mac.
+    case neverPaired
+    /// A Mac is on record but currently unreachable (offline, asleep, or its
+    /// route went stale). The user gets an offline/asleep message and a reconnect
+    /// control.
+    case offline
+    /// A reconnect attempt is actively running. A bounded, indeterminate
+    /// indicator is shown rather than the offline message.
+    case reconnecting
+}

--- a/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/DisconnectedShellPolicyTests.swift
+++ b/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/DisconnectedShellPolicyTests.swift
@@ -1,0 +1,65 @@
+import Testing
+
+@testable import CmuxMobileWorkspace
+
+@Suite struct DisconnectedShellPolicyTests {
+    @Test func neverPairedWhenNoMacKnownAndNotReconnecting() {
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: false,
+                isReconnectingStoredMac: false,
+                isRecoveringConnection: false
+            ) == .neverPaired
+        )
+    }
+
+    @Test func offlineWhenMacKnownAndNotReconnecting() {
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: true,
+                isReconnectingStoredMac: false,
+                isRecoveringConnection: false
+            ) == .offline
+        )
+    }
+
+    @Test func reconnectingWhenStoredMacReconnectInFlight() {
+        // An in-flight stored-Mac reconnect wins over the known-Mac offline state.
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: true,
+                isReconnectingStoredMac: true,
+                isRecoveringConnection: false
+            ) == .reconnecting
+        )
+    }
+
+    @Test func reconnectingWhenRecoveryInFlight() {
+        // A user-initiated / network recovery attempt also shows the reconnecting
+        // state, even for a device that has no persisted hint yet.
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: true,
+                isReconnectingStoredMac: false,
+                isRecoveringConnection: true
+            ) == .reconnecting
+        )
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: false,
+                isReconnectingStoredMac: false,
+                isRecoveringConnection: true
+            ) == .reconnecting
+        )
+    }
+
+    @Test func inFlightAttemptOverridesEvenWithoutKnownMac() {
+        #expect(
+            DisconnectedShellPolicy.state(
+                hasKnownPairedMac: false,
+                isReconnectingStoredMac: true,
+                isRecoveringConnection: false
+            ) == .reconnecting
+        )
+    }
+}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -834,6 +834,125 @@
         }
       }
     },
+    "mobile.disconnected.offlineDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open cmux on the Mac or wake the computer, then reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac で cmux を開くかコンピュータのスリープを解除してから、再接続してください。"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.offlineDescriptionNamed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't reach %@. Open cmux on the Mac or wake the computer, then reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ に接続できません。Mac で cmux を開くかコンピュータのスリープを解除してから、再接続してください。"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.offlineTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac is offline or asleep"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac はオフラインまたはスリープ中です"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.pairAnother": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pair another Mac"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別の Mac をペアリング"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.reconnect": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnect"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再接続"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.reconnectingDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trying to reach your Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac への接続を試みています。"
+          }
+        }
+      }
+    },
+    "mobile.disconnected.reconnectingTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reconnecting…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再接続中…"
+          }
+        }
+      }
+    },
     "mobile.hostPicker.active": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Problem

On iOS, `DisconnectedWorkspaceShellView` (the screen shown when the phone has no live Mac connection) showed one generic "No devices / Add device" screen no matter *why* it was disconnected, and auto-popped the pairing sheet. A user whose paired Mac was just asleep got pushed toward re-pairing instead of a quick reconnect, and a never-paired user and an offline user saw identical copy.

## Change

A pure `DisconnectedShellPolicy` classifies the disconnected state from the store's existing signals (`hasKnownPairedMac`, `isReconnectingStoredMac`, `isRecoveringConnection`) into three states, and the view branches on them:

- **Never paired** (no Mac on record): pairing guidance, auto-opens the pairing sheet.
- **Paired but offline/asleep** (known Mac, unreachable): "Mac is offline or asleep" (named when the Mac name is known) with a one-tap **Reconnect** plus **Pair another Mac**, and no auto-popped sheet.
- **Reconnecting** (attempt in flight): a bounded indicator. The full-screen `RestoringSessionView` (bounded by the store's existing reconnect deadline) stays the primary reconnect UI; this inline state covers the brief window where a user-initiated retry has set `isRecoveringConnection` before the stored-Mac reconnect flag flips.

Reconnect speed: the new **Reconnect** button calls the existing `retryMobileConnection()` recovery path directly (instead of forcing a re-pair detour), so it is request-timeout-bounded with no new fixed waits, and `isRecoveringConnection` gives instant UI feedback. The path also already auto-retries on network-path changes.

## Notes

- All new strings localized (English + Japanese) in `Localizable.xcstrings`.
- Pure `DisconnectedShellPolicy` covered by Swift Testing (5 cases) in `CmuxMobileWorkspace`, mirroring `MobileRootAuthGate`.
- No change to the in-session recovery banner or the Mac-status pill, so this does not regress PR #5610 (which moved the reconnecting indicator and removed the redundant in-session "Mac offline" pill). The files there (`MobileMacConnectionStatusPill`, `WorkspaceShellView`, `WorkspaceDetailView`, `WorkspaceDetailContainer`) are untouched; this is a separate full-screen surface.

## Verification

- iOS simulator build (build-only, tagged derivedDataPath): **BUILD SUCCEEDED**.
- `CmuxMobileWorkspace` package builds; 5 `DisconnectedShellPolicyTests` pass.
- Localization audit: 7 new keys, each with en + ja; xcstrings compiles to both lprojs.
- Codex autoreview clean; cmux policy check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and localization only; reconnect uses the existing recovery path with no auth or persistence changes beyond display-name resolution.
> 
> **Overview**
> The disconnected full-screen shell no longer uses one generic “No devices / Add device” flow for every outage. **`DisconnectedShellPolicy`** maps existing store flags (`hasKnownPairedMac`, `isReconnectingStoredMac`, `isRecoveringConnection`) into **`neverPaired`**, **`offline`**, and **`reconnecting`**, and **`DisconnectedWorkspaceShellView`** branches on that state.
> 
> **Never paired** keeps pairing guidance and still auto-opens the pairing sheet on appear. **Known Mac offline** shows offline/asleep copy (optionally naming the Mac via new **`activeMacDisplayName`** on the shell store), **Reconnect** wired to **`retryMobileConnection()`**, and **Pair another Mac**, without auto-popping the sheet; the root view loads paired Macs on appear for the name. **Reconnecting** shows a short inline spinner when recovery is in flight but the full **`RestoringSessionView`** path has not taken over yet.
> 
> New **en/ja** strings support the offline and reconnecting copy; **`DisconnectedShellPolicy`** has five unit tests in **CmuxMobileWorkspace**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac24cbda9bfc0424716cee9be7e67ea1004d83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783486757&installation_id=133855650&pr_number=5623&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5623&signature=20e966bcac80cb1da76a129db660abaca74cce3b35ccd2020bc15a4477722068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the iOS disconnected screen to explain why you’re disconnected and guide the right action. The UI now distinguishes never paired, offline/asleep, and reconnecting, with a quick Reconnect path.

- New Features
  - Added a pure `DisconnectedShellPolicy` and `DisconnectedShellState` to classify from existing store signals.
  - Updated `DisconnectedWorkspaceShellView` to branch by state: never paired (pairing guidance + auto-open sheet), offline/asleep (named Mac when known, Reconnect + Pair another), reconnecting (bounded indicator).
  - Added `activeMacDisplayName` in the store to name the offline Mac in the copy.
  - Reconnect uses the existing `retryMobileConnection()` for a fast, timeout-bounded retry with instant feedback; the full-screen restoring view remains the primary reconnect UI.
  - Localized new strings (en, ja) and added unit tests in `CmuxMobileWorkspace`. No changes to the in-session banner or status pill.

<sup>Written for commit aac24cbda9bfc0424716cee9be7e67ea1004d83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced disconnected state handling with distinct screens for offline and reconnecting scenarios
  * Improved Mac device naming display throughout the interface
  * New offline reconnection UI with clearer user guidance

* **Localization**
  * Added localized strings for offline and reconnection flows in English and Japanese

* **Tests**
  * Added test coverage for disconnected state classification logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->