### PR TITLE
Add devbox.new creator

### DIFF
--- a/web/app/devbox/devbox-creator.tsx
+++ b/web/app/devbox/devbox-creator.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { FormEvent } from "react";
+
+type CreatedDevbox = {
+  id: string;
+  provider?: string;
+  image?: string;
+  imageVersion?: string;
+  createdAt?: string;
+};
+
+type VmErrorBody = {
+  error?: string;
+  message?: string;
+  action?: string;
+  reason?: string;
+};
+
+function createIdempotencyKey() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function userMessage(status: number, body: VmErrorBody | null) {
+  if (status === 401) {
+    return "Sign in first, then create the devbox again.";
+  }
+
+  const pieces = [body?.message, body?.action ?? body?.reason].filter(
+    Boolean,
+  );
+  return pieces.join(" ") || `Devbox create failed with status ${status}.`;
+}
+
+export function DevboxCreator() {
+  const [prompt, setPrompt] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [created, setCreated] = useState<CreatedDevbox | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (isCreating) return;
+
+    setIsCreating(true);
+    setError(null);
+    setCreated(null);
+
+    try {
+      const response = await fetch("/api/vm", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": createIdempotencyKey(),
+        },
+        body: JSON.stringify({
+          initialPrompt: prompt.trim() || undefined,
+          source: "devbox.new",
+        }),
+      });
+
+      const body = (await response.json().catch(() => null)) as
+        | CreatedDevbox
+        | VmErrorBody
+        | null;
+
+      if (!response.ok) {
+        setError(userMessage(response.status, body as VmErrorBody | null));
+        return;
+      }
+
+      setCreated(body as CreatedDevbox);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Devbox create failed.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-5xl">
+          Create a devbox
+        </h1>
+        <p className="mx-auto mt-4 max-w-xl text-base leading-7 text-muted sm:text-lg">
+          Start a fresh cmux Cloud VM. Add the first prompt now, attach from
+          cmux when it is ready.
+        </p>
+      </div>
+
+      <form onSubmit={submit} className="space-y-4">
+        <label htmlFor="devbox-prompt" className="sr-only">
+          Initial prompt
+        </label>
+        <textarea
+          id="devbox-prompt"
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder="What should this devbox work on?"
+          rows={5}
+          className="min-h-36 w-full resize-y rounded-lg border border-border bg-background px-4 py-3 text-base leading-6 outline-none transition-colors placeholder:text-muted focus:border-foreground"
+        />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href="/handler/sign-in?after_auth_return_to=/devbox"
+            className="text-sm text-muted underline underline-offset-4 transition-colors hover:text-foreground"
+          >
+            Sign in
+          </Link>
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="inline-flex h-11 items-center justify-center rounded-md bg-foreground px-5 text-sm font-medium text-background transition-opacity disabled:cursor-not-allowed disabled:opacity-55"
+          >
+            {isCreating ? "Creating..." : "Create devbox"}
+          </button>
+        </div>
+      </form>
+
+      {error ? (
+        <p
+          role="alert"
+          className="mt-5 rounded-md border border-red-500/35 bg-red-500/10 px-4 py-3 text-sm leading-6 text-foreground"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {created ? (
+        <section className="mt-6 rounded-lg border border-border bg-code-bg p-4">
+          <h2 className="text-sm font-semibold">Devbox created</h2>
+          <dl className="mt-3 grid gap-2 text-sm">
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              <dt className="text-muted">ID</dt>
+              <dd className="font-mono">{created.id}</dd>
+            </div>
+            {created.provider ? (
+              <div className="flex flex-wrap gap-x-3 gap-y-1">
+                <dt className="text-muted">Provider</dt>
+                <dd>{created.provider}</dd>
+              </div>
+            ) : null}
+          </dl>
+          <div className="mt-4 space-y-2">
+            <code className="block overflow-x-auto rounded-md border border-border bg-background px-3 py-2 text-sm">
+              cmux vm attach {created.id}
+            </code>
+            <code className="block overflow-x-auto rounded-md border border-border bg-background px-3 py-2 text-sm">
+              cmux vm ssh {created.id}
+            </code>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/devbox/layout.tsx
+++ b/web/app/devbox/layout.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "../globals.css";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "devbox.new",
+  description: "Create a new cmux devbox from a prompt.",
+  metadataBase: new URL("https://devbox.new"),
+  alternates: {
+    canonical: "https://devbox.new",
+  },
+  openGraph: {
+    title: "devbox.new",
+    description: "Create a new cmux devbox from a prompt.",
+    url: "https://devbox.new",
+    siteName: "devbox.new",
+    type: "website",
+  },
+};
+
+export default function DevboxLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} bg-background font-sans text-foreground antialiased`}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/web/app/devbox/page.tsx
+++ b/web/app/devbox/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { DevboxCreator } from "./devbox-creator";
+
+export default function DevboxPage() {
+  return (
+    <main className="min-h-screen px-5 py-6 sm:px-8">
+      <div className="mx-auto flex min-h-[calc(100vh-3rem)] w-full max-w-3xl flex-col">
+        <header className="flex items-center justify-between gap-4 text-sm">
+          <Link href="/" className="font-semibold tracking-tight">
+            devbox.new
+          </Link>
+          <a
+            href="https://cmux.com"
+            className="text-muted transition-colors hover:text-foreground"
+          >
+            cmux
+          </a>
+        </header>
+
+        <section className="flex flex-1 items-center justify-center py-16">
+          <DevboxCreator />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/web/devbox-routing.ts
+++ b/web/devbox-routing.ts
@@ -1,0 +1,7 @@
+const devboxHosts = new Set(["devbox.new", "www.devbox.new"]);
+
+export function shouldRewriteToDevbox(host: string | null, pathname: string) {
+  const normalizedHost = host?.split(":")[0]?.toLowerCase() ?? "";
+  if (!devboxHosts.has(normalizedHost)) return false;
+  return pathname === "/" || pathname === "/devbox";
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -2,11 +2,18 @@ import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { isAgentPageVariantPath } from "./app/lib/agent-page-paths";
+import { shouldRewriteToDevbox } from "./devbox-routing";
 
 const intlMiddleware = createMiddleware(routing);
 
-export default function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const host = request.headers.get("host") ?? "";
+
+  if (shouldRewriteToDevbox(host, request.nextUrl.pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/devbox";
+    return NextResponse.rewrite(url);
+  }
 
   // 301 redirect cmux.dev (and www.cmux.dev) to cmux.com, preserving path and query
   if (host === "cmux.dev" || host === "www.cmux.dev") {
@@ -18,7 +25,7 @@ export default function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
-  // Temporary redirect: /changelog → /docs/changelog, preserving any locale prefix.
+  // Temporary redirect: /changelog -> /docs/changelog, preserving any locale prefix.
   const changelogMatch = pathname.match(/^(\/[a-z]{2}(?:-[A-Z]{2})?)?\/changelog\/?$/);
   if (changelogMatch) {
     const url = request.nextUrl.clone();

--- a/web/tests/devbox-proxy.test.ts
+++ b/web/tests/devbox-proxy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRewriteToDevbox } from "../devbox-routing";
+
+describe("devbox.new host routing", () => {
+  test("rewrites the devbox.new homepage to the devbox creator", () => {
+    expect(shouldRewriteToDevbox("devbox.new", "/")).toBe(true);
+    expect(shouldRewriteToDevbox("www.devbox.new", "/")).toBe(true);
+    expect(shouldRewriteToDevbox("devbox.new:443", "/")).toBe(true);
+  });
+
+  test("does not rewrite cmux.com or API paths", () => {
+    expect(shouldRewriteToDevbox("cmux.com", "/")).toBe(false);
+    expect(shouldRewriteToDevbox("devbox.new", "/api/vm")).toBe(false);
+    expect(shouldRewriteToDevbox("devbox.new", "/handler/sign-in")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a standalone `/devbox` creator page for `devbox.new`.
- Rewrite `devbox.new` and `www.devbox.new` homepage requests to `/devbox` while preserving existing cmux proxy behavior.
- Submit prompt text to `POST /api/vm` with a source marker and show the created VM id plus attach commands.

## Verification

- `bun test tests/devbox-proxy.test.ts`
- `bun run lint` (passes with existing warnings outside this change)
- `VERCEL_ENV=preview bun run build`
- `curl -fsS -H 'Host: devbox.new' http://localhost:4117/` renders `devbox.new` and the create form
- unauthenticated `POST /api/vm` returns `401`, which the page maps to sign-in guidance

## Notes

The Cloud VM backend currently ignores `initialPrompt`; this page sends it for forward compatibility, but the current shipped behavior is create-first and attach from cmux with `cmux vm attach <id>` or `cmux vm ssh <id>`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783573486&installation_id=133855650&pr_number=5677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5677&signature=570510ba73cdc0fc4c51edd03c3d8b31abb44a1b4e7cb3c7c9ecc7f816c51951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request routing for a new production host and triggers authenticated VM provisioning via /api/vm; scope is limited but mis-routing could affect devbox.new traffic.
> 
> **Overview**
> Adds a **devbox.new** landing experience: a standalone `/devbox` route with its own layout/metadata and a client **DevboxCreator** form that POSTs to the existing **`/api/vm`** endpoint (optional `initialPrompt`, `source: "devbox.new"`, idempotency header), surfaces auth/errors, and shows attach/SSH CLI hints after success.
> 
> **Host routing** is extended via `shouldRewriteToDevbox` and an early rewrite in **`proxy`**: requests to `devbox.new` / `www.devbox.new` on `/` or `/devbox` are rewritten to `/devbox`, while `/api/*` and sign-in paths are left alone. Unit tests cover the routing helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fed97bb9ec6b4d62042fc106465e60cbaab7fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone `/devbox` creator and changes `devbox.new` and `www.devbox.new` homepages from the localized cmux site to it, while leaving `/api/*` and sign-in paths untouched. Users can optionally provide a prompt, create an authenticated Cloud VM, and receive its ID with cmux attach and SSH commands.

- Sends `POST /api/vm` with an idempotency key and `source: "devbox.new"`; 401 responses link to sign-in and other errors are shown in the form.
- The backend currently ignores `initialPrompt`, so the prompt is forwarded for compatibility but does not affect provisioning yet.
- Adds canonical page metadata and middleware tests covering host rewrites, query preservation, auth paths, and existing redirects.

<sup>Written for commit b6184d955914e13dcc253946a69f5d4ef60e8b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched a new devbox creation experience on devbox.new domain where users can submit a form to create a devbox and receive connection commands upon successful creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->