### PR TITLE
Add new workspace above and below actions

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6748,6 +6748,22 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.newWorkspaceAbove",
+                title: constant(String(localized: "command.newWorkspaceAbove.title", defaultValue: "New Workspace Above")),
+                subtitle: constant(String(localized: "command.newWorkspace.subtitle", defaultValue: "Workspace")),
+                keywords: ["create", "new", "workspace", "above", "before"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.newWorkspaceBelow",
+                title: constant(String(localized: "command.newWorkspaceBelow.title", defaultValue: "New Workspace Below")),
+                subtitle: constant(String(localized: "command.newWorkspace.subtitle", defaultValue: "Workspace")),
+                keywords: ["create", "new", "workspace", "below", "after"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.newWindow",
                 title: constant(String(localized: "command.newWindow.title", defaultValue: "New Window")),
                 subtitle: constant(String(localized: "command.newWindow.subtitle", defaultValue: "Window")),
@@ -7951,6 +7967,26 @@ struct ContentView: View {
                 tabManager: tabManager,
                 debugSource: "palette.newWorkspace"
             )
+        }
+        registry.register(commandId: "palette.newWorkspaceAbove") {
+            guard let selectedTabId = tabManager.selectedTabId else {
+                NSSound.beep()
+                return
+            }
+            guard tabManager.createWorkspaceAdjacent(to: selectedTabId, position: .above) != nil else {
+                NSSound.beep()
+                return
+            }
+        }
+        registry.register(commandId: "palette.newWorkspaceBelow") {
+            guard let selectedTabId = tabManager.selectedTabId else {
+                NSSound.beep()
+                return
+            }
+            guard tabManager.createWorkspaceAdjacent(to: selectedTabId, position: .below) != nil else {
+                NSSound.beep()
+                return
+            }
         }
         registry.register(commandId: "palette.openFolder") {
             // Defer so the command palette dismisses before the modal sheet appears.
@@ -16023,6 +16059,20 @@ struct TabItemView: View, Equatable {
             syncSelectionAfterMutation()
         }
         .disabled(contextMenuPinState == nil)
+
+        Button(String(localized: "contextMenu.newWorkspaceAbove", defaultValue: "New Workspace Above")) {
+            guard tabManager.createWorkspaceAdjacent(to: tab.id, position: .above) != nil else {
+                NSSound.beep()
+                return
+            }
+        }
+
+        Button(String(localized: "contextMenu.newWorkspaceBelow", defaultValue: "New Workspace Below")) {
+            guard tabManager.createWorkspaceAdjacent(to: tab.id, position: .below) != nil else {
+                NSSound.beep()
+                return
+            }
+        }
 
         workspaceGroupContextMenuSection(targetIds: targetIds, isMulti: isMulti)
 

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -58,6 +58,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onToggleCollapsed: () -> Void
     let onFocusAnchor: () -> Void
     let onTapPlus: () -> Void
+    let onNewWorkspaceAbove: () -> Void
+    let onNewWorkspaceBelow: () -> Void
     let onRunResolvedItem: (CmuxResolvedConfigMenuAction) -> Void
     let onRename: () -> Void
     let onTogglePinned: () -> Void
@@ -241,6 +243,21 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             isHovered = hovering
         }
         .contextMenu {
+            Button(
+                String(
+                    localized: "contextMenu.newWorkspaceAbove",
+                    defaultValue: "New Workspace Above"
+                ),
+                action: onNewWorkspaceAbove
+            )
+            Button(
+                String(
+                    localized: "contextMenu.newWorkspaceBelow",
+                    defaultValue: "New Workspace Below"
+                ),
+                action: onNewWorkspaceBelow
+            )
+            Divider()
             Button(
                 String(
                     localized: "workspaceGroup.contextMenu.rename",

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -126,6 +126,11 @@ enum NewWorkspacePlacement: String, CaseIterable, Identifiable {
     }
 }
 
+enum WorkspaceAdjacentInsertionPosition: Sendable {
+    case above
+    case below
+}
+
 enum WorkspaceAutoReorderSettings {
     static let key = "workspaceAutoReorderOnNotification"
     static let defaultValue = true
@@ -2612,11 +2617,12 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: NewWorkspacePlacement? = nil,
+        sourceWorkspaceOverride: Workspace? = nil,
         autoWelcomeIfNeeded: Bool = true,
         autoRefreshMetadata: Bool = true,
         normalizeWorkspaceGroupsAfterInsert: Bool = true
     ) -> Workspace {
-        let sourceWorkspace = selectedWorkspace
+        let sourceWorkspace = sourceWorkspaceOverride ?? selectedWorkspace
         let capturedTabs = tabs
         // Snapshot the selected tab from the pinned workspace instead of rereading the
         // @Published selectedTabId storage after the inheritance helpers. The arm64 Nightly
@@ -4271,6 +4277,122 @@ class TabManager: ObservableObject {
         normalizeWorkspaceGroupContiguity()
         postWorkspaceOrderDidChange(movedWorkspaceIds: [newWorkspace.id])
         return newWorkspace
+    }
+
+    @discardableResult
+    func createWorkspaceAdjacent(
+        to referenceWorkspaceId: UUID,
+        position: WorkspaceAdjacentInsertionPosition,
+        select: Bool = true
+    ) -> Workspace? {
+        guard let referenceWorkspace = tabs.first(where: { $0.id == referenceWorkspaceId }) else {
+            return nil
+        }
+
+        if let groupId = referenceWorkspace.groupId,
+           let group = workspaceGroups.first(where: { $0.id == groupId }) {
+            if group.anchorWorkspaceId == referenceWorkspaceId {
+                return createWorkspaceAdjacentToGroup(
+                    groupId: groupId,
+                    position: position,
+                    select: select
+                )
+            }
+            return createWorkspaceAdjacentWithinGroup(
+                to: referenceWorkspace,
+                groupId: groupId,
+                position: position,
+                select: select
+            )
+        }
+
+        let newWorkspace = addWorkspace(
+            select: select,
+            placementOverride: .end,
+            sourceWorkspaceOverride: referenceWorkspace
+        )
+        reorderCreatedWorkspace(
+            newWorkspace.id,
+            adjacentTo: referenceWorkspaceId,
+            position: position
+        )
+        return newWorkspace
+    }
+
+    private func createWorkspaceAdjacentWithinGroup(
+        to referenceWorkspace: Workspace,
+        groupId: UUID,
+        position: WorkspaceAdjacentInsertionPosition,
+        select: Bool
+    ) -> Workspace? {
+        guard let group = workspaceGroups.first(where: { $0.id == groupId }) else { return nil }
+        let cwd = tabs.first(where: { $0.id == group.anchorWorkspaceId })?.currentDirectory
+        let newWorkspace = addWorkspace(
+            workingDirectory: cwd,
+            inheritWorkingDirectory: cwd == nil,
+            select: select,
+            placementOverride: .end,
+            sourceWorkspaceOverride: referenceWorkspace,
+            autoWelcomeIfNeeded: false
+        )
+        assignGroup(workspaceId: newWorkspace.id, groupId: groupId)
+        reorderCreatedWorkspace(
+            newWorkspace.id,
+            adjacentTo: referenceWorkspace.id,
+            position: position
+        )
+        expandGroupIfNeeded(groupId: groupId, select: select)
+        return newWorkspace
+    }
+
+    private func createWorkspaceAdjacentToGroup(
+        groupId: UUID,
+        position: WorkspaceAdjacentInsertionPosition,
+        select: Bool
+    ) -> Workspace? {
+        guard let group = workspaceGroups.first(where: { $0.id == groupId }),
+              let anchorWorkspace = tabs.first(where: { $0.id == group.anchorWorkspaceId }) else {
+            return nil
+        }
+        let newWorkspace = addWorkspace(
+            select: select,
+            placementOverride: .end,
+            sourceWorkspaceOverride: anchorWorkspace
+        )
+        let groupMemberIds = tabs.filter { $0.groupId == groupId && $0.id != newWorkspace.id }.map(\.id)
+        switch position {
+        case .above:
+            if let firstGroupWorkspaceId = groupMemberIds.first {
+                _ = reorderWorkspace(tabId: newWorkspace.id, before: firstGroupWorkspaceId)
+            }
+        case .below:
+            if let lastGroupWorkspaceId = groupMemberIds.last {
+                _ = reorderWorkspace(tabId: newWorkspace.id, after: lastGroupWorkspaceId)
+            }
+        }
+        return newWorkspace
+    }
+
+    private func reorderCreatedWorkspace(
+        _ workspaceId: UUID,
+        adjacentTo referenceWorkspaceId: UUID,
+        position: WorkspaceAdjacentInsertionPosition
+    ) {
+        switch position {
+        case .above:
+            _ = reorderWorkspace(tabId: workspaceId, before: referenceWorkspaceId)
+        case .below:
+            _ = reorderWorkspace(tabId: workspaceId, after: referenceWorkspaceId)
+        }
+    }
+
+    private func expandGroupIfNeeded(groupId: UUID, select: Bool) {
+        guard select,
+              let idx = workspaceGroups.firstIndex(where: { $0.id == groupId }),
+              workspaceGroups[idx].isCollapsed else {
+            return
+        }
+        workspaceGroups[idx].isCollapsed = false
     }
 
     /// Move an existing group member to the requested in-group slot. Called

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -118,6 +118,20 @@ extension VerticalTabsSidebar {
                 let resolved = placement ?? WorkspaceGroupNewWorkspacePlacementSettings.resolved()
                 _ = tabManager.createWorkspaceInGroup(groupId: groupId, placement: resolved)
             },
+            onNewWorkspaceAbove: { [weak tabManager, anchorId = group.anchorWorkspaceId] in
+                guard let tabManager,
+                      tabManager.createWorkspaceAdjacent(to: anchorId, position: .above) != nil else {
+                    NSSound.beep()
+                    return
+                }
+            },
+            onNewWorkspaceBelow: { [weak tabManager, anchorId = group.anchorWorkspaceId] in
+                guard let tabManager,
+                      tabManager.createWorkspaceAdjacent(to: anchorId, position: .below) != nil else {
+                    NSSound.beep()
+                    return
+                }
+            },
             onRunResolvedItem: { [weak tabManager, groupId = group.id] item in
                 guard let tabManager else { return }
                 SidebarWorkspaceGroupContextMenuRunner.run(

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -8,7 +8,7 @@ import Testing
 #endif
 
 @MainActor
-@Suite("Workspace group model")
+@Suite("Workspace group model", .serialized)
 struct WorkspaceGroupTests {
 
     private func makeTabManager() -> TabManager {
@@ -573,6 +573,127 @@ struct WorkspaceGroupTests {
             inserted.id,
             originalIds[1],
             originalIds[2],
+        ])
+    }
+
+    @Test func createWorkspaceAdjacentPlacesUngroupedWorkspaceAboveAndBelowReference() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+
+        let insertedAbove = try #require(manager.createWorkspaceAdjacent(
+            to: originalIds[1],
+            position: .above,
+            select: false
+        ))
+
+        #expect(manager.tabs.map(\.id) == [
+            originalIds[0],
+            insertedAbove.id,
+            originalIds[1],
+            originalIds[2],
+            originalIds[3],
+        ])
+
+        let insertedBelow = try #require(manager.createWorkspaceAdjacent(
+            to: originalIds[2],
+            position: .below,
+            select: false
+        ))
+
+        #expect(manager.tabs.map(\.id) == [
+            originalIds[0],
+            insertedAbove.id,
+            originalIds[1],
+            originalIds[2],
+            insertedBelow.id,
+            originalIds[3],
+        ])
+    }
+
+    @Test func createWorkspaceAdjacentPlacesGroupedMemberAboveAndBelowReferenceInsideGroup() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            originalIds[1],
+            originalIds[2],
+        ]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+
+        let insertedAbove = try #require(manager.createWorkspaceAdjacent(
+            to: originalIds[2],
+            position: .above,
+            select: false
+        ))
+
+        #expect(insertedAbove.groupId == groupId)
+        #expect(manager.tabs.filter { $0.groupId == groupId }.map(\.id) == [
+            group.anchorWorkspaceId,
+            originalIds[1],
+            insertedAbove.id,
+            originalIds[2],
+        ])
+
+        let insertedBelow = try #require(manager.createWorkspaceAdjacent(
+            to: originalIds[1],
+            position: .below,
+            select: false
+        ))
+
+        #expect(insertedBelow.groupId == groupId)
+        #expect(manager.tabs.filter { $0.groupId == groupId }.map(\.id) == [
+            group.anchorWorkspaceId,
+            originalIds[1],
+            insertedBelow.id,
+            insertedAbove.id,
+            originalIds[2],
+        ])
+    }
+
+    @Test func createWorkspaceAdjacentToGroupHeaderPlacesOutsideWholeGroup() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            originalIds[1],
+            originalIds[2],
+        ]))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+
+        let insertedAbove = try #require(manager.createWorkspaceAdjacent(
+            to: group.anchorWorkspaceId,
+            position: .above,
+            select: false
+        ))
+
+        #expect(insertedAbove.groupId == nil)
+        #expect(manager.tabs.map(\.id) == [
+            originalIds[0],
+            insertedAbove.id,
+            group.anchorWorkspaceId,
+            originalIds[1],
+            originalIds[2],
+            originalIds[3],
+        ])
+
+        let insertedBelow = try #require(manager.createWorkspaceAdjacent(
+            to: group.anchorWorkspaceId,
+            position: .below,
+            select: false
+        ))
+
+        #expect(insertedBelow.groupId == nil)
+        #expect(manager.tabs.map(\.id) == [
+            originalIds[0],
+            insertedAbove.id,
+            group.anchorWorkspaceId,
+            originalIds[1],
+            originalIds[2],
+            insertedBelow.id,
+            originalIds[3],
         ])
     }
 


### PR DESCRIPTION
## Summary
- Add command palette actions for New Workspace Above and New Workspace Below.
- Add matching right-click menu actions on workspace rows and workspace group headers.
- Route all entrypoints through a shared TabManager adjacent-insertion API so group member insertion stays inside the group, while group header insertion targets outside the whole group.
- Add localized English and Japanese strings.

## Testing
- `node -e 'JSON.parse(require("fs").readFileSync("Resources/Localizable.xcstrings","utf8")); console.log("Localizable.xcstrings JSON OK")'`
- `git diff --check`
- `./scripts/reload-cloud.sh --tag wspabv`
- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-workspace-position-actions-rerun -only-testing:cmuxTests/WorkspaceGroupTests` built and ran the suite locally. The three new adjacent-insertion tests passed. The run still failed existing WorkspaceGroupTests expectations unrelated to these new actions, including pinned/group reorder cases.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783503421&installation_id=133855650&pr_number=5644&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5644&signature=b57e609007b2b3c90fb0c97c8f22cafbd92eb04a020c1bea11fa6c576048bd17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace ordering, group membership, and `addWorkspace` inheritance paths; mistakes could mis-order tabs or break group contiguity, though behavior is covered by new unit tests.
> 
> **Overview**
> Adds **New Workspace Above** and **New Workspace Below** so users can insert a workspace next to the current one instead of only using generic “new workspace” placement.
> 
> **Command palette** registers two new commands (with keywords above/below) that require a selected workspace and call `TabManager.createWorkspaceAdjacent`. **Workspace row** and **workspace group header** context menus get the same two actions; group headers wire through `onNewWorkspaceAbove` / `onNewWorkspaceBelow` in `VerticalTabsSidebar+WorkspaceGroups`.
> 
> **`TabManager`** introduces `WorkspaceAdjacentInsertionPosition` and `createWorkspaceAdjacent(to:position:)`, plus `sourceWorkspaceOverride` on `addWorkspace` so inheritance follows the reference row, not only the current selection. Ungrouped tabs insert via create-then-reorder; grouped members stay in the group and expand collapsed groups when selecting; acting on the **group anchor** inserts **outside** the whole group (before first / after last member). English and Japanese strings cover palette and context menu labels.
> 
> **Tests:** `WorkspaceGroupTests` is marked `.serialized` and adds three tests for ungrouped, in-group, and group-header adjacent insertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0f3501adec110a21a89957af7e1aebea5baf49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add actions to create a new workspace above or below the current selection. Uses a shared `TabManager` adjacent-insertion API to place new workspaces inside groups or outside the group when triggered from a group header.

- **New Features**
  - Command palette actions: `palette.newWorkspaceAbove` and `palette.newWorkspaceBelow` with localized titles.
  - Right-click menu actions on workspace rows and workspace group headers.
  - Shared `TabManager.createWorkspaceAdjacent(to:position:)` ensures:
    - Group member insertion stays inside the group.
    - Group header insertion targets outside the whole group.
  - Added English and Japanese strings and unit tests covering ungrouped, grouped member, and group header cases.

<sup>Written for commit 4e0f3501adec110a21a89957af7e1aebea5baf49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "New Workspace Above" and "New Workspace Below" commands accessible via command palette and workspace context menus for creating adjacent workspaces
  * Extended multi-language support with English and Japanese translations for the new commands
  * Workspace groups now support creating adjacent workspaces from the group header menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->