### PR TITLE
Review-bot rules: prevent sync expensive-load + cache-substitution regressions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -31,6 +31,12 @@ reviews:
     - path: "**/*.{swift,ts,tsx,js,jsx,mjs,cjs,sh,zsh}"
       instructions: |
         Apply `.github/review-bot-rules/algorithmic-complexity.md` during review. For production code over scalable user data, flag nested full-collection scans, per-target rescans for batch actions, repeated sort/filter/map work in hot paths, in-memory joins that belong in the data store, and unbenchmarked algorithm choices for paths expected to handle roughly 1000 workspaces or similar records. Pass for tiny fixed-size collections, tests and benchmark harnesses, existing inefficient code not worsened, and documented bounds with measurements.
+    - path: "**/*.swift"
+      instructions: |
+        Apply `.github/review-bot-rules/swift-expensive-sync-load.md` during review. Flag heavy synchronous loaders (the canonical case is `RestorableAgentSessionIndex.load()`: per-record `sysctl` plus disk reads, 350ms-1.8s) added to or moved onto the main actor or interactive paths (workspace/panel/tab/window close, SwiftUI body, didSet, menu evaluation, socket handlers). Require routing through the off-main cached accessor `SharedLiveAgentIndex.shared`. Pass for the cache's own background loader and explicit cold-cache fallbacks guarded by a nil check.
+    - path: "**/*.{swift,ts,tsx,js,jsx,mjs,cjs}"
+      instructions: |
+        Apply `.github/review-bot-rules/cache-substitution-correctness.md` during review. When the diff replaces a fresh authoritative read with a cached value in a persistence, history, undo, or snapshot path, require explicit handling of cold (never-loaded) and stale (older-than-source) caches, or a documented graceful-degradation rationale. Pass for transient non-persisted UI hints and documented staleness tolerance.
     - path: "**/*.{swift,ts,tsx,js,jsx,mjs,cjs}"
       instructions: |
         Apply `.github/review-bot-rules/user-facing-errors.md` during review. For production user-facing errors, alerts, command output, API error bodies, and recovery copy, flag implementation leaks such as upstream vendor names, internal provider names, environment variables, database or migration details, raw upstream messages, internal billing ids, or unredacted payloads.
@@ -60,6 +66,14 @@ reviews:
         mode: error
         instructions: |
           For production Swift changes, fail when the diff introduces or materially expands blocking or timing-based synchronization from `.github/review-bot-rules/swift-blocking-runtime.md`: semaphores, blocking waits, sleeps, delayed dispatch, polling, main-queue sync, or manual locks where an actor or explicit signal should own synchronization. Pass for deterministic test-only scaffolding and short user-visible UI animation delays that do not use `Task.sleep`.
+      - name: "cmux expensive synchronous load"
+        mode: error
+        instructions: |
+          For production Swift changes, fail when the diff adds or moves an expensive synchronous loader onto the main actor or an interactive path per `.github/review-bot-rules/swift-expensive-sync-load.md`: the canonical case is `RestorableAgentSessionIndex.load()` (per-record `sysctl` plus disk reads) on workspace/panel/tab/window close, SwiftUI body/didSet, menu or command-palette evaluation, or socket handlers. Require the off-main cached accessor `SharedLiveAgentIndex.shared`. Pass for the cache's own `Task.detached` loader, explicit cold-cache fallbacks guarded by a nil check, and existing call sites not worsened.
+      - name: "cmux cache substitution correctness"
+        mode: error
+        instructions: |
+          For production Swift, TypeScript, and JavaScript changes, fail when the diff swaps a fresh authoritative read for a cached or opportunistic value in a persistence, history, undo, or snapshot path without handling cold (never-loaded) and stale (older-than-source) caches per `.github/review-bot-rules/cache-substitution-correctness.md`. Pass for transient non-persisted UI hints, a cold-cache fallback plus an event-driven or freshness-checked cache, or a documented graceful-degradation rationale at the call site.
       - name: "cmux no hacky sleeps"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -9,6 +9,7 @@ Greptile is configured to publish a GitHub status check and inline findings. Cod
 Current rules:
 
 - `algorithmic-complexity.md`
+- `cache-substitution-correctness.md`
 - `full-internationalization.md`
 - `runtime-no-hacky-sleeps.md`
 - `source-control-artifacts.md`
@@ -18,6 +19,7 @@ Current rules:
 - `swift-blocking-runtime.md`
 - `swift-concurrency-modernization.md`
 - `swift-concurrent-annotation.md`
+- `swift-expensive-sync-load.md`
 - `swift-file-package-boundaries.md`
 - `swift-logging.md`
 - `swiftui-state-layout.md`

--- a/.github/review-bot-rules/cache-substitution-correctness.md
+++ b/.github/review-bot-rules/cache-substitution-correctness.md
@@ -1,0 +1,24 @@
+# Cache Substitution Correctness
+
+Flag replacing a fresh authoritative read with a cached value in correctness-sensitive paths.
+
+Report a failure when the diff swaps a synchronous fresh read of authoritative state (an on-disk index, a database row, a file) for a cached or opportunistic value in a persistence, history, undo, or snapshot path, without handling staleness.
+
+The change must account for both failure modes:
+
+- Cold cache: the cache has never loaded (for example right after launch). Returning nil or empty here can silently drop data the fresh read would have captured.
+- Stale cache: the cache is older than the underlying state. Persisting a stale value can record the wrong identity (for example a previous agent session for a reused panel) that a later read or restore will trust.
+
+Acceptable resolutions:
+
+- A cold-cache fallback to a fresh read, plus an event-driven or freshness-checked cache so the persisted value cannot be arbitrarily stale.
+- A documented graceful-degradation rationale explaining why staleness is harmless for this consumer (for example another always-fresh mechanism takes precedence, or the value is re-resolved downstream from disk).
+
+Allowed cases:
+
+- Caches used only for transient, non-persisted UI hints.
+- Reads where staleness is explicitly tolerated and the reason is documented at the call site.
+
+When reporting, name the authoritative source that was replaced, the persistence/undo consumer that now trusts the cache, and which of cold or stale is unhandled.
+
+Background: substituting an opportunistic cache for a fresh load in the close-history snapshot introduced a stale-undo edge (https://github.com/manaflow-ai/cmux/pull/5669); the durable fix made the cache event-driven so it is always current.

--- a/.github/review-bot-rules/swift-expensive-sync-load.md
+++ b/.github/review-bot-rules/swift-expensive-sync-load.md
@@ -1,0 +1,27 @@
+# Swift Expensive Synchronous Index Loads
+
+Flag heavy synchronous disk/syscall loads on the main actor or in interactive paths.
+
+Report a failure when the diff adds or moves a call to an expensive whole-corpus loader onto a latency-sensitive path in non-test Swift. The canonical case is `RestorableAgentSessionIndex.load()`, which reads every agent kind's hook-store file from disk, resolves transcripts, and runs `sysctl(KERN_PROCARGS2)` per recorded session (measured 350ms-1.8s on machines with large agent history, and it scales with agent history, not tab count). Treat any similarly heavy synchronous loader the same way: full-directory scans, per-record syscalls, or broad JSON decode of unbounded files.
+
+Interactive / main-actor paths where this must not appear:
+
+- workspace / panel / tab / window close and other close-history or session snapshotting
+- SwiftUI `body`, `didSet`, menu or command-palette evaluation, row rendering
+- socket / telemetry command handlers
+- any `@MainActor` function reachable from user input
+
+Required shape:
+
+- Read the off-main, cached accessor instead (in cmux: `SharedLiveAgentIndex.shared`), which loads on a background task and serves a cached result.
+- A synchronous load is allowed only as a cold-cache fallback guarded by a nil-cache check, or inside the cache's own off-main loader. Such call sites should carry a brief justification comment.
+
+Allowed cases:
+
+- The cache's own background loader (`Task.detached`).
+- An explicit cold-cache fallback such as `cache ?? RestorableAgentSessionIndex.load()`.
+- Existing call sites the PR does not introduce or worsen.
+
+When reporting, name the heavy loader, the interactive path it now runs on, and the cached/off-main accessor that should replace it.
+
+Background: this rule exists because a synchronous `RestorableAgentSessionIndex.load()` added to the workspace/tab close paths froze the UI 350ms-1.8s on every close (https://github.com/manaflow-ai/cmux/pull/5669).

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -18,6 +18,8 @@ Review production Swift and runtime changes for:
 - Architectural fixes that patch symptoms while leaving bad state representable.
 - User-facing errors, alerts, command output, API error bodies, and recovery copy that expose implementation details.
 - Algorithmic complexity regressions on scalable user-owned collections.
+- Expensive synchronous index/disk/syscall loads (such as `RestorableAgentSessionIndex.load()`) on the main actor or interactive paths instead of the off-main cached accessor.
+- Substituting a cached value for a fresh authoritative read in persistence/history/undo paths without handling cold and stale caches.
 - Local/generated artifacts, dependency checkouts, caches, logs, screenshots, temp folders, and scratch directories that accidentally enter source control.
 
 ## Runtime No Hacky Sleeps


### PR DESCRIPTION
Codifies the two hazards from the tab-close investigation (https://github.com/manaflow-ai/cmux/pull/5669) into the shared review-bot rules so they are caught at PR time, since LLM review missed the original (it shipped).

New rules in `.github/review-bot-rules/`:
- **swift-expensive-sync-load.md** — heavy synchronous loaders (canonical: `RestorableAgentSessionIndex.load()`, 350ms-1.8s of per-record `sysctl` + disk) on the main actor or interactive paths (close/body/didSet/menu/socket). Require the off-main `SharedLiveAgentIndex.shared` cache. This is the exact class that froze every tab close.
- **cache-substitution-correctness.md** — replacing a fresh authoritative read with a cached value in persistence/history/undo paths without handling cold + stale caches (the residual autoreview flagged on #5669).

Wired into:
- `.greptile/rules.md` (summary bullets; the rule files are the source of truth).
- `.coderabbit.yaml` (two `path_instructions` + two error-mode `pre_merge_checks` so unresolved findings can block merge).
- `.github/review-bot-rules/README.md` (rule list).

Meta-only: no runtime/app behavior changes, so no tagged build or dogfood.

Note: a deterministic CI lint (fail on new `RestorableAgentSessionIndex.load(` outside an allowlist) would be a stronger guard than probabilistic bot review. Deferred pending a decision on lint strictness/false-positive tolerance.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783562198&installation_id=133855650&pr_number=5672&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5672&signature=0ae5e2e934d8eebee0c2484aecf5ca690dfc397018878ce9862a1c87978d481b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-bot configuration only; no production app or runtime code paths change.
> 
> **Overview**
> Adds two shared review-bot rules from the tab-close investigation (#5669) and hooks them into **Greptile**, **CodeRabbit**, and the rules README.
> 
> **`swift-expensive-sync-load.md`** blocks putting heavy synchronous loaders (especially `RestorableAgentSessionIndex.load()`) on the main actor or interactive paths; reviews should push callers toward **`SharedLiveAgentIndex.shared`**, with narrow cold-cache fallback exceptions.
> 
> **`cache-substitution-correctness.md`** blocks swapping fresh authoritative reads for caches in persistence/history/undo/snapshot paths unless **cold** and **stale** cache cases are handled or documented.
> 
> **`.coderabbit.yaml`** gains matching `path_instructions` and **error-mode** `pre_merge_checks` so unresolved findings can block merge. **`.greptile/rules.md`** adds summary bullets. No runtime or app behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6fb561f94c56a21a7d2481def6d95d3978c0c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two review-bot rules to block regressions: prevent expensive synchronous Swift index loads on interactive paths and enforce cache substitution correctness in persistence flows. Integrated into Greptile and CodeRabbit with blocking pre-merge checks; no runtime changes.

- **New Features**
  - `swift-expensive-sync-load.md`: Flags heavy sync loaders (e.g., `RestorableAgentSessionIndex.load()`) on main/interactive paths; requires using the off-main cached accessor `SharedLiveAgentIndex.shared`; allows cache loader and guarded cold-cache fallback.
  - `cache-substitution-correctness.md`: Blocks swapping a fresh authoritative read for a cached value in persistence/history/undo paths without cold and stale handling; allows transient UI hints or documented staleness tolerance.
  - Tooling: Added `path_instructions` and error-mode `pre_merge_checks` in `.coderabbit.yaml`; added summary bullets to `.greptile/rules.md`; listed in `.github/review-bot-rules/README.md`.

<sup>Written for commit 4e6fb561f94c56a21a7d2481def6d95d3978c0c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review guidelines and configurations to enforce performance standards for synchronous operations on interactive execution paths and to ensure cache correctness in persistence workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->