### PR TITLE
Fix status pills not rendering on workspaces created after launch

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15829,6 +15829,17 @@ struct TabItemView: View, Equatable {
         .onAppear {
             refreshWorkspaceSnapshot(force: true)
         }
+        // Re-read current state after the modifier chain is fully established.
+        // .onAppear fires synchronously during view insertion, before .onReceive
+        // subscriptions are live. Sidebar data (status pills, metadata, etc.) set
+        // by socket commands between .onAppear and subscription can be missed by
+        // the change-only observation publishers. This one-shot async refresh runs
+        // on the next main-actor tick — after .onReceive is subscribed — so it
+        // picks up any state that .onAppear saw as empty but that was mutated in
+        // the gap. The snapshot comparison no-ops when nothing changed.
+        .task {
+            refreshWorkspaceSnapshot()
+        }
         .task(id: finderDirectoryCacheKey) {
             let cache = await WorkspaceFinderDirectoryResolver.cache(for: finderDirectoryCacheKey)
             guard !Task.isCancelled else { return }


### PR DESCRIPTION
Status pills set on a workspace created after app launch are stored in the `Tab` model but never render in the sidebar — while pre-existing workspaces render immediately. `list-status` confirms the data; the UI shows nothing.

### Why

`.onAppear` fires synchronously during view insertion, before `.onReceive` subscriptions are live. Sidebar data set by socket commands (e.g. agent hook `set_status`) between `.onAppear` and subscription goes unobserved: the observation publishers use `.dropFirst()` to skip the current-value replay, making them change-only — so a mutation that lands before the subscriber connects isn't replayed, and the `.onAppear` snapshot captured the pre-mutation (empty) state. Pre-existing workspaces work because their `.onReceive` subscriptions were established before any status was set.

### What didn't work: removing `.dropFirst()` globally

The initial approach removed `.dropFirst()` from `sidebarObservationSignal` and the `$panels` chain, turning the publishers from change-only into replay-on-subscribe. This fixed the immediate bug but introduced three problems caught by adversarial review (GPT-5.5 + GPT-5.4, independently):

1. **Extension sidebar refresh loop** — `extensionSidebarDebouncedObservationPublisher` is a computed function that creates a new `MergeMany` per body evaluation. Subscription-time replay → handler increments `@State` token → body re-eval → new subscription → replay → self-sustaining churn.
2. **Immediate publisher fires ~7 un-debounced replays per row** on the typing-latency-sensitive path, each calling `makeWorkspaceSnapshot()`.
3. **Test breakage** — existing tests assume change-only semantics (`publishCount == 0` after subscribe + heartbeat mutation).

### What works: targeted deferred refresh

Add a one-shot `.task` to `TabItemView` that calls `refreshWorkspaceSnapshot()` — running asynchronously on the next main-actor tick after the view's modifier chain (including `.onReceive` subscriptions) is fully established. It re-reads tab state at that point, catching any mutations that landed in the `.onAppear`-to-subscription gap. `SidebarWorkspaceSnapshotRefreshPolicy.decision` no-ops when nothing has changed, so the cost for pre-existing workspaces is one cheap snapshot comparison per row appearance.

The observation publishers keep their `.dropFirst()` and change-only contract. No other consumers are affected.

### Validation

Couldn't build locally (SPM resolution failures in the worktree) — CI will validate. The change is +11 lines in one file (a `.task` modifier on `TabItemView`).

Closes #5659

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
