### PR TITLE
push: raise per-user notification rate limit to 200/10min

### DIFF
--- a/web/services/apns/rateLimit.ts
+++ b/web/services/apns/rateLimit.ts
@@ -6,7 +6,10 @@ import { notificationSendEvents } from "../../db/schema";
 type NotificationDb = ReturnType<typeof cloudDb>;
 
 const PUSH_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
-const PUSH_RATE_LIMIT_MAX_EVENTS = 60;
+// Per-user cap (keyed on user.id), so this only bounds a user's own phone — it is
+// a runaway-loop / APNs-volume guard, not anti-abuse (a user cannot spam others).
+// Power users running many agents legitimately exceed 60/10min, so allow 200/10min.
+const PUSH_RATE_LIMIT_MAX_EVENTS = 200;
 
 export class PushRateLimitExceededError extends Error {
   readonly retryAfterSeconds: number;


### PR DESCRIPTION
Bumps `PUSH_RATE_LIMIT_MAX_EVENTS` 60 → 200. Per-user cap (keyed on `user.id`), so it only bounds a user's own phone — a runaway-loop / APNs-volume guard, not anti-abuse. Power users running many agents legitimately exceed 60/10min.

Note: the Vercel edge rate limit (`CMUX_PUSH_RATE_LIMIT_ID`) is a separate config and would need aligning to actually allow 200 (whichever is lower wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585795&installation_id=133855650&pr_number=5688&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5688&signature=d05292df3b38d072a84c5f563a99292dc83754163cfaa169b5f0deea344dadca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change to a per-user safety cap; no auth or routing changes, though APNs volume per user increases if the edge limit allows it.
> 
> **Overview**
> Raises the **per-user** push notification cap in `rateLimit.ts` from **60 to 200 events per 10 minutes**, with comments clarifying the limit is keyed on `user.id` (runaway-loop / APNs volume on the user’s own devices, not cross-user abuse).
> 
> The **10-minute window** and `recordPushSendOrThrow` behavior are unchanged; only the threshold constant updates. Effective throughput may still be capped by the separate **Vercel** `CMUX_PUSH_RATE_LIMIT_ID` edge limit if that config stays lower than 200.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef03c6f365c95fd1b74d95d6ce1eb4adfcae120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the per-user push notification rate limit from 60 to 200 events per 10 minutes (keyed by `user.id`). This relaxes the APNs volume guard for power users running multiple agents while remaining scoped to a user’s own device.

- **Migration**
  - Align the Vercel edge rate limit (`CMUX_PUSH_RATE_LIMIT_ID`) to 200/10min if needed; the lower limit still applies.

<sup>Written for commit 5ef03c6f365c95fd1b74d95d6ce1eb4adfcae120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased push notification rate limit from 60 to 200 events per 10-minute window to better support users with multiple devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->