### PR TITLE
Fix sidebar status pills for newly created workspaces

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9785,44 +9785,6 @@ struct SidebarGitBranchState: Equatable {
     let isDirty: Bool
 }
 
-private struct SidebarPanelObservationState: Equatable {
-    let panelIds: [UUID]
-
-    init(panels: [UUID: any Panel]) {
-        panelIds = panels.keys.sorted { $0.uuidString < $1.uuidString }
-    }
-}
-
-private struct SidebarImmediateObservationState: Equatable {
-    let title: String
-    let customDescription: String?
-    let isPinned: Bool
-    let customColor: String?
-    let latestConversationMessage: String?
-    let latestSubmittedMessage: String?
-    let latestSubmittedAt: Date?
-}
-
-private struct SidebarObservationState: Equatable {
-    let currentDirectory: String
-    let extensionSidebarProjectRootPath: String?
-    let panels: SidebarPanelObservationState
-    let panelDirectories: [UUID: String]
-    let statusEntries: [String: SidebarStatusEntry]
-    let metadataBlocks: [String: SidebarMetadataBlock]
-    let logEntries: [SidebarLogEntry]
-    let progress: SidebarProgressState?
-    let gitBranch: SidebarGitBranchState?
-    let panelGitBranches: [UUID: SidebarGitBranchState]
-    let pullRequest: SidebarPullRequestState?
-    let panelPullRequests: [UUID: SidebarPullRequestState]
-    let remoteConfiguration: WorkspaceRemoteConfiguration?
-    let remoteConnectionState: WorkspaceRemoteConnectionState
-    let remoteConnectionDetail: String?
-    let activeRemoteTerminalSessionCount: Int
-    let listeningPorts: [Int]
-}
-
 enum WorkspaceRemoteConnectionState: String, Equatable {
     case disconnected
     case connecting
@@ -10685,99 +10647,8 @@ final class Workspace: Identifiable, ObservableObject {
     // Sidebar rows cache snapshots, so observation must begin with the current
     // workspace state. Build state publishers from @Published current values
     // instead of dropping the first value and repairing timing with a Void event.
-    lazy var sidebarImmediateObservationPublisher: AnyPublisher<Void, Never> = {
-        let workspaceFields = Publishers.CombineLatest4(
-            $title,
-            $customDescription,
-            $isPinned,
-            $customColor
-        )
-        let conversationFields = Publishers.CombineLatest3(
-            $latestConversationMessage,
-            $latestSubmittedMessage,
-            $latestSubmittedAt
-        )
-
-        return workspaceFields
-            .combineLatest(conversationFields)
-            .map { workspaceFields, conversationFields in
-                SidebarImmediateObservationState(
-                    title: workspaceFields.0,
-                    customDescription: workspaceFields.1,
-                    isPinned: workspaceFields.2,
-                    customColor: workspaceFields.3,
-                    latestConversationMessage: conversationFields.0,
-                    latestSubmittedMessage: conversationFields.1,
-                    latestSubmittedAt: conversationFields.2
-                )
-            }
-            .removeDuplicates()
-            .map { _ in () }
-            .eraseToAnyPublisher()
-    }()
-
-    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
-        let workspaceFields = Publishers.CombineLatest4(
-            $currentDirectory,
-            $extensionSidebarProjectRootPath,
-            $panels.map(SidebarPanelObservationState.init),
-            $panelDirectories
-        )
-        let metadataFields = Publishers.CombineLatest4(
-            $statusEntries,
-            $metadataBlocks,
-            $logEntries,
-            $progress
-        )
-        let gitFields = Publishers.CombineLatest4(
-            $gitBranch,
-            $panelGitBranches,
-            $pullRequest,
-            $panelPullRequests
-        )
-        let remoteFields = Publishers.CombineLatest4(
-            $remoteConfiguration,
-            $remoteConnectionState,
-            $remoteConnectionDetail,
-            $activeRemoteTerminalSessionCount
-        )
-
-        return Publishers.CombineLatest4(
-            workspaceFields,
-            metadataFields,
-            gitFields,
-            remoteFields
-        )
-        .combineLatest($listeningPorts)
-        .map { groupedFields, listeningPorts in
-            let workspaceFields = groupedFields.0
-            let metadataFields = groupedFields.1
-            let gitFields = groupedFields.2
-            let remoteFields = groupedFields.3
-            return SidebarObservationState(
-                currentDirectory: workspaceFields.0,
-                extensionSidebarProjectRootPath: workspaceFields.1,
-                panels: workspaceFields.2,
-                panelDirectories: workspaceFields.3,
-                statusEntries: metadataFields.0,
-                metadataBlocks: metadataFields.1,
-                logEntries: metadataFields.2,
-                progress: metadataFields.3,
-                gitBranch: gitFields.0,
-                panelGitBranches: gitFields.1,
-                pullRequest: gitFields.2,
-                panelPullRequests: gitFields.3,
-                remoteConfiguration: remoteFields.0,
-                remoteConnectionState: remoteFields.1,
-                remoteConnectionDetail: remoteFields.2,
-                activeRemoteTerminalSessionCount: remoteFields.3,
-                listeningPorts: listeningPorts
-            )
-        }
-        .removeDuplicates()
-        .map { _ in () }
-        .eraseToAnyPublisher()
-    }()
+    lazy var sidebarImmediateObservationPublisher: AnyPublisher<Void, Never> = makeSidebarImmediateObservationPublisher()
+    lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = makeSidebarObservationPublisher()
 
     private func scheduleExtensionSidebarProjectRootRefresh(for directory: String) {
         extensionSidebarProjectRootRefreshID &+= 1

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10702,7 +10702,12 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($listeningPorts),
         ]
 
-        return Publishers.MergeMany(publishers).eraseToAnyPublisher()
+        return Publishers.MergeMany(publishers)
+            // Rows cache an immutable sidebar snapshot. Emit once per subscription
+            // so rows mounted after metadata already changed still rebuild from
+            // the workspace's current state instead of waiting for another change.
+            .prepend(())
+            .eraseToAnyPublisher()
     }()
 
     private func scheduleExtensionSidebarProjectRootRefresh(for directory: String) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9793,7 +9793,37 @@ private struct SidebarPanelObservationState: Equatable {
     }
 }
 
-enum WorkspaceRemoteConnectionState: String {
+private struct SidebarImmediateObservationState: Equatable {
+    let title: String
+    let customDescription: String?
+    let isPinned: Bool
+    let customColor: String?
+    let latestConversationMessage: String?
+    let latestSubmittedMessage: String?
+    let latestSubmittedAt: Date?
+}
+
+private struct SidebarObservationState: Equatable {
+    let currentDirectory: String
+    let extensionSidebarProjectRootPath: String?
+    let panels: SidebarPanelObservationState
+    let panelDirectories: [UUID: String]
+    let statusEntries: [String: SidebarStatusEntry]
+    let metadataBlocks: [String: SidebarMetadataBlock]
+    let logEntries: [SidebarLogEntry]
+    let progress: SidebarProgressState?
+    let gitBranch: SidebarGitBranchState?
+    let panelGitBranches: [UUID: SidebarGitBranchState]
+    let pullRequest: SidebarPullRequestState?
+    let panelPullRequests: [UUID: SidebarPullRequestState]
+    let remoteConfiguration: WorkspaceRemoteConfiguration?
+    let remoteConnectionState: WorkspaceRemoteConnectionState
+    let remoteConnectionDetail: String?
+    let activeRemoteTerminalSessionCount: Int
+    let listeningPorts: [Int]
+}
+
+enum WorkspaceRemoteConnectionState: String, Equatable {
     case disconnected
     case connecting
     case reconnecting
@@ -10652,62 +10682,101 @@ final class Workspace: Identifiable, ObservableObject {
     var invalidatedRestoredAgentFingerprintsByPanelId: [UUID: Int] = [:]
     private var pendingTerminalInputObserversByPanelId: [UUID: [WorkspacePendingTerminalInputObserver]] = [:]
 
-    private func sidebarObservationSignal<Value: Equatable>(
-        _ publisher: Published<Value>.Publisher
-    ) -> AnyPublisher<Void, Never> {
-        publisher
-            .dropFirst()
+    // Sidebar rows cache snapshots, so observation must begin with the current
+    // workspace state. Build state publishers from @Published current values
+    // instead of dropping the first value and repairing timing with a Void event.
+    lazy var sidebarImmediateObservationPublisher: AnyPublisher<Void, Never> = {
+        let workspaceFields = Publishers.CombineLatest4(
+            $title,
+            $customDescription,
+            $isPinned,
+            $customColor
+        )
+        let conversationFields = Publishers.CombineLatest3(
+            $latestConversationMessage,
+            $latestSubmittedMessage,
+            $latestSubmittedAt
+        )
+
+        return workspaceFields
+            .combineLatest(conversationFields)
+            .map { workspaceFields, conversationFields in
+                SidebarImmediateObservationState(
+                    title: workspaceFields.0,
+                    customDescription: workspaceFields.1,
+                    isPinned: workspaceFields.2,
+                    customColor: workspaceFields.3,
+                    latestConversationMessage: conversationFields.0,
+                    latestSubmittedMessage: conversationFields.1,
+                    latestSubmittedAt: conversationFields.2
+                )
+            }
             .removeDuplicates()
             .map { _ in () }
             .eraseToAnyPublisher()
-    }
-
-    lazy var sidebarImmediateObservationPublisher: AnyPublisher<Void, Never> = {
-        let publishers: [AnyPublisher<Void, Never>] = [
-            sidebarObservationSignal($title),
-            sidebarObservationSignal($customDescription),
-            sidebarObservationSignal($isPinned),
-            sidebarObservationSignal($customColor),
-            sidebarObservationSignal($latestConversationMessage),
-            sidebarObservationSignal($latestSubmittedMessage),
-            sidebarObservationSignal($latestSubmittedAt),
-        ]
-
-        return Publishers.MergeMany(publishers).eraseToAnyPublisher()
     }()
 
     lazy var sidebarObservationPublisher: AnyPublisher<Void, Never> = {
-        let publishers: [AnyPublisher<Void, Never>] = [
-            sidebarObservationSignal($currentDirectory),
-            sidebarObservationSignal($extensionSidebarProjectRootPath),
-            $panels
-                .map(SidebarPanelObservationState.init)
-                .dropFirst()
-                .removeDuplicates()
-                .map { _ in () }
-                .eraseToAnyPublisher(),
-            sidebarObservationSignal($panelDirectories),
-            sidebarObservationSignal($statusEntries),
-            sidebarObservationSignal($metadataBlocks),
-            sidebarObservationSignal($logEntries),
-            sidebarObservationSignal($progress),
-            sidebarObservationSignal($gitBranch),
-            sidebarObservationSignal($panelGitBranches),
-            sidebarObservationSignal($pullRequest),
-            sidebarObservationSignal($panelPullRequests),
-            sidebarObservationSignal($remoteConfiguration),
-            sidebarObservationSignal($remoteConnectionState),
-            sidebarObservationSignal($remoteConnectionDetail),
-            sidebarObservationSignal($activeRemoteTerminalSessionCount),
-            sidebarObservationSignal($listeningPorts),
-        ]
+        let workspaceFields = Publishers.CombineLatest4(
+            $currentDirectory,
+            $extensionSidebarProjectRootPath,
+            $panels.map(SidebarPanelObservationState.init),
+            $panelDirectories
+        )
+        let metadataFields = Publishers.CombineLatest4(
+            $statusEntries,
+            $metadataBlocks,
+            $logEntries,
+            $progress
+        )
+        let gitFields = Publishers.CombineLatest4(
+            $gitBranch,
+            $panelGitBranches,
+            $pullRequest,
+            $panelPullRequests
+        )
+        let remoteFields = Publishers.CombineLatest4(
+            $remoteConfiguration,
+            $remoteConnectionState,
+            $remoteConnectionDetail,
+            $activeRemoteTerminalSessionCount
+        )
 
-        return Publishers.MergeMany(publishers)
-            // Rows cache an immutable sidebar snapshot. Emit once per subscription
-            // so rows mounted after metadata already changed still rebuild from
-            // the workspace's current state instead of waiting for another change.
-            .prepend(())
-            .eraseToAnyPublisher()
+        return Publishers.CombineLatest4(
+            workspaceFields,
+            metadataFields,
+            gitFields,
+            remoteFields
+        )
+        .combineLatest($listeningPorts)
+        .map { groupedFields, listeningPorts in
+            let workspaceFields = groupedFields.0
+            let metadataFields = groupedFields.1
+            let gitFields = groupedFields.2
+            let remoteFields = groupedFields.3
+            return SidebarObservationState(
+                currentDirectory: workspaceFields.0,
+                extensionSidebarProjectRootPath: workspaceFields.1,
+                panels: workspaceFields.2,
+                panelDirectories: workspaceFields.3,
+                statusEntries: metadataFields.0,
+                metadataBlocks: metadataFields.1,
+                logEntries: metadataFields.2,
+                progress: metadataFields.3,
+                gitBranch: gitFields.0,
+                panelGitBranches: gitFields.1,
+                pullRequest: gitFields.2,
+                panelPullRequests: gitFields.3,
+                remoteConfiguration: remoteFields.0,
+                remoteConnectionState: remoteFields.1,
+                remoteConnectionDetail: remoteFields.2,
+                activeRemoteTerminalSessionCount: remoteFields.3,
+                listeningPorts: listeningPorts
+            )
+        }
+        .removeDuplicates()
+        .map { _ in () }
+        .eraseToAnyPublisher()
     }()
 
     private func scheduleExtensionSidebarProjectRootRefresh(for directory: String) {

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -1,0 +1,136 @@
+import Combine
+import Foundation
+
+private struct SidebarPanelObservationState: Equatable {
+    let panelIds: [UUID]
+
+    init(panels: [UUID: any Panel]) {
+        panelIds = panels.keys.sorted { $0.uuidString < $1.uuidString }
+    }
+}
+
+private struct SidebarImmediateObservationState: Equatable {
+    let title: String
+    let customDescription: String?
+    let isPinned: Bool
+    let customColor: String?
+    let latestConversationMessage: String?
+    let latestSubmittedMessage: String?
+    let latestSubmittedAt: Date?
+}
+
+private struct SidebarObservationState: Equatable {
+    let currentDirectory: String
+    let extensionSidebarProjectRootPath: String?
+    let panels: SidebarPanelObservationState
+    let panelDirectories: [UUID: String]
+    let statusEntries: [String: SidebarStatusEntry]
+    let metadataBlocks: [String: SidebarMetadataBlock]
+    let logEntries: [SidebarLogEntry]
+    let progress: SidebarProgressState?
+    let gitBranch: SidebarGitBranchState?
+    let panelGitBranches: [UUID: SidebarGitBranchState]
+    let pullRequest: SidebarPullRequestState?
+    let panelPullRequests: [UUID: SidebarPullRequestState]
+    let remoteConfiguration: WorkspaceRemoteConfiguration?
+    let remoteConnectionState: WorkspaceRemoteConnectionState
+    let remoteConnectionDetail: String?
+    let activeRemoteTerminalSessionCount: Int
+    let listeningPorts: [Int]
+}
+
+extension Workspace {
+    func makeSidebarImmediateObservationPublisher() -> AnyPublisher<Void, Never> {
+        let workspaceFields = Publishers.CombineLatest4(
+            $title,
+            $customDescription,
+            $isPinned,
+            $customColor
+        )
+        let conversationFields = Publishers.CombineLatest3(
+            $latestConversationMessage,
+            $latestSubmittedMessage,
+            $latestSubmittedAt
+        )
+
+        return workspaceFields
+            .combineLatest(conversationFields)
+            .map { workspaceFields, conversationFields in
+                SidebarImmediateObservationState(
+                    title: workspaceFields.0,
+                    customDescription: workspaceFields.1,
+                    isPinned: workspaceFields.2,
+                    customColor: workspaceFields.3,
+                    latestConversationMessage: conversationFields.0,
+                    latestSubmittedMessage: conversationFields.1,
+                    latestSubmittedAt: conversationFields.2
+                )
+            }
+            .removeDuplicates()
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    func makeSidebarObservationPublisher() -> AnyPublisher<Void, Never> {
+        let workspaceFields = Publishers.CombineLatest4(
+            $currentDirectory,
+            $extensionSidebarProjectRootPath,
+            $panels.map(SidebarPanelObservationState.init),
+            $panelDirectories
+        )
+        let metadataFields = Publishers.CombineLatest4(
+            $statusEntries,
+            $metadataBlocks,
+            $logEntries,
+            $progress
+        )
+        let gitFields = Publishers.CombineLatest4(
+            $gitBranch,
+            $panelGitBranches,
+            $pullRequest,
+            $panelPullRequests
+        )
+        let remoteFields = Publishers.CombineLatest4(
+            $remoteConfiguration,
+            $remoteConnectionState,
+            $remoteConnectionDetail,
+            $activeRemoteTerminalSessionCount
+        )
+
+        return Publishers.CombineLatest4(
+            workspaceFields,
+            metadataFields,
+            gitFields,
+            remoteFields
+        )
+            .combineLatest($listeningPorts)
+            .map { groupedFields, listeningPorts in
+                let workspaceFields = groupedFields.0
+                let metadataFields = groupedFields.1
+                let gitFields = groupedFields.2
+                let remoteFields = groupedFields.3
+                return SidebarObservationState(
+                    currentDirectory: workspaceFields.0,
+                    extensionSidebarProjectRootPath: workspaceFields.1,
+                    panels: workspaceFields.2,
+                    panelDirectories: workspaceFields.3,
+                    statusEntries: metadataFields.0,
+                    metadataBlocks: metadataFields.1,
+                    logEntries: metadataFields.2,
+                    progress: metadataFields.3,
+                    gitBranch: gitFields.0,
+                    panelGitBranches: gitFields.1,
+                    pullRequest: gitFields.2,
+                    panelPullRequests: gitFields.3,
+                    remoteConfiguration: remoteFields.0,
+                    remoteConnectionState: remoteFields.1,
+                    remoteConnectionDetail: remoteFields.2,
+                    activeRemoteTerminalSessionCount: remoteFields.3,
+                    listeningPorts: listeningPorts
+                )
+            }
+            .removeDuplicates()
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -699,6 +699,8 @@
 		F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		E30770000000000000000002 /* WorkspaceRemoteSSHBatchCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30770000000000000000001 /* WorkspaceRemoteSSHBatchCommandBuilder.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
+		5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */; };
+		5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */; };
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
 		6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */; };
 		F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */; };
@@ -1422,6 +1424,8 @@
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
 		E30770000000000000000001 /* WorkspaceRemoteSSHBatchCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteSSHBatchCommandBuilder.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
+		5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservation.swift; sourceTree = "<group>"; };
+		5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservationTests.swift; sourceTree = "<group>"; };
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
 		71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSplitStartupCommandTests.swift; sourceTree = "<group>"; };
 		F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSSHFishShellTests.swift; sourceTree = "<group>"; };
@@ -1773,6 +1777,7 @@
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
+				5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */,
 				D7AB3605C10DEF0000000004 /* WorkspaceCloseTabsBatching.swift */,
 				C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */,
 				E30780000000000000000001 /* WorkspaceRemoteConfiguration.swift */,
@@ -2202,6 +2207,7 @@
 				42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */,
 				F1C3F1DBF6BF5D7223C4A30C /* SidebarMarkdownRendererTests.swift */,
 				14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
+				5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */,
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
@@ -3049,6 +3055,7 @@
 				E30780000000000000000002 /* WorkspaceRemoteConfiguration.swift in Sources */,
 				E30770000000000000000002 /* WorkspaceRemoteSSHBatchCommandBuilder.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
+				5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */,
 				D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */,
 				C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */,
 				E30750000000000000000002 /* WorkspaceTabColorResolution.swift in Sources */,
@@ -3313,6 +3320,7 @@
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,
 				DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
+				5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */,
 				6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */,
 				F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */,
 				FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,

--- a/cmuxTests/WorkspaceSidebarObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarObservationTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import XCTest
+@testable import cmux
+
+final class WorkspaceSidebarObservationTests: XCTestCase {
+    func testSidebarObservationPublisherEmitsForLateStatusSubscriber() {
+        let workspace = Workspace()
+        workspace.statusEntries["test_probe"] = SidebarStatusEntry(
+            key: "test_probe",
+            value: "VISIBLE?",
+            icon: "star.fill",
+            color: "#FF0000",
+            priority: 200
+        )
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        XCTAssertGreaterThan(
+            publishCount,
+            0,
+            "A sidebar row that subscribes after status metadata already exists must still refresh from the current workspace state."
+        )
+    }
+
+    func testSidebarImmediateObservationPublisherEmitsForLateTitleSubscriber() {
+        let workspace = Workspace()
+        workspace.title = "Restored Workspace"
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        XCTAssertGreaterThan(
+            publishCount,
+            0,
+            "A sidebar row that subscribes after immediate workspace fields already exist must still refresh from the current workspace state."
+        )
+    }
+
+    func testSidebarObservationPublisherIgnoresRemoteHeartbeatOnlyChanges() {
+        let workspace = Workspace()
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+        publishCount = 0
+
+        workspace.remoteHeartbeatCount = 1
+        workspace.remoteLastHeartbeatAt = Date()
+
+        XCTAssertEqual(
+            publishCount,
+            0,
+            "Expected non-visible remote heartbeat updates to avoid invalidating sidebar rows"
+        )
+    }
+}

--- a/cmuxTests/WorkspaceSidebarObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarObservationTests.swift
@@ -7,6 +7,7 @@ import XCTest
 @testable import cmux
 #endif
 
+@MainActor
 final class WorkspaceSidebarObservationTests: XCTestCase {
     func testSidebarObservationPublisherEmitsForLateStatusSubscriber() {
         let workspace = Workspace()

--- a/cmuxTests/WorkspaceSidebarObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarObservationTests.swift
@@ -1,6 +1,11 @@
 import Foundation
 import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
 @testable import cmux
+#endif
 
 final class WorkspaceSidebarObservationTests: XCTestCase {
     func testSidebarObservationPublisherEmitsForLateStatusSubscriber() {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -105,6 +105,7 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
             observedSidebarInvalidation = true
         }
+        observedSidebarInvalidation = false
 
         manager.setTabColor(tabId: workspace.id, color: "#C0392B")
 
@@ -140,6 +141,7 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
             observedSidebarInvalidation = true
         }
+        observedSidebarInvalidation = false
 
         manager.setTabColor(tabId: workspace.id, color: "#C0392B")
 
@@ -6401,6 +6403,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             publishCount += 1
         }
         defer { cancellable.cancel() }
+        publishCount = 0
 
         workspace.updatePanelGitBranch(panelId: panelId, branch: "main", isDirty: false)
         let baselinePublishCount = publishCount
@@ -6438,6 +6441,23 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             publishCount,
             0,
             "A sidebar row that subscribes after status metadata already exists must still refresh from the current workspace state."
+        )
+    }
+
+    func testSidebarImmediateObservationPublisherEmitsForLateTitleSubscriber() {
+        let workspace = Workspace()
+        workspace.title = "Restored Workspace"
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        XCTAssertGreaterThan(
+            publishCount,
+            0,
+            "A sidebar row that subscribes after immediate workspace fields already exist must still refresh from the current workspace state."
         )
     }
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6449,6 +6449,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             publishCount += 1
         }
         defer { cancellable.cancel() }
+        publishCount = 0
 
         workspace.remoteHeartbeatCount = 1
         workspace.remoteLastHeartbeatAt = Date()

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6418,6 +6418,29 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testSidebarObservationPublisherEmitsForLateStatusSubscriber() {
+        let workspace = Workspace()
+        workspace.statusEntries["test_probe"] = SidebarStatusEntry(
+            key: "test_probe",
+            value: "VISIBLE?",
+            icon: "star.fill",
+            color: "#FF0000",
+            priority: 200
+        )
+
+        var publishCount = 0
+        let cancellable = workspace.sidebarObservationPublisher.sink {
+            publishCount += 1
+        }
+        defer { cancellable.cancel() }
+
+        XCTAssertGreaterThan(
+            publishCount,
+            0,
+            "A sidebar row that subscribes after status metadata already exists must still refresh from the current workspace state."
+        )
+    }
+
     func testSidebarObservationPublisherIgnoresRemoteHeartbeatOnlyChanges() {
         let workspace = Workspace()
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -6421,66 +6421,6 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
-    func testSidebarObservationPublisherEmitsForLateStatusSubscriber() {
-        let workspace = Workspace()
-        workspace.statusEntries["test_probe"] = SidebarStatusEntry(
-            key: "test_probe",
-            value: "VISIBLE?",
-            icon: "star.fill",
-            color: "#FF0000",
-            priority: 200
-        )
-
-        var publishCount = 0
-        let cancellable = workspace.sidebarObservationPublisher.sink {
-            publishCount += 1
-        }
-        defer { cancellable.cancel() }
-
-        XCTAssertGreaterThan(
-            publishCount,
-            0,
-            "A sidebar row that subscribes after status metadata already exists must still refresh from the current workspace state."
-        )
-    }
-
-    func testSidebarImmediateObservationPublisherEmitsForLateTitleSubscriber() {
-        let workspace = Workspace()
-        workspace.title = "Restored Workspace"
-
-        var publishCount = 0
-        let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
-            publishCount += 1
-        }
-        defer { cancellable.cancel() }
-
-        XCTAssertGreaterThan(
-            publishCount,
-            0,
-            "A sidebar row that subscribes after immediate workspace fields already exist must still refresh from the current workspace state."
-        )
-    }
-
-    func testSidebarObservationPublisherIgnoresRemoteHeartbeatOnlyChanges() {
-        let workspace = Workspace()
-
-        var publishCount = 0
-        let cancellable = workspace.sidebarObservationPublisher.sink {
-            publishCount += 1
-        }
-        defer { cancellable.cancel() }
-        publishCount = 0
-
-        workspace.remoteHeartbeatCount = 1
-        workspace.remoteLastHeartbeatAt = Date()
-
-        XCTAssertEqual(
-            publishCount,
-            0,
-            "Expected non-visible remote heartbeat updates to avoid invalidating sidebar rows"
-        )
-    }
-
     @MainActor
     func testSidebarPullRequestsTrackFocusedPanelOnly() {
         let workspace = Workspace()


### PR DESCRIPTION
## Summary
- Fix late sidebar row subscriptions by making `Workspace.sidebarObservationPublisher` emit one initial sync event per subscriber before normal debounced updates.
- Add a regression test for a workspace whose status metadata exists before the sidebar observer subscribes.
- Preserve the heartbeat-only no-invalidation behavior after the initial sync baseline.

## Root cause
New workspace rows could cache an empty `workspaceSnapshotStorage` before their `tab.sidebarObservationPublisher` subscription became active. Because the workspace publisher dropped the first `@Published` value, a publisher materialized after the first status mutation treated the already-mutated status dictionary as its initial value and dropped it, leaving the row stuck on the empty cached snapshot. This rules out ForEach identity and status filtering: the model data was present and the snapshot builder renders it when refreshed.

## Testing
- Not run locally per repo policy.

Closes #5659

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539377&installation_id=133855650&pr_number=5662&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5662&signature=e517f6a1dbcf49d4e62ad5f0eaa7d972a8338a27e51ebd77c64fda53a8e371b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure sidebar status pills render for newly created workspaces by emitting the current workspace state to new subscribers. Addresses #5659 and prevents late-subscribing rows from caching empty snapshots.

- **Bug Fixes**
  - Rebuilt `sidebarImmediateObservationPublisher` and `sidebarObservationPublisher` to emit current `@Published` values with `removeDuplicates`, so each subscriber gets an initial event; made `WorkspaceRemoteConnectionState` `Equatable` and moved helpers to `WorkspaceSidebarObservation.swift`.
  - Added regression tests for late subscribers on both publishers, kept heartbeat-only changes ignored, fixed test imports for `cmux`/`cmux_DEV`, and marked tests `@MainActor` for stable execution.

<sup>Written for commit 3c6fe022d1f7d8f0bed1344092998250f0b52c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar reliably delivers current workspace state to subscribers that attach late and emits immediate updates (e.g., title/status).
  * Sidebar no longer invalidates or refreshes when only remote heartbeat details change.

* **Tests**
  * Added deterministic unit tests covering immediate-emission behavior, late-subscriber scenarios, and heartbeat-only ignore cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->