### PR TITLE
Re-enable FileExplorerStore XCTest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,6 @@ jobs:
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
               CMUX_SKIP_ZIG_BUILD=1 \
-              -skip-testing:cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath \
               test 2>&1 &
             local xcodebuild_pid=$!
             local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-900}"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -153,6 +153,15 @@ check_release_helper_upload_retry() {
   echo "PASS: release-ghostty-cli-helper retries required Ghostty helper artifact uploads"
 }
 
+check_no_ci_xctest_skips() {
+  if grep -nE '(^|[[:space:]])-skip-testing:' "$CI_FILE"; then
+    echo "FAIL: ci.yml must not exclude individual XCTest methods with -skip-testing; fix or isolate the flaky test instead"
+    exit 1
+  fi
+
+  echo "PASS: ci.yml does not exclude XCTest methods"
+}
+
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
@@ -173,3 +182,4 @@ check_e2e_runner_fallbacks
 check_xcode_selection
 check_release_build_signal
 check_release_helper_upload_retry
+check_no_ci_xctest_skips


### PR DESCRIPTION
Restores coverage for the last explicit XCTest method exclusion in `.github/workflows/ci.yml`.

Flaky path:
- Workflow/job: `CI` / `tests`
- Test: `cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath`
- Failure signature: unavailable in current CI because the method was excluded with `-skip-testing:`. The original quarantine came from app-host unit runner hangs and post-test XCTest cleanup issues.

Coverage preserved:
- Removes the `-skip-testing:` exclusion from the `Run unit tests` xcodebuild invocation.
- Adds a workflow guard that fails if `ci.yml` grows another `-skip-testing:` XCTest quarantine.
- No skips, disables, or assertion weakening.

Before:
- Attempts: current `main` CI runs execute the `tests` job, but this one method is excluded.
- Reliability: 0 active attempts for this method while excluded.
- Timing: recent `main` `tests` jobs with the exclusion: 42m13s, 24m04s, 25m05s, 21m18s, 22m10s from GitHub Actions run list.
- Data source: `.github/workflows/ci.yml`, GitHub Actions CI run history.

After:
- Attempts: pending hosted CI on this PR.
- Reliability: pending hosted CI on this PR.
- Timing: pending hosted CI on this PR.
- Data source: pending hosted CI on this PR.

Local verification:
- `bash tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

Related context:
- A broader stale PR also targeted this path: https://github.com/manaflow-ai/cmux/pull/4891
- The large dogfood-gated CI PR already contains a stronger no-quarantine guard: https://github.com/manaflow-ai/cmux/pull/4945

No tagged reload: CI/workflow-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783577074&installation_id=133855650&pr_number=5682&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5682&signature=d9a1baeca43aa640d4f52ac048d167d3060a13bf2a478b48d950e577c4ec7006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; main risk is CI flakiness or hangs if the previously quarantined app-host test still misbehaves on macOS runners.
> 
> **Overview**
> Removes the **`-skip-testing:`** quarantine for `FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath` so that method runs again in the **`tests`** job’s full **`cmux-unit`** **`xcodebuild test`** invocation.
> 
> Adds **`check_no_ci_xctest_skips`** in **`test_ci_self_hosted_guard.sh`** (already run by **`workflow-guard-tests`**) so **`ci.yml`** cannot reintroduce per-method XCTest exclusions via **`-skip-testing:`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea3e1f6c30d7d55bbabf28a25bbde5c9188ec1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the excluded XCTest in CI by removing the `-skip-testing:` for `cmuxTests/FileExplorerStoreTests/testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath`. Added a guard in `tests/test_ci_self_hosted_guard.sh` that fails if `.github/workflows/ci.yml` contains any `-skip-testing:` entries.

<sup>Written for commit 0ea3e1f6c30d7d55bbabf28a25bbde5c9188ec1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously excluded unit test in continuous integration.
  * Added a regression check to prevent unit test exclusions in CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->