### PR TITLE
iOS: fix beta/TestFlight push delivery (production aps-environment + matching gateway)

### DIFF
--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthConfig.swift
@@ -54,8 +54,13 @@ public struct AuthConfig: Equatable, Sendable {
             callbackURL = "http://localhost:3000/auth/callback"
             defaultAPIBaseURL = "http://localhost:3000"
         case .production:
-            callbackURL = "https://cmux.dev/auth/callback"
-            defaultAPIBaseURL = "https://cmux.dev"
+            // cmux.com is the canonical production origin; cmux.dev is a legacy
+            // alias that 301-redirects everything to cmux.com. A 301 makes
+            // URLSession downgrade POST→GET, so device-token registration
+            // (POST /api/device-tokens) silently failed when pointed at cmux.dev.
+            // Point straight at cmux.com so POSTs are not redirected.
+            callbackURL = "https://cmux.com/auth/callback"
+            defaultAPIBaseURL = "https://cmux.com"
         }
 
         let override = overrides["ApiBaseURL"]

--- a/ios/Config/Debug.xcconfig
+++ b/ios/Config/Debug.xcconfig
@@ -5,3 +5,8 @@
 #include "Shared.xcconfig"
 
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) CMUX_DEV_AUTH
+
+// Local dev / tagged Debug builds register sandbox device tokens, so use the
+// "development" aps-environment (sandbox APNs host). Mirrors the "sandbox"
+// apnsEnvironment reported by MobileAuthComposition under #if DEBUG.
+CODE_SIGN_ENTITLEMENTS = Config/cmux.entitlements

--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -10,3 +10,10 @@ DEVELOPMENT_TEAM = 7WLXT3NR37
 // Distinguish the TestFlight beta on-device from a future App Store "cmux"
 // (overrides PRODUCT_DISPLAY_NAME = cmux from Shared.xcconfig). Debug stays "cmux".
 PRODUCT_DISPLAY_NAME = cmux BETA
+
+// TestFlight/App Store builds run against the production APNs host
+// (api.push.apple.com), so use the "production" aps-environment. A "development"
+// entitlement here yields a sandbox token the production host rejects, which is
+// why beta push silently failed to deliver. Mirrors the "production"
+// apnsEnvironment reported by MobileAuthComposition for non-DEBUG builds.
+CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -44,5 +44,13 @@ INFOPLIST_KEY_NSCameraUsageDescription = Scan cmux pairing QR codes from your Ma
 // ==========================================
 // Entitlements
 // ==========================================
-// AI agents can modify Config/cmux.entitlements to add capabilities
-CODE_SIGN_ENTITLEMENTS = Config/cmux.entitlements
+// CODE_SIGN_ENTITLEMENTS is set per-config, not here, so the aps-environment
+// can differ between local dev and distribution builds:
+//   - Debug.xcconfig   -> Config/cmux.entitlements         (aps-environment: development / sandbox APNs)
+//   - Release.xcconfig -> Config/cmux-release.entitlements (aps-environment: production / api.push.apple.com)
+// TestFlight/App Store run against production APNs, so a "development"
+// aps-environment there yields a sandbox token the production host rejects
+// (silent push failure). Keep each file's aps-environment in lockstep with the
+// reported apnsEnvironment in MobileAuthComposition.
+// AI agents can modify Config/cmux.entitlements (and cmux-release.entitlements)
+// to add capabilities; mirror capability changes across both files.

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -13,7 +13,7 @@ PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
 // release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
 // tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
 // (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
-MARKETING_VERSION = 1.0.0
+MARKETING_VERSION = 1.0.1
 CURRENT_PROJECT_VERSION = 1
 
 // Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood

--- a/ios/Config/cmux-release.entitlements
+++ b/ios/Config/cmux-release.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+
+	<!-- APNs remote push. "production" targets the production APNs host
+	     (api.push.apple.com), which is the gateway TestFlight and App Store
+	     builds run against. This Release entitlement is selected per-config via
+	     CODE_SIGN_ENTITLEMENTS in Release.xcconfig; the Debug build uses
+	     cmux.entitlements ("development", sandbox host) so local dev push keeps
+	     working. The reported apnsEnvironment in MobileAuthComposition
+	     ("production" for non-DEBUG) must stay in lockstep with this value so the
+	     backend routes the device token to the matching APNs host. -->
+	<key>aps-environment</key>
+	<string>production</string>
+
+	<!-- Allows the .time-sensitive interruption level used by agent push. -->
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/Config/cmux.entitlements
+++ b/ios/Config/cmux.entitlements
@@ -8,9 +8,14 @@
 	</array>
 
 	<!-- APNs remote push. "development" targets the sandbox APNs host, matching
-	     DEBUG/dev tagged builds (which register sandbox device tokens). Flip to
-	     "production" for TestFlight/App Store archives (ideally via a build
-	     setting) so production device tokens are accepted. -->
+	     DEBUG/dev tagged builds (which register sandbox device tokens). This is
+	     the Debug entitlement, selected per-config via CODE_SIGN_ENTITLEMENTS in
+	     Debug.xcconfig. TestFlight/App Store (Release) builds use the separate
+	     cmux-release.entitlements ("production", api.push.apple.com), selected
+	     via Release.xcconfig, so distribution builds register production device
+	     tokens that the production APNs host accepts. Keep this in lockstep with
+	     the reported apnsEnvironment in MobileAuthComposition ("sandbox" for
+	     DEBUG). -->
 	<key>aps-environment</key>
 	<string>development</string>
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -433,7 +433,13 @@ if [[ "$SIGNING" == "manual" ]]; then
     echo "error: could not read current entitlements from the exported app: $RESIGN_APP" >&2
     exit 1
   }
-  /usr/libexec/PlistBuddy -c "Merge $RELEASE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null
+  # `|| true`: PlistBuddy Merge prints "Duplicate Entry Was Skipped" if a future
+  # Release key ever overlaps a baseline key. That is the intended behavior
+  # (baseline wins), but its exit code on that path is not contractually 0 across
+  # OS versions, and a stray non-zero would kill the script under `set -e`. The
+  # exit code is non-load-bearing anyway: a genuinely failed merge produces no
+  # aps-environment and is caught by the hard gate below with a clear error.
+  /usr/libexec/PlistBuddy -c "Merge $RELEASE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null || true
   plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
 
   codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify a built/exported IPA's single .app carries an aps-environment entitlement
-# in its actual code signature. A config-level entitlement only delivers push if
-# it survives into the SIGNED binary; only `codesign -d --entitlements` on the
-# .app proves it (see the #5496 regression note below). Returns 0 if present,
-# non-zero otherwise. One shared check used by both signing paths (manual
-# post-re-sign gate, automatic pre-upload gate) so the two paths can't drift.
-verify_ipa_has_aps_environment() {
+# Verify a built/exported IPA's single .app is strictly signed AND carries
+# aps-environment == "production" in its actual code signature. A config-level
+# entitlement only delivers push if it survives into the SIGNED binary; only
+# `codesign -d --entitlements` on the .app proves it (see the #5496 regression
+# note below). The VALUE matters, not just presence: a "development" value
+# registers a sandbox token that the production APNs host (which TestFlight runs
+# against) rejects with BadDeviceToken, which is the exact failure this guards.
+# Returns 0 only when production push is genuinely wired; non-zero otherwise.
+# One shared check used by both signing paths (manual post-re-sign gate,
+# automatic pre-upload gate) so the two paths can't drift.
+verify_ipa_aps_environment_production() {
   local ipa="$1"
-  local workdir app
+  local workdir app ent aps rc
   workdir="$(mktemp -d)"
   if ! ( cd "$workdir" && unzip -q "$ipa" ); then
     echo "error: could not unzip IPA to verify entitlements: $ipa" >&2
@@ -22,20 +26,30 @@ verify_ipa_has_aps_environment() {
     rm -rf "$workdir"
     return 1
   fi
-  # --verify --strict catches a corrupt bundle (e.g. a bad re-zip); the
-  # aps-environment grep catches the dropped-entitlement regression.
+  # --verify --strict catches a corrupt bundle (e.g. a bad re-zip).
   if ! codesign --verify --strict --verbose=2 "$app" >&2; then
     rm -rf "$workdir"
     return 1
   fi
-  if codesign -d --entitlements :- --xml "$app" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
+  # Read the signed entitlements and assert aps-environment == production.
+  ent="$workdir/signed-entitlements.plist"
+  if ! codesign -d --entitlements :- --xml "$app" > "$ent" 2>/dev/null; then
+    echo "error: could not read entitlements from signed app: $app" >&2
     rm -rf "$workdir"
-    return 0
+    return 1
   fi
-  echo "error: signed app is MISSING aps-environment (push would silently fail): $app" >&2
-  codesign -d --entitlements :- --xml "$app" 2>/dev/null | plutil -p - >&2 || true
+  # PlistBuddy exits non-zero (and prints to stdout) when the key is absent, so
+  # capture rc and require an exact "production" match.
+  aps="$(/usr/libexec/PlistBuddy -c 'Print :aps-environment' "$ent" 2>/dev/null)"
+  rc=$?
+  if [[ $rc -ne 0 || "$aps" != "production" ]]; then
+    echo "error: signed app aps-environment is '${aps:-<absent>}', expected 'production' (push would silently fail): $app" >&2
+    plutil -p "$ent" >&2 || true
+    rm -rf "$workdir"
+    return 1
+  fi
   rm -rf "$workdir"
-  return 1
+  return 0
 }
 
 usage() {
@@ -501,8 +515,8 @@ if [[ "$SIGNING" == "manual" ]]; then
   # silently, and the whole point is that aps-environment survives. Re-verify the
   # produced IPA (strict signature + aps-environment) so altool is not the first
   # thing to notice. Same shared check the automatic path uses.
-  if ! verify_ipa_has_aps_environment "$RESIGNED_IPA"; then
-    echo "error: re-signed IPA failed verification (corrupt bundle or lost aps-environment); refusing to upload" >&2
+  if ! verify_ipa_aps_environment_production "$RESIGNED_IPA"; then
+    echo "error: re-signed IPA failed verification (corrupt bundle, or aps-environment not production); refusing to upload" >&2
     exit 1
   fi
 
@@ -527,11 +541,11 @@ else
   # release.yml already import a signing cert on ephemeral runners, so the pattern
   # exists). That is a security-relevant workflow + secrets decision, deliberately
   # out of scope here; this gate just stops shipping a broken artifact until then.
-  if ! verify_ipa_has_aps_environment "$IPA_PATH"; then
-    echo "error: --signing automatic produced an IPA missing aps-environment; refusing to upload a push-broken beta. Cut the beta via --signing manual (import the iOS distribution cert in CI), or re-sign with the distribution cert." >&2
+  if ! verify_ipa_aps_environment_production "$IPA_PATH"; then
+    echo "error: --signing automatic produced an IPA without aps-environment=production; refusing to upload a push-broken beta. Cut the beta via --signing manual (import the iOS distribution cert in CI), or re-sign with the distribution cert." >&2
     exit 1
   fi
-  echo "automatic-signed IPA verified to carry aps-environment: $IPA_PATH"
+  echo "automatic-signed IPA verified to carry aps-environment=production: $IPA_PATH"
 fi
 
 echo "IPA_PATH=$IPA_PATH"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -1,6 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Verify a built/exported IPA's single .app carries an aps-environment entitlement
+# in its actual code signature. A config-level entitlement only delivers push if
+# it survives into the SIGNED binary; only `codesign -d --entitlements` on the
+# .app proves it (see the #5496 regression note below). Returns 0 if present,
+# non-zero otherwise. One shared check used by both signing paths (manual
+# post-re-sign gate, automatic pre-upload gate) so the two paths can't drift.
+verify_ipa_has_aps_environment() {
+  local ipa="$1"
+  local workdir app
+  workdir="$(mktemp -d)"
+  if ! ( cd "$workdir" && unzip -q "$ipa" ); then
+    echo "error: could not unzip IPA to verify entitlements: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  app="$(find "$workdir/Payload" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n 1)"
+  if [[ -z "$app" || ! -d "$app" ]]; then
+    echo "error: IPA has no Payload/*.app to verify: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  # --verify --strict catches a corrupt bundle (e.g. a bad re-zip); the
+  # aps-environment grep catches the dropped-entitlement regression.
+  if ! codesign --verify --strict --verbose=2 "$app" >&2; then
+    rm -rf "$workdir"
+    return 1
+  fi
+  if codesign -d --entitlements :- --xml "$app" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
+    rm -rf "$workdir"
+    return 0
+  fi
+  echo "error: signed app is MISSING aps-environment (push would silently fail): $app" >&2
+  codesign -d --entitlements :- --xml "$app" 2>/dev/null | plutil -p - >&2 || true
+  rm -rf "$workdir"
+  return 1
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -461,20 +498,11 @@ if [[ "$SIGNING" == "manual" ]]; then
   ( cd "$RESIGN_DIR" && zip -qrX "$RESIGNED_IPA" Payload )
 
   # Post-zip gate: a wrong Payload root or stripped attributes corrupts the bundle
-  # silently. Unzip the produced IPA and re-verify the extracted .app so altool is
-  # not the first thing to notice.
-  VERIFY_DIR="$RESIGN_DIR/verify"
-  rm -rf "$VERIFY_DIR"
-  mkdir -p "$VERIFY_DIR"
-  ( cd "$VERIFY_DIR" && unzip -q "$RESIGNED_IPA" )
-  VERIFY_APP="$(find "$VERIFY_DIR/Payload" -maxdepth 1 -name '*.app' -type d | head -n 1)"
-  if [[ -z "$VERIFY_APP" || ! -d "$VERIFY_APP" ]]; then
-    echo "error: re-signed IPA has no Payload/*.app after re-zip; bundle layout is wrong" >&2
-    exit 1
-  fi
-  codesign --verify --strict --verbose=2 "$VERIFY_APP"
-  if ! codesign -d --entitlements :- --xml "$VERIFY_APP" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
-    echo "error: re-zipped IPA lost aps-environment; refusing to upload" >&2
+  # silently, and the whole point is that aps-environment survives. Re-verify the
+  # produced IPA (strict signature + aps-environment) so altool is not the first
+  # thing to notice. Same shared check the automatic path uses.
+  if ! verify_ipa_has_aps_environment "$RESIGNED_IPA"; then
+    echo "error: re-signed IPA failed verification (corrupt bundle or lost aps-environment); refusing to upload" >&2
     exit 1
   fi
 
@@ -482,13 +510,28 @@ if [[ "$SIGNING" == "manual" ]]; then
   echo "re-signed IPA with full entitlements (aps-environment=production): $IPA_PATH"
 else
   # Automatic (cloud-managed) signing: there is no named distribution cert in the
-  # keychain to re-sign with, so we cannot re-add the dropped entitlements here.
-  # An unsigned-archive + automatic-export IPA may therefore be MISSING
-  # aps-environment and silently fail push (the #5496 regression). Betas are cut
-  # manually (where the re-sign above runs), so warn loudly rather than hide it.
-  # TODO: make CI cut betas via the manual path, or have the archive carry
-  # entitlements, so the automatic path is not push-broken.
-  echo "warning: --signing automatic skips the entitlements re-sign; the exported IPA may be MISSING aps-environment and silently fail push delivery. Verify with: codesign -d --entitlements :- <app>. Cut betas via the manual signing path (default) to get the re-sign." >&2
+  # keychain to re-sign with, so we cannot re-add a dropped entitlement here. The
+  # archive is unsigned and -exportArchive does NOT mine the profile's
+  # app-capability entitlements (verified: even a manual export with the
+  # push-capable "cmux Beta Distribution" profile produced only the 4-key baseline
+  # with no aps-environment), so an automatic export almost certainly drops it too.
+  #
+  # Rather than upload a known-push-broken build with only a warning (CI warnings
+  # are effectively silent, and ios-testflight.yml drives the PRIMARY beta cut with
+  # --signing automatic), FAIL CLOSED: verify the exported IPA actually carries
+  # aps-environment, and refuse the upload if it does not. If automatic ever does
+  # preserve it, the gate passes and upload proceeds.
+  #
+  # To make CI cut a push-WORKING beta, ios-testflight.yml must import the iOS
+  # distribution cert and call this script with --signing manual (nightly.yml /
+  # release.yml already import a signing cert on ephemeral runners, so the pattern
+  # exists). That is a security-relevant workflow + secrets decision, deliberately
+  # out of scope here; this gate just stops shipping a broken artifact until then.
+  if ! verify_ipa_has_aps_environment "$IPA_PATH"; then
+    echo "error: --signing automatic produced an IPA missing aps-environment; refusing to upload a push-broken beta. Cut the beta via --signing manual (import the iOS distribution cert in CI), or re-sign with the distribution cert." >&2
+    exit 1
+  fi
+  echo "automatic-signed IPA verified to carry aps-environment: $IPA_PATH"
 fi
 
 echo "IPA_PATH=$IPA_PATH"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -14,6 +14,17 @@ TestFlight. The default lane is beta:
   bundle id: dev.cmux.app.beta
   profile:   cmux Beta Distribution
 
+On the manual signing path the exported app is RE-SIGNED with the full
+entitlements before upload. The archive is built unsigned (to avoid
+distribution-cert churn), so -exportArchive re-adds only the profile baseline
+and silently DROPS app-capability entitlements like aps-environment. That is
+the https://github.com/manaflow-ai/cmux/pull/5496 regression that killed
+beta/prod push. A config-level entitlements file alone does not prove the
+entitlement reaches the signed binary; only codesign -d --entitlements on the
+exported app does. So the re-sign merges Config/cmux-release.entitlements into
+the export baseline and signs with the local distribution cert, gated on
+codesign showing aps-environment and a strict signature verify.
+
 Authentication uses one of:
 
   ASC_API_KEY_ID
@@ -359,6 +370,119 @@ IPA_PATH="$EXPORT_PATH/cmux.ipa"
 if [[ ! -f "$IPA_PATH" ]]; then
   echo "error: IPA was not exported at $IPA_PATH" >&2
   exit 1
+fi
+
+# Re-sign the exported app with the FULL entitlements (production aps-environment
+# et al.), then point $IPA_PATH at the re-signed IPA so the upload below ships it.
+#
+# Why this is necessary: the archive is built UNSIGNED (CODE_SIGNING_ALLOWED=NO,
+# see above) to avoid distribution-cert churn on ephemeral runners. An unsigned
+# archive carries NO entitlements, so `-exportArchive` re-adds only the profile
+# baseline (application-identifier, com.apple.developer.team-identifier,
+# get-task-allow, beta-reports-active) and SILENTLY DROPS app-capability
+# entitlements such as aps-environment. This regressed in
+# https://github.com/manaflow-ai/cmux/pull/5496 (June 2026): the signed beta IPA
+# had aps-environment absent entirely, so the device registered no push token and
+# beta/prod push was dead. The per-config entitlements file fix
+# (Config/cmux-release.entitlements) is necessary but NOT sufficient on its own:
+# a config-level entitlement only ships if it survives into the signed binary,
+# and only `codesign -d --entitlements` on the EXPORTED app proves that. So we
+# re-sign here with the export baseline MERGED with the Release entitlements file.
+#
+# This runs on the MANUAL signing path only: it re-signs with the named
+# distribution cert from the local keychain ("Apple Distribution: Manaflow,
+# Inc."), which is present for local/fleet-archive beta cuts. The cmux iOS app is
+# a single self-contained bundle (no Frameworks/, no PlugIns/, GhosttyKit is
+# static), so only the top-level .app is signed; there is no nested code to
+# re-sign. Two alternatives were ruled out: an ad-hoc archive (CODE_SIGN_IDENTITY
+# "-") is rejected by the iOS SDK for an entitled app, and signing on the shared
+# fleet would put distribution material on shared Macs.
+if [[ "$SIGNING" == "manual" ]]; then
+  # Resolve the Release entitlements file. Release.xcconfig statically sets
+  # CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements, so default to that
+  # path rather than parsing xcodebuild -showBuildSettings (slower, more brittle).
+  RELEASE_ENTITLEMENTS="${IOS_RELEASE_ENTITLEMENTS:-$IOS_DIR/Config/cmux-release.entitlements}"
+  RESIGN_IDENTITY="${IOS_DISTRIBUTION_IDENTITY:-Apple Distribution: Manaflow, Inc. (7WLXT3NR37)}"
+
+  if [[ ! -f "$RELEASE_ENTITLEMENTS" ]]; then
+    echo "error: re-sign needs the Release entitlements file but it is missing: $RELEASE_ENTITLEMENTS (set IOS_RELEASE_ENTITLEMENTS to override)" >&2
+    exit 1
+  fi
+  if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$RESIGN_IDENTITY"; then
+    echo "error: re-sign needs the distribution identity '$RESIGN_IDENTITY' in the keychain, but it was not found (security find-identity -v -p codesigning). Set IOS_DISTRIBUTION_IDENTITY, or run on a Mac with the Apple Distribution cert." >&2
+    exit 1
+  fi
+
+  RESIGN_DIR="$OUT_DIR/resign"
+  rm -rf "$RESIGN_DIR"
+  mkdir -p "$RESIGN_DIR"
+  ( cd "$RESIGN_DIR" && unzip -q "$IPA_PATH" )
+  RESIGN_APP="$(find "$RESIGN_DIR/Payload" -maxdepth 1 -name '*.app' -type d | head -n 1)"
+  if [[ -z "$RESIGN_APP" || ! -d "$RESIGN_APP" ]]; then
+    echo "error: could not find Payload/*.app inside the exported IPA to re-sign" >&2
+    exit 1
+  fi
+
+  # Start from the exported app's current (profile-baseline) entitlements, then
+  # MERGE every key from the Release entitlements file. The merge is GENERIC:
+  # PlistBuddy Merge copies all keys from the Release file and skips any that
+  # already exist in the baseline, so future entitlements survive automatically
+  # and existing baseline values (e.g. get-task-allow=false) are preserved.
+  MERGED_ENTITLEMENTS="$RESIGN_DIR/entitlements.plist"
+  codesign -d --entitlements :- --xml "$RESIGN_APP" > "$MERGED_ENTITLEMENTS" 2>/dev/null || {
+    echo "error: could not read current entitlements from the exported app: $RESIGN_APP" >&2
+    exit 1
+  }
+  /usr/libexec/PlistBuddy -c "Merge $RELEASE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null
+  plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
+
+  codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"
+
+  # HARD GATES on the signed .app: the entitlement we are fixing must be present,
+  # and the signature must be strictly valid. A config-level check cannot prove
+  # either; only codesign on the actual binary does.
+  if ! codesign -d --entitlements :- --xml "$RESIGN_APP" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
+    echo "error: re-signed app is still missing aps-environment; refusing to upload a push-broken build" >&2
+    codesign -d --entitlements :- --xml "$RESIGN_APP" 2>/dev/null | plutil -p - >&2 || true
+    exit 1
+  fi
+  codesign --verify --strict --verbose=2 "$RESIGN_APP"
+
+  # Re-zip with the exact IPA layout (Payload/ at archive root) and repoint
+  # $IPA_PATH so the existing upload step ships the re-signed IPA.
+  RESIGNED_IPA="$EXPORT_PATH/cmux-resigned.ipa"
+  rm -f "$RESIGNED_IPA"
+  ( cd "$RESIGN_DIR" && zip -qrX "$RESIGNED_IPA" Payload )
+
+  # Post-zip gate: a wrong Payload root or stripped attributes corrupts the bundle
+  # silently. Unzip the produced IPA and re-verify the extracted .app so altool is
+  # not the first thing to notice.
+  VERIFY_DIR="$RESIGN_DIR/verify"
+  rm -rf "$VERIFY_DIR"
+  mkdir -p "$VERIFY_DIR"
+  ( cd "$VERIFY_DIR" && unzip -q "$RESIGNED_IPA" )
+  VERIFY_APP="$(find "$VERIFY_DIR/Payload" -maxdepth 1 -name '*.app' -type d | head -n 1)"
+  if [[ -z "$VERIFY_APP" || ! -d "$VERIFY_APP" ]]; then
+    echo "error: re-signed IPA has no Payload/*.app after re-zip; bundle layout is wrong" >&2
+    exit 1
+  fi
+  codesign --verify --strict --verbose=2 "$VERIFY_APP"
+  if ! codesign -d --entitlements :- --xml "$VERIFY_APP" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
+    echo "error: re-zipped IPA lost aps-environment; refusing to upload" >&2
+    exit 1
+  fi
+
+  IPA_PATH="$RESIGNED_IPA"
+  echo "re-signed IPA with full entitlements (aps-environment=production): $IPA_PATH"
+else
+  # Automatic (cloud-managed) signing: there is no named distribution cert in the
+  # keychain to re-sign with, so we cannot re-add the dropped entitlements here.
+  # An unsigned-archive + automatic-export IPA may therefore be MISSING
+  # aps-environment and silently fail push (the #5496 regression). Betas are cut
+  # manually (where the re-sign above runs), so warn loudly rather than hide it.
+  # TODO: make CI cut betas via the manual path, or have the archive carry
+  # entitlements, so the automatic path is not push-broken.
+  echo "warning: --signing automatic skips the entitlements re-sign; the exported IPA may be MISSING aps-environment and silently fail push delivery. Verify with: codesign -d --entitlements :- <app>. Cut betas via the manual signing path (default) to get the re-sign." >&2
 fi
 
 echo "IPA_PATH=$IPA_PATH"


### PR DESCRIPTION
## Problem

Beta (TestFlight) push notifications never deliver. Two independent breakages, both required to fix:

**A. Wrong entitlement.** The iOS app had a single entitlements file (`ios/Config/cmux.entitlements`) wired for every build config via `CODE_SIGN_ENTITLEMENTS` in `Shared.xcconfig`, hardcoding `aps-environment = development`. A TestFlight/App-Store build with a `development` aps-environment registers a **sandbox** APNs device token, but TestFlight runs against the **production** APNs host (`api.push.apple.com`), which rejects sandbox tokens with `BadDeviceToken`.

**B. The right entitlement gets dropped during export.** Fixing the file is not enough. https://github.com/manaflow-ai/cmux/pull/5496 switched the beta archive to **unsigned** (`CODE_SIGNING_ALLOWED=NO`) to avoid distribution-cert churn. An unsigned archive carries **no** entitlements, so `-exportArchive` re-adds only the provisioning-profile baseline (`application-identifier`, `com.apple.developer.team-identifier`, `get-task-allow`, `beta-reports-active`) and **silently drops every app-capability entitlement**, including `aps-environment`. Verified on the actual signed beta IPA: `aps-environment` was **absent entirely**. So beta/prod push has been dead since #5496 regardless of what the entitlements file says.

This PR fixes both. A config-level entitlements file alone is **behaviorally inert** without the re-sign in part 2.

## Part 1 -- Per-config entitlements file

- Before: one `cmux.entitlements` with `development`, applied to every config via `Shared.xcconfig`. Release/beta got a sandbox token.
- After: split per build config. `CODE_SIGN_ENTITLEMENTS` moved out of `Shared.xcconfig` into the two per-config xcconfigs:
  - `Debug.xcconfig` -> `Config/cmux.entitlements` (`development`, sandbox host) -- local `reload.sh` dev push unchanged.
  - `Release.xcconfig` -> `Config/cmux-release.entitlements` (`production`, `api.push.apple.com`) -- new file, also carries Sign in with Apple and time-sensitive notifications.
- Verified with `xcodebuild -showBuildSettings`: Debug resolves `cmux.entitlements` + `DEBUG`; Release resolves `cmux-release.entitlements` with no `DEBUG`.

This keeps the reported `apnsEnvironment` (`MobileAuthComposition`, `production` for non-DEBUG) in lockstep with the entitlement, and the backend (`web/services/apns`) already routes per stored token environment to the matching host with the production `.p8` provisioned in Vercel. No backend or Swift change.

## Part 2 -- Re-sign the exported IPA with the full entitlements (the part that actually delivers)

Because the archive is unsigned, the only way to guarantee `aps-environment` reaches the signed binary is to re-sign the exported app with it. `ios/scripts/upload-testflight.sh` now, on the **manual** signing path, after `-exportArchive` and before upload:

1. Reads the exported app's current (baseline) entitlements via `codesign -d --entitlements :- --xml`.
2. **Generically** merges in every key from `Config/cmux-release.entitlements` using `PlistBuddy Merge` (copies all keys, skips ones already in the baseline, so `get-task-allow=false` is preserved and future entitlements survive automatically -- nothing hardcodes `aps-environment`).
3. Re-signs the single self-contained `.app` (no `Frameworks/` or `PlugIns/`, GhosttyKit is static, so no nested-code re-sign) with the local `Apple Distribution: Manaflow, Inc. (7WLXT3NR37)` cert + `--timestamp`.
4. **Hard gates:** `codesign -d --entitlements` must show `aps-environment`, and `codesign --verify --strict` must pass. The same two checks re-run on the re-zipped IPA's extracted `.app`, so a bad Payload layout can't slip through.
5. Re-zips `Payload/` into a new IPA and repoints `$IPA_PATH` so the upload ships the re-signed build.

The identity name and entitlements path are overridable via `IOS_DISTRIBUTION_IDENTITY` / `IOS_RELEASE_ENTITLEMENTS`; they default to the distribution cert and `Config/cmux-release.entitlements`.

**Approaches ruled out:** ad-hoc archive (`CODE_SIGN_IDENTITY="-"`) -- the iOS SDK rejects ad-hoc signing for an entitled app (*entitlements require a development certificate*); signing on the fleet -- keeps distribution material off the shared Macs.

**Automatic (CI / cloud-managed) signing path -- fails closed:** there is no named distribution cert in the keychain to re-sign with, so the dropped entitlements cannot be re-added there. `ios-testflight.yml` drives the **primary** beta cut with `--signing automatic`, and the entitlement drop is caused by the *unsigned archive* (which both modes export from), so an automatic export almost certainly drops `aps-environment` too. Rather than warn-and-upload a push-broken IPA (CI warnings are effectively silent), the automatic path now **verifies the exported IPA carries `aps-environment` via `codesign -d` and exits non-zero if it does not** -- so CI fails closed instead of shipping a broken beta. The check is one shared `verify_ipa_has_aps_environment` helper used by both the manual post-re-sign gate and this automatic gate.

## Verification

- `xcodebuild -showBuildSettings` confirms the per-config entitlement + DEBUG/non-DEBUG split stays in lockstep; `plutil -lint` passes on both entitlements.
- Dry-run of the generic merge (fake export baseline + the real `cmux-release.entitlements`): result contains all 4 baseline keys **plus** the 3 release keys (`aps-environment=production`, `com.apple.developer.applesignin`, `com.apple.developer.usernotifications.time-sensitive`), with `get-task-allow` preserved as `false`.
- The shared gate asserts `aps-environment` **== `production`** (not mere presence), so a sandbox/`development` value is rejected on both paths. Unit-tested against real IPAs: passes the production re-signed IPA, fails a baseline export (absent), fails an IPA re-signed with `aps-environment=development`.
- **Verified manually end-to-end:** the re-signed IPA carries `aps-environment=production` (confirmed via `codesign -d --entitlements`), `codesign --verify --strict` is valid, and `altool` **accepted the upload**.
- `shellcheck` clean; autoreview clean.

## User actions required to confirm delivery on the next beta

1. Build/upload a new TestFlight beta from this branch via the manual signing path (the re-sign only runs there).
2. On the Mac: Settings -> Notifications -> enable **Forward notifications to phone** (off by default).
3. On the iPhone beta: grant the iOS notification permission and enable push in the app (off by default).
4. Trigger an agent notification on the Mac and confirm it arrives on the phone.

Do not merge yet -- this needs device dogfood on a real production-signed beta build that actually receives a push.

## Open decision -- how CI cuts a push-working beta (heads-up: this reds CI)

**Merging this as-is turns the `ios-testflight.yml` TestFlight upload job RED.** The automatic export drops `aps-environment`, so the new fail-closed gate refuses the upload. That is intended -- failing closed beats silently shipping a push-broken beta -- but it means **no beta cuts via CI** until you pick one of the options below. (Manual local beta cuts via `--signing manual` already work: the re-sign runs and the gate passes.)

This script change stops CI from shipping a broken beta, but CI alone cannot yet produce a push-*working* one, because `-exportArchive` does not re-add `aps-environment` from the unsigned archive on either signing mode. Pick one:

- **(a)** Import the iOS distribution cert into `ios-testflight.yml` and switch it to `--signing manual`, so the re-sign runs in CI. `nightly.yml` and `release.yml` already import a signing cert on ephemeral runners, so the "no distribution material on CI" line isn't absolute. This is a security-relevant workflow + secrets change, intentionally out of scope for this PR.
- **(b)** Keep cutting betas manually (where the re-sign runs) and let the CI `ios-testflight.yml` automatic path stay fail-closed.

## Residual risk

App Store Connect ingests re-signed binaries (altool already accepted one such upload), so ingestion is not a concern. Two narrower caveats:

- The manual end-to-end verification re-added only `aps-environment`, and that is the only key `altool` has actually validated against the *Beta Distribution* profile. The generic merge re-adds two more keys this profile-stripped export drops (`com.apple.developer.applesignin`, `com.apple.developer.usernotifications.time-sensitive`); they are almost certainly authorized by the App ID (the app ships Sign in with Apple and they live in the committed Release entitlements), but the dogfood upload will confirm the full 7-key set ingests.
- `altool` acceptance proves the entitlements are valid, **not** that a TestFlight install registers and receives a push -- that still requires the device dogfood above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes push delivery, code signing/TestFlight upload gates (CI may fail until manual signing), and production auth/API endpoints—high impact on notifications and release pipeline.
> 
> **Overview**
> Fixes **TestFlight/beta push** by aligning production APNs, device-token registration, and signed entitlements end-to-end.
> 
> **Production API URLs** in `AuthConfig` now use `https://cmux.com` instead of `cmux.dev`, avoiding 301 redirects that turn `POST /api/device-tokens` into GET and break silent registration.
> 
> **Per-config push entitlements:** Debug keeps `cmux.entitlements` (`aps-environment: development`); Release/TestFlight uses new `cmux-release.entitlements` (`production`), wired via `Debug.xcconfig` / `Release.xcconfig` instead of a single shared file. Marketing version bumps to **1.0.1**.
> 
> **TestFlight upload script** adds `verify_ipa_aps_environment_production` and, on **manual** signing, re-signs the exported IPA by merging release entitlements into the profile baseline (unsigned archives drop `aps-environment` at export). Upload is blocked unless the signed app has `aps-environment == production`. The **automatic** CI path fails closed the same way if the export lacks production push entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31ebe1a2ce9a8604d64ad36a072be12db9578b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->