### PR TITLE
Retry Ghostty helper artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,11 +728,22 @@ jobs:
           lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
 
       - name: Upload universal Ghostty CLI helper
+        id: upload-ghostty-cli-helper
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cmux-ghostty-cli-helper
           path: ghostty-cli-helper/ghostty
           if-no-files-found: error
+
+      - name: Retry universal Ghostty CLI helper upload
+        if: steps.upload-ghostty-cli-helper.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper/ghostty
+          if-no-files-found: error
+          overwrite: true
 
   release-build:
     needs: release-ghostty-cli-helper

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -123,6 +123,36 @@ check_release_build_signal() {
   echo "PASS: release-build keeps universal artifact verification"
 }
 
+check_release_helper_upload_retry() {
+  if ! awk '
+    /^  release-ghostty-cli-helper:/ { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
+
+    in_job && /- name: Upload universal Ghostty CLI helper/ { in_upload=1; next }
+    in_upload && /^[[:space:]]*- name:/ { in_upload=0 }
+    in_upload && /id:[[:space:]]*upload-ghostty-cli-helper/ { upload_id=1 }
+    in_upload && /continue-on-error:[[:space:]]*true/ { upload_continue=1 }
+    in_upload && /uses: actions\/upload-artifact@/ { upload_action=1 }
+    in_upload && /if-no-files-found:[[:space:]]*error/ { upload_required=1 }
+
+    in_job && /- name: Retry universal Ghostty CLI helper upload/ { in_retry=1; retry_step=1; next }
+    in_retry && /^[[:space:]]*- name:/ { in_retry=0 }
+    in_retry && index($0, "steps.upload-ghostty-cli-helper.outcome == '\''failure'\''") { retry_if=1 }
+    in_retry && /uses: actions\/upload-artifact@/ { retry_action=1 }
+    in_retry && /if-no-files-found:[[:space:]]*error/ { retry_required=1 }
+    in_retry && /overwrite:[[:space:]]*true/ { retry_overwrite=1 }
+
+    END {
+      exit !(upload_id && upload_continue && upload_action && upload_required && retry_step && retry_if && retry_action && retry_required && retry_overwrite)
+    }
+  ' "$CI_FILE"; then
+    echo "FAIL: release-ghostty-cli-helper must retry required Ghostty helper artifact uploads instead of failing on a single transient upload error"
+    exit 1
+  fi
+
+  echo "PASS: release-ghostty-cli-helper retries required Ghostty helper artifact uploads"
+}
+
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
@@ -142,3 +172,4 @@ check_e2e_runner_fallbacks
 
 check_xcode_selection
 check_release_build_signal
+check_release_helper_upload_retry


### PR DESCRIPTION
Summary
- Retry the required Ghostty CLI helper artifact upload if the first upload action fails.
- Keep the artifact required with if-no-files-found: error on both attempts.
- Add a workflow guard so this retry shape stays in place.

Flake evidence
- Failed run: https://github.com/manaflow-ai/cmux/actions/runs/27179522374/job/80235473006
- Signature: helper build produced one upload file, then actions/upload-artifact failed creating the artifact with ENOTFOUND.
- Recent observed helper reliability before this patch: 7 / 8 attempts passed in the sampled CI runs from 2026-06-09T02:03:30Z through 2026-06-09T03:01:56Z.

Verification
- bash tests/test_ci_self_hosted_guard.sh
- git diff --check

Coverage
- No tests, jobs, assertions, artifact requirements, or release-build checks were removed.
- The retry only handles the artifact transport failure. If both upload attempts fail, the job still fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783568570&installation_id=133855650&pr_number=5675&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5675&signature=52f5d6e2d16a9acab8b09f627e6d0a9d850a68dc1dfedf84e31ff7ce1777baa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only resilience for artifact upload; artifact requirements and release-build verification are unchanged, and the job still fails if both uploads fail.
> 
> **Overview**
> Adds a **second-chance upload** for the universal Ghostty CLI helper artifact in the `release-ghostty-cli-helper` CI job when `actions/upload-artifact` fails after a successful build (e.g. transient `ENOTFOUND`).
> 
> The initial upload step now has `id: upload-ghostty-cli-helper` and `continue-on-error: true`, and a follow-up **Retry universal Ghostty CLI helper upload** step runs only when that step’s outcome is `failure`, re-uploading the same path with `if-no-files-found: error` and `overwrite: true`. If both attempts fail, the job still fails.
> 
> `tests/test_ci_self_hosted_guard.sh` gains `check_release_helper_upload_retry()` so `workflow-guard-tests` keeps enforcing this retry shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e379fa47e9aa4aa2e23eb0bcaec327bc63b59b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time retry for the Ghostty CLI helper artifact upload in CI to reduce flaky ENOTFOUND failures. The artifact remains required; the job still fails if both attempts fail.

- **Bug Fixes**
  - In `.github/workflows/ci.yml`, make the first `actions/upload-artifact` step `continue-on-error` and retry once on failure with `overwrite: true` while keeping `if-no-files-found: error`.
  - Add a guard in `tests/test_ci_self_hosted_guard.sh` to enforce this retry shape and required artifact.

<sup>Written for commit e379fa47e9aa4aa2e23eb0bcaec327bc63b59b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release artifact upload reliability with automatic retry logic for transient failures.
  * Updated CI validation checks to verify proper upload retry configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->