### PR TITLE
Fix nightly Xcode selection on single-Xcode runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Validate nightly tag push auth
         run: ./tests/test_ci_nightly_tag_push_auth.sh
 
+      - name: Validate nightly Xcode selection
+        run: ./tests/test_ci_nightly_xcode_selection.sh
+
+      - name: Validate universal nightly workflow
+        run: bash ./tests/test_nightly_universal_build.sh
+
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,13 +100,12 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    # Run on the macOS 15 host because zig 0.15.2 can cross-link the universal
-    # (arm64 + x86_64) Ghostty CLI helper only against a pre-26 SDK. The Swift
-    # app is built with the macOS 26 Xcode on this same runner so it adopts
-    # Liquid Glass on Tahoe; the helper is built separately with the older Xcode
-    # and injected before signing (see Select Xcode + the helper build/inject
-    # steps). Building the whole app with Xcode 16 (#5022) shipped a macOS 15 SDK
-    # binary that Tahoe forced into the legacy non-Liquid-Glass appearance.
+    # Run on the macOS 15 host that carries the signing/notarization secrets.
+    # The Swift app still selects an Xcode with the macOS 26 SDK so it adopts
+    # Liquid Glass on Tahoe. The Ghostty CLI helper is built separately and
+    # injected before signing, preferring a pre-26 SDK when the runner image has
+    # one but falling back to the selected app Xcode when the image only ships
+    # Xcode 26. The helper build remains required and lipo-verified below.
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 30
     steps:
@@ -141,57 +140,7 @@ jobs:
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
           set -euo pipefail
-          # The app must link against the macOS 26 SDK so it adopts Liquid Glass
-          # on Tahoe (the team is pinned to Xcode 26 via .xcode-version). The zig
-          # Ghostty CLI helper must link against a pre-26 SDK because zig 0.15.2
-          # cannot cross-link x86_64 against the macOS 26 SDK. Both Xcodes ship on
-          # the macOS 15 runner image, so pick the newest of each by SDK version.
-          # Compare SDK versions numerically (not lexicographically) so e.g.
-          # 26.10 sorts above 26.3.
-          sdk_rank() {
-            # "26.2" -> 26002 ; "26" -> 26000
-            local v="$1" maj min
-            maj="${v%%.*}"
-            min="${v#*.}"
-            [ "$min" = "$v" ] && min=0
-            min="${min%%.*}"
-            printf '%d' "$(( maj * 1000 + min ))"
-          }
-          APP_DEVELOPER_DIR=""; APP_SDK_VER=""; APP_RANK=-1
-          HELPER_DEVELOPER_DIR=""; HELPER_SDK_VER=""; HELPER_RANK=-1
-          while IFS= read -r app; do
-            [ -n "$app" ] || continue
-            dev="$app/Contents/Developer"
-            [ -d "$dev" ] || continue
-            sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
-            [ -n "$sdk_ver" ] || continue
-            rank="$(sdk_rank "$sdk_ver")"
-            echo "Found $app -> macOS SDK $sdk_ver (rank $rank)"
-            if [ "${sdk_ver%%.*}" -ge 26 ]; then
-              if [ "$rank" -gt "$APP_RANK" ]; then
-                APP_DEVELOPER_DIR="$dev"; APP_SDK_VER="$sdk_ver"; APP_RANK="$rank"
-              fi
-            else
-              if [ "$rank" -gt "$HELPER_RANK" ]; then
-                HELPER_DEVELOPER_DIR="$dev"; HELPER_SDK_VER="$sdk_ver"; HELPER_RANK="$rank"
-              fi
-            fi
-          done < <(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null)
-
-          if [ -z "$APP_DEVELOPER_DIR" ]; then
-            echo "No Xcode with the macOS 26+ SDK found; the app would ship without Liquid Glass on Tahoe." >&2
-            exit 1
-          fi
-          if [ -z "$HELPER_DEVELOPER_DIR" ]; then
-            echo "No pre-26 Xcode found to cross-link the universal Ghostty CLI helper (zig 0.15.2 cannot link x86_64 against the macOS 26 SDK)." >&2
-            exit 1
-          fi
-
-          echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_VER)"
-          echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_VER)"
-          DEVELOPER_DIR="$APP_DEVELOPER_DIR" xcodebuild -version
-          echo "DEVELOPER_DIR=$APP_DEVELOPER_DIR" >> "$GITHUB_ENV"
-          echo "HELPER_DEVELOPER_DIR=$HELPER_DEVELOPER_DIR" >> "$GITHUB_ENV"
+          ./scripts/select-nightly-xcodes.sh
 
       - name: Install build deps
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
@@ -203,7 +152,6 @@ jobs:
       - name: Build universal Ghostty CLI helper
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         env:
-          # zig 0.15.2 can cross-link the x86_64 slice only against a pre-26 SDK.
           DEVELOPER_DIR: ${{ env.HELPER_DEVELOPER_DIR }}
         run: |
           set -euo pipefail

--- a/scripts/select-nightly-xcodes.sh
+++ b/scripts/select-nightly-xcodes.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Select Xcodes for the nightly macOS build.
+set -euo pipefail
+
+APPLICATIONS_DIR="${CMUX_XCODE_APPLICATIONS_DIR:-/Applications}"
+PRINT_VERSION="${CMUX_SELECT_XCODE_PRINT_VERSION:-1}"
+
+sdk_major() {
+  local v="$1" maj
+  maj="${v%%.*}"
+  case "$maj" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%d' "$maj"
+}
+
+sdk_rank() {
+  local v="$1" maj min
+  maj="${v%%.*}"
+  min="${v#*.}"
+  [ "$min" = "$v" ] && min=0
+  min="${min%%.*}"
+  case "$maj" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  case "$min" in
+    ''|*[!0-9]*) min=0 ;;
+  esac
+  printf '%d' "$(( maj * 1000 + min ))"
+}
+
+APP_DEVELOPER_DIR=""
+APP_SDK_VER=""
+APP_RANK=-1
+HELPER_DEVELOPER_DIR=""
+HELPER_SDK_VER=""
+HELPER_RANK=-1
+
+while IFS= read -r app; do
+  [ -n "$app" ] || continue
+  dev="$app/Contents/Developer"
+  [ -d "$dev" ] || continue
+  sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
+  [ -n "$sdk_ver" ] || continue
+  if ! major="$(sdk_major "$sdk_ver")"; then
+    echo "Ignoring $app with unparsable macOS SDK version: $sdk_ver" >&2
+    continue
+  fi
+  if ! rank="$(sdk_rank "$sdk_ver")"; then
+    echo "Ignoring $app with unparsable macOS SDK version: $sdk_ver" >&2
+    continue
+  fi
+  echo "Found $app -> macOS SDK $sdk_ver (rank $rank)"
+  if [ "$major" -ge 26 ]; then
+    if [ "$rank" -gt "$APP_RANK" ]; then
+      APP_DEVELOPER_DIR="$dev"
+      APP_SDK_VER="$sdk_ver"
+      APP_RANK="$rank"
+    fi
+  else
+    if [ "$rank" -gt "$HELPER_RANK" ]; then
+      HELPER_DEVELOPER_DIR="$dev"
+      HELPER_SDK_VER="$sdk_ver"
+      HELPER_RANK="$rank"
+    fi
+  fi
+done < <(find "$APPLICATIONS_DIR" -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort)
+
+if [ -z "$APP_DEVELOPER_DIR" ]; then
+  echo "No Xcode with the macOS 26+ SDK found; the app would ship without Liquid Glass on Tahoe." >&2
+  exit 1
+fi
+
+if [ -z "$HELPER_DEVELOPER_DIR" ]; then
+  HELPER_DEVELOPER_DIR="$APP_DEVELOPER_DIR"
+  HELPER_SDK_VER="$APP_SDK_VER"
+  echo "No pre-26 Xcode found for the Ghostty CLI helper; falling back to the app Xcode. The universal helper build and lipo verification remain required." >&2
+fi
+
+echo "App build Xcode (DEVELOPER_DIR): $APP_DEVELOPER_DIR (macOS SDK $APP_SDK_VER)"
+echo "Helper build Xcode (HELPER_DEVELOPER_DIR): $HELPER_DEVELOPER_DIR (macOS SDK $HELPER_SDK_VER)"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "DEVELOPER_DIR=$APP_DEVELOPER_DIR" >> "$GITHUB_ENV"
+  echo "HELPER_DEVELOPER_DIR=$HELPER_DEVELOPER_DIR" >> "$GITHUB_ENV"
+fi
+
+if [ "$PRINT_VERSION" != "0" ]; then
+  DEVELOPER_DIR="$APP_DEVELOPER_DIR" xcodebuild -version
+fi

--- a/tests/test_ci_nightly_xcode_selection.sh
+++ b/tests/test_ci_nightly_xcode_selection.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression test for nightly Xcode selection on one-Xcode runner images.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/select-nightly-xcodes.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+BIN_DIR="$TMP_DIR/bin"
+APPS_DIR="$TMP_DIR/Applications"
+mkdir -p "$BIN_DIR" "$APPS_DIR"
+
+cat > "$BIN_DIR/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "--sdk" ] && [ "${2:-}" = "macosx" ] && [ "${3:-}" = "--show-sdk-version" ]; then
+  cat "${DEVELOPER_DIR:?}/sdk-version"
+  exit 0
+fi
+
+echo "unexpected xcrun invocation: $*" >&2
+exit 2
+EOF
+chmod +x "$BIN_DIR/xcrun"
+
+make_xcode() {
+  local name="$1" sdk="$2" dev
+  dev="$APPS_DIR/$name/Contents/Developer"
+  mkdir -p "$dev"
+  printf '%s\n' "$sdk" > "$dev/sdk-version"
+}
+
+run_selector() {
+  local out="$1" env_file="$2"
+  PATH="$BIN_DIR:$PATH" \
+    CMUX_XCODE_APPLICATIONS_DIR="$APPS_DIR" \
+    CMUX_SELECT_XCODE_PRINT_VERSION=0 \
+    GITHUB_ENV="$env_file" \
+    "$SCRIPT" > "$out" 2>&1
+}
+
+assert_env_line() {
+  local env_file="$1" expected="$2"
+  if ! grep -Fxq "$expected" "$env_file"; then
+    echo "FAIL: missing env line: $expected" >&2
+    echo "--- env file ---" >&2
+    cat "$env_file" >&2
+    exit 1
+  fi
+}
+
+make_xcode "Xcode.app" "26.2"
+ONLY_OUT="$TMP_DIR/only.out"
+ONLY_ENV="$TMP_DIR/only.env"
+run_selector "$ONLY_OUT" "$ONLY_ENV"
+assert_env_line "$ONLY_ENV" "DEVELOPER_DIR=$APPS_DIR/Xcode.app/Contents/Developer"
+assert_env_line "$ONLY_ENV" "HELPER_DEVELOPER_DIR=$APPS_DIR/Xcode.app/Contents/Developer"
+if ! grep -Fq "falling back to the app Xcode" "$ONLY_OUT"; then
+  echo "FAIL: one-Xcode selection must explain the helper fallback" >&2
+  cat "$ONLY_OUT" >&2
+  exit 1
+fi
+
+make_xcode "Xcode_16.app" "15.5"
+DUAL_OUT="$TMP_DIR/dual.out"
+DUAL_ENV="$TMP_DIR/dual.env"
+run_selector "$DUAL_OUT" "$DUAL_ENV"
+assert_env_line "$DUAL_ENV" "DEVELOPER_DIR=$APPS_DIR/Xcode.app/Contents/Developer"
+assert_env_line "$DUAL_ENV" "HELPER_DEVELOPER_DIR=$APPS_DIR/Xcode_16.app/Contents/Developer"
+
+rm -rf "$APPS_DIR"
+mkdir -p "$APPS_DIR"
+make_xcode "Xcode_16.app" "15.5"
+MISSING_OUT="$TMP_DIR/missing.out"
+MISSING_ENV="$TMP_DIR/missing.env"
+if run_selector "$MISSING_OUT" "$MISSING_ENV"; then
+  echo "FAIL: selection must fail when no macOS 26+ SDK app Xcode exists" >&2
+  cat "$MISSING_OUT" >&2
+  exit 1
+fi
+if ! grep -Fq "No Xcode with the macOS 26+ SDK found" "$MISSING_OUT"; then
+  echo "FAIL: missing app Xcode failure did not explain the macOS 26 requirement" >&2
+  cat "$MISSING_OUT" >&2
+  exit 1
+fi
+
+echo "PASS: nightly Xcode selection supports one-Xcode macOS 26 runners"

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -5,10 +5,10 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 RELEASE_FILE="$ROOT_DIR/.github/workflows/release.yml"
 
-# nightly.yml is intentionally not covered here. It builds the macOS 26 SDK app
-# with its own inline helper-build model (PR #5077) and self-guards via its
-# "Select Xcode" loud-fail and "Verify nightly binary architectures" steps.
-# This lane guards the release/CI artifact-download model added by this change.
+# nightly.yml is intentionally not covered here. It has its own helper-build
+# model and guards via test_ci_nightly_xcode_selection.sh plus
+# test_nightly_universal_build.sh. This lane guards the release/CI
+# artifact-download model.
 
 job_section() {
   local file="$1" job="$2"

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -1,56 +1,73 @@
 #!/usr/bin/env bash
-# Regression test for dual nightly macOS tracks.
+# Regression test for the universal nightly macOS track.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
 
 if ! awk '
-  /^      - name: Build Apple Silicon app \(Release\)/ { in_arm=1; next }
-  /^      - name: Build universal app \(Release\)/ { in_universal=1; next }
-  in_arm && /^      - name:/ { in_arm=0 }
+  /^      - name: Build universal nightly app \(Release\)/ { in_universal=1; next }
   in_universal && /^      - name:/ { in_universal=0 }
-  in_arm && /-destination '\''platform=macOS,arch=arm64'\''/ { saw_arm_destination=1 }
-  in_arm && /ARCHS="arm64"/ { saw_arm_archs=1 }
-  in_arm && /ONLY_ACTIVE_ARCH=YES/ { saw_arm_only_active_arch=1 }
   in_universal && /-destination '\''generic\/platform=macOS'\''/ { saw_universal_destination=1 }
   in_universal && /ARCHS="arm64 x86_64"/ { saw_universal_archs=1 }
   in_universal && /ONLY_ACTIVE_ARCH=NO/ { saw_universal_only_active_arch=1 }
   END {
-    exit !(saw_arm_destination && saw_arm_archs && saw_arm_only_active_arch && saw_universal_destination && saw_universal_archs && saw_universal_only_active_arch)
+    exit !(saw_universal_destination && saw_universal_archs && saw_universal_only_active_arch)
   }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must force Apple Silicon nightly to arm64-only and universal nightly to both slices"
+  echo "FAIL: nightly workflow must build the nightly app as universal arm64+x86_64"
+  exit 1
+fi
+
+if ! awk '
+  /^      - name: Build universal Ghostty CLI helper/ { in_helper=1; next }
+  in_helper && /^      - name:/ { in_helper=0 }
+  in_helper && /build-ghostty-cli-helper\.sh --universal/ { saw_build=1 }
+  in_helper && /helper missing arm64 slice/ { saw_arm64_assert=1 }
+  in_helper && /helper missing x86_64 slice/ { saw_x86_assert=1 }
+  END { exit !(saw_build && saw_arm64_assert && saw_x86_assert) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must build and verify the real universal Ghostty helper"
+  exit 1
+fi
+
+if ! awk '
+  /^      - name: Inject universal Ghostty CLI helper/ { in_inject=1; next }
+  in_inject && /^      - name:/ { in_inject=0 }
+  in_inject && /install -m 755 \/tmp\/cmux-ghostty-helper-universal "\$DEST"/ { saw_install=1 }
+  END { exit !saw_install }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must inject the verified universal Ghostty helper into the app"
   exit 1
 fi
 
 if ! awk '
   /^      - name: Verify nightly binary architectures/ { in_verify=1; next }
   in_verify && /^      - name:/ { in_verify=0 }
-  in_verify && /lipo -archs "\$ARM_APP_BINARY"/ { saw_arm_app=1 }
-  in_verify && /lipo -archs "\$ARM_CLI_BINARY"/ { saw_arm_cli=1 }
   in_verify && /lipo -archs "\$APP_BINARY"/ { saw_app=1 }
   in_verify && /lipo -archs "\$CLI_BINARY"/ { saw_cli=1 }
-  in_verify && /\[\[ "\$ARM_APP_ARCHS" == "arm64" \]\]/ { saw_arm_app_assert=1 }
-  in_verify && /\[\[ "\$ARM_CLI_ARCHS" == "arm64" \]\]/ { saw_arm_cli_assert=1 }
-  END { exit !(saw_arm_app && saw_arm_cli && saw_app && saw_cli && saw_arm_app_assert && saw_arm_cli_assert) }
+  in_verify && /lipo -archs "\$HELPER_BINARY"/ { saw_helper=1 }
+  in_verify && /\[\[ "\$APP_ARCHS" == \*arm64\* && "\$APP_ARCHS" == \*x86_64\* \]\]/ { saw_app_assert=1 }
+  in_verify && /\[\[ "\$CLI_ARCHS" == \*arm64\* && "\$CLI_ARCHS" == \*x86_64\* \]\]/ { saw_cli_assert=1 }
+  in_verify && /\[\[ "\$HELPER_ARCHS" == \*arm64\* && "\$HELPER_ARCHS" == \*x86_64\* \]\]/ { saw_helper_assert=1 }
+  END { exit !(saw_app && saw_cli && saw_helper && saw_app_assert && saw_cli_assert && saw_helper_assert) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must verify arm-only and universal slices with lipo"
+  echo "FAIL: nightly workflow must verify universal app, CLI, and helper slices with lipo"
   exit 1
 fi
 
-if ! grep -Fq 'com.cmuxterm.app.nightly.universal' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must set a distinct .universal bundle ID"
+if ! grep -Fq 'bundle ID `com.cmuxterm.app.nightly`' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must publish the unified nightly bundle ID"
   exit 1
 fi
 
-if ! grep -Fq 'https://github.com/manaflow-ai/cmux/releases/download/nightly/appcast-universal.xml' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must publish a separate universal appcast feed"
+if ! grep -Fq 'cp appcast.xml appcast-universal.xml' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must keep the compatibility appcast-universal.xml feed"
   exit 1
 fi
 
-if ! grep -Fq './scripts/sparkle_generate_appcast.sh "$NIGHTLY_UNIVERSAL_DMG_IMMUTABLE" nightly appcast-universal.xml' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must generate a separate universal appcast"
+if ! grep -Fq './scripts/sparkle_generate_appcast.sh "$NIGHTLY_DMG_IMMUTABLE" nightly appcast.xml' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must generate the unified nightly appcast"
   exit 1
 fi
 
@@ -63,13 +80,12 @@ if ! awk '
   /^      - name: Upload branch nightly artifacts/ { in_upload=1; next }
   in_upload && /^      - name:/ { in_upload=0 }
   in_upload && /if: needs\.decide\.outputs\.should_publish != '\''true'\''/ { saw_if=1 }
-  in_upload && /uses: actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4/ { saw_upload=1 }
+  in_upload && /uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7/ { saw_upload=1 }
   in_upload && /cmux-nightly-macos\*\.dmg/ { saw_arm_artifacts=1 }
-  in_upload && /cmux-nightly-universal-macos\*\.dmg/ { saw_universal_artifacts=1 }
   in_upload && /appcast-universal\.xml/ { saw_universal_appcast=1 }
-  END { exit !(saw_if && saw_upload && saw_arm_artifacts && saw_universal_artifacts && saw_universal_appcast) }
+  END { exit !(saw_if && saw_upload && saw_arm_artifacts && saw_universal_appcast) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: non-main nightly runs must upload both nightly variants and both appcasts"
+  echo "FAIL: non-main nightly runs must upload nightly artifacts and compatibility appcasts"
   exit 1
 fi
 
@@ -87,13 +103,13 @@ if ! awk '
   /^      - name: Publish nightly release assets/ { in_publish=1; next }
   in_publish && /^      - name:/ { in_publish=0 }
   in_publish && /if: needs\.decide\.outputs\.should_publish == '\''true'\''/ { saw_publish_if=1 }
-  in_publish && /cmux-nightly-universal-macos-\$\{\{ github\.run_id \}\}\*\.dmg/ { saw_universal_immutable=1 }
-  in_publish && /cmux-nightly-universal-macos\.dmg/ { saw_universal_stable=1 }
+  in_publish && /cmux-nightly-macos-\$\{\{ github\.run_id \}\}\*\.dmg/ { saw_immutable=1 }
+  in_publish && /cmux-nightly-macos\.dmg/ { saw_stable=1 }
   in_publish && /appcast-universal\.xml/ { saw_universal_appcast=1 }
-  END { exit !(saw_publish_if && saw_universal_immutable && saw_universal_stable && saw_universal_appcast) }
+  END { exit !(saw_publish_if && saw_immutable && saw_stable && saw_universal_appcast) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: main nightly publish must include the universal assets and appcast"
+  echo "FAIL: main nightly publish must include immutable/stable assets and compatibility appcast"
   exit 1
 fi
 
-echo "PASS: nightly workflow keeps separate Apple Silicon and universal nightly tracks"
+echo "PASS: nightly workflow keeps the universal nightly track guarded"


### PR DESCRIPTION
## Summary
- replace the inline nightly Xcode selector with a tested script
- keep macOS 26 SDK selection required for the app
- fall back to the app Xcode for the Ghostty helper when no pre-26 Xcode is installed, while keeping the universal helper build and lipo checks required
- wire guard tests for one-Xcode runners and the current universal nightly workflow

## Failure fixed
- https://github.com/manaflow-ai/cmux/actions/runs/27199055536/job/80298102680 failed in `Select Xcode` because the runner only had Xcode.app with macOS SDK 26.2.

## Verification
- `./tests/test_ci_nightly_xcode_selection.sh`
- `bash ./tests/test_nightly_universal_build.sh`
- `./tests/test_ci_release_sdk_lane.sh`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783592300&installation_id=133855650&pr_number=5694&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5694&signature=9b5c72663abf47c337a58c5f8a34bb88edb7b1140482a3b97da426f7c1d66d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nightly signing/build toolchain selection and helper SDK fallback; mis-selection or a failed universal helper link on SDK 26 could break nightlies, though behavior is regression-tested in CI guards.
> 
> **Overview**
> Fixes nightly macOS CI failing on runners that only ship **Xcode 26** (macOS 26 SDK), where the old inline **Select Xcode** step hard-required a separate pre-26 Xcode for the Ghostty CLI helper.
> 
> **Nightly workflow** now calls **`scripts/select-nightly-xcodes.sh`** instead of inlined bash. The script still **requires** a macOS **26+** SDK Xcode for the Swift app (Liquid Glass on Tahoe) and prefers a **pre-26** Xcode for the universal helper when present, but **falls back** to the app Xcode when no pre-26 install exists—while keeping the universal helper build and **lipo** arm64/x86_64 checks mandatory. Workflow comments were updated to document that behavior.
> 
> **CI guard tests** were added in **`ci.yml`**: `test_ci_nightly_xcode_selection.sh` (mocked Xcode layouts: one-Xcode, dual-Xcode, missing 26+ failure) and an updated **`test_nightly_universal_build.sh`** wired into **`workflow-guard-tests`**. **`test_ci_release_sdk_lane.sh`** comments now point at these nightly-specific guards instead of inline workflow steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d03dcebc212664c22e78c74d7f31c2a287fc6ba3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nightly Xcode selection to work on single‑Xcode runners by moving selection into a tested script with a safe helper fallback. The app still builds with a macOS 26 SDK; the Ghostty helper prefers a pre‑26 SDK but falls back to the app Xcode, with universal build and lipo checks enforced.

- **Bug Fixes**
  - Nightly “Select Xcode” no longer fails when the runner only has Xcode 26; the helper falls back to the app’s Xcode if no pre‑26 Xcode is present.

- **Refactors**
  - Replaced inline selection with `scripts/select-nightly-xcodes.sh` and invoked it from `nightly.yml` (exports `DEVELOPER_DIR` and `HELPER_DEVELOPER_DIR`).
  - Added CI guards: `test_ci_nightly_xcode_selection.sh` for one‑Xcode runners and stronger `test_nightly_universal_build.sh`; wired into `ci.yml`.

<sup>Written for commit d03dcebc212664c22e78c74d7f31c2a287fc6ba3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly CI pipeline with improved Xcode selection logic and validation steps for universal builds.
  * Refactored nightly macOS workflow to streamline SDK version management.

* **Tests**
  * Added regression tests to validate nightly Xcode selection behavior across different runner configurations.
  * Added validation tests for universal nightly build configurations and architecture verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->