### PR TITLE
Fix launch crash on macOS 27 from zero-size SF Symbol rasterization

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14428,9 +14428,18 @@ private struct SidebarHelpMenuButton: View {
             isPopoverPresented.toggle()
         } label: {
             Image(systemName: "questionmark.circle")
+                .resizable()
+                .scaledToFit()
+                .fontWeight(.medium)
                 .symbolRenderingMode(.monochrome)
-                .font(.system(size: iconSize, weight: .medium))
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                // Drive the symbol's raster size from an explicit frame rather
+                // than font metrics. During the window's pre-visible layout pass
+                // the font metrics aren't resolved yet, so a `.font`-sized symbol
+                // rasterizes at 0×0 — which macOS 26+ rejects with an uncaught
+                // `NSInvalidArgumentException` (targetSizeInPoints.width/height>0),
+                // crashing on launch. A fixed frame keeps the raster size positive.
+                .frame(width: iconSize, height: iconSize, alignment: .center)
                 .frame(width: buttonSize, height: buttonSize, alignment: .center)
         }
         .buttonStyle(SidebarFooterIconButtonStyle())

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1069,6 +1069,12 @@ private enum SessionTranscriptLoader {
     private static let maxTurnTextCharacters = 40_000
     private static let newlineByte: UInt8 = 10
 
+    // Wrapping `Data(string.utf8)` in a helper keeps large needle array literals
+    // cheap to type-check. The Xcode 27 / Swift 6.4 expression solver otherwise
+    // times out on the bigger literals below ("unable to type-check this
+    // expression in reasonable time"), which Xcode 26 tolerated.
+    private static func needle(_ string: String) -> Data { Data(string.utf8) }
+
     private static let claudeUserNeedles = [
         Data(#""type":"user""#.utf8),
         Data(#""type": "user""#.utf8),
@@ -1116,30 +1122,30 @@ private enum SessionTranscriptLoader {
         Data(#""type": "developer""#.utf8)
     ]
     private static let grokToolRoleNeedles = [
-        Data(#""role":"tool""#.utf8),
-        Data(#""role": "tool""#.utf8),
-        Data(#""role":"tool_use""#.utf8),
-        Data(#""role": "tool_use""#.utf8),
-        Data(#""role":"tool_result""#.utf8),
-        Data(#""role": "tool_result""#.utf8),
-        Data(#""role":"function_call""#.utf8),
-        Data(#""role": "function_call""#.utf8),
-        Data(#""role":"function_call_output""#.utf8),
-        Data(#""role": "function_call_output""#.utf8),
-        Data(#""type":"tool""#.utf8),
-        Data(#""type": "tool""#.utf8),
-        Data(#""type":"tool_use""#.utf8),
-        Data(#""type": "tool_use""#.utf8),
-        Data(#""type":"tool_result""#.utf8),
-        Data(#""type": "tool_result""#.utf8),
-        Data(#""type":"function_call""#.utf8),
-        Data(#""type": "function_call""#.utf8),
-        Data(#""type":"function_call_output""#.utf8),
-        Data(#""type": "function_call_output""#.utf8)
+        needle(#""role":"tool""#),
+        needle(#""role": "tool""#),
+        needle(#""role":"tool_use""#),
+        needle(#""role": "tool_use""#),
+        needle(#""role":"tool_result""#),
+        needle(#""role": "tool_result""#),
+        needle(#""role":"function_call""#),
+        needle(#""role": "function_call""#),
+        needle(#""role":"function_call_output""#),
+        needle(#""role": "function_call_output""#),
+        needle(#""type":"tool""#),
+        needle(#""type": "tool""#),
+        needle(#""type":"tool_use""#),
+        needle(#""type": "tool_use""#),
+        needle(#""type":"tool_result""#),
+        needle(#""type": "tool_result""#),
+        needle(#""type":"function_call""#),
+        needle(#""type": "function_call""#),
+        needle(#""type":"function_call_output""#),
+        needle(#""type": "function_call_output""#)
     ]
     private static let grokRoleNeedles = [
-        Data(#""role":"#.utf8),
-        Data(#""role": "#.utf8)
+        needle(#""role":"#),
+        needle(#""role": "#)
     ]
         + grokAssistantRoleNeedles
         + grokUserRoleNeedles


### PR DESCRIPTION
## Summary

Fixes the launch crash on **macOS 27.0 (26A5353q)** reported in #5668. cmux crashes immediately on launch, before any window appears, on the new macOS — reproduced on 0.64.5, 0.64.14, and a fresh build of `main`.

## Root cause

The crash is an **uncaught `NSInvalidArgumentException`** that AppKit converts into a hard crash via `+[NSApplication _crashOnException:]` (`EXC_BREAKPOINT`/`SIGTRAP`).

Captured under lldb, the throwing call is CoreUI rasterizing an SF Symbol at **zero size**:

```
<CUINamedVectorGlyph: …> 'questionmark.circle' @2x, 11-points, Medium weight  … Width=0; Height=0
*** Invalid parameter not satisfying: targetSizeInPoints.width>0 && targetSizeInPoints.height>0
objc_exception_throw
  -[NSAssertionHandler handleFailureInMethod:…]
  -[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:forTargetSize:renderingMode:colorResolver:]
  …  RenderBox  RBSymbolUpdateTemplateImage
  …  SwiftUI    _ShapeStyle_RenderedShape.renderVectorGlyph(…)
  …  AppKit     -[NSWindow _setUpFirstResponderBeforeBecomingVisible] → layout
  …  cmux       MainWindowVisibilityController.focus → AppDelegate.createMainWindow
```

The glyph (`questionmark.circle`, 11pt, medium weight) is the sidebar **Help** button in `SidebarHelpMenuButton`, which sizes the symbol with `.font(.system(size: iconSize, weight: .medium))`. During the main window's pre-visible layout pass (`_setUpFirstResponderBeforeBecomingVisible`), font metrics aren't resolved yet, so the symbol's raster target size collapses to `0×0`. macOS 26+ now rejects a zero raster size with the assertion above instead of silently returning nil as earlier versions did — so the app dies on launch.

## Fix

Drive the symbol's raster size from an explicit `.frame` via `.resizable().scaledToFit()` rather than from font metrics, so the size stays positive across every layout pass. Visual output is unchanged (still an 11×11 monochrome `questionmark.circle`).

## Verification

- Built with **Xcode 27 (macOS 27 SDK)** and launched repeatedly on **macOS 27.0 (26A5353q)**: the window now opens and the app stays up; no crash report is generated. Before the fix, the same build crashed within ~1s of launch, every time.

## Note on the second commit (Xcode 27 build enablement)

Building `main` with the Xcode 27 / Swift 6.4 compiler fails before linking: the expression solver times out type-checking the large `[Data(string.utf8)]` literals in `SessionTranscriptLoader` ("unable to type-check this expression in reasonable time"; Xcode 26 tolerated them). The second commit wraps element construction in a tiny `needle(_:)` helper so the literals type-check cheaply. It's a no-op behaviorally and harmless on Xcode 26, but required to build/repro on macOS 27. Happy to split it into its own PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783559981&installation_id=133855650&pr_number=5670&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5670&signature=b4cc020e94ef44ffd2c1ba08912a1cffd355b4b62d6d4e5d4ff59d4b49b79c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash on macOS 27 caused by zero-size SF Symbol rasterization in the sidebar Help button, and unblocks Xcode 27 builds by avoiding a Swift 6.4 type-checker timeout.

- **Bug Fixes**
  - Size the `questionmark.circle` symbol via `.resizable().scaledToFit()` with an explicit `.frame(iconSize)` instead of `.font(...)`, preventing a 0×0 raster during pre-visible layout on macOS 26+.
  - Visual unchanged; app no longer crashes on launch. Fixes #5668.

- **Refactors**
  - Add `needle(_:)` to build `Data` elements in `SessionTranscriptLoader`, avoiding expression-solver timeouts in Xcode 27 / Swift 6.4. No behavior change.

<sup>Written for commit 119f314d1ff63842d750f3227dc7ae66d5eff501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed question-mark icon rendering in popovers that caused crashes on macOS 26+. Icon sizing now uses explicit frame dimensions for reliable display.

* **Refactor**
  * Optimized data construction to reduce Swift compiler type-checking time for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->