### PR TITLE
iOS: pin + mark-read/unread swipe actions on workspace rows

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -242,6 +242,17 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             return false
         case "mobile.terminal.create", "terminal.create":
             return false
+        case "workspace.close":
+            return !ticketCoversWorkspaceRequest(
+                ticket: ticket,
+                workspaceSelection: workspaceSelection.value
+            )
+        case "surface.close":
+            return !ticketCoversTerminalRequest(
+                ticket: ticket,
+                workspaceSelection: workspaceSelection.value,
+                terminalSelection: terminalSelection.value
+            )
         case "mobile.terminal.input", "terminal.input",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
@@ -264,6 +275,23 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         // attach token yet (it mints the ticket), so requiring auth routes it through
         // the Stack Auth account token: a ticket can only be created by a signed-in user.
         return method != "mobile.host.status"
+    }
+
+    private static func ticketCoversWorkspaceRequest(
+        ticket: CmxAttachTicket,
+        workspaceSelection: String?
+    ) -> Bool {
+        let ticketWorkspaceID = ticket.workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Empty workspaceID means the ticket is Mac-wide (general pairing).
+        // It covers any explicitly targeted workspace on the paired Mac.
+        if ticketWorkspaceID.isEmpty {
+            return workspaceSelection != nil
+        }
+        if let ticketTerminalID = ticket.terminalID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !ticketTerminalID.isEmpty {
+            return false
+        }
+        return workspaceSelection == ticketWorkspaceID
     }
 
     private static func ticketCoversTerminalRequest(

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -18,6 +18,10 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         /// Whether this workspace is pinned, if the Mac reported it. `nil` when
         /// connected to a Mac old enough not to emit `is_pinned`.
         public let isPinned: Bool?
+        /// Whether this workspace has an unread indicator on the Mac, if
+        /// reported. `nil` when connected to a Mac old enough not to emit
+        /// `has_unread`; the mobile row then hides the read/unread swipe action.
+        public let hasUnread: Bool?
         /// Terminals belonging to this workspace.
         public let terminals: [Terminal]
 
@@ -27,6 +31,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             case currentDirectory = "current_directory"
             case isSelected = "is_selected"
             case isPinned = "is_pinned"
+            case hasUnread = "has_unread"
             case terminals
         }
     }

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -8,6 +8,7 @@ extension MobileWorkspacePreview {
             id: ID(rawValue: remote.id),
             name: remote.title,
             isPinned: remote.isPinned ?? false,
+            hasUnread: remote.hasUnread ?? false,
             terminals: remote.terminals.map { terminal in
                 MobileTerminalPreview(remote: terminal)
             }

--- a/Packages/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
+++ b/Packages/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileRPC
@@ -158,6 +159,45 @@ import Testing
         #expect(workspace.isSelected)
         #expect(workspace.terminals.first?.isFocused == true)
         #expect(workspace.terminals.first?.isReady == true)
+        // Absent `has_unread` decodes to nil and maps to a non-unread preview, so
+        // an older Mac that doesn't emit the field hides the read/unread swipe.
+        #expect(workspace.hasUnread == nil)
+        #expect(MobileWorkspacePreview(remote: workspace).hasUnread == false)
+    }
+
+    @Test func workspaceListResponseDecodesHasUnreadAndMapsToPreview() throws {
+        let json = Data("""
+        {
+          "workspaces": [
+            {
+              "id": "ws-unread",
+              "title": "agent",
+              "is_selected": false,
+              "is_pinned": true,
+              "has_unread": true,
+              "terminals": []
+            },
+            {
+              "id": "ws-read",
+              "title": "docs",
+              "is_selected": true,
+              "is_pinned": false,
+              "has_unread": false,
+              "terminals": []
+            }
+          ]
+        }
+        """.utf8)
+
+        let response = try MobileSyncWorkspaceListResponse.decode(json)
+        let unread = try #require(response.workspaces.first { $0.id == "ws-unread" })
+        let read = try #require(response.workspaces.first { $0.id == "ws-read" })
+        #expect(unread.hasUnread == true)
+        #expect(read.hasUnread == false)
+        // The remote mapping carries the unread flag into the value model that
+        // drives the row's Mark Read vs Mark Unread swipe direction.
+        #expect(MobileWorkspacePreview(remote: unread).hasUnread == true)
+        #expect(MobileWorkspacePreview(remote: read).hasUnread == false)
     }
 
     @Test func attachTicketInputDecodesAttachURL() throws {

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -59,6 +59,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
+    private static let deleteActionsCapability = "mobile.delete.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
 
     /// How long the render-grid stream may stay silent (no event of any topic)
@@ -178,6 +179,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// for older Macs that lack the handler, so the UI can hide rename/pin rather
     /// than offer actions that would fail with `method_not_found`.
     public private(set) var supportsWorkspaceActions: Bool = false
+    /// Whether the connected Mac advertises mobile delete support for
+    /// workspace/terminal rows. `false` until host status is read, and for older
+    /// Macs that do not expose the mobile close wrappers.
+    public private(set) var supportsDeleteActions: Bool = false
     public var terminalInputText: String
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
@@ -568,6 +573,57 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             _ = try await client.sendRequest(request)
         } catch {
             mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Close a workspace through the Mac's existing workspace-close path.
+    ///
+    /// The phone moves selection to the same-order neighbor before the remote
+    /// mutation completes so deleting the visible workspace never leaves the
+    /// detail column pointing at a removed id. The authoritative workspace list
+    /// is then refreshed from the Mac after the close RPC.
+    public func deleteWorkspace(id: MobileWorkspacePreview.ID) {
+        let neighborID = neighboringWorkspaceID(afterDeleting: id)
+        if selectedWorkspaceID == id {
+            setSelectedWorkspaceID(neighborID)
+        }
+
+        guard remoteClient != nil else {
+            deleteLocalWorkspace(id: id, neighborID: neighborID)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            await self?.deleteRemoteWorkspace(id: id)
+        }
+    }
+
+    /// Close a terminal surface through the Mac's existing surface/workspace
+    /// close paths. If the surface is the last terminal in the workspace, the
+    /// Mac may close the containing workspace; selection is moved first so the
+    /// phone does not show a blank detail while the remote list catches up.
+    public func deleteTerminal(
+        id terminalID: MobileTerminalPreview.ID,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) {
+        let terminalNeighborID = neighboringTerminalID(
+            afterDeleting: terminalID,
+            in: workspaceID
+        )
+        if selectedWorkspaceID == workspaceID, selectedTerminalID == terminalID {
+            selectedTerminalID = terminalNeighborID
+        }
+        if terminalNeighborID == nil, selectedWorkspaceID == workspaceID {
+            setSelectedWorkspaceID(neighboringWorkspaceID(afterDeleting: workspaceID))
+        }
+
+        guard remoteClient != nil else {
+            deleteLocalTerminal(id: terminalID, in: workspaceID)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            await self?.deleteRemoteTerminal(id: terminalID, in: workspaceID)
         }
     }
 
@@ -1858,6 +1914,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalReplaySurfaceIDsInFlight = []
         terminalOutputTransport = .rawBytes
         supportsWorkspaceActions = false
+        supportsDeleteActions = false
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
         stopRenderGridLivenessWatchdog(listenerID: nil)
@@ -2094,6 +2151,145 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    private func deleteRemoteWorkspace(id: MobileWorkspacePreview.ID) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "workspace.close",
+                params: [
+                    "workspace_id": id.rawValue,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+            guard isCurrentRemoteOperation(client: client, generation: generation),
+                  !Task.isCancelled else { return }
+            try await refreshRemoteWorkspaceListAfterMutation(client: client, generation: generation)
+        } catch {
+            handleRemoteMutationError(error, generation: generation)
+        }
+    }
+
+    private func deleteRemoteTerminal(
+        id terminalID: MobileTerminalPreview.ID,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "surface.close",
+                params: [
+                    "workspace_id": workspaceID.rawValue,
+                    "surface_id": terminalID.rawValue,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+            guard isCurrentRemoteOperation(client: client, generation: generation),
+                  !Task.isCancelled else { return }
+            try await refreshRemoteWorkspaceListAfterMutation(client: client, generation: generation)
+        } catch {
+            handleRemoteMutationError(error, generation: generation)
+        }
+    }
+
+    private func refreshRemoteWorkspaceListAfterMutation(
+        client: MobileCoreRPCClient,
+        generation: UUID
+    ) async throws {
+        let resultData = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(method: "mobile.workspace.list", params: [:])
+        )
+        let response = try MobileSyncWorkspaceListResponse.decode(resultData)
+        guard isCurrentRemoteOperation(client: client, generation: generation),
+              !Task.isCancelled else { return }
+        applyRemoteWorkspaceList(response)
+    }
+
+    private func handleRemoteMutationError(_ error: any Error, generation: UUID) {
+        guard generation == connectionGeneration, !Task.isCancelled else { return }
+        guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
+        markMacConnectionUnavailableIfNeeded(after: error)
+        connectionError = Self.localizedConnectionError(for: error)
+    }
+
+    private func deleteLocalWorkspace(
+        id workspaceID: MobileWorkspacePreview.ID,
+        neighborID: MobileWorkspacePreview.ID? = nil
+    ) {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }),
+              workspaces.count > 1 else {
+            return
+        }
+        let fallbackNeighborID = neighborID ?? neighboringWorkspaceID(afterDeleting: workspaceID)
+        workspaces.remove(at: index)
+        let selectedWorkspaceStillExists = selectedWorkspaceID.map { selectedID in
+            workspaces.contains { $0.id == selectedID }
+        } ?? false
+        if selectedWorkspaceID == workspaceID ||
+            selectedWorkspaceID == nil ||
+            !selectedWorkspaceStillExists {
+            setSelectedWorkspaceID(fallbackNeighborID ?? workspaces.first?.id)
+        }
+    }
+
+    private func deleteLocalTerminal(
+        id terminalID: MobileTerminalPreview.ID,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) {
+        guard let workspaceIndex = workspaces.firstIndex(where: { $0.id == workspaceID }),
+              let terminalIndex = workspaces[workspaceIndex].terminals.firstIndex(where: { $0.id == terminalID }) else {
+            return
+        }
+        guard workspaces[workspaceIndex].terminals.count > 1 else {
+            deleteLocalWorkspace(id: workspaceID)
+            return
+        }
+
+        let fallbackTerminalID = neighboringTerminalID(afterDeleting: terminalID, in: workspaceID)
+        workspaces[workspaceIndex].terminals.remove(at: terminalIndex)
+        terminalAutoFocusSuppressedSurfaceIDs.remove(terminalID.rawValue)
+        let selectedTerminalStillExists = selectedTerminalID.map { selectedID in
+            workspaces[workspaceIndex].terminals.contains { $0.id == selectedID }
+        } ?? false
+        if selectedWorkspaceID == workspaceID,
+           (selectedTerminalID == terminalID ||
+            selectedTerminalID == nil ||
+            !selectedTerminalStillExists) {
+            selectedTerminalID = fallbackTerminalID ?? workspaces[workspaceIndex].terminals.first?.id
+        }
+    }
+
+    private func neighboringWorkspaceID(
+        afterDeleting workspaceID: MobileWorkspacePreview.ID
+    ) -> MobileWorkspacePreview.ID? {
+        guard let index = workspaces.firstIndex(where: { $0.id == workspaceID }) else {
+            return selectedWorkspaceID
+        }
+        let remainingWorkspaces = workspaces.enumerated()
+            .filter { $0.offset != index }
+            .map(\.element)
+        guard !remainingWorkspaces.isEmpty else { return nil }
+        return remainingWorkspaces[min(index, remainingWorkspaces.count - 1)].id
+    }
+
+    private func neighboringTerminalID(
+        afterDeleting terminalID: MobileTerminalPreview.ID,
+        in workspaceID: MobileWorkspacePreview.ID
+    ) -> MobileTerminalPreview.ID? {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }),
+              let index = workspace.terminals.firstIndex(where: { $0.id == terminalID }) else {
+            return selectedTerminalID
+        }
+        let remainingTerminals = workspace.terminals.enumerated()
+            .filter { $0.offset != index }
+            .map(\.element)
+        guard !remainingTerminals.isEmpty else { return nil }
+        return remainingTerminals[min(index, remainingTerminals.count - 1)].id
+    }
+
     private func sendRemoteTerminalInput(_ text: String) async {
         guard let workspaceID = selectedWorkspace?.id,
               let terminalID = selectedTerminalID else {
@@ -2265,9 +2461,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let payload = try? MobileHostStatusResponse.decode(data) else {
                 terminalOutputTransport = fallback
                 supportsWorkspaceActions = false
+                supportsDeleteActions = false
                 return fallback
             }
             supportsWorkspaceActions = payload.capabilities.contains(Self.workspaceActionsCapability)
+            supportsDeleteActions = payload.capabilities.contains(Self.deleteActionsCapability)
             let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
                 payload.terminalFidelity == "render_grid" ? .renderGrid : .rawBytes
             terminalOutputTransport = transport
@@ -2276,6 +2474,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             terminalOutputTransport = fallback
             supportsWorkspaceActions = false
+            supportsDeleteActions = false
             MobileDebugLog.anchormux("sync.transport=raw_bytes reason=status_failed")
             return fallback
         }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -576,6 +576,43 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    /// Mark a workspace read or unread on the Mac.
+    ///
+    /// Unlike pin (whose `$isPinned` change the mobile workspace-list observer
+    /// already watches), unread state lives in the Mac's notification store,
+    /// which the observer does not subscribe to and whose value is not in its
+    /// dedup hash. So a pure read/unread toggle never pushes `workspace.updated`
+    /// on its own. We therefore explicitly refresh the authoritative list after
+    /// the action completes (mirroring the delete path) so the row's Mark
+    /// Read/Unread direction reflects the Mac. The Mac applies the mark
+    /// synchronously, so by the time the action RPC returns the new `has_unread`
+    /// is already current. No local optimistic mutation; the refresh is the
+    /// single source of truth.
+    /// - Parameters:
+    ///   - id: The workspace to mark.
+    ///   - read: `true` to mark read (clear the unread indicator), `false` to
+    ///     mark unread.
+    public func setWorkspaceRead(id: MobileWorkspacePreview.ID, _ read: Bool) async {
+        guard let client = remoteClient else { return }
+        let generation = connectionGeneration
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "workspace.action",
+                params: [
+                    "workspace_id": id.rawValue,
+                    "action": read ? "mark_read" : "mark_unread",
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+            guard isCurrentRemoteOperation(client: client, generation: generation),
+                  !Task.isCancelled else { return }
+            try await refreshRemoteWorkspaceListAfterMutation(client: client, generation: generation)
+        } catch {
+            handleRemoteMutationError(error, generation: generation)
+        }
+    }
+
     /// Close a workspace through the Mac's existing workspace-close path.
     ///
     /// The phone moves selection to the same-order neighbor before the remote

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -94,6 +94,46 @@ import Testing
         #expect(store.selectedTerminalID?.rawValue == "workspace-main-terminal-4")
     }
 
+    @Test func deleteSelectedWorkspaceSelectsNeighbor() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        store.pairingCode = "debug"
+        store.connectPreviewHost()
+
+        store.deleteWorkspace(id: "workspace-main")
+
+        #expect(store.workspaces.map(\.id.rawValue) == ["workspace-docs"])
+        #expect(store.selectedWorkspace?.id.rawValue == "workspace-docs")
+        #expect(store.selectedTerminalID?.rawValue == "terminal-notes")
+    }
+
+    @Test func deleteSelectedTerminalSelectsNeighbor() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        store.pairingCode = "debug"
+        store.connectPreviewHost()
+
+        store.deleteTerminal(id: "terminal-build", in: "workspace-main")
+
+        #expect(store.selectedWorkspace?.id.rawValue == "workspace-main")
+        #expect(store.selectedWorkspace?.terminals.map(\.id.rawValue) == ["terminal-agent", "terminal-tui"])
+        #expect(store.selectedTerminalID?.rawValue == "terminal-agent")
+    }
+
+    @Test func deleteLastTerminalClosesWorkspaceAndSelectsNeighbor() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        store.pairingCode = "debug"
+        store.connectPreviewHost()
+        store.selectedWorkspaceID = "workspace-docs"
+
+        store.deleteTerminal(id: "terminal-notes", in: "workspace-docs")
+
+        #expect(store.workspaces.map(\.id.rawValue) == ["workspace-main"])
+        #expect(store.selectedWorkspace?.id.rawValue == "workspace-main")
+        #expect(store.selectedTerminalID?.rawValue == "terminal-build")
+    }
+
     @Test func createdTerminalIsAutoFocusSuppressedUntilConsumed() throws {
         let store = MobileShellComposite.preview()
         store.signIn()

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -32,6 +32,9 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// Whether the workspace is pinned on the Mac. Pinned workspaces sort to the
     /// top of the mobile list.
     public var isPinned: Bool
+    /// Whether the workspace currently has an unread indicator on the Mac. Drives
+    /// the row's Mark Read vs Mark Unread swipe action so it points the right way.
+    public var hasUnread: Bool
     /// The terminals contained in the workspace, in display order.
     public var terminals: [MobileTerminalPreview]
 
@@ -40,11 +43,13 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     ///   - id: The workspace's stable identifier.
     ///   - name: The workspace's user-facing display name.
     ///   - isPinned: Whether the workspace is pinned on the Mac. Defaults to `false`.
+    ///   - hasUnread: Whether the workspace has an unread indicator on the Mac. Defaults to `false`.
     ///   - terminals: The terminals contained in the workspace, in display order.
-    public init(id: ID, name: String, isPinned: Bool = false, terminals: [MobileTerminalPreview]) {
+    public init(id: ID, name: String, isPinned: Bool = false, hasUnread: Bool = false, terminals: [MobileTerminalPreview]) {
         self.id = id
         self.name = name
         self.isPinned = isPinned
+        self.hasUnread = hasUnread
         self.terminals = terminals
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
@@ -31,6 +31,9 @@ struct WorkspaceDetailContainer: View {
                 store: store,
                 createWorkspace: createWorkspace,
                 createTerminal: { store.createTerminal(in: workspace.id) },
+                deleteTerminal: { workspaceID, terminalID in
+                    store.deleteTerminal(id: terminalID, in: workspaceID)
+                },
                 reportTerminalViewport: store.reportTerminalViewport,
                 sendTerminalInput: store.sendTerminalRawInput,
                 safeAreaContext: safeAreaContext

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -18,6 +18,7 @@ struct WorkspaceDetailView: View {
     @Bindable var store: CMUXMobileShellStore
     let createWorkspace: () -> Void
     let createTerminal: () -> Void
+    let deleteTerminal: (MobileWorkspacePreview.ID, MobileTerminalPreview.ID) -> Void
     let reportTerminalViewport: (MobileWorkspacePreview.ID, MobileTerminalPreview.ID, MobileTerminalViewportSize) -> Void
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
@@ -159,22 +160,7 @@ struct WorkspaceDetailView: View {
                 .padding(.top, 14)
                 .padding(.bottom, 8)
 
-            ForEach(workspace.terminals) { terminal in
-                Button {
-                    selectTerminalFromPicker(terminal.id)
-                } label: {
-                    Label(
-                        terminal.name,
-                        systemImage: terminal.id == selectedTerminal?.id ? "checkmark.circle.fill" : "terminal"
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
-            }
+            terminalPickerList
 
             Divider()
                 .padding(.vertical, 4)
@@ -225,6 +211,48 @@ struct WorkspaceDetailView: View {
         }
         .frame(minWidth: 240, maxWidth: 320, alignment: .leading)
         .presentationCompactAdaptation(.popover)
+    }
+
+    private var terminalPickerList: some View {
+        let canDeleteTerminals = store.supportsDeleteActions
+        let selectedTerminalID = selectedTerminal?.id
+        return List {
+            ForEach(workspace.terminals) { terminal in
+                Button {
+                    selectTerminalFromPicker(terminal.id)
+                } label: {
+                    Label(
+                        terminal.name,
+                        systemImage: terminal.id == selectedTerminalID ? "checkmark.circle.fill" : "terminal"
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .padding(.vertical, 10)
+                }
+                .buttonStyle(.plain)
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                .listRowSeparator(.hidden)
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    if canDeleteTerminals {
+                        Button(role: .destructive) {
+                            deleteTerminal(workspace.id, terminal.id)
+                        } label: {
+                            Label(L10n.string("mobile.common.delete", defaultValue: "Delete"), systemImage: "trash")
+                        }
+                        .tint(.red)
+                        .accessibilityIdentifier("MobileTerminalDeleteButton-\(terminal.id.rawValue)")
+                    }
+                }
+                .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .frame(height: terminalPickerListHeight)
+    }
+
+    private var terminalPickerListHeight: CGFloat {
+        min(max(CGFloat(workspace.terminals.count) * 44, 44), 280)
     }
 
     #if DEBUG && canImport(UIKit)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -160,7 +160,11 @@ struct WorkspaceDetailView: View {
                 .padding(.top, 14)
                 .padding(.bottom, 8)
 
-            terminalPickerList
+            if store.supportsDeleteActions {
+                terminalPickerList
+            } else {
+                terminalPickerPlainRows
+            }
 
             Divider()
                 .padding(.vertical, 4)
@@ -249,6 +253,26 @@ struct WorkspaceDetailView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .frame(height: terminalPickerListHeight)
+    }
+
+    private var terminalPickerPlainRows: some View {
+        let selectedTerminalID = selectedTerminal?.id
+        return ForEach(workspace.terminals) { terminal in
+            Button {
+                selectTerminalFromPicker(terminal.id)
+            } label: {
+                Label(
+                    terminal.name,
+                    systemImage: terminal.id == selectedTerminalID ? "checkmark.circle.fill" : "terminal"
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
+        }
     }
 
     private var terminalPickerListHeight: CGFloat {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -34,6 +34,9 @@ struct WorkspaceListView: View {
     /// Optional: pin/unpin a workspace on the Mac. When present, each row offers
     /// a Pin/Unpin context-menu action and pinned workspaces sort to the top.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
+    /// Optional: delete a workspace on the Mac. When present, each row supports
+    /// a trailing destructive swipe action.
+    var deleteWorkspace: ((MobileWorkspacePreview.ID) -> Void)?
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
@@ -81,7 +84,8 @@ struct WorkspaceListView: View {
                         wrapWorkspaceTitles: wrapWorkspaceTitles,
                         selectWorkspace: selectWorkspace,
                         renameWorkspace: renameWorkspace,
-                        setPinned: setPinned
+                        setPinned: setPinned,
+                        deleteWorkspace: deleteWorkspace
                     )
                     .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
                     .listRowSeparator(.hidden)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -34,6 +34,9 @@ struct WorkspaceListView: View {
     /// Optional: pin/unpin a workspace on the Mac. When present, each row offers
     /// a Pin/Unpin context-menu action and pinned workspaces sort to the top.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
+    /// Optional: mark a workspace read/unread on the Mac. When present, each row
+    /// offers a leading Mark Read/Unread swipe action.
+    var setRead: ((MobileWorkspacePreview.ID, Bool) -> Void)?
     /// Optional: delete a workspace on the Mac. When present, each row supports
     /// a trailing destructive swipe action.
     var deleteWorkspace: ((MobileWorkspacePreview.ID) -> Void)?
@@ -85,6 +88,7 @@ struct WorkspaceListView: View {
                         selectWorkspace: selectWorkspace,
                         renameWorkspace: renameWorkspace,
                         setPinned: setPinned,
+                        setRead: setRead,
                         deleteWorkspace: deleteWorkspace
                     )
                     .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -15,6 +15,9 @@ struct WorkspaceNavigationRow: View {
     /// Pin or unpin the workspace on the Mac. When `nil` the pin affordance is
     /// hidden.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
+    /// Delete the workspace on the Mac. When `nil` the destructive swipe
+    /// affordance is hidden.
+    var deleteWorkspace: ((MobileWorkspacePreview.ID) -> Void)?
 
     @State private var isRenaming = false
 
@@ -48,6 +51,17 @@ struct WorkspaceNavigationRow: View {
             }
         }
         .contextMenu { contextMenu }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            if let deleteWorkspace {
+                Button(role: .destructive) {
+                    deleteWorkspace(workspace.id)
+                } label: {
+                    Label(L10n.string("mobile.common.delete", defaultValue: "Delete"), systemImage: "trash")
+                }
+                .tint(.red)
+                .accessibilityIdentifier("MobileWorkspaceDeleteButton-\(workspace.id.rawValue)")
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -15,6 +15,9 @@ struct WorkspaceNavigationRow: View {
     /// Pin or unpin the workspace on the Mac. When `nil` the pin affordance is
     /// hidden.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
+    /// Mark the workspace read or unread on the Mac. When `nil` the read/unread
+    /// affordance is hidden.
+    var setRead: ((MobileWorkspacePreview.ID, Bool) -> Void)?
     /// Delete the workspace on the Mac. When `nil` the destructive swipe
     /// affordance is hidden.
     var deleteWorkspace: ((MobileWorkspacePreview.ID) -> Void)?
@@ -51,16 +54,14 @@ struct WorkspaceNavigationRow: View {
             }
         }
         .contextMenu { contextMenu }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            readSwipeAction
+        }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            if let deleteWorkspace {
-                Button(role: .destructive) {
-                    deleteWorkspace(workspace.id)
-                } label: {
-                    Label(L10n.string("mobile.common.delete", defaultValue: "Delete"), systemImage: "trash")
-                }
-                .tint(.red)
-                .accessibilityIdentifier("MobileWorkspaceDeleteButton-\(workspace.id.rawValue)")
-            }
+            // Delete is declared first so it stays the full-swipe action; Pin is
+            // a deliberate tap so a careless full swipe can never pin/unpin.
+            deleteSwipeAction
+            pinSwipeAction
         }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
@@ -74,8 +75,83 @@ struct WorkspaceNavigationRow: View {
         }
     }
 
+    /// Leading swipe: mark the workspace read or unread, mirroring the Mac's
+    /// unread indicator so the direction always matches current state.
+    @ViewBuilder
+    private var readSwipeAction: some View {
+        if let setRead {
+            Button {
+                setRead(workspace.id, workspace.hasUnread)
+            } label: {
+                if workspace.hasUnread {
+                    Label(
+                        L10n.string("mobile.workspace.markRead", defaultValue: "Read"),
+                        systemImage: "envelope.open"
+                    )
+                } else {
+                    Label(
+                        L10n.string("mobile.workspace.markUnread", defaultValue: "Unread"),
+                        systemImage: "envelope.badge"
+                    )
+                }
+            }
+            .tint(.blue)
+            .accessibilityIdentifier("MobileWorkspaceMarkReadButton-\(workspace.id.rawValue)")
+        }
+    }
+
+    /// Trailing swipe: pin or unpin the workspace.
+    @ViewBuilder
+    private var pinSwipeAction: some View {
+        if let setPinned {
+            Button {
+                setPinned(workspace.id, !workspace.isPinned)
+            } label: {
+                if workspace.isPinned {
+                    Label(L10n.string("mobile.workspace.unpin", defaultValue: "Unpin"), systemImage: "pin.slash")
+                } else {
+                    Label(L10n.string("mobile.workspace.pin", defaultValue: "Pin"), systemImage: "pin")
+                }
+            }
+            .tint(.orange)
+            .accessibilityIdentifier("MobileWorkspacePinSwipeButton-\(workspace.id.rawValue)")
+        }
+    }
+
+    /// Trailing swipe: destructively delete the workspace (full-swipe target).
+    @ViewBuilder
+    private var deleteSwipeAction: some View {
+        if let deleteWorkspace {
+            Button(role: .destructive) {
+                deleteWorkspace(workspace.id)
+            } label: {
+                Label(L10n.string("mobile.common.delete", defaultValue: "Delete"), systemImage: "trash")
+            }
+            .tint(.red)
+            .accessibilityIdentifier("MobileWorkspaceDeleteButton-\(workspace.id.rawValue)")
+        }
+    }
+
     @ViewBuilder
     private var contextMenu: some View {
+        if let setRead {
+            Button {
+                setRead(workspace.id, workspace.hasUnread)
+            } label: {
+                if workspace.hasUnread {
+                    Label(
+                        L10n.string("mobile.workspace.markRead", defaultValue: "Read"),
+                        systemImage: "envelope.open"
+                    )
+                } else {
+                    Label(
+                        L10n.string("mobile.workspace.markUnread", defaultValue: "Unread"),
+                        systemImage: "envelope.badge"
+                    )
+                }
+            }
+            .accessibilityIdentifier("MobileWorkspaceMarkReadMenuButton-\(workspace.id.rawValue)")
+        }
         if let setPinned {
             Button {
                 setPinned(workspace.id, !workspace.isPinned)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -68,7 +68,8 @@ struct WorkspaceShellView: View {
                 signOut: signOut,
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
-                setPinned: setWorkspacePinnedClosure
+                setPinned: setWorkspacePinnedClosure,
+                deleteWorkspace: deleteWorkspaceClosure
             )
             .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
                 workspaceDestination(for: workspaceID, createWorkspace: createWorkspaceInCompactStack)
@@ -122,7 +123,8 @@ struct WorkspaceShellView: View {
                 signOut: signOut,
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
-                setPinned: setWorkspacePinnedClosure
+                setPinned: setWorkspacePinnedClosure,
+                deleteWorkspace: deleteWorkspaceClosure
             )
             .navigationSplitViewColumnWidth(min: 320, ideal: 380, max: 440)
         } detail: {
@@ -161,6 +163,14 @@ struct WorkspaceShellView: View {
         guard store.supportsWorkspaceActions else { return nil }
         let store = store
         return { id, pinned in Task { await store.setWorkspacePinned(id: id, pinned) } }
+    }
+
+    /// Delete is advertised separately from rename/pin because older Mac builds
+    /// may support workspace actions without exposing the mobile close wrappers.
+    private var deleteWorkspaceClosure: ((MobileWorkspacePreview.ID) -> Void)? {
+        guard store.supportsDeleteActions else { return nil }
+        let store = store
+        return { id in store.deleteWorkspace(id: id) }
     }
 
     private func createWorkspaceInCompactStack() {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -69,6 +69,7 @@ struct WorkspaceShellView: View {
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
                 setPinned: setWorkspacePinnedClosure,
+                setRead: setWorkspaceReadClosure,
                 deleteWorkspace: deleteWorkspaceClosure
             )
             .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
@@ -124,6 +125,7 @@ struct WorkspaceShellView: View {
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
                 setPinned: setWorkspacePinnedClosure,
+                setRead: setWorkspaceReadClosure,
                 deleteWorkspace: deleteWorkspaceClosure
             )
             .navigationSplitViewColumnWidth(min: 320, ideal: 380, max: 440)
@@ -163,6 +165,12 @@ struct WorkspaceShellView: View {
         guard store.supportsWorkspaceActions else { return nil }
         let store = store
         return { id, pinned in Task { await store.setWorkspacePinned(id: id, pinned) } }
+    }
+
+    private var setWorkspaceReadClosure: ((MobileWorkspacePreview.ID, Bool) -> Void)? {
+        guard store.supportsWorkspaceActions else { return nil }
+        let store = store
+        return { id, read in Task { await store.setWorkspaceRead(id: id, read) } }
     }
 
     /// Delete is advertised separately from rename/pin because older Mac builds

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -296,7 +296,7 @@ final class MobileHostService {
     /// clients via `mobile.host.status`. Every status path (the public-status
     /// cache, the live `publicHostStatusResult`, and `TerminalController`'s
     /// full status) reads this so the lists cannot drift; iOS gates features
-    /// like rename/pin on the entries present here.
+    /// like rename/pin/delete on the entries present here.
     ///
     /// In DEBUG builds this also advertises `dogfood.v1`, the DEV dogfood
     /// feedback round-trip (`dogfood.feedback.submit`). It is absent from
@@ -309,6 +309,7 @@ final class MobileHostService {
             "terminal.replay.v1",
             "terminal.viewport.v1",
             "workspace.actions.v1",
+            "mobile.delete.v1",
         ]
         #if DEBUG
         capabilities.append("dogfood.v1")
@@ -1273,6 +1274,17 @@ final class MobileHostService {
             return nil
         case "mobile.terminal.create", "terminal.create":
             return nil
+        case "workspace.close":
+            return ticketWorkspaceAuthorizationError(
+                authorization: authorization,
+                workspaceSelection: workspaceSelection.value
+            )
+        case "surface.close":
+            return ticketTerminalAuthorizationError(
+                authorization: authorization,
+                workspaceSelection: workspaceSelection.value,
+                terminalSelection: terminalSelection.value
+            )
         case "mobile.terminal.input", "terminal.input",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
@@ -1290,6 +1302,34 @@ final class MobileHostService {
         default:
             return scopedTicketError
         }
+    }
+
+    private static func ticketWorkspaceAuthorizationError(
+        authorization: MobileAttachTicketAuthorization,
+        workspaceSelection: String?
+    ) -> MobileHostRPCError? {
+        guard let workspaceSelection else {
+            return scopedTicketError
+        }
+        if authorization.createdWorkspaceIDs.contains(workspaceSelection) {
+            return nil
+        }
+
+        let ticket = authorization.ticket
+        let ticketWorkspaceID = ticket.workspaceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Empty workspaceID means the ticket is Mac-wide (general pairing).
+        // Allow any explicitly named workspace under it.
+        if ticketWorkspaceID.isEmpty {
+            return nil
+        }
+        if let terminalID = ticket.terminalID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !terminalID.isEmpty {
+            return scopedTicketError
+        }
+        guard workspaceSelection == ticketWorkspaceID else {
+            return scopedTicketError
+        }
+        return nil
     }
 
     private static func ticketTerminalAuthorizationError(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20686,6 +20686,10 @@ class TerminalController {
             result = v2MobileTerminalScroll(params: request.params)
         case "mobile.terminal.mouse", "terminal.mouse":
             result = v2MobileTerminalMouse(params: request.params)
+        case "workspace.close":
+            result = v2WorkspaceClose(params: request.params)
+        case "surface.close":
+            result = v2MobileSurfaceClose(params: request.params)
         case "workspace.action":
             result = v2MobileWorkspaceAction(params: request.params)
 #if DEBUG
@@ -20937,8 +20941,9 @@ class TerminalController {
         let status = MobileHostService.shared.statusSnapshot()
         // Single source of truth shared with the mobile listener's public-status
         // paths, so the advertised capabilities can never drift. Includes
-        // workspace.actions.v1 (the mobile-gated pin/unpin/rename handler), which
-        // the iOS client uses to show or hide rename/pin.
+        // workspace.actions.v1 (the mobile-gated pin/unpin/rename handler) and
+        // mobile.delete.v1 (workspace/surface close wrappers), which the iOS
+        // client uses to show or hide row actions.
         let capabilities = MobileHostService.mobileHostCapabilities
         guard includePrivateMetadata else {
             return .ok([
@@ -21384,6 +21389,36 @@ class TerminalController {
             tabManager: tabManager,
             createdTerminalID: terminal.id.uuidString
         )
+    }
+
+    private func v2MobileSurfaceClose(params: [String: Any]) -> V2CallResult {
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        guard v2UUID(params, "workspace_id") != nil else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        switch mobileTerminalAliasUUID(params: params) {
+        case .value:
+            break
+        case .missing, .invalid:
+            return .err(code: "invalid_params", message: "Missing or invalid terminal_id", data: nil)
+        case .conflict:
+            return .err(code: "invalid_params", message: "Conflicting terminal identifiers", data: nil)
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              resolved.workspace.terminalPanel(for: surfaceId) != nil else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        if resolved.workspace.panels.count <= 1 {
+            var closeWorkspaceParams = params
+            closeWorkspaceParams["workspace_id"] = resolved.workspace.id.uuidString
+            return v2WorkspaceClose(params: closeWorkspaceParams)
+        }
+
+        return v2SurfaceClose(params: params)
     }
 
     private func v2MobileTerminalReplay(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20883,19 +20883,20 @@ class TerminalController {
 
     /// The `workspace.action` sub-actions the mobile data plane may invoke.
     ///
-    /// Mobile gets pin/unpin/rename only. The other sub-actions of
+    /// Mobile gets pin/unpin/rename plus mark_read/mark_unread. These all mutate
+    /// a single targeted workspace's own state. The remaining sub-actions of
     /// ``v2WorkspaceAction(params:)`` (`move_*`, `close_*`, `set_color`,
-    /// `set_description`, `mark_*`, …) reorder the global sidebar or destroy
-    /// sibling workspaces, so they stay on the Mac/automation socket. The action
-    /// is normalized exactly as ``v2ActionKey(_:_:)`` so this gate and the
-    /// handler can never disagree on which action runs.
+    /// `set_description`, …) reorder the global sidebar or destroy sibling
+    /// workspaces, so they stay on the Mac/automation socket. The action is
+    /// normalized exactly as ``v2ActionKey(_:_:)`` so this gate and the handler
+    /// can never disagree on which action runs.
     /// - Parameter rawAction: The raw `action` param value.
     /// - Returns: `true` when the normalized action is mobile-allowed.
     nonisolated static func mobileAllowsWorkspaceAction(_ rawAction: String?) -> Bool {
         guard let trimmed = rawAction?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else { return false }
         let normalized = trimmed.lowercased().replacingOccurrences(of: "-", with: "_")
-        return ["pin", "unpin", "rename"].contains(normalized)
+        return ["pin", "unpin", "rename", "mark_read", "mark_unread"].contains(normalized)
     }
 
     /// Mobile-gated wrapper over ``v2WorkspaceAction(params:)``: rejects every
@@ -21222,12 +21223,21 @@ class TerminalController {
             ]
         }
 
+        // The phone mirrors the Mac's per-workspace unread state so its swipe
+        // action can offer Mark Read vs Mark Unread in the correct direction.
+        // Use the store's canonical `workspaceIsUnread` (the same source the
+        // sidebar badge uses) so this can't drift from the manual/panel/restored
+        // axes: a phone `mark_unread` sets the manual axis, and reading only the
+        // notification index would miss it and make the toggle look stuck.
+        let hasUnread = AppDelegate.shared?.notificationStore?.workspaceIsUnread(forTabId: workspace.id) ?? false
+
         return [
             "id": workspace.id.uuidString,
             "title": workspace.title,
             "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
             "is_selected": isSelected,
             "is_pinned": workspace.isPinned,
+            "has_unread": hasUnread,
             "terminals": terminals
         ]
     }

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -689,6 +689,100 @@ final class MobileHostAuthorizationTests: XCTestCase {
         XCTAssertNil(error)
     }
 
+    func testWorkspaceScopedAttachTicketAcceptsWorkspaceCloseInWorkspace() throws {
+        let ticket = try scopedAttachTicket(workspaceID: "workspace", terminalID: nil)
+        let request = MobileHostRPCRequest(
+            id: "workspace-close",
+            method: "workspace.close",
+            params: ["workspace_id": "workspace"],
+            auth: MobileHostRPCAuth(
+                attachToken: ticket.authToken,
+                stackAccessToken: nil
+            )
+        )
+
+        let error = MobileHostService.debugTicketAuthorizationError(ticket: ticket, request: request)
+
+        XCTAssertNil(error)
+    }
+
+    func testTerminalScopedAttachTicketRejectsWorkspaceCloseWithoutTerminal() throws {
+        let ticket = try scopedAttachTicket(workspaceID: "workspace", terminalID: "terminal")
+        let request = MobileHostRPCRequest(
+            id: "workspace-close",
+            method: "workspace.close",
+            params: ["workspace_id": "workspace"],
+            auth: MobileHostRPCAuth(
+                attachToken: ticket.authToken,
+                stackAccessToken: nil
+            )
+        )
+
+        let error = MobileHostService.debugTicketAuthorizationError(ticket: ticket, request: request)
+
+        XCTAssertEqual(error?.code, "forbidden")
+    }
+
+    func testTerminalScopedAttachTicketRejectsWorkspaceCloseWithTerminalAlias() throws {
+        let ticket = try scopedAttachTicket(workspaceID: "workspace", terminalID: "terminal")
+        let request = MobileHostRPCRequest(
+            id: "workspace-close",
+            method: "workspace.close",
+            params: [
+                "workspace_id": "workspace",
+                "surface_id": "terminal",
+            ],
+            auth: MobileHostRPCAuth(
+                attachToken: ticket.authToken,
+                stackAccessToken: nil
+            )
+        )
+
+        let error = MobileHostService.debugTicketAuthorizationError(ticket: ticket, request: request)
+
+        XCTAssertEqual(error?.code, "forbidden")
+    }
+
+    func testTerminalScopedAttachTicketAcceptsSurfaceCloseForNamedTerminal() throws {
+        let ticket = try scopedAttachTicket(workspaceID: "workspace", terminalID: "terminal")
+        let request = MobileHostRPCRequest(
+            id: "surface-close",
+            method: "surface.close",
+            params: [
+                "workspace_id": "workspace",
+                "surface_id": "terminal",
+            ],
+            auth: MobileHostRPCAuth(
+                attachToken: ticket.authToken,
+                stackAccessToken: nil
+            )
+        )
+
+        let error = MobileHostService.debugTicketAuthorizationError(ticket: ticket, request: request)
+
+        XCTAssertNil(error)
+    }
+
+    func testWorkspaceScopedAttachTicketRejectsSurfaceCloseOutsideWorkspace() throws {
+        let ticket = try scopedAttachTicket(workspaceID: "workspace", terminalID: nil)
+        let request = MobileHostRPCRequest(
+            id: "surface-close",
+            method: "surface.close",
+            params: [
+                "workspace_id": "other-workspace",
+                "surface_id": "terminal",
+            ],
+            auth: MobileHostRPCAuth(
+                attachToken: ticket.authToken,
+                stackAccessToken: nil
+            )
+        )
+
+        let error = MobileHostService.debugTicketAuthorizationError(ticket: ticket, request: request)
+
+        XCTAssertEqual(error?.code, "forbidden")
+    }
+
     func testMacScopedAttachTicketAcceptsTerminalReplayInAnyWorkspace() throws {
         let ticket = try scopedAttachTicket(workspaceID: "", terminalID: nil)
         let request = MobileHostRPCRequest(
@@ -1112,11 +1206,13 @@ final class MobileHostAuthorizationTests: XCTestCase {
     // MARK: - Advertised mobile host capabilities
 
     func testMobileHostAdvertisesWorkspaceActionsCapability() {
-        // The iOS client gates rename/pin on `workspace.actions.v1`; every
-        // mobile.host.status path reads this single list, so advertising it here
-        // is what makes the feature visible to a supporting Mac.
+        // The iOS client gates rename/pin on `workspace.actions.v1` and
+        // swipe-delete on `mobile.delete.v1`; every mobile.host.status path
+        // reads this single list, so advertising them here is what makes the
+        // features visible to a supporting Mac.
         let capabilities = MobileHostService.mobileHostCapabilities
         XCTAssertTrue(capabilities.contains("workspace.actions.v1"))
+        XCTAssertTrue(capabilities.contains("mobile.delete.v1"))
         XCTAssertTrue(capabilities.contains("terminal.render_grid.v1"))
     }
 

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -1218,8 +1218,11 @@ final class MobileHostAuthorizationTests: XCTestCase {
 
     // MARK: - Mobile workspace.action sub-action gate
 
-    func testMobileWorkspaceActionGateAllowsOnlyPinUnpinRename() {
-        for action in ["pin", "unpin", "rename", "PIN", "UnPin", "RENAME"] {
+    func testMobileWorkspaceActionGateAllowsPinUnpinRenameMarkRead() {
+        for action in [
+            "pin", "unpin", "rename", "PIN", "UnPin", "RENAME",
+            "mark_read", "mark_unread", "Mark-Read", "MARK_UNREAD",
+        ] {
             XCTAssertTrue(
                 TerminalController.mobileAllowsWorkspaceAction(action),
                 "mobile workspace.action '\(action)' should be allowed"
@@ -1229,7 +1232,7 @@ final class MobileHostAuthorizationTests: XCTestCase {
             "move_up", "move-down", "move_top",
             "close_others", "close_above", "close_below",
             "set_color", "clear_color", "set_description", "clear_description",
-            "clear_name", "mark_read", "mark_unread", "self_destruct", "",
+            "clear_name", "self_destruct", "",
         ] {
             XCTAssertFalse(
                 TerminalController.mobileAllowsWorkspaceAction(action),

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3231,6 +3231,40 @@
         }
       }
     },
+    "mobile.workspace.markRead": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既読"
+          }
+        }
+      }
+    },
+    "mobile.workspace.markUnread": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unread"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未読"
+          }
+        }
+      }
+    },
     "mobile.workspaces.title": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Adds iMessage/Mail-style swipe actions to each iOS workspace row, on top of the swipe-delete work in https://github.com/manaflow-ai/cmux/pull/5619 (author: lleewwiiss). Lawrence dogfooded the prior build and reported he still could not swipe to pin or mark read/unread; this adds those actions.

**Stacked on https://github.com/manaflow-ai/cmux/pull/5619.** Base is `issue-5615-ios-swipe-delete` so this diff is only the new commit. Merge #5619 first, then retarget this to `main`.

## What you get per workspace row
- Leading swipe: Mark Read / Mark Unread (state-aware, full-swipe enabled), like Mail.
- Trailing swipe: Delete (the full-swipe target, unchanged from #5619) plus a deliberate-tap Pin / Unpin. Delete stays declared first so a full trailing swipe can never accidentally pin/unpin.
- The same actions are mirrored into the row context menu.

## Reused from the referenced branches
- From #5619 / `issue-5615-ios-swipe-delete`: the `.swipeActions` row scaffold, the `deleteWorkspace` closure threading (`WorkspaceShellView` → `WorkspaceListView` → row), and the `refreshRemoteWorkspaceListAfterMutation` + generation/cancellation guards that the new read/unread path reuses.
- From `feat-ios-workspace-rename-pin` (already on `main`): the pin model. Pin/unpin already route through the authoritative `workspace.action` mobile path via `setWorkspacePinned`; the new read/unread action follows the exact same pattern.

## Which verb each swipe calls
All go through the existing `workspace.action` mobile RPC (no new verb invented):
- Pin / Unpin → `setWorkspacePinned` → `workspace.action` `pin`/`unpin` (`MobileShellComposite.swift`).
- Mark Read / Unread → new `setWorkspaceRead` → `workspace.action` `mark_read`/`mark_unread` (`Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift`).
- Delete → `deleteWorkspace` → `workspace.close` (from #5619).

The desktop `v2WorkspaceAction` handler already implements `mark_read`/`mark_unread` (`Sources/TerminalController.swift` ~6840). The only desktop change needed was extending the mobile allowlist `mobileAllowsWorkspaceAction` (`Sources/TerminalController.swift` ~20890) to permit `mark_read`/`mark_unread`; the gate test in `cmuxTests/MobileHostAuthorizationTests.swift` is updated to match.

## Carrying unread state to the phone
The toggle needs the Mac's per-workspace unread state to point the right way, which the mobile workspace list did not carry. Added `has_unread` to:
- the producer payload `mobileWorkspacePayload` (`Sources/TerminalController.swift` ~21220), sourced from the store's canonical `workspaceIsUnread(forTabId:)` so it matches the sidebar badge and can't drift across the manual/panel-derived/restored unread axes (a phone `mark_unread` sets the manual axis, which a notification-index-only read would miss),
- the RPC response decoder (`MobileSyncWorkspaceListResponse`),
- the `MobileWorkspacePreview` value model,
- the remote mapping.

Unread state is not in the mobile-list observer's dedup hash and the observer does not watch the notification store, so a pure read/unread toggle never pushes `workspace.updated` on its own. `setWorkspaceRead` therefore explicitly refreshes the authoritative list after the action (mirroring delete, with the same generation/cancellation guards) so the initiating phone reflects the change.

## Notes for the parallel groups work
Row-only changes (swipe modifier + actions). The localization insert touches only the `mobile.workspace.*` neighborhood (no re-sort), and the list sectioning structure is untouched, so this should merge cleanly with the collapsible-groups work on this same list.

## Tests / verification
- New decoder test: `has_unread` round-trips through the response and the remote mapping, and absent `has_unread` defaults to non-unread (older Macs hide the swipe). `Packages/CmuxMobileRPC/Tests/...MobileCoreRPCClientTests.swift` (passing locally).
- Updated gate test: `mark_read`/`mark_unread` now mobile-allowed, others still rejected.
- Build-verified on the iOS simulator (arm64-sim, build-only). Not installed to a device (a separate consolidated dog build owns the phone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783487212&installation_id=133855650&pr_number=5624&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5624&signature=2f9a9e9aa74256d9da84bf5009a9a2265bc5638f910f86506b181169ee10c956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing mobile list and workspace-action allowlist changes; behavior is gated on capability and backward-compatible when `has_unread` is absent.
> 
> **Overview**
> Adds **Mail-style workspace row actions** on iOS: a leading swipe (and context menu) to **Mark Read / Mark Unread**, plus a trailing **Pin/Unpin** swipe alongside existing delete (delete stays first on the trailing edge so full-swipe stays destructive).
> 
> **Wire + model:** The Mac mobile workspace list now emits optional `has_unread` (from `notificationStore.workspaceIsUnread`, same source as sidebar badges). That field is decoded on the phone, mapped into `MobileWorkspacePreview.hasUnread`, and omitted on older Macs so read/unread UI stays hidden.
> 
> **RPC:** `setWorkspaceRead` calls `workspace.action` with `mark_read` / `mark_unread`, then **refreshes** `mobile.workspace.list` after success (unread changes don’t push `workspace.updated` like pin does). The Mac **mobile allowlist** now permits `mark_read` and `mark_unread` for the mobile data plane.
> 
> **Tests / strings:** Decoder/gate tests and en/ja strings for the new labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0fda1ea71e49e9fbc6694e07150f16dda461bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mail-style swipe actions to iOS workspace rows: leading swipe to mark read/unread, trailing swipe to delete (full-swipe) and pin/unpin. Propagates the Mac’s unread state to iOS and routes actions through `workspace.action`.

- New Features
  - Leading swipe: Mark Read/Unread (state-aware, full swipe).
  - Trailing swipe: Delete (full swipe) and Pin/Unpin (tap-only).
  - Same actions in the row context menu.
  - Adds `has_unread` to the mobile payload and model (`TerminalController`, `MobileSyncWorkspaceListResponse`, `MobileWorkspacePreview`, remote mapping).
  - New `setWorkspaceRead` in `MobileShellComposite` calls `workspace.action` `mark_read`/`mark_unread` and refreshes the list after.
  - Updates the allowlist to permit `mark_read`/`mark_unread`; tests and localizations (EN/JA) included.

<sup>Written for commit d0fda1ea71e49e9fbc6694e07150f16dda461bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

