### PR TITLE
Analytics: cross-platform identity, drop noisy events, iOS retention

### DIFF
--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/AnalyticsEmitting.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/AnalyticsEmitting.swift
@@ -17,13 +17,13 @@ import Foundation
 /// It must never be `await`-ed inline on a hot path (terminal input, render),
 /// and conformers must never do network or disk I/O on the calling thread:
 /// `capture` enqueues onto an off-main actor and returns. Fire-sites call
-/// `analytics.capture("ios_event", props)` with **no `await`**.
+/// `analytics.capture("ios_<event_name>", props)` with **no `await`**.
 ///
 /// ```swift
-/// // On the terminal-input hot path — note: no await.
-/// analytics.capture("ios_terminal_input_submitted", [
+/// // On a hot path (e.g. dropped terminal input) — note: no await.
+/// analytics.capture("ios_terminal_input_dropped", [
 ///     "byte_count": .int(payload.utf8.count),
-///     "line_count": .int(lineCount),
+///     "reason": .string(reason),
 /// ])
 /// ```
 public protocol AnalyticsEmitting: Sendable {

--- a/Packages/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/AnalyticsActivePeriodStore.swift
+++ b/Packages/CmuxMobileAnalytics/Sources/CmuxMobileAnalytics/AnalyticsActivePeriodStore.swift
@@ -1,0 +1,83 @@
+public import Foundation
+
+/// Once-per-period dedup for the iOS daily + hourly active retention pings.
+///
+/// Mirrors the macOS `PostHogAnalytics` `cmux_daily_active` / `cmux_hourly_active`
+/// pattern: the app records a UTC day/hour key the first time it is active in a
+/// period, and suppresses the event for the rest of that period. Together with
+/// the shared Stack-user-id distinct id (the iOS proxy stamps `user.id`), this
+/// makes iOS DAU + hourly retention line up symmetrically with macOS.
+///
+/// The type holds no mutable in-memory state: persistence lives in the injected
+/// `UserDefaults` (so the dedup survives relaunches and is testable without
+/// `.standard`), and the period boundaries are computed from injected `Date`s.
+/// `claimDaily`/`claimHourly` are the only mutating calls — each returns whether
+/// the caller should emit and atomically records the period when it does, so a
+/// double foreground in the same period emits once.
+public struct AnalyticsActivePeriodStore: Sendable {
+    private static let lastDayKey = "dev.cmux.analytics.lastActiveDayUTC"
+    private static let lastHourKey = "dev.cmux.analytics.lastActiveHourUTC"
+
+    // UserDefaults is Apple-documented thread-safe; OK to hold nonisolated.
+    private nonisolated(unsafe) let defaults: UserDefaults
+
+    /// Creates an active-period store.
+    /// - Parameter defaults: The persistence store. Inject a suite-scoped store
+    ///   in tests; the app uses `.standard`.
+    public init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// The UTC day string (`yyyy-MM-dd`) for `date`. Exposed so the emitted
+    /// event can carry the same `day_utc` property macOS uses.
+    public static func dayUTCString(_ date: Date) -> String {
+        dayFormatter.string(from: date)
+    }
+
+    /// The UTC hour string (`yyyy-MM-dd'T'HH`) for `date`. Exposed so the emitted
+    /// event can carry the same `hour_utc` property macOS uses.
+    public static func hourUTCString(_ date: Date) -> String {
+        hourFormatter.string(from: date)
+    }
+
+    /// Claims the daily-active period for `date`.
+    ///
+    /// - Returns: The UTC day key when this is the first active moment of that
+    ///   UTC day (and records it so the rest of the day is suppressed), or `nil`
+    ///   when the day was already claimed.
+    @discardableResult
+    public func claimDaily(now date: Date) -> String? {
+        let day = Self.dayUTCString(date)
+        if defaults.string(forKey: Self.lastDayKey) == day { return nil }
+        defaults.set(day, forKey: Self.lastDayKey)
+        return day
+    }
+
+    /// Claims the hourly-active period for `date`.
+    ///
+    /// - Returns: The UTC hour key when this is the first active moment of that
+    ///   UTC hour (and records it so the rest of the hour is suppressed), or
+    ///   `nil` when the hour was already claimed.
+    @discardableResult
+    public func claimHourly(now date: Date) -> String? {
+        let hour = Self.hourUTCString(date)
+        if defaults.string(forKey: Self.lastHourKey) == hour { return nil }
+        defaults.set(hour, forKey: Self.lastHourKey)
+        return hour
+    }
+
+    // Type-scoped (not file-scope free funcs) to satisfy the iOS package
+    // conventions lint (`lint-ios-package-conventions.sh` errors on free
+    // functions). The formatters are stateless after init and only read.
+    private static let dayFormatter = makeUTCFormatter("yyyy-MM-dd")
+    private static let hourFormatter = makeUTCFormatter("yyyy-MM-dd'T'HH")
+
+    private static func makeUTCFormatter(_ format: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .iso8601)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = format
+        return formatter
+    }
+}

--- a/Packages/CmuxMobileAnalytics/Tests/CmuxMobileAnalyticsTests/AnalyticsActivePeriodStoreTests.swift
+++ b/Packages/CmuxMobileAnalytics/Tests/CmuxMobileAnalyticsTests/AnalyticsActivePeriodStoreTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileAnalytics
+
+@Suite struct AnalyticsActivePeriodStoreTests {
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "analytics-active-test-\(UUID().uuidString)")!
+    }
+
+    /// 2024-01-02T03:04:05Z — fixed instant so the UTC keys are deterministic.
+    private let base = Date(timeIntervalSince1970: 1_704_164_645)
+
+    @Test func firstClaimReturnsKeyAndIsDedupedWithinPeriod() {
+        let store = AnalyticsActivePeriodStore(defaults: makeDefaults())
+
+        #expect(store.claimDaily(now: base) == "2024-01-02")
+        #expect(store.claimHourly(now: base) == "2024-01-02T03")
+
+        // A second foreground in the same UTC day/hour must not re-emit.
+        #expect(store.claimDaily(now: base.addingTimeInterval(5 * 60)) == nil)
+        #expect(store.claimHourly(now: base.addingTimeInterval(5 * 60)) == nil)
+    }
+
+    @Test func hourlyReclaimsAcrossHourBoundaryButDailyDoesNot() {
+        let store = AnalyticsActivePeriodStore(defaults: makeDefaults())
+        _ = store.claimDaily(now: base)
+        _ = store.claimHourly(now: base)
+
+        // One hour later (still the same UTC day): hourly re-claims, daily stays
+        // suppressed.
+        let nextHour = base.addingTimeInterval(60 * 60)
+        #expect(store.claimDaily(now: nextHour) == nil)
+        #expect(store.claimHourly(now: nextHour) == "2024-01-02T04")
+    }
+
+    @Test func bothReclaimAcrossDayBoundary() {
+        let store = AnalyticsActivePeriodStore(defaults: makeDefaults())
+        _ = store.claimDaily(now: base)
+        _ = store.claimHourly(now: base)
+
+        let nextDay = base.addingTimeInterval(24 * 60 * 60)
+        #expect(store.claimDaily(now: nextDay) == "2024-01-03")
+        #expect(store.claimHourly(now: nextDay) == "2024-01-03T03")
+    }
+
+    @Test func dedupSurvivesRelaunch() {
+        let defaults = makeDefaults()
+        let store = AnalyticsActivePeriodStore(defaults: defaults)
+        #expect(store.claimDaily(now: base) == "2024-01-02")
+        #expect(store.claimHourly(now: base) == "2024-01-02T03")
+
+        // A fresh store backed by the same defaults (a relaunch) sees the period
+        // as already claimed and does not re-emit.
+        let reread = AnalyticsActivePeriodStore(defaults: defaults)
+        #expect(reread.claimDaily(now: base) == nil)
+        #expect(reread.claimHourly(now: base) == nil)
+    }
+
+    @Test func formattersUseUTCRegardlessOfHostTimeZone() {
+        // The keys are UTC-stable, independent of the device's local zone.
+        #expect(AnalyticsActivePeriodStore.dayUTCString(base) == "2024-01-02")
+        #expect(AnalyticsActivePeriodStore.hourUTCString(base) == "2024-01-02T03")
+    }
+}

--- a/Packages/CmuxMobileAnalytics/Tests/CmuxMobileAnalyticsTests/AnalyticsEmitterTests.swift
+++ b/Packages/CmuxMobileAnalytics/Tests/CmuxMobileAnalyticsTests/AnalyticsEmitterTests.swift
@@ -58,7 +58,7 @@ private final class MutableConsent: AnalyticsConsentProviding, @unchecked Sendab
     @Test func consentDisabledDropsEverything() async {
         let uploader = RecordingAnalyticsUploader()
         let emitter = makeEmitter(uploader: uploader, consentEnabled: false)
-        emitter.capture("ios_terminal_input_submitted", ["byte_count": .int(12)])
+        emitter.capture("ios_terminal_input_dropped", ["byte_count": .int(12)])
         await emitter.flush()
         let events = await uploader.uploadedEvents
         #expect(events.isEmpty)
@@ -117,7 +117,7 @@ private final class MutableConsent: AnalyticsConsentProviding, @unchecked Sendab
         let uploader = RecordingAnalyticsUploader()
         let emitter = makeEmitter(uploader: uploader, anonymousID: "anon-9")
         emitter.identify(userId: "user-3", alias: nil, properties: [:])
-        emitter.capture("ios_terminal_input_submitted", ["byte_count": .int(4)])
+        emitter.capture("ios_terminal_input_dropped", ["byte_count": .int(4)])
         await emitter.flush()
         let event = await uploader.uploadedEvents.first
         #expect(event?.distinctID == "user-3")
@@ -144,7 +144,7 @@ private final class MutableConsent: AnalyticsConsentProviding, @unchecked Sendab
         let consent = MutableConsent(enabled: true)
         let uploader = RecordingAnalyticsUploader(result: .retry)
         let emitter = makeEmitter(uploader: uploader, consent: consent)
-        emitter.capture("ios_terminal_input_submitted", ["byte_count": .int(7)])
+        emitter.capture("ios_terminal_input_dropped", ["byte_count": .int(7)])
         await emitter.flush() // .retry leaves the event buffered
         let batchesBeforeWithdrawal = await uploader.uploadedBatches.count
         // Withdraw consent, then let uploads succeed: the next flush must clear the
@@ -169,7 +169,7 @@ private final class MutableConsent: AnalyticsConsentProviding, @unchecked Sendab
             maxPendingEvents: 4
         )
         for index in 0..<20 {
-            emitter.capture("ios_event", ["seq": .int(index)])
+            emitter.capture("ios_app_foregrounded", ["seq": .int(index)])
         }
         // Let the outage clear; the bounded backlog ships on the next flush. The
         // final accepted batch is the only one whose events were actually retired,

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1557,15 +1557,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         terminalInputText = ""
         guard remoteClient != nil else { return }
-        // North-star event. One per submit, never per keystroke. Sizes/counts
-        // only — never the text itself (the call below ships the text; analytics
-        // ships only its byte and line counts, mirroring the code's own
-        // `byteCount` privacy:.public logging posture).
-        analytics.capture("ios_terminal_input_submitted", [
-            "byte_count": .int(text.utf8.count),
-            "line_count": .int(text.split(separator: "\n", omittingEmptySubsequences: false).count),
-            "had_attachment": .bool(false),
-        ])
         await sendRemoteTerminalInput(text + "\r")
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -835,6 +835,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     weak var sidebarState: SidebarState?
     /// The auth graph, injected once via `configure(...)` at app startup.
     private(set) var auth: MacAuthComposition?
+    /// The PostHog identity already applied by the identity observer, so
+    /// re-arming on unrelated coordinator changes does not re-apply the same
+    /// identity. `nil` means "nothing applied yet this process", which forces
+    /// the first settled auth state to apply (including a startup `reset()` that
+    /// clears any user distinct id the SDK persisted from a prior launch).
+    private var appliedAnalyticsIdentity: AnalyticsIdentity?
+
+    /// The resolved PostHog identity for the current settled auth state.
+    /// `internal` so ``resolveAnalyticsIdentity(isAuthenticated:isRestoringSession:stackUserID:)``
+    /// is unit-testable.
+    enum AnalyticsIdentity: Equatable {
+        /// Identified as a signed-in Stack user.
+        case identified(String)
+        /// Anonymous (signed out), distinct id reset to a fresh anonymous id.
+        case anonymous
+    }
     /// Strongly-held observers for every active TabManager. Each observer owns
     /// Combine subscriptions that publish workspace.updated to mobile clients.
     private var mobileWorkspaceListObservers: [ObjectIdentifier: MobileWorkspaceListObserver] = [:]
@@ -1929,6 +1945,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             browserSignIn: auth.browserSignIn
         )
         auth.start()
+        startAnalyticsIdentityObserver(coordinator: auth.coordinator)
         ensureMobileWorkspaceListObserver(for: tabManager)
         MobileTerminalRenderObserver.shared.start()
         installMobileHostSettingsObserver()
@@ -1952,6 +1969,96 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             scheduleUITestSocketSanityCheckIfNeeded()
         }
 #endif
+    }
+
+    /// Keeps PostHog's distinct id in lockstep with the signed-in Stack user so
+    /// the desktop app correlates with iOS, which routes analytics through the
+    /// web proxy that stamps the same Stack `user.id` as the distinct id.
+    ///
+    /// Observes the `@Observable` ``AuthCoordinator`` rather than hooking a
+    /// single sign-in callback: observation is the one seam that covers fresh
+    /// sign-in, launch session restore, the preserve-cached-session path, and
+    /// every sign-out/clear uniformly. Identity is resolved only from *settled*
+    /// auth state:
+    ///
+    /// - Authenticated with a non-empty Stack user id → `identify(id)` (PostHog
+    ///   back-merges the pre-login anonymous events into that user).
+    /// - Settled signed-out (`isAuthenticated == false`, not restoring) →
+    ///   `reset()` back to a fresh anonymous distinct id.
+    /// - Mid-restore (`isRestoringSession == true`) → leave the applied identity
+    ///   unchanged until the session validates, so a cached-but-unvalidated
+    ///   `currentUser` is never identified.
+    ///
+    /// The applied identity is tracked explicitly (starting `nil`), so the first
+    /// settled state is always applied even when it is "signed out": the SDK
+    /// persists its distinct id across launches, so a signed-out launch after a
+    /// prior identified session must actively `reset()` rather than assume it is
+    /// already anonymous. Re-arming on unrelated coordinator changes is a no-op
+    /// when the resolved identity is unchanged.
+    private func startAnalyticsIdentityObserver(coordinator: AuthCoordinator) {
+        let resolved = Self.resolveAnalyticsIdentity(
+            isAuthenticated: coordinator.isAuthenticated,
+            isRestoringSession: coordinator.isRestoringSession,
+            stackUserID: coordinator.currentUser?.id
+        )
+        if let resolved, resolved != appliedAnalyticsIdentity {
+            appliedAnalyticsIdentity = resolved
+            switch resolved {
+            case let .identified(stackUserID):
+                PostHogAnalytics.shared.identify(stackUserID: stackUserID)
+            case .anonymous:
+                // `reset()` is a no-op when PostHog already holds an anonymous
+                // distinct id (it checks the SDK's own persisted identity), so a
+                // never-identified / perpetually-signed-out user keeps a stable
+                // anonymous id and signed-out retention is not fragmented.
+                PostHogAnalytics.shared.reset()
+            }
+        }
+        withObservationTracking {
+            _ = coordinator.isAuthenticated
+            _ = coordinator.isRestoringSession
+            _ = coordinator.currentUser?.id
+        } onChange: { [weak self, weak coordinator] in
+            Task { @MainActor in
+                guard let self, let coordinator else { return }
+                self.startAnalyticsIdentityObserver(coordinator: coordinator)
+            }
+        }
+    }
+
+    /// Resolves the PostHog identity from settled auth state, or `nil` while a
+    /// session is still restoring (apply nothing until it settles). Pure (and
+    /// `nonisolated`, since `AppDelegate` is `@MainActor`) so it is unit-testable
+    /// from any context without the coordinator or the PostHog SDK.
+    nonisolated static func resolveAnalyticsIdentity(
+        isAuthenticated: Bool,
+        isRestoringSession: Bool,
+        stackUserID: String?
+    ) -> AnalyticsIdentity? {
+        if isAuthenticated,
+           let stackUserID,
+           !stackUserID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .identified(stackUserID)
+        }
+        // A cached user can be exposed while the session is still validating; do
+        // not change identity until restore settles.
+        //
+        // Known limitation (accepted): on a relaunch with cached tokens that
+        // later fail validation, the SDK still holds the prior session's
+        // identified distinct id during this restore window, so a `trackActive`
+        // daily/hourly ping that fires before `revalidateSession` settles can be
+        // attributed to the previous user for that one period. This carries no
+        // PII (the active events are just `day_utc`/`hour_utc`/version), is
+        // bounded to a single period (the next activation or the 30-min active
+        // timer re-counts correctly once the session settles to anonymous), and
+        // only occurs for stale-but-present cached tokens; a genuinely
+        // signed-out launch has no tokens, so `resolveAnalyticsIdentity` returns
+        // `.anonymous` synchronously at `configure()` and resets before the
+        // first active event. Gating active capture on `isRestoringSession`
+        // would instead risk undercounting DAU (the metric this exists to
+        // produce), so the rare one-period overcount is preferred.
+        if isRestoringSession { return nil }
+        return .anonymous
     }
 
     private func scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: TerminalNotificationStore) {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -80,6 +80,65 @@ final class PostHogAnalytics {
         }
     }
 
+    /// Associates subsequent events with the signed-in Stack user id so the
+    /// desktop app keys on the same distinct id as the iOS proxy (which stamps
+    /// the authenticated Stack `user.id`). PostHog back-merges the pre-login
+    /// anonymous events into the identified user, so the desktop install's
+    /// pre-sign-in funnel attaches to the same person across iOS and macOS.
+    ///
+    /// - Parameter stackUserID: The signed-in Stack user id. Empty values are
+    ///   ignored so a partially-resolved identity can't identify as "".
+    func identify(stackUserID: String) {
+        let trimmed = stackUserID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self else { return }
+            self.startIfNeededOnWorkQueue()
+            guard self.didStart else { return }
+            // Identify must run after `setup()` or the SDK drops it; the
+            // `startIfNeededOnWorkQueue()` guard above mirrors the active-event path.
+            PostHogSDK.shared.identify(trimmed)
+        }
+    }
+
+    /// Resets analytics identity back to a fresh anonymous distinct id when
+    /// PostHog currently holds an *identified* (signed-in) distinct id, so a
+    /// subsequent different sign-in does not merge into the prior user. Mirrors
+    /// the iOS `identify(userId: nil)` reset.
+    ///
+    /// The SDK's own persisted distinct id is the single source of truth (no
+    /// parallel flag): the reset fires only when the current distinct id differs
+    /// from the anonymous id (`reset()` regenerates the anonymous id, so calling
+    /// it on an already-anonymous user would fragment a perpetually-signed-out
+    /// user's retention into a new id per launch). Starts the SDK first (like
+    /// ``identify(stackUserID:)``) so the persisted distinct id from a prior
+    /// identified session is reset *before* the first active/retention event
+    /// starts it with the stale id. When telemetry is disabled
+    /// `startIfNeededOnWorkQueue()` leaves `didStart` false, so this is a no-op
+    /// (and no analytics are emitted at all); the SDK's persisted identity is
+    /// untouched, so a later launch with telemetry on still resets it on the
+    /// same signed-out edge.
+    func reset() {
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self else { return }
+            self.startIfNeededOnWorkQueue()
+            guard self.didStart else { return }
+            guard Self.shouldResetIdentity(
+                distinctID: PostHogSDK.shared.getDistinctId(),
+                anonymousID: PostHogSDK.shared.getAnonymousId()
+            ) else { return }
+            PostHogSDK.shared.reset()
+        }
+    }
+
+    /// Whether a `reset()` is needed: true only when PostHog currently holds an
+    /// identified distinct id (one that differs from the anonymous id). Pure and
+    /// `nonisolated` so the signed-out / perpetually-anonymous / re-login
+    /// invariants are unit-testable without the SDK.
+    nonisolated static func shouldResetIdentity(distinctID: String, anonymousID: String) -> Bool {
+        !distinctID.isEmpty && distinctID != anonymousID
+    }
+
     private func startIfNeededOnWorkQueue() {
         guard !didStart else { return }
         guard isEnabled else { return }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		A9E050000000000000000002 /* AgentSessionWebRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */; };
 		A9E02000000000000000000D /* AgentSessionWebTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000D /* AgentSessionWebTheme.swift */; };
 		A9F200000000000000000014 /* AgentSessionWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000014 /* AgentSessionWebView.swift */; };
+		ANA1D000000000000000A000 /* AnalyticsIdentityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ANA1D000000000000000A001 /* AnalyticsIdentityResolverTests.swift */; };
 		F4350A110000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		F4350A120000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */; };
@@ -815,6 +816,7 @@
 		A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionWebRendererTests.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000D /* AgentSessionWebTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionWebTheme.swift; sourceTree = "<group>"; };
 		A9F100000000000000000014 /* AgentSessionWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionWebView.swift; sourceTree = "<group>"; };
+		ANA1D000000000000000A001 /* AnalyticsIdentityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsIdentityResolverTests.swift; sourceTree = "<group>"; };
 		F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AppBundleIconPersistencePolicy.swift; sourceTree = "<group>"; };
 		C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ClosedItemHistory.swift"; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
@@ -2184,6 +2186,7 @@
 				C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */,
 				D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */,
 				17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */,
+				ANA1D000000000000000A001 /* AnalyticsIdentityResolverTests.swift */,
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
 				C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
@@ -3152,6 +3155,7 @@
 				D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,
 				A9E030000000000000000002 /* AgentSessionSocketSurfaceTests.swift in Sources */,
 				A9E050000000000000000002 /* AgentSessionWebRendererTests.swift in Sources */,
+				ANA1D000000000000000A000 /* AnalyticsIdentityResolverTests.swift in Sources */,
 				725746692D9647948561044D /* AppDelegateBareSpaceShortcutRoutingTests.swift in Sources */,
 				E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */,
 				2907A0032907A0032907A003 /* AppDelegateIssue2907RoutingTests.swift in Sources */,

--- a/cmuxTests/AnalyticsIdentityResolverTests.swift
+++ b/cmuxTests/AnalyticsIdentityResolverTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+/// Behavioral coverage for ``AppDelegate/resolveAnalyticsIdentity`` — the pure
+/// decision that keeps PostHog's distinct id in lockstep with the signed-in
+/// Stack user so the desktop app correlates with iOS (which keys on the same
+/// Stack user id via the analytics proxy).
+@Suite struct AnalyticsIdentityResolverTests {
+    @Test func authenticatedUserResolvesToIdentified() {
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: true,
+                isRestoringSession: false,
+                stackUserID: "user-123"
+            ) == .identified("user-123")
+        )
+    }
+
+    @Test func settledSignedOutResolvesToAnonymousReset() {
+        // A signed-out launch after a prior identified session must actively
+        // reset: the SDK persists its distinct id across launches, so leaving it
+        // alone would attribute anonymous events to the previous Stack user.
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: false,
+                isRestoringSession: false,
+                stackUserID: nil
+            ) == .anonymous
+        )
+    }
+
+    @Test func restoringSessionDefersUntilSettled() {
+        // A cached `currentUser` can be exposed while the session is still
+        // validating (isAuthenticated == false, isRestoringSession == true).
+        // Identity must not change until restore settles, so a cached-but-
+        // unvalidated user is never identified.
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: false,
+                isRestoringSession: true,
+                stackUserID: "cached-user-7"
+            ) == nil
+        )
+    }
+
+    @Test func authenticatedWithEmptyOrBlankIDResolvesToAnonymous() {
+        // A partially-resolved identity (empty/blank id) must not identify as "".
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: true,
+                isRestoringSession: false,
+                stackUserID: ""
+            ) == .anonymous
+        )
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: true,
+                isRestoringSession: false,
+                stackUserID: "   "
+            ) == .anonymous
+        )
+    }
+
+    @Test func preserveCachedSessionWithUserStillIdentifies() {
+        // The preserve-cached-session path sets isAuthenticated == true with a
+        // user but isRestoringSession == false; that is a usable signed-in state.
+        #expect(
+            AppDelegate.resolveAnalyticsIdentity(
+                isAuthenticated: true,
+                isRestoringSession: false,
+                stackUserID: "user-9"
+            ) == .identified("user-9")
+        )
+    }
+}
+
+/// Coverage for ``PostHogAnalytics/shouldResetIdentity(distinctID:anonymousID:)``,
+/// the pure gate that keeps signed-out PostHog `reset()` from fragmenting a
+/// perpetually-anonymous user's retention while still clearing a prior user's
+/// persisted identified distinct id exactly once.
+@Suite struct PostHogResetGateTests {
+    @Test func resetsWhenIdentifiedDistinctIDDiffersFromAnonymous() {
+        // Identified→signed-out (including after a relaunch, since the SDK
+        // persists the identified id): the distinct id is the Stack user id, so
+        // a reset is needed to return to anonymous.
+        #expect(PostHogAnalytics.shouldResetIdentity(distinctID: "stack-user-1", anonymousID: "anon-abc"))
+    }
+
+    @Test func doesNotResetWhenAlreadyAnonymous() {
+        // Perpetually-signed-out: distinct id already equals the anonymous id, so
+        // resetting would needlessly mint a fresh anonymous id and split the
+        // user's signed-out retention across launches.
+        #expect(!PostHogAnalytics.shouldResetIdentity(distinctID: "anon-abc", anonymousID: "anon-abc"))
+    }
+
+    @Test func doesNotResetWhenDistinctIDUnknown() {
+        // The SDK returns "" before it is enabled/set up; never reset on that.
+        #expect(!PostHogAnalytics.shouldResetIdentity(distinctID: "", anonymousID: ""))
+        #expect(!PostHogAnalytics.shouldResetIdentity(distinctID: "", anonymousID: "anon-abc"))
+    }
+}

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -98,6 +98,7 @@ final class AppCompositionRoot {
                 foregroundProps["seconds_since_backgrounded"] = .int(Int(gap))
             }
             emitter.capture("ios_app_foregrounded", foregroundProps)
+            emitActiveRetentionPings(emitter: emitter, now: now)
             hasForegrounded = true
         case .background:
             let now = Date()
@@ -119,6 +120,35 @@ final class AppCompositionRoot {
             break
         @unknown default:
             break
+        }
+    }
+
+    /// Emits the iOS daily + hourly active retention pings, deduped once per UTC
+    /// day/hour by ``CmuxMobileAnalytics/AnalyticsActivePeriodStore``.
+    ///
+    /// Mirrors the macOS `cmux_daily_active` / `cmux_hourly_active` events so iOS
+    /// DAU + hourly retention line up symmetrically with desktop (the shared
+    /// Stack-user-id distinct id makes them the same person across platforms).
+    /// Unlike macOS there is no long-running midnight-rollover timer: iOS
+    /// suspends in the background, so the `.active` foreground transition is the
+    /// only reliable trigger, and a user who stays foregrounded across a period
+    /// boundary is re-counted on their next foreground.
+    private func emitActiveRetentionPings(emitter: any AnalyticsEmitting, now: Date) {
+        // Don't consume the period when telemetry is off: the emitter drops the
+        // capture, so claiming the day/hour anyway would suppress the ping for
+        // the rest of the period if the user re-enables telemetry within it.
+        guard analytics.consent.isTelemetryEnabled else { return }
+        if let dayUTC = analytics.activePeriodStore.claimDaily(now: now) {
+            emitter.capture("ios_daily_active", [
+                "day_utc": .string(dayUTC),
+                "reason": .string("foreground"),
+            ])
+        }
+        if let hourUTC = analytics.activePeriodStore.claimHourly(now: now) {
+            emitter.capture("ios_hourly_active", [
+                "hour_utc": .string(hourUTC),
+                "reason": .string("foreground"),
+            ])
         }
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAnalyticsComposition.swift
@@ -31,6 +31,14 @@ public struct MobileAnalyticsComposition {
     public let sessionStore: AnalyticsSessionStore
     /// The 30-minute-window sessionizer used with ``sessionStore``.
     public let sessionizer = AnalyticsSessionizer()
+    /// Once-per-period dedup for the daily + hourly active retention pings,
+    /// mirroring macOS `cmux_daily_active` / `cmux_hourly_active`.
+    public let activePeriodStore: AnalyticsActivePeriodStore
+    /// The telemetry opt-out gate, so the active-period claim is only consumed
+    /// when an event would actually be enqueued (the emitter drops captures when
+    /// telemetry is off; claiming the period anyway would suppress the ping for
+    /// the rest of the period if telemetry is re-enabled within it).
+    public let consent: any AnalyticsConsentProviding
 
     /// Builds the analytics graph.
     ///
@@ -56,6 +64,7 @@ public struct MobileAnalyticsComposition {
             session: session ?? Self.analyticsSession()
         )
         let consent = UserDefaultsAnalyticsConsentProvider(defaults: defaults)
+        self.consent = consent
         // Resolve the per-install id once, here, at the single point that owns
         // analytics. This composition is built before the app shell, so reading
         // the id is also what *mints* it on a fresh install — which is exactly why
@@ -74,6 +83,7 @@ public struct MobileAnalyticsComposition {
         }
         self.emitter = emitter
         self.sessionStore = AnalyticsSessionStore(defaults: defaults)
+        self.activePeriodStore = AnalyticsActivePeriodStore(defaults: defaults)
     }
 
     /// A short-timeout `URLSession` for analytics uploads.

--- a/web/services/analytics/iosEventPolicy.ts
+++ b/web/services/analytics/iosEventPolicy.ts
@@ -30,6 +30,9 @@ const ALLOWED_EVENTS: ReadonlySet<string> = new Set([
   "ios_app_backgrounded",
   "ios_session_started",
   "ios_session_ended",
+  // Retention (once-per-period active pings; mirror macOS cmux_daily/hourly_active)
+  "ios_daily_active",
+  "ios_hourly_active",
   // Sign-in
   "ios_sign_in_started",
   "ios_sign_in_completed",
@@ -47,7 +50,6 @@ const ALLOWED_EVENTS: ReadonlySet<string> = new Set([
   // Workspace + terminal
   "ios_workspace_opened",
   "ios_first_frame_latency",
-  "ios_terminal_input_submitted",
   "ios_terminal_input_dropped",
   // Push
   "ios_push_optin_prompt_shown",

--- a/web/tests/ios-analytics-policy.test.ts
+++ b/web/tests/ios-analytics-policy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { isAllowedAnalyticsEvent } from "../services/analytics/iosEventPolicy";
+
+describe("iOS analytics event allowlist", () => {
+  test("rejects the removed high-volume / vague events", () => {
+    // `ios_terminal_input_submitted` fired on every submit (highest-volume,
+    // pure product-analytics noise) and `ios_event` was a placeholder name with
+    // no meaning. Neither should be forwarded to PostHog anymore.
+    expect(isAllowedAnalyticsEvent("ios_terminal_input_submitted")).toBe(false);
+    expect(isAllowedAnalyticsEvent("ios_event")).toBe(false);
+  });
+
+  test("allows the new iOS retention pings", () => {
+    // Mirror macOS `cmux_daily_active` / `cmux_hourly_active` so iOS DAU +
+    // hourly retention line up symmetrically.
+    expect(isAllowedAnalyticsEvent("ios_daily_active")).toBe(true);
+    expect(isAllowedAnalyticsEvent("ios_hourly_active")).toBe(true);
+  });
+
+  test("keeps the rare dropped-input signal and other real events", () => {
+    expect(isAllowedAnalyticsEvent("ios_terminal_input_dropped")).toBe(true);
+    expect(isAllowedAnalyticsEvent("ios_app_foregrounded")).toBe(true);
+    expect(isAllowedAnalyticsEvent("ios_sign_in_completed")).toBe(true);
+    expect(isAllowedAnalyticsEvent("$identify")).toBe(true);
+  });
+
+  test("rejects non-string and unknown event names", () => {
+    expect(isAllowedAnalyticsEvent("totally_made_up_event")).toBe(false);
+    expect(isAllowedAnalyticsEvent(undefined)).toBe(false);
+    expect(isAllowedAnalyticsEvent(123)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes PostHog so we can run DAU + retention for the iOS app and correlate the same user across iOS and macOS.

## Cross-platform identity (the unlock)

iOS analytics route through the web proxy (`web/app/api/analytics/events/route.ts`), which stamps the authenticated Stack `user.id` as the distinct id. macOS used a separate embedded PostHog SDK that posted with the SDK's auto-generated anonymous id and never called `identify()`, so the same person on iOS and macOS were two unrelated PostHog users.

macOS now calls PostHog `identify(<stackUserId>)` when authenticated and `reset()` when settled signed-out (`Sources/PostHogAnalytics.swift`, wired from `Sources/AppDelegate.swift`). It keys on the same Stack user id the iOS proxy stamps (`CMUXAuthUser.id` is `await user.id` from Stack's `CurrentUser`, the same value `verifyRequest(...).user.id` yields), so iOS and macOS now share the Stack user id and cross-platform correlation works. PostHog back-merges the pre-login anonymous events into the identified user.

Identity is driven by observing the `@Observable` `AuthCoordinator` (`isAuthenticated` / `isRestoringSession` / `currentUser`) rather than a single sign-in callback, so it covers fresh sign-in, launch session restore, preserve-cached-session, and every clear uniformly. It resolves only from settled auth state (a cached but unvalidated user during restore is never identified) and tracks the applied identity explicitly: because the SDK persists its distinct id across launches, a signed-out launch after a prior identified session actively `reset()`s instead of attributing anonymous events to the previous user (`reset()` starts the SDK first so the reset lands even before the first active event). iOS already identifies by the Stack user id via the proxy, so no iOS identity change was needed.

## Removed noisy events

`ios_terminal_input_submitted` fired on every submit (highest-volume event, pure product-analytics noise). Removed its fire-site (`Packages/CmuxMobileShell/.../MobileShellComposite.swift`) and its proxy allowlist entry. `ios_event` turned out to be only a doc-comment and emitter-mechanics-test placeholder name, never a real emitted event and never in the allowlist; those sample names were updated off the placeholder. Kept `ios_terminal_input_dropped` (rare, signals a real bug).

## iOS retention

Added `ios_daily_active` + `ios_hourly_active`, emitted on foreground with once-per-UTC-period dedup (`AnalyticsActivePeriodStore`), mirroring macOS `cmux_daily_active` / `cmux_hourly_active` so iOS DAU + hourly retention line up symmetrically. Chose plain `ios_*` names (not the shared `cmux_*`) so per-platform DAU stays clean; cross-platform retention already comes free from the shared Stack-user-id distinct id. No midnight-rollover timer since iOS suspends in the background, so the foreground transition is the only reliable trigger. Added both names to the proxy allowlist.

## Verification

- iOS simulator build (arm64) and macOS app build: both green (build-only, not installed).
- web `bun tsc --noEmit`: clean. New `web/tests/ios-analytics-policy.test.ts` locks the allowlist change (4 tests pass).
- `swift test` for `CmuxMobileAnalytics` (incl. 6 new `AnalyticsActivePeriodStore` tests) and `CMUXMobileCore`: green.
- New `cmuxTests/AnalyticsIdentityResolverTests.swift` covers the macOS identity resolver (wired into `project.pbxproj`); validated in CI.
- autoreview clean after fixing two real P1s it caught (persisted-identity reset ordering).
- No new user-facing strings (analytics event names/properties are not localizable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783507719&installation_id=133855650&pr_number=5649&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5649&signature=bbd1c1c0603a1e884de0edcca4acf7ebe6b9b0e57bbf35f851803815f57eefe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-linked PostHog identify/reset on macOS and retention dedup/consent on iOS; mis-timed identity during session restore could mis-attribute one period of active pings (documented edge case).
> 
> **Overview**
> Aligns **PostHog identity on macOS** with iOS by observing settled `AuthCoordinator` state: **`identify(stackUserID)`** when signed in, **`reset()`** when signed out (with guards so restore-in-progress and already-anonymous users aren’t mishandled), plus unit tests for the resolver and reset gate.
> 
> On **iOS**, adds **`ios_daily_active`** / **`ios_hourly_active`** on foreground via new **`AnalyticsActivePeriodStore`** (UTC day/hour dedup in `UserDefaults`, consent-gated so opt-out doesn’t burn a period). The web proxy **allowlist** gains those events and drops **`ios_terminal_input_submitted`**; the per-submit fire-site in the mobile shell is **removed** (docs/tests shift to **`ios_terminal_input_dropped`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054f28c89f6c1647b61ecc080a39a9b47056f770. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns PostHog identity across iOS and macOS and adds iOS DAU/hourly retention pings so we can measure usage and correlate the same Stack user across platforms. Also removes a noisy iOS event to keep analytics clean.

- **New Features**
  - macOS identifies with the Stack user id and resets to anonymous on settled sign-out by observing `AuthCoordinator`; identity only updates when it changes (verified by `resolveAnalyticsIdentity` and `shouldResetIdentity` tests).
  - iOS emits `ios_daily_active` and `ios_hourly_active` on foreground, deduped per UTC day/hour via `CmuxMobileAnalytics`’s `AnalyticsActivePeriodStore` and gated by telemetry consent. Both are added to the proxy allowlist.

- **Refactors**
  - Removed `ios_terminal_input_submitted` and the placeholder `ios_event`; kept `ios_terminal_input_dropped`. Updated the proxy allowlist and tests.

<sup>Written for commit 054f28c89f6c1647b61ecc080a39a9b47056f770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily and hourly active-retention pings with once-per-period deduplication
  * Analytics identity sync (identify/reset) to align telemetry with auth state

* **Bug Fixes**
  * Terminal input event switched to a dropped-input signal for more accurate tracking
  * iOS analytics allowlist updated to include retention pings and the dropped-input event

* **Tests**
  * Added coverage for activity deduplication, identity resolution, event allowlist, and emitter behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->