### PR TITLE
Retry required release asset attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 
+      - name: Validate release attestation retry guard
+        run: ./tests/test_ci_attestation_retry.sh
+
       - name: Validate current GhosttyKit checksum pin
         run: ./tests/test_ci_ghosttykit_checksum_present.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -619,7 +619,21 @@ jobs:
           cp appcast.xml appcast-universal.xml
 
       - name: Attest remote daemon nightly assets
+        id: attest-remote-daemon-nightly-assets
         if: needs.decide.outputs.should_publish != 'true' || (steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true')
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            remote-daemon-assets/cmuxd-remote-darwin-arm64-${{ env.NIGHTLY_BUILD }}
+            remote-daemon-assets/cmuxd-remote-darwin-amd64-${{ env.NIGHTLY_BUILD }}
+            remote-daemon-assets/cmuxd-remote-linux-arm64-${{ env.NIGHTLY_BUILD }}
+            remote-daemon-assets/cmuxd-remote-linux-amd64-${{ env.NIGHTLY_BUILD }}
+            remote-daemon-assets/cmuxd-remote-checksums-${{ env.NIGHTLY_BUILD }}.txt
+            remote-daemon-assets/cmuxd-remote-manifest-${{ env.NIGHTLY_BUILD }}.json
+
+      - name: Retry remote daemon nightly asset attestation
+        if: (needs.decide.outputs.should_publish != 'true' || (steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true')) && steps.attest-remote-daemon-nightly-assets.outcome == 'failure'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,21 @@ jobs:
           ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
 
       - name: Attest remote daemon release assets
+        id: attest-remote-daemon-release-assets
         if: steps.guard_release_assets.outputs.skip_all != 'true'
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            remote-daemon-assets/cmuxd-remote-darwin-arm64
+            remote-daemon-assets/cmuxd-remote-darwin-amd64
+            remote-daemon-assets/cmuxd-remote-linux-arm64
+            remote-daemon-assets/cmuxd-remote-linux-amd64
+            remote-daemon-assets/cmuxd-remote-checksums.txt
+            remote-daemon-assets/cmuxd-remote-manifest.json
+
+      - name: Retry remote daemon release asset attestation
+        if: steps.guard_release_assets.outputs.skip_all != 'true' && steps.attest-remote-daemon-release-assets.outcome == 'failure'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |

--- a/tests/test_ci_attestation_retry.sh
+++ b/tests/test_ci_attestation_retry.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Guard release/nightly provenance attestation against transient Sigstore/Rekor
+# network failures without making attestation optional.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ACTION='actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32'
+
+check_attestation_retry() {
+  local file="$1"
+  local first_step="$2"
+  local first_id="$3"
+  local retry_step="$4"
+  local subject_marker="$5"
+
+  if ! awk -v first_step="$first_step" -v first_id="$first_id" -v action="$ACTION" -v subject="$subject_marker" '
+    $0 ~ "^[[:space:]]*- name: " first_step "$" { in_step=1; next }
+    in_step && /^      - name:/ { in_step=0 }
+    in_step && $0 ~ "id: " first_id "$" { saw_id=1 }
+    in_step && /continue-on-error:[[:space:]]*true/ { saw_continue=1 }
+    in_step && index($0, "uses: " action) { saw_action=1 }
+    in_step && index($0, subject) { saw_subject=1 }
+    END { exit !(saw_id && saw_continue && saw_action && saw_subject) }
+  ' "$file"; then
+    echo "FAIL: $(basename "$file") first attestation step must have id=$first_id, continue-on-error, pinned action, and expected subject"
+    exit 1
+  fi
+
+  if ! awk -v retry_step="$retry_step" -v first_id="$first_id" -v action="$ACTION" -v subject="$subject_marker" '
+    $0 ~ "^[[:space:]]*- name: " retry_step "$" { in_step=1; next }
+    in_step && /^      - name:/ { in_step=0 }
+    in_step && index($0, "steps." first_id ".outcome == '\''failure'\''") { saw_outcome=1 }
+    in_step && index($0, "uses: " action) { saw_action=1 }
+    in_step && index($0, subject) { saw_subject=1 }
+    in_step && /continue-on-error:/ { saw_retry_continue=1 }
+    END { exit !(saw_outcome && saw_action && saw_subject && !saw_retry_continue) }
+  ' "$file"; then
+    echo "FAIL: $(basename "$file") retry attestation step must run only after first failure and remain required"
+    exit 1
+  fi
+
+  echo "PASS: $(basename "$file") retries required remote daemon asset attestation"
+}
+
+check_attestation_retry \
+  "$ROOT_DIR/.github/workflows/nightly.yml" \
+  "Attest remote daemon nightly assets" \
+  "attest-remote-daemon-nightly-assets" \
+  "Retry remote daemon nightly asset attestation" \
+  'remote-daemon-assets/cmuxd-remote-manifest-${{ env.NIGHTLY_BUILD }}.json'
+
+check_attestation_retry \
+  "$ROOT_DIR/.github/workflows/release.yml" \
+  "Attest remote daemon release assets" \
+  "attest-remote-daemon-release-assets" \
+  "Retry remote daemon release asset attestation" \
+  "remote-daemon-assets/cmuxd-remote-manifest.json"


### PR DESCRIPTION
## Summary

- retry nightly and release remote-daemon provenance attestation once after a transient failure
- keep the retry required, so attestation remains a hard release/nightly gate
- add a workflow guard for the retry pattern

## Deflake report

Flaky path:
- Workflow/job: Nightly macOS build / build-sign-notarize-nightly / Attest remote daemon nightly assets
- Test(s): remote daemon asset provenance attestation
- Failure signature: `InternalError: error fetching tlog entry`, `FetchError: network timeout at: https://rekor.sigstore.dev/api/v1/log/entries/...`

Coverage preserved:
- Kept test active in: nightly and release macOS workflows
- Assertions preserved or strengthened: attestation remains required; only the first attempt is allowed to fail, and the retry has no `continue-on-error`
- No skips/disables/removals: no attestation step was removed, skipped, or made optional

Before:
- Attempts: 1 observed nightly failure
- Reliability: 0/1 for the observed transient Rekor timeout path
- Timing: failed after about 66s in `Attest remote daemon nightly assets`
- Data source: https://github.com/manaflow-ai/cmux/actions/runs/27189098891

After:
- Attempts: local guard 1/1
- Reliability: local guard 1/1; hosted PR validation pending
- Timing: local guard <1s
- Data source: `./tests/test_ci_attestation_retry.sh`, `./tests/test_ci_self_hosted_guard.sh`, `./tests/test_ci_release_sdk_lane.sh`, `git diff --check`

Change:
- Root cause: GitHub artifact attestation can fail on a transient Sigstore/Rekor network timeout, and the action has no retry input
- Fix: make the first attestation attempt retryable, then run a required second attestation step only when the first attempt fails
- Why this improves reliability without reducing coverage: a single transient external timeout no longer kills the workflow, but release/nightly artifacts still cannot pass without a successful attestation

## Verification

- `./tests/test_ci_attestation_retry.sh`
- `bash -n tests/test_ci_attestation_retry.sh && bash -n tests/test_ci_self_hosted_guard.sh`
- `./tests/test_ci_self_hosted_guard.sh`
- `./tests/test_ci_release_sdk_lane.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783583546&installation_id=133855650&pr_number=5686&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5686&signature=66869a94997ca428e3696f1ea75cd6995dc63dabc2df95c6bb646582ae00441d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change for release/nightly attestation; provenance remains required and is guarded by a new CI test.
> 
> **Overview**
> Adds a **retry path** for remote-daemon **build provenance attestation** in **nightly** and **release** workflows so transient Sigstore/Rekor failures do not fail the whole job on the first try.
> 
> Each attestation step is split into an initial `actions/attest-build-provenance` run with `continue-on-error: true` and a step `id`, plus a **second required** attestation that runs only when `steps.<id>.outcome == 'failure'`. Successful first attempts skip the retry; if both fail, the workflow still fails.
> 
> **CI** gains `tests/test_ci_attestation_retry.sh`, invoked from `workflow-guard-tests`, to enforce the pinned action, subjects, `continue-on-error` on the first step only, and failure-gated retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b24442c01dcd296380449d6a6ad28894577e62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-shot retry for remote-daemon provenance attestation in nightly and release workflows to reduce flakiness from transient Sigstore/Rekor timeouts. Attestation stays required; only the first attempt can fail.

- **Bug Fixes**
  - Nightly: first attestation step has id `attest-remote-daemon-nightly-assets` with `continue-on-error: true`; a required retry runs only if the first fails.
  - Release: same pattern with id `attest-remote-daemon-release-assets`; retry step has no `continue-on-error`.
  - Attestation action pinned to `actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32`.
  - Added `tests/test_ci_attestation_retry.sh` and wired it into `ci.yml` to enforce the retry guard and expected subjects.

<sup>Written for commit 0b24442c01dcd296380449d6a6ad28894577e62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation script for CI attestation retry behavior across nightly and release workflows.

* **Chores**
  * Enhanced macOS nightly and release workflows with improved attestation retry logic to ensure more reliable asset provenance verification.
  * Attestation steps now gracefully handle transient failures and automatically retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->