### PR TITLE
CI: skip macOS desktop jobs on pure-iOS / web / docs PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,145 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Path gate for the expensive macOS desktop jobs (tests, tests-build-and-lag,
+  # release-ghostty-cli-helper, release-build, ui-regressions). It does NOT gate
+  # the four required checks (workflow-guard-tests, remote-daemon-tests,
+  # web-typecheck, web-db-migrations) — those stay always-on so a PR that
+  # legitimately skips desktop CI is still mergeable (no "Expected — waiting for
+  # status" deadlock against ruleset "main: require PR + checks").
+  #
+  # Logic is negation/fail-safe: desktop CI RUNS unless EVERY changed file is in
+  # a known safe-to-skip set (pure-iOS app/packages/scripts, web/**, or
+  # docs/markdown). Anything unrecognized — including shared Swift in Sources/**,
+  # shared Packages/** (CMUXMobileCore, CMUXAuthCore, CmuxAuthRuntime are linked
+  # by the desktop app), GhosttyKit/ghostty, cmux.xcodeproj, or shared scripts —
+  # forces desktop CI to run. This is intentionally asymmetric with
+  # test-ios.yml's broad iOS trigger: iOS CI errs toward running, desktop CI errs
+  # toward running, and only a strictly pure-iOS (or web/docs-only) PR skips the
+  # macOS build.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      desktop: ${{ steps.detect.outputs.desktop }}
+      react: ${{ steps.detect.outputs.react }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Detect desktop-affecting changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          emit() {
+            # $1 = desktop, $2 = react
+            echo "desktop=$1" >> "$GITHUB_OUTPUT"
+            echo "react=$2" >> "$GITHUB_OUTPUT"
+            echo "==> desktop=$1 react=$2"
+          }
+
+          # Fail safe: anything that is not a pull_request (push to main,
+          # workflow_dispatch) always runs the full suite.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Non-PR event (${{ github.event_name }}); running everything."
+            emit true true
+            exit 0
+          fi
+
+          # Fail safe: if we cannot compute a clean diff, run everything.
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Missing base/head SHA; running everything."
+            emit true true
+            exit 0
+          fi
+          if ! BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Could not compute merge-base; running everything."
+            emit true true
+            exit 0
+          fi
+          git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
+          echo "Changed files:"
+          cat /tmp/changed-files.txt
+
+          # Empty diff (e.g. rebase/no-op) is safe to skip the optional jobs.
+          if [ ! -s /tmp/changed-files.txt ]; then
+            echo "No changed files; skipping optional jobs."
+            emit false false
+            exit 0
+          fi
+
+          # --- desktop gate ----------------------------------------------------
+          # Safe-to-skip set. A PR whose changed files are ALL covered by these
+          # patterns does not need the macOS desktop build. Keep this list narrow
+          # and pure: only files that provably cannot affect the macOS app build.
+          #   - ios/**                       iOS app target
+          #   - ios scripts                  iOS-only build/dev scripts
+          #   - Packages/Cmux Mobile* UI/shell/transport packages NOT linked by
+          #     the desktop pbxproj (verified 0 references). CMUXMobileCore,
+          #     CMUXAuthCore, CmuxAuthRuntime are deliberately EXCLUDED here
+          #     because the desktop app links them (Sources/Mobile/**, etc.).
+          #   - web/**                       Next.js docs/site + Cloud VM web API
+          #   - **/*.md, docs/**             documentation
+          #   - .github/workflows/{test-ios,ios-testflight}.yml  iOS-only CI
+          SKIP_RE='^(ios/'
+          SKIP_RE+='|scripts/(lint-ios-package-conventions\.sh|mobile-attach-qr-server\.sh|mobile-attach-qr\.sh|mobile-dev-launch\.sh|mobile-snapshot-diff\.py|mobile-stability-soak(\.sh)?|mobile-terminal-cursor-snapshot-check\.sh)$'
+          SKIP_RE+='|Packages/CmuxMobileAnalytics/'
+          SKIP_RE+='|Packages/CmuxMobileCamera/'
+          SKIP_RE+='|Packages/CmuxMobileDiagnostics/'
+          SKIP_RE+='|Packages/CmuxMobilePairedMac/'
+          SKIP_RE+='|Packages/CmuxMobileRPC/'
+          SKIP_RE+='|Packages/CmuxMobileShell/'
+          SKIP_RE+='|Packages/CmuxMobileShellModel/'
+          SKIP_RE+='|Packages/CmuxMobileShellUI/'
+          SKIP_RE+='|Packages/CmuxMobileSupport/'
+          SKIP_RE+='|Packages/CmuxMobileTerminal/'
+          SKIP_RE+='|Packages/CmuxMobileTerminalKit/'
+          SKIP_RE+='|Packages/CmuxMobileTransport/'
+          SKIP_RE+='|Packages/CmuxMobileWorkspace/'
+          SKIP_RE+='|web/'
+          SKIP_RE+='|docs/'
+          SKIP_RE+='|.github/workflows/(test-ios|ios-testflight)\.yml$'
+          SKIP_RE+='|[^/]*\.md$'
+          SKIP_RE+='|.*/[^/]*\.md$'
+          SKIP_RE+=')'
+
+          DESKTOP=false
+          # Any changed file that does NOT match the skip set forces desktop CI.
+          if grep -Ev "$SKIP_RE" /tmp/changed-files.txt > /tmp/desktop-files.txt; then
+            echo "Desktop-affecting files changed; running desktop CI:"
+            cat /tmp/desktop-files.txt
+            DESKTOP=true
+          else
+            echo "Only iOS-only / web / docs files changed; skipping desktop CI."
+          fi
+
+          # --- react webviews gate --------------------------------------------
+          # react-apps-check verifies webviews/ source against the committed
+          # generated assets under Resources/markdown-viewer/, so it must run when
+          # either side or its build scripts change.
+          REACT_RE='^(webviews/'
+          REACT_RE+='|Resources/markdown-viewer/'
+          REACT_RE+='|scripts/(build-webviews-app\.sh|check-webviews-react-compiler\.mjs)$'
+          REACT_RE+=')'
+
+          REACT=false
+          if grep -Eq "$REACT_RE" /tmp/changed-files.txt; then
+            echo "webviews-affecting files changed; running react-apps-check."
+            REACT=true
+          else
+            echo "No webviews files changed; skipping react-apps-check."
+          fi
+
+          emit "$DESKTOP" "$REACT"
+
   workflow-guard-tests:
     runs-on: ubuntu-latest
     steps:
@@ -126,8 +265,11 @@ jobs:
         run: bun test
 
   # Checks for in-app React webviews (currently the diff viewer; more cmux React
-  # surfaces will live alongside it).
+  # surfaces will live alongside it). Not a required check, so it is safe to gate
+  # on webviews-affecting changes.
   react-apps-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.react == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -210,6 +352,8 @@ jobs:
           bun test tests/vm-db-read-model.test.ts
 
   tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 75
     env:
@@ -492,6 +636,8 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
 
   tests-build-and-lag:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     # Build the full cmux scheme and run the lag regression on macOS CI.
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
@@ -701,6 +847,8 @@ jobs:
           rm -f /tmp/create-virtual-display
 
   release-ghostty-cli-helper:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
@@ -734,7 +882,8 @@ jobs:
           if-no-files-found: error
 
   release-build:
-    needs: release-ghostty-cli-helper
+    needs: [changes, release-ghostty-cli-helper]
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
@@ -849,6 +998,8 @@ jobs:
           [[ "$SDK_VERSION" == 26.* ]]
 
   ui-regressions:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     # Cold builds after project/package changes can spend more than 25 minutes
     # in build-for-testing before the UI regression script starts.

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -38,7 +38,90 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Same desktop path gate as ci.yml: skip the expensive macOS activation perf
+  # job on PRs that only touch pure-iOS, web, or docs files. This workflow has no
+  # branch-protection required checks, so gating its only job cannot deadlock a
+  # PR. Fail-safe: non-PR events and any diff failure run the perf job.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      desktop: ${{ steps.detect.outputs.desktop }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: false
+
+      - name: Detect desktop-affecting changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Non-PR event (${{ github.event_name }}); running perf job."
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            echo "Missing base/head SHA; running perf job."
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Could not compute merge-base; running perf job."
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
+          echo "Changed files:"
+          cat /tmp/changed-files.txt
+          if [ ! -s /tmp/changed-files.txt ]; then
+            echo "No changed files; skipping perf job."
+            echo "desktop=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Keep this skip set identical to ci.yml's desktop gate.
+          SKIP_RE='^(ios/'
+          SKIP_RE+='|scripts/(lint-ios-package-conventions\.sh|mobile-attach-qr-server\.sh|mobile-attach-qr\.sh|mobile-dev-launch\.sh|mobile-snapshot-diff\.py|mobile-stability-soak(\.sh)?|mobile-terminal-cursor-snapshot-check\.sh)$'
+          SKIP_RE+='|Packages/CmuxMobileAnalytics/'
+          SKIP_RE+='|Packages/CmuxMobileCamera/'
+          SKIP_RE+='|Packages/CmuxMobileDiagnostics/'
+          SKIP_RE+='|Packages/CmuxMobilePairedMac/'
+          SKIP_RE+='|Packages/CmuxMobileRPC/'
+          SKIP_RE+='|Packages/CmuxMobileShell/'
+          SKIP_RE+='|Packages/CmuxMobileShellModel/'
+          SKIP_RE+='|Packages/CmuxMobileShellUI/'
+          SKIP_RE+='|Packages/CmuxMobileSupport/'
+          SKIP_RE+='|Packages/CmuxMobileTerminal/'
+          SKIP_RE+='|Packages/CmuxMobileTerminalKit/'
+          SKIP_RE+='|Packages/CmuxMobileTransport/'
+          SKIP_RE+='|Packages/CmuxMobileWorkspace/'
+          SKIP_RE+='|web/'
+          SKIP_RE+='|docs/'
+          SKIP_RE+='|.github/workflows/(test-ios|ios-testflight)\.yml$'
+          SKIP_RE+='|[^/]*\.md$'
+          SKIP_RE+='|.*/[^/]*\.md$'
+          SKIP_RE+=')'
+
+          if grep -Ev "$SKIP_RE" /tmp/changed-files.txt > /tmp/desktop-files.txt; then
+            echo "Desktop-affecting files changed; running perf job:"
+            cat /tmp/desktop-files.txt
+            echo "desktop=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only iOS-only / web / docs files changed; skipping perf job."
+            echo "desktop=false" >> "$GITHUB_OUTPUT"
+          fi
+
   activation-session:
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop == 'true' }}
     runs-on: ${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}
     timeout-minutes: 45
     env:


### PR DESCRIPTION
Path-based CI gating so iOS-only, web-only, and docs-only PRs no longer pay for the macOS desktop build, while shared or desktop changes still run the full suite.

## What changes
A cheap ubuntu `changes` job runs a merge-base diff and emits a `desktop` (and, in `ci.yml`, a `react`) output. The expensive macOS jobs gate on `needs.changes.outputs.desktop == 'true'`:

- `ci.yml`: `tests`, `tests-build-and-lag`, `release-ghostty-cli-helper`, `release-build`, `ui-regressions` (gated on `desktop`); `react-apps-check` (gated on `react`).
- `perf-activation.yml`: `activation-session` (gated on `desktop`).

## Why it can't deadlock a required check
Branch-protection ruleset "main: require PR + checks" requires exactly four checks: `workflow-guard-tests`, `remote-daemon-tests`, `web-typecheck`, `web-db-migrations`. All four are cheap ubuntu jobs and are left **always-on and ungated**. The gated jobs are the expensive macOS builds and `react-apps-check`, none of which are required checks. So a PR that skips desktop CI still satisfies every required check and stays mergeable (no "Expected — Waiting for status").

The gate is **negation / fail-safe**: desktop CI runs unless EVERY changed file is in a narrow safe-to-skip set. Anything unrecognized forces desktop CI to run.

## Path sets
Safe-to-skip (desktop CI off when ALL changed files match):
- `ios/**` and iOS-only scripts (`mobile-*`, `lint-ios-package-conventions.sh`)
- `Packages/Cmux*Mobile*` UI/shell/transport packages that are **not** linked by the desktop project (verified 0 references in `cmux.xcodeproj/project.pbxproj`)
- `web/**`, `docs/**`, markdown

Always force desktop CI (NOT in the skip set, because the desktop app builds/links them):
- `Sources/**` including `Sources/Mobile/**` (Mac host side of pairing)
- `Packages/CMUXMobileCore`, `Packages/CMUXAuthCore`, `Packages/CmuxAuthRuntime` (referenced by `Sources/AppDelegate.swift`, `Sources/TerminalController.swift`, and the desktop pbxproj)
- `ghostty`/GhosttyKit, `cmux.xcodeproj`, shared scripts, and any other unrecognized path

`react-apps-check` gates separately on `webviews/**`, `Resources/markdown-viewer/**`, and its two build scripts, since it verifies webviews source against the committed generated assets.

This is intentionally asymmetric with `test-ios.yml`'s broad iOS trigger: iOS CI errs toward running, desktop CI errs toward running, and only a strictly pure-iOS (or web/docs-only) PR skips the macOS build.

## Scenarios
- **iOS-only PR** → `desktop=false`: macOS jobs skip; the 4 required ubuntu checks still run → mergeable.
- **Shared-code PR** (`Sources/**`, shared `Packages/**`, `ghostty`, `cmux.xcodeproj`) → `desktop=true`: full desktop + (when relevant) iOS CI run. A mixed PR with even one shared file runs desktop CI.
- **Web-only PR** → `desktop=false`, `react=false`: macOS + react jobs skip; `web-typecheck`/`web-db-migrations` run → mergeable.

Non-PR events (push to main, `workflow_dispatch`) and any diff failure run everything.

## Untouched
GhosttyKit/zig cache steps are inside the gated jobs and are not restructured (whole-job gating only). No test coverage that should run for a given change is weakened. `test-ios.yml` and `tmux-corpus.yml` were already path-filtered and are left as-is.

## Verification
`actionlint 1.7.12` is clean on the added logic (the one remaining warning in `perf-activation.yml` is a pre-existing SC2024 in the untouched `activation-session` job). The skip/react regexes were exercised against all three scenarios plus a mixed PR and the webviews case; results matched the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect skip-regex coverage could skip macOS CI for desktop-relevant changes, but the gate defaults to running on ambiguity and does not weaken required branch-protection checks.
> 
> **Overview**
> Adds a cheap Ubuntu **`changes`** job that diffs the PR against merge-base and sets **`desktop`** / **`react`** outputs so expensive macOS work can be skipped when every touched path is in a narrow safe set (pure iOS app/packages/scripts, `web/**`, docs/markdown).
> 
> In **`ci.yml`**, **`tests`**, **`tests-build-and-lag`**, **`release-ghostty-cli-helper`**, **`release-build`**, and **`ui-regressions`** now **`needs: changes`** and only run when **`desktop == 'true'`**; **`react-apps-check`** runs only when **`react == 'true'`** (webviews paths/scripts). The four branch-protection required jobs (**`workflow-guard-tests`**, **`remote-daemon-tests`**, **`web-typecheck`**, **`web-db-migrations`**) stay always-on so iOS/web/docs-only PRs remain mergeable.
> 
> Detection is **fail-safe**: non-PR events, missing SHAs, or diff errors force full runs; any file outside the skip regex forces desktop CI; shared desktop-linked paths (e.g. **`Sources/**`**, shared packages, **`cmux.xcodeproj`**) are intentionally not skippable.
> 
> **`perf-activation.yml`** gets the same **`changes`** gate (desktop only) for **`activation-session`**, with the skip regex kept in sync with **`ci.yml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1fdd3bda7a5dc775eb3c4ae15d5cedafd0d96e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783502865&installation_id=133855650&pr_number=5643&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5643&signature=2be298c8bfee876db97ce143a544d4b1c6553b1fa3ea3e06ea003e523a8b4611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip macOS desktop CI on PRs that only change iOS, web, or docs to cut queue time and cost. Required Ubuntu checks stay always on, so these PRs remain mergeable.

- **New Features**
  - Added a cheap Ubuntu `changes` job that diffs merge-base and outputs `desktop` and `react`.
  - Gated macOS jobs (`tests`, `tests-build-and-lag`, `release-ghostty-cli-helper`, `release-build`, `ui-regressions`) and perf `activation-session` on `desktop == 'true'`.
  - Gated `react-apps-check` on webviews changes (`webviews/**`, `Resources/markdown-viewer/**`, and its build/check scripts).
  - Negation/fail-safe: desktop CI runs unless all changed files are in the skip set (`ios/**`, iOS-only scripts, `Packages/Cmux*Mobile*` not linked by desktop, `web/**`, `docs/**`, markdown). Non-PR events or diff failures run everything.

<sup>Written for commit b1fdd3bda7a5dc775eb3c4ae15d5cedafd0d96e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized testing pipeline to conditionally execute test suites based on code changes, automatically skipping unnecessary tests for improved efficiency.
  * Improved performance testing to run only when relevant code areas are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->