### PR TITLE
Recover stale restored SSH PTY sessions

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10194,7 +10194,11 @@ struct CMUXCLI {
                 responseTimeout: waitForReady ? 185 : nil
             )
         } catch {
-            throw CLIError(message: "ssh-pty-attach: \(userFacingRemotePTYErrorMessage(error))")
+            let userFacingMessage = userFacingRemotePTYErrorMessage(error)
+            throw CLIError(
+                message: "ssh-pty-attach: \(userFacingMessage)",
+                exitCode: remotePTYErrorIndicatesMissingSession(error) ? 253 : 1
+            )
         }
         var connectedFD: Int32?
         let controlSocketLock = NSLock()
@@ -10433,6 +10437,21 @@ struct CMUXCLI {
             return userFacingRemotePTYErrorMessage(String(describing: error))
         }
         return userFacingRemotePTYErrorMessage(debugString(value) ?? "unknown error")
+    }
+
+    private func remotePTYErrorIndicatesMissingSession(_ value: Any?) -> Bool {
+        if let error = value as? Error {
+            return remotePTYErrorIndicatesMissingSession(String(describing: error))
+        }
+        return remotePTYErrorIndicatesMissingSession(debugString(value) ?? "")
+    }
+
+    private func remotePTYErrorIndicatesMissingSession(_ message: String) -> Bool {
+        let lowered = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !lowered.isEmpty else { return false }
+        return lowered.contains("pty_session_not_found") ||
+            (lowered.contains("persistent ssh pty session") && lowered.contains("not running")) ||
+            (lowered.contains("persistent pty session") && lowered.contains("not running"))
     }
 
     private func userFacingRemotePTYErrorMessage(_ message: String) -> String {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -13941,7 +13941,10 @@ final class Workspace: Identifiable, ObservableObject {
         )
         return SSHPTYAttachStartupCommandBuilder.command(
             sessionID: sessionID,
-            foregroundAuth: foregroundAuth
+            foregroundAuth: foregroundAuth,
+            remoteCommand: remoteConfiguration.relayPort.map(
+                SSHPTYAttachStartupCommandBuilder.restoredRemoteShellCommand(relayPort:)
+            )
         )
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7062,10 +7062,22 @@ final class WorkspaceRemoteSessionController {
                 process: process,
                 stderrPipe: stderrPipe
             ) {
-                let retryDelay = 2.0
+                let retryDelay: TimeInterval
+                let didCleanStaleListener: Bool
+                if Self.reverseRelayStartupFailureIndicatesStaleRemoteListener(
+                    startupFailure,
+                    relayPort: relayPort
+                ) {
+                    didCleanStaleListener = cleanupStaleRemoteRelayListenerLocked(relayPort: relayPort)
+                    retryDelay = didCleanStaleListener ? 0.25 : 2.0
+                } else {
+                    didCleanStaleListener = false
+                    retryDelay = 2.0
+                }
                 let retrySeconds = max(1, Int(retryDelay.rounded()))
                 debugLog(
                     "remote.relay.startFailed relayPort=\(relayPort) " +
+                    "cleanedStaleListener=\(didCleanStaleListener ? 1 : 0) " +
                     "error=\(startupFailure)"
                 )
                 if let relayServer {
@@ -7074,10 +7086,12 @@ final class WorkspaceRemoteSessionController {
                         cliRelayServer = nil
                     }
                 }
-                publishDaemonStatus(
-                    .error,
-                    detail: "Remote SSH relay unavailable: \(startupFailure) (retry in \(retrySeconds)s)"
-                )
+                if !didCleanStaleListener {
+                    publishDaemonStatus(
+                        .error,
+                        detail: "Remote SSH relay unavailable: \(startupFailure) (retry in \(retrySeconds)s)"
+                    )
+                }
                 scheduleReverseRelayRestartLocked(remotePath: remotePath, delay: retryDelay)
                 return
             }
@@ -9251,6 +9265,16 @@ final class WorkspaceRemoteSessionController {
         let stderrData = ProcessPipeReader.readDataToEndOfFileOrEmpty(from: stderrPipe.fileHandleForReading)
         let stderr = String(data: stderrData, encoding: .utf8) ?? ""
         return bestErrorLine(stderr: stderr) ?? "status=\(process.terminationStatus)"
+    }
+
+    static func reverseRelayStartupFailureIndicatesStaleRemoteListener(
+        _ detail: String,
+        relayPort: Int
+    ) -> Bool {
+        guard relayPort > 0 else { return false }
+        let lowered = detail.lowercased()
+        return lowered.contains("remote port forwarding failed")
+            && lowered.contains("listen port \(relayPort)")
     }
 
     private static func meaningfulErrorLine(in text: String) -> String? {

--- a/Sources/WorkspaceRemoteConfiguration.swift
+++ b/Sources/WorkspaceRemoteConfiguration.swift
@@ -152,7 +152,10 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
             " --command-b64 \(shellQuote(Data($0.utf8).base64EncodedString()))"
         } ?? ""
         let attachCommand = "\"$cmux_ssh_attach_cli\" --socket \"$CMUX_SOCKET_PATH\" ssh-pty-attach --wait\(requireExistingFlag) --workspace \"$CMUX_WORKSPACE_ID\" --session-id \"$cmux_ssh_attach_session_id\" --attachment-id \"${CMUX_SURFACE_ID:-}\"\(commandB64Flag)"
-        lines += retryingAttachLines(command: attachCommand)
+        let fallbackCommand = requireExisting && !commandB64Flag.isEmpty
+            ? "\"$cmux_ssh_attach_cli\" --socket \"$CMUX_SOCKET_PATH\" ssh-pty-attach --wait --workspace \"$CMUX_WORKSPACE_ID\" --session-id \"$cmux_ssh_attach_session_id\" --attachment-id \"${CMUX_SURFACE_ID:-}\"\(commandB64Flag)"
+            : nil
+        lines += retryingAttachLines(command: attachCommand, missingSessionFallbackCommand: fallbackCommand)
         return "/bin/sh -c \(shellQuote(lines.joined(separator: "\n")))"
     }
 
@@ -169,8 +172,11 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
         )
     }
 
-    private static func retryingAttachLines(command: String) -> [String] {
-        [
+    private static func retryingAttachLines(
+        command: String,
+        missingSessionFallbackCommand: String? = nil
+    ) -> [String] {
+        var lines = [
             "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-20}\"",
             "case \"$cmux_ssh_attach_reconnect_limit\" in ''|*[!0-9]*) cmux_ssh_attach_reconnect_limit=20 ;; esac",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
@@ -179,6 +185,17 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
             "while :; do",
             "  \(command)",
             "  cmux_ssh_attach_status=$?",
+        ]
+        if let missingSessionFallbackCommand {
+            lines += [
+                "  if [ \"$cmux_ssh_attach_status\" -eq 253 ]; then",
+                "    if [ -t 2 ]; then printf '\\n\\033[33m[cmux] persisted SSH PTY session is gone; starting a new remote shell.\\033[0m\\n' >&2 || true; fi",
+                "    \(missingSessionFallbackCommand)",
+                "    exit \"$?\"",
+                "  fi",
+            ]
+        }
+        lines += [
             "  case \"$cmux_ssh_attach_status\" in 254|255) ;; *) exit \"$cmux_ssh_attach_status\" ;; esac",
             "  if [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_retry=$((cmux_ssh_attach_retry + 1))",
@@ -186,6 +203,7 @@ nonisolated enum SSHPTYAttachStartupCommandBuilder {
             "  if [ \"$cmux_ssh_attach_reconnect_delay\" -gt 0 ]; then sleep \"$cmux_ssh_attach_reconnect_delay\"; fi",
             "done",
         ]
+        return lines
     }
 
     private static func foregroundAuthLines(_ auth: ForegroundAuth) -> [String] {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -3835,7 +3835,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         wait(for: [socketHandled], timeout: 3)
         XCTAssertFalse(result.timedOut, result.stderr)
-        XCTAssertEqual(result.status, 1, result.stderr)
+        XCTAssertEqual(result.status, 253, result.stderr)
         XCTAssertTrue(result.stderr.contains("persistent SSH PTY session is no longer running"), result.stderr)
         let methods = state.snapshot().compactMap { self.jsonObject($0)?["method"] as? String }
         XCTAssertEqual(methods, [

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -2259,9 +2259,16 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertTrue(restoredInitialCommand.contains(restoredForegroundAuthToken), restoredInitialCommand)
         XCTAssertTrue(restoredInitialCommand.contains("--require-existing"), restoredInitialCommand)
         XCTAssertTrue(restoredInitialCommand.contains("254|255"), restoredInitialCommand)
+        XCTAssertTrue(restoredInitialCommand.contains("\"$cmux_ssh_attach_status\" -eq 253"), restoredInitialCommand)
+        XCTAssertTrue(restoredInitialCommand.contains("persisted SSH PTY session is gone"), restoredInitialCommand)
         XCTAssertTrue(restoredInitialCommand.contains(expectedSessionID), restoredInitialCommand)
         XCTAssertTrue(restoredInitialCommand.contains("CMUX_SURFACE_ID"), restoredInitialCommand)
-        XCTAssertFalse(restoredInitialCommand.contains("--command-b64 "), restoredInitialCommand)
+        XCTAssertTrue(restoredInitialCommand.contains("--command-b64 "), restoredInitialCommand)
+        let restoredInitialRemoteCommand = try XCTUnwrap(Self.decodedSSHPTYCommandB64(in: restoredInitialCommand))
+        XCTAssertTrue(
+            restoredInitialRemoteCommand.contains("export CMUX_SOCKET_PATH=127.0.0.1:64003"),
+            restoredInitialRemoteCommand
+        )
 
         let roundTrip = restoredWorkspace.sessionSnapshot(includeScrollback: false)
         XCTAssertEqual(roundTrip.remote?.preserveAfterTerminalExit, true)
@@ -2334,7 +2341,8 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
             let command = try XCTUnwrap(panel.surface.debugInitialCommand())
             XCTAssertTrue(command.contains("ssh-pty-attach"), command)
             XCTAssertTrue(command.contains("--require-existing"), command)
-            XCTAssertFalse(command.contains("--command-b64 "), command)
+            XCTAssertTrue(command.contains("--command-b64 "), command)
+            XCTAssertTrue(command.contains("\"$cmux_ssh_attach_status\" -eq 253"), command)
             XCTAssertTrue(
                 expectedSessionIDs.contains { command.contains($0) },
                 command

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -986,6 +986,27 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertEqual(detail, "remote port forwarding failed for listen port 64009")
     }
 
+    func testReverseRelayStartupFailureDetectsExactStaleRemoteListenerPort() {
+        XCTAssertTrue(
+            WorkspaceRemoteSessionController.reverseRelayStartupFailureIndicatesStaleRemoteListener(
+                "remote port forwarding failed for listen port 64009",
+                relayPort: 64009
+            )
+        )
+        XCTAssertFalse(
+            WorkspaceRemoteSessionController.reverseRelayStartupFailureIndicatesStaleRemoteListener(
+                "remote port forwarding failed for listen port 64010",
+                relayPort: 64009
+            )
+        )
+        XCTAssertFalse(
+            WorkspaceRemoteSessionController.reverseRelayStartupFailureIndicatesStaleRemoteListener(
+                "Permission denied (publickey)",
+                relayPort: 64009
+            )
+        )
+    }
+
     func testExecutableSearchPathsIncludesHomebrewAndHomeFallbacks() {
         let paths = WorkspaceRemoteSessionController.executableSearchPaths(
             environment: [

--- a/tests_v2/test_ssh_remote_detachable_pty.py
+++ b/tests_v2/test_ssh_remote_detachable_pty.py
@@ -112,6 +112,25 @@ def _resolve_workspace_id(client: cmux, payload: dict, *, before_workspace_ids: 
     raise cmuxError(f"Unable to resolve workspace_id from payload: {payload}")
 
 
+def _resolve_surface_id(client: cmux, workspace_id: str, payload: dict, *, before_surface_ids: set[str]) -> str:
+    surface_id = str(payload.get("surface_id") or "")
+    if surface_id:
+        return surface_id
+
+    surface_ref = str(payload.get("surface_ref") or "")
+    current_surfaces = client.list_surfaces(workspace_id)
+    if surface_ref.startswith("surface:"):
+        for index, resolved_surface_id, _focused in current_surfaces:
+            if f"surface:{index}" == surface_ref:
+                return resolved_surface_id
+
+    new_ids = sorted({surface_id for _index, surface_id, _focused in current_surfaces} - before_surface_ids)
+    if len(new_ids) == 1:
+        return new_ids[0]
+
+    raise cmuxError(f"Unable to resolve surface_id from payload: {payload}")
+
+
 def _workspace_row(client: cmux, workspace_id: str) -> dict:
     rows = (client._call("workspace.list", {}) or {}).get("workspaces") or []
     for row in rows:
@@ -233,12 +252,19 @@ def main() -> int:
                 f"detached session should keep bounded scrollback metadata: {row_after_detach}",
             )
 
+            before_attach_surface_ids = {
+                surface_id for _index, surface_id, _focused in client.list_surfaces(workspace_id)
+            }
             attach_payload = _run_cli_json(
                 cli,
                 ["ssh-session-attach", "--workspace", workspace_id, "--session-id", session_id],
             )
-            reattached_surface = str(attach_payload.get("surface_id") or "")
-            _must(reattached_surface, f"ssh-session-attach output missing surface_id: {attach_payload}")
+            reattached_surface = _resolve_surface_id(
+                client,
+                workspace_id,
+                attach_payload,
+                before_surface_ids=before_attach_surface_ids,
+            )
 
             second_probe = _run_surface_probe(
                 client,


### PR DESCRIPTION
## Summary
- Treat missing restored SSH PTY sessions as a distinct attach outcome.
- Fall back to a fresh restored remote shell when a persisted PTY is gone after app restart/update.
- Keep existing retry behavior for transient bridge closes and preserve same-shell reattach when the PTY still exists.

## Testing
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-stalepty-tests test -only-testing:cmuxTests/TabManagerSessionSnapshotTests/testSessionSnapshotRestoresSplitPersistentSSHPTYWithoutDefaultAttachScaffold -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHPTYAttachRequireExistingSessionNotFoundFailsWithoutWaitRetry` passed.
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-stalepty-tests test -only-testing:cmuxTests/TabManagerSessionSnapshotTests/testSessionSnapshotRestoresPersistentSSHPTYSessionAfterRelaunch` passed.
- Docker-backed `tests_v2/test_ssh_remote_detachable_pty.py` passed against tagged build `spty` and `/tmp/cmux-debug-spty.sock`.

## Issues
- Related: user-reported stale persistent SSH PTY after restarting/updating cmux Nightly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783586540&installation_id=133855650&pr_number=5689&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5689&signature=e1558375ea9a47796d9d1b15535db1dfebb31397663fc8dfa7753d7354c1627a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote SSH PTY attach exit semantics, restore startup scripts, and reverse-relay recovery—important for session continuity but scoped with tests and distinct exit codes.
> 
> **Overview**
> **Recovers stale persistent SSH PTY sessions** after restart/update by treating a missing PTY as a distinct outcome and optionally starting a fresh remote shell instead of failing or looping on reconnect.
> 
> `ssh-pty-attach` now exits with **253** when the persisted PTY is gone (via `remotePTYErrorIndicatesMissingSession`), and restored startup scripts handle that code: they show a user message and run a **fallback attach without `--require-existing`**, using an embedded **`--command-b64`** remote shell when a relay port is available. Transient bridge closes still retry on **254/255** only.
> 
> Restored panel attach commands now pass **`restoredRemoteShellCommand(relayPort:)`** as `remoteCommand` so the fallback can bootstrap a new interactive shell on the same relay.
> 
> **Reverse SSH relay startup** detects “remote port forwarding failed for listen port N” as a stale remote listener, runs **`cleanupStaleRemoteRelayListenerLocked`**, uses a shorter retry when cleanup succeeds, and skips publishing a noisy error status when cleanup handled the stale case.
> 
> Tests and the detachable-PTY integration test were updated for exit **253**, fallback shell wiring, stale-listener detection, and more reliable **`surface_id`** resolution after attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf59442a16e74836c6c636d3714ab148bcb722d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and recovers from stale restored SSH PTY sessions and stale SSH relay listeners. Falls back to a new remote shell when the persisted PTY is gone, cleans stuck relay ports on relaunch, and keeps the retry loop for transient bridge closures with same-session reattach when the PTY still exists.

- **Bug Fixes**
  - `ssh-pty-attach` returns exit code 253 when the PTY session is missing and shows a clearer error.
  - Startup attach script falls back to a new remote shell on 253 using `--command-b64`; retries only on 254/255.
  - Detects stale SSH relay listeners (“remote port forwarding failed for listen port X”), cleans the remote listener, shortens the retry delay, and avoids duplicate error toasts.
  - Tests updated to cover missing-session fallback, stale relay listener detection, and more robust `surface_id` resolution.

<sup>Written for commit bdf59442a16e74836c6c636d3714ab148bcb722d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for SSH PTY session attachment with distinct exit codes (253 for missing sessions, 1 for other errors).
  * Improved detection and automatic recovery of stale SSH relay listeners.
  * Added fallback attach mechanism when persistent SSH PTY sessions are unavailable.

* **Tests**
  * Updated test expectations to reflect new exit codes and session recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->