### PR TITLE
Run all DB-gated web tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,7 @@ jobs:
           CMUX_DB_TEST: "1"
           DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
           DIRECT_DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
-        run: |
-          bun test tests/db-schema.test.ts
-          bun test tests/drizzle-effect.test.ts
-          bun test tests/vm-db-read-model.test.ts
-          bun test tests/devices-route.test.ts
+        run: bun run test:db:behavior
 
   tests:
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -162,6 +162,37 @@ check_no_ci_xctest_skips() {
   echo "PASS: ci.yml does not exclude XCTest methods"
 }
 
+check_web_db_behavior_tests() {
+  local db_runner="$ROOT_DIR/web/scripts/run-db-behavior-tests.sh"
+  if [[ ! -x "$db_runner" ]]; then
+    echo "FAIL: web DB behavior runner must exist and be executable"
+    exit 1
+  fi
+
+  if ! grep -Fq '"test:db:behavior": "bash scripts/run-db-behavior-tests.sh"' "$ROOT_DIR/web/package.json"; then
+    echo "FAIL: web/package.json must expose test:db:behavior for DB-gated web tests"
+    exit 1
+  fi
+
+  if ! awk '
+    /- name: Database behavior tests/ { in_step=1; next }
+    in_step && /^[[:space:]]*- name:/ { in_step=0 }
+    in_step && /CMUX_DB_TEST:[[:space:]]*"1"/ { saw_env=1 }
+    in_step && /bun run test:db:behavior/ { saw_runner=1 }
+    END { exit !(saw_env && saw_runner) }
+  ' "$CI_FILE"; then
+    echo "FAIL: ci.yml must run the DB behavior test discovery runner with CMUX_DB_TEST=1"
+    exit 1
+  fi
+
+  if ! grep -Fq 'grep -q "process\\.env\\.CMUX_DB_TEST"' "$db_runner"; then
+    echo "FAIL: DB behavior runner must discover CMUX_DB_TEST-gated files instead of hard-coding a subset"
+    exit 1
+  fi
+
+  echo "PASS: web DB behavior tests run through the discovery runner"
+}
+
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
@@ -183,3 +214,4 @@ check_xcode_selection
 check_release_build_signal
 check_release_helper_upload_retry
 check_no_ci_xctest_skips
+check_web_db_behavior_tests

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "db:url": "bash scripts/db-local.sh url",
     "start": "next start",
     "test": "bun test",
+    "test:db:behavior": "bash scripts/run-db-behavior-tests.sh",
     "lint": "eslint"
   },
   "dependencies": {

--- a/web/scripts/db-local.sh
+++ b/web/scripts/db-local.sh
@@ -129,10 +129,7 @@ case "$command" in
     export DIRECT_DATABASE_URL="$DATABASE_URL"
     bunx drizzle-kit migrate --config "$ROOT_DIR/drizzle.config.ts"
     bunx drizzle-kit migrate --config "$ROOT_DIR/drizzle.config.ts"
-    bun test tests/db-schema.test.ts
-    bun test tests/drizzle-effect.test.ts
-    bun test tests/vm-db-read-model.test.ts
-    bun test tests/vm-workflows.test.ts
+    bash "$ROOT_DIR/scripts/run-db-behavior-tests.sh"
     ;;
   url)
     printf '%s\n' "$DATABASE_URL"

--- a/web/scripts/run-db-behavior-tests.sh
+++ b/web/scripts/run-db-behavior-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -z "${DIRECT_DATABASE_URL:-${DATABASE_URL:-}}" ]]; then
+  echo "DATABASE_URL or DIRECT_DATABASE_URL is required for DB behavior tests" >&2
+  exit 2
+fi
+
+export CMUX_DB_TEST=1
+
+test_files=()
+while IFS= read -r test_file; do
+  if grep -q "process\\.env\\.CMUX_DB_TEST" "$test_file"; then
+    test_files+=("$test_file")
+  fi
+done < <(find tests \( -name "*.test.ts" -o -name "*.test.tsx" \) -print | sort)
+
+if [[ "${#test_files[@]}" -eq 0 ]]; then
+  echo "No CMUX_DB_TEST-gated test files found" >&2
+  exit 1
+fi
+
+printf 'Running %s DB behavior test file(s) with CMUX_DB_TEST=1\n' "${#test_files[@]}"
+failed_files=()
+zero_test_files=()
+skipped_test_files=()
+for test_file in "${test_files[@]}"; do
+  printf '\n==> bun test %s\n' "$test_file"
+  output_file="$(mktemp /tmp/cmux-db-behavior-test.XXXXXX.log)"
+  set +e
+  bun test "$test_file" 2>&1 | tee "$output_file"
+  test_status=${PIPESTATUS[0]}
+  set -e
+
+  if ! grep -Eq 'Ran [1-9][0-9]* tests? across [1-9][0-9]* files?' "$output_file"; then
+    zero_test_files+=("$test_file")
+  fi
+  if grep -Eq '^\(skip\) |^[[:space:]]*[1-9][0-9]* skips?$' "$output_file"; then
+    skipped_test_files+=("$test_file")
+  fi
+  rm -f "$output_file"
+
+  if [[ "$test_status" -ne 0 ]]; then
+    failed_files+=("$test_file")
+  fi
+done
+
+if [[ "${#zero_test_files[@]}" -gt 0 ]]; then
+  printf '\n%s DB behavior test file(s) executed zero tests:\n' "${#zero_test_files[@]}" >&2
+  printf '  %s\n' "${zero_test_files[@]}" >&2
+  exit 1
+fi
+
+if [[ "${#skipped_test_files[@]}" -gt 0 ]]; then
+  printf '\n%s DB behavior test file(s) skipped tests while CMUX_DB_TEST=1:\n' "${#skipped_test_files[@]}" >&2
+  printf '  %s\n' "${skipped_test_files[@]}" >&2
+  exit 1
+fi
+
+if [[ "${#failed_files[@]}" -gt 0 ]]; then
+  printf '\n%s DB behavior test file(s) failed:\n' "${#failed_files[@]}" >&2
+  printf '  %s\n' "${failed_files[@]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a web DB behavior runner that discovers every `CMUX_DB_TEST`-gated test file
- run that runner from the `web-db-migrations` CI job and local `bun db:test`
- add a workflow guard so CI keeps using the discovery runner instead of a hard-coded subset

## Coverage
Before, CI ran 4 DB-backed web test files in `web-db-migrations`. This branch runs all 7 `CMUX_DB_TEST`-gated files currently in `web/tests`.

This is a small split from the stale/conflicting broader CI branch at https://github.com/manaflow-ai/cmux/pull/4945.

## Verification
- `bash tests/test_ci_self_hosted_guard.sh`
- `bash -n web/scripts/run-db-behavior-tests.sh web/scripts/db-local.sh tests/test_ci_self_hosted_guard.sh`
- `git diff --check`
- `cd web && bun test`
- `cd web && bun db:test`

## Deflake report
Flaky path:
- Workflow/job: CI / `web-db-migrations`
- Test(s): DB-backed web tests gated by `CMUX_DB_TEST`
- Failure signature: tests were present but skipped unless explicitly enumerated in the DB CI job

Coverage preserved:
- Kept DB tests active in `web-db-migrations`
- Assertions preserved
- No skips/disables/removals

Before:
- Attempts: CI ran 4 DB-backed web test files
- Reliability: unavailable for the 3 unlisted DB-gated files because they were not active in CI
- Timing: `web-db-migrations` was 34s on https://github.com/manaflow-ai/cmux/pull/5682

After:
- Attempts: local DB runner executed 7 files
- Reliability: 1/1 local run passed
- Timing: local `bun db:test` completed in 4.65s after dependencies were installed

Change:
- Root cause: DB behavior coverage depended on a hard-coded file list
- Fix: discover `CMUX_DB_TEST`-gated files and fail if any execute zero tests or still skip under `CMUX_DB_TEST=1`
- Why this improves reliability without reducing coverage: new DB-backed tests automatically join the DB CI lane and the guard prevents silently narrowing coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783580181&installation_id=133855650&pr_number=5683&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5683&signature=80efab66f4845fee15164d78488fe05a1916df9a89f05af8e9b95a6dd1f18b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 52b2c6d147173f01b73f97e213f78927dbdcd3f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run all CMUX_DB_TEST-gated web tests in CI by replacing hard-coded file lists with a discovery runner. Increases coverage in the web-db-migrations job from 4 files to all 7 DB-backed test files and prevents silent skips.

- **New Features**
  - Added `web/scripts/run-db-behavior-tests.sh` to auto-discover tests gated by `process.env.CMUX_DB_TEST` and run them with CMUX_DB_TEST=1; fails on zero executed tests or if any are skipped.
  - Exposed `test:db:behavior` in `web/package.json` and run it in CI via `bun run test:db:behavior`; also used in `db-local.sh`.
  - Added a guard in `tests/test_ci_self_hosted_guard.sh` to ensure CI uses the discovery runner with CMUX_DB_TEST=1.

<sup>Written for commit 52b2c6d147173f01b73f97e213f78927dbdcd3f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined database behavior testing in CI by consolidating multiple test commands into a single unified test runner.
  * Enhanced CI validation with automated checks to ensure database behavior tests are correctly integrated and executed in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->