### PR TITLE
Fix #1027: clear stuck "Needs input" when the follow-up event turnId drifts

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1217,36 +1217,43 @@ private final class ClaudeHookSessionStore {
         }
     }
 
-    /// Relaxed gate for Claude CLEARING transitions (stop->idle, prompt-submit->running,
-    /// pre-tool-use->running). Returns true when the event is current (`isCurrent`) OR when it
-    /// belongs to the SAME active session and that session is currently stuck on `.needsInput`.
-    /// The second clause lets a follow-up event whose `turnId` drifted (Notification leaves the
-    /// active turn pointing at the prior prompt) still clear a stale "Needs input" badge, while a
-    /// DIFFERENT-session event stays blocked because it requires `active.sessionId == sessionId`.
-    /// Fixes https://github.com/manaflow-ai/cmux/issues/1027.
+    /// Gate for Claude CLEARING transitions (stop->idle, prompt-submit->running,
+    /// pre-tool-use->running). Equivalent to `isCurrent`, except that when an event matches the
+    /// active session but its `turnId` has drifted (a Notification leaves the active turn pointing
+    /// at the prior prompt), it still returns true IF that session is currently stuck on
+    /// `.needsInput` -- so a follow-up clearing event can drop a stale "Needs input" badge. A
+    /// DIFFERENT-session event always fails closed (`active.sessionId == sessionId` is required).
+    /// The whole decision is taken under a SINGLE `withLockedState` (the `isCurrent` predicate is
+    /// inlined) so the turn-identity check and the `needsInput` check can't race a concurrent
+    /// session update across two lock windows. Fixes https://github.com/manaflow-ai/cmux/issues/1027.
     func isCurrentOrClearsStaleNeedsInput(
         sessionId: String?,
         workspaceId: String,
         turnId: String? = nil
     ) throws -> Bool {
-        if try isCurrent(sessionId: sessionId, workspaceId: workspaceId, turnId: turnId) {
-            return true
-        }
         guard let normalizedSessionId = normalizeOptional(sessionId),
               let normalizedWorkspace = normalizeOptional(workspaceId) else {
-            return false
+            // Matches isCurrent's fail-open: an event that can't identify a session/workspace is
+            // treated as current.
+            return true
         }
-        // The two-phase read (the `isCurrent` lock above + this one) is intentional: this is an
-        // optimistic gate hint, not a critical section. A benign TOCTOU can at most let a clearing
-        // event proceed against a `needsInput` that just changed -- which only ever clears a stale
-        // badge, never the reverse -- so a single combined lock isn't needed.
+        let normalizedTurnId = normalizeOptional(turnId)
         return try withLockedState { state in
-            guard let active = state.activeSessionsByWorkspace[normalizedWorkspace],
-                  active.sessionId == normalizedSessionId,
-                  state.sessions[normalizedSessionId]?.agentLifecycle == .needsInput else {
+            guard let active = state.activeSessionsByWorkspace[normalizedWorkspace] else {
+                return true
+            }
+            guard active.sessionId == normalizedSessionId else {
                 return false
             }
-            return true
+            guard let activeTurnId = normalizeOptional(active.turnId),
+                  let normalizedTurnId else {
+                return true
+            }
+            if activeTurnId == normalizedTurnId {
+                return true
+            }
+            // Same session, but the turnId drifted: still clear a stale "Needs input" badge.
+            return state.sessions[normalizedSessionId]?.agentLifecycle == .needsInput
         }
     }
 
@@ -22394,7 +22401,7 @@ struct CMUXCLI {
             )
         } catch {
             telemetry.breadcrumb(
-                "claude-hook.is-current.error",
+                "claude-hook.clearing-gate.error",
                 data: [
                     "error": String(describing: error),
                     "session_id": parsedInput.sessionId ?? "",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1217,6 +1217,35 @@ private final class ClaudeHookSessionStore {
         }
     }
 
+    /// Relaxed gate for Claude CLEARING transitions (stop->idle, prompt-submit->running,
+    /// pre-tool-use->running). Returns true when the event is current (`isCurrent`) OR when it
+    /// belongs to the SAME active session and that session is currently stuck on `.needsInput`.
+    /// The second clause lets a follow-up event whose `turnId` drifted (Notification leaves the
+    /// active turn pointing at the prior prompt) still clear a stale "Needs input" badge, while a
+    /// DIFFERENT-session event stays blocked because it requires `active.sessionId == sessionId`.
+    /// Fixes https://github.com/manaflow-ai/cmux/issues/1027.
+    func isCurrentOrClearsStaleNeedsInput(
+        sessionId: String?,
+        workspaceId: String,
+        turnId: String? = nil
+    ) throws -> Bool {
+        if try isCurrent(sessionId: sessionId, workspaceId: workspaceId, turnId: turnId) {
+            return true
+        }
+        guard let normalizedSessionId = normalizeOptional(sessionId),
+              let normalizedWorkspace = normalizeOptional(workspaceId) else {
+            return false
+        }
+        return try withLockedState { state in
+            guard let active = state.activeSessionsByWorkspace[normalizedWorkspace],
+                  active.sessionId == normalizedSessionId,
+                  state.sessions[normalizedSessionId]?.agentLifecycle == .needsInput else {
+                return false
+            }
+            return true
+        }
+    }
+
     func canReplaceActiveSession(sessionId: String?, workspaceId: String) throws -> Bool {
         guard let normalizedSessionId = normalizeOptional(sessionId),
               let normalizedWorkspace = normalizeOptional(workspaceId) else {
@@ -21727,7 +21756,11 @@ struct CMUXCLI {
                 )
                 sendClaudeFeedTelemetry(workspaceId: workspaceId)
 
-                guard shouldApplyClaudeHookVisibleMutation(
+                // Stop is a CLEARING transition (-> idle). Use the relaxed gate so a stale
+                // same-session "Needs input" is cleared even when this Stop's turnId drifted from
+                // the active turn (https://github.com/manaflow-ai/cmux/issues/1027). A
+                // different-session Stop still fails closed.
+                guard shouldApplyClaudeHookClearingMutation(
                     sessionStore: sessionStore,
                     parsedInput: parsedInput,
                     workspaceId: workspaceId,
@@ -21828,8 +21861,12 @@ struct CMUXCLI {
                 env: ProcessInfo.processInfo.environment
             )
             sendClaudeFeedTelemetry(workspaceId: workspaceId)
+            // prompt-submit is a CLEARING transition (-> running). Use the relaxed gate so a stale
+            // same-session "Needs input" is cleared even when this prompt's turnId drifted from the
+            // active turn (https://github.com/manaflow-ai/cmux/issues/1027). A different-session
+            // event still fails closed (and the stopped-session replacement path is unchanged).
             let shouldApplyPromptSubmit =
-                shouldApplyClaudeHookVisibleMutation(
+                shouldApplyClaudeHookClearingMutation(
                     sessionStore: sessionStore,
                     parsedInput: parsedInput,
                     workspaceId: workspaceId,
@@ -22070,7 +22107,12 @@ struct CMUXCLI {
                 currentAgentPID: claudePid,
                 env: ProcessInfo.processInfo.environment
             )
-            guard shouldApplyClaudeHookVisibleMutation(
+            // pre-tool-use clears "Needs input" (-> running) when Claude resumes work, so use the
+            // relaxed gate to clear a stale same-session badge even on turnId drift
+            // (https://github.com/manaflow-ai/cmux/issues/1027). The AskUserQuestion branch below
+            // (which SETS needsInput) keeps the strict `isCurrent` gate, so the relaxation only ever
+            // clears, never spuriously sets. A different-session event still fails closed.
+            guard shouldApplyClaudeHookClearingMutation(
                 sessionStore: sessionStore,
                 parsedInput: parsedInput,
                 workspaceId: workspaceId,
@@ -22089,10 +22131,17 @@ struct CMUXCLI {
             // AskUserQuestion means Claude is about to ask the user something.
             // Save question text in session so the Notification handler can use it
             // instead of the generic "Claude Code needs your attention".
+            // The SETTING path stays on the strict gate: only a current event may raise needsInput.
             if let toolName = parsedInput.object?["tool_name"] as? String,
                toolName == "AskUserQuestion",
                let question = describeAskUserQuestion(parsedInput.object),
-               let sessionId = parsedInput.sessionId {
+               let sessionId = parsedInput.sessionId,
+               shouldApplyClaudeHookVisibleMutation(
+                   sessionStore: sessionStore,
+                   parsedInput: parsedInput,
+                   workspaceId: workspaceId,
+                   telemetry: telemetry
+               ) {
                 // Preserve a non-empty surfaceId from SessionStart; passing ""
                 // would overwrite it and cause notifications to target the wrong workspace.
                 let existingSurfaceId = nonEmptyClaudeHookIdentifier(mappedSession?.surfaceId) ?? surfaceId
@@ -22307,6 +22356,38 @@ struct CMUXCLI {
                     "session_id": sessionId ?? "",
                     "workspace_id": workspaceId,
                     "turn_id": turnId ?? "",
+                ]
+            )
+            return true
+        }
+    }
+
+    /// Gate for Claude CLEARING transitions only. Identical to
+    /// `shouldApplyClaudeHookVisibleMutation` except it also applies when the SAME active session
+    /// is stuck on `.needsInput` after the follow-up event's `turnId` drifted, so a stale
+    /// "Needs input" badge is cleared instead of being stranded. A different-session event still
+    /// fails closed via `isCurrentOrClearsStaleNeedsInput`. See
+    /// https://github.com/manaflow-ai/cmux/issues/1027.
+    private func shouldApplyClaudeHookClearingMutation(
+        sessionStore: ClaudeHookSessionStore,
+        parsedInput: ClaudeHookParsedInput,
+        workspaceId: String,
+        telemetry: CLISocketSentryTelemetry
+    ) -> Bool {
+        do {
+            return try sessionStore.isCurrentOrClearsStaleNeedsInput(
+                sessionId: parsedInput.sessionId,
+                workspaceId: workspaceId,
+                turnId: parsedInput.turnId
+            )
+        } catch {
+            telemetry.breadcrumb(
+                "claude-hook.is-current.error",
+                data: [
+                    "error": String(describing: error),
+                    "session_id": parsedInput.sessionId ?? "",
+                    "workspace_id": workspaceId,
+                    "turn_id": parsedInput.turnId ?? "",
                 ]
             )
             return true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1236,6 +1236,10 @@ private final class ClaudeHookSessionStore {
               let normalizedWorkspace = normalizeOptional(workspaceId) else {
             return false
         }
+        // The two-phase read (the `isCurrent` lock above + this one) is intentional: this is an
+        // optimistic gate hint, not a critical section. A benign TOCTOU can at most let a clearing
+        // event proceed against a `needsInput` that just changed -- which only ever clears a stale
+        // badge, never the reverse -- so a single combined lock isn't needed.
         return try withLockedState { state in
             guard let active = state.activeSessionsByWorkspace[normalizedWorkspace],
                   active.sessionId == normalizedSessionId,
@@ -22107,11 +22111,59 @@ struct CMUXCLI {
                 currentAgentPID: claudePid,
                 env: ProcessInfo.processInfo.environment
             )
-            // pre-tool-use clears "Needs input" (-> running) when Claude resumes work, so use the
-            // relaxed gate to clear a stale same-session badge even on turnId drift
-            // (https://github.com/manaflow-ai/cmux/issues/1027). The AskUserQuestion branch below
-            // (which SETS needsInput) keeps the strict `isCurrent` gate, so the relaxation only ever
-            // clears, never spuriously sets. A different-session event still fails closed.
+            // AskUserQuestion means Claude is about to ask the user something: it is a needsInput
+            // SETTING event, not a clearing one. Handle it BEFORE the relaxed clearing gate and
+            // always return, so a drifted/stale AskUserQuestion can never fall through to the
+            // running path below and wipe a live "Needs input"
+            // (https://github.com/manaflow-ai/cmux/issues/1027). Raising needsInput stays on the
+            // STRICT gate: only a current event may set it; a stale one simply leaves state as-is.
+            if let toolName = parsedInput.object?["tool_name"] as? String,
+               toolName == "AskUserQuestion" {
+                if !suppressVisibleMutations,
+                   let question = describeAskUserQuestion(parsedInput.object),
+                   let sessionId = parsedInput.sessionId,
+                   shouldApplyClaudeHookVisibleMutation(
+                       sessionStore: sessionStore,
+                       parsedInput: parsedInput,
+                       workspaceId: workspaceId,
+                       telemetry: telemetry
+                   ) {
+                    // Save question text in session so the Notification handler can use it
+                    // instead of the generic "Claude Code needs your attention".
+                    // Preserve a non-empty surfaceId from SessionStart; passing ""
+                    // would overwrite it and cause notifications to target the wrong workspace.
+                    let existingSurfaceId = nonEmptyClaudeHookIdentifier(mappedSession?.surfaceId) ?? surfaceId
+                    try? sessionStore.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: existingSurfaceId,
+                        cwd: parsedInput.cwd,
+                        transcriptPath: parsedInput.transcriptPath,
+                        agentLifecycle: .needsInput,
+                        lastSubtitle: "Waiting",
+                        lastBody: question
+                    )
+                    setAgentLifecycle(
+                        client: client,
+                        key: Self.claudeCodeStatusKey,
+                        lifecycle: .needsInput,
+                        workspaceId: workspaceId,
+                        surfaceId: existingSurfaceId
+                    )
+                    // Don't clear notifications or set status here.
+                    // The Notification hook fires right after and will use the saved question.
+                } else {
+                    telemetry.breadcrumb("claude-hook.pre-tool-use.ask-user-question.skipped")
+                }
+                print("OK")
+                return
+            }
+
+            // A non-AskUserQuestion pre-tool-use means Claude resumed work, so this is a CLEARING
+            // transition (-> running). Use the relaxed gate so a stale same-session "Needs input"
+            // is cleared even when this event's turnId drifted from the active turn
+            // (https://github.com/manaflow-ai/cmux/issues/1027). A different-session event still
+            // fails closed.
             guard shouldApplyClaudeHookClearingMutation(
                 sessionStore: sessionStore,
                 parsedInput: parsedInput,
@@ -22124,46 +22176,6 @@ struct CMUXCLI {
             }
             guard !suppressVisibleMutations else {
                 telemetry.breadcrumb("claude-hook.pre-tool-use.nested-suppressed")
-                print("OK")
-                return
-            }
-
-            // AskUserQuestion means Claude is about to ask the user something.
-            // Save question text in session so the Notification handler can use it
-            // instead of the generic "Claude Code needs your attention".
-            // The SETTING path stays on the strict gate: only a current event may raise needsInput.
-            if let toolName = parsedInput.object?["tool_name"] as? String,
-               toolName == "AskUserQuestion",
-               let question = describeAskUserQuestion(parsedInput.object),
-               let sessionId = parsedInput.sessionId,
-               shouldApplyClaudeHookVisibleMutation(
-                   sessionStore: sessionStore,
-                   parsedInput: parsedInput,
-                   workspaceId: workspaceId,
-                   telemetry: telemetry
-               ) {
-                // Preserve a non-empty surfaceId from SessionStart; passing ""
-                // would overwrite it and cause notifications to target the wrong workspace.
-                let existingSurfaceId = nonEmptyClaudeHookIdentifier(mappedSession?.surfaceId) ?? surfaceId
-                try? sessionStore.upsert(
-                    sessionId: sessionId,
-                    workspaceId: workspaceId,
-                    surfaceId: existingSurfaceId,
-                    cwd: parsedInput.cwd,
-                    transcriptPath: parsedInput.transcriptPath,
-                    agentLifecycle: .needsInput,
-                    lastSubtitle: "Waiting",
-                    lastBody: question
-                )
-                setAgentLifecycle(
-                    client: client,
-                    key: Self.claudeCodeStatusKey,
-                    lifecycle: .needsInput,
-                    workspaceId: workspaceId,
-                    surfaceId: existingSurfaceId
-                )
-                // Don't clear notifications or set status here.
-                // The Notification hook fires right after and will use the saved question.
                 print("OK")
                 return
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22147,7 +22147,7 @@ struct CMUXCLI {
                         cwd: parsedInput.cwd,
                         transcriptPath: parsedInput.transcriptPath,
                         agentLifecycle: .needsInput,
-                        lastSubtitle: "Waiting",
+                        lastSubtitle: String(localized: "agent.claude.input.subtitle.waiting", defaultValue: "Waiting"),
                         lastBody: question
                     )
                     setAgentLifecycle(

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -565,6 +565,114 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    // https://github.com/manaflow-ai/cmux/issues/1027 — the third clearing transition: a
+    // same-session prompt-submit whose turnId drifted from the active turn must also clear a stale
+    // needsInput to running (companion to the Stop and pre-tool-use turn-drift tests above).
+    func testClaudeNotificationNeedsInputClearsOnSameSessionTurnDriftPromptSubmit() throws {
+        let context = try makeClaudeHookContext(name: "claude-needsinput-clear-promptsubmit")
+        defer { context.cleanup() }
+
+        let sessionId = "stuck-needsinput-promptsubmit-session"
+
+        let promptSubmit1 = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#
+        )
+        XCTAssertFalse(promptSubmit1.timedOut, promptSubmit1.stderr)
+        XCTAssertEqual(promptSubmit1.status, 0, promptSubmit1.stderr)
+
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput",
+            "Notification should leave the session stuck on needsInput before the drifted prompt-submit"
+        )
+
+        let cmdStart = context.state.commands.count
+        // Same session, but the prompt-submit reports a DIFFERENT turn id than the active turn-1.
+        let promptSubmit2 = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-2","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"yes go ahead"}"#
+        )
+        XCTAssertFalse(promptSubmit2.timedOut, promptSubmit2.stderr)
+        XCTAssertEqual(promptSubmit2.status, 0, promptSubmit2.stderr)
+
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "running",
+            "A same-session prompt-submit with a drifted turn id must clear the stale needsInput to running"
+        )
+        let cmds = Array(context.state.commands.dropFirst(cmdStart))
+        XCTAssertTrue(
+            cmds.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code running --tab=\(context.workspaceId)")
+            },
+            "Expected the drifted prompt-submit to clear the visible lifecycle to running, saw \(cmds)"
+        )
+    }
+
+    // https://github.com/manaflow-ai/cmux/issues/1027 — guardrail for the relaxed pre-tool-use
+    // gate: an AskUserQuestion pre-tool-use is a needsInput-SETTING event, so even when its turnId
+    // has drifted it must NOT fall through to the clearing (-> running) path and wipe a live
+    // "Needs input". (Regression test for the codex review finding on the first revision of the fix.)
+    func testClaudeAskUserQuestionWithDriftedTurnDoesNotClearNeedsInput() throws {
+        let context = try makeClaudeHookContext(name: "claude-askuserquestion-drift")
+        defer { context.cleanup() }
+
+        let sessionId = "askuserquestion-drift-session"
+
+        let promptSubmit = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#
+        )
+        XCTAssertFalse(promptSubmit.timedOut, promptSubmit.stderr)
+        XCTAssertEqual(promptSubmit.status, 0, promptSubmit.stderr)
+
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude needs your permission"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput"
+        )
+
+        let cmdStart = context.state.commands.count
+        // Same session, drifted turn id, tool = AskUserQuestion (a needsInput-SETTING event).
+        let askPreToolUse = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "pre-tool-use"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-2","cwd":"\#(context.root.path)","hook_event_name":"PreToolUse","tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which option?"}]}}"#
+        )
+        XCTAssertFalse(askPreToolUse.timedOut, askPreToolUse.stderr)
+        XCTAssertEqual(askPreToolUse.status, 0, askPreToolUse.stderr)
+
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput",
+            "A drifted AskUserQuestion pre-tool-use must NOT clear the live needsInput to running"
+        )
+        let cmds = Array(context.state.commands.dropFirst(cmdStart))
+        XCTAssertFalse(
+            cmds.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code running --tab=\(context.workspaceId)")
+            },
+            "A drifted AskUserQuestion must not emit a running lifecycle, saw \(cmds)"
+        )
+    }
+
     func testClaudePromptSubmitFromNewSessionCanReplaceStoppedSession() throws {
         let context = try makeClaudeHookContext(name: "claude-new-session-after-stop")
         defer { context.cleanup() }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -399,6 +399,172 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         XCTAssertEqual(resumeBindingRequests.first?["auto_resume"] as? Bool, true)
     }
 
+    // https://github.com/manaflow-ai/cmux/issues/1027 — a Notification leaves the active turn
+    // pointing at the prior prompt, so a follow-up Stop whose turnId drifted used to be gated out
+    // by `isCurrent`, stranding the sidebar on "Needs input". The relaxed clearing gate must clear
+    // a stale SAME-session needsInput even on turn drift.
+    func testClaudeNotificationNeedsInputClearsOnSameSessionTurnDriftStop() throws {
+        let context = try makeClaudeHookContext(name: "claude-needsinput-clear-stop")
+        defer { context.cleanup() }
+
+        let sessionId = "stuck-needsinput-session"
+
+        let promptSubmit = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#
+        )
+        XCTAssertFalse(promptSubmit.timedOut, promptSubmit.stderr)
+        XCTAssertEqual(promptSubmit.status, 0, promptSubmit.stderr)
+
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput",
+            "Notification should leave the session stuck on needsInput before the drifted Stop"
+        )
+
+        let stopStart = context.state.commands.count
+        // Same session, but the Stop reports a DIFFERENT turn id than the active turn (turn-1).
+        let staleTurnStop = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "stop"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-2","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"done"}"#
+        )
+        XCTAssertFalse(staleTurnStop.timedOut, staleTurnStop.stderr)
+        XCTAssertEqual(staleTurnStop.status, 0, staleTurnStop.stderr)
+
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "idle",
+            "A same-session Stop with a drifted turn id must clear the stale needsInput to idle"
+        )
+        let stopCommands = Array(context.state.commands.dropFirst(stopStart))
+        XCTAssertTrue(
+            stopCommands.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code idle --tab=\(context.workspaceId)")
+            },
+            "Expected the drifted Stop to clear the visible lifecycle to idle, saw \(stopCommands)"
+        )
+        XCTAssertFalse(
+            stopCommands.contains {
+                $0.hasPrefix("set_status claude_code Needs input")
+            },
+            "The drifted Stop must not re-assert Needs input, saw \(stopCommands)"
+        )
+    }
+
+    // Companion to the Stop case: a pre-tool-use (Claude resuming after a permission grant) whose
+    // turnId drifted must also clear a stale SAME-session needsInput, transitioning to running.
+    func testClaudeNotificationNeedsInputClearsOnSameSessionTurnDriftPreToolUse() throws {
+        let context = try makeClaudeHookContext(name: "claude-needsinput-clear-pretool")
+        defer { context.cleanup() }
+
+        let sessionId = "stuck-needsinput-pretool-session"
+
+        let promptSubmit = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#
+        )
+        XCTAssertFalse(promptSubmit.timedOut, promptSubmit.stderr)
+        XCTAssertEqual(promptSubmit.status, 0, promptSubmit.stderr)
+
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput"
+        )
+
+        let preToolStart = context.state.commands.count
+        // Same session, drifted turn id (no turn-id match against the active turn-1).
+        let preToolUse = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "pre-tool-use"],
+            standardInput: #"{"session_id":"\#(sessionId)","turn_id":"turn-2","cwd":"\#(context.root.path)","hook_event_name":"PreToolUse","tool_name":"Bash"}"#
+        )
+        XCTAssertFalse(preToolUse.timedOut, preToolUse.stderr)
+        XCTAssertEqual(preToolUse.status, 0, preToolUse.stderr)
+
+        XCTAssertEqual(
+            try readClaudeHookSession(sessionId, context: context)["agentLifecycle"] as? String,
+            "running",
+            "A same-session pre-tool-use with a drifted turn id must clear the stale needsInput to running"
+        )
+        let preToolCommands = Array(context.state.commands.dropFirst(preToolStart))
+        XCTAssertTrue(
+            preToolCommands.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code running --tab=\(context.workspaceId)")
+            },
+            "Expected the drifted pre-tool-use to clear the visible lifecycle to running, saw \(preToolCommands)"
+        )
+    }
+
+    // Guardrail for the issue #1027 fix: the relaxation is SAME-session only. A Stop from a
+    // DIFFERENT session must NOT clear a needsInput that belongs to the active session (mirrors
+    // testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus).
+    func testClaudeNotificationNeedsInputStaysStuckForDifferentSessionStop() throws {
+        let context = try makeClaudeHookContext(name: "claude-needsinput-other-session")
+        defer { context.cleanup() }
+
+        let activeSessionId = "active-needsinput-session"
+        let otherSessionId = "other-session"
+
+        let promptSubmit = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "prompt-submit"],
+            standardInput: #"{"session_id":"\#(activeSessionId)","turn_id":"turn-1","cwd":"\#(context.root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#
+        )
+        XCTAssertFalse(promptSubmit.timedOut, promptSubmit.stderr)
+        XCTAssertEqual(promptSubmit.status, 0, promptSubmit.stderr)
+
+        let notification = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "notification"],
+            standardInput: #"{"session_id":"\#(activeSessionId)","cwd":"\#(context.root.path)","hook_event_name":"Notification","message":"Claude needs your permission to use Bash"}"#
+        )
+        XCTAssertFalse(notification.timedOut, notification.stderr)
+        XCTAssertEqual(notification.status, 0, notification.stderr)
+        XCTAssertEqual(
+            try readClaudeHookSession(activeSessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput"
+        )
+
+        let stopStart = context.state.commands.count
+        let otherSessionStop = runClaudeHook(
+            context: context,
+            arguments: ["hooks", "claude", "stop"],
+            standardInput: #"{"session_id":"\#(otherSessionId)","turn_id":"turn-9","cwd":"\#(context.root.path)","hook_event_name":"Stop","last_assistant_message":"old turn finished late"}"#
+        )
+        XCTAssertFalse(otherSessionStop.timedOut, otherSessionStop.stderr)
+        XCTAssertEqual(otherSessionStop.status, 0, otherSessionStop.stderr)
+
+        XCTAssertEqual(
+            try readClaudeHookSession(activeSessionId, context: context)["agentLifecycle"] as? String,
+            "needsInput",
+            "A different-session Stop must not clear the active session's needsInput"
+        )
+        let stopCommands = Array(context.state.commands.dropFirst(stopStart))
+        XCTAssertFalse(
+            stopCommands.contains {
+                $0.hasPrefix("set_agent_lifecycle claude_code idle --tab=\(context.workspaceId)")
+            },
+            "A different-session Stop must not write idle for the workspace, saw \(stopCommands)"
+        )
+    }
+
     func testClaudePromptSubmitFromNewSessionCanReplaceStoppedSession() throws {
         let context = try makeClaudeHookContext(name: "claude-new-session-after-stop")
         defer { context.cleanup() }


### PR DESCRIPTION
## Summary

**What changed?** Fixes #1027 — the sidebar agent status getting stuck on **"Needs input"**.

**Root cause.** When Claude fires a `Notification`, the CLI sets the session lifecycle to `needsInput` but does **not** advance the active turn (it stays pointing at the prior prompt's turn). The events that should later clear it — `stop` (→ idle), `prompt-submit` (→ running), `pre-tool-use` (→ running) — are all gated by `ClaudeHookSessionStore.isCurrent(...)`, which requires the event's `turnId` **and** `sessionId` to match the workspace's active turn. On a resume / turn drift the follow-up event carries a different `turnId`, so `isCurrent` returns `false`, the clearing mutation is dropped, and the badge is stranded on "Needs input". It's intermittent precisely because it depends on whether the turn ids happen to line up.

**Fix.** New `ClaudeHookSessionStore.isCurrentOrClearsStaleNeedsInput(...)`, used **only** by the three Claude *clearing* handlers (`stop`, `prompt-submit`, `pre-tool-use`). It returns `true` when `isCurrent` is true **or** when the event is for the **same active session** and that session is currently stuck on `.needsInput` (ignoring the `turnId`). Because it still requires `active.sessionId == sessionId`, a **different**-session event keeps failing closed — so the protection asserted by `testClaudeStopFromPreviousSessionDoesNotClobberClearRunningStatus` is preserved. The needsInput-*setting* paths (`Notification`, `AskUserQuestion`) keep the strict `isCurrent` gate, so this relaxation can only ever **clear** a stale "Needs input", never spuriously raise one.

Scoped intentionally to the stuck-`needsInput` root cause. The related "Running persists after stop" and "status pill missing on new workspaces" symptoms are separate and already have in-flight PRs (#5500 / #5662 / #5660), so I kept this minimal and did not touch the app-side aggregation or the generic-agent notification path.

Two files: `CLI/cmux.swift` (gate + wiring) and `cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift` (regression tests).

## Testing

Three regression tests added to the already-wired `CLINotifyProcessIntegrationRegressionTests.swift`, each driving the **real CLI hook binary**:

- `testClaudeNotificationNeedsInputClearsOnSameSessionTurnDriftStop` — prompt-submit(turn-1) → notification (→ needsInput) → **stop(turn-2, same session)**: asserts the lifecycle clears to `idle`, emits `set_agent_lifecycle claude_code idle`, and does not re-assert "Needs input".
- `testClaudeNotificationNeedsInputClearsOnSameSessionTurnDriftPreToolUse` — same setup, `pre-tool-use(turn-2, Bash)` → clears to `running`.
- `testClaudeNotificationNeedsInputStaysStuckForDifferentSessionStop` — guardrail: a **different**-session Stop must **not** clear the active session's `needsInput`.

⚠️ **Local verification note.** My machine only has Xcode 15; this repo needs Xcode 16+/26 (`swift-tools-version: 6.0`), so I could **not** run the full `xcodebuild -scheme cmux-unit` suite locally. What I *did* verify locally:

- `swiftc -parse` clean on both changed files.
- `scripts/lint-pbxproj-test-wiring.sh` → ok (the test file is already wired; no new pbxproj entries needed).
- A standalone harness compiling the **verbatim** `isCurrent` + `isCurrentOrClearsStaleNeedsInput` functions and asserting: same-session turn-drift **clears**, different-session **stays blocked**, non-`needsInput` status is **not** over-cleared, and same-turn behavior is unchanged — all pass.

Please run the suite on CI to confirm end-to-end:

```
xcodebuild -scheme cmux-unit -configuration Debug -destination 'platform=macOS' test \
  -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests
```

## Demo Video

N/A — internal status-state logic, covered by the new integration tests.

## Checklist

- [x] I tested the change locally (logic harness + `swiftc -parse` + pbxproj wiring lint; full `xcodebuild` suite needs Xcode 26 — see note above)
- [x] I added tests for the behavior change
- [ ] Docs/changelog — n/a (bugfix)
- [x] Requesting bot reviews after this commit (comment below)
- [ ] All code review bot comments resolved
- [ ] All human review comments resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783550238&installation_id=133855650&pr_number=5666&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5666&signature=95bbab337beb38efb04280032f71b4887329c7fcff4299624b709265c538f315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1027 by clearing a stuck "Needs input" even when the follow-up `stop`, `prompt-submit`, or `pre-tool-use` event has a different `turnId`. Adds an atomic, same-session clearing gate that preserves cross-session safety, and localizes the Claude "Waiting" subtitle.

- **Bug Fixes**
  - Added `ClaudeHookSessionStore.isCurrentOrClearsStaleNeedsInput` and `shouldApplyClaudeHookClearingMutation`; applied to `stop`, `prompt-submit`, and non-`AskUserQuestion` `pre-tool-use`. The gate runs under a single `withLockedState` and logs with `claude-hook.clearing-gate.error`.
  - Restructured `pre-tool-use` so `AskUserQuestion` is handled first as a needsInput-setting event with the strict gate and an early return; a drifted/stale question can’t clear a live "Needs input". Localized the "Waiting" subtitle via `agent.claude.input.subtitle.waiting` (en/ja).
  - Added regression tests covering same-session drift clears (stop, prompt-submit, pre-tool-use) and guards that different-session events and drifted `AskUserQuestion` do not clear the state.

<sup>Written for commit 1733504a271ea1cd4781ada03356ff3fbdad92d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of drifted turn IDs so same-session events can clear stale "Needs input" indicators without affecting other sessions; AskUserQuestion no longer overwrites live "Needs input".

* **Tests**
  * Added integration tests validating lifecycle clearing and session isolation for drifted-turn scenarios.

* **New Features**
  * Added a localized "Waiting" subtitle for Claude agent input (English and Japanese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->