### PR TITLE
Show SSH remote filesystem in Files panel + revert to local on session exit

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -985,6 +985,7 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
         let remoteConnectionState: WorkspaceRemoteConnectionState?
         let remoteConnectionDetail: String?
         let remoteDaemonStatus: WorkspaceRemoteDaemonStatus?
+        let title: String?
     }
 
     @Published private(set) var directoryChangeGeneration: UInt64 = 0
@@ -1009,7 +1010,8 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                             remoteConfiguration: nil,
                             remoteConnectionState: nil,
                             remoteConnectionDetail: nil,
-                            remoteDaemonStatus: nil
+                            remoteDaemonStatus: nil,
+                            title: nil
                         )
                     )
                     .eraseToAnyPublisher()
@@ -1021,7 +1023,9 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                         workspace.$remoteConnectionDetail
                     )
                     .combineLatest(workspace.$remoteDaemonStatus)
-                    .map { values, remoteDaemonStatus in
+                    .combineLatest(workspace.$title)
+                    .map { combined, title in
+                        let (values, remoteDaemonStatus) = combined
                         let (
                             currentDirectory,
                             remoteConfiguration,
@@ -1034,7 +1038,8 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                             remoteConfiguration: remoteConfiguration,
                             remoteConnectionState: remoteConnectionState,
                             remoteConnectionDetail: remoteConnectionDetail,
-                            remoteDaemonStatus: remoteDaemonStatus
+                            remoteDaemonStatus: remoteDaemonStatus,
+                            title: title
                         )
                     }
                     .eraseToAnyPublisher()
@@ -2658,6 +2663,35 @@ struct ContentView: View {
                     rootPath: tab.currentDirectory,
                     isAvailable: tab.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
+                )
+            )
+            return
+        }
+
+        let detectedSSH: DetectedSSHSession? = tab.focusedPanelId.flatMap { panelId in
+            tab.candidateTTYNames(forPanel: panelId).lazy
+                .compactMap { TerminalSSHSessionDetector.detect(forTTY: $0) }
+                .first
+        }
+        if let sshSession = detectedSSH {
+            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
+            guard shouldSyncFileExplorerStore else {
+                fileExplorerStore.applyWorkspaceRoot(.none)
+                return
+            }
+            fileExplorerStore.applyWorkspaceRoot(
+                .remoteSSH(
+                    workspaceId: tab.id,
+                    connection: SSHFileExplorerConnection(
+                        destination: sshSession.destination,
+                        port: sshSession.port,
+                        identityFile: sshSession.identityFile,
+                        sshOptions: sshSession.sshOptions
+                    ),
+                    displayTarget: sshSession.destination,
+                    rootPath: TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: tab.title),
+                    isAvailable: true,
+                    unavailableDetail: nil
                 )
             )
             return

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1185,15 +1185,31 @@ final class FileExplorerStore: ObservableObject {
         }
 
         let requestedRootPath = Self.normalizedRootPath(requestedRootPath)
+        let currentHomePath = sshProvider.homePath.trimmingCharacters(in: .whitespacesAndNewlines)
+
         if let requestedRootPath {
-            cancelRemoteHomeResolution()
-            setRootStatusMessage(nil)
-            setRootPath(requestedRootPath)
-            return
+            // Tilde-prefixed paths come from the remote shell title and must be
+            // expanded against the resolved remote home before listing (the SSH
+            // `ls` path is single-quoted, so `~` would not expand remotely).
+            if requestedRootPath == "~" || requestedRootPath.hasPrefix("~/") {
+                if !currentHomePath.isEmpty {
+                    cancelRemoteHomeResolution()
+                    setRootStatusMessage(nil)
+                    setRootPath(Self.expandTilde(requestedRootPath, home: currentHomePath))
+                    return
+                }
+                // Home not resolved yet: fall through to resolve it (rooting at
+                // home). A subsequent title-change sync re-applies the cwd once
+                // the home path is cached.
+            } else {
+                cancelRemoteHomeResolution()
+                setRootStatusMessage(nil)
+                setRootPath(requestedRootPath)
+                return
+            }
         }
 
-        let currentHomePath = sshProvider.homePath
-        if !currentHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if !currentHomePath.isEmpty {
             setRootStatusMessage(nil)
             setRootPath(currentHomePath)
             return
@@ -1284,6 +1300,17 @@ final class FileExplorerStore: ObservableObject {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return trimmed
+    }
+
+    /// Expands a leading `~` (home) in a remote path against the resolved remote
+    /// home directory. Non-tilde paths are returned unchanged.
+    private static func expandTilde(_ path: String, home: String) -> String {
+        let base = home.hasSuffix("/") && home != "/" ? String(home.dropLast()) : home
+        if path == "~" { return base }
+        if path.hasPrefix("~/") {
+            return base + "/" + path.dropFirst(2)
+        }
+        return path
     }
 
     private static func remotePreviewCacheURL(displayTarget: String, remotePath: String) -> URL {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5385,6 +5385,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// rejected and quarantined.
     var hasLiveSurface: Bool { surface != nil && portalLifecycleState == .live }
 
+    var ttyName: String? {
+        guard let surface else { return nil }
+        let str = ghostty_surface_tty_name(surface)
+        defer { ghostty_string_free(str) }
+        guard let ptr = str.ptr, str.len > 0 else { return nil }
+        return String(decoding: UnsafeRawBufferPointer(start: ptr, count: Int(str.len)), as: UTF8.self)
+    }
+
     /// Whether the terminal surface view is currently attached to a window.
     ///
     /// Use the hosted view rather than the inner surface view, since the surface can be

--- a/Sources/RightSidebarToolPanel.swift
+++ b/Sources/RightSidebarToolPanel.swift
@@ -167,8 +167,17 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
     }
 
     private func observeWorkspaceRootChanges(_ workspace: Workspace) {
+        // `$title` reflects the live terminal/OSC title. A remote shell sets it to
+        // `user@host:cwd` when an `ssh` session starts and the local shell resets
+        // it on exit (Ctrl+D), so observing it drives the file-explorer root in
+        // BOTH directions event-driven: switch to the remote root when SSH is
+        // detected, and revert to the local cwd once the session ends. Without
+        // this, `currentDirectory` never changes during a local-terminal SSH
+        // session (Ghostty rejects remote OSC 7 pwd reports), so the sidebar would
+        // stay stuck on the remote workspace after the session closed.
         workspaceObservationCancellable = Publishers.MergeMany(
             workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
+            workspace.$title.map { _ in () }.eraseToAnyPublisher(),
             workspace.$remoteConfiguration.map { _ in () }.eraseToAnyPublisher(),
             workspace.$remoteConnectionState.map { _ in () }.eraseToAnyPublisher(),
             workspace.$remoteConnectionDetail.map { _ in () }.eraseToAnyPublisher(),
@@ -205,6 +214,30 @@ final class RightSidebarToolPanel: Panel, ObservableObject {
                     rootPath: workspace.currentDirectory,
                     isAvailable: workspace.remoteConnectionState == .connected,
                     unavailableDetail: unavailableDetail
+                )
+            )
+            return
+        }
+
+        let detectedSSH: DetectedSSHSession? = workspace.focusedPanelId.flatMap { panelId in
+            workspace.candidateTTYNames(forPanel: panelId).lazy
+                .compactMap { TerminalSSHSessionDetector.detect(forTTY: $0) }
+                .first
+        }
+        if let sshSession = detectedSSH {
+            store.applyWorkspaceRoot(
+                .remoteSSH(
+                    workspaceId: workspace.id,
+                    connection: SSHFileExplorerConnection(
+                        destination: sshSession.destination,
+                        port: sshSession.port,
+                        identityFile: sshSession.identityFile,
+                        sshOptions: sshSession.sshOptions
+                    ),
+                    displayTarget: sshSession.destination,
+                    rootPath: TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: workspace.title),
+                    isAvailable: true,
+                    unavailableDetail: nil
                 )
             )
             return

--- a/Sources/TerminalSSHSessionDetector.swift
+++ b/Sources/TerminalSSHSessionDetector.swift
@@ -392,6 +392,25 @@ enum TerminalSSHSessionDetector {
         let executableName: String
     }
 
+    /// Best-effort extraction of the remote working directory from a terminal
+    /// title produced by a remote shell prompt (commonly `user@host:cwd`).
+    ///
+    /// Ghostty rejects OSC 7 (pwd) reports from non-local hosts, so during an SSH
+    /// session the only signal for the remote cwd is the window title the remote
+    /// shell sets. The returned path may be tilde-prefixed (`~/...`); callers that
+    /// need an absolute path must expand it against the resolved remote home.
+    /// Returns `nil` when the title does not look like a `user@host:path` prompt.
+    static func remoteWorkingDirectory(fromTitle title: String) -> String? {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let atIndex = trimmed.firstIndex(of: "@") else { return nil }
+        let afterAt = trimmed[trimmed.index(after: atIndex)...]
+        guard let colonIndex = afterAt.firstIndex(of: ":") else { return nil }
+        let cwd = afterAt[afterAt.index(after: colonIndex)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard cwd == "~" || cwd.hasPrefix("/") || cwd.hasPrefix("~/") else { return nil }
+        return cwd
+    }
+
     static func detect(forTTY ttyName: String) -> DetectedSSHSession? {
         let normalizedTTY = normalizeTTYName(ttyName)
         guard !normalizedTTY.isEmpty else { return nil }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11872,6 +11872,31 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] as? TerminalPanel
     }
 
+    func ttyName(forPanel panelId: UUID) -> String? {
+        candidateTTYNames(forPanel: panelId).first
+    }
+
+    /// Candidate TTY device names for a panel, most authoritative first.
+    ///
+    /// The live Ghostty surface PTY (queried via `TIOCPTYGNAME`) is preferred
+    /// because shell-integration-reported names in `surfaceTTYNames` can be stale
+    /// (e.g. they may capture the launching terminal's TTY rather than the panel's
+    /// own PTY). Callers that need to resolve a real session (such as SSH
+    /// detection) should try every candidate and use the first that resolves.
+    func candidateTTYNames(forPanel panelId: UUID) -> [String] {
+        var result: [String] = []
+        if let live = terminalPanel(for: panelId)?.surface.ttyName,
+           !live.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            result.append(live)
+        }
+        if let reported = surfaceTTYNames[panelId],
+           !reported.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !result.contains(reported) {
+            result.append(reported)
+        }
+        return result
+    }
+
     func browserPanel(for panelId: UUID) -> BrowserPanel? {
         panels[panelId] as? BrowserPanel
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		B37A00000000000000000003 /* RightSidebarMode+Availability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000004 /* RightSidebarMode+Availability.swift */; };
 		FE003103 /* RightSidebarPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003003 /* RightSidebarPanelView.swift */; };
 		B37A0000000000000000000D /* RightSidebarRemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */; };
+		94B2B339E12C9583D895BF06 /* RightSidebarSSHTeardownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF69A3A1140315BD094144BB /* RightSidebarSSHTeardownTests.swift */; };
 		FE0031A3 /* RightSidebarToolPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0030A3 /* RightSidebarToolPanel.swift */; };
 		C46790000000000000000005 /* RosettaNativeRelaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000006 /* RosettaNativeRelaunch.swift */; };
 		C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */; };
@@ -1219,6 +1220,7 @@
 		B37A00000000000000000004 /* RightSidebarMode+Availability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RightSidebarMode+Availability.swift"; sourceTree = "<group>"; };
 		FE003003 /* RightSidebarPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelView.swift; sourceTree = "<group>"; };
 		B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarRemoteCommand.swift; sourceTree = "<group>"; };
+		AF69A3A1140315BD094144BB /* RightSidebarSSHTeardownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarSSHTeardownTests.swift; sourceTree = "<group>"; };
 		FE0030A3 /* RightSidebarToolPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarToolPanel.swift; sourceTree = "<group>"; };
 		C46790000000000000000006 /* RosettaNativeRelaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RosettaNativeRelaunch.swift; sourceTree = "<group>"; };
 		C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosettaNativeRelaunchTests.swift; sourceTree = "<group>"; };
@@ -2179,6 +2181,7 @@
 		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
 				768CFCBC86433F91FFCBC078 /* TerminalSSHSessionDetectorTitleTests.swift */,
+				AF69A3A1140315BD094144BB /* RightSidebarSSHTeardownTests.swift */,
 				A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
@@ -3261,6 +3264,7 @@
 					F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
 					F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */,
 				C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */,
+				94B2B339E12C9583D895BF06 /* RightSidebarSSHTeardownTests.swift in Sources */,
 				C46790000000000000000007 /* RosettaNativeRelaunchTests.swift in Sources */,
 				F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */,
 				F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -622,6 +622,7 @@
 		C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */; };
 		C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE53360000000000000002 /* TerminalSearchOverlayMouseReleaseTests.swift */; };
 		A5001543 /* TerminalSSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* TerminalSSHSessionDetector.swift */; };
+		512446B4D1ED8F4BC140C222 /* TerminalSSHSessionDetectorTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768CFCBC86433F91FFCBC078 /* TerminalSSHSessionDetectorTitleTests.swift */; };
 		C13519000000000000000001 /* TerminalStartupEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000002 /* TerminalStartupEnvironment.swift */; };
 		A9F200000000000000000009 /* TerminalSurfaceClaudeCommandShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000009 /* TerminalSurfaceClaudeCommandShim.swift */; };
 		A9F20000000000000000000A /* TerminalSurfaceCmuxContextEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000000A /* TerminalSurfaceCmuxContextEnvironment.swift */; };
@@ -1345,6 +1346,7 @@
 		C0DE53350000000000000002 /* TerminalSearchOverlayHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/TerminalSearchOverlayHostingView.swift; sourceTree = "<group>"; };
 		C0DE53360000000000000002 /* TerminalSearchOverlayMouseReleaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSearchOverlayMouseReleaseTests.swift; sourceTree = "<group>"; };
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
+		768CFCBC86433F91FFCBC078 /* TerminalSSHSessionDetectorTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetectorTitleTests.swift; sourceTree = "<group>"; };
 		C13519000000000000000002 /* TerminalStartupEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalStartupEnvironment.swift; sourceTree = "<group>"; };
 		A9F100000000000000000009 /* TerminalSurfaceClaudeCommandShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceClaudeCommandShim.swift; sourceTree = "<group>"; };
 		A9F10000000000000000000A /* TerminalSurfaceCmuxContextEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceCmuxContextEnvironment.swift; sourceTree = "<group>"; };
@@ -2176,6 +2178,7 @@
 				E50320010000000000000002 /* ExtensionWorktreeSpawnArgsTests.swift */,
 		C0DE49950000000000000002 /* FilePreviewKindResolverTests.swift */,
 				120A1EF846214C938416846E /* FileExplorerRootSyncPolicyTests.swift */,
+				768CFCBC86433F91FFCBC078 /* TerminalSSHSessionDetectorTitleTests.swift */,
 				A4880BD05924400E5279D632 /* MobilePairingConnectionTransitionTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
@@ -3296,6 +3299,7 @@
 				A5A5A503A1B2C3D4E5F60718 /* TerminalNotificationQueueTests.swift in Sources */,
 				A5E380700000000000000001 /* TerminalNotificationSocketActionTests.swift in Sources */,
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
+				512446B4D1ED8F4BC140C222 /* TerminalSSHSessionDetectorTitleTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,

--- a/cmuxTests/RightSidebarSSHTeardownTests.swift
+++ b/cmuxTests/RightSidebarSSHTeardownTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5685:
+/// after an `ssh` session ends in a local terminal, the right-sidebar Files
+/// panel must revert from the remote host back to the local workspace.
+///
+/// The bug was a missing *trigger*, not a wrong decision. During a
+/// local-terminal SSH session `currentDirectory` never changes (Ghostty rejects
+/// remote OSC 7 pwd reports), so the only signal that the session started or
+/// ended is the terminal title. `RightSidebarToolPanel.observeWorkspaceRootChanges`
+/// originally watched only `currentDirectory` / `remote*`, so when the user
+/// pressed `Ctrl+D` nothing re-synced and the panel stayed stuck on the remote
+/// host. The fix adds `workspace.$title` to the observed publishers.
+///
+/// This test drives the exact repro: it puts the panel's store into a stale
+/// remote state, then changes ONLY the title (leaving `currentDirectory`
+/// untouched) and asserts the panel reverts to the local root. Without the
+/// `$title` observation the title change fires no re-sync and the store stays on
+/// the SSH provider, so this test fails — i.e. it genuinely catches the bug.
+@MainActor
+@Suite("Files panel reverts to local when an SSH session ends")
+struct RightSidebarSSHTeardownTests {
+    @Test("Terminal title reset reverts the Files panel from remote to local")
+    func titleResetRevertsRemoteToLocal() async throws {
+        let localDir = "/private/tmp"
+
+        let workspace = Workspace()
+        workspace.currentDirectory = localDir
+
+        let panel = RightSidebarToolPanel(workspace: workspace, mode: .files)
+        // Lazily create the store; its initial sync roots at the local cwd because
+        // there is no focused terminal panel (so no SSH session is detected).
+        let store = panel.fileExplorerStore
+
+        // Precondition: force the store into the "stuck on remote" state that an
+        // earlier SSH detection would have produced. A stub transport keeps this
+        // off the network.
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: workspace.id,
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@remote-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@remote-host",
+                rootPath: "/home/dev",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: StubSSHFileExplorerTransport()
+        )
+        try await waitUntil("store is on the SSH provider") {
+            store.provider is SSHFileExplorerProvider
+        }
+
+        // The SSH session ends. `currentDirectory` is unchanged; only the live
+        // terminal title resets (here, to the local shell's prompt).
+        workspace.title = "alice@localhost:~"
+
+        // The Files panel must revert to the local workspace root.
+        try await waitUntil("Files panel reverts to the local root") {
+            store.provider is LocalFileExplorerProvider && store.rootPath == localDir
+        }
+    }
+
+    /// Polls `condition` on the main actor until it holds or the timeout elapses,
+    /// giving the panel's async title-observation sink time to run.
+    private func waitUntil(
+        _ description: String,
+        timeout: Double = 2.0,
+        _ condition: () -> Bool
+    ) async throws {
+        let stepNanos: UInt64 = 20_000_000 // 20ms
+        let maxSteps = Int(timeout / 0.02)
+        for _ in 0..<maxSteps {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: stepNanos)
+        }
+        #expect(condition(), "Timed out waiting for: \(description)")
+    }
+}
+
+private final class StubSSHFileExplorerTransport: SSHFileExplorerTransport {
+    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
+        "/home/dev"
+    }
+
+    func listDirectory(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        showHidden: Bool
+    ) async throws -> [FileExplorerEntry] {
+        []
+    }
+
+    func downloadFile(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        to localURL: URL
+    ) async throws {}
+}

--- a/cmuxTests/TerminalSSHSessionDetectorTitleTests.swift
+++ b/cmuxTests/TerminalSSHSessionDetectorTitleTests.swift
@@ -1,0 +1,78 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Covers `TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle:)`, the
+/// pure helper that extracts the remote cwd from a `user@host:cwd` shell title.
+/// This path is the only signal for the remote working directory during a
+/// local-terminal SSH session (Ghostty rejects remote OSC 7 pwd reports), so the
+/// Files panel's remote root depends on it parsing exactly these shapes.
+@Suite("SSH remote working directory from terminal title")
+struct TerminalSSHSessionDetectorTitleTests {
+    @Test("Home title yields tilde")
+    func homeTitleYieldsTilde() {
+        #expect(
+            TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:~") == "~"
+        )
+    }
+
+    @Test("Absolute path is returned verbatim")
+    func absolutePathReturnedVerbatim() {
+        #expect(
+            TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:/var/www") == "/var/www"
+        )
+    }
+
+    @Test("Tilde-prefixed subpath is preserved")
+    func tildeSubpathPreserved() {
+        #expect(
+            TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "deploy@web-01:~/projects/cmux")
+                == "~/projects/cmux"
+        )
+    }
+
+    @Test("Surrounding whitespace is trimmed")
+    func surroundingWhitespaceTrimmed() {
+        #expect(
+            TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "  user@host:/srv  ") == "/srv"
+        )
+    }
+
+    @Test("A colon inside the path is kept")
+    func colonInsidePathKept() {
+        #expect(
+            TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:/a:b/c") == "/a:b/c"
+        )
+    }
+
+    @Test("Title without an @ is not a remote prompt")
+    func titleWithoutAtIsNil() {
+        #expect(TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "localshell") == nil)
+    }
+
+    @Test("Title without a colon has no cwd")
+    func titleWithoutColonIsNil() {
+        #expect(TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host") == nil)
+    }
+
+    @Test("Relative cwd is rejected")
+    func relativeCwdIsNil() {
+        #expect(TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:project") == nil)
+    }
+
+    @Test("Empty cwd is rejected")
+    func emptyCwdIsNil() {
+        #expect(TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:") == nil)
+    }
+
+    @Test("Tilde-username form is not treated as a path")
+    func tildeUsernameFormIsNil() {
+        // `~user` (home of another user) is not `~` or `~/...`, so it must not be
+        // mistaken for an expandable remote root.
+        #expect(TerminalSSHSessionDetector.remoteWorkingDirectory(fromTitle: "user@host:~user") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Shows the **remote** filesystem in the right-sidebar **Files** panel while a terminal is connected over `ssh`, and — critically — reverts back to the **local** workspace once the SSH session ends.

The Files panel now tracks SSH sessions in a local terminal: when an `ssh user@host` session is detected on the focused panel's TTY, the explorer roots at the remote host (using the remote cwd parsed from the shell title); when the session exits (e.g. `Ctrl+D`), it switches back to the local cwd.

## The teardown bug (fixes #5685)

Previously the panel could switch **to** the remote workspace but never switched **back**. During an SSH session `currentDirectory` never changes (Ghostty rejects remote OSC 7 pwd reports), so the sidebar's workspace observation — which only watched `currentDirectory` / `remote*` — received no event on exit and stayed stuck on the remote host.

Fix: `RightSidebarToolPanel.observeWorkspaceRootChanges` now also observes `workspace.$title`. The live terminal title reflects the remote shell's `user@host:cwd` while connected and is reset by the local shell on exit, so observing it re-syncs the explorer root in **both** directions, event-driven:

- SSH starts → title becomes `user@host:cwd` → re-sync → SSH detected → root at remote
- SSH exits (Ctrl+D) → local shell resets title → re-sync → no SSH → root back at local cwd

This replaces an earlier 2s polling timer (which walked the panel's process tree every 2 seconds even while idle) with a single event-driven mechanism, consistent with the `ContentView` file-explorer path and the repo's recent event-driven direction (#5673).

## Changes

- `RightSidebarToolPanel.swift` — observe `$title` to drive the explorer root in both directions; removed the polling timer.
- `ContentView.swift` — observe `$title` in the selected-workspace directory observer; detect SSH on the focused panel's TTY and root the explorer remotely.
- `TerminalSSHSessionDetector.swift` — `remoteWorkingDirectory(fromTitle:)` to parse the remote cwd from a `user@host:cwd` shell title.
- `FileExplorerStore.swift` — expand a leading `~` in remote root paths against the resolved remote home before listing.
- `Workspace.swift` — `candidateTTYNames(forPanel:)` (live Ghostty PTY first, then shell-integration-reported names) for SSH detection.
- `GhosttyTerminalView.swift` — expose the live surface TTY name via `ghostty_surface_tty_name`.

## Testing

- cmux Swift target compiles cleanly.
- Runtime dogfooding of the local→remote→local transition is recommended on a normal build environment.

## Notes

- No user-facing strings added or changed; no localization audit items.

Fixes #5685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588952&installation_id=133855650&pr_number=5691&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5691&signature=3adc6efa2bcd5f29ea73917eea493580846adc951c9a36d91f62a0d17cc527f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the remote filesystem in the Files panel when a terminal is connected via `ssh`, and automatically switches back to the local workspace when the session ends. Detection is event-driven from the focused panel’s TTY and shell title, removing the polling timer.

- **New Features**
  - Roots the explorer at the remote host using the cwd parsed from `user@host:cwd`; expands leading `~` against the resolved remote home.
  - Detects SSH on the focused panel by trying the live Ghostty PTY name first, then shell-reported TTY names.
  - Adds unit tests for parsing the remote cwd from `user@host:cwd` titles to keep behavior stable.

- **Bug Fixes**
  - Fixes the Files panel getting stuck on the remote host after SSH exit by observing `workspace.$title` and re-syncing to the local cwd (Fixes #5685).
  - Adds a regression test to ensure the panel reverts to local on SSH teardown.

<sup>Written for commit 66b4d83073b896f18c670971c577b2171026755b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prioritized SSH-session detection in terminals to drive remote workflows and apply remote roots.
  * Sidebar/workspace root sync now reacts to terminal titles so file explorer follows SSH sessions and also reverts when sessions end.

* **Bug Fixes**
  * Tilde (~) root paths from SSH are expanded against the remote home when available.

* **Tests**
  * Added unit tests for SSH title parsing and sidebar SSH teardown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->