### PR TITLE
Isolate tmux corpus terminal CI DerivedData

### DIFF
--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -63,6 +63,11 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 30
+    env:
+      # XCTest app-host crashes can leave xcodebuild waiting in Swift's crash
+      # backtracer until the job timeout. Keep crash handling non-interactive
+      # and cheap so xcodebuild can restart/finish the suite.
+      SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -117,12 +122,21 @@ jobs:
           key: tmux-corpus-spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: tmux-corpus-spm-
 
+      - name: Prepare isolated DerivedData
+        run: |
+          set -euo pipefail
+          DERIVED_DATA_PATH="${RUNNER_TEMP}/cmux-derived-data-tmux-corpus-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "$DERIVED_DATA_PATH"
+          mkdir -p "$DERIVED_DATA_PATH"
+          echo "CMUX_DERIVED_DATA_PATH=$DERIVED_DATA_PATH" >> "$GITHUB_ENV"
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
           mkdir -p "$SOURCE_PACKAGES_DIR"
           xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+            -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
             -resolvePackageDependencies
 
@@ -130,12 +144,28 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
-            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
-            -disableAutomaticPackageResolution \
-            -destination "platform=macOS" \
-            -only-testing:cmuxTests/GhosttyCommandShiftForwardingTests \
-            -only-testing:cmuxTests/GhosttyTerminalStartupEnvironmentTests \
-            -only-testing:cmuxTests/CmuxConfigNamedColorTests \
-            -only-testing:cmuxTests/SessionPersistenceTests \
-            test
+          set +e
+          scripts/ci/xcodebuild_noninteractive.py \
+            xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+              -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
+              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+              -disableAutomaticPackageResolution \
+              -destination "platform=macOS" \
+              -only-testing:cmuxTests/GhosttyCommandShiftForwardingTests \
+              -only-testing:cmuxTests/GhosttyTerminalStartupEnvironmentTests \
+              -only-testing:cmuxTests/CmuxConfigNamedColorTests \
+              -only-testing:cmuxTests/SessionPersistenceTests \
+              test 2>&1 | tee /tmp/tmux-terminal-corpus-output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          OUTPUT=$(cat /tmp/tmux-terminal-corpus-output.txt)
+          set -e
+
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1 || true)
+            if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
+              echo "All failures are expected, treating as pass"
+            else
+              echo "Unexpected terminal corpus test failures detected"
+              exit 1
+            fi
+          fi

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -13,6 +13,7 @@ CI_FILE="$ROOT_DIR/.github/workflows/ci.yml"
 GHOSTTYKIT_FILE="$ROOT_DIR/.github/workflows/build-ghosttykit.yml"
 COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 E2E_FILE="$ROOT_DIR/.github/workflows/test-e2e.yml"
+TMUX_CORPUS_FILE="$ROOT_DIR/.github/workflows/tmux-corpus.yml"
 
 check_macos_runner() {
   local file="$1" job="$2"
@@ -202,6 +203,26 @@ check_web_db_behavior_tests() {
   echo "PASS: web DB behavior tests run through the discovery runner"
 }
 
+check_tmux_terminal_nightly_isolation() {
+  check_macos_runner "$TMUX_CORPUS_FILE" "terminal-nightly"
+
+  if ! awk '
+    /^  terminal-nightly:/ { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
+    in_job && /CMUX_DERIVED_DATA_PATH/ { saw_env=1 }
+    in_job && /-derivedDataPath "\$CMUX_DERIVED_DATA_PATH"/ { saw_flag=1 }
+    in_job && /scripts\/ci\/xcodebuild_noninteractive\.py/ { saw_noninteractive=1 }
+    in_job && /SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"/ { saw_backtrace=1 }
+    in_job && /All failures are expected, treating as pass/ { saw_expected_failure_handling=1 }
+    END { exit !(saw_env && saw_flag && saw_noninteractive && saw_backtrace && saw_expected_failure_handling) }
+  ' "$TMUX_CORPUS_FILE"; then
+    echo "FAIL: tmux corpus terminal-nightly must use isolated DerivedData, the noninteractive xcodebuild wrapper, and expected-failure handling"
+    exit 1
+  fi
+
+  echo "PASS: tmux corpus terminal-nightly uses isolated DerivedData, noninteractive xcodebuild, and expected-failure handling"
+}
+
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
@@ -225,3 +246,4 @@ check_release_helper_upload_retry
 check_no_ci_xctest_skips
 check_no_ci_swift_package_skips
 check_web_db_behavior_tests
+check_tmux_terminal_nightly_isolation


### PR DESCRIPTION
## Summary
- give the scheduled/manual tmux corpus terminal job a run-scoped DerivedData path
- pass that DerivedData path to package resolution and terminal corpus xcodebuild tests
- run the terminal corpus xcodebuild through the noninteractive wrapper and set noninteractive Swift backtraces
- preserve `SessionPersistenceTests` expected-failure semantics in `terminal-nightly`
- extend the workflow guard so `terminal-nightly` cannot regress to shared DerivedData, direct xcodebuild, interactive backtraces, or missing expected-failure handling

## Failure context
- Current main failure: https://github.com/manaflow-ai/cmux/actions/runs/27202820912/job/80310835202
- Workflow/job: `tmux corpus` / `terminal-nightly`
- Runner context: Xcode 16.4, macOS 15 self-hosted runner
- Failure signature: `SessionPersistenceTests` exited via xcodebuild code 65 with `Executed 139 tests, with 6 failures (0 unexpected)`. The job should treat those known expected failures as pass, like main CI does, while still failing unexpected failures.
- Reliability risk also found in the same job: app-host XCTest used default shared DerivedData and direct `xcodebuild`, unlike the hardened main CI test path.

## Verification
- `./tests/test_ci_self_hosted_guard.sh`
- `git diff --check`
- Fresh manual tmux corpus run from this branch: https://github.com/manaflow-ai/cmux/actions/runs/27203650811
  - `terminal-nightly` passed: https://github.com/manaflow-ai/cmux/actions/runs/27203650811/job/80313964001
  - log showed `Executed 139 tests, with 6 failures (0 unexpected)`, `** TEST FAILED **`, then `All failures are expected, treating as pass`
- PR checks green: https://github.com/manaflow-ai/cmux/pull/5697/checks

No local xcodebuild test run; repository policy keeps XCTest on hosted CI.
