### PR TITLE
Fix sidebar row-ID layout preference feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,11 @@ jobs:
           fi
 
           if [ "$EXIT_CODE" -ne 0 ]; then
+            if grep -Fq "The legacy row-ID preference key must not aggregate per-row IDs" /tmp/test-output.txt \
+              || grep -Fq "The default workspace sidebar must not publish non-empty row-ID layout preferences" /tmp/test-output.txt; then
+              echo "Sidebar row-ID preference regression failed"
+              exit 1
+            fi
             SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)
             if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
               echo "All failures are expected, treating as pass"

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10585,8 +10585,6 @@ struct VerticalTabsSidebar: View {
     // row sitting behind the open menu. See `SidebarShortcutHintFreezePolicy`.
     @State private var frozenShortcutHintsTabId: UUID?
     @State private var frozenShortcutHintsValue: Bool = false
-    @State private var laidOutWorkspaceRowIds: Set<UUID> = []
-    @State private var pendingSelectedWorkspaceScrollId: UUID?
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
     @State private var extensionSidebarUpdateToken: UInt64 = 0
@@ -10865,28 +10863,14 @@ struct VerticalTabsSidebar: View {
         return KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
     }
 
-    private func requestSelectedWorkspaceScroll(_ proxy: ScrollViewProxy, workspaceIds: [UUID]) {
+    private func scrollSelectedWorkspaceIfNeeded(_ proxy: ScrollViewProxy, workspaceIds: [UUID]) {
         guard let selectedWorkspaceId = tabManager.selectedTabId,
               workspaceIds.contains(selectedWorkspaceId) else {
-            pendingSelectedWorkspaceScrollId = nil
             return
         }
 
-        pendingSelectedWorkspaceScrollId = selectedWorkspaceId
-        flushPendingSelectedWorkspaceScroll(proxy)
-    }
-
-    private func flushPendingSelectedWorkspaceScroll(
-        _ proxy: ScrollViewProxy,
-        laidOutWorkspaceRowIds: Set<UUID>? = nil
-    ) {
-        guard let selectedWorkspaceId = pendingSelectedWorkspaceScrollId else { return }
-        let rowIds = laidOutWorkspaceRowIds ?? self.laidOutWorkspaceRowIds
-        guard rowIds.contains(selectedWorkspaceId) else { return }
-
         // No anchor means SwiftUI scrolls the minimum needed to reveal the row.
         proxy.scrollTo(selectedWorkspaceId)
-        pendingSelectedWorkspaceScrollId = nil
     }
 
     private func shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
@@ -10900,14 +10884,13 @@ struct VerticalTabsSidebar: View {
         )
     }
 
-    private func requestSelectedWorkspaceScrollAfterWorkspaceOrderChange(_ notification: Notification) {
+    private func shouldScrollSelectedWorkspaceAfterWorkspaceOrderChange(_ notification: Notification) -> Bool {
         guard let manager = notification.object as? TabManager, manager === tabManager else {
-            return
+            return false
         }
-        guard let selectedWorkspaceId = tabManager.selectedTabId else { return }
+        guard let selectedWorkspaceId = tabManager.selectedTabId else { return false }
         let movedWorkspaceIds = notification.userInfo?[WorkspaceOrderChangeNotificationKey.movedWorkspaceIds] as? [UUID] ?? []
-        guard movedWorkspaceIds.contains(selectedWorkspaceId) else { return }
-        pendingSelectedWorkspaceScrollId = selectedWorkspaceId
+        return movedWorkspaceIds.contains(selectedWorkspaceId)
     }
 
     struct WorkspaceListRenderContext {
@@ -11173,23 +11156,25 @@ struct VerticalTabsSidebar: View {
                 .background(Color.clear)
                 .modifier(ClearScrollBackground())
                 .onAppear {
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: renderContext.workspaceIds)
+                    scrollSelectedWorkspaceIfNeeded(scrollProxy, workspaceIds: renderContext.workspaceIds)
                 }
                 .onChange(of: tabManager.selectedTabId) { _, _ in
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: renderContext.workspaceIds)
+                    scrollSelectedWorkspaceIfNeeded(scrollProxy, workspaceIds: renderContext.workspaceIds)
                 }
                 .onChange(of: renderContext.workspaceIds) { oldWorkspaceIds, newWorkspaceIds in
                     guard shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
                         from: oldWorkspaceIds,
                         to: newWorkspaceIds
                     ) else {
-                        flushPendingSelectedWorkspaceScroll(scrollProxy)
                         return
                     }
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: newWorkspaceIds)
+                    scrollSelectedWorkspaceIfNeeded(scrollProxy, workspaceIds: newWorkspaceIds)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .workspaceOrderDidChange)) { notification in
-                    requestSelectedWorkspaceScrollAfterWorkspaceOrderChange(notification)
+                    guard shouldScrollSelectedWorkspaceAfterWorkspaceOrderChange(notification) else {
+                        return
+                    }
+                    scrollSelectedWorkspaceIfNeeded(scrollProxy, workspaceIds: renderContext.workspaceIds)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .workspaceCurrentDirectoryDidChange)) { _ in
                     // Drive a revision counter that the group-header resolver
@@ -11235,10 +11220,6 @@ struct VerticalTabsSidebar: View {
                     if let index = tabManager.tabs.firstIndex(where: { $0.id == focusedId }) {
                         lastSidebarSelectionIndex = index
                     }
-                }
-                .onPreferenceChange(SidebarWorkspaceRowIdsPreferenceKey.self) { rowIds in
-                    laidOutWorkspaceRowIds = rowIds
-                    flushPendingSelectedWorkspaceScroll(scrollProxy, laidOutWorkspaceRowIds: rowIds)
                 }
             }
         }
@@ -12625,7 +12606,6 @@ struct VerticalTabsSidebar: View {
         .equatable()
         .id(tab.id)
         .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
 
         row
             .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)
@@ -12638,11 +12618,16 @@ struct VerticalTabsSidebar: View {
     }
 }
 
+/// Legacy row-ID preference key kept for regression coverage.
+///
+/// The default workspace sidebar must not emit this preference from rows: doing
+/// so forces SwiftUI to aggregate a layout-derived value across the lazy list
+/// during every transaction, which can feed a non-converging layout loop.
 struct SidebarWorkspaceRowIdsPreferenceKey: PreferenceKey {
     static let defaultValue: Set<UUID> = []
 
     static func reduce(value: inout Set<UUID>, nextValue: () -> Set<UUID>) {
-        value.formUnion(nextValue())
+        value = []
     }
 }
 

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -156,7 +156,6 @@ extension VerticalTabsSidebar {
         .equatable()
         .id(group.anchorWorkspaceId)
         .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
 
         header
             .sidebarWorkspaceFrameAnchor(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A5570A000000000000000001 /* AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5570A000000000000000002 /* AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift */; };
 		A9E020000000000000000006 /* agent-session-react in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000006 /* agent-session-react */; };
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
@@ -771,6 +772,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A5570A000000000000000002 /* AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000006 /* agent-session-react */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-react"; sourceTree = "<group>"; };
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
@@ -2055,6 +2057,7 @@
 		F1000003A1B2C3D4E5F60718 /* cmuxTests */ = {
 			isa = PBXGroup;
 			children = (
+				A5570A000000000000000002 /* AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift */,
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
@@ -3120,6 +3123,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5570A000000000000000001 /* AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift in Sources */,
 				A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */,
 				D36A00020000000000000001 /* AgentHibernationTests.swift in Sources */,
 				D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,

--- a/cmuxTests/AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift
+++ b/cmuxTests/AAASidebarWorkspaceRowIdPreferenceRegressionTests.swift
@@ -1,0 +1,130 @@
+import AppKit
+import CmuxUpdater
+import SwiftUI
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class AAASidebarWorkspaceRowIdPreferenceRegressionTests: XCTestCase {
+    func testAAARowIdPreferenceKeyDoesNotAggregatePerRowIds() {
+        let rowIds = (0..<32).map { _ in UUID() }
+        var reducedRowIds: Set<UUID> = []
+
+        for rowId in rowIds {
+            SidebarWorkspaceRowIdsPreferenceKey.reduce(value: &reducedRowIds) {
+                Set([rowId])
+            }
+        }
+
+        XCTAssertTrue(
+            reducedRowIds.isEmpty,
+            "The legacy row-ID preference key must not aggregate per-row IDs. Aggregating this key performs Set.formUnion across the lazy sidebar rows in the SwiftUI/AttributeGraph layout loop reported in https://github.com/manaflow-ai/cmux/issues/5570 and https://github.com/manaflow-ai/cmux/issues/2586."
+        )
+    }
+
+    @MainActor
+    func testDefaultWorkspaceSidebarDoesNotPublishRowIdLayoutPreferences() {
+        _ = NSApplication.shared
+
+        let defaults = UserDefaults.standard
+        let previousProviderId = defaults.object(forKey: CmuxExtensionSidebarSelection.defaultsKey)
+        CmuxExtensionSidebarSelection.setProviderId(CmuxExtensionSidebarSelection.defaultProviderId)
+        defer {
+            if let previousProviderId {
+                defaults.set(previousProviderId, forKey: CmuxExtensionSidebarSelection.defaultsKey)
+            } else {
+                defaults.removeObject(forKey: CmuxExtensionSidebarSelection.defaultsKey)
+            }
+        }
+
+        let tabManager = TabManager(
+            initialWorkspaceTitle: "Workspace 0",
+            autoWelcomeIfNeeded: false
+        )
+        for index in 1..<32 {
+            tabManager.addWorkspace(
+                title: "Workspace \(index)",
+                select: false,
+                eagerLoadTerminal: false,
+                autoWelcomeIfNeeded: false,
+                autoRefreshMetadata: false
+            )
+        }
+
+        var observedRowIdPreferences: [Set<UUID>] = []
+        let root = SidebarWorkspaceRowIdPreferenceProbe(
+            tabManager: tabManager,
+            onRowIdsPreference: { rowIds in
+                observedRowIdPreferences.append(rowIds)
+            }
+        )
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 260, height: 520),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let hostingView = MainWindowHostingView(rootView: root)
+        hostingView.frame = window.contentRect(forFrameRect: window.frame)
+        window.contentView = hostingView
+        defer {
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+        for _ in 0..<5 {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            window.displayIfNeeded()
+            hostingView.layoutSubtreeIfNeeded()
+        }
+
+        let nonEmptyRowIdPreferences = observedRowIdPreferences.filter { !$0.isEmpty }
+        XCTAssertTrue(
+            nonEmptyRowIdPreferences.isEmpty,
+            "The default workspace sidebar must not publish non-empty row-ID layout preferences in steady state. A row-wide layout preference feeds the SwiftUI/AttributeGraph layout loop reported in https://github.com/manaflow-ai/cmux/issues/5570 and https://github.com/manaflow-ai/cmux/issues/2586."
+        )
+    }
+}
+
+private struct SidebarWorkspaceRowIdPreferenceProbe: View {
+    @State private var selection: SidebarSelection = .tabs
+    @State private var selectedTabIds: Set<UUID> = []
+    @State private var lastSidebarSelectionIndex: Int?
+
+    let tabManager: TabManager
+    let onRowIdsPreference: (Set<UUID>) -> Void
+    private let updateViewModel = UpdateStateModel()
+    private let fileExplorerState = FileExplorerState()
+    private let cmuxConfigStore = CmuxConfigStore()
+    private let windowId = UUID()
+
+    var body: some View {
+        VerticalTabsSidebar(
+            updateViewModel: updateViewModel,
+            fileExplorerState: fileExplorerState,
+            windowId: windowId,
+            onSendFeedback: {},
+            onToggleSidebar: {},
+            onNewTab: {},
+            observedWindow: nil,
+            selection: $selection,
+            selectedTabIds: $selectedTabIds,
+            lastSidebarSelectionIndex: $lastSidebarSelectionIndex
+        )
+        .environmentObject(tabManager)
+        .environmentObject(TerminalNotificationStore.shared)
+        .environmentObject(cmuxConfigStore)
+        .frame(width: 260, height: 520)
+        .onPreferenceChange(SidebarWorkspaceRowIdsPreferenceKey.self) { rowIds in
+            onRowIdsPreference(rowIds)
+        }
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxUpdater
 import SwiftUI
 import XCTest
 


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5570.

Summary:
- remove the default sidebar row-ID preference emission and layout-state observer
- scroll selected workspaces from model IDs instead of row layout preferences
- add an early cmuxTests regression for the legacy row-ID preference key and hosted default sidebar

Evidence:
- Red test-only CI: https://github.com/manaflow-ai/cmux/actions/runs/27124575071
- Green fixed CI: https://github.com/manaflow-ai/cmux/actions/runs/27125701054
- Green PR CI: https://github.com/manaflow-ai/cmux/actions/runs/27127016023
- Green e2e dispatch: https://github.com/manaflow-ai/cmux/actions/runs/27127036362

Local tests were not run per repo policy.