### PR TITLE
iOS terminal: inherit Mac font-family + Settings font size with reset

### DIFF
--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
@@ -36,6 +36,11 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
     public var terminalForeground: String?
     public var terminalBackground: String?
     public var terminalCursorColor: String?
+    /// The Mac's resolved primary terminal `font-family`, so the phone's local
+    /// libghostty surface inherits it instead of hardcoding Menlo. `nil` when the
+    /// Mac leaves `font-family` unset (the phone then keeps its built-in default).
+    /// Carried only on a full snapshot, like the dynamic colors above.
+    public var terminalFontFamily: String?
     /// Count of scrollback lines carried in ``scrollbackSpans`` (rows above the
     /// visible viewport, oldest first). Only meaningful on a full primary-screen
     /// snapshot; the alternate screen has no scrollback.
@@ -60,6 +65,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
         terminalForeground: String? = nil,
         terminalBackground: String? = nil,
         terminalCursorColor: String? = nil,
+        terminalFontFamily: String? = nil,
         scrollbackRows: Int = 0,
         scrollbackSpans: [RowSpan] = []
     ) throws {
@@ -136,6 +142,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
         self.terminalForeground = terminalForeground
         self.terminalBackground = terminalBackground
         self.terminalCursorColor = terminalCursorColor
+        self.terminalFontFamily = full ? terminalFontFamily : nil
         self.scrollbackRows = full ? resolvedScrollbackRows : 0
         self.scrollbackSpans = full ? scrollbackSpans : []
     }
@@ -157,6 +164,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
         let terminalForeground = try container.decodeIfPresent(String.self, forKey: .terminalForeground)
         let terminalBackground = try container.decodeIfPresent(String.self, forKey: .terminalBackground)
         let terminalCursorColor = try container.decodeIfPresent(String.self, forKey: .terminalCursorColor)
+        let terminalFontFamily = try container.decodeIfPresent(String.self, forKey: .terminalFontFamily)
         let scrollbackRows = try container.decodeIfPresent(Int.self, forKey: .scrollbackRows) ?? 0
         let scrollbackSpans = try container.decodeIfPresent([RowSpan].self, forKey: .scrollbackSpans) ?? []
         try self.init(
@@ -175,6 +183,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
             terminalForeground: terminalForeground,
             terminalBackground: terminalBackground,
             terminalCursorColor: terminalCursorColor,
+            terminalFontFamily: terminalFontFamily,
             scrollbackRows: scrollbackRows,
             scrollbackSpans: scrollbackSpans
         )
@@ -293,6 +302,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
             terminalForeground: full ? terminalForeground : nil,
             terminalBackground: full ? terminalBackground : nil,
             terminalCursorColor: full ? terminalCursorColor : nil,
+            terminalFontFamily: full ? terminalFontFamily : nil,
             scrollbackRows: full ? scrollbackRows : 0,
             scrollbackSpans: full ? scrollbackSpans : []
         )
@@ -403,6 +413,7 @@ public struct MobileTerminalRenderGridFrame: Codable, Equatable, Sendable {
         case terminalForeground = "terminal_foreground"
         case terminalBackground = "terminal_background"
         case terminalCursorColor = "terminal_cursor_color"
+        case terminalFontFamily = "terminal_font_family"
         case scrollbackRows = "scrollback_rows"
         case scrollbackSpans = "scrollback_spans"
     }

--- a/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileTerminalRenderGridTests.swift
+++ b/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/MobileTerminalRenderGridTests.swift
@@ -379,6 +379,57 @@ import Testing
     #expect(!vt.contains("\u{1B}[?1000h"))
 }
 
+@Test func renderGridFullSnapshotCarriesInheritedFontFamily() throws {
+    let frame = try MobileTerminalRenderGridFrame(
+        surfaceID: "terminal-a",
+        stateSeq: 3,
+        columns: 4,
+        rows: 1,
+        rowSpans: [],
+        terminalFontFamily: "JetBrains Mono"
+    )
+
+    // The Mac's resolved font-family round-trips on a full frame so the phone
+    // can inherit it (it is config, not VT, so it does not appear in the byte
+    // stream like the dynamic colors do).
+    let decoded = try MobileTerminalRenderGridFrame.decodeJSONObject(frame.jsonObject())
+    #expect(decoded == frame)
+    #expect(decoded.terminalFontFamily == "JetBrains Mono")
+    let object = try frame.jsonObject()
+    #expect(object["terminal_font_family"] as? String == "JetBrains Mono")
+}
+
+@Test func renderGridDeltaDropsInheritedFontFamily() throws {
+    // A delta frame carries no full-state restore data, so it must not re-send
+    // the inherited font-family; the phone keeps the last family from the
+    // previous full snapshot.
+    let delta = try MobileTerminalRenderGridFrame(
+        surfaceID: "terminal-a",
+        stateSeq: 5,
+        columns: 4,
+        rows: 1,
+        full: false,
+        rowSpans: [.init(row: 0, column: 0, text: "x")],
+        terminalFontFamily: "JetBrains Mono"
+    )
+    #expect(delta.terminalFontFamily == nil)
+
+    // filteredRows(full: false) likewise strips it, like the dynamic colors.
+    let full = try MobileTerminalRenderGridFrame(
+        surfaceID: "terminal-a",
+        stateSeq: 6,
+        columns: 4,
+        rows: 2,
+        rowSpans: [.init(row: 0, column: 0, text: "x"), .init(row: 1, column: 0, text: "y")],
+        terminalFontFamily: "JetBrains Mono"
+    )
+    #expect(full.terminalFontFamily == "JetBrains Mono")
+    let filteredDelta = try full.filteredRows([1], full: false)
+    #expect(filteredDelta.terminalFontFamily == nil)
+    let filteredFull = try full.filteredRows([0, 1], full: true)
+    #expect(filteredFull.terminalFontFamily == "JetBrains Mono")
+}
+
 @Test func replaySynthesizerMatchesFrameForwardersAcrossFrameShapes() throws {
     // Full primary-screen snapshot with scrollback, styles, and a cursor.
     let fullFrame = try MobileTerminalRenderGridFrame(

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2555,9 +2555,29 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Mac hosts.
     private var terminalByteContinuationsBySurfaceID: [String: AsyncStream<Data>.Continuation] = [:]
 
+    /// The Mac's resolved terminal `font-family` per surface, carried on full
+    /// render-grid frames so the phone's local libghostty inherits it. Only set
+    /// when a frame actually carries a family (deltas omit it), so the last known
+    /// family survives across delta frames. The mounted surface reads it via
+    /// ``inheritedFontFamily(surfaceID:)`` and applies it on change.
+    private var inheritedFontFamilyBySurfaceID: [String: String] = [:]
+
     /// Yield a chunk of output bytes to the surface's stream, if one is attached.
     private func deliverTerminalBytes(_ bytes: Data, surfaceID: String) {
         terminalByteContinuationsBySurfaceID[surfaceID]?.yield(bytes)
+    }
+
+    /// Record the Mac's resolved terminal font-family for `surfaceID`. Called
+    /// before the frame's bytes are delivered, so the surface's output loop sees
+    /// the current family before processing that snapshot.
+    private func recordInheritedFontFamily(_ family: String, surfaceID: String) {
+        inheritedFontFamilyBySurfaceID[surfaceID] = family
+    }
+
+    /// The Mac's resolved terminal font-family the phone should inherit for
+    /// `surfaceID`, or `nil` if none has been seen (keep the built-in default).
+    public func inheritedFontFamily(surfaceID: String) -> String? {
+        inheritedFontFamilyBySurfaceID[surfaceID]
     }
 
     /// Whether a surface currently has an attached output stream consumer.
@@ -2580,6 +2600,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func unregisterTerminalOutput(surfaceID: String) {
         terminalByteContinuationsBySurfaceID.removeValue(forKey: surfaceID)
+        inheritedFontFamilyBySurfaceID.removeValue(forKey: surfaceID)
         deliveredTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
         pendingTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
         // Tell the Mac this device is no longer viewing the surface so it stops
@@ -2725,6 +2746,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 }
                 let deliverBytes: Data?
                 if let renderGrid {
+                    if let family = renderGrid.terminalFontFamily {
+                        self.recordInheritedFontFamily(family, surfaceID: surfaceID)
+                    }
                     deliverBytes = renderGrid.vtPatchBytes()
                     MobileDebugLog.anchormux("CMUX_REPLAY render_grid surface=\(surfaceID) spans=\(renderGrid.rowSpans.count) seq=\(renderGrid.stateSeq)")
                 } else if let snapshotBytes, !snapshotBytes.isEmpty {
@@ -2779,6 +2803,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 "sync.render_grid_stale surface=\(renderGrid.surfaceID) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
             )
             return
+        }
+        if let family = renderGrid.terminalFontFamily {
+            recordInheritedFontFamily(family, surfaceID: renderGrid.surfaceID)
         }
         let bytes = renderGrid.vtPatchBytes()
         markTerminalBytesDelivered(surfaceID: renderGrid.surfaceID, endSeq: renderGrid.stateSeq)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -16,11 +16,18 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     let surfaceID: String
     let store: CMUXMobileShellStore
     /// The shared persisted terminal font-size base, injected from the scene
-    /// root. The surface launches at `effectiveFontSize` and the overlay's
-    /// save/reset actions write this same instance, so Settings and the overlay
-    /// stay in sync. Reading it here also makes `updateUIView` re-run when a
-    /// Settings change flips the size (the @Observable invalidates the body).
+    /// root. The surface launches at `baseFontSize` and the overlay's save/reset
+    /// actions write this same instance, so Settings and the overlay stay in
+    /// sync.
     let zoomPreference: MobileTerminalZoomPreference
+    /// The current persisted base size (`zoomPreference.effectiveFontSize`),
+    /// passed as a value the host (`WorkspaceDetailView`) read in its body. That
+    /// read is what registers the Observation dependency, so a Settings change
+    /// re-renders the host and re-runs `updateUIView` even on an idle terminal
+    /// (passing only the object reference would not, since `body` reads no
+    /// property of it). `applyBaseFontSize` then no-ops unless it actually
+    /// changed.
+    let baseFontSize: Float32
     /// Whether the mounted surface should grab the keyboard when it attaches to
     /// a window. Driven by the host's autofocus-suppression state so chrome
     /// actions (create workspace/terminal, switch terminal) do not pop the
@@ -46,7 +53,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         let view = GhosttySurfaceView(
             runtime: runtime,
             delegate: context.coordinator,
-            fontSize: zoomPreference.effectiveFontSize,
+            fontSize: baseFontSize,
             zoomPreference: zoomPreference
         )
         view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
@@ -57,11 +64,12 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: UIView, context: Context) {
         guard let surfaceView = uiView as? GhosttySurfaceView else { return }
         surfaceView.autoFocusOnWindowAttach = autoFocusOnWindowAttach
-        // A Settings stepper / reset change flips the @Observable preference,
-        // which re-runs the host body and this update. `applyBaseFontSize`
-        // no-ops unless the base actually changed, so an unrelated re-render
-        // never snaps a transient pinch back to the persisted base.
-        surfaceView.applyBaseFontSize(zoomPreference.effectiveFontSize)
+        // `baseFontSize` reflects a Settings stepper / reset change because the
+        // host read it in its body (registering the Observation dependency), so
+        // this runs even on an idle terminal. `applyBaseFontSize` no-ops unless
+        // the base actually changed, so an unrelated re-render never snaps a
+        // transient pinch back to the persisted base.
+        surfaceView.applyBaseFontSize(baseFontSize)
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -15,7 +15,12 @@ import UIKit
 struct GhosttySurfaceRepresentable: UIViewRepresentable {
     let surfaceID: String
     let store: CMUXMobileShellStore
-    let fontSize: Float32
+    /// The shared persisted terminal font-size base, injected from the scene
+    /// root. The surface launches at `effectiveFontSize` and the overlay's
+    /// save/reset actions write this same instance, so Settings and the overlay
+    /// stay in sync. Reading it here also makes `updateUIView` re-run when a
+    /// Settings change flips the size (the @Observable invalidates the body).
+    let zoomPreference: MobileTerminalZoomPreference
     /// Whether the mounted surface should grab the keyboard when it attaches to
     /// a window. Driven by the host's autofocus-suppression state so chrome
     /// actions (create workspace/terminal, switch terminal) do not pop the
@@ -41,7 +46,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         let view = GhosttySurfaceView(
             runtime: runtime,
             delegate: context.coordinator,
-            fontSize: fontSize
+            fontSize: zoomPreference.effectiveFontSize,
+            zoomPreference: zoomPreference
         )
         view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
         context.coordinator.attach(surfaceView: view)
@@ -49,7 +55,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        (uiView as? GhosttySurfaceView)?.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        guard let surfaceView = uiView as? GhosttySurfaceView else { return }
+        surfaceView.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        // A Settings stepper / reset change flips the @Observable preference,
+        // which re-runs the host body and this update. `applyBaseFontSize`
+        // no-ops unless the base actually changed, so an unrelated re-render
+        // never snaps a transient pinch back to the persisted base.
+        surfaceView.applyBaseFontSize(zoomPreference.effectiveFontSize)
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
@@ -79,6 +91,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             outputTask = Task { @MainActor [weak surfaceView] in
                 for await data in store.terminalOutputStream(surfaceID: surfaceID) {
                     guard !Task.isCancelled else { return }
+                    // Inherit the Mac's resolved font-family before painting this
+                    // chunk. The store records it (from full render-grid frames)
+                    // before yielding the bytes, so it is current here; the
+                    // surface no-ops unless the family actually changed.
+                    if let family = store.inheritedFontFamily(surfaceID: surfaceID) {
+                        surfaceView?.applyInheritedFontFamily(family)
+                    }
                     surfaceView?.processOutput(data)
                 }
             }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -2,6 +2,7 @@
 import CmuxAuthRuntime
 import CmuxMobileShell
 import CmuxMobileSupport
+import CmuxMobileTerminal
 import SwiftUI
 
 /// The mobile app's settings page. Surfaces the signed-in account (so the user
@@ -12,6 +13,7 @@ struct MobileSettingsView: View {
     @Environment(AuthCoordinator.self) private var authManager
     @Environment(MobilePushCoordinator.self) private var pushCoordinator
     @Environment(MobileDisplaySettings.self) private var displaySettings
+    @Environment(MobileTerminalZoomPreference.self) private var terminalZoomPreference
     let connectedHostName: String
     let rescanQR: (() -> Void)?
     let signOut: (() -> Void)?
@@ -95,7 +97,7 @@ struct MobileSettingsView: View {
                     }
                 }
 
-                Section(L10n.string("mobile.settings.terminal", defaultValue: "Terminal")) {
+                Section {
                     Button {
                         showingShortcuts = true
                     } label: {
@@ -105,6 +107,26 @@ struct MobileSettingsView: View {
                         )
                     }
                     .accessibilityIdentifier("MobileSettingsTerminalShortcuts")
+
+                    terminalFontSizeControl
+
+                    Button {
+                        terminalZoomPreference.clear()
+                    } label: {
+                        Label(
+                            L10n.string("mobile.settings.terminalFontSizeReset", defaultValue: "Reset to Default"),
+                            systemImage: "arrow.counterclockwise"
+                        )
+                    }
+                    .disabled(!terminalZoomPreference.hasCustomFontSize)
+                    .accessibilityIdentifier("MobileSettingsTerminalFontSizeReset")
+                } header: {
+                    Text(L10n.string("mobile.settings.terminal", defaultValue: "Terminal"))
+                } footer: {
+                    Text(L10n.string(
+                        "mobile.settings.terminalFontSizeFooter",
+                        defaultValue: "Sets the terminal's base text size on this device. The font family follows the Mac you pair with."
+                    ))
                 }
 
                 Section(L10n.string("mobile.settings.display", defaultValue: "Display")) {
@@ -170,6 +192,31 @@ struct MobileSettingsView: View {
             }
         }
         .accessibilityIdentifier("MobileSettingsView")
+    }
+
+    /// Stepper that nudges the terminal's base font size by one point, clamped
+    /// to the supported zoom range. Writes the shared
+    /// ``MobileTerminalZoomPreference``, so the change persists and applies live
+    /// to the open terminal surface (no rebuild, no timer).
+    private var terminalFontSizeControl: some View {
+        let size = terminalZoomPreference.effectiveFontSize
+        return Stepper {
+            LabeledContent {
+                Text(verbatim: "\(Int(size.rounded())) pt")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("MobileSettingsTerminalFontSizeValue")
+            } label: {
+                Label(
+                    L10n.string("mobile.settings.terminalFontSize", defaultValue: "Font Size"),
+                    systemImage: "textformat.size"
+                )
+            }
+        } onIncrement: {
+            terminalZoomPreference.step(by: 1)
+        } onDecrement: {
+            terminalZoomPreference.step(by: -1)
+        }
+        .accessibilityIdentifier("MobileSettingsTerminalFontSize")
     }
 
     private var accountEmail: String {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -21,6 +21,10 @@ struct WorkspaceDetailView: View {
     let reportTerminalViewport: (MobileWorkspacePreview.ID, MobileTerminalPreview.ID, MobileTerminalViewportSize) -> Void
     let sendTerminalInput: (String) -> Void
     let safeAreaContext: MobileTerminalSafeAreaContext
+    /// Shared persisted terminal font-size base, injected from the scene root.
+    /// Passed to the surface so its launch size and zoom overlay use the same
+    /// instance the Settings stepper binds.
+    @Environment(MobileTerminalZoomPreference.self) private var terminalZoomPreference
     @State private var isTerminalPickerPresented = false
     #if DEBUG && canImport(UIKit)
     @State private var isFeedbackComposerPresented = false
@@ -49,7 +53,7 @@ struct WorkspaceDetailView: View {
                 GhosttySurfaceRepresentable(
                     surfaceID: terminalID,
                     store: store,
-                    fontSize: MobileTerminalFontPreference.defaultSize,
+                    zoomPreference: terminalZoomPreference,
                     autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
                 )
                 // Identity must track the selected terminal. The representable's

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -54,6 +54,14 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     zoomPreference: terminalZoomPreference,
+                    // Read `effectiveFontSize` here (in the host body) so a
+                    // Settings stepper / reset change invalidates THIS view and
+                    // re-runs the representable's updateUIView, applying the new
+                    // size live even when the terminal is idle. Observation is
+                    // property-granular: passing only the object would not
+                    // re-render this view, so the change would not reach the
+                    // surface until an unrelated re-render.
+                    baseFontSize: terminalZoomPreference.effectiveFontSize,
                     autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
                 )
                 // Identity must track the selected terminal. The representable's

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -181,10 +181,27 @@ public final class GhosttyRuntime {
         }
     }
 
-    private static func applyiOSDefaults(_ config: ghostty_config_t) {
-        let monokai = """
-        font-family = Menlo
-        font-size = 10
+    /// The default font-family the iOS terminal renders with until the Mac's
+    /// resolved `font-family` is inherited over the render channel. Ghostty
+    /// resolves a real fallback chain for glyph coverage; this is just the
+    /// primary face.
+    nonisolated static let defaultFontFamily = "Menlo"
+
+    /// The iOS terminal's full ghostty config text (theme, padding, cursor, and
+    /// the Monokai palette) with the font-family and font-size made explicit.
+    ///
+    /// Single source of truth so the launch config (`applyiOSDefaults` /
+    /// `ensureDefaultiOSConfig`) and a live `ghostty_surface_update_config`
+    /// font-family inherit cannot drift: a runtime config swap must reapply the
+    /// whole block, since `ghostty_surface_update_config` re-derives the entire
+    /// surface config and would otherwise wipe the theme.
+    nonisolated static func iOSGhosttyConfigText(
+        fontFamily: String = defaultFontFamily,
+        fontSize: Float32 = MobileTerminalFontPreference.defaultSize
+    ) -> String {
+        """
+        font-family = \(fontFamily)
+        font-size = \(Int(fontSize.rounded()))
         window-padding-balance = false
         window-padding-y = 0
         cursor-style = bar
@@ -211,6 +228,38 @@ public final class GhosttyRuntime {
         palette = 14=#66d9ef
         palette = 15=#fdfff1
         """
+    }
+
+    /// Build a finalized ghostty config carrying the full iOS defaults block
+    /// with `fontFamily` and `fontSize` made explicit, for a live
+    /// `ghostty_surface_update_config` on a mounted surface.
+    ///
+    /// `ghostty_surface_update_config` re-derives the entire surface config from
+    /// the passed config, so this reapplies the whole theme (not just the font)
+    /// to avoid wiping the Monokai palette/padding/cursor. The caller owns the
+    /// returned pointer and must `ghostty_config_free` it after the update; the
+    /// C API does not retain it (see the Mac's `reloadSurfaceConfiguration`).
+    /// Returns `nil` if config allocation fails.
+    nonisolated static func makeSurfaceFontConfig(fontFamily: String, fontSize: Float32) -> ghostty_config_t? {
+        guard let config = ghostty_config_new() else { return nil }
+        let text = iOSGhosttyConfigText(fontFamily: fontFamily, fontSize: fontSize)
+        let syntheticPath = "/__cmux_ios_font__/inherit.conf"
+        text.withCString { contents in
+            syntheticPath.withCString { path in
+                ghostty_config_load_string(
+                    config,
+                    contents,
+                    UInt(text.lengthOfBytes(using: .utf8)),
+                    path
+                )
+            }
+        }
+        ghostty_config_finalize(config)
+        return config
+    }
+
+    private static func applyiOSDefaults(_ config: ghostty_config_t) {
+        let monokai = iOSGhosttyConfigText()
         let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent("ghostty-ios-config-\(ProcessInfo.processInfo.processIdentifier)")
         do {
             try monokai.write(to: tmpFile, atomically: true, encoding: .utf8)
@@ -234,35 +283,7 @@ public final class GhosttyRuntime {
         let configFile = configDir.appendingPathComponent("config", isDirectory: false)
         guard !FileManager.default.fileExists(atPath: configFile.path) else { return }
 
-        let defaultConfig = """
-        font-family = Menlo
-        font-size = 10
-        window-padding-balance = false
-        window-padding-y = 0
-        cursor-style = bar
-        cursor-style-blink = true
-        background = #272822
-        foreground = #fdfff1
-        cursor-color = #c0c1b5
-        selection-background = #57584f
-        selection-foreground = #fdfff1
-        palette = 0=#272822
-        palette = 1=#f92672
-        palette = 2=#a6e22e
-        palette = 3=#e6db74
-        palette = 4=#fd971f
-        palette = 5=#ae81ff
-        palette = 6=#66d9ef
-        palette = 7=#fdfff1
-        palette = 8=#6e7066
-        palette = 9=#f92672
-        palette = 10=#a6e22e
-        palette = 11=#e6db74
-        palette = 12=#fd971f
-        palette = 13=#ae81ff
-        palette = 14=#66d9ef
-        palette = 15=#fdfff1
-        """
+        let defaultConfig = iOSGhosttyConfigText()
 
         do {
             try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -606,9 +606,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var zoomOverlayLastInteraction: CFTimeInterval = 0
     private static let zoomOverlayVisibleDuration: CFTimeInterval = 2.5
     /// Persisted user "default zoom" backing the zoom-control overlay's
-    /// reset/save/restore actions. Owned by the surface (constructed at init)
-    /// rather than reached through a singleton, so it is injectable in tests.
-    private let zoomPreference = MobileTerminalZoomPreference()
+    /// reset/save/restore actions. Injected from the app composition root so the
+    /// overlay and the Settings > Terminal stepper drive the same instance; a
+    /// fresh default keeps previews and tests isolated.
+    private let zoomPreference: MobileTerminalZoomPreference
+    /// Last base size pushed through `applyBaseFontSize`, so an incidental
+    /// SwiftUI re-render that re-invokes the representable's `updateUIView` does
+    /// not snap a transient pinch back to the persisted base. `nil` until the
+    /// first explicit Settings-driven push.
+    private var lastAppliedBaseFontSize: Float32?
+    /// Last `font-family` inherited from the Mac and applied via
+    /// `ghostty_surface_update_config`, so an unchanged family on every full
+    /// frame is a no-op (re-deriving the whole font stack per frame is
+    /// expensive). `nil` until the first inherited family arrives.
+    private var lastAppliedFontFamily: String?
     private let bridge = GhosttySurfaceBridge()
     private let prefersSnapshotFallbackRendering = false
     var onFocusInputRequestedForTesting: (() -> Void)?
@@ -875,11 +886,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return inputProxy
     }()
 
-    public init(runtime: GhosttyRuntime, delegate: GhosttySurfaceViewDelegate, fontSize: Float32 = 10) {
+    public init(
+        runtime: GhosttyRuntime,
+        delegate: GhosttySurfaceViewDelegate,
+        fontSize: Float32 = 10,
+        zoomPreference: MobileTerminalZoomPreference = MobileTerminalZoomPreference()
+    ) {
         self.runtime = runtime
         self.delegate = delegate
+        self.zoomPreference = zoomPreference
+        // `fontSize` is the launch base. The representable computes it from the
+        // injected `zoomPreference.effectiveFontSize`, so a saved Settings base
+        // now applies at launch (the latent bug was the surface always opening
+        // at the built-in default regardless of the saved size). Previews and
+        // the stress harness pass an explicit size and a throwaway preference,
+        // so honoring `fontSize` here keeps their intent.
         self.fontSize = fontSize
         self.liveFontSize = fontSize
+        self.lastAppliedBaseFontSize = fontSize
         super.init(frame: CGRect(x: 0, y: 0, width: 402, height: 700))
         bridge.attach(to: self)
         backgroundColor = .black
@@ -1312,6 +1336,56 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         scheduleDisplayLinkWork()
     }
 
+    /// Apply a new persisted base font size from the Settings stepper / reset.
+    ///
+    /// Called from the representable's `updateUIView` when the injected
+    /// preference changes. `updateUIView` fires on *every* SwiftUI update, so
+    /// this no-ops unless `base` actually differs from the last applied base:
+    /// that keeps an incidental re-render from snapping a transient pinch back to
+    /// the persisted size. An explicit Settings change does differ, so it
+    /// legitimately overrides the current pinch. Drives the same coalesced
+    /// `set_font_size` apply path as a pinch step (no timer, no rebuild).
+    public func applyBaseFontSize(_ base: Float32) {
+        guard lastAppliedBaseFontSize != base else { return }
+        lastAppliedBaseFontSize = base
+        applyAbsoluteFontSize(base)
+        zoomOverlay?.updateZoom(points: base)
+    }
+
+    /// Inherit the Mac's resolved terminal `font-family` on this local surface.
+    ///
+    /// Called from the representable's output loop when a full render-grid frame
+    /// carried a family. Set-on-change: re-deriving the whole font stack per
+    /// frame is expensive, so an unchanged family no-ops. Applies via
+    /// `ghostty_surface_update_config`, which re-derives the entire surface
+    /// config; the config carries the full iOS defaults block so the theme is
+    /// preserved, and bakes in the current live font size so the family swap is
+    /// size-neutral (does not reset a pinch / Settings size). Enqueued on the
+    /// same serial `outputQueue` as `processOutput` and the `set_font_size`
+    /// binding action, which take the surface's internal lock — running off it
+    /// would race surface state, and FIFO ordering also keeps the config swap
+    /// ahead of the snapshot bytes the same frame delivers.
+    public func applyInheritedFontFamily(_ family: String) {
+        let trimmed = family.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != lastAppliedFontFamily, let surface else { return }
+        lastAppliedFontFamily = trimmed
+        let size = pendingFontSize ?? liveFontSize
+        MobileDebugLog.anchormux("font.inherit family=\(trimmed) size=\(size)")
+        Self.outputQueue.async {
+            guard let config = GhosttyRuntime.makeSurfaceFontConfig(fontFamily: trimmed, fontSize: size) else {
+                return
+            }
+            ghostty_surface_update_config(surface, config)
+            ghostty_config_free(config)
+        }
+        // The new face changes cell metrics, so the grid must reflow and the
+        // letterbox re-pin once — same settle path as an absolute font size
+        // change (no per-frame geometry thrash).
+        needsDraw = true
+        zoomSettleFrames = Self.zoomSettleFrameThreshold
+        scheduleDisplayLinkWork()
+    }
+
     /// Present (or refresh) the zoom-control HUD and restart its auto-fade
     /// timer. Called on every zoom step so the header tracks the live size.
     private func showZoomOverlay() {
@@ -1350,18 +1424,25 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         overlay.onResetToDefault = { [weak self] in
             guard let self else { return }
-            let target = self.zoomPreference.savedFontSize
-                ?? MobileTerminalFontPreference.defaultSize
+            let target = self.zoomPreference.effectiveFontSize
+            self.lastAppliedBaseFontSize = target
             self.applyAbsoluteFontSize(target)
             self.zoomOverlay?.updateZoom(points: target)
         }
         overlay.onSaveAsDefault = { [weak self] in
             guard let self else { return }
+            // The current live size becomes the new persisted base. `save`
+            // clamps and stores; reading back `effectiveFontSize` gives the
+            // stored value, which we mark as already-applied so the @Observable
+            // change does not bounce back through the representable's
+            // updateUIView as a redundant re-apply.
             self.zoomPreference.save(self.pendingFontSize ?? self.liveFontSize)
+            self.lastAppliedBaseFontSize = self.zoomPreference.effectiveFontSize
         }
         overlay.onRestoreBuiltIn = { [weak self] in
             guard let self else { return }
             self.zoomPreference.clear()
+            self.lastAppliedBaseFontSize = MobileTerminalFontPreference.defaultSize
             self.applyAbsoluteFontSize(MobileTerminalFontPreference.defaultSize)
             self.zoomOverlay?.updateZoom(points: MobileTerminalFontPreference.defaultSize)
         }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalFontPreference.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalFontPreference.swift
@@ -1,4 +1,3 @@
-#if canImport(UIKit)
 import Foundation
 
 /// Terminal font sizing constants for the iOS app, in points.
@@ -20,9 +19,8 @@ public struct MobileTerminalFontPreference {
     /// scale as macOS (see the iOS DPI handling in `ghostty/src/font/face.zig`);
     /// the Retina pixel multiplier is applied separately via content scale.
     public static let defaultSize: Float32 = 10
-    /// Smallest size the zoom controls will reach.
-    static let minimumSize: Float32 = 8
-    /// Largest size the zoom controls will reach.
-    static let maximumSize: Float32 = 28
+    /// Smallest size the zoom controls and the Settings stepper will reach.
+    public static let minimumSize: Float32 = 8
+    /// Largest size the zoom controls and the Settings stepper will reach.
+    public static let maximumSize: Float32 = 28
 }
-#endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalZoomPreference.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalZoomPreference.swift
@@ -1,27 +1,38 @@
 import Foundation
+import Observation
 
-/// Persisted "default zoom" for the mobile terminal: the font size the user has
-/// chosen as their baseline and can restore on demand from the zoom-control
-/// overlay.
+/// Persisted "default zoom" for the mobile terminal: the base font size the user
+/// has chosen and can restore on demand. Shared by two entrypoints that drive the
+/// same model: the zoom-control overlay's "set as default" / "restore built-in"
+/// actions, and the Settings > Terminal "Terminal Font Size" stepper + reset.
 ///
-/// The *live* zoom (``GhosttySurfaceView`` `liveFontSize`) is intentionally not
-/// persisted across launches; this is the separate, explicit default the user
-/// saves with the overlay's "Set as default" action. ``savedFontSize`` is `nil`
-/// when the user has not saved one, in which case a reset falls back to the
+/// The *live* zoom (``GhosttySurfaceView`` `liveFontSize`) is a transient pinch on
+/// top of this base and is intentionally not persisted across launches; this is
+/// the separate, explicit base the user saves. ``savedFontSize`` is `nil` when the
+/// user has not chosen one, in which case the surface and a reset fall back to the
 /// built-in ``MobileTerminalFontPreference/defaultSize``.
+///
+/// Constructed once at the app composition root and injected into the SwiftUI
+/// environment (no singleton), mirroring `MobileDisplaySettings`. Settings binds
+/// it with `@Bindable`; the surface reads the same injected instance so a Settings
+/// change and the overlay stay in sync. The backing store is injected so tests
+/// pass a scoped `UserDefaults(suiteName:)` instead of polluting `.standard`.
 ///
 /// ```swift
 /// let zoom = MobileTerminalZoomPreference()
-/// zoom.save(16)          // remember 16pt as the default
-/// let target = zoom.savedFontSize ?? MobileTerminalFontPreference.defaultSize
+/// zoom.save(16)          // remember 16pt as the base
+/// let target = zoom.effectiveFontSize   // savedFontSize ?? defaultSize
 /// ```
 @MainActor
+@Observable
 public final class MobileTerminalZoomPreference {
     private static let savedSizeKey = "cmux.terminal.zoom.userDefaultSize.v1"
 
-    private let defaults: UserDefaults
+    // UserDefaults is Apple-documented thread-safe; the synchronous read in
+    // `init` and the write-through in `save`/`clear` are safe nonisolated.
+    private nonisolated(unsafe) let defaults: UserDefaults
 
-    /// The user's saved default font size in points, or `nil` if none saved.
+    /// The user's saved base font size in points, or `nil` if none saved.
     public private(set) var savedFontSize: Float32?
 
     /// Creates a preference store.
@@ -39,15 +50,43 @@ public final class MobileTerminalZoomPreference {
         }
     }
 
-    /// Saves `size` (points) as the user's default zoom.
-    public func save(_ size: Float32) {
-        savedFontSize = size
-        defaults.set(size, forKey: Self.savedSizeKey)
+    /// The base size the terminal should launch at and a reset should restore:
+    /// the user's saved size when set, otherwise the built-in default. Always
+    /// clamped into the supported zoom range so a stale or hand-edited stored
+    /// value can never push the surface outside `[minimumSize, maximumSize]`.
+    public var effectiveFontSize: Float32 {
+        let target = savedFontSize ?? MobileTerminalFontPreference.defaultSize
+        return min(
+            max(target, MobileTerminalFontPreference.minimumSize),
+            MobileTerminalFontPreference.maximumSize
+        )
     }
 
-    /// Clears the saved default zoom so a reset falls back to the built-in size.
+    /// Whether a non-default base size is currently saved. Drives the Settings
+    /// "Reset to default" button's enabled state.
+    public var hasCustomFontSize: Bool { savedFontSize != nil }
+
+    /// Saves `size` (points, clamped to the supported range) as the user's base.
+    public func save(_ size: Float32) {
+        let clamped = min(
+            max(size, MobileTerminalFontPreference.minimumSize),
+            MobileTerminalFontPreference.maximumSize
+        )
+        savedFontSize = clamped
+        defaults.set(clamped, forKey: Self.savedSizeKey)
+    }
+
+    /// Clears the saved base so the terminal and a reset fall back to the
+    /// built-in ``MobileTerminalFontPreference/defaultSize``.
     public func clear() {
         savedFontSize = nil
         defaults.removeObject(forKey: Self.savedSizeKey)
+    }
+
+    /// Nudges the saved base by `delta` points from the current effective size,
+    /// clamped to the supported range. Used by the Settings stepper, which always
+    /// writes an explicit base (even when stepping from the built-in default).
+    public func step(by delta: Float32) {
+        save(effectiveFontSize + delta)
     }
 }

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -21,6 +21,10 @@ struct GhosttyConfig {
     static let maxSurfaceTabBarFontSize = CGFloat(CmuxGhosttyConfigSettingEditor.maxSurfaceTabBarFontSize)
 
     var fontFamily: String = "Menlo"
+    /// Whether the user explicitly set `font-family` (vs the "Menlo" default).
+    /// Lets callers that want the user's actual choice (e.g. surfacing it to the
+    /// iOS app to inherit) send nil when unset rather than a false "Menlo".
+    var hasFontFamilyDirective = false
     var fontSize: CGFloat = 12
     var surfaceTabBarFontSize: CGFloat = Self.defaultSurfaceTabBarFontSize
     var sidebarFontSize: CGFloat = Self.defaultSidebarFontSize
@@ -399,7 +403,15 @@ struct GhosttyConfig {
 
                 switch key {
                 case "font-family":
-                    fontFamily = value
+                    // An empty value (`font-family =`) resets to the default in
+                    // Ghostty's RepeatableString semantics, so treat it as unset.
+                    if value.isEmpty {
+                        fontFamily = "Menlo"
+                        hasFontFamilyDirective = false
+                    } else {
+                        fontFamily = value
+                        hasFontFamilyDirective = true
+                    }
                 case "font-size":
                     if let size = Double(value) {
                         fontSize = CGFloat(size)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7321,9 +7321,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         guard let ptr = exported.ptr, exported.len > 0 else { return nil }
 
         let data = Data(bytes: ptr, count: Int(exported.len))
-        guard let fullFrame = try? JSONDecoder().decode(MobileTerminalRenderGridFrame.self, from: data) else {
+        guard var fullFrame = try? JSONDecoder().decode(MobileTerminalRenderGridFrame.self, from: data) else {
             return nil
         }
+        // Surface the Mac's resolved primary `font-family` so the phone's local
+        // libghostty inherits it instead of hardcoding Menlo. libghostty's JSON
+        // export does not carry it, so populate it here from the surface config.
+        // Only meaningful on a full snapshot (like the dynamic colors), and
+        // `filteredRows(full:)` carries it forward / nils it for deltas.
+        fullFrame.terminalFontFamily = resolvedTerminalFontFamily()
         let frame: MobileTerminalRenderGridFrame
         if full, changedRows == nil {
             frame = fullFrame
@@ -7335,6 +7341,23 @@ final class TerminalSurface: Identifiable, ObservableObject {
             frame = filtered
         }
         return (frame, frame.plainRows())
+    }
+
+    /// The Mac's resolved primary terminal `font-family`, read from the surface's
+    /// finalized ghostty config, or `nil` when the user has not set one (so the
+    /// phone keeps its built-in default rather than an assumed "Menlo"). Returns
+    /// the first family libghostty resolved; the phone applies it as its primary
+    /// family and keeps its own fallback chain for glyph coverage.
+    private func resolvedTerminalFontFamily() -> String? {
+        guard let config = GhosttyApp.shared.config else { return nil }
+        var value: UnsafePointer<Int8>?
+        let key = "font-family"
+        guard ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))),
+              let value else {
+            return nil
+        }
+        let family = String(cString: value).trimmingCharacters(in: .whitespacesAndNewlines)
+        return family.isEmpty ? nil : family
     }
 
     /// Send text with control characters (Return, Tab, etc.) delivered as key

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7343,20 +7343,20 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return (frame, frame.plainRows())
     }
 
-    /// The Mac's resolved primary terminal `font-family`, read from the surface's
-    /// finalized ghostty config, or `nil` when the user has not set one (so the
-    /// phone keeps its built-in default rather than an assumed "Menlo"). Returns
-    /// the first family libghostty resolved; the phone applies it as its primary
-    /// family and keeps its own fallback chain for glyph coverage.
+    /// The Mac's terminal `font-family` the iOS app should inherit, or `nil` when
+    /// the user has not set one (so the phone keeps its built-in default rather
+    /// than an assumed "Menlo").
+    ///
+    /// Read from the parsed `GhosttyConfig`, not `ghostty_config_get`: the C API
+    /// has no string getter for `font-family` (it is a `RepeatableString`, which
+    /// `ghostty_config_get` does not export, so it would always return false).
+    /// `hasFontFamilyDirective` distinguishes a user-set family from the default.
+    /// For a multi-line fallback chain the parser keeps the last entry; the phone
+    /// applies it as its primary face and keeps its own fallback for coverage.
     private func resolvedTerminalFontFamily() -> String? {
-        guard let config = GhosttyApp.shared.config else { return nil }
-        var value: UnsafePointer<Int8>?
-        let key = "font-family"
-        guard ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))),
-              let value else {
-            return nil
-        }
-        let family = String(cString: value).trimmingCharacters(in: .whitespacesAndNewlines)
+        let config = GhosttyConfig.load()
+        guard config.hasFontFamilyDirective else { return nil }
+        let family = config.fontFamily.trimmingCharacters(in: .whitespacesAndNewlines)
         return family.isEmpty ? nil : family
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -6487,3 +6487,31 @@ final class BrowserImportScopeTests: XCTestCase {
         XCTAssertNil(scope)
     }
 }
+
+/// Covers the `font-family` directive tracking the iOS app relies on to inherit
+/// the Mac's terminal font: the phone must receive the user's family only when
+/// they actually set one (not the silent "Menlo" default).
+final class GhosttyConfigFontFamilyDirectiveTests: XCTestCase {
+    func testUnsetFontFamilyHasNoDirective() {
+        var config = GhosttyConfig()
+        config.parse("font-size = 14")
+        XCTAssertFalse(config.hasFontFamilyDirective)
+        XCTAssertEqual(config.fontFamily, "Menlo")
+    }
+
+    func testExplicitFontFamilySetsDirective() {
+        var config = GhosttyConfig()
+        config.parse("font-family = JetBrains Mono")
+        XCTAssertTrue(config.hasFontFamilyDirective)
+        XCTAssertEqual(config.fontFamily, "JetBrains Mono")
+    }
+
+    func testEmptyFontFamilyResetsDirective() {
+        var config = GhosttyConfig()
+        config.parse("font-family = Berkeley Mono\nfont-family =")
+        // An empty value resets to the default in Ghostty's RepeatableString
+        // semantics, so the phone should fall back to its built-in default.
+        XCTAssertFalse(config.hasFontFamilyDirective)
+        XCTAssertEqual(config.fontFamily, "Menlo")
+    }
+}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1514,6 +1514,57 @@
         }
       }
     },
+    "mobile.settings.terminalFontSize": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font Size"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズ"
+          }
+        }
+      }
+    },
+    "mobile.settings.terminalFontSizeReset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset to Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに戻す"
+          }
+        }
+      }
+    },
+    "mobile.settings.terminalFontSizeFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sets the terminal's base text size on this device. The font family follows the Mac you pair with."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この端末のターミナル文字の基準サイズを設定します。フォントの種類はペアリングしている Mac に従います。"
+          }
+        }
+      }
+    },
     "mobile.shortcuts.addAction": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -4,14 +4,11 @@ import CmuxMobileAnalytics
 import CmuxMobilePairedMac
 import CmuxMobileShell
 @_exported import CmuxMobileShellUI
+import CmuxMobileTerminal
 import CmuxMobileTransport
 import Foundation
 import OSLog
 import SwiftUI
-
-#if canImport(UIKit) && DEBUG
-import CmuxMobileTerminal
-#endif
 
 private let mobileRootSceneLog = Logger(subsystem: "dev.cmux.ios", category: "mobile-root-scene")
 
@@ -34,6 +31,10 @@ public struct CMUXMobileRootScene: View {
     #if os(iOS)
     private let pushCoordinator: MobilePushCoordinator
     private let displaySettings: MobileDisplaySettings
+    /// The persisted terminal font-size base, constructed once at this scene
+    /// root and injected into the environment so the Settings > Terminal stepper
+    /// and the live terminal surface (overlay + launch size) drive one instance.
+    @State private var terminalZoomPreference = MobileTerminalZoomPreference()
     #endif
     private let pairedMacStore: (any MobilePairedMacStoring)?
     #if DEBUG
@@ -114,6 +115,7 @@ public struct CMUXMobileRootScene: View {
             #if os(iOS)
             .environment(pushCoordinator)
             .environment(displaySettings)
+            .environment(terminalZoomPreference)
             #endif
     }
 


### PR DESCRIPTION
The iOS terminal hardcoded `font-family = Menlo` and never learned the Mac's Ghostty font. Font size was only adjustable via the transient pinch overlay, with no persisted Settings control, and a saved "default zoom" never actually applied at launch.

## Inherit the Mac's font-family
The phone renders its own local libghostty surface from render-grid deltas, so it has its own font-family (cosmetic to the phone). To make it follow the Mac:

- Add an optional `terminal_font_family` field to the render-grid frame (`Packages/CMUXMobileCore/.../MobileTerminalRenderGrid.swift`), mirroring the existing `terminal_foreground/background/cursor` color fields. Additive, backward-compatible, carried only on full snapshots and nil'd on deltas. The Mac emit path re-encodes the struct via Codable (`MobileTerminalRenderObserver.emitRenderGrid` -> `frame.jsonObject()`), so the field actually ships.
- The Mac producer `TerminalSurface.mobileRenderGridFrame` (`Sources/GhosttyTerminalView.swift`) stamps the user's resolved `font-family` on full frames. It reads from the parsed `GhosttyConfig`, **not** `ghostty_config_get`: `font-family` is a Ghostty `RepeatableString`, which the C API does not export (it always returns false), so a new `GhosttyConfig.hasFontFamilyDirective` flag distinguishes a user-set family from the default. `nil` when unset, so the phone keeps its built-in default rather than assuming Menlo.
- The phone records the family per surface in `MobileShellComposite` (live + cold-attach replay paths) and applies it in the surface output loop before painting. New `GhosttySurfaceView.applyInheritedFontFamily` is set-on-change and applies via `ghostty_surface_update_config` (enqueued on the same serial `outputQueue` as the byte feed and `set_font_size`). The config reapplies the full iOS defaults block (theme preserved) with the family swapped and the current live font-size baked in, so the swap is size-neutral. Factored `iOSGhosttyConfigText` so the launch config and the runtime swap can't drift.

Colors flow as in-band OSC bytes through the replay path; font-family is a config property, not a VT property, so it can't ride there. The coordinator output loop is the surface-level hook.

## Settings font size + reset
- `MobileTerminalZoomPreference` is now `@Observable` and injected once at the scene root, so the existing zoom overlay and a new Settings > Terminal "Font Size" stepper drive one persisted base (UserDefaults), per the shared-behavior policy. No parallel store.
- "Reset to Default" calls `clear()`, falling back to the built-in default size.
- The surface launches at `effectiveFontSize` (saved base, else built-in), fixing the latent bug where a saved default never applied at launch. Live Settings changes push through `updateUIView` -> `applyBaseFontSize`, set-on-change so an incidental re-render never snaps a transient pinch back. No timers, no effects.

## Notes
- Localized en + ja (`ios/cmux/Resources/Localizable.xcstrings`).
- Tests: render-grid frame round-trip + delta-drop for `terminal_font_family` (CMUXMobileCore, green locally); `GhosttyConfig` parser tests for the font-family directive (unset/set/reset) in the existing wired `cmuxTests/GhosttyConfigTests.swift` (run on CI). The pure `MobileTerminalZoomPreference` size logic + the launch-size fix are build-verified only (the package links GhosttyKit and has no SPM test target).
- Scoped to font config; new methods are additive, no changed surface method signatures, to merge cleanly against the in-flight scroll/toolbar worktrees.

## Verification & dogfood
- iOS simulator build: SUCCEEDED (arm64-sim, build-only). macOS app build: SUCCEEDED. CMUXMobileCore tests: green.
- The runtime font-family apply on a live iOS surface (`ghostty_surface_update_config`) is build-verified only and needs paired-device dogfood. **Dogfood with a real custom Mac font (e.g. JetBrains Mono / Berkeley Mono), not the default** — the only reason to set `font-family` is a non-default font, which may not be installed on iOS and could fall back. Confirm:
  1. With a custom `font-family` set on the Mac: the phone terminal renders in that font (or a sensible fallback) after a full frame / cold attach.
  2. With no `font-family` set on the Mac: the phone stays on its built-in default (Menlo), unchanged.
  3. Pinch zoom and the Settings font size survive a family change (theme preserved, size not reset).

Known follow-up: for a multi-line `font-family` fallback chain the Mac sends the last entry as the phone's primary; and `applyInheritedFontFamily` does not yet check whether the family resolves on iOS before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Mac→iOS sync protocol and live `ghostty_surface_update_config` on the terminal surface; additive fields and guarded applies, but paired-device behavior for custom fonts still needs dogfood.
> 
> **Overview**
> The iOS terminal can **inherit the Mac’s Ghostty `font-family`** and **persist base font size** from Settings, with the zoom overlay and launch size sharing one preference.
> 
> **Mac → phone font:** Full render-grid frames gain optional `terminal_font_family` (full snapshots only; deltas omit it, like dynamic colors). The Mac stamps it from parsed `GhosttyConfig` when the user explicitly set `font-family` (`hasFontFamilyDirective`), not the silent Menlo default. The shell store records it per surface on live/replay delivery; `GhosttySurfaceView` applies it via `ghostty_surface_update_config` on the output queue before painting, with set-on-change and full iOS theme preserved in `iOSGhosttyConfigText`.
> 
> **Font size:** `MobileTerminalZoomPreference` is `@Observable`, injected at the scene root, and wired to Settings **Font Size** stepper plus **Reset to Default**. The surface launches at `effectiveFontSize`, and `applyBaseFontSize` in `updateUIView` updates live without snapping transient pinch zoom on unrelated re-renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13cf36937a66844a93651b6587a626e412b0a4c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now inherits the font family from your paired Mac, providing consistent typography.
  * Added font size adjustment controls in Terminal settings with a "Reset to Default" button for easy customization.
  * Improved zoom and font preference system with better persistence across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->