### PR TITLE
Run Swift package settings alias test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,16 +421,9 @@ jobs:
             CmuxSocketControl
             CMUXAgentLaunch
           )
-          # Pre-existing failure unrelated to package correctness: the catalog
-          # intentionally reuses some UserDefaults keys across sections (e.g. a
-          # toggle surfaced under both automation.* and integrations.*), which
-          # userDefaultsStorageKeysAreUnique flags. Skip just that assertion so
-          # the package suites still gate CI. Remove the skip if the catalog is
-          # de-duplicated.
           for pkg in "${PACKAGES[@]}"; do
             echo "::group::swift test Packages/$pkg"
-            swift test --package-path "Packages/$pkg" \
-              --skip userDefaultsStorageKeysAreUnique
+            swift test --package-path "Packages/$pkg"
             echo "::endgroup::"
           done
 

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
@@ -10,11 +10,70 @@ struct SettingCatalogTests {
     }
 
     @Test func userDefaultsStorageKeysAreUnique() {
-        let keys = SettingCatalog().all.compactMap { entry -> String? in
-            if case let .userDefaults(key, _, _) = entry.kind { return key }
-            return nil
+        let expectedAliases: [String: Set<String>] = [
+            "ampHooksEnabled": [
+                "automation.ampIntegration",
+                "integrations.amp.hooksEnabled",
+            ],
+            "claudeCodeCustomClaudePath": [
+                "automation.claudeBinaryPath",
+                "integrations.claudeCode.customClaudePath",
+            ],
+            "claudeCodeHooksEnabled": [
+                "automation.claudeCodeIntegration",
+                "integrations.claudeCode.hooksEnabled",
+            ],
+            "cursorHooksEnabled": [
+                "automation.cursorIntegration",
+                "integrations.cursor.hooksEnabled",
+            ],
+            "geminiHooksEnabled": [
+                "automation.geminiIntegration",
+                "integrations.gemini.hooksEnabled",
+            ],
+            "kiroHooksEnabled": [
+                "automation.kiroIntegration",
+                "integrations.kiro.hooksEnabled",
+            ],
+            "kiroNotificationLevel": [
+                "automation.kiroNotificationLevel",
+                "integrations.kiro.notificationLevel",
+            ],
+            "ripgrepCustomBinaryPath": [
+                "automation.ripgrepBinaryPath",
+                "integrations.ripgrep.customBinaryPath",
+            ],
+            "suppressSubagentNotifications": [
+                "automation.suppressSubagentNotifications",
+                "integrations.suppressSubagentNotifications",
+            ],
+            "sidebarActiveTabIndicatorStyle": [
+                "sidebar.activeTabIndicatorStyle",
+                "workspaceColors.indicatorStyle",
+            ],
+            "sidebarNotificationBadgeColorHex": [
+                "sidebar.notificationBadgeColor",
+                "workspaceColors.notificationBadgeColor",
+            ],
+            "sidebarSelectionColorHex": [
+                "sidebar.selectionColor",
+                "workspaceColors.selectionColor",
+            ],
+        ]
+
+        var idsByStorageKey: [String: Set<String>] = [:]
+        for entry in SettingCatalog().all {
+            if case let .userDefaults(storageKey, _, _) = entry.kind {
+                idsByStorageKey[storageKey, default: []].insert(entry.id)
+            }
         }
-        #expect(keys.count == Set(keys).count)
+
+        let aliases = idsByStorageKey.filter { $0.value.count > 1 }
+        #expect(aliases == expectedAliases)
+
+        for storageKey in expectedAliases.keys {
+            #expect(idsByStorageKey[storageKey] == expectedAliases[storageKey])
+        }
     }
 
     @Test func jsonBackedKeysUseTheirIdAsPath() {

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -162,6 +162,15 @@ check_no_ci_xctest_skips() {
   echo "PASS: ci.yml does not exclude XCTest methods"
 }
 
+check_no_ci_swift_package_skips() {
+  if grep -nE '(^|[[:space:]])swift[[:space:]]+test([[:space:]].*)?[[:space:]]--skip([[:space:]]|$)' "$CI_FILE"; then
+    echo "FAIL: ci.yml must not exclude Swift package tests with swift test --skip; fix or isolate the failing package test instead"
+    exit 1
+  fi
+
+  echo "PASS: ci.yml does not exclude Swift package tests"
+}
+
 check_web_db_behavior_tests() {
   local db_runner="$ROOT_DIR/web/scripts/run-db-behavior-tests.sh"
   if [[ ! -x "$db_runner" ]]; then
@@ -214,4 +223,5 @@ check_xcode_selection
 check_release_build_signal
 check_release_helper_upload_retry
 check_no_ci_xctest_skips
+check_no_ci_swift_package_skips
 check_web_db_behavior_tests


### PR DESCRIPTION
## Summary
- removes the CI `swift test --skip userDefaultsStorageKeysAreUnique` mask
- changes the settings catalog storage-key test to allow only documented aliases
- adds a workflow guard blocking future Swift package `--skip` masks

## Deflake / coverage report
Flaky path:
- Workflow/job: CI / `tests` / Run Swift package unit tests
- Test(s): `SettingCatalogTests.userDefaultsStorageKeysAreUnique` in `Packages/CmuxSettings`
- Failure signature: CI skipped the test with `swift test --skip userDefaultsStorageKeysAreUnique` because intentional catalog aliases made the old uniqueness assertion fail

Coverage preserved:
- Kept test active in: CI SwiftPM package loop
- Assertions preserved or strengthened: unexpected duplicate UserDefaults storage keys still fail; intentional aliases must exactly match the whitelist
- No skips/disables/removals: removed the only SwiftPM `--skip` in CI and added a guard against reintroducing it

Before:
- Attempts: CI package loop passed by skipping this test
- Reliability: unavailable for the skipped assertion
- Timing: prior PR `CI/tests` job was 21m33s, package substep timing unavailable from check summary
- Data source: `https://github.com/manaflow-ai/cmux/pull/5683` check summary and current `main` CI config

After:
- Attempts: local 1/1 focused `CmuxSettings`; local 1/1 full CI SwiftPM package loop
- Reliability: 1/1 focused, 1/1 package loop
- Timing: focused `CmuxSettings` 0.98s after warm build; full local SwiftPM package loop 67s wall clock
- Data source: local commands in this worktree

Change:
- Root cause: the test treated intentional cross-section storage aliases as accidental duplicates, so CI skipped it entirely
- Fix: assert the exact alias map and fail on any unexpected alias, then remove `--skip` from CI
- Why this improves reliability without reducing coverage: CI now exercises the settings catalog invariant and fails on new masked duplicates instead of silently skipping the test

## Verification
- `swift test --package-path Packages/CmuxSettings`
- CI package loop locally: `swift test --package-path` for all packages listed in `.github/workflows/ci.yml`
- `bash tests/test_ci_self_hosted_guard.sh`
- `bash -n tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783581860&installation_id=133855650&pr_number=5684&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5684&signature=44e7cf0a5cb1eedbcb66e1a89b354334e943a8f347756cf31b2b23c274032c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI guard changes only; no runtime settings or persistence behavior is modified.
> 
> **Overview**
> CI no longer skips **`userDefaultsStorageKeysAreUnique`** in the SwiftPM package loop; **`CmuxSettings`** tests now treat intentional cross-section **UserDefaults** aliases as an explicit whitelist instead of requiring globally unique storage keys.
> 
> **`SettingCatalogTests`** builds storage-key → setting-id sets, requires duplicates to match **`expectedAliases`** exactly, and still fails on any new undocumented alias. **`test_ci_self_hosted_guard.sh`** adds **`check_no_ci_swift_package_skips`** so **`ci.yml`** cannot reintroduce **`swift test --skip`** masks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7b03b8b4efba302772aedc72f52c2fea4bbaa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the `userDefaultsStorageKeysAreUnique` test in CI by removing the `swift test --skip` mask. The test now allows only documented aliases and CI blocks future `swift test --skip` usage.

- **Bug Fixes**
  - `Packages/CmuxSettings`: test asserts an explicit `expectedAliases` map and fails on any unexpected alias; duplicates still fail.
  - CI: run `swift test` for all packages without `--skip`; add `tests/test_ci_self_hosted_guard.sh` check to reject `swift test --skip` in `.github/workflows/ci.yml`.

<sup>Written for commit 0f7b03b8b4efba302772aedc72f52c2fea4bbaa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CI validation by enabling previously skipped tests for more comprehensive quality assurance.
  * Implemented stricter CI checks to prevent selective test exclusions in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->