### PR TITLE
iOS: render workspace groups as collapsible sections

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 32547	CLI/cmux.swift
-21983	Sources/TerminalController.swift
+21831	Sources/TerminalController.swift
 19875	Sources/Workspace.swift
 19052	Sources/ContentView.swift
 17860	Sources/AppDelegate.swift
@@ -30,7 +30,7 @@
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
-3255	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+3222	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift
 2953	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 2887	cmuxTests/CMUXOpenCommandTests.swift
@@ -43,7 +43,7 @@
 2327	cmuxTests/CJKIMEInputTests.swift
 2290	Sources/FileExplorerView.swift
 2260	Sources/TerminalWindowPortal.swift
-2193	Sources/Mobile/MobileHostService.swift
+2175	Sources/Mobile/MobileHostService.swift
 2134	Sources/SessionPersistence.swift
 2117	cmuxTests/CmuxConfigTests.swift
 2107	cmuxTests/ShortcutAndCommandPaletteTests.swift

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -104,6 +104,11 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         case createdTerminalID = "created_terminal_id"
     }
 
+    /// Decodes a workspace-list response, defaulting `groups` to empty so a Mac
+    /// old enough not to emit the field still decodes (the grouped UI then stays
+    /// flat). `created_workspace_id` / `created_terminal_id` are optional.
+    /// - Parameter decoder: The decoder for the RPC result payload.
+    /// - Throws: A decoding error if `workspaces` is missing or malformed.
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         workspaces = try container.decode([Workspace].self, forKey: .workspaces)

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -18,6 +18,9 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         /// Whether this workspace is pinned, if the Mac reported it. `nil` when
         /// connected to a Mac old enough not to emit `is_pinned`.
         public let isPinned: Bool?
+        /// The id of the group this workspace belongs to, if any. `nil` for
+        /// ungrouped workspaces and for Macs old enough not to emit groups.
+        public let groupID: String?
         /// Terminals belonging to this workspace.
         public let terminals: [Terminal]
 
@@ -27,7 +30,38 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             case currentDirectory = "current_directory"
             case isSelected = "is_selected"
             case isPinned = "is_pinned"
+            case groupID = "group_id"
             case terminals
+        }
+    }
+
+    /// A workspace group section in the list response. Mirrors the iOS-facing
+    /// subset the Mac emits (no v2 handle refs, color, or icon). Members are
+    /// listed in the Mac's spatial (`tabs`) order. Absent on Macs old enough not
+    /// to emit groups.
+    public struct Group: Decodable, Sendable {
+        /// Stable group identifier.
+        public let id: String
+        /// User-facing group name (shown as the section header label).
+        public let name: String
+        /// Whether the group is currently collapsed on the Mac.
+        public let isCollapsed: Bool
+        /// Whether the group is pinned on the Mac.
+        public let isPinned: Bool
+        /// The anchor workspace that owns this group. It is represented by the
+        /// group header and never rendered as a separate row.
+        public let anchorWorkspaceID: String
+
+        // The Mac also emits `member_workspace_ids`, but membership is derived on
+        // the client from each workspace's `group_id` (which preserves spatial
+        // order), so the explicit member list is intentionally not decoded here.
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case isCollapsed = "is_collapsed"
+            case isPinned = "is_pinned"
+            case anchorWorkspaceID = "anchor_workspace_id"
         }
     }
 
@@ -55,6 +89,9 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
 
     /// The full workspace list.
     public let workspaces: [Workspace]
+    /// Group sections, in section order. Empty on Macs old enough not to emit
+    /// groups (the field is decoded with `decodeIfPresent`).
+    public let groups: [Group]
     /// Identifier of a workspace created by the request, if any.
     public let createdWorkspaceID: String?
     /// Identifier of a terminal created by the request, if any.
@@ -62,8 +99,17 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case workspaces
+        case groups
         case createdWorkspaceID = "created_workspace_id"
         case createdTerminalID = "created_terminal_id"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workspaces = try container.decode([Workspace].self, forKey: .workspaces)
+        groups = try container.decodeIfPresent([Group].self, forKey: .groups) ?? []
+        createdWorkspaceID = try container.decodeIfPresent(String.self, forKey: .createdWorkspaceID)
+        createdTerminalID = try container.decodeIfPresent(String.self, forKey: .createdTerminalID)
     }
 
     /// Decode a workspace-list response from raw JSON data.

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -8,9 +8,24 @@ extension MobileWorkspacePreview {
             id: ID(rawValue: remote.id),
             name: remote.title,
             isPinned: remote.isPinned ?? false,
+            groupID: remote.groupID.map { MobileWorkspaceGroupPreview.ID(rawValue: $0) },
             terminals: remote.terminals.map { terminal in
                 MobileTerminalPreview(remote: terminal)
             }
+        )
+    }
+}
+
+extension MobileWorkspaceGroupPreview {
+    /// Build a group preview value from a remote workspace-list group entry.
+    /// - Parameter remote: A group decoded from the RPC response.
+    public init(remote: MobileSyncWorkspaceListResponse.Group) {
+        self.init(
+            id: ID(rawValue: remote.id),
+            name: remote.name,
+            isCollapsed: remote.isCollapsed,
+            isPinned: remote.isPinned,
+            anchorWorkspaceID: MobileWorkspacePreview.ID(rawValue: remote.anchorWorkspaceID)
         )
     }
 }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -1,0 +1,98 @@
+internal import CmuxMobileRPC
+public import CmuxMobileShellModel
+internal import Foundation
+internal import OSLog
+
+private let mobileShellLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "mobile-shell"
+)
+
+// MARK: - Workspace actions (rename / pin / group collapse)
+//
+// The mobile-gated workspace mutations, all fire-and-forget against the Mac's
+// authoritative state: the Mac applies the mutation and its workspace-list
+// observer pushes `workspace.updated`, which refreshes the list. No local
+// optimistic copies, so overlapping actions can never leave stale state.
+extension MobileShellComposite {
+
+    /// Rename a workspace on the Mac.
+    ///
+    /// Fire-and-forget against the authoritative state: the Mac applies the title
+    /// and its workspace-list observer pushes `workspace.updated`, which refreshes
+    /// this list. No local optimistic mutation, so overlapping actions can never
+    /// leave stale state.
+    /// - Parameters:
+    ///   - id: The workspace to rename.
+    ///   - title: The new title. Whitespace-only titles are ignored.
+    public func renameWorkspace(id: MobileWorkspacePreview.ID, title: String) async {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let client = remoteClient else { return }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "workspace.action",
+                params: [
+                    "workspace_id": id.rawValue,
+                    "action": "rename",
+                    "title": trimmed,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            mobileShellLog.error("workspace rename failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Pin or unpin a workspace on the Mac.
+    ///
+    /// Fire-and-forget against the authoritative state: the Mac toggles the pin
+    /// and its workspace-list observer (which watches `$isPinned`) pushes
+    /// `workspace.updated`, which refreshes this list. No local optimistic
+    /// mutation, so overlapping pin/unpin taps can never leave stale state.
+    /// - Parameters:
+    ///   - id: The workspace to pin or unpin.
+    ///   - pinned: `true` to pin, `false` to unpin.
+    public func setWorkspacePinned(id: MobileWorkspacePreview.ID, _ pinned: Bool) async {
+        guard let client = remoteClient else { return }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "workspace.action",
+                params: [
+                    "workspace_id": id.rawValue,
+                    "action": pinned ? "pin" : "unpin",
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Collapse or expand a workspace group on the Mac.
+    ///
+    /// Fire-and-forget against the authoritative state, mirroring pin/rename: the
+    /// Mac toggles the group's `isCollapsed` and its workspace-list observer
+    /// (which watches `$workspaceGroups`) pushes `workspace.updated`, which
+    /// refreshes this list with the new collapse state. No local optimistic
+    /// mutation, so overlapping collapse/expand taps can never leave stale state.
+    /// - Parameters:
+    ///   - id: The group to collapse or expand.
+    ///   - collapsed: `true` to collapse (hide members), `false` to expand.
+    public func setWorkspaceGroupCollapsed(id: MobileWorkspaceGroupPreview.ID, _ collapsed: Bool) async {
+        guard let client = remoteClient else { return }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: collapsed ? "workspace.group.collapse" : "workspace.group.expand",
+                params: [
+                    "group_id": id.rawValue,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            mobileShellLog.error("workspace group collapse failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -219,7 +219,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private let identityProvider: (any MobileIdentityProviding)?
     private let reachability: any ReachabilityProviding
     private let pairingHintDefaults: UserDefaults
-    private let clientID: String
+    let clientID: String
     /// The injected, fire-and-forget product-analytics emitter. Defaults to
     /// ``NoopAnalytics`` so previews/tests inject nothing.
     private let analytics: any AnalyticsEmitting
@@ -252,7 +252,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// `public` so the DEV feedback-submit affordance can ``DiagnosticLog/export()``
     /// it.
     public let diagnosticLog: DiagnosticLog?
-    private var remoteClient: MobileCoreRPCClient? {
+    var remoteClient: MobileCoreRPCClient? {
         didSet {
             if remoteClient == nil {
                 stopTerminalRefreshPolling()
@@ -530,88 +530,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             _ = try await client.sendRequest(request)
         } catch {
             mobileShellLog.error("click forward failed surface=\(surfaceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
-        }
-    }
-
-    // MARK: - Workspace actions
-
-    /// Rename a workspace on the Mac.
-    ///
-    /// Fire-and-forget against the authoritative state: the Mac applies the title
-    /// and its workspace-list observer pushes `workspace.updated`, which refreshes
-    /// this list. No local optimistic mutation, so overlapping actions can never
-    /// leave stale state.
-    /// - Parameters:
-    ///   - id: The workspace to rename.
-    ///   - title: The new title. Whitespace-only titles are ignored.
-    public func renameWorkspace(id: MobileWorkspacePreview.ID, title: String) async {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let client = remoteClient else { return }
-        do {
-            let request = try MobileCoreRPCClient.requestData(
-                method: "workspace.action",
-                params: [
-                    "workspace_id": id.rawValue,
-                    "action": "rename",
-                    "title": trimmed,
-                    "client_id": clientID,
-                ]
-            )
-            _ = try await client.sendRequest(request)
-        } catch {
-            mobileShellLog.error("workspace rename failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
-        }
-    }
-
-    /// Pin or unpin a workspace on the Mac.
-    ///
-    /// Fire-and-forget against the authoritative state: the Mac toggles the pin
-    /// and its workspace-list observer (which watches `$isPinned`) pushes
-    /// `workspace.updated`, which refreshes this list. No local optimistic
-    /// mutation, so overlapping pin/unpin taps can never leave stale state.
-    /// - Parameters:
-    ///   - id: The workspace to pin or unpin.
-    ///   - pinned: `true` to pin, `false` to unpin.
-    public func setWorkspacePinned(id: MobileWorkspacePreview.ID, _ pinned: Bool) async {
-        guard let client = remoteClient else { return }
-        do {
-            let request = try MobileCoreRPCClient.requestData(
-                method: "workspace.action",
-                params: [
-                    "workspace_id": id.rawValue,
-                    "action": pinned ? "pin" : "unpin",
-                    "client_id": clientID,
-                ]
-            )
-            _ = try await client.sendRequest(request)
-        } catch {
-            mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
-        }
-    }
-
-    /// Collapse or expand a workspace group on the Mac.
-    ///
-    /// Fire-and-forget against the authoritative state, mirroring pin/rename: the
-    /// Mac toggles the group's `isCollapsed` and its workspace-list observer
-    /// (which watches `$workspaceGroups`) pushes `workspace.updated`, which
-    /// refreshes this list with the new collapse state. No local optimistic
-    /// mutation, so overlapping collapse/expand taps can never leave stale state.
-    /// - Parameters:
-    ///   - id: The group to collapse or expand.
-    ///   - collapsed: `true` to collapse (hide members), `false` to expand.
-    public func setWorkspaceGroupCollapsed(id: MobileWorkspaceGroupPreview.ID, _ collapsed: Bool) async {
-        guard let client = remoteClient else { return }
-        do {
-            let request = try MobileCoreRPCClient.requestData(
-                method: collapsed ? "workspace.group.collapse" : "workspace.group.expand",
-                params: [
-                    "group_id": id.rawValue,
-                    "client_id": clientID,
-                ]
-            )
-            _ = try await client.sendRequest(request)
-        } catch {
-            mobileShellLog.error("workspace group collapse failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
     }
 

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -59,6 +59,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private static let terminalRenderGridCapability = "terminal.render_grid.v1"
     private static let workspaceActionsCapability = "workspace.actions.v1"
+    private static let workspaceGroupsCapability = "workspace.groups.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
 
     /// How long the render-grid stream may stay silent (no event of any topic)
@@ -173,6 +174,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
     public var pairingCode: String
     public var workspaces: [MobileWorkspacePreview]
+    /// The Mac's workspace groups, in section order. Empty when the Mac reports no
+    /// groups (or is old enough not to emit them). Drives the collapsible group
+    /// sections in the workspace list.
+    public var workspaceGroups: [MobileWorkspaceGroupPreview] = []
+    /// Whether the connected Mac advertises the `workspace.groups.v1` capability
+    /// (group sections in the list + `workspace.group.collapse`/`expand` over the
+    /// mobile RPC). `false` until host status is read, and for older Macs that
+    /// lack the handler, so the UI can render a flat list instead of group UI that
+    /// would not round-trip.
+    public private(set) var supportsWorkspaceGroups: Bool = false
     /// Whether the connected Mac advertises the `workspace.actions.v1` capability
     /// (rename/pin over the mobile RPC). `false` until host status is read, and
     /// for older Macs that lack the handler, so the UI can hide rename/pin rather
@@ -575,6 +586,32 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             _ = try await client.sendRequest(request)
         } catch {
             mobileShellLog.error("workspace pin failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Collapse or expand a workspace group on the Mac.
+    ///
+    /// Fire-and-forget against the authoritative state, mirroring pin/rename: the
+    /// Mac toggles the group's `isCollapsed` and its workspace-list observer
+    /// (which watches `$workspaceGroups`) pushes `workspace.updated`, which
+    /// refreshes this list with the new collapse state. No local optimistic
+    /// mutation, so overlapping collapse/expand taps can never leave stale state.
+    /// - Parameters:
+    ///   - id: The group to collapse or expand.
+    ///   - collapsed: `true` to collapse (hide members), `false` to expand.
+    public func setWorkspaceGroupCollapsed(id: MobileWorkspaceGroupPreview.ID, _ collapsed: Bool) async {
+        guard let client = remoteClient else { return }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: collapsed ? "workspace.group.collapse" : "workspace.group.expand",
+                params: [
+                    "group_id": id.rawValue,
+                    "client_id": clientID,
+                ]
+            )
+            _ = try await client.sendRequest(request)
+        } catch {
+            mobileShellLog.error("workspace group collapse failed id=\(id.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }
     }
 
@@ -1928,6 +1965,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalReplaySurfaceIDsInFlight = []
         terminalOutputTransport = .rawBytes
         supportsWorkspaceActions = false
+        supportsWorkspaceGroups = false
         terminalSubscriptionRefreshTask?.cancel()
         terminalSubscriptionRefreshTask = nil
         stopRenderGridLivenessWatchdog(listenerID: nil)
@@ -2335,9 +2373,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard let payload = try? MobileHostStatusResponse.decode(data) else {
                 terminalOutputTransport = fallback
                 supportsWorkspaceActions = false
+                supportsWorkspaceGroups = false
                 return fallback
             }
             supportsWorkspaceActions = payload.capabilities.contains(Self.workspaceActionsCapability)
+            supportsWorkspaceGroups = payload.capabilities.contains(Self.workspaceGroupsCapability)
             let transport: TerminalOutputTransport = payload.capabilities.contains(Self.terminalRenderGridCapability) ||
                 payload.terminalFidelity == "render_grid" ? .renderGrid : .rawBytes
             terminalOutputTransport = transport
@@ -2346,6 +2386,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             terminalOutputTransport = fallback
             supportsWorkspaceActions = false
+            supportsWorkspaceGroups = false
             MobileDebugLog.anchormux("sync.transport=raw_bytes reason=status_failed")
             return fallback
         }
@@ -2955,6 +2996,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             workspaces = mergedWorkspaces
         } else {
             workspaces = remoteWorkspaces
+        }
+        // Group sections always reflect the latest full response (never merged):
+        // a merge path is a single-entry create/refresh that omits groups, so
+        // applying its empty groups array would wrongly clear the sections. Only a
+        // full-list response (the non-merge path, which the event-driven refresh
+        // and initial sync use) carries authoritative group state.
+        if !mergeExistingWorkspaces {
+            workspaceGroups = response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
         }
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupPreview.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceGroupPreview.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// A lightweight, `Sendable` snapshot of a remote workspace group shown in the
+/// mobile shell.
+///
+/// Workspaces on the Mac can be organized into named, collapsible groups. An
+/// anchor workspace owns each group; on the Mac sidebar the anchor renders as the
+/// group header (no separate row), and collapsing the group hides its members but
+/// keeps the header. The mobile shell mirrors those semantics. This is a pure
+/// value model decoupled from any RPC or rendering concern.
+public struct MobileWorkspaceGroupPreview: Identifiable, Equatable, Sendable {
+    /// A stable, string-backed identifier for a ``MobileWorkspaceGroupPreview``.
+    public struct ID: RawRepresentable, Hashable, Codable, Sendable, ExpressibleByStringLiteral {
+        /// The underlying group identifier string.
+        public var rawValue: String
+
+        /// Creates an identifier from its raw string value.
+        /// - Parameter rawValue: The backing group identifier.
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        /// Creates an identifier from a string literal.
+        /// - Parameter value: The backing group identifier.
+        public init(stringLiteral value: String) {
+            self.rawValue = value
+        }
+    }
+
+    /// The group's stable identifier.
+    public var id: ID
+    /// The group's user-facing name, shown as the section header label.
+    public var name: String
+    /// Whether the group is currently collapsed (members hidden, header shown).
+    public var isCollapsed: Bool
+    /// Whether the group is pinned on the Mac.
+    public var isPinned: Bool
+    /// The anchor workspace that owns this group. It is represented by the group
+    /// header and never rendered as a separate row.
+    public var anchorWorkspaceID: MobileWorkspacePreview.ID
+
+    /// Creates a workspace group preview.
+    /// - Parameters:
+    ///   - id: The group's stable identifier.
+    ///   - name: The group's user-facing name.
+    ///   - isCollapsed: Whether the group is collapsed. Defaults to `false`.
+    ///   - isPinned: Whether the group is pinned. Defaults to `false`.
+    ///   - anchorWorkspaceID: The anchor workspace that owns the group.
+    public init(
+        id: ID,
+        name: String,
+        isCollapsed: Bool = false,
+        isPinned: Bool = false,
+        anchorWorkspaceID: MobileWorkspacePreview.ID
+    ) {
+        self.id = id
+        self.name = name
+        self.isCollapsed = isCollapsed
+        self.isPinned = isPinned
+        self.anchorWorkspaceID = anchorWorkspaceID
+    }
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
@@ -39,6 +39,12 @@ public enum MobileWorkspaceListItem: Identifiable, Equatable, Sendable {
     /// payload skew) degrades gracefully: the workspace renders as an ungrouped
     /// row rather than vanishing.
     ///
+    /// Non-contiguous members of an already-emitted group (possible when the
+    /// Mac's spatial order interleaves another row between members) do not
+    /// re-emit the header: the stray member renders at its own position, still
+    /// indented to mark its membership, and is still hidden while its group is
+    /// collapsed. Membership is never silently dropped.
+    ///
     /// - Parameters:
     ///   - workspaces: The workspaces in the Mac's spatial order.
     ///   - groups: The group sections, keyed by id for header lookup.

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
@@ -17,6 +17,9 @@ public enum MobileWorkspaceListItem: Identifiable, Equatable, Sendable {
     /// a group header, so the view can inset them.
     case workspace(MobileWorkspacePreview, indented: Bool)
 
+    /// A stable, list-unique identity for SwiftUI diffing. Namespaced by item
+    /// kind (`group.` / `workspace.`) so a group header and a workspace row can
+    /// never collide even though both wrap UUID-backed ids.
     public var id: String {
         switch self {
         case .groupHeader(let group):

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// One drawable item in the mobile workspace list.
+///
+/// The mobile list mirrors the Mac sidebar's group semantics: a group is shown as
+/// a header (representing its anchor workspace) followed by its non-anchor members;
+/// collapsing a group hides its members but keeps the header; ungrouped workspaces
+/// interleave inline by their position. This is a pure value type so the SwiftUI
+/// `List` can consume an immutable snapshot with no store reference below the list
+/// boundary.
+public enum MobileWorkspaceListItem: Identifiable, Equatable, Sendable {
+    /// A collapsible group header. The associated group's anchor workspace is
+    /// represented by this header and is never emitted as a separate
+    /// ``workspace`` item.
+    case groupHeader(MobileWorkspaceGroupPreview)
+    /// A workspace row. `indented` is `true` for non-anchor members nested under
+    /// a group header, so the view can inset them.
+    case workspace(MobileWorkspacePreview, indented: Bool)
+
+    public var id: String {
+        switch self {
+        case .groupHeader(let group):
+            return "group.\(group.id.rawValue)"
+        case .workspace(let workspace, _):
+            return "workspace.\(workspace.id.rawValue)"
+        }
+    }
+
+    /// Build the ordered list items from a workspace list and its groups.
+    ///
+    /// Mirrors `SidebarWorkspaceRenderItem.renderItems` on the Mac:
+    /// - Items follow `workspaces` order. A group header is emitted at the first
+    ///   member's position.
+    /// - The anchor workspace is never a separate row (the header represents it).
+    /// - When a group is collapsed, its members are skipped (header kept).
+    /// - Ungrouped workspaces interleave inline by position.
+    ///
+    /// A `groupID` referencing a group not present in `groups` (e.g. a transient
+    /// payload skew) degrades gracefully: the workspace renders as an ungrouped
+    /// row rather than vanishing.
+    ///
+    /// - Parameters:
+    ///   - workspaces: The workspaces in the Mac's spatial order.
+    ///   - groups: The group sections, keyed by id for header lookup.
+    /// - Returns: The ordered drawable items.
+    public static func items(
+        workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview]
+    ) -> [MobileWorkspaceListItem] {
+        guard !workspaces.isEmpty else { return [] }
+        let groupsByID = Dictionary(groups.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        var items: [MobileWorkspaceListItem] = []
+        items.reserveCapacity(workspaces.count + groups.count)
+        var lastEmittedGroupID: MobileWorkspaceGroupPreview.ID?
+        var emittedHeaders: Set<MobileWorkspaceGroupPreview.ID> = []
+        var collapsedByGroupID: [MobileWorkspaceGroupPreview.ID: Bool] = [:]
+
+        for workspace in workspaces {
+            // Resolve the membership only when the referenced group actually
+            // exists; otherwise treat the workspace as ungrouped.
+            let groupID: MobileWorkspaceGroupPreview.ID? = workspace.groupID
+                .flatMap { groupsByID[$0] != nil ? $0 : nil }
+
+            if groupID != lastEmittedGroupID {
+                lastEmittedGroupID = groupID
+                if let groupID, let group = groupsByID[groupID], !emittedHeaders.contains(groupID) {
+                    items.append(.groupHeader(group))
+                    emittedHeaders.insert(groupID)
+                    collapsedByGroupID[groupID] = group.isCollapsed
+                }
+            }
+
+            if let groupID, let group = groupsByID[groupID], group.anchorWorkspaceID == workspace.id {
+                // Anchor is represented exclusively by the group header.
+                continue
+            }
+
+            let isCollapsed = groupID.map { collapsedByGroupID[$0] ?? false } ?? false
+            if groupID == nil || !isCollapsed {
+                items.append(.workspace(workspace, indented: groupID != nil))
+            }
+        }
+        return items
+    }
+}

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -32,6 +32,10 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// Whether the workspace is pinned on the Mac. Pinned workspaces sort to the
     /// top of the mobile list.
     public var isPinned: Bool
+    /// The id of the group this workspace belongs to, if any. `nil` for ungrouped
+    /// workspaces. Used to fold contiguous same-group workspaces under their
+    /// group header, mirroring the Mac sidebar.
+    public var groupID: MobileWorkspaceGroupPreview.ID?
     /// The terminals contained in the workspace, in display order.
     public var terminals: [MobileTerminalPreview]
 
@@ -40,11 +44,19 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     ///   - id: The workspace's stable identifier.
     ///   - name: The workspace's user-facing display name.
     ///   - isPinned: Whether the workspace is pinned on the Mac. Defaults to `false`.
+    ///   - groupID: The group this workspace belongs to, if any. Defaults to `nil`.
     ///   - terminals: The terminals contained in the workspace, in display order.
-    public init(id: ID, name: String, isPinned: Bool = false, terminals: [MobileTerminalPreview]) {
+    public init(
+        id: ID,
+        name: String,
+        isPinned: Bool = false,
+        groupID: MobileWorkspaceGroupPreview.ID? = nil,
+        terminals: [MobileTerminalPreview]
+    ) {
         self.id = id
         self.name = name
         self.isPinned = isPinned
+        self.groupID = groupID
         self.terminals = terminals
     }
 }

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListItemTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListItemTests.swift
@@ -1,0 +1,103 @@
+import Testing
+
+@testable import CmuxMobileShellModel
+
+@Suite struct MobileWorkspaceListItemTests {
+    private func workspace(
+        _ id: String,
+        group: String? = nil
+    ) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            name: id,
+            groupID: group.map { .init(rawValue: $0) },
+            terminals: []
+        )
+    }
+
+    private func group(
+        _ id: String,
+        anchor: String,
+        collapsed: Bool = false,
+        pinned: Bool = false,
+        name: String? = nil
+    ) -> MobileWorkspaceGroupPreview {
+        MobileWorkspaceGroupPreview(
+            id: .init(rawValue: id),
+            name: name ?? id,
+            isCollapsed: collapsed,
+            isPinned: pinned,
+            anchorWorkspaceID: .init(rawValue: anchor)
+        )
+    }
+
+    @Test func ungroupedWorkspacesRenderFlatInOrder() {
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [workspace("a"), workspace("b")],
+            groups: []
+        )
+        #expect(items == [
+            .workspace(workspace("a"), indented: false),
+            .workspace(workspace("b"), indented: false),
+        ])
+    }
+
+    @Test func anchorRendersAsHeaderNotARow() {
+        // Anchor "a" owns group "g"; member "b" is nested. The anchor must not
+        // also appear as a workspace row.
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [workspace("a", group: "g"), workspace("b", group: "g")],
+            groups: [group("g", anchor: "a")]
+        )
+        #expect(items == [
+            .groupHeader(group("g", anchor: "a")),
+            .workspace(workspace("b", group: "g"), indented: true),
+        ])
+    }
+
+    @Test func collapsedGroupHidesMembersButKeepsHeader() {
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [workspace("a", group: "g"), workspace("b", group: "g")],
+            groups: [group("g", anchor: "a", collapsed: true)]
+        )
+        #expect(items == [.groupHeader(group("g", anchor: "a", collapsed: true))])
+    }
+
+    @Test func ungroupedAndGroupedInterleaveByPosition() {
+        // Mirrors the Mac sidebar: items follow `workspaces` order, the group
+        // header lands at its first member's position.
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [
+                workspace("top"),
+                workspace("anchor", group: "g"),
+                workspace("member", group: "g"),
+                workspace("bottom"),
+            ],
+            groups: [group("g", anchor: "anchor")]
+        )
+        #expect(items == [
+            .workspace(workspace("top"), indented: false),
+            .groupHeader(group("g", anchor: "anchor")),
+            .workspace(workspace("member", group: "g"), indented: true),
+            .workspace(workspace("bottom"), indented: false),
+        ])
+    }
+
+    @Test func unknownGroupIDDegradesToUngroupedRow() {
+        // A workspace referencing a group that is not in `groups` (transient
+        // payload skew) must still render, as an ungrouped row, not vanish.
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [workspace("a", group: "missing")],
+            groups: []
+        )
+        #expect(items == [.workspace(workspace("a", group: "missing"), indented: false)])
+    }
+
+    @Test func anchorOnlyGroupRendersHeaderWithNoMembers() {
+        let items = MobileWorkspaceListItem.items(
+            workspaces: [workspace("a", group: "g")],
+            groups: [group("g", anchor: "a")]
+        )
+        #expect(items == [.groupHeader(group("g", anchor: "a"))])
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -30,6 +30,10 @@ struct WorkspaceGroupHeaderRow: View {
             .frame(width: 22, height: 22)
             .contentShape(Rectangle())
 
+        // `.isButton` only when there is an actual activation action: a passive
+        // chevron (no `toggleCollapsed`) must not announce as a button VoiceOver
+        // can press to no effect. The collapsed/expanded state stays readable
+        // through the label either way.
         return Group {
             if let toggleCollapsed {
                 Button {
@@ -38,11 +42,11 @@ struct WorkspaceGroupHeaderRow: View {
                     image
                 }
                 .buttonStyle(.plain)
+                .accessibilityAddTraits(.isButton)
             } else {
                 image
             }
         }
-        .accessibilityAddTraits(.isButton)
         .accessibilityLabel(
             group.isCollapsed
                 ? L10n.string("mobile.workspaceGroup.expand.a11y", defaultValue: "Expand group")

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -1,0 +1,116 @@
+import CmuxMobileShellModel
+import CmuxMobileSupport
+import SwiftUI
+
+/// A collapsible group-section header in the mobile workspace list.
+///
+/// Mirrors the Mac sidebar group header, which doubles as the group's anchor
+/// workspace row: the leading disclosure chevron toggles collapse, while tapping
+/// the name/body selects (and, in push navigation, opens) the anchor workspace.
+/// The anchor is represented by this header and never rendered as a separate row,
+/// so this split is what keeps the anchor's terminals reachable from the phone.
+struct WorkspaceGroupHeaderRow: View {
+    let group: MobileWorkspaceGroupPreview
+    let navigationStyle: WorkspaceNavigationStyle
+    /// Whether the anchor workspace is the current selection (sidebar style only).
+    let isAnchorSelected: Bool
+    /// Select (and, in push style, navigate to) the anchor workspace.
+    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    /// Toggle the group's collapsed state on the Mac. When `nil` (previews, or a
+    /// Mac without the groups capability), the chevron renders without a tap
+    /// action.
+    let toggleCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
+
+    /// The leading disclosure chevron. Its own hit target, so tapping it only
+    /// collapses/expands and never opens the anchor.
+    private var chevron: some View {
+        let image = Image(systemName: group.isCollapsed ? "chevron.right" : "chevron.down")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.secondary)
+            .frame(width: 22, height: 22)
+            .contentShape(Rectangle())
+
+        return Group {
+            if let toggleCollapsed {
+                Button {
+                    toggleCollapsed(group.id, !group.isCollapsed)
+                } label: {
+                    image
+                }
+                .buttonStyle(.plain)
+            } else {
+                image
+            }
+        }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(
+            group.isCollapsed
+                ? L10n.string("mobile.workspaceGroup.expand.a11y", defaultValue: "Expand group")
+                : L10n.string("mobile.workspaceGroup.collapse.a11y", defaultValue: "Collapse group")
+        )
+        .accessibilityIdentifier("MobileWorkspaceGroupDisclosure-\(group.id.rawValue)")
+    }
+
+    /// The group name plus icon. Tapping it opens the anchor workspace, mirroring
+    /// the desktop header whose body focuses the anchor.
+    private var nameLabel: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text(group.name)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if group.isPinned {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+            }
+            Spacer(minLength: 0)
+        }
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var anchorTarget: some View {
+        switch navigationStyle {
+        case .push:
+            NavigationLink(value: group.anchorWorkspaceID) {
+                nameLabel
+            }
+            .simultaneousGesture(TapGesture().onEnded {
+                selectWorkspace(group.anchorWorkspaceID)
+            })
+        case .sidebar:
+            Button {
+                selectWorkspace(group.anchorWorkspaceID)
+            } label: {
+                nameLabel
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            chevron
+            anchorTarget
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .background(
+            // Sidebar style highlights the active anchor's header, mirroring the
+            // desktop header background when its anchor is selected. Push style
+            // has no persistent selection, so it stays clear.
+            (navigationStyle == .sidebar && isAnchorSelected)
+                ? Color.primary.opacity(0.08)
+                : Color.clear
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("MobileWorkspaceGroupHeader-\(group.id.rawValue)")
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -39,8 +39,9 @@ struct WorkspaceListView: View {
     /// a Pin/Unpin context-menu action and pinned workspaces sort to the top.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
     /// Optional: collapse/expand a group on the Mac. When present, group headers
-    /// toggle their section. `nil` when the Mac lacks the groups capability (the
-    /// list then renders flat regardless of `groups`).
+    /// toggle their section; when `nil` the chevron renders as a passive
+    /// disclosure indicator. Grouped rendering itself is gated on `groups`, not
+    /// on this closure.
     var toggleGroupCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
@@ -50,13 +51,17 @@ struct WorkspaceListView: View {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Whether the list renders grouped sections. Groups are honored only when the
-    /// Mac advertises the capability (`toggleGroupCollapsed != nil`), there are
-    /// groups, and the user is not searching. A search flattens to a single
-    /// matched, pinned-first list so members can be found across groups; floating
-    /// pinned members out of their group is acceptable while filtering.
+    /// Whether the list renders grouped sections. Groups are honored whenever the
+    /// Mac actually emitted group sections and the user is not searching. The
+    /// gate is the payload itself, not `toggleGroupCollapsed`: a Mac that emits
+    /// groups also handles collapse/expand, but the capability flag arrives via a
+    /// separate `mobile.host.status` call, and a slow or failed status fetch must
+    /// not flatten sections the list already has (it would only lose the chevron
+    /// action). A search flattens to a single matched, pinned-first list so
+    /// members can be found across groups; floating pinned members out of their
+    /// group is acceptable while filtering.
     private var rendersGroupedSections: Bool {
-        toggleGroupCollapsed != nil && !groups.isEmpty && trimmedQuery.isEmpty
+        !groups.isEmpty && trimmedQuery.isEmpty
     }
 
     private func matchesQuery(_ workspace: MobileWorkspacePreview, query: String) -> Bool {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -10,6 +10,10 @@ import AppKit
 
 struct WorkspaceListView: View {
     let workspaces: [MobileWorkspacePreview]
+    /// The Mac's workspace groups, in section order. Empty when the Mac reports no
+    /// groups; the list then renders flat. Passed as value snapshots so no
+    /// `@Observable` store crosses the `List` boundary.
+    var groups: [MobileWorkspaceGroupPreview] = []
     let selectedWorkspaceID: MobileWorkspacePreview.ID?
     let host: String
     let connectionStatus: MobileMacConnectionStatus
@@ -34,23 +38,43 @@ struct WorkspaceListView: View {
     /// Optional: pin/unpin a workspace on the Mac. When present, each row offers
     /// a Pin/Unpin context-menu action and pinned workspaces sort to the top.
     var setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)?
+    /// Optional: collapse/expand a group on the Mac. When present, group headers
+    /// toggle their section. `nil` when the Mac lacks the groups capability (the
+    /// list then renders flat regardless of `groups`).
+    var toggleGroupCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
 
+    private var trimmedQuery: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Whether the list renders grouped sections. Groups are honored only when the
+    /// Mac advertises the capability (`toggleGroupCollapsed != nil`), there are
+    /// groups, and the user is not searching. A search flattens to a single
+    /// matched, pinned-first list so members can be found across groups; floating
+    /// pinned members out of their group is acceptable while filtering.
+    private var rendersGroupedSections: Bool {
+        toggleGroupCollapsed != nil && !groups.isEmpty && trimmedQuery.isEmpty
+    }
+
+    private func matchesQuery(_ workspace: MobileWorkspacePreview, query: String) -> Bool {
+        workspace.name.localizedCaseInsensitiveContains(query)
+            || workspace.previewLine.localizedCaseInsensitiveContains(query)
+            || workspace.terminals.contains { $0.name.localizedCaseInsensitiveContains(query) }
+    }
+
     /// Workspaces after search filtering, pinned ones first (stable within each
-    /// group so the Mac's order is otherwise preserved).
+    /// group so the Mac's order is otherwise preserved). Used for the flat
+    /// (ungrouped or searching) presentation.
     private var filteredWorkspaces: [MobileWorkspacePreview] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = trimmedQuery
         let matches: [MobileWorkspacePreview]
         if query.isEmpty {
             matches = workspaces
         } else {
-            matches = workspaces.filter { workspace in
-                workspace.name.localizedCaseInsensitiveContains(query)
-                    || workspace.previewLine.localizedCaseInsensitiveContains(query)
-                    || workspace.terminals.contains { $0.name.localizedCaseInsensitiveContains(query) }
-            }
+            matches = workspaces.filter { matchesQuery($0, query: query) }
         }
         return matches.enumerated()
             .sorted { lhs, rhs in
@@ -60,6 +84,13 @@ struct WorkspaceListView: View {
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
+    }
+
+    /// Ordered drawable items for the grouped presentation. Preserves the Mac's
+    /// member order and contiguity (no pinned-first flattening, which would
+    /// scatter group members).
+    private var groupedListItems: [MobileWorkspaceListItem] {
+        MobileWorkspaceListItem.items(workspaces: workspaces, groups: groups)
     }
 
     var body: some View {
@@ -72,19 +103,10 @@ struct WorkspaceListView: View {
                 }
             }
             Section {
-                ForEach(filteredWorkspaces) { workspace in
-                    WorkspaceNavigationRow(
-                        workspace: workspace,
-                        connectionStatus: connectionStatus,
-                        isSelected: navigationStyle == .sidebar && selectedWorkspaceID == workspace.id,
-                        navigationStyle: navigationStyle,
-                        wrapWorkspaceTitles: wrapWorkspaceTitles,
-                        selectWorkspace: selectWorkspace,
-                        renameWorkspace: renameWorkspace,
-                        setPinned: setPinned
-                    )
-                    .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
-                    .listRowSeparator(.hidden)
+                if rendersGroupedSections {
+                    groupedRows
+                } else {
+                    flatRows
                 }
             }
         }
@@ -120,6 +142,54 @@ struct WorkspaceListView: View {
             )
         }
         #endif
+    }
+
+    /// Flat presentation: a pinned-first list with no group headers. Used when the
+    /// Mac has no groups (or lacks the capability) or while searching.
+    @ViewBuilder
+    private var flatRows: some View {
+        ForEach(filteredWorkspaces) { workspace in
+            workspaceRow(workspace, indented: false)
+        }
+    }
+
+    /// Grouped presentation: collapsible group headers with their members nested
+    /// underneath, mirroring the Mac sidebar. Order and contiguity follow the Mac.
+    @ViewBuilder
+    private var groupedRows: some View {
+        ForEach(groupedListItems) { item in
+            switch item {
+            case .groupHeader(let group):
+                WorkspaceGroupHeaderRow(
+                    group: group,
+                    navigationStyle: navigationStyle,
+                    isAnchorSelected: navigationStyle == .sidebar
+                        && selectedWorkspaceID == group.anchorWorkspaceID,
+                    selectWorkspace: selectWorkspace,
+                    toggleCollapsed: toggleGroupCollapsed
+                )
+                .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                .listRowSeparator(.hidden)
+            case .workspace(let workspace, let indented):
+                workspaceRow(workspace, indented: indented)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func workspaceRow(_ workspace: MobileWorkspacePreview, indented: Bool) -> some View {
+        WorkspaceNavigationRow(
+            workspace: workspace,
+            connectionStatus: connectionStatus,
+            isSelected: navigationStyle == .sidebar && selectedWorkspaceID == workspace.id,
+            navigationStyle: navigationStyle,
+            wrapWorkspaceTitles: wrapWorkspaceTitles,
+            selectWorkspace: selectWorkspace,
+            renameWorkspace: renameWorkspace,
+            setPinned: setPinned
+        )
+        .listRowInsets(EdgeInsets(top: 4, leading: indented ? 32 : 12, bottom: 4, trailing: 12))
+        .listRowSeparator(.hidden)
     }
 
     private var newWorkspaceButton: some View {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -167,11 +167,15 @@ struct WorkspaceShellView: View {
         return { id, pinned in Task { await store.setWorkspacePinned(id: id, pinned) } }
     }
 
-    /// Group collapse/expand closure, present only when the connected Mac
-    /// advertises `workspace.groups.v1`, so the list stays flat on older Macs that
-    /// would not round-trip a collapse.
+    /// Group collapse/expand closure. Present when the Mac advertises
+    /// `workspace.groups.v1` or has actually emitted group sections: a Mac that
+    /// emits groups in the workspace list also handles collapse/expand (both
+    /// shipped together), and the capability flag arrives via a separate
+    /// `mobile.host.status` call that can lag or fail without making the
+    /// already-received groups read-only. Older Macs emit no groups, so this
+    /// stays `nil` and the list renders flat.
     private var toggleGroupCollapsedClosure: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)? {
-        guard store.supportsWorkspaceGroups else { return nil }
+        guard store.supportsWorkspaceGroups || !store.workspaceGroups.isEmpty else { return nil }
         let store = store
         return { id, collapsed in Task { await store.setWorkspaceGroupCollapsed(id: id, collapsed) } }
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -57,6 +57,7 @@ struct WorkspaceShellView: View {
         NavigationStack(path: $compactNavigationPath) {
             WorkspaceListView(
                 workspaces: store.workspaces,
+                groups: store.workspaceGroups,
                 selectedWorkspaceID: store.selectedWorkspaceID,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
@@ -68,7 +69,8 @@ struct WorkspaceShellView: View {
                 signOut: signOut,
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
-                setPinned: setWorkspacePinnedClosure
+                setPinned: setWorkspacePinnedClosure,
+                toggleGroupCollapsed: toggleGroupCollapsedClosure
             )
             .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
                 workspaceDestination(for: workspaceID, createWorkspace: createWorkspaceInCompactStack)
@@ -111,6 +113,7 @@ struct WorkspaceShellView: View {
         NavigationSplitView(columnVisibility: $splitColumnVisibility) {
             WorkspaceListView(
                 workspaces: store.workspaces,
+                groups: store.workspaceGroups,
                 selectedWorkspaceID: store.selectedWorkspaceID,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
@@ -122,7 +125,8 @@ struct WorkspaceShellView: View {
                 signOut: signOut,
                 store: store,
                 renameWorkspace: renameWorkspaceClosure,
-                setPinned: setWorkspacePinnedClosure
+                setPinned: setWorkspacePinnedClosure,
+                toggleGroupCollapsed: toggleGroupCollapsedClosure
             )
             .navigationSplitViewColumnWidth(min: 320, ideal: 380, max: 440)
         } detail: {
@@ -161,6 +165,15 @@ struct WorkspaceShellView: View {
         guard store.supportsWorkspaceActions else { return nil }
         let store = store
         return { id, pinned in Task { await store.setWorkspacePinned(id: id, pinned) } }
+    }
+
+    /// Group collapse/expand closure, present only when the connected Mac
+    /// advertises `workspace.groups.v1`, so the list stays flat on older Macs that
+    /// would not round-trip a collapse.
+    private var toggleGroupCollapsedClosure: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)? {
+        guard store.supportsWorkspaceGroups else { return nil }
+        let store = store
+        return { id, collapsed in Task { await store.setWorkspaceGroupCollapsed(id: id, collapsed) } }
     }
 
     private func createWorkspaceInCompactStack() {

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension MobileHostService {
+    /// The single source of truth for the capabilities advertised to mobile
+    /// clients via `mobile.host.status`. Every status path (the public-status
+    /// cache, the live `publicHostStatusResult`, and `TerminalController`'s
+    /// full status) reads this so the lists cannot drift; iOS gates features
+    /// like rename/pin on the entries present here.
+    ///
+    /// In DEBUG builds this also advertises `dogfood.v1`, the DEV dogfood
+    /// feedback round-trip (`dogfood.feedback.submit`). It is absent from
+    /// release builds, so a release client never sees the verb advertised.
+    nonisolated static var mobileHostCapabilities: [String] {
+        var capabilities = [
+            "events.v1",
+            "terminal.bytes.v1",
+            "terminal.render_grid.v1",
+            "terminal.replay.v1",
+            "terminal.viewport.v1",
+            "workspace.actions.v1",
+            // The workspace list carries group sections (group_id per workspace +
+            // a top-level groups array) and the host accepts
+            // workspace.group.collapse/expand from mobile. iOS feature-detects
+            // this to render collapsible groups only against a Mac that emits them.
+            "workspace.groups.v1",
+        ]
+        #if DEBUG
+        capabilities.append("dogfood.v1")
+        #endif
+        return capabilities
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -309,6 +309,11 @@ final class MobileHostService {
             "terminal.replay.v1",
             "terminal.viewport.v1",
             "workspace.actions.v1",
+            // The workspace list carries group sections (group_id per workspace +
+            // a top-level groups array) and the host accepts
+            // workspace.group.collapse/expand from mobile. iOS feature-detects
+            // this to render collapsible groups only against a Mac that emits them.
+            "workspace.groups.v1",
         ]
         #if DEBUG
         capabilities.append("dogfood.v1")
@@ -1270,6 +1275,12 @@ final class MobileHostService {
         case "mobile.workspace.list", "workspace.list":
             return nil
         case "workspace.create":
+            return nil
+        case "workspace.group.collapse", "workspace.group.expand":
+            // Display-only group state. Keyed by `group_id` (not a workspace or
+            // terminal selection), so it is Mac-scoped like the workspace list and
+            // not constrained by the ticket's workspace/terminal pin. The Stack
+            // same-account gate in `authorizationError` remains authoritative.
             return nil
         case "mobile.terminal.create", "terminal.create":
             return nil

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -292,35 +292,6 @@ final class MobileHostService {
     static let shared = MobileHostService()
     nonisolated private static let maximumActiveConnectionCount = 10
 
-    /// The single source of truth for the capabilities advertised to mobile
-    /// clients via `mobile.host.status`. Every status path (the public-status
-    /// cache, the live `publicHostStatusResult`, and `TerminalController`'s
-    /// full status) reads this so the lists cannot drift; iOS gates features
-    /// like rename/pin on the entries present here.
-    ///
-    /// In DEBUG builds this also advertises `dogfood.v1`, the DEV dogfood
-    /// feedback round-trip (`dogfood.feedback.submit`). It is absent from
-    /// release builds, so a release client never sees the verb advertised.
-    nonisolated static var mobileHostCapabilities: [String] {
-        var capabilities = [
-            "events.v1",
-            "terminal.bytes.v1",
-            "terminal.render_grid.v1",
-            "terminal.replay.v1",
-            "terminal.viewport.v1",
-            "workspace.actions.v1",
-            // The workspace list carries group sections (group_id per workspace +
-            // a top-level groups array) and the host accepts
-            // workspace.group.collapse/expand from mobile. iOS feature-detects
-            // this to render collapsible groups only against a Mac that emits them.
-            "workspace.groups.v1",
-        ]
-        #if DEBUG
-        capabilities.append("dogfood.v1")
-        #endif
-        return capabilities
-    }
-
     private let callbackQueue = DispatchQueue(label: "dev.cmux.mobile.host-listener")
     private let routeResolver = MobileRouteResolver()
     private let ticketStore = MobileAttachTicketStore()

--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -100,6 +100,12 @@ final class MobileWorkspaceListObserver {
                 // a pure pin toggle need not change the panel set or title, so
                 // without this the phone never learns the workspace was pinned.
                 workspace.$isPinned.map { _ in () }.eraseToAnyPublisher(),
+                // Group membership is iOS-facing (the phone nests members under
+                // their group header). Moving a workspace into or out of a group
+                // mutates only this workspace's `groupId`; it need not change the
+                // tab set, `workspaceGroups`, the panel set, or the title, so
+                // without this the phone never learns the membership changed.
+                workspace.$groupId.map { _ in () }.eraseToAnyPublisher(),
                 workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
                 workspace.$panelDirectories.map { _ in () }.eraseToAnyPublisher(),
                 // Pure drag-reorders change spatial order without changing the panel

--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -15,6 +15,7 @@ final class MobileWorkspaceListObserver {
     private weak var tabManager: TabManager?
     private var tabsCancellable: AnyCancellable?
     private var selectionCancellable: AnyCancellable?
+    private var groupsCancellable: AnyCancellable?
     private var perWorkspaceCancellables: [UUID: AnyCancellable] = [:]
     private var lastSummaryHash: Int = 0
     /// Throttle window with `latest: true`. First event in a burst emits
@@ -36,7 +37,11 @@ final class MobileWorkspaceListObserver {
         // Initial snapshot. Every observer's first emit is unconditional so
         // freshly-paired clients see the current state without waiting for
         // the first mutation.
-        let initial = Self.summaryHash(for: tabManager.tabs, selectedTabID: tabManager.selectedTabId)
+        let initial = Self.summaryHash(
+            for: tabManager.tabs,
+            groups: tabManager.workspaceGroups,
+            selectedTabID: tabManager.selectedTabId
+        )
         lastSummaryHash = initial
         emitIfNeeded(force: true)
 
@@ -54,6 +59,17 @@ final class MobileWorkspaceListObserver {
         // to push to iPhone too. iPhone's selectedWorkspaceID drives which
         // terminal it displays.
         selectionCancellable = tabManager.$selectedTabId
+            .throttle(for: .milliseconds(throttleMilliseconds), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] _ in
+                self?.emitIfNeeded(force: false)
+            }
+        // Group structure (order, name, collapse/pin, anchor, membership) is
+        // iOS-facing: the phone renders collapsible group sections. A pure
+        // collapse/expand or group rename need not change the tab set, so without
+        // observing `$workspaceGroups` the phone would never learn a group was
+        // collapsed from the Mac (or from the phone's own collapse RPC, which is
+        // authoritative + re-fetch based, not optimistic).
+        groupsCancellable = tabManager.$workspaceGroups
             .throttle(for: .milliseconds(throttleMilliseconds), scheduler: RunLoop.main, latest: true)
             .sink { [weak self] _ in
                 self?.emitIfNeeded(force: false)
@@ -101,7 +117,11 @@ final class MobileWorkspaceListObserver {
 
     private func emitIfNeeded(force: Bool) {
         guard let tabManager else { return }
-        let hash = Self.summaryHash(for: tabManager.tabs, selectedTabID: tabManager.selectedTabId)
+        let hash = Self.summaryHash(
+            for: tabManager.tabs,
+            groups: tabManager.workspaceGroups,
+            selectedTabID: tabManager.selectedTabId
+        )
         if !force, hash == lastSummaryHash {
             #if DEBUG
             cmuxDebugLog("mobile.observer skip: hash unchanged=\(hash) tabs=\(tabManager.tabs.count)")
@@ -127,14 +147,34 @@ final class MobileWorkspaceListObserver {
     /// produces a different hash and re-emits to the phone. Titles are hashed via
     /// `panelTitle(panelId:)` so a custom terminal rename (which sets
     /// `panelCustomTitles`, not `panelTitles`) is detected too.
-    private static func summaryHash(for tabs: [Workspace], selectedTabID: UUID?) -> Int {
+    private static func summaryHash(
+        for tabs: [Workspace],
+        groups: [WorkspaceGroup],
+        selectedTabID: UUID?
+    ) -> Int {
         var hasher = Hasher()
         hasher.combine(tabs.count)
         hasher.combine(selectedTabID)
+        // Group sections are iOS-facing. Hash group order + the fields the phone
+        // renders (name, collapse, pin, anchor) so a pure collapse/expand, rename,
+        // or reorder re-emits to the phone. Membership is already covered by each
+        // workspace's `groupId`, hashed in the per-workspace loop below.
+        hasher.combine(groups.count)
+        for group in groups {
+            hasher.combine(group.id)
+            hasher.combine(group.name)
+            hasher.combine(group.isCollapsed)
+            hasher.combine(group.isPinned)
+            hasher.combine(group.anchorWorkspaceId)
+        }
         for workspace in tabs {
             hasher.combine(workspace.id)
             hasher.combine(workspace.title)
             hasher.combine(workspace.isPinned)
+            // Group membership is iOS-facing (the phone nests members under the
+            // group header), and a pure move-into/out-of-group need not change the
+            // panel set or title, so hash it here.
+            hasher.combine(workspace.groupId)
             // Spatial order is significant: hash the ordered id sequence so a
             // reorder of the same panel set changes the hash.
             let panelIDs = workspace.orderedPanelIds
@@ -158,8 +198,12 @@ final class MobileWorkspaceListObserver {
     }
 
     #if DEBUG
-    static func summaryHashForTesting(tabs: [Workspace], selectedTabID: UUID?) -> Int {
-        summaryHash(for: tabs, selectedTabID: selectedTabID)
+    static func summaryHashForTesting(
+        tabs: [Workspace],
+        groups: [WorkspaceGroup] = [],
+        selectedTabID: UUID?
+    ) -> Int {
+        summaryHash(for: tabs, groups: groups, selectedTabID: selectedTabID)
     }
     #endif
 }

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -1,0 +1,236 @@
+import AppKit
+import Foundation
+
+// MARK: - Mobile workspace list (iOS-facing payloads)
+//
+// The phone's `workspace.list` surface: enumerating workspaces across windows,
+// serializing the workspace and group-section payloads, and the mobile-gated
+// group collapse/expand handler. Lives in its own file so the mobile list
+// payload code stays together without growing TerminalController.swift.
+extension TerminalController {
+    /// Mobile-gated collapse/expand of a workspace group. P1 group support on
+    /// iOS is display-only: the phone renders collapsible group sections and can
+    /// toggle a section open/closed, but cannot create, rename, or restructure
+    /// groups. This requires an explicit, resolvable `group_id` (it must never
+    /// fall back to the Mac's selected group) and delegates to the same
+    /// `v2WorkspaceGroupSetCollapsed` the CLI and sidebar use, so the mutation
+    /// path stays shared. `v2ResolveTabManager` routes by `group_id` to the
+    /// owning window even in the multi-window case.
+    func v2MobileWorkspaceGroupSetCollapsed(params: [String: Any], isCollapsed: Bool) -> V2CallResult {
+        guard v2HasNonNullParam(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        guard v2UUID(params, "group_id") != nil else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        return v2WorkspaceGroupSetCollapsed(params: params, isCollapsed: isCollapsed)
+    }
+
+    func v2MobileWorkspaceList(
+        params: [String: Any],
+        tabManager resolvedTabManager: TabManager? = nil,
+        createdWorkspaceID: String? = nil,
+        createdTerminalID: String? = nil
+    ) -> V2CallResult {
+        let requestedWorkspaceID = v2UUID(params, "workspace_id")
+        if v2HasNonNullParam(params, "workspace_id"), requestedWorkspaceID == nil {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        let requestedTerminalID: UUID?
+        switch mobileTerminalAliasUUID(params: params) {
+        case .missing:
+            requestedTerminalID = nil
+        case let .value(terminalID):
+            requestedTerminalID = terminalID
+        case .invalid:
+            return .err(code: "invalid_params", message: "Missing or invalid terminal_id", data: nil)
+        case .conflict:
+            return .err(code: "invalid_params", message: "Conflicting terminal identifiers", data: nil)
+        }
+
+        // The phone shows workspaces from *every* open Mac window. Enumerate all
+        // registered main windows and flatten their workspaces into one list,
+        // but only when the caller has not named a specific target. When a
+        // `workspace_id`, `window_id`, terminal alias, or an explicit
+        // `resolvedTabManager` (the create/terminal-create paths pass one) is
+        // present, keep today's single-window scoped behavior so those requests
+        // resolve exactly the named target.
+        let scopeToSingleWindow = resolvedTabManager != nil
+            || requestedWorkspaceID != nil
+            || v2HasNonNullParam(params, "window_id")
+            || requestedTerminalID != nil
+
+        // `is_selected` has no single answer across multiple windows. Mark only
+        // the frontmost/key window's selected workspace as selected; in the old
+        // single-window path this is exactly the one selected workspace. Using
+        // `currentScriptableMainWindow()` (not `isKeyWindow`) means a backgrounded
+        // app, where no window is key, still reports the same selection the old
+        // path would have, instead of marking nothing selected.
+        let selectedWorkspaceID = scopeToSingleWindow
+            ? nil
+            : AppDelegate.shared?.currentScriptableMainWindow()?.tabManager.selectedTabId
+
+        let workspaces: [[String: Any]]
+        // Group sections shown on the phone. Aggregated alongside the workspace
+        // list so the iOS client can fold contiguous same-group workspaces under a
+        // collapsible header that mirrors the Mac sidebar.
+        var groups: [[String: Any]] = []
+        if scopeToSingleWindow {
+            guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
+                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+            }
+            // Only include groups when listing the whole window. A request scoped
+            // to one workspace or terminal is a targeted lookup (create/refresh of
+            // a single entry), not a sidebar render, so it omits group sections to
+            // keep the response minimal. The phone always lists the full window.
+            if requestedWorkspaceID == nil, requestedTerminalID == nil {
+                groups = mobileWorkspaceGroupPayloads(tabManager.workspaceGroups, tabs: tabManager.tabs)
+            }
+            let visibleWorkspaces = requestedWorkspaceID.map { workspaceID in
+                tabManager.tabs.filter { $0.id == workspaceID }
+            } ?? tabManager.tabs
+            if let requestedWorkspaceID, visibleWorkspaces.isEmpty {
+                return .err(
+                    code: "not_found",
+                    message: "Workspace not found",
+                    data: ["workspace_id": requestedWorkspaceID.uuidString]
+                )
+            }
+            let scopedWorkspaces = visibleWorkspaces.map { workspace in
+                mobileWorkspacePayload(
+                    workspace: workspace,
+                    isSelected: workspace.id == tabManager.selectedTabId,
+                    requestedTerminalID: requestedTerminalID
+                )
+            }
+            if let requestedTerminalID,
+               !scopedWorkspaces.contains(where: { workspace in
+                   guard let terminals = workspace["terminals"] as? [[String: Any]] else { return false }
+                   return terminals.contains { ($0["id"] as? String) == requestedTerminalID.uuidString }
+               }) {
+                return .err(
+                    code: "not_found",
+                    message: "Terminal not found",
+                    data: ["surface_id": requestedTerminalID.uuidString]
+                )
+            }
+            workspaces = scopedWorkspaces
+        } else {
+            guard let app = AppDelegate.shared else {
+                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+            }
+            var flattened: [[String: Any]] = []
+            // `listMainWindowSummaries()` already dedupes window ids, but guard
+            // against the same window or workspace appearing twice anyway: a
+            // workspace lives in exactly one window, and ids are globally unique.
+            var seenWindowIDs: Set<UUID> = []
+            var seenWorkspaceIDs: Set<UUID> = []
+            // Groups are per-TabManager (per window). Aggregate them in the same
+            // window-iteration order the workspaces are flattened in, so a group's
+            // header lands at its first member's position in the combined list.
+            var aggregatedGroups: [[String: Any]] = []
+            for summary in app.listMainWindowSummaries() {
+                guard seenWindowIDs.insert(summary.windowId).inserted else { continue }
+                guard let windowTabManager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                aggregatedGroups.append(
+                    contentsOf: mobileWorkspaceGroupPayloads(
+                        windowTabManager.workspaceGroups,
+                        tabs: windowTabManager.tabs
+                    )
+                )
+                for workspace in windowTabManager.tabs where seenWorkspaceIDs.insert(workspace.id).inserted {
+                    flattened.append(
+                        mobileWorkspacePayload(
+                            workspace: workspace,
+                            isSelected: workspace.id == selectedWorkspaceID,
+                            requestedTerminalID: requestedTerminalID
+                        )
+                    )
+                }
+            }
+            workspaces = flattened
+            groups = aggregatedGroups
+        }
+
+        var payload: [String: Any] = [
+            "workspaces": workspaces,
+            "groups": groups
+        ]
+        if let createdWorkspaceID {
+            payload["created_workspace_id"] = createdWorkspaceID
+        }
+        if let createdTerminalID {
+            payload["created_terminal_id"] = createdTerminalID
+        }
+        return .ok(payload)
+    }
+
+    /// Serializes one workspace into the iOS-facing mobile workspace list shape.
+    ///
+    /// Shared by the single-window (scoped) and all-windows enumeration branches
+    /// of `v2MobileWorkspaceList` so the two never diverge. When
+    /// `requestedTerminalID` is non-nil the terminals array is filtered to that
+    /// one terminal (only the scoped branch passes it; the all-windows branch
+    /// always passes nil, so it lists every terminal). The scoped
+    /// terminal-not-found check is enforced by the caller after the list is built.
+    func mobileWorkspacePayload(
+        workspace: Workspace,
+        isSelected: Bool,
+        requestedTerminalID: UUID?
+    ) -> [String: Any] {
+        let terminals = mobileTerminalPanels(in: workspace).compactMap { terminal -> [String: Any]? in
+            if let requestedTerminalID, terminal.id != requestedTerminalID {
+                return nil
+            }
+            return [
+                "id": terminal.id.uuidString,
+                "title": workspace.panelTitle(panelId: terminal.id) ?? terminal.displayTitle,
+                "current_directory": v2OrNull(
+                    mobileNonEmpty(workspace.panelDirectories[terminal.id])
+                        ?? mobileNonEmpty(terminal.directory)
+                        ?? mobileNonEmpty(terminal.requestedWorkingDirectory)
+                ),
+                "is_ready": terminal.surface.surface != nil,
+                "is_focused": terminal.id == workspace.focusedPanelId
+            ]
+        }
+
+        return [
+            "id": workspace.id.uuidString,
+            "title": workspace.title,
+            "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
+            "is_selected": isSelected,
+            "is_pinned": workspace.isPinned,
+            // Group membership so the phone can fold contiguous same-group
+            // workspaces under their group header. nil for ungrouped workspaces.
+            "group_id": v2OrNull(workspace.groupId?.uuidString),
+            "terminals": terminals
+        ]
+    }
+
+    /// Serializes the window's workspace groups into the iOS-facing mobile shape.
+    ///
+    /// A subset of `v2WorkspaceGroupPayload` carrying only what the phone needs to
+    /// render collapsible sections (no v2 handle refs, color, or icon). Member ids
+    /// are taken in `tabs` spatial order so the phone's grouping matches the Mac.
+    /// Membership is resolved with a single pass over `tabs` (not a scan per
+    /// group), keeping this synchronous RPC path linear on large workspace sets.
+    func mobileWorkspaceGroupPayloads(_ groups: [WorkspaceGroup], tabs: [Workspace]) -> [[String: Any]] {
+        guard !groups.isEmpty else { return [] }
+        var memberIDsByGroup: [UUID: [String]] = [:]
+        for workspace in tabs {
+            guard let groupId = workspace.groupId else { continue }
+            memberIDsByGroup[groupId, default: []].append(workspace.id.uuidString)
+        }
+        return groups.map { group in
+            [
+                "id": group.id.uuidString,
+                "name": group.name,
+                "is_collapsed": group.isCollapsed,
+                "is_pinned": group.isPinned,
+                "anchor_workspace_id": group.anchorWorkspaceId.uuidString,
+                "member_workspace_ids": memberIDsByGroup[group.id] ?? []
+            ]
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20823,6 +20823,10 @@ class TerminalController {
             result = v2MobileTerminalMouse(params: request.params)
         case "workspace.action":
             result = v2MobileWorkspaceAction(params: request.params)
+        case "workspace.group.collapse":
+            result = v2MobileWorkspaceGroupSetCollapsed(params: request.params, isCollapsed: true)
+        case "workspace.group.expand":
+            result = v2MobileWorkspaceGroupSetCollapsed(params: request.params, isCollapsed: false)
 #if DEBUG
         case "dogfood.feedback.submit":
             result = await v2MobileDogfoodFeedbackSubmit(params: request.params)
@@ -21054,6 +21058,24 @@ class TerminalController {
         return v2WorkspaceAction(params: params)
     }
 
+    /// Mobile-gated collapse/expand of a workspace group. P1 group support on
+    /// iOS is display-only: the phone renders collapsible group sections and can
+    /// toggle a section open/closed, but cannot create, rename, or restructure
+    /// groups. This requires an explicit, resolvable `group_id` (it must never
+    /// fall back to the Mac's selected group) and delegates to the same
+    /// `v2WorkspaceGroupSetCollapsed` the CLI and sidebar use, so the mutation
+    /// path stays shared. `v2ResolveTabManager` routes by `group_id` to the
+    /// owning window even in the multi-window case.
+    private func v2MobileWorkspaceGroupSetCollapsed(params: [String: Any], isCollapsed: Bool) -> V2CallResult {
+        guard v2HasNonNullParam(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        guard v2UUID(params, "group_id") != nil else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        return v2WorkspaceGroupSetCollapsed(params: params, isCollapsed: isCollapsed)
+    }
+
     private func mobileHostResult(_ result: V2CallResult) -> MobileHostRPCResult {
         switch result {
         case let .ok(payload):
@@ -21251,9 +21273,22 @@ class TerminalController {
             : AppDelegate.shared?.currentScriptableMainWindow()?.tabManager.selectedTabId
 
         let workspaces: [[String: Any]]
+        // Group sections shown on the phone. Aggregated alongside the workspace
+        // list so the iOS client can fold contiguous same-group workspaces under a
+        // collapsible header that mirrors the Mac sidebar.
+        var groups: [[String: Any]] = []
         if scopeToSingleWindow {
             guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
                 return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+            }
+            // Only include groups when listing the whole window. A request scoped
+            // to one workspace or terminal is a targeted lookup (create/refresh of
+            // a single entry), not a sidebar render, so it omits group sections to
+            // keep the response minimal. The phone always lists the full window.
+            if requestedWorkspaceID == nil, requestedTerminalID == nil {
+                groups = tabManager.workspaceGroups.map {
+                    mobileWorkspaceGroupPayload($0, tabs: tabManager.tabs)
+                }
             }
             let visibleWorkspaces = requestedWorkspaceID.map { workspaceID in
                 tabManager.tabs.filter { $0.id == workspaceID }
@@ -21294,9 +21329,18 @@ class TerminalController {
             // workspace lives in exactly one window, and ids are globally unique.
             var seenWindowIDs: Set<UUID> = []
             var seenWorkspaceIDs: Set<UUID> = []
+            // Groups are per-TabManager (per window). Aggregate them in the same
+            // window-iteration order the workspaces are flattened in, so a group's
+            // header lands at its first member's position in the combined list.
+            var aggregatedGroups: [[String: Any]] = []
             for summary in app.listMainWindowSummaries() {
                 guard seenWindowIDs.insert(summary.windowId).inserted else { continue }
                 guard let windowTabManager = app.tabManagerFor(windowId: summary.windowId) else { continue }
+                for group in windowTabManager.workspaceGroups {
+                    aggregatedGroups.append(
+                        mobileWorkspaceGroupPayload(group, tabs: windowTabManager.tabs)
+                    )
+                }
                 for workspace in windowTabManager.tabs where seenWorkspaceIDs.insert(workspace.id).inserted {
                     flattened.append(
                         mobileWorkspacePayload(
@@ -21308,10 +21352,12 @@ class TerminalController {
                 }
             }
             workspaces = flattened
+            groups = aggregatedGroups
         }
 
         var payload: [String: Any] = [
-            "workspaces": workspaces
+            "workspaces": workspaces,
+            "groups": groups
         ]
         if let createdWorkspaceID {
             payload["created_workspace_id"] = createdWorkspaceID
@@ -21358,7 +21404,27 @@ class TerminalController {
             "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
             "is_selected": isSelected,
             "is_pinned": workspace.isPinned,
+            // Group membership so the phone can fold contiguous same-group
+            // workspaces under their group header. nil for ungrouped workspaces.
+            "group_id": v2OrNull(workspace.groupId?.uuidString),
             "terminals": terminals
+        ]
+    }
+
+    /// Serializes one workspace group into the iOS-facing mobile shape.
+    ///
+    /// A subset of `v2WorkspaceGroupPayload` carrying only what the phone needs to
+    /// render collapsible sections (no v2 handle refs, color, or icon). Member ids
+    /// are taken in `tabs` spatial order so the phone's grouping matches the Mac.
+    private func mobileWorkspaceGroupPayload(_ group: WorkspaceGroup, tabs: [Workspace]) -> [String: Any] {
+        let memberIds = tabs.compactMap { $0.groupId == group.id ? $0.id.uuidString : nil }
+        return [
+            "id": group.id.uuidString,
+            "name": group.name,
+            "is_collapsed": group.isCollapsed,
+            "is_pinned": group.isPinned,
+            "anchor_workspace_id": group.anchorWorkspaceId.uuidString,
+            "member_workspace_ids": memberIds
         ]
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5090,7 +5090,7 @@ class TerminalController {
             : .err(code: "not_found", message: "Group not found", data: ["group_id": gid.uuidString])
     }
 
-    private func v2WorkspaceGroupSetCollapsed(params: [String: Any], isCollapsed: Bool) -> V2CallResult {
+    func v2WorkspaceGroupSetCollapsed(params: [String: Any], isCollapsed: Bool) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
@@ -21058,24 +21058,6 @@ class TerminalController {
         return v2WorkspaceAction(params: params)
     }
 
-    /// Mobile-gated collapse/expand of a workspace group. P1 group support on
-    /// iOS is display-only: the phone renders collapsible group sections and can
-    /// toggle a section open/closed, but cannot create, rename, or restructure
-    /// groups. This requires an explicit, resolvable `group_id` (it must never
-    /// fall back to the Mac's selected group) and delegates to the same
-    /// `v2WorkspaceGroupSetCollapsed` the CLI and sidebar use, so the mutation
-    /// path stays shared. `v2ResolveTabManager` routes by `group_id` to the
-    /// owning window even in the multi-window case.
-    private func v2MobileWorkspaceGroupSetCollapsed(params: [String: Any], isCollapsed: Bool) -> V2CallResult {
-        guard v2HasNonNullParam(params, "group_id") else {
-            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
-        }
-        guard v2UUID(params, "group_id") != nil else {
-            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
-        }
-        return v2WorkspaceGroupSetCollapsed(params: params, isCollapsed: isCollapsed)
-    }
-
     private func mobileHostResult(_ result: V2CallResult) -> MobileHostRPCResult {
         switch result {
         case let .ok(payload):
@@ -21228,214 +21210,14 @@ class TerminalController {
         }
     }
 
-    private func v2MobileWorkspaceList(
-        params: [String: Any],
-        tabManager resolvedTabManager: TabManager? = nil,
-        createdWorkspaceID: String? = nil,
-        createdTerminalID: String? = nil
-    ) -> V2CallResult {
-        let requestedWorkspaceID = v2UUID(params, "workspace_id")
-        if v2HasNonNullParam(params, "workspace_id"), requestedWorkspaceID == nil {
-            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
-        }
-        let requestedTerminalID: UUID?
-        switch mobileTerminalAliasUUID(params: params) {
-        case .missing:
-            requestedTerminalID = nil
-        case let .value(terminalID):
-            requestedTerminalID = terminalID
-        case .invalid:
-            return .err(code: "invalid_params", message: "Missing or invalid terminal_id", data: nil)
-        case .conflict:
-            return .err(code: "invalid_params", message: "Conflicting terminal identifiers", data: nil)
-        }
-
-        // The phone shows workspaces from *every* open Mac window. Enumerate all
-        // registered main windows and flatten their workspaces into one list,
-        // but only when the caller has not named a specific target. When a
-        // `workspace_id`, `window_id`, terminal alias, or an explicit
-        // `resolvedTabManager` (the create/terminal-create paths pass one) is
-        // present, keep today's single-window scoped behavior so those requests
-        // resolve exactly the named target.
-        let scopeToSingleWindow = resolvedTabManager != nil
-            || requestedWorkspaceID != nil
-            || v2HasNonNullParam(params, "window_id")
-            || requestedTerminalID != nil
-
-        // `is_selected` has no single answer across multiple windows. Mark only
-        // the frontmost/key window's selected workspace as selected; in the old
-        // single-window path this is exactly the one selected workspace. Using
-        // `currentScriptableMainWindow()` (not `isKeyWindow`) means a backgrounded
-        // app, where no window is key, still reports the same selection the old
-        // path would have, instead of marking nothing selected.
-        let selectedWorkspaceID = scopeToSingleWindow
-            ? nil
-            : AppDelegate.shared?.currentScriptableMainWindow()?.tabManager.selectedTabId
-
-        let workspaces: [[String: Any]]
-        // Group sections shown on the phone. Aggregated alongside the workspace
-        // list so the iOS client can fold contiguous same-group workspaces under a
-        // collapsible header that mirrors the Mac sidebar.
-        var groups: [[String: Any]] = []
-        if scopeToSingleWindow {
-            guard let tabManager = resolvedTabManager ?? v2ResolveTabManager(params: params) else {
-                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
-            }
-            // Only include groups when listing the whole window. A request scoped
-            // to one workspace or terminal is a targeted lookup (create/refresh of
-            // a single entry), not a sidebar render, so it omits group sections to
-            // keep the response minimal. The phone always lists the full window.
-            if requestedWorkspaceID == nil, requestedTerminalID == nil {
-                groups = tabManager.workspaceGroups.map {
-                    mobileWorkspaceGroupPayload($0, tabs: tabManager.tabs)
-                }
-            }
-            let visibleWorkspaces = requestedWorkspaceID.map { workspaceID in
-                tabManager.tabs.filter { $0.id == workspaceID }
-            } ?? tabManager.tabs
-            if let requestedWorkspaceID, visibleWorkspaces.isEmpty {
-                return .err(
-                    code: "not_found",
-                    message: "Workspace not found",
-                    data: ["workspace_id": requestedWorkspaceID.uuidString]
-                )
-            }
-            let scopedWorkspaces = visibleWorkspaces.map { workspace in
-                mobileWorkspacePayload(
-                    workspace: workspace,
-                    isSelected: workspace.id == tabManager.selectedTabId,
-                    requestedTerminalID: requestedTerminalID
-                )
-            }
-            if let requestedTerminalID,
-               !scopedWorkspaces.contains(where: { workspace in
-                   guard let terminals = workspace["terminals"] as? [[String: Any]] else { return false }
-                   return terminals.contains { ($0["id"] as? String) == requestedTerminalID.uuidString }
-               }) {
-                return .err(
-                    code: "not_found",
-                    message: "Terminal not found",
-                    data: ["surface_id": requestedTerminalID.uuidString]
-                )
-            }
-            workspaces = scopedWorkspaces
-        } else {
-            guard let app = AppDelegate.shared else {
-                return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
-            }
-            var flattened: [[String: Any]] = []
-            // `listMainWindowSummaries()` already dedupes window ids, but guard
-            // against the same window or workspace appearing twice anyway: a
-            // workspace lives in exactly one window, and ids are globally unique.
-            var seenWindowIDs: Set<UUID> = []
-            var seenWorkspaceIDs: Set<UUID> = []
-            // Groups are per-TabManager (per window). Aggregate them in the same
-            // window-iteration order the workspaces are flattened in, so a group's
-            // header lands at its first member's position in the combined list.
-            var aggregatedGroups: [[String: Any]] = []
-            for summary in app.listMainWindowSummaries() {
-                guard seenWindowIDs.insert(summary.windowId).inserted else { continue }
-                guard let windowTabManager = app.tabManagerFor(windowId: summary.windowId) else { continue }
-                for group in windowTabManager.workspaceGroups {
-                    aggregatedGroups.append(
-                        mobileWorkspaceGroupPayload(group, tabs: windowTabManager.tabs)
-                    )
-                }
-                for workspace in windowTabManager.tabs where seenWorkspaceIDs.insert(workspace.id).inserted {
-                    flattened.append(
-                        mobileWorkspacePayload(
-                            workspace: workspace,
-                            isSelected: workspace.id == selectedWorkspaceID,
-                            requestedTerminalID: requestedTerminalID
-                        )
-                    )
-                }
-            }
-            workspaces = flattened
-            groups = aggregatedGroups
-        }
-
-        var payload: [String: Any] = [
-            "workspaces": workspaces,
-            "groups": groups
-        ]
-        if let createdWorkspaceID {
-            payload["created_workspace_id"] = createdWorkspaceID
-        }
-        if let createdTerminalID {
-            payload["created_terminal_id"] = createdTerminalID
-        }
-        return .ok(payload)
-    }
-
-    /// Serializes one workspace into the iOS-facing mobile workspace list shape.
-    ///
-    /// Shared by the single-window (scoped) and all-windows enumeration branches
-    /// of `v2MobileWorkspaceList` so the two never diverge. When
-    /// `requestedTerminalID` is non-nil the terminals array is filtered to that
-    /// one terminal (only the scoped branch passes it; the all-windows branch
-    /// always passes nil, so it lists every terminal). The scoped
-    /// terminal-not-found check is enforced by the caller after the list is built.
-    private func mobileWorkspacePayload(
-        workspace: Workspace,
-        isSelected: Bool,
-        requestedTerminalID: UUID?
-    ) -> [String: Any] {
-        let terminals = mobileTerminalPanels(in: workspace).compactMap { terminal -> [String: Any]? in
-            if let requestedTerminalID, terminal.id != requestedTerminalID {
-                return nil
-            }
-            return [
-                "id": terminal.id.uuidString,
-                "title": workspace.panelTitle(panelId: terminal.id) ?? terminal.displayTitle,
-                "current_directory": v2OrNull(
-                    mobileNonEmpty(workspace.panelDirectories[terminal.id])
-                        ?? mobileNonEmpty(terminal.directory)
-                        ?? mobileNonEmpty(terminal.requestedWorkingDirectory)
-                ),
-                "is_ready": terminal.surface.surface != nil,
-                "is_focused": terminal.id == workspace.focusedPanelId
-            ]
-        }
-
-        return [
-            "id": workspace.id.uuidString,
-            "title": workspace.title,
-            "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
-            "is_selected": isSelected,
-            "is_pinned": workspace.isPinned,
-            // Group membership so the phone can fold contiguous same-group
-            // workspaces under their group header. nil for ungrouped workspaces.
-            "group_id": v2OrNull(workspace.groupId?.uuidString),
-            "terminals": terminals
-        ]
-    }
-
-    /// Serializes one workspace group into the iOS-facing mobile shape.
-    ///
-    /// A subset of `v2WorkspaceGroupPayload` carrying only what the phone needs to
-    /// render collapsible sections (no v2 handle refs, color, or icon). Member ids
-    /// are taken in `tabs` spatial order so the phone's grouping matches the Mac.
-    private func mobileWorkspaceGroupPayload(_ group: WorkspaceGroup, tabs: [Workspace]) -> [String: Any] {
-        let memberIds = tabs.compactMap { $0.groupId == group.id ? $0.id.uuidString : nil }
-        return [
-            "id": group.id.uuidString,
-            "name": group.name,
-            "is_collapsed": group.isCollapsed,
-            "is_pinned": group.isPinned,
-            "anchor_workspace_id": group.anchorWorkspaceId.uuidString,
-            "member_workspace_ids": memberIds
-        ]
-    }
-
-    private enum MobileTerminalAliasUUID {
+    enum MobileTerminalAliasUUID {
         case missing
         case value(UUID)
         case invalid
         case conflict
     }
 
-    private func mobileTerminalAliasUUID(params: [String: Any]) -> MobileTerminalAliasUUID {
+    func mobileTerminalAliasUUID(params: [String: Any]) -> MobileTerminalAliasUUID {
         var selected: UUID?
         var sawAlias = false
         for key in ["surface_id", "terminal_id", "tab_id"] {
@@ -22027,7 +21809,7 @@ class TerminalController {
         return (tabManager, workspace, surfaceId)
     }
 
-    private func mobileTerminalPanels(in workspace: Workspace) -> [TerminalPanel] {
+    func mobileTerminalPanels(in workspace: Workspace) -> [TerminalPanel] {
         // Use the workspace's spatial (left-to-right, top-to-bottom) panel order
         // so the phone's terminal dropdown matches the on-screen bonsplit layout,
         // rather than focused-first/UUID order. `is_focused` in the payload still
@@ -22035,7 +21817,7 @@ class TerminalController {
         orderedPanels(in: workspace).compactMap { $0 as? TerminalPanel }
     }
 
-    private func mobileNonEmpty(_ raw: String?) -> String? {
+    func mobileNonEmpty(_ raw: String?) -> String? {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed?.isEmpty == false ? trimmed : nil
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */; };
 		6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */; };
 		4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */; };
+		C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */; };
 		F67FBC88671C40AC3A3284CE /* MobileHostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACA497A6831165EA879C642 /* MobileHostService.swift */; };
 		C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */; };
 		9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */; };
@@ -600,6 +601,7 @@
 		C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A502000000000000000001 /* TaskManagerWindowController.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
+		C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */; };
 		D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */; };
 		A5001007 /* TerminalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001019 /* TerminalController.swift */; };
 		C7A50A000000000000000002 /* TerminalControllerPaneResizeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */; };
@@ -1157,6 +1159,7 @@
 		8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAttachTicketStore.swift; sourceTree = "<group>"; };
 		9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostAuthorizationTests.swift; sourceTree = "<group>"; };
 		47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostRPC.swift; sourceTree = "<group>"; };
+		C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileHostService+Capabilities.swift"; sourceTree = "<group>"; };
 		7ACA497A6831165EA879C642 /* MobileHostService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostService.swift; sourceTree = "<group>"; };
 		C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostServiceSettingsTests.swift; sourceTree = "<group>"; };
 		A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePairingConnectionTransitionTests.swift; sourceTree = "<group>"; };
@@ -1326,6 +1329,7 @@
 		C7A502000000000000000001 /* TaskManagerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerWindowController.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
+		C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileWorkspaceList.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		A5001019 /* TerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalController.swift; sourceTree = "<group>"; };
 		C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerPaneResizeSupport.swift; sourceTree = "<group>"; };
@@ -1604,6 +1608,7 @@
 				8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */,
 				47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */,
 				7ACA497A6831165EA879C642 /* MobileHostService.swift */,
+				C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */,
 				7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */,
 				04CE82AE8B39EA0C1395F696 /* MobilePairingModel.swift */,
 				B76EC5E03C345BEAC25828A7 /* MobilePairingQRImageView.swift */,
@@ -1826,6 +1831,7 @@
 				D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */,
 				C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */,
 				C7A50B000000000000000001 /* TerminalControllerV2ParamParsingSupport.swift */,
+				C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */,
 				C7A505000000000000000001 /* TerminalControllerTopSupport.swift */,
 				C7A501000000000000000001 /* CmuxTopSnapshot.swift */,
 				C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */,
@@ -2883,6 +2889,7 @@
 				C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */,
 				284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */,
 				4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */,
+				C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */,
 				F67FBC88671C40AC3A3284CE /* MobileHostService.swift in Sources */,
 				0099C2865D9D468747D14593 /* MobilePairingModel.swift in Sources */,
 				325AF8814443BDA97AC3CC98 /* MobilePairingQRImageView.swift in Sources */,
@@ -2984,6 +2991,7 @@
 				C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */,
 				C7A506000000000000000002 /* TaskManagerView.swift in Sources */,
 				C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */,
+				C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */,
 				D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */,
 				A5001007 /* TerminalController.swift in Sources */,
 				C7A50A000000000000000002 /* TerminalControllerPaneResizeSupport.swift in Sources */,

--- a/cmuxTests/MobileWorkspaceListFidelityTests.swift
+++ b/cmuxTests/MobileWorkspaceListFidelityTests.swift
@@ -139,4 +139,34 @@ struct MobileWorkspaceListFidelityTests {
         )
         #expect(before != after, "a workspace rename must change the mobile summary hash")
     }
+
+    /// A pure group-membership move (a workspace's `groupId` changes while the tab
+    /// set, group list, panels, title, and pin state stay put) must change the
+    /// mobile summary hash so the observer re-emits `workspace.updated`. The phone
+    /// nests members under their group header keyed by `group_id`, so a stale hash
+    /// here would leave the mobile sidebar showing the workspace in the wrong
+    /// section. Guards the per-workspace `$groupId` subscription that drives it.
+    @Test func movingWorkspaceBetweenGroupsChangesObserverHash() throws {
+        let manager = TabManager()
+        let member = try #require(manager.selectedWorkspace)
+        // A real group with its own anchor; the member starts ungrouped.
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Group A"))
+        #expect(member.groupId == nil)
+
+        let before = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: manager.tabs,
+            groups: manager.workspaceGroups,
+            selectedTabID: manager.selectedTabId
+        )
+
+        // Move the workspace into the group: only `groupId` changes.
+        member.groupId = groupId
+
+        let after = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: manager.tabs,
+            groups: manager.workspaceGroups,
+            selectedTabID: manager.selectedTabId
+        )
+        #expect(before != after, "a pure group-membership move must change the mobile summary hash")
+    }
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3638,6 +3638,40 @@
           }
         }
       }
+    },
+    "mobile.workspaceGroup.expand.a11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループを展開"
+          }
+        }
+      }
+    },
+    "mobile.workspaceGroup.collapse.a11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループを折りたたむ"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/plans/feat-ios-groups-mobile/DESIGN.md
+++ b/plans/feat-ios-groups-mobile/DESIGN.md
@@ -1,0 +1,66 @@
+# Groups on mobile (P1: display + collapse/expand)
+
+Desktop organizes workspaces into collapsible named GROUPS. An anchor workspace
+owns each group; the anchor renders as the group header (no separate row);
+collapsed groups hide members but keep the header. iOS currently flattens and
+ignores groups. P1 = render groups on iOS + expand/collapse from the phone.
+Phone-side group create/edit/rename/delete/reorder is DEFERRED.
+
+Canonical desktop semantics (mirror these): `Sources/SidebarWorkspaceRenderItem.swift`
+- Items follow `tabs` order. A group header is emitted at the first member's position.
+- The anchor workspace is NEVER a separate row (header represents it).
+- Header label = `group.name`. Collapsed => members skipped, header kept.
+- Ungrouped workspaces interleave inline by `tabs` position.
+
+## Payload did NOT carry group info before this change
+`mobileWorkspacePayload` emitted only id/title/current_directory/is_selected/
+is_pinned/terminals. No group id, no groups array. So step 1 was to surface it.
+
+## Phase 1 — Mac host (surface group structure)
+1. `mobileWorkspacePayload` (TerminalController.swift): add `group_id` (nullable).
+2. `v2MobileWorkspaceList`: add top-level `groups` array. Scoped branch uses the
+   resolved TabManager's `workspaceGroups`; all-windows branch aggregates each
+   window's groups in window-iteration order (groups are per-TabManager). Each
+   group entry: id, name, is_collapsed, is_pinned, anchor_workspace_id,
+   member_workspace_ids (subset of v2WorkspaceGroupPayload shape).
+3. `MobileWorkspaceListObserver`: subscribe to `$workspaceGroups` and fold group
+   order + id + name + is_collapsed + is_pinned + anchor + member set into
+   `summaryHash`. Without this, a phone collapse toggles `isCollapsed` on the Mac
+   but the observer never emits `workspace.updated`, so the disclosure looks
+   frozen. (Memory: "observer must hash the @Published it pushes".)
+4. Expose `workspace.group.collapse`/`workspace.group.expand` to mobile: add cases
+   to BOTH `mobileHostHandleRPC` (the real mobile gate) and the ticket-auth switch
+   in `MobileHostService.swift`. Display-only state behind the same-account Stack
+   gate, so authorized (return nil) like `mobile.workspace.list`. Route by
+   `group_id` (v2ResolveTabManager already locates the owning window's TabManager
+   across all windows by group_id; group ids are globally unique).
+5. Advertise `workspace.groups.v1` capability so iOS feature-detects.
+
+## Phase 2 — iOS (decode + render + collapse)
+6. `MobileSyncWorkspaceListResponse`: add optional `groupId` per workspace +
+   optional `groups: [Group]` (all optional => backward compatible).
+7. New `MobileWorkspaceGroupPreview` value model. Add `groupId` to
+   `MobileWorkspacePreview`.
+8. Store: parallel `workspaceGroups: [MobileWorkspaceGroupPreview]`, populated in
+   `applyRemoteWorkspaceList`. `supportsWorkspaceGroups` capability flag (mirror
+   `supportsWorkspaceActions`). `setWorkspaceGroupCollapsed(groupId:_)` RPC
+   (fire-and-forget, authoritative re-fetch via observer; no local optimistic
+   state, per the optimistic-UI rule).
+9. Render-item builder mirroring SidebarWorkspaceRenderItem (anchor-as-header,
+   collapsed hides members). `WorkspaceListView` renders collapsible sections.
+   Snapshot boundary: pass value models + a `collapseGroup: (id, Bool) -> Void`
+   closure into the List, no store ref below the List boundary.
+
+## Ordering caveat
+Existing `filteredWorkspaces` does pinned-first sort which scatters group members.
+The grouped render path must preserve Mac member contiguity. P1 keeps Mac order
+(render items already encode order); the flat pinned-first sort applies only when
+there are no groups, to avoid breaking contiguity.
+
+## Localize
+New strings via L10n.string/String(localized:) keys in
+`ios/cmux/Resources/Localizable.xcstrings` (en + ja).
+
+## Verify
+Build-only on iOS simulator with tagged derivedDataPath. No xcodebuild test
+locally. No stray cmux DEV launch.


### PR DESCRIPTION
The iOS app flattened workspaces and ignored the desktop's named, collapsible groups. This renders groups on the phone: collapsible named sections in group order, members nested under the group header, mirroring desktop semantics (the anchor workspace renders as the header, not a separate row; collapsing hides members but keeps the header).

P1 is display plus expand/collapse from the phone. Phone-side group create/rename/restructure is deferred.

## Did the mobile payload already carry group info?
No. `mobileWorkspacePayload` emitted only id/title/current_directory/is_selected/is_pinned/terminals, and `v2MobileWorkspaceList` had no groups. The first step was to surface it on the Mac host, then render it.

## Mac host (surface group structure)
- `mobileWorkspacePayload` now emits `group_id` per workspace (nil for ungrouped). `v2MobileWorkspaceList` adds a top-level `groups` array (`id`, `name`, `is_collapsed`, `is_pinned`, `anchor_workspace_id`, `member_workspace_ids`). The all-windows branch aggregates each window's groups in window-iteration order (groups are per-TabManager).
- `MobileWorkspaceListObserver` now subscribes to `$workspaceGroups` and folds group order/name/collapse/pin/anchor plus each workspace's `groupId` into its summary hash. Without this a phone collapse toggles `isCollapsed` on the Mac but the observer never re-emits `workspace.updated`, so the disclosure would look frozen.
- `workspace.group.collapse`/`workspace.group.expand` are exposed to mobile (added to `mobileHostHandleRPC` and the ticket-auth model in `MobileHostService`), gated by the same same-account Stack auth as the rest of the data plane. Routing is by `group_id`, which `v2ResolveTabManager` already resolves to the owning window across all windows. New `workspace.groups.v1` capability so iOS feature-detects.

## iOS (decode + render + collapse)
- `MobileSyncWorkspaceListResponse` decodes an optional `group_id` per workspace and an optional `groups` array (backward compatible: both absent on older Macs).
- `MobileWorkspaceGroupPreview` value model; `MobileWorkspaceListItem.items` builds the ordered render items mirroring `SidebarWorkspaceRenderItem` (anchor as header, collapsed hides members, ungrouped interleave by position, unknown group degrades to an ungrouped row).
- `WorkspaceGroupHeaderRow`: the chevron toggles collapse; tapping the name selects/opens the anchor workspace, so the anchor's terminals stay reachable (mirrors the desktop header, whose chevron collapses and whose body focuses the anchor).
- Store carries `workspaceGroups` + `supportsWorkspaceGroups` and a fire-and-forget `setWorkspaceGroupCollapsed` RPC (authoritative re-fetch via the observer, no local optimistic state). The grouped section renders only when the Mac advertises the capability and the user is not searching; otherwise the list stays flat (pinned-first), preserving member contiguity. Search deliberately flattens so members are findable across groups.

## Where the list renders groups
- `Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift` (render-item builder)
- `Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift` `groupedRows` (the grouped List section)
- `Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift` (the collapsible header)

## Verification
- iOS simulator build (tagged derivedDataPath, build-only): BUILD SUCCEEDED.
- macOS app build (build-only): BUILD SUCCEEDED.
- 6 pure unit tests for the render-item grouping logic (`MobileWorkspaceListItemTests`) pass.
- Collapse/expand round-trip is wired and the observer hash makes it sound, but the autonomous simulator cannot pair to a Mac, so the end-to-end collapse round-trip is pending on-device dogfood.

New user-facing strings localized (en + ja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783487495&installation_id=133855650&pr_number=5625&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5625&signature=5c52c034a6e1dd2b49513f15dd982c94830d194c2687be30c370897bad5625e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile RPC payloads, multi-window list aggregation, and sync observer hashing; display-only mutations but incorrect merge/refresh logic could flatten or freeze group UI on iOS.
> 
> **Overview**
> The iOS workspace list no longer ignores Mac sidebar groups: it can show **collapsible named sections** (anchor as header, indented members) and **collapse/expand from the phone**, with search still using a flat pinned-first list.
> 
> **Mac host** extends the mobile `workspace.list` payload with per-workspace `group_id` and a top-level `groups` array (including multi-window aggregation). It adds mobile RPC handlers for `workspace.group.collapse` / `expand`, advertises **`workspace.groups.v1`**, and moves list serialization into `TerminalController+MobileWorkspaceList.swift`. **`MobileWorkspaceListObserver`** now watches `$workspaceGroups` and each workspace’s `groupId` in its summary hash so collapse and membership changes push `workspace.updated`.
> 
> **iOS** decodes the new fields (backward compatible), maps them to `MobileWorkspaceGroupPreview` / `groupID` on previews, and builds rows via **`MobileWorkspaceListItem`** plus **`WorkspaceGroupHeaderRow`**. The shell store keeps `workspaceGroups`, gates on capability (or emitted groups), and sends fire-and-forget collapse RPCs without optimistic local state; full-list refreshes only update groups so merge paths do not clear sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660cd478fe5a70fbeda04c15ba07b0486c1ce233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds collapsible workspace groups to the iOS workspace list to mirror desktop: the anchor renders as the header, members nest beneath, and collapsing hides members. The Mac now emits group data in the mobile payload and supports collapse/expand over mobile RPC.

- **New Features**
  - Mac host: adds `group_id` per workspace and a top-level `groups` array in `v2MobileWorkspaceList` (aggregated across windows in order); exposes `workspace.group.collapse`/`workspace.group.expand`; advertises `workspace.groups.v1`.
  - iOS: decodes optional `group_id` and `groups` (defaults `groups` to empty for older Macs); maps to `MobileWorkspaceGroupPreview`; `MobileWorkspaceListItem` builds ordered items (anchor-as-header, collapsed hides members, unknown groups render ungrouped); `WorkspaceGroupHeaderRow` toggles collapse and opens the anchor, and the chevron is passive when toggle isn’t available; grouped layout renders when the payload includes groups and search is empty, otherwise the list stays flat (pinned-first); groups update only on full-list refresh (merge responses omit `groups`); adds a11y labels (en, ja).

- **Bug Fixes**
  - `MobileWorkspaceListObserver` now watches `$workspaceGroups` and per-workspace `$groupId`, so collapse/rename/membership moves re-emit `workspace.updated`; adds tests (including a pure membership-move hash check).

<sup>Written for commit 660cd478fe5a70fbeda04c15ba07b0486c1ce233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile now supports Mac-synced workspace groups with collapsible sections, anchor headers, and host-capability detection; iOS can send collapse/expand requests.

* **UI Changes**
  * Workspace list renders Mac-style grouped presentation (falls back to flat during search or when unsupported); headers toggle collapse and select anchor workspaces.

* **Accessibility**
  * Added localized labels for expand/collapse.

* **Tests**
  * Added unit tests validating grouped rendering and observer change detection.

* **Documentation**
  * Added iOS design spec for mobile workspace groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->