### PR TITLE
Deflake browser find UI test launch readiness

### DIFF
--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -498,9 +498,6 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_TAG"] = "ui-esc-\(UUID().uuidString.prefix(8))"
         launchAndEnsureForeground(app)
-
-        let window = app.windows.firstMatch
-        _ = window.waitForExistence(timeout: 2.0)
         XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
 
         guard let workspace = currentWorkspaceContext() else {
@@ -833,9 +830,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         launchAndEnsureForeground(app)
-
-        let window = app.windows.firstMatch
-        _ = window.waitForExistence(timeout: 2.0)
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
 
         app.typeKey("d", modifierFlags: [.command])
         XCTAssertTrue(
@@ -898,10 +893,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         launchAndEnsureForeground(app)
-
-        let window = app.windows.firstMatch
-        // On some CI runners the app accepts key events before XCUI exposes the window tree.
-        _ = window.waitForExistence(timeout: 2.0)
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
 
         app.typeKey("d", modifierFlags: [.command])
         XCTAssertTrue(
@@ -964,9 +956,6 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         launchAndEnsureForeground(app)
-
-        let window = app.windows.firstMatch
-        _ = window.waitForExistence(timeout: 2.0)
         XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
 
         guard let originalWorkspace = currentWorkspaceContext() else {


### PR DESCRIPTION
Fixes a flaky `ui-regressions` failure where `BrowserPaneNavigationKeybindUITests.testCmdFOpensBrowserFindAfterCmdDCmdLNavigation` timed out evaluating `Window (First Match)` before exercising the browser find regression.

Failure evidence: https://github.com/manaflow-ai/cmux/actions/runs/27197515212/job/80292835034

Baseline from recent main `ci.yml` runs: 10 passes / 11 completed `ui-regressions` attempts, with the failed attempt timing out in this test after launch. The newest main run was still in progress when this PR was opened: https://github.com/manaflow-ai/cmux/actions/runs/27205331533/job/80319527330

Change:
- Remove ignored `app.windows.firstMatch.waitForExistence(timeout: 2.0)` launch probes from this test class.
- Gate command-key driving on the app control socket instead, which proves the launched app is ready without forcing XCUI to snapshot a possibly unavailable window tree.

Coverage preserved:
- No tests skipped, disabled, removed, or weakened.
- The browser find test still drives the real Cmd+D, Cmd+L, navigation, Cmd+F, and text-input path, then asserts typing lands in `BrowserFindSearchTextField` and not the omnibar or file search.

Local verification:
- `./tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783599562&installation_id=133855650&pr_number=5699&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5699&signature=7e4251f3d4997e99bf2ea95db6977fb64bc65546bea6bf674f4af5e007599947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 03713e70d9ab30eeb03c3f9cde30294f035d847e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the browser find UI tests by waiting on the app’s control socket instead of the first window, preventing CI launch-time timeouts and keeping the real Cmd+D/Cmd+L/Cmd+F flow intact.

- **Bug Fixes**
  - Removed `app.windows.firstMatch.waitForExistence(timeout: 2.0)` probes.
  - Gate key events on `waitForSocketPong(timeout: 12.0)` to confirm app readiness without relying on XCUI window snapshots.

<sup>Written for commit 03713e70d9ab30eeb03c3f9cde30294f035d847e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved UI test synchronization and reliability through enhanced control mechanisms, reducing timing-related failures across browser navigation test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->