### PR TITLE
Fix UI freeze when closing tabs (synchronous agent-index load on main)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1245,6 +1245,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         StartupBreadcrumbLog.append("appDelegate.didFinish.activationPolicy.synced")
 
+        // Prewarm the shared restorable-agent index off the main thread so the first
+        // tab/workspace/window close after launch reads a warm cache instead of paying a
+        // synchronous RestorableAgentSessionIndex.load() on the main thread. See
+        // closedPanelHistoryEntry.
+        if !isRunningUnderXCTest {
+            SharedLiveAgentIndex.shared.scheduleRefreshIfStale()
+        }
+
         claimAuthCallbackURLSchemes()
         StartupBreadcrumbLog.append("appDelegate.didFinish.authSchemes.claimed")
 
@@ -15924,10 +15932,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               !isApplyingSessionRestore else {
             return
         }
+        // Closing the last tab closes the window, recording undo history. Prefer the warm
+        // cached agent index over a synchronous `RestorableAgentSessionIndex.load()` so the
+        // close does not freeze the main thread; fall back to a fresh load only while the
+        // cache has not loaded yet (see closedPanelHistoryEntry).
         let snapshot = sessionWindowSnapshot(
             for: context,
             includeScrollback: true,
-            restorableAgentIndex: RestorableAgentSessionIndex.load()
+            restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+                ?? RestorableAgentSessionIndex.load()
         )
         guard !snapshot.tabManager.workspaces.isEmpty else {
             return

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -923,6 +923,13 @@ struct RestorableAgentSessionIndex: Sendable {
         !processIDs(workspaceId: workspaceId, panelId: panelId).isEmpty
     }
 
+    // WARNING: Expensive. This reads every agent kind's hook-store file from disk,
+    // resolves transcripts, and runs sysctl(KERN_PROCARGS2) per recorded session for
+    // live-PID filtering (measured 350ms-1.8s on machines with large agent history).
+    // NEVER call it synchronously on the main actor or in interactive paths (workspace/
+    // panel/window close, SwiftUI body, didSet, menu evaluation, socket handlers). Read
+    // the off-main, cached `SharedLiveAgentIndex.shared` instead. The only sanctioned
+    // synchronous callers are cold-cache fallbacks guarded by a nil cache check.
     static func load(
         homeDirectory: String = NSHomeDirectory(),
         fileManager: FileManager = .default

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5270,9 +5270,14 @@ class TabManager: ObservableObject {
         if recordHistory,
            workspace.isRestorableInSessionSnapshot,
            let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
+            // Prefer the warm cached agent index over a synchronous
+            // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
+            // workspace does not freeze the main thread; fall back to a fresh load only
+            // while the cache has not loaded yet. See closedPanelHistoryEntry.
             let snapshot = workspace.sessionSnapshot(
                 includeScrollback: true,
-                restorableAgentIndex: RestorableAgentSessionIndex.load()
+                restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+                    ?? RestorableAgentSessionIndex.load()
             )
             ClosedItemHistoryStore.shared.push(.workspace(ClosedWorkspaceHistoryEntry(
                 workspaceId: workspace.id,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -761,11 +761,22 @@ extension Workspace {
                 anchorPanelId: fallbackAnchorPanelId
             )
         }
-        let restorableAgentIndex = RestorableAgentSessionIndex.load()
+        // Prefer the warm cached agent index over a synchronous
+        // `RestorableAgentSessionIndex.load()` (sysctl-per-record + disk, ~350ms-1.8s on
+        // machines with large agent history) so closing a tab does not freeze the main
+        // thread. Fall back to a fresh load only when the cache has not loaded yet (the
+        // brief window after launch before the first refresh completes; the cache is
+        // prewarmed at launch so this is rare). A cached entry at most one refresh stale
+        // is acceptable here because restore prefers the always-fresh in-memory
+        // resumeBinding and only consults this agent snapshot when no binding exists, so
+        // cmux-launched agents reopen correctly regardless of cache freshness.
+        let agentIndex = SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+            ?? RestorableAgentSessionIndex.load()
+        let restorableAgent = agentIndex.snapshot(workspaceId: id, panelId: panelId)
         guard let snapshot = sessionPanelSnapshot(
             panelId: panelId,
             includeScrollback: true,
-            restorableAgent: restorableAgentIndex.snapshot(workspaceId: id, panelId: panelId),
+            restorableAgent: restorableAgent,
             resumeBinding: effectiveSurfaceResumeBinding(
                 panelId: panelId,
                 surfaceResumeBindingIndex: nil
@@ -10322,6 +10333,18 @@ final class SharedLiveAgentIndex: ObservableObject {
     func snapshot(workspaceId: UUID, panelId: UUID) -> SessionRestorableAgentSnapshot? {
         scheduleRefreshIfStale()
         return index?.snapshot(workspaceId: workspaceId, panelId: panelId)
+    }
+
+    /// Current cached index, scheduling a background refresh if stale. Never blocks.
+    /// Used by the workspace-close undo snapshot so closing a tab does not pay the
+    /// synchronous `RestorableAgentSessionIndex.load()` cost (sysctl-per-record live-PID
+    /// probe + hook-store/transcript disk reads) on the main thread. The sidebar keeps
+    /// this warm while the app is open; stale tolerance is fine here because the
+    /// restore/resume path re-reads transcripts from disk and only uses the cached
+    /// snapshot's session identity, not the live PID set.
+    func currentIndexSchedulingRefresh() -> RestorableAgentSessionIndex? {
+        scheduleRefreshIfStale()
+        return index
     }
 
     func scheduleRefreshIfStale() {


### PR DESCRIPTION
## Problem

Closing a tab froze the UI for ~0.35-1.8s in recent nightlies. `TabManager.closeWorkspace`, `Workspace.closedPanelHistoryEntry` (in-pane tab close), and `AppDelegate.recordClosedWindowHistoryIfNeeded` (window close) each called `RestorableAgentSessionIndex.load()` **synchronously on the `@MainActor`** to record the undo-close snapshot.

`load()` reads every agent kind's hook-store file off disk, resolves transcripts, and runs `sysctl(KERN_PROCARGS2)` **per recorded agent session** for live-PID filtering. Its cost scales with total agent-session history (not tab count). The codebase already documents it as "too expensive to do synchronously" and built `SharedLiveAgentIndex` (off-main, cached) to avoid it, but the close paths bypassed the cache. This was introduced with the undo-close feature (~v0.64.12).

## Fix

Route the three close paths through the off-main `SharedLiveAgentIndex` cache, falling back to a fresh `load()` only when the cache has not loaded yet (cold), and prewarm the cache at launch.

Measured on a tagged DEBUG build (probe around each close segment):

| path | before | after |
|---|---|---|
| sidebar workspace close | 393 ms | 1.4 ms |
| in-pane tab close (`closedPanelHistoryEntry`) | 346 ms main freeze | ~0 main-thread load |

A `// WARNING:` comment on `load()` documents that it must never be called synchronously on the main actor.

## Known residual (tracked follow-up)

When the cache is stale, undo-reopening (`Cmd-Shift-T`) an agent tab whose agent **identity changed** since the last cache refresh can restore the previous conversation. This is **not data loss**, and cmux-launched agents are unaffected because restore prefers the always-fresh in-memory `resumeBinding`; the gap is binding-less process-detected agents. Accepted consciously to ship the freeze fix that affects every close for every user.

Follow-up: make `SharedLiveAgentIndex` event-driven (file-watch the hook stores) so the cache is always current. That fixes this residual **and** removes the cache's separate background reload churn (it currently reloads ~continuously because its 1s TTL is shorter than the 1.6s load time).

## Tests

No automated regression test: the bug is a main-thread-latency property, not cleanly assertable without a large-corpus perf harness, and an "assert the cache is used" test would only check implementation shape (discouraged by the repo test policy). Prevention is better served by a CI lint + review-bot rules (separate meta PR).

## Dogfood

Confirmed fast by hand on tag `fasttab` (closing in-pane tabs no longer hitches).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes undo-close snapshot data sources (stale-cache edge case for agent undo-restore) but avoids blocking the main thread on every close; cold-cache still falls back to synchronous load.
> 
> **Overview**
> **Eliminates main-thread UI freezes when closing tabs, workspaces, or windows** by stopping synchronous `RestorableAgentSessionIndex.load()` during undo-close snapshot recording.
> 
> **Launch** prewarms `SharedLiveAgentIndex` off the main thread (`scheduleRefreshIfStale()`), so the first close after startup usually hits a warm cache.
> 
> **Close paths** (`TabManager.closeWorkspace`, `Workspace.closedPanelHistoryEntry`, `AppDelegate.recordClosedWindowHistoryIfNeeded`) now use **`SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()`** (new helper that returns the cached index and kicks a background refresh if stale) and only **fall back to synchronous `load()`** when the cache is still nil (cold start).
> 
> A **`// WARNING:`** on `RestorableAgentSessionIndex.load()` documents that it must not run on the main actor in interactive paths; callers should use the shared cache instead.
> 
> **Trade-off:** undo-restore can briefly use a slightly stale agent identity when the cache is behind; cmux-launched agents are largely unaffected because restore prefers in-memory `resumeBinding`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c68dc3e75eae1036ae497877e6d35baad15297e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783556571&installation_id=133855650&pr_number=5669&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5669&signature=330cb30fd25ffdab4063a06963709a30183a180ddce3da5323a3151282a7425b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the UI freeze when closing tabs, workspaces, or windows by using an off-main cached agent index and prewarming it at launch. Tab/workspace close no longer blocks the main thread (e.g., 393ms -> 1.4ms; ~346ms freeze -> ~0 main-thread load).

- **Bug Fixes**
  - Route all close paths to `SharedLiveAgentIndex` instead of sync `RestorableAgentSessionIndex.load()` on `@MainActor`.
  - Fall back to `load()` only when the cache is not loaded yet.
  - Prewarm the shared index at app launch.
  - Add a WARNING on `RestorableAgentSessionIndex.load()` to prevent main-thread usage.
  - Known residual: with a stale cache, undo-reopen may restore a previous conversation for binding-less, process-detected agents; follow-up will make the cache event-driven.

<sup>Written for commit 8c68dc3e75eae1036ae497877e6d35baad15297e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized app launch speed and session restoration responsiveness by leveraging pre-warmed cached data.
  * Eliminated synchronous disk operations during tab closure and undo workflows, improving application responsiveness.

* **Documentation**
  * Added technical notes clarifying performance characteristics of internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->