### PR TITLE
Event-driven SharedLiveAgentIndex: kill reload churn + close-undo staleness

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10305,16 +10305,22 @@ struct ClosedBrowserPanelRestoreSnapshot {
     }
 }
 
-/// Process-wide cache of `RestorableAgentSessionIndex.load()` results, used by every
-/// workspace's right-click "Fork Conversation" availability check. The load runs
-/// `sysctl(KERN_PROCARGS2)` per hook record for live-PID filtering, which is too
-/// expensive to do synchronously during SwiftUI menu evaluation, so refreshes run on a
-/// `Task.detached(priority: .utility)` and the cached snapshot is read synchronously
-/// (stale-tolerant: agent `--resume` / `--fork-session` paths read transcripts from disk
-/// and don't care whether the cmux-recorded PID is still alive). `ObservableObject`
-/// conformance lets each workspace forward `objectWillChange` when a refresh lands so
-/// ContentView re-renders and bonsplit's TabBarView picks up the new snapshot on the
-/// same frame.
+/// Process-wide, event-driven cache of `RestorableAgentSessionIndex.load()` results, used
+/// by the right-click "Fork Conversation" availability check and the close-history undo
+/// snapshot. `load()` runs `sysctl(KERN_PROCARGS2)` per hook record plus disk reads
+/// (350ms-1.8s on large agent histories), far too expensive to do synchronously on the
+/// main actor, so reloads run on a `Task.detached(priority: .utility)` and callers read
+/// the cached snapshot synchronously.
+///
+/// Freshness is driven by a watcher on the hook-store directory (`~/.cmuxterm`), which the
+/// `cmux hooks` CLI writes when an agent session starts or updates. The cache reloads
+/// shortly after an actual change (coalesced + rate-limited) and otherwise idles, with a
+/// long fallback TTL for pull access. This replaced a 1s pull TTL that reloaded
+/// near-continuously while the sidebar was visible, because each load outlasts a 1s TTL.
+///
+/// `ObservableObject` conformance lets each workspace forward `objectWillChange` when a
+/// reload lands so ContentView re-renders and bonsplit's TabBarView picks up the new
+/// snapshot on the same frame.
 @MainActor
 final class SharedLiveAgentIndex: ObservableObject {
     static let shared = SharedLiveAgentIndex()
@@ -10322,39 +10328,56 @@ final class SharedLiveAgentIndex: ObservableObject {
     @Published private(set) var index: RestorableAgentSessionIndex?
     private var loadedAt: Date?
     private var refreshTask: Task<Void, Never>?
-    private static let cacheTTL: TimeInterval = 1.0
+    // A hook-store change arrived while a reload was in flight; reload again after.
+    private var changePending = false
+    // Holds a pending rate-limited reload when changes arrive faster than the floor.
+    private var deferredReloadTask: Task<Void, Never>?
+
+    // The directory watcher is the primary freshness mechanism; pull access only needs an
+    // occasional safety refresh.
+    private static let cacheTTL: TimeInterval = 60.0
+    // Floor between event-driven reloads so a chatty agent cannot thrash the ~1.6s loader.
+    private static let minEventReloadInterval: TimeInterval = 2.0
+
+    private var directoryWatchSource: DispatchSourceFileSystemObject?
+    private let watchQueue = DispatchQueue(label: "com.cmuxterm.app.sharedLiveAgentIndexWatch")
 
     private init() {}
 
-    /// Read the cached snapshot for the given (workspaceId, panelId) and kick off a
-    /// background refresh if the cache has aged out. Never blocks; the first call after a
-    /// stale-out returns the previous (possibly nil) value, and the next view re-render
-    /// after the async load completes sees the fresh snapshot.
+    /// Read the cached snapshot for the given (workspaceId, panelId). Never blocks.
     func snapshot(workspaceId: UUID, panelId: UUID) -> SessionRestorableAgentSnapshot? {
         scheduleRefreshIfStale()
         return index?.snapshot(workspaceId: workspaceId, panelId: panelId)
     }
 
-    /// Current cached index, scheduling a background refresh if stale. Never blocks.
-    /// Used by the workspace-close undo snapshot so closing a tab does not pay the
-    /// synchronous `RestorableAgentSessionIndex.load()` cost (sysctl-per-record live-PID
-    /// probe + hook-store/transcript disk reads) on the main thread. The sidebar keeps
-    /// this warm while the app is open; stale tolerance is fine here because the
-    /// restore/resume path re-reads transcripts from disk and only uses the cached
-    /// snapshot's session identity, not the live PID set.
+    /// Current cached index. Never blocks. Used by the close-history undo snapshot so
+    /// closing a tab does not pay the synchronous `RestorableAgentSessionIndex.load()`
+    /// cost on the main thread. The directory watcher keeps this current; stale tolerance
+    /// is fine because restore/resume re-reads transcripts from disk and only uses the
+    /// cached snapshot's session identity, not the live PID set.
     func currentIndexSchedulingRefresh() -> RestorableAgentSessionIndex? {
         scheduleRefreshIfStale()
         return index
     }
 
+    /// Ensure the hook-store watcher is running and refresh if the cache has aged past the
+    /// long fallback TTL. The watcher, not this TTL, is the primary freshness path.
     func scheduleRefreshIfStale() {
-        if refreshTask != nil { return }
-        let now = Date()
-        if let loadedAt, now.timeIntervalSince(loadedAt) < Self.cacheTTL {
+        ensureWatchingHookStoreDirectory()
+        guard refreshTask == nil else { return }
+        if let loadedAt, Date().timeIntervalSince(loadedAt) < Self.cacheTTL {
             return
         }
+        startReload()
+    }
+
+    private func startReload() {
+        deferredReloadTask?.cancel()
+        deferredReloadTask = nil
         refreshTask = Task { @MainActor [weak self] in
             let newIndex = await Task.detached(priority: .utility) {
+                // agent-index-load-ok: off-main cache loader (this IS the sanctioned home
+                // for load(); everything else should read SharedLiveAgentIndex.shared).
                 RestorableAgentSessionIndex.load()
             }.value
             guard let self else { return }
@@ -10363,6 +10386,80 @@ final class SharedLiveAgentIndex: ObservableObject {
             self.index = newIndex
             self.loadedAt = Date()
             self.refreshTask = nil
+            if self.changePending {
+                self.changePending = false
+                self.handleHookStoreChange()
+            }
+        }
+    }
+
+    /// Coalesce and rate-limit reloads triggered by hook-store directory changes.
+    private func handleHookStoreChange() {
+        if refreshTask != nil {
+            changePending = true
+            return
+        }
+        let elapsed = loadedAt.map { Date().timeIntervalSince($0) } ?? .infinity
+        if elapsed >= Self.minEventReloadInterval {
+            startReload()
+        } else if deferredReloadTask == nil {
+            // Bounded, cancellable delay to honor the reload floor (not a sync
+            // substitute): wait the remainder, then re-evaluate.
+            let wait = Self.minEventReloadInterval - elapsed
+            deferredReloadTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .seconds(wait))
+                guard !Task.isCancelled, let self else { return }
+                self.deferredReloadTask = nil
+                self.handleHookStoreChange()
+            }
+        }
+    }
+
+    private func ensureWatchingHookStoreDirectory() {
+        guard directoryWatchSource == nil else { return }
+        let dir = RestorableAgentKind.claude
+            .hookStoreFileURL()
+            .deletingLastPathComponent()
+            .path
+        // Ensure the hook-store directory exists so the watcher installs at launch and
+        // observes the very first hook write. On a fresh/cleaned install it would
+        // otherwise not exist yet, the watcher would not install, and the first agent's
+        // session could stay invisible behind the fallback TTL. This is cmux's own state
+        // directory (the `cmux hooks` CLI writes here too), so creating it empty is benign.
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let fd = open(dir, O_EVTONLY)
+        guard fd >= 0 else {
+            // Directory still unavailable (e.g. permissions); retried on the next
+            // scheduleRefreshIfStale() (sidebar render / close).
+            return
+        }
+        // A directory-level kqueue source reports entry changes (create/delete/rename) but
+        // not in-place data writes to an existing child file. That is sufficient here
+        // because every hook-store write is atomic (write-temp + rename, e.g.
+        // ClaudeHookSessionStore.saveUnlocked uses `.write(options: .atomic)`), so each
+        // update lands as a rename into this directory and fires the source. This matches
+        // cmux's existing CmuxConfig watcher, which relies on the same atomic-write
+        // invariant. The 60s fallback TTL backstops anything a future non-atomic writer
+        // to ~/.cmuxterm might add.
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .link, .rename],
+            queue: watchQueue
+        )
+        source.setEventHandler { [weak self] in
+            Task { @MainActor in self?.handleHookStoreChange() }
+        }
+        source.setCancelHandler { Darwin.close(fd) }
+        source.resume()
+        directoryWatchSource = source
+        // The watcher may have just been installed after `~/.cmuxterm` first appeared
+        // (first run / cleaned state); any hook writes before this moment were unobserved
+        // and an earlier empty load may have stamped a "fresh" loadedAt that would
+        // suppress the fallback-TTL reload. Force a catch-up reload now.
+        if refreshTask == nil {
+            startReload()
+        } else {
+            changePending = true
         }
     }
 }


### PR DESCRIPTION
Fast-follow to https://github.com/manaflow-ai/cmux/pull/5669.

## Problem

`SharedLiveAgentIndex` (the off-main cache the close paths and Fork menu read) used a **1s pull TTL**. Each `RestorableAgentSessionIndex.load()` takes ~1.6s (per-record `sysctl` + disk), so while the sidebar was visible the cache reloaded **near-continuously**, burning a CPU core. The 1s TTL also meant the close-history undo snapshot could read a stale cache (the residual consciously accepted in #5669: undo-reopening an agent tab whose identity changed since the last refresh could restore the previous conversation).

## Fix

Replace the pull TTL with a **watcher on the hook-store directory** (`~/.cmuxterm`, written by the `cmux hooks` CLI when an agent session starts/updates), reusing cmux's existing `DispatchSource` directory-watch pattern. The cache now reloads shortly after an actual change (coalesced + rate-limited to a 2s floor) and otherwise idles, with a long 60s fallback TTL for pull access.

Result: the cache stays current (so close-history records the right agent identity, closing the #5669 undo residual) **without** background churn.

## Verified on a tagged build

- `watch.started` at launch, one initial reload.
- **0 reloads during 12s idle** (was ~1/sec continuous).
- Creating a file in `~/.cmuxterm` → one coalesced, off-main reload.

## Notes

- No new synchronous main-thread `load()`; the reload still runs on `Task.detached`. Close paths keep the #5669 cold-cache fallback.
- Rate-limit deferral uses a bounded, cancellable `Task.sleep` (allowed per the runtime sleep policy: bounded/cancellable/intended, not a sync substitute).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783562377&installation_id=133855650&pr_number=5673&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5673&signature=e17f69292a21d87ea7407d9672433758434c2bcaabde286b13daa629235db1d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-actor cache freshness for Fork Conversation and close-undo agent identity; behavior depends on atomic hook writes and directory watch semantics, with 60s TTL as backstop.
> 
> **Overview**
> **`SharedLiveAgentIndex`** stops polling every second and instead watches the hook-store directory (`~/.cmuxterm`) with a **`DispatchSource`** pattern aligned with **`CmuxConfig`**. Reloads run only after hook-store changes (coalesced, **2s** minimum spacing) or on a **60s** fallback TTL when something reads the cache without a recent event.
> 
> The watcher is installed lazily, creates the directory if missing, and forces a catch-up reload on first attach so early hook writes are not missed. In-flight reloads set **`changePending`**; rapid events defer via a cancellable **`Task.sleep`** before **`handleHookStoreChange`** runs again. Off-main **`RestorableAgentSessionIndex.load()`** is unchanged; **`startReload`** centralizes refresh scheduling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcf18b99e0221b44ee2b24eb703054a69c660fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `SharedLiveAgentIndex` from a 1s polling TTL to an event-driven watcher on `~/.cmuxterm` with coalesced, rate-limited reloads. This removes reload churn, fixes close-undo staleness, and safely handles late-created hook dirs.

- **New Features**
  - Watch `~/.cmuxterm` and trigger coalesced reloads (2s minimum).
  - Keep a 60s fallback TTL; reloads run off-main via `Task.detached`.
  - Lazily install the watcher, create the dir if missing, force a first-attach catch-up; queue a follow-up if a reload is in flight (rate-limit via cancellable `Task.sleep`).

- **Bug Fixes**
  - Eliminates near-continuous reloads while the sidebar is visible.
  - Close-history undo now restores the correct agent identity (resolves the residual from #5669).

<sup>Written for commit cdcf18b99e0221b44ee2b24eb703054a69c660fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced frequent polling and extended fallback cache lifetime to improve responsiveness and lower resource use.
* **Reliability**
  * More reliable change detection with coordinated reloads so pending updates are applied promptly.
* **Stability**
  * Coalesced and rate-limited reloads to prevent rapid repeat reloads and improve overall system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->