### PR TITLE
Fail bundled CLI tests when helper is missing

### DIFF
--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}
     timeout-minutes: 45
     env:
-      PERF_TAG: perfci
+      PERF_TAG: perf-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/cmuxTests/BundledCLILinkageTests.swift
+++ b/cmuxTests/BundledCLILinkageTests.swift
@@ -1,5 +1,55 @@
 import XCTest
 
+enum BundledCLITestSupport {
+    static func bundledCLIPath(
+        for bundleClass: AnyClass,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> String {
+        try bundledCLIURL(for: bundleClass, file: file, line: line).path
+    }
+
+    static func bundledCLIURL(
+        for bundleClass: AnyClass,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> URL {
+        let fileManager = FileManager.default
+        let appBundleURL = Bundle(for: bundleClass)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let expectedCLIURL = appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux", isDirectory: false)
+
+        if fileManager.isExecutableFile(atPath: expectedCLIURL.path) {
+            return expectedCLIURL
+        }
+
+        let enumerator = fileManager.enumerator(
+            at: appBundleURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        while let item = enumerator?.nextObject() as? URL {
+            guard item.lastPathComponent == "cmux",
+                  item.path.contains(".app/Contents/Resources/bin/cmux"),
+                  fileManager.isExecutableFile(atPath: item.path) else { continue }
+            return item
+        }
+
+        let message = "Bundled cmux CLI not found at \(expectedCLIURL.path)"
+        XCTFail(message, file: file, line: line)
+        throw NSError(domain: "cmux.tests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: message,
+        ])
+    }
+}
+
 final class BundledCLILinkageTests: XCTestCase {
     deinit {}
 
@@ -18,23 +68,7 @@ final class BundledCLILinkageTests: XCTestCase {
     }
 
     private func bundledCLIURL() throws -> URL {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIURL(for: Self.self)
     }
 
     private func linkedLibraries(for executableURL: URL) throws -> [String] {

--- a/cmuxTests/CLINotifyProcessTestSupport.swift
+++ b/cmuxTests/CLINotifyProcessTestSupport.swift
@@ -33,27 +33,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
     }
 
     func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(
-            at: appBundleURL,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     func makeSocketPath(_ name: String) -> String {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1266,23 +1266,7 @@ final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     /// A throwaway home directory for hermetic CLI socket-resolution tests.

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -2534,23 +2534,7 @@ final class CMUXOpenCommandTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     private func writeTestDiffViewerAssets(resourcesURL: URL, appMain: String) throws {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1329,27 +1329,7 @@ final class GhosttyConfigTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(
-            at: appBundleURL,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     private func runCLI(

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -66,14 +66,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self).bundleURL.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux", item.path.contains(".app/Contents/Resources/bin/cmux") else { continue }
-            return item.path
-        }
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     private func runProcess(

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3572,27 +3572,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(
-            at: appBundleURL,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     private func runProcess(

--- a/cmuxTests/WorkspaceSSHFishShellTests.swift
+++ b/cmuxTests/WorkspaceSSHFishShellTests.swift
@@ -304,27 +304,7 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
     }
 
     private func bundledCLIPath() throws -> String {
-        let fileManager = FileManager.default
-        let appBundleURL = Bundle(for: Self.self)
-            .bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let enumerator = fileManager.enumerator(
-            at: appBundleURL,
-            includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
-        )
-
-        while let item = enumerator?.nextObject() as? URL {
-            guard item.lastPathComponent == "cmux",
-                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
-                continue
-            }
-            return item.path
-        }
-
-        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+        try BundledCLITestSupport.bundledCLIPath(for: Self.self)
     }
 
     private func requireExecutable(_ candidates: [String], name: String) throws -> String {


### PR DESCRIPTION
## Summary
- add one shared bundled CLI test helper that checks the expected app-bundle path first
- make bundled CLI regression tests fail when Contents/Resources/bin/cmux is missing instead of reporting an XCTest skip
- remove duplicate skip-based CLI lookup code across the CLI test files
- make the activation-performance workflow use a run-specific dev tag so stale self-hosted DerivedData cannot reuse a precompiled header from another GhosttyKit header

## Verification
- git diff --check
- rg -n 'XCTSkip\(\"Bundled cmux CLI not found' cmuxTests -g '*.swift' (no matches)
- python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
- python3 tests/test_bash_integration_no_done_notifications.py

Hosted XCTest coverage must run in CI per repo policy; local xcodebuild test is intentionally not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor plus a CI env tag change; no production app or CLI behavior changes.
> 
> **Overview**
> Introduces **`BundledCLITestSupport`** so bundled CLI regression tests resolve `Contents/Resources/bin/cmux` in one place (canonical path first, then a scoped bundle search with an executable check). When the helper is missing, tests now **`XCTFail`** and throw instead of **`XCTSkip`**, so CI surfaces a missing bundled CLI as a real failure rather than a silent skip. Duplicate per-file lookup helpers across several `cmuxTests` CLI suites are removed in favor of the shared helper.
> 
> The activation performance workflow changes **`PERF_TAG`** from a fixed `perfci` to **`perf-${{ github.run_id }}-${{ github.run_attempt }}`**, giving each run a unique tagged app/socket identity and reducing collisions between concurrent or retried jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1a53deef5b6d8697be8eb89fd5099956c8515a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow artifact naming to ensure uniqueness per benchmark run.

* **Refactor**
  * Centralized bundled CLI tool path resolution logic across test suites for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->