### PR TITLE
Import Safari cookies in browser data importer

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -12259,12 +12259,16 @@ enum BrowserDataImporter {
     // represented unambiguously in a header (so the caller keeps the exact value via
     // the properties path instead).
     private static func httpOnlyCookieViaHeader(_ p: SafariBinaryCookiesParser.ParsedCookie) -> HTTPCookie? {
-        // Any ";"/"," in a field would be misparsed as an attribute/cookie boundary
-        // by the Set-Cookie parser, and "=" in the name would corrupt the name=value
-        // split. Bail to the caller's properties path for those (rare) cookies.
-        guard !p.value.contains(";"), !p.value.contains(","),
-              !p.name.contains(";"), !p.name.contains(","), !p.name.contains("="),
-              !p.path.contains(";"), !p.path.contains(",") else { return nil }
+        // Bail to the caller's properties path for any field that can't be safely
+        // represented in a Set-Cookie header. ";"/"," are attribute/cookie separators;
+        // a quote or ASCII control character can make the parser reinterpret the cookie
+        // (and the post-parse check below only verifies name/value, not path/scope);
+        // "=" in the name would corrupt the name=value split.
+        let disallowedInField = CharacterSet(charactersIn: ";,\"").union(.controlCharacters)
+        let disallowedInName = disallowedInField.union(CharacterSet(charactersIn: "="))
+        guard p.value.rangeOfCharacter(from: disallowedInField) == nil,
+              p.path.rangeOfCharacter(from: disallowedInField) == nil,
+              p.name.rangeOfCharacter(from: disallowedInName) == nil else { return nil }
         let scheme = p.isSecure ? "https" : "http"
         let host = p.domain.hasPrefix(".") ? String(p.domain.dropFirst()) : p.domain
         guard let url = URL(string: "\(scheme)://\(host)/") else { return nil }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -12259,8 +12259,12 @@ enum BrowserDataImporter {
     // represented unambiguously in a header (so the caller keeps the exact value via
     // the properties path instead).
     private static func httpOnlyCookieViaHeader(_ p: SafariBinaryCookiesParser.ParsedCookie) -> HTTPCookie? {
+        // Any ";"/"," in a field would be misparsed as an attribute/cookie boundary
+        // by the Set-Cookie parser, and "=" in the name would corrupt the name=value
+        // split. Bail to the caller's properties path for those (rare) cookies.
         guard !p.value.contains(";"), !p.value.contains(","),
-              !p.name.contains(";"), !p.name.contains("=") else { return nil }
+              !p.name.contains(";"), !p.name.contains(","), !p.name.contains("="),
+              !p.path.contains(";"), !p.path.contains(",") else { return nil }
         let scheme = p.isSecure ? "https" : "http"
         let host = p.domain.hasPrefix(".") ? String(p.domain.dropFirst()) : p.domain
         guard let url = URL(string: "\(scheme)://\(host)/") else { return nil }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -11626,15 +11626,11 @@ enum BrowserDataImporter {
             )
         case .webkit:
             if browser.descriptor.id == "safari" {
-                return CookieImportResult(
-                    importedCount: 0,
-                    skippedCount: 0,
-                    warnings: [
-                        String(
-                            localized: "browser.import.warning.safariCookiesUnsupported",
-                            defaultValue: "Safari cookies are stored in Cookies.binarycookies and are not yet supported by this importer."
-                        )
-                    ]
+                return await importSafariCookies(
+                    from: browser,
+                    sourceProfiles: sourceProfiles,
+                    destinationProfileID: destinationProfileID,
+                    domainFilters: domainFilters
                 )
             }
             return CookieImportResult(
@@ -11836,6 +11832,98 @@ enum BrowserDataImporter {
         }
         let skippedCount = max(0, dedupedCookies.count - importedCount) + skippedEncryptedCookies
         return CookieImportResult(importedCount: importedCount, skippedCount: skippedCount, warnings: warnings)
+    }
+
+    private static func importSafariCookies(
+        from browser: InstalledBrowserCandidate,
+        sourceProfiles: [InstalledBrowserProfile],
+        destinationProfileID: UUID,
+        domainFilters: [String]
+    ) async -> CookieImportResult {
+        let fileManager = FileManager.default
+        var cookies: [HTTPCookie] = []
+        var warnings: [String] = []
+
+        // Profile roots may contain Cookies.binarycookies for non-default profiles.
+        var candidateURLs = sourceProfiles.map {
+            $0.rootURL.appendingPathComponent("Cookies.binarycookies", isDirectory: false)
+        }
+        // Modern sandboxed Safari stores its primary cookies file inside its container:
+        // ~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies
+        candidateURLs.append(
+            browser.homeDirectoryURL
+                .appendingPathComponent(
+                    "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
+                    isDirectory: false
+                )
+        )
+        // Legacy (pre-sandbox) location, kept as a fallback.
+        candidateURLs.append(
+            browser.homeDirectoryURL
+                .appendingPathComponent("Library/Cookies/Cookies.binarycookies", isDirectory: false)
+        )
+
+        let uniqueURLs = dedupedCanonicalURLs(candidateURLs).filter { fileManager.fileExists(atPath: $0.path) }
+
+        if uniqueURLs.isEmpty {
+            return CookieImportResult(
+                importedCount: 0,
+                skippedCount: 0,
+                warnings: [
+                    String(
+                        format: String(
+                            localized: "browser.import.warning.noCookiesFile",
+                            defaultValue: "No cookies file found for %@."
+                        ),
+                        browser.displayName
+                    )
+                ]
+            )
+        }
+
+        for cookieFileURL in uniqueURLs {
+            do {
+                let parsed = try SafariBinaryCookiesParser.parse(fileURL: cookieFileURL)
+                for p in parsed {
+                    guard !p.name.isEmpty else { continue }
+                    // Reject syntactically invalid hosts from the untrusted file so a
+                    // planted cookie can't be injected for an arbitrary/garbage domain,
+                    // independent of whether a domain filter narrows the import further.
+                    guard isPlausibleCookieHost(p.domain) else { continue }
+                    guard domainMatches(host: p.domain, filters: domainFilters) else { continue }
+                    var properties: [HTTPCookiePropertyKey: Any] = [
+                        .domain: p.domain,
+                        .path: p.path.isEmpty ? "/" : p.path,
+                        .name: p.name,
+                        .value: p.value,
+                    ]
+                    if p.isSecure { properties[.secure] = "TRUE" }
+                    if let exp = p.expiresDate { properties[.expires] = exp }
+                    if let cookie = HTTPCookie(properties: properties) {
+                        cookies.append(cookie)
+                    }
+                }
+            } catch {
+                warnings.append(
+                    String(
+                        format: String(
+                            localized: "browser.import.warning.safariCookiesReadFailed",
+                            defaultValue: "Failed reading Safari cookies at %@: %@"
+                        ),
+                        cookieFileURL.lastPathComponent,
+                        error.localizedDescription
+                    )
+                )
+            }
+        }
+
+        let dedupedCookies = dedupeCookies(cookies)
+        let importedCount = await setCookiesInStore(dedupedCookies, destinationProfileID: destinationProfileID)
+        return CookieImportResult(
+            importedCount: importedCount,
+            skippedCount: max(0, dedupedCookies.count - importedCount),
+            warnings: warnings
+        )
     }
 
     private static func importFirefoxHistory(
@@ -12115,6 +12203,22 @@ enum BrowserDataImporter {
             if normalizedHost.hasSuffix(".\(filter)") { return true }
         }
         return false
+    }
+
+    // Basic hostname sanity check for cookie domains read from an untrusted file.
+    // Accepts a leading "." (cookie domain attribute). Rejects empty hosts, hosts
+    // with whitespace/control characters, and bare single-label names with no dot
+    // (e.g. "localhost" is allowed; "garbage value" or "" is not).
+    private static func isPlausibleCookieHost(_ rawHost: String) -> Bool {
+        var host = rawHost
+        while host.hasPrefix(".") { host.removeFirst() }
+        guard !host.isEmpty, host.count <= 253 else { return false }
+        guard host.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return false }
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._")
+        guard host.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return false }
+        // No empty labels (rejects "..", leading/trailing/double dots).
+        let labels = host.split(separator: ".", omittingEmptySubsequences: false)
+        return labels.allSatisfy { !$0.isEmpty }
     }
 
     private static func chromiumDate(fromWebKitMicroseconds rawValue: Int64) -> Date? {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -11844,24 +11844,29 @@ enum BrowserDataImporter {
         var cookies: [HTTPCookie] = []
         var warnings: [String] = []
 
-        // Profile roots may contain Cookies.binarycookies for non-default profiles.
+        // Per-profile cookie jars live next to each (non-default) profile root.
         var candidateURLs = sourceProfiles.map {
             $0.rootURL.appendingPathComponent("Cookies.binarycookies", isDirectory: false)
         }
-        // Modern sandboxed Safari stores its primary cookies file inside its container:
-        // ~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies
-        candidateURLs.append(
-            browser.homeDirectoryURL
-                .appendingPathComponent(
-                    "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
-                    isDirectory: false
-                )
-        )
-        // Legacy (pre-sandbox) location, kept as a fallback.
-        candidateURLs.append(
-            browser.homeDirectoryURL
-                .appendingPathComponent("Library/Cookies/Cookies.binarycookies", isDirectory: false)
-        )
+        // The global Safari cookie jar belongs to the default profile, so only add it
+        // when the default profile is part of this import. Otherwise importing a
+        // non-default profile would also pull in the default jar and cross-contaminate.
+        if sourceProfiles.contains(where: \.isDefault) {
+            // Modern sandboxed Safari stores its primary cookies file inside its container:
+            // ~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies
+            candidateURLs.append(
+                browser.homeDirectoryURL
+                    .appendingPathComponent(
+                        "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
+                        isDirectory: false
+                    )
+            )
+            // Legacy (pre-sandbox) location, kept as a fallback.
+            candidateURLs.append(
+                browser.homeDirectoryURL
+                    .appendingPathComponent("Library/Cookies/Cookies.binarycookies", isDirectory: false)
+            )
+        }
 
         let uniqueURLs = dedupedCanonicalURLs(candidateURLs).filter { fileManager.fileExists(atPath: $0.path) }
 
@@ -11885,21 +11890,12 @@ enum BrowserDataImporter {
             do {
                 let parsed = try SafariBinaryCookiesParser.parse(fileURL: cookieFileURL)
                 for p in parsed {
-                    guard !p.name.isEmpty else { continue }
                     // Reject syntactically invalid hosts from the untrusted file so a
                     // planted cookie can't be injected for an arbitrary/garbage domain,
                     // independent of whether a domain filter narrows the import further.
                     guard isPlausibleCookieHost(p.domain) else { continue }
                     guard domainMatches(host: p.domain, filters: domainFilters) else { continue }
-                    var properties: [HTTPCookiePropertyKey: Any] = [
-                        .domain: p.domain,
-                        .path: p.path.isEmpty ? "/" : p.path,
-                        .name: p.name,
-                        .value: p.value,
-                    ]
-                    if p.isSecure { properties[.secure] = "TRUE" }
-                    if let exp = p.expiresDate { properties[.expires] = exp }
-                    if let cookie = HTTPCookie(properties: properties) {
+                    if let cookie = makeSafariHTTPCookie(from: p) {
                         cookies.append(cookie)
                     }
                 }
@@ -12220,6 +12216,69 @@ enum BrowserDataImporter {
         let labels = host.split(separator: ".", omittingEmptySubsequences: false)
         return labels.allSatisfy { !$0.isEmpty }
     }
+
+    // Builds an HTTPCookie from a parsed Safari cookie, preserving the secure and
+    // HttpOnly attributes. Internal (not private) so the mapping — especially the
+    // easy-to-drop HttpOnly flag — can be covered by a regression test. Returns nil
+    // for an empty name (an unusable cookie).
+    static func makeSafariHTTPCookie(from p: SafariBinaryCookiesParser.ParsedCookie) -> HTTPCookie? {
+        guard !p.name.isEmpty else { return nil }
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .domain: p.domain,
+            .path: p.path.isEmpty ? "/" : p.path,
+            .name: p.name,
+            .value: p.value,
+        ]
+        if p.isSecure { properties[.secure] = "TRUE" }
+        if let exp = p.expiresDate { properties[.expires] = exp }
+
+        guard p.isHttpOnly else {
+            return HTTPCookie(properties: properties)
+        }
+
+        // Preserve HttpOnly so an imported cookie stays inaccessible to page
+        // JavaScript, matching how the origin server set it. There is no public
+        // HTTPCookiePropertyKey for HttpOnly: the "HttpOnly" key is honored by
+        // HTTPCookie on current macOS but is undocumented and has varied across
+        // OS versions. Try it first (it preserves arbitrary values exactly), fall
+        // back to the documented Set-Cookie header parser, and only as a last
+        // resort drop the flag rather than dropping the cookie entirely.
+        var httpOnlyProperties = properties
+        httpOnlyProperties[HTTPCookiePropertyKey("HttpOnly")] = "TRUE"
+        if let cookie = HTTPCookie(properties: httpOnlyProperties), cookie.isHTTPOnly {
+            return cookie
+        }
+        if let cookie = httpOnlyCookieViaHeader(p), cookie.isHTTPOnly {
+            return cookie
+        }
+        return HTTPCookie(properties: properties)
+    }
+
+    // Builds an HttpOnly cookie via the documented Set-Cookie header parser, which
+    // honors HttpOnly on every macOS version. Returns nil when the value can't be
+    // represented unambiguously in a header (so the caller keeps the exact value via
+    // the properties path instead).
+    private static func httpOnlyCookieViaHeader(_ p: SafariBinaryCookiesParser.ParsedCookie) -> HTTPCookie? {
+        guard !p.value.contains(";"), !p.value.contains(","),
+              !p.name.contains(";"), !p.name.contains("=") else { return nil }
+        let scheme = p.isSecure ? "https" : "http"
+        let host = p.domain.hasPrefix(".") ? String(p.domain.dropFirst()) : p.domain
+        guard let url = URL(string: "\(scheme)://\(host)/") else { return nil }
+        var header = "\(p.name)=\(p.value); Path=\(p.path.isEmpty ? "/" : p.path); Domain=\(p.domain); HttpOnly"
+        if p.isSecure { header += "; Secure" }
+        if let exp = p.expiresDate { header += "; Expires=\(httpCookieExpiresFormatter.string(from: exp))" }
+        let cookies = HTTPCookie.cookies(withResponseHeaderFields: ["Set-Cookie": header], for: url)
+        guard let cookie = cookies.first, cookie.name == p.name, cookie.value == p.value else { return nil }
+        return cookie
+    }
+
+    private static let httpCookieExpiresFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+        return formatter
+    }()
 
     private static func chromiumDate(fromWebKitMicroseconds rawValue: Int64) -> Date? {
         guard rawValue > 0 else { return nil }

--- a/Sources/Panels/SafariBinaryCookiesParser.swift
+++ b/Sources/Panels/SafariBinaryCookiesParser.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+// Parses Safari's Cookies.binarycookies binary format.
+// Format uses mixed endianness: file header is big-endian, all page and cookie
+// fields are little-endian. Timestamps are LE IEEE-754 doubles in Mac absolute
+// time (seconds since 2001-01-01); add 978_307_200 to convert to Unix epoch.
+enum SafariBinaryCookiesParser {
+    struct ParsedCookie: Sendable {
+        let domain: String
+        let name: String
+        let path: String
+        let value: String
+        let expiresDate: Date?
+        let isSecure: Bool
+        let isHttpOnly: Bool
+    }
+
+    enum ParseError: LocalizedError {
+        case tooShort
+        case invalidMagic
+        case pageOutOfBounds(Int)
+        case cookieOutOfBounds(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .tooShort: return "File is too short to be a valid Cookies.binarycookies file"
+            case .invalidMagic: return "File does not have the expected 'cook' magic header"
+            case .pageOutOfBounds(let i): return "Page \(i) offset is out of file bounds"
+            case .cookieOutOfBounds(let i): return "Cookie \(i) offset is out of page bounds"
+            }
+        }
+    }
+
+    static func parse(fileURL: URL) throws -> [ParsedCookie] {
+        let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        return try parse(data: data)
+    }
+
+    static func parse(data rawData: Data) throws -> [ParsedCookie] {
+        // Normalize to a buffer whose startIndex is 0 so all offset arithmetic
+        // below (including the magic check and readCString bounds) is consistent
+        // even if the caller passes a Data slice.
+        let data = rawData.startIndex == 0 ? rawData : Data(rawData)
+        guard data.count >= 8 else { throw ParseError.tooShort }
+
+        // Magic: "cook" (0x636F6F6B)
+        guard data[0] == 0x63, data[1] == 0x6F, data[2] == 0x6F, data[3] == 0x6B
+        else { throw ParseError.invalidMagic }
+
+        let pageCount = Int(readBEUInt32(data, offset: 4))
+        let pageSizesEnd = 8 + pageCount * 4
+        guard data.count >= pageSizesEnd else { throw ParseError.tooShort }
+
+        var fileOffset = pageSizesEnd
+        var result: [ParsedCookie] = []
+
+        for pageIndex in 0 ..< pageCount {
+            let pageSize = Int(readBEUInt32(data, offset: 8 + pageIndex * 4))
+            guard fileOffset + pageSize <= data.count else {
+                throw ParseError.pageOutOfBounds(pageIndex)
+            }
+            let pageData = data[fileOffset ..< fileOffset + pageSize]
+            let pageCookies = try parsePage(Data(pageData), pageIndex: pageIndex)
+            result.append(contentsOf: pageCookies)
+            fileOffset += pageSize
+        }
+
+        return result
+    }
+
+    // MARK: - Page parsing
+
+    private static func parsePage(_ page: Data, pageIndex: Int) throws -> [ParsedCookie] {
+        // Page header: 4-byte signature, LE UInt32 cookie count, cookie offsets
+        guard page.count >= 8 else { return [] }
+
+        let cookieCount = Int(readLEUInt32(page, offset: 4))
+        guard page.count >= 8 + cookieCount * 4 else { return [] }
+
+        var cookies: [ParsedCookie] = []
+        for i in 0 ..< cookieCount {
+            let cookieOffset = Int(readLEUInt32(page, offset: 8 + i * 4))
+            guard cookieOffset < page.count else {
+                throw ParseError.cookieOutOfBounds(i)
+            }
+            if let cookie = parseCookie(page, at: cookieOffset) {
+                cookies.append(cookie)
+            }
+        }
+        return cookies
+    }
+
+    // MARK: - Cookie record parsing
+
+    private static func parseCookie(_ page: Data, at offset: Int) -> ParsedCookie? {
+        // Fixed 56-byte header (all little-endian)
+        guard offset + 56 <= page.count else { return nil }
+
+        let cookieSize = Int(readLEUInt32(page, offset: offset + 0))
+        guard cookieSize > 56, offset + cookieSize <= page.count else { return nil }
+
+        let flags = readLEUInt32(page, offset: offset + 8)
+        let domainOff = Int(readLEUInt32(page, offset: offset + 16))
+        let nameOff   = Int(readLEUInt32(page, offset: offset + 20))
+        let pathOff   = Int(readLEUInt32(page, offset: offset + 24))
+        let valueOff  = Int(readLEUInt32(page, offset: offset + 28))
+
+        let expiryMac  = readLEDouble(page, offset: offset + 40)
+        // Skip creation at offset+48; not needed for HTTPCookie
+
+        let domain = readCString(page, from: offset + domainOff, to: offset + nameOff)
+        let name   = readCString(page, from: offset + nameOff,   to: offset + pathOff)
+        let path   = readCString(page, from: offset + pathOff,   to: offset + valueOff)
+        let value  = readCString(page, from: offset + valueOff,  to: offset + cookieSize)
+
+        let expiresDate: Date? = (expiryMac.isFinite && expiryMac > 0)
+            ? Date(timeIntervalSince1970: expiryMac + 978_307_200)
+            : nil
+
+        return ParsedCookie(
+            domain: domain,
+            name: name,
+            path: path,
+            value: value,
+            expiresDate: expiresDate,
+            isSecure: (flags & 0x01) != 0,
+            isHttpOnly: (flags & 0x04) != 0
+        )
+    }
+
+    // MARK: - Binary reading helpers
+
+    private static func readBEUInt32(_ data: Data, offset: Int) -> UInt32 {
+        let b0 = UInt32(data[data.startIndex + offset])
+        let b1 = UInt32(data[data.startIndex + offset + 1])
+        let b2 = UInt32(data[data.startIndex + offset + 2])
+        let b3 = UInt32(data[data.startIndex + offset + 3])
+        return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3
+    }
+
+    private static func readLEUInt32(_ data: Data, offset: Int) -> UInt32 {
+        let b0 = UInt32(data[data.startIndex + offset])
+        let b1 = UInt32(data[data.startIndex + offset + 1])
+        let b2 = UInt32(data[data.startIndex + offset + 2])
+        let b3 = UInt32(data[data.startIndex + offset + 3])
+        return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+    }
+
+    private static func readLEDouble(_ data: Data, offset: Int) -> Double {
+        var bits: UInt64 = 0
+        for i in 0 ..< 8 {
+            bits |= UInt64(data[data.startIndex + offset + i]) << (i * 8)
+        }
+        return Double(bitPattern: bits)
+    }
+
+    // Reads a null-terminated string in [from, to); strips the null terminator.
+    private static func readCString(_ data: Data, from: Int, to: Int) -> String {
+        guard from >= 0, to > from, to <= data.startIndex + data.count else { return "" }
+        let start = data.startIndex + from
+        let end   = data.startIndex + to
+        // Find null terminator within range
+        var len = 0
+        while start + len < end, data[start + len] != 0 { len += 1 }
+        guard len > 0 else { return "" }
+        return String(data: data[start ..< start + len], encoding: .utf8) ?? ""
+    }
+}

--- a/Sources/Panels/SafariBinaryCookiesParser.swift
+++ b/Sources/Panels/SafariBinaryCookiesParser.swift
@@ -21,33 +21,25 @@ enum SafariBinaryCookiesParser {
         case pageOutOfBounds(Int)
         case cookieOutOfBounds(Int)
 
+        // User-facing copy stays product-level and action-oriented. The page/cookie
+        // indices carried by the associated values are diagnostics, not shown to
+        // users; a caller can log them if needed.
         var errorDescription: String? {
             switch self {
             case .tooShort:
                 return String(
                     localized: "safari.cookies.parse.error.tooShort",
-                    defaultValue: "The Safari cookies file is too short or incomplete to read."
+                    defaultValue: "The Safari cookies file appears incomplete. Try re-exporting it from Safari, then import again."
                 )
             case .invalidMagic:
                 return String(
                     localized: "safari.cookies.parse.error.invalidMagic",
-                    defaultValue: "The Safari cookies file is not in the expected format."
+                    defaultValue: "This file isn't a recognizable Safari cookies file."
                 )
-            case .pageOutOfBounds(let i):
+            case .pageOutOfBounds, .cookieOutOfBounds:
                 return String(
-                    format: String(
-                        localized: "safari.cookies.parse.error.pageOutOfBounds",
-                        defaultValue: "The Safari cookies file is corrupted (page %d is out of bounds)."
-                    ),
-                    i
-                )
-            case .cookieOutOfBounds(let i):
-                return String(
-                    format: String(
-                        localized: "safari.cookies.parse.error.cookieOutOfBounds",
-                        defaultValue: "The Safari cookies file is corrupted (cookie %d is out of bounds)."
-                    ),
-                    i
+                    localized: "safari.cookies.parse.error.corrupted",
+                    defaultValue: "The Safari cookies file appears to be corrupted. Try re-exporting it from Safari, then import again."
                 )
             }
         }

--- a/Sources/Panels/SafariBinaryCookiesParser.swift
+++ b/Sources/Panels/SafariBinaryCookiesParser.swift
@@ -23,10 +23,32 @@ enum SafariBinaryCookiesParser {
 
         var errorDescription: String? {
             switch self {
-            case .tooShort: return "File is too short to be a valid Cookies.binarycookies file"
-            case .invalidMagic: return "File does not have the expected 'cook' magic header"
-            case .pageOutOfBounds(let i): return "Page \(i) offset is out of file bounds"
-            case .cookieOutOfBounds(let i): return "Cookie \(i) offset is out of page bounds"
+            case .tooShort:
+                return String(
+                    localized: "safari.cookies.parse.error.tooShort",
+                    defaultValue: "The Safari cookies file is too short or incomplete to read."
+                )
+            case .invalidMagic:
+                return String(
+                    localized: "safari.cookies.parse.error.invalidMagic",
+                    defaultValue: "The Safari cookies file is not in the expected format."
+                )
+            case .pageOutOfBounds(let i):
+                return String(
+                    format: String(
+                        localized: "safari.cookies.parse.error.pageOutOfBounds",
+                        defaultValue: "The Safari cookies file is corrupted (page %d is out of bounds)."
+                    ),
+                    i
+                )
+            case .cookieOutOfBounds(let i):
+                return String(
+                    format: String(
+                        localized: "safari.cookies.parse.error.cookieOutOfBounds",
+                        defaultValue: "The Safari cookies file is corrupted (cookie %d is out of bounds)."
+                    ),
+                    i
+                )
             }
         }
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		B42450010000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */; };
 		4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */; };
 		FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
+		SC000001SC000001SC000001 /* SafariBinaryCookiesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = SC000002SC000002SC000002 /* SafariBinaryCookiesParser.swift */; };
+		SC000003SC000003SC000003 /* SafariBinaryCookiesParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SC000004SC000004SC000004 /* SafariBinaryCookiesParserTests.swift */; };
 		FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */; };
 		A500MH01 /* BrowserMediaPlaybackMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */; };
 		A500MR01 /* BrowserMediaPlaybackReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MR00 /* BrowserMediaPlaybackReport.swift */; };
@@ -854,6 +856,8 @@
 		B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardPolicy.swift; sourceTree = "<group>"; };
 		19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHistorySuggestionCacheTests.swift; sourceTree = "<group>"; };
 		FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportMappingTests.swift; sourceTree = "<group>"; };
+		SC000002SC000002SC000002 /* SafariBinaryCookiesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SafariBinaryCookiesParser.swift; sourceTree = "<group>"; };
+		SC000004SC000004SC000004 /* SafariBinaryCookiesParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariBinaryCookiesParserTests.swift; sourceTree = "<group>"; };
 		FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportProfilesUITests.swift; sourceTree = "<group>"; };
 		A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserMediaPlaybackMessageHandler.swift; sourceTree = "<group>"; };
 		A500MR00 /* BrowserMediaPlaybackReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserMediaPlaybackReport.swift; sourceTree = "<group>"; };
@@ -1878,6 +1882,7 @@
 				B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				B3770BA00000000000000002 /* BrowserAutomation.swift */,
+				SC000002SC000002SC000002 /* SafariBinaryCookiesParser.swift */,
 				4472B0014472B0014472B001 /* BrowserScreenshot.swift */,
 				4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */,
 				4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */,
@@ -2108,6 +2113,7 @@
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
+				SC000004SC000004SC000004 /* SafariBinaryCookiesParserTests.swift */,
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
 				C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
@@ -2696,6 +2702,7 @@
 				D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,
 				D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */,
 				B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */,
+				SC000001SC000001SC000001 /* SafariBinaryCookiesParser.swift in Sources */,
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
 				A5008373 /* BrowserFindJavaScript.swift in Sources */,
 				B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */,
@@ -3165,6 +3172,7 @@
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 				4E1F28554F1B908F18559390 /* BrowserHistorySuggestionCacheTests.swift in Sources */,
 				FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */,
+				SC000003SC000003SC000003 /* SafariBinaryCookiesParserTests.swift in Sources */,
 				C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,

--- a/cmuxTests/SafariBinaryCookiesParserTests.swift
+++ b/cmuxTests/SafariBinaryCookiesParserTests.swift
@@ -202,6 +202,60 @@ final class SafariBinaryCookiesParserTests: XCTestCase {
         XCTAssertEqual(cookies.count, 0)
     }
 
+    // MARK: - Import mapping (ParsedCookie -> HTTPCookie)
+
+    func testImportPreservesHttpOnly() {
+        let parsed = SafariBinaryCookiesParser.ParsedCookie(
+            domain: "example.com", name: "sid", path: "/", value: "v",
+            expiresDate: nil, isSecure: false, isHttpOnly: true
+        )
+        let cookie = BrowserDataImporter.makeSafariHTTPCookie(from: parsed)
+        XCTAssertNotNil(cookie)
+        XCTAssertTrue(cookie?.isHTTPOnly ?? false, "HttpOnly must survive import into HTTPCookie")
+    }
+
+    func testImportPreservesSecureAndValueAndPersistence() {
+        let parsed = SafariBinaryCookiesParser.ParsedCookie(
+            domain: "example.com", name: "sid", path: "/app", value: "abc=123",
+            expiresDate: Date(timeIntervalSince1970: 1_893_456_000), isSecure: true, isHttpOnly: false
+        )
+        let cookie = BrowserDataImporter.makeSafariHTTPCookie(from: parsed)
+        XCTAssertNotNil(cookie)
+        XCTAssertTrue(cookie?.isSecure ?? false)
+        XCTAssertFalse(cookie?.isHTTPOnly ?? true)
+        XCTAssertEqual(cookie?.name, "sid")
+        XCTAssertEqual(cookie?.value, "abc=123")
+        XCTAssertEqual(cookie?.path, "/app")
+        // Persistent cookie must stay persistent. The exact expiry is intentionally
+        // not asserted: HTTPCookie clamps far-future dates to the platform's max
+        // cookie lifetime (~400 days), which is time- and OS-version-dependent.
+        XCTAssertNotNil(cookie?.expiresDate)
+    }
+
+    func testImportSessionCookieHasNoExpiry() {
+        let parsed = SafariBinaryCookiesParser.ParsedCookie(
+            domain: "example.com", name: "sid", path: "/", value: "v",
+            expiresDate: nil, isSecure: false, isHttpOnly: false
+        )
+        XCTAssertNil(BrowserDataImporter.makeSafariHTTPCookie(from: parsed)?.expiresDate)
+    }
+
+    func testImportEmptyPathDefaultsToRoot() {
+        let parsed = SafariBinaryCookiesParser.ParsedCookie(
+            domain: "example.com", name: "sid", path: "", value: "v",
+            expiresDate: nil, isSecure: false, isHttpOnly: false
+        )
+        XCTAssertEqual(BrowserDataImporter.makeSafariHTTPCookie(from: parsed)?.path, "/")
+    }
+
+    func testImportEmptyNameReturnsNil() {
+        let parsed = SafariBinaryCookiesParser.ParsedCookie(
+            domain: "example.com", name: "", path: "/", value: "v",
+            expiresDate: nil, isSecure: false, isHttpOnly: false
+        )
+        XCTAssertNil(BrowserDataImporter.makeSafariHTTPCookie(from: parsed))
+    }
+
     // MARK: - Byte helpers
 
     private func leUInt32(_ v: UInt32) -> Data {

--- a/cmuxTests/SafariBinaryCookiesParserTests.swift
+++ b/cmuxTests/SafariBinaryCookiesParserTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SafariBinaryCookiesParserTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a minimal valid Cookies.binarycookies Data with one page and one cookie.
+    private func makeSingleCookieData(
+        domain: String = "example.com",
+        name: String = "session",
+        path: String = "/",
+        value: String = "abc123",
+        flags: UInt32 = 0x00,
+        expiryMacTime: Double = 0
+    ) -> Data {
+        // Strings (null-terminated)
+        let domainBytes = domain.utf8 + [0]
+        let nameBytes   = name.utf8   + [0]
+        let pathBytes   = path.utf8   + [0]
+        let valueBytes  = value.utf8  + [0]
+
+        // Cookie record offsets (relative to cookie start, fixed header = 56 bytes)
+        let domainOff = UInt32(56)
+        let nameOff   = domainOff + UInt32(domainBytes.count)
+        let pathOff   = nameOff   + UInt32(nameBytes.count)
+        let valueOff  = pathOff   + UInt32(pathBytes.count)
+        let cookieSize = Int(valueOff) + valueBytes.count
+
+        var cookie = Data()
+        cookie += leUInt32(UInt32(cookieSize))  // offset  0: size
+        cookie += leUInt32(0)                    // offset  4: unknown
+        cookie += leUInt32(flags)               // offset  8: flags
+        cookie += leUInt32(0)                    // offset 12: unknown
+        cookie += leUInt32(domainOff)           // offset 16: domain offset
+        cookie += leUInt32(nameOff)             // offset 20: name offset
+        cookie += leUInt32(pathOff)             // offset 24: path offset
+        cookie += leUInt32(valueOff)            // offset 28: value offset
+        cookie += leUInt64(0)                   // offset 32: unknown (8 bytes)
+        cookie += leDouble(expiryMacTime)       // offset 40: expiry
+        cookie += leDouble(0)                   // offset 48: creation
+        // Strings
+        cookie += Data(domainBytes)
+        cookie += Data(nameBytes)
+        cookie += Data(pathBytes)
+        cookie += Data(valueBytes)
+
+        // Page: 4-byte signature + 4-byte count + (4 * M)-byte offset array + 4-byte footer + cookies
+        // For M=1: header is 16 bytes, so first cookie is at page offset 16.
+        var page = Data()
+        page += Data([0x00, 0x01, 0x00, 0x00])  // page signature (bytes 0-3)
+        page += leUInt32(1)                       // 1 cookie (bytes 4-7)
+        page += leUInt32(16)                      // cookie offset = 16 (bytes 8-11)
+        page += leUInt32(0)                       // page footer (bytes 12-15)
+        page += cookie                            // cookie data starts at byte 16
+
+        let pageSize = UInt32(page.count)
+
+        // File header
+        var file = Data()
+        file += Data([0x63, 0x6F, 0x6F, 0x6B])  // magic "cook"
+        file += beUInt32(1)                        // 1 page
+        file += beUInt32(pageSize)                 // page size
+        file += page
+
+        // Footer (8-byte checksum placeholder)
+        file += Data(count: 8)
+        return file
+    }
+
+    // MARK: - Tests
+
+    func testParsesBasicCookieFields() throws {
+        let data = makeSingleCookieData(domain: "example.com", name: "token", path: "/app", value: "xyz")
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].domain, "example.com")
+        XCTAssertEqual(cookies[0].name, "token")
+        XCTAssertEqual(cookies[0].path, "/app")
+        XCTAssertEqual(cookies[0].value, "xyz")
+    }
+
+    func testSecureFlag() throws {
+        let data = makeSingleCookieData(flags: 0x01)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertTrue(cookies[0].isSecure)
+        XCTAssertFalse(cookies[0].isHttpOnly)
+    }
+
+    func testHttpOnlyFlag() throws {
+        let data = makeSingleCookieData(flags: 0x04)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertFalse(cookies[0].isSecure)
+        XCTAssertTrue(cookies[0].isHttpOnly)
+    }
+
+    func testBothFlags() throws {
+        let data = makeSingleCookieData(flags: 0x05)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertTrue(cookies[0].isSecure)
+        XCTAssertTrue(cookies[0].isHttpOnly)
+    }
+
+    func testNoFlags() throws {
+        let data = makeSingleCookieData(flags: 0x00)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertFalse(cookies[0].isSecure)
+        XCTAssertFalse(cookies[0].isHttpOnly)
+    }
+
+    func testExpiryConversionFromMacAbsoluteTime() throws {
+        // Mac absolute time 1.0 = 2001-01-01 00:00:01 UTC = Unix 978307201
+        let macTime: Double = 1.0
+        let data = makeSingleCookieData(expiryMacTime: macTime)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        let expectedUnix: TimeInterval = 978_307_201
+        XCTAssertEqual(cookies[0].expiresDate?.timeIntervalSince1970 ?? 0, expectedUnix, accuracy: 1.0)
+    }
+
+    func testZeroMacTimeMeansSessionCookie() throws {
+        // Mac absolute time 0.0 means "session cookie" (no expiry) in the binary format
+        let data = makeSingleCookieData(expiryMacTime: 0.0)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertNil(cookies[0].expiresDate, "0.0 mac time = session cookie = nil expiry")
+    }
+
+    func testExpiryConversionKnownDate() throws {
+        // 2030-01-01 00:00:00 UTC = Unix 1893456000
+        // Mac absolute = 1893456000 - 978307200 = 915148800
+        let macTime: Double = 915_148_800
+        let data = makeSingleCookieData(expiryMacTime: macTime)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].expiresDate?.timeIntervalSince1970 ?? 0, 1_893_456_000, accuracy: 1.0)
+    }
+
+    func testZeroExpiryYieldsNilDate() throws {
+        // expiryMacTime <= 0 should produce nil expiresDate
+        let data = makeSingleCookieData(expiryMacTime: -1)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertNil(cookies[0].expiresDate)
+    }
+
+    func testNonFiniteExpiryYieldsNilDate() throws {
+        // A malformed file with a non-finite (infinity) expiry must not produce a Date.
+        let data = makeSingleCookieData(expiryMacTime: .infinity)
+        let cookies = try SafariBinaryCookiesParser.parse(data: data)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertNil(cookies[0].expiresDate)
+    }
+
+    func testParsesDataSliceWithNonZeroStartIndex() throws {
+        // Callers may pass a Data slice (startIndex != 0); parsing must still work.
+        let base = makeSingleCookieData(domain: "example.com", name: "token", value: "xyz")
+        var padded = Data([0xAA, 0xBB, 0xCC])
+        padded.append(base)
+        let slice = padded[3...]
+        XCTAssertNotEqual(slice.startIndex, 0)
+        let cookies = try SafariBinaryCookiesParser.parse(data: slice)
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].name, "token")
+    }
+
+    func testInvalidMagicThrows() {
+        var data = makeSingleCookieData()
+        data[0] = 0xFF
+        XCTAssertThrowsError(try SafariBinaryCookiesParser.parse(data: data)) { error in
+            XCTAssertTrue(error is SafariBinaryCookiesParser.ParseError)
+        }
+    }
+
+    func testEmptyDataThrows() {
+        XCTAssertThrowsError(try SafariBinaryCookiesParser.parse(data: Data())) { error in
+            XCTAssertTrue(error is SafariBinaryCookiesParser.ParseError)
+        }
+    }
+
+    func testTruncatedDataThrows() {
+        let data = Data([0x63, 0x6F, 0x6F, 0x6B, 0x00])  // magic + partial page count
+        XCTAssertThrowsError(try SafariBinaryCookiesParser.parse(data: data))
+    }
+
+    func testEmptyPageYieldsNoCookies() throws {
+        // Build a file with 0 pages
+        var file = Data()
+        file += Data([0x63, 0x6F, 0x6F, 0x6B])
+        file += beUInt32(0)  // 0 pages
+        file += Data(count: 8)
+        let cookies = try SafariBinaryCookiesParser.parse(data: file)
+        XCTAssertEqual(cookies.count, 0)
+    }
+
+    // MARK: - Byte helpers
+
+    private func leUInt32(_ v: UInt32) -> Data {
+        Data([UInt8(v & 0xFF), UInt8((v >> 8) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 24) & 0xFF)])
+    }
+
+    private func beUInt32(_ v: UInt32) -> Data {
+        Data([UInt8((v >> 24) & 0xFF), UInt8((v >> 16) & 0xFF), UInt8((v >> 8) & 0xFF), UInt8(v & 0xFF)])
+    }
+
+    private func leUInt64(_ v: UInt64) -> Data {
+        var d = Data(count: 8)
+        for i in 0 ..< 8 { d[i] = UInt8((v >> (i * 8)) & 0xFF) }
+        return d
+    }
+
+    private func leDouble(_ v: Double) -> Data {
+        leUInt64(v.bitPattern)
+    }
+}


### PR DESCRIPTION
Wires the Safari/webkit branch of `BrowserDataImporter` so `cmux browser import --from safari` works like Chrome/Firefox (previously it returned an "unsupported" warning).

## What
- New `SafariBinaryCookiesParser` parses Safari's `Cookies.binarycookies` binary format (mixed-endian, Mac-absolute-time expiries).
- `importSafariCookies` discovers the file from the sandboxed container path (`~/Library/Containers/com.apple.Safari/Data/Library/Cookies`), with the legacy `~/Library/Cookies` path as fallback. No hardcoded per-machine paths — all relative to the home dir.

## Hardening (untrusted file input)
- Reject non-finite expiries and syntactically invalid cookie hosts.
- Normalize `Data` slices before parsing to avoid offset-arithmetic edge cases.

## Tests / i18n
- Unit tests for the parser (fields, flags, expiry conversion, malformed input, slices), wired into the test target.
- en/ja/uk/ko warning strings.

Verified end-to-end against a real Safari profile: 1716 cookies imported into a cmux browser profile produced a live authenticated session.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783552869&installation_id=133855650&pr_number=5667&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5667&signature=5a14d00179ec8af7dfc3e7c8fe497ce61e9e6f3a6cefb8d54c4b057abc8007ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Safari cookie import to `BrowserDataImporter`, so `cmux browser import --from safari` works like Chrome/Firefox. Parses Safari’s `Cookies.binarycookies`, filters by domain, dedupes, preserves HttpOnly/Secure, and shows localized, user-friendly errors.

- **New Features**
  - Added `SafariBinaryCookiesParser` for the mixed-endian format and Mac absolute time conversion.
  - Scoped discovery to per-profile jars; only adds the global container and legacy paths when the default profile is selected.
  - Hardened import: validate hosts and expiries; normalize `Data` slices; preserve HttpOnly/Secure with a safe header fallback that now rejects ';', ',', quotes, and control chars; localized parse/read errors and warnings (en/ja/uk/ko). Added parser and import‑mapping tests.

<sup>Written for commit 28e3eae878b23e0c91d3b32bda4990befbbc9b41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safari cookie import: import cookies from Safari profiles and legacy locations into the app, with domain filtering, deduplication, safer domain validation, and improved preservation of Secure/HttpOnly and expiry semantics.
  * Localized warnings/messages (en/ja/uk/ko) for missing cookie files and specific Safari cookie parse/read errors.

* **Tests**
  * Added unit tests covering Safari binary cookie parsing, mapping to app cookies, edge cases, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->