### PR TITLE
Preserve user Claude settings on resume

### DIFF
--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -7,6 +7,15 @@ public enum AgentLaunchSanitizer {
     private static let runtimeOnlyOptionWidths: [String: Int] = [
         "--use-system-ca": 1,
     ]
+    private static let claudeCmuxSettingsKeys: Set<String> = [
+        "hooks",
+        "preferredNotifChannel",
+    ]
+
+    private enum ClaudeHookSettingsReplacement {
+        case drop
+        case settings(String)
+    }
 
     struct Policy {
         var valueOptions: Set<String>
@@ -327,7 +336,9 @@ public enum AgentLaunchSanitizer {
                 continue
             }
 
-            if policy.skipClaudeHookSettings, isClaudeHookSettingsOption(args, index: index) {
+            if policy.skipClaudeHookSettings,
+               let replacement = claudeHookSettingsReplacement(args, index: index) {
+                result.append(contentsOf: replacement)
                 index += width
                 continue
             }
@@ -464,15 +475,87 @@ public enum AgentLaunchSanitizer {
         return following == nil || value.contains(",") || (following?.hasPrefix("-") == true)
     }
 
-    private static func isClaudeHookSettingsOption(_ args: [String], index: Int) -> Bool {
+    private static func claudeHookSettingsReplacement(_ args: [String], index: Int) -> [String]? {
         let arg = args[index]
         if arg.hasPrefix("--settings=") {
-            return arg.contains("claude-hook") || arg.contains("hooks claude")
+            let value = String(arg.dropFirst("--settings=".count))
+            switch claudeHookSettingsReplacementValue(value) {
+            case .none:
+                return nil
+            case .some(.drop):
+                return []
+            case .some(.settings(let userSettings)):
+                return ["--settings=\(userSettings)"]
+            }
         }
         guard arg == "--settings", index + 1 < args.count else {
+            return nil
+        }
+        let value = args[index + 1]
+        switch claudeHookSettingsReplacementValue(value) {
+        case .none:
+            return nil
+        case .some(.drop):
+            return []
+        case .some(.settings(let userSettings)):
+            return ["--settings", userSettings]
+        }
+    }
+
+    private static func claudeHookSettingsReplacementValue(_ value: String) -> ClaudeHookSettingsReplacement? {
+        if let object = claudeSettingsObject(from: value) {
+            guard isClaudeHookSettingsObject(object) else { return nil }
+            guard let userSettings = userClaudeSettingsJSON(fromMergedHookSettingsObject: object) else {
+                return .drop
+            }
+            return .settings(userSettings)
+        }
+        return isLegacyClaudeHookSettingsValue(value) ? .drop : nil
+    }
+
+    private static func isLegacyClaudeHookSettingsValue(_ value: String) -> Bool {
+        value.contains("claude-hook") || value.contains("hooks claude")
+    }
+
+    private static func claudeSettingsObject(from value: String) -> [String: Any]? {
+        guard let data = value.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
+    }
+
+    private static func isClaudeHookSettingsObject(_ object: [String: Any]) -> Bool {
+        if object["preferredNotifChannel"] as? String == "notifications_disabled" {
+            return true
+        }
+        return containsLegacyClaudeHookSettingsValue(object["hooks"])
+    }
+
+    private static func containsLegacyClaudeHookSettingsValue(_ value: Any?) -> Bool {
+        switch value {
+        case let string as String:
+            return isLegacyClaudeHookSettingsValue(string)
+        case let array as [Any]:
+            return array.contains { containsLegacyClaudeHookSettingsValue($0) }
+        case let dictionary as [String: Any]:
+            return dictionary.values.contains { containsLegacyClaudeHookSettingsValue($0) }
+        default:
             return false
         }
-        return args[index + 1].contains("claude-hook") || args[index + 1].contains("hooks claude")
+    }
+
+    private static func userClaudeSettingsJSON(fromMergedHookSettingsObject object: [String: Any]) -> String? {
+        var object = object
+        for key in claudeCmuxSettingsKeys {
+            object.removeValue(forKey: key)
+        }
+        guard !object.isEmpty,
+              JSONSerialization.isValidJSONObject(object),
+              let userData = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: userData, encoding: .utf8)
     }
 
     private static func isOpenCodeInternalWorkerArgument(_ value: String) -> Bool {

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
@@ -78,7 +78,43 @@ struct ClaudeResumeHookSettingsTests {
 
         let settingsIndex = try #require(argv.firstIndex(of: "--settings"))
         try #require(settingsIndex + 1 < argv.count)
-        let settingsData = try #require(argv[settingsIndex + 1].data(using: .utf8))
+        try assertUserSettingsJSON(argv[settingsIndex + 1])
+    }
+
+    @Test("Merged inline hook --settings keeps user keys when resuming")
+    func mergedInlineHookSettingsKeepsUserKeysOnResume() throws {
+        let mergedSettings = #"{"effortLevel":"max","preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"cmux hooks claude session-start","timeout":10}]}]}}"#
+
+        let argv = try #require(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "s",
+                executablePath: "/opt/homebrew/bin/claude",
+                arguments: ["/opt/homebrew/bin/claude", "--settings=\(mergedSettings)"]
+            )
+        )
+
+        let prefix = "--settings="
+        let settingsArgument = try #require(argv.first { $0.hasPrefix(prefix) })
+        try assertUserSettingsJSON(String(settingsArgument.dropFirst(prefix.count)))
+    }
+
+    @Test("User JSON that only mentions hook text is preserved")
+    func userJSONMentioningHookTextPreserved() {
+        let userSettings = #"{"effortLevel":"max","note":"docs mention hooks claude"}"#
+
+        let argv = AgentResumeArgv().builtInKind(
+            kind: "claude",
+            sessionId: "s",
+            executablePath: "/opt/homebrew/bin/claude",
+            arguments: ["/opt/homebrew/bin/claude", "--settings", userSettings]
+        )
+
+        #expect(argv == ["claude", "--resume", "s", "--settings", userSettings])
+    }
+
+    private func assertUserSettingsJSON(_ settingsJSON: String) throws {
+        let settingsData = try #require(settingsJSON.data(using: .utf8))
         let settingsObject = try #require(JSONSerialization.jsonObject(with: settingsData) as? [String: Any])
 
         #expect(settingsObject["effortLevel"] as? String == "max")

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeResumeHookSettingsTests.swift
@@ -1,4 +1,5 @@
 import CMUXAgentLaunch
+import Foundation
 import Testing
 
 /// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5427.
@@ -60,5 +61,28 @@ struct ClaudeResumeHookSettingsTests {
             arguments: ["/opt/homebrew/bin/claude", "--settings", "/home/me/settings.json"]
         )
         #expect(argv == ["claude", "--resume", "s", "--settings", "/home/me/settings.json"])
+    }
+
+    @Test("Merged hook --settings keeps user keys when resuming")
+    func mergedHookSettingsKeepsUserKeysOnResume() throws {
+        let mergedSettings = #"{"effortLevel":"max","preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"cmux hooks claude session-start","timeout":10}]}]}}"#
+
+        let argv = try #require(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "s",
+                executablePath: "/opt/homebrew/bin/claude",
+                arguments: ["/opt/homebrew/bin/claude", "--settings", mergedSettings]
+            )
+        )
+
+        let settingsIndex = try #require(argv.firstIndex(of: "--settings"))
+        try #require(settingsIndex + 1 < argv.count)
+        let settingsData = try #require(argv[settingsIndex + 1].data(using: .utf8))
+        let settingsObject = try #require(JSONSerialization.jsonObject(with: settingsData) as? [String: Any])
+
+        #expect(settingsObject["effortLevel"] as? String == "max")
+        #expect(!settingsObject.keys.contains("hooks"))
+        #expect(!settingsObject.keys.contains("preferredNotifChannel"))
     }
 }


### PR DESCRIPTION
Closes #5558.

## Summary
- Reproduced #5558 on current `origin/main` with a resume-path Swift Testing regression: a merged Claude hook `--settings` payload dropped the user `effortLevel` key on native resume.
- Updated `AgentLaunchSanitizer` so Claude resume parsing strips only cmux-owned settings keys (`hooks`, `preferredNotifChannel`) from hook-looking JSON payloads and preserves remaining user keys.
- Kept #5427 behavior intact: hook-only/stale hook settings are still removed so the wrapper re-injects current cmux hooks on resume. This also preserves the #5388/#2816 fresh-launch contract that user settings can be folded into the wrapper payload.

## Verification
Before fix, with commit `00792f2f8` (test only):

```text
swift test --package-path Packages/CMUXAgentLaunch
✘ Test "Merged hook --settings keeps user keys when resuming" recorded an issue at ClaudeResumeHookSettingsTests.swift:79:33: Expectation failed: (argv → ["claude", "--resume", "s"]).firstIndex(of: "--settings") → nil
✘ Test run with 75 tests in 11 suites failed after 0.014 seconds with 1 issue.
```

After fix, with commit `5eebb1f6c`:

```text
swift test --package-path Packages/CMUXAgentLaunch
✔ Test "Merged hook --settings keeps user keys when resuming" passed
✔ Test "A captured hook --settings is still stripped (the wrapper re-adds current hooks)" passed
✔ Test run with 75 tests in 11 suites passed after 0.012 seconds.
```

Refs #5388, #5427, #2816.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539142&installation_id=133855650&pr_number=5661&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5661&signature=5bfbc9bc5940c7477c9f829830d14f3a373cb3d213efc44df27f9732e8bba83c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a resume regression where user Claude settings (e.g., effortLevel) were dropped when resuming with a merged hook --settings payload. We now keep user keys and only strip cmux-owned keys. Fixes #5558.

- **Bug Fixes**
  - Updated `AgentLaunchSanitizer` in `CMUXAgentLaunch` to detect JSON merged hook `--settings` and remove only `hooks` and `preferredNotifChannel`, preserving user keys; supports both `--settings=value` and `--settings value`, and ignores user-only JSON that just mentions hook text.
  - Added tests for merged JSON settings (inline and separate) and for preserving user JSON; still strips hook-only/stale hook settings so the wrapper re-injects current hooks.

<sup>Written for commit d3b0909ecdaeec4b51464efea526fb0e81042377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings handling when resuming agents routed through the Claude wrapper: CMUX-specific keys are removed while preserving user-provided top-level settings; legacy-style hook configs are dropped and unparsable or emptied settings are stripped.

* **Tests**
  * Added regression tests covering resumed settings (both inline and separate forms) to ensure user keys are kept and wrapper-managed keys removed; includes helper-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->