### PR TITLE
Fail CI on unit test failures

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -121,40 +121,8 @@ jobs:
           CMUX_SKIP_ZIG_BUILD: ${{ matrix.skip_zig && '1' || '0' }}
         run: |
           set -euo pipefail
-          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          run_unit_tests() {
-            scripts/ci/xcodebuild_noninteractive.py \
-              xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
-              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
-              -disableAutomaticPackageResolution \
-              -destination "platform=macOS" \
-              test 2>&1
-          }
-
-          set +e
-          run_unit_tests | tee /tmp/test-output.txt
-          EXIT_CODE=${PIPESTATUS[0]}
-          OUTPUT=$(cat /tmp/test-output.txt)
-          set -e
-
-          # SwiftPM binary artifact resolution can occasionally fail on ephemeral
-          # runners. Retry once after clearing caches.
-          if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | grep -q "Could not resolve package dependencies"; then
-            echo "SwiftPM package resolution failed, clearing caches and retrying once"
-            rm -rf ~/Library/Caches/org.swift.swiftpm
-            mkdir -p ~/Library/Caches/org.swift.swiftpm
-            rm -rf ~/Library/Developer/Xcode/DerivedData/cmux-*
-            set +e
-            run_unit_tests | tee /tmp/test-output.txt
-            EXIT_CODE=${PIPESTATUS[0]}
-            OUTPUT=$(cat /tmp/test-output.txt)
-            set -e
-          fi
-
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "Unit tests failed"
-            exit "$EXIT_CODE"
-          fi
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+            scripts/ci/run-unit-tests-with-failure-gate.sh
 
       - name: Create virtual display
         if: matrix.virtual_display

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -122,6 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+            CMUX_UNIT_TEST_TIMEOUT_SECONDS=900 \
             scripts/ci/run-unit-tests-with-failure-gate.sh
 
       - name: Create virtual display

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -152,13 +152,8 @@ jobs:
           fi
 
           if [ "$EXIT_CODE" -ne 0 ]; then
-            SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)
-            if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
-              echo "All failures are expected, treating as pass"
-            else
-              echo "Unexpected test failures detected"
-              exit 1
-            fi
+            echo "Unit tests failed"
+            exit "$EXIT_CODE"
           fi
 
       - name: Create virtual display

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,67 +334,9 @@ jobs:
       - name: Run unit tests
         run: |
           set -euo pipefail
-          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          run_unit_tests() {
-            # These app-host tests create real SwiftUI/WebKit/Ghostty windows and
-            # intermittently crash inside XCTest's post-test memory checker or
-            # leave native display/WebKit work alive on GitHub macOS runners.
-            # When that happens, Swift's crash/backtrace handling or the stale
-            # app-host process keeps xcodebuild alive until the job-level timeout,
-            # hiding the actual unit test summary.
-            scripts/ci/xcodebuild_noninteractive.py \
-              xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
-              -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
-              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
-              -disableAutomaticPackageResolution \
-              -destination "platform=macOS" \
-              CMUX_SKIP_ZIG_BUILD=1 \
-              test 2>&1 &
-            local xcodebuild_pid=$!
-            local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-1800}"
-            local deadline=$((SECONDS + timeout_seconds))
-            while kill -0 "$xcodebuild_pid" 2>/dev/null; do
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "xcodebuild unit test timeout after ${timeout_seconds}s; terminating"
-                kill -TERM "$xcodebuild_pid" 2>/dev/null || true
-                sleep 5
-                kill -KILL "$xcodebuild_pid" 2>/dev/null || true
-                wait "$xcodebuild_pid" 2>/dev/null || true
-                return 124
-              fi
-              sleep 5
-            done
-            wait "$xcodebuild_pid"
-          }
-
-          # Stream output via tee so CI logs are visible in real time while
-          # preserving the xcodebuild exit status for the failure gate.
-          set +e
-          run_unit_tests | tee /tmp/test-output.txt
-          EXIT_CODE=${PIPESTATUS[0]}
-          OUTPUT=$(cat /tmp/test-output.txt)
-          set -e
-
-          # SwiftPM binary artifact resolution can occasionally fail on ephemeral
-          # runners with "Could not resolve package dependencies". Retry once after
-          # clearing SwiftPM/DerivedData caches to recover from transient corruption.
-          if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | grep -q "Could not resolve package dependencies"; then
-            echo "SwiftPM package resolution failed, clearing caches and retrying once"
-            rm -rf ~/Library/Caches/org.swift.swiftpm
-            mkdir -p ~/Library/Caches/org.swift.swiftpm
-            rm -rf "$CMUX_DERIVED_DATA_PATH"
-            mkdir -p "$CMUX_DERIVED_DATA_PATH"
-            set +e
-            run_unit_tests | tee /tmp/test-output.txt
-            EXIT_CODE=${PIPESTATUS[0]}
-            OUTPUT=$(cat /tmp/test-output.txt)
-            set -e
-          fi
-
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "Unit tests failed"
-            exit "$EXIT_CODE"
-          fi
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            scripts/ci/run-unit-tests-with-failure-gate.sh
 
       - name: Run bundled Ghostty theme picker helper regression
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
               CMUX_SKIP_ZIG_BUILD=1 \
               test 2>&1 &
             local xcodebuild_pid=$!
-            local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-900}"
+            local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-1800}"
             local deadline=$((SECONDS + timeout_seconds))
             while kill -0 "$xcodebuild_pid" 2>/dev/null; do
               if [ "$SECONDS" -ge "$deadline" ]; then
@@ -367,8 +367,8 @@ jobs:
             wait "$xcodebuild_pid"
           }
 
-          # Stream output via tee so CI logs are visible in real time, while still
-          # capturing for post-run analysis of expected vs unexpected failures.
+          # Stream output via tee so CI logs are visible in real time while
+          # preserving the xcodebuild exit status for the failure gate.
           set +e
           run_unit_tests | tee /tmp/test-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
@@ -392,13 +392,8 @@ jobs:
           fi
 
           if [ "$EXIT_CODE" -ne 0 ]; then
-            SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)
-            if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
-              echo "All failures are expected, treating as pass"
-            else
-              echo "Unexpected test failures detected"
-              exit 1
-            fi
+            echo "Unit tests failed"
+            exit "$EXIT_CODE"
           fi
 
       - name: Run bundled Ghostty theme picker helper regression
@@ -611,6 +606,17 @@ jobs:
       - name: Validate Swift warning budget
         run: python3 scripts/swift_warning_budget.py --log /tmp/cmux-build-output.txt
 
+      - name: Create virtual display
+        run: |
+          set -euo pipefail
+          clang -framework Foundation -framework CoreGraphics \
+            -o /tmp/create-virtual-display scripts/create-virtual-display.m
+          /tmp/create-virtual-display &
+          VDISPLAY_PID=$!
+          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
+          sleep 3
+          kill -0 "$VDISPLAY_PID"
+
       - name: Run CoreAnimation main-thread startup regression
         run: |
           set -euo pipefail
@@ -629,17 +635,6 @@ jobs:
           CMUX_CA_ASSERT_HOLD_SECONDS=15 \
           CMUX_TAG="ci-ca-main-thread" \
           ./scripts/verify-main-thread-ca-transactions.sh "$APP"
-
-      - name: Create virtual display
-        run: |
-          set -euo pipefail
-          clang -framework Foundation -framework CoreGraphics \
-            -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
-          VDISPLAY_PID=$!
-          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
-          kill -0 "$VDISPLAY_PID"
 
       - name: Run workspace churn typing-lag regression
         run: |

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -170,13 +170,8 @@ jobs:
 
           echo "$OUTPUT"
           if [ "$EXIT_CODE" -ne 0 ]; then
-            SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)
-            if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
-              echo "All failures are expected, treating as pass"
-            else
-              echo "Unexpected test failures detected"
-              exit 1
-            fi
+            echo "Unit tests failed"
+            exit "$EXIT_CODE"
           fi
 
       - name: Run UI tests

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -141,38 +141,8 @@ jobs:
         if: ${{ !inputs.skip_unit_tests }}
         run: |
           set -euo pipefail
-          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          run_unit_tests() {
-            scripts/ci/xcodebuild_noninteractive.py \
-              xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
-              -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
-              -disableAutomaticPackageResolution \
-              -destination "platform=macOS" test 2>&1
-          }
-
-          set +e
-          OUTPUT=$(run_unit_tests)
-          EXIT_CODE=$?
-          set -e
-
-          # SwiftPM binary artifact resolution can occasionally fail with
-          # "Could not resolve package dependencies". Retry once after clearing
-          # SwiftPM/DerivedData caches to recover from transient corruption.
-          if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | grep -q "Could not resolve package dependencies"; then
-            echo "SwiftPM package resolution failed, clearing caches and retrying once"
-            rm -rf ~/Library/Caches/org.swift.swiftpm
-            rm -rf ~/Library/Developer/Xcode/DerivedData/cmux-*
-            set +e
-            OUTPUT=$(run_unit_tests)
-            EXIT_CODE=$?
-            set -e
-          fi
-
-          echo "$OUTPUT"
-          if [ "$EXIT_CODE" -ne 0 ]; then
-            echo "Unit tests failed"
-            exit "$EXIT_CODE"
-          fi
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+            scripts/ci/run-unit-tests-with-failure-gate.sh
 
       - name: Run UI tests
         if: ${{ !inputs.skip_ui_tests }}

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+            CMUX_UNIT_TEST_TIMEOUT_SECONDS=900 \
             scripts/ci/run-unit-tests-with-failure-gate.sh
 
       - name: Run UI tests

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4550,7 +4550,7 @@ final class BrowserPanel: Panel, ObservableObject {
             hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
             currentURL = initialRequest.url
             shouldRenderWebView = renderInitialNavigation
-            guard renderInitialNavigation else { return }
+            guard renderInitialNavigation else { refreshWebViewLifecycleState(); return }
             if let url = initialRequest.url,
                insecureHTTPBypassHostOnce == nil,
                shouldBlockInsecureHTTPNavigation(to: url) {
@@ -4569,7 +4569,7 @@ final class BrowserPanel: Panel, ObservableObject {
             hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
             currentURL = url
             shouldRenderWebView = renderInitialNavigation
-            guard renderInitialNavigation else { return }
+            guard renderInitialNavigation else { refreshWebViewLifecycleState(); return }
             navigate(to: url)
         }
     }
@@ -5273,15 +5273,12 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         webViewObservers.append(microphoneCaptureObserver)
 
-        NotificationCenter.default.publisher(for: .ghosttyDefaultBackgroundDidChange)
-            .sink { [weak self] notification in
-                guard let self else { return }
-                self.applyWebViewBackground(color: GhosttyBackgroundTheme.color(from: notification))
-            }
+        let ghosttyBackgroundObserver = NotificationCenter.default.addObserver(forName: .ghosttyDefaultBackgroundDidChange, object: nil, queue: .main) { [weak self] notification in
+            MainActor.assumeIsolated { self?.applyWebViewBackground(color: GhosttyBackgroundTheme.color(from: notification)) }
+        }
+        AnyCancellable { NotificationCenter.default.removeObserver(ghosttyBackgroundObserver) }
             .store(in: &webViewCancellables)
 
-        // Apply the configured background for the freshly bound webview (covers
-        // the initial bind and every post-crash replacement).
         applyConfiguredWebViewBackground()
     }
 
@@ -6947,6 +6944,7 @@ extension BrowserPanel {
         }
 
         prepareDeveloperToolsForRevealIfNeeded(inspector)
+        if inspector.cmuxCallBool(selector: isVisibleSelector) ?? false { developerToolsDetachedOpenGraceDeadline = nil; developerToolsLastKnownVisibleAt = Date(); return true }
 
         let showSelector = NSSelectorFromString("show")
         guard inspector.responds(to: showSelector) else { return false }
@@ -7379,7 +7377,8 @@ extension BrowserPanel {
     }
 
     func requestDeveloperToolsRefreshAfterNextAttach(reason: String) {
-        guard preferredDeveloperToolsVisible else { return }
+        guard preferredDeveloperToolsVisible || developerToolsLastKnownVisibleAt != nil else { return }
+        setPreferredDeveloperToolsVisible(true)
         forceDeveloperToolsRefreshOnNextAttach = true
         #if DEBUG
         cmuxDebugLog("browser.devtools refresh.request panel=\(id.uuidString.prefix(5)) reason=\(reason) \(debugDeveloperToolsStateSummary())")

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7026,7 +7026,7 @@ extension BrowserPanel {
             pendingDeveloperToolsTransitionTargetVisible = targetVisible
             setPreferredDeveloperToolsVisible(targetVisible)
             if !targetVisible {
-                developerToolsDetachedOpenGraceDeadline = nil
+                developerToolsDetachedOpenGraceDeadline = nil; developerToolsLastKnownVisibleAt = nil
                 forceDeveloperToolsRefreshOnNextAttach = false
                 cancelDeveloperToolsRestoreRetry()
             }
@@ -7071,7 +7071,7 @@ extension BrowserPanel {
                     return false
                 }
             }
-            developerToolsDetachedOpenGraceDeadline = nil
+            developerToolsDetachedOpenGraceDeadline = nil; developerToolsLastKnownVisibleAt = nil
         }
 
         if targetVisible {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */; };
 		3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */; };
 		C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE10001A1B2C3D4E5F719 /* grok */; };
+		C1F10A000000000000000001 /* HeadlessWindowTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F10A000000000000000002 /* HeadlessWindowTestHelpers.swift */; };
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
@@ -1103,6 +1104,7 @@
 		3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPanelCaptureManager.swift; sourceTree = "<group>"; };
 		3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsTests.swift; sourceTree = "<group>"; };
 		C1ADE10001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
+		C1F10A000000000000000002 /* HeadlessWindowTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessWindowTestHelpers.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000006 /* HelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuUITests.swift; sourceTree = "<group>"; };
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
@@ -2117,6 +2119,7 @@
 				17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */,
 				C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */,
 				C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */,
+				C1F10A000000000000000002 /* HeadlessWindowTestHelpers.swift */,
 				3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */,
 				E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */,
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
@@ -3233,6 +3236,7 @@
 				C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,
+				C1F10A000000000000000001 /* HeadlessWindowTestHelpers.swift in Sources */,
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,
 				C34670020000000000000001 /* KeyboardShortcutContextTests.swift in Sources */,
 				E3309A0B /* KeyboardShortcutSettingsEqualizeSplitsTests.swift in Sources */,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -992,8 +992,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        secondWindow.makeKeyAndOrderFront(nil)
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        cmuxMakeWindowKeyForTesting(secondWindow)
 
         // Force a stale app-level pointer to another manager. Window-local UI
         // controls should still target the key/main window, not this stale pointer.
@@ -5991,12 +5990,12 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
-        window.makeKeyAndOrderFront(nil)
+        cmuxMakeWindowKeyForTesting(window)
         window.displayIfNeeded()
         terminalPanel.hostedView.setVisibleInUI(true)
         terminalPanel.hostedView.setActive(true)
         terminalPanel.hostedView.moveFocus()
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        waitUntil(timeout: 1.0) { terminalPanel.hostedView.isSurfaceViewFirstResponder() }
 
         XCTAssertTrue(
             terminalPanel.hostedView.isSurfaceViewFirstResponder(),
@@ -6348,7 +6347,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         staleMenu.addItem(staleCloseItem)
         NSApp.mainMenu = staleMenu
 
-        window.makeKeyAndOrderFront(nil)
+        cmuxMakeWindowKeyForTesting(window)
         window.displayIfNeeded()
 
         guard let event = makeKeyDownEvent(
@@ -6533,12 +6532,12 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         contentView.addSubview(strayView)
         defer { strayView.removeFromSuperview() }
 
-        window.makeKeyAndOrderFront(nil)
+        cmuxMakeWindowKeyForTesting(window)
         window.displayIfNeeded()
         terminalPanel.hostedView.setVisibleInUI(true)
         terminalPanel.hostedView.setActive(true)
         terminalPanel.hostedView.moveFocus()
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        waitUntil(timeout: 1.0) { terminalPanel.hostedView.isSurfaceViewFirstResponder() }
 
         XCTAssertTrue(
             terminalPanel.hostedView.isSurfaceViewFirstResponder(),
@@ -7387,10 +7386,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.string = "@a"
         textView.setSelectedRange(NSRange(location: 2, length: 0))
         let staleSuggestion = TextBoxMentionSuggestion(
-            id: "alpha",
-            title: "@alpha.txt",
-            subtitle: "alpha.txt",
-            insertionText: "[@alpha.txt](/tmp/alpha.txt)",
+            id: "zeta",
+            title: "@zeta.txt",
+            subtitle: "zeta.txt",
+            insertionText: "[@zeta.txt](/tmp/zeta.txt)",
             systemImageName: "doc"
         )
 
@@ -7791,6 +7790,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 completed = true
             }
 
+            waitFor(timeout: 1.0, until: { surface.sentKeys == ["paste_from_clipboard"] })
             XCTAssertEqual(surface.sentKeys, ["paste_from_clipboard"])
             waitFor(timeout: 1.0, until: { completed })
 
@@ -7829,7 +7829,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 completions.append("second")
             }
 
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            waitFor(timeout: 1.0, until: { surface.sentKeys == ["paste_from_clipboard"] })
             XCTAssertEqual(surface.sentText, [])
             XCTAssertEqual(completions, [])
             XCTAssertEqual(surface.sentKeys, ["paste_from_clipboard"])
@@ -7884,7 +7884,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 completions.append("second")
             }
 
-            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            waitFor(timeout: 1.0, until: { firstSurface.sentKeys == ["paste_from_clipboard"] })
             XCTAssertEqual(firstSurface.sentKeys, ["paste_from_clipboard"])
             XCTAssertEqual(secondSurface.sentKeys, [])
             XCTAssertEqual(completions, [])
@@ -7945,7 +7945,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 completions.append("finishing")
             }
 
-            waitFor(timeout: 1.0, until: { completions == ["finishing"] })
+            waitFor(timeout: 1.0, until: { completions == ["finishing"] && activeSurface.sentKeys == ["paste_from_clipboard"] })
             XCTAssertEqual(finishingSurface.sentText, ["finishing"])
             XCTAssertEqual(activeSurface.sentText, [])
             XCTAssertEqual(activeSurface.sentKeys, ["paste_from_clipboard"])
@@ -10271,6 +10271,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         textView.insertPendingAttachmentUploadPlaceholder(id: uploadID)
 
         XCTAssertTrue(textView.replacePendingAttachmentUploadPlaceholder(id: uploadID, with: [attachment]))
+        TextBoxInputTextView.flushPendingSessionDraftAttachmentCopies()
         GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles([temporaryURL])
 
         let draft = try XCTUnwrap(textView.sessionDraftSnapshot(isActive: true))
@@ -10754,8 +10755,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
 
         originalWindow.orderFront(nil)
-        focusedWindow.makeKeyAndOrderFront(nil)
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        cmuxMakeWindowKeyForTesting(focusedWindow)
 
         // Model the observed bug: the user-visible focused window is the new window,
         // but the key event still carries the original window number.

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -6004,7 +6004,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
 
         XCTAssertTrue(window.makeFirstResponder(nil), "Expected test to clear the window first responder")
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
 
         XCTAssertFalse(
             terminalPanel.hostedView.isSurfaceViewFirstResponder(),
@@ -6547,7 +6546,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
 
         XCTAssertTrue(window.makeFirstResponder(strayView), "Expected test to install a visible wrong first responder")
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
 
         XCTAssertFalse(
             terminalPanel.hostedView.isSurfaceViewFirstResponder(),
@@ -10624,12 +10622,13 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let searchState = TerminalSurface.SearchState(needle: "")
         terminalPanel.surface.searchState = searchState
         terminalPanel.hostedView.setSearchOverlay(searchState: searchState)
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        waitFor(timeout: 1.0, until: { findEditableTextField(in: terminalPanel.hostedView) != nil })
 
         guard let searchField = findEditableTextField(in: terminalPanel.hostedView) else {
             XCTFail("Expected mounted terminal search field")
             return
         }
+        waitFor(timeout: 1.0, until: { firstResponderOwnsTextField(window.firstResponder, textField: searchField) })
 
         XCTAssertTrue(
             firstResponderOwnsTextField(window.firstResponder, textField: searchField),
@@ -10637,7 +10636,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
 
         XCTAssertTrue(window.makeFirstResponder(nil), "Expected test to clear the window first responder")
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
 
         XCTAssertFalse(
             firstResponderOwnsTextField(window.firstResponder, textField: searchField),

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3809,9 +3809,9 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
 
         panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test")
         XCTAssertTrue(panel.hasPendingDeveloperToolsRefreshAfterAttach())
-
         panel.restoreDeveloperToolsAfterAttachIfNeeded()
         XCTAssertFalse(panel.hasPendingDeveloperToolsRefreshAfterAttach())
+        XCTAssertTrue(panel.hideDeveloperTools()); waitForDeveloperToolsTransitions(); panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test-after-hide"); XCTAssertFalse(panel.hasPendingDeveloperToolsRefreshAfterAttach())
     }
 
     func testRapidToggleCoalescesToFinalVisibleIntentWithoutExtraInspectorCalls() {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1846,6 +1846,7 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
                 GhosttyNotificationKey.backgroundOpacity: updatedOpacity
             ]
         )
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
 
         guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
               let expected = updatedColor.withAlphaComponent(updatedOpacity).usingColorSpace(.sRGB) else {
@@ -1916,6 +1917,7 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
                 GhosttyNotificationKey.backgroundOpacity: NSNumber(value: 0.57),
             ]
         )
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
 
         guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
               let expected = updatedColor.withAlphaComponent(0.57).usingColorSpace(.sRGB) else {
@@ -2932,6 +2934,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     }
 
     private final class FakeInspector: NSObject {
+        private static var retainedFrontendWebViews: [WKWebView] = []
         enum HideBehavior {
             case unsupported
             case noEffect
@@ -3001,9 +3004,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             frontendWebView
         }
 
-        func setFrontendWebView(_ webView: WKWebView?) {
-            frontendWebView = webView
-        }
+        func setFrontendWebView(_ webView: WKWebView?) { frontendWebView = webView; if let webView { Self.retainedFrontendWebViews.append(webView) } }
     }
 
     override class func setUp() {
@@ -3048,6 +3049,8 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     private func waitForDeveloperToolsTransitions() {
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))
     }
+
+    private func makeWindowKeyForNilTargetAction(_ window: NSWindow) { NSApp.activate(ignoringOtherApps: true); window.orderFrontRegardless(); window.makeKeyAndOrderFront(nil); window.makeKey(); RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05)) }
 
     private func closeBrowserPanel(_ panel: BrowserPanel) {
         panel.close()
@@ -3280,11 +3283,9 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             defer: false
         )
         inspectorWindow.title = "Web Inspector — example.com"
-        let frontendWebView = WKInspectorProbeWebView(
-            frame: inspectorWindow.contentView?.bounds ?? .zero,
-            configuration: WKWebViewConfiguration()
-        )
+        let frontendWebView = WKInspectorProbeWebView(frame: inspectorWindow.contentView?.bounds ?? .zero, configuration: WKWebViewConfiguration())
         inspectorWindow.contentView?.addSubview(frontendWebView)
+        inspectorWindow.contentView?.addSubview(WKInspectorProbeView(frame: inspectorWindow.contentView?.bounds ?? .zero))
         inspector.setFrontendWebView(frontendWebView)
         defer { closeWindow(inspectorWindow) }
 
@@ -3365,8 +3366,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         inspector.setFrontendWebView(frontendWebView)
         defer { closeWindow(inspectorWindow) }
 
-        inspectorWindow.makeKeyAndOrderFront(nil)
-        inspectorWindow.makeKey()
+        makeWindowKeyForNilTargetAction(inspectorWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertEqual(inspector.closeCount, 0)
         XCTAssertTrue(inspectorWindow.isKeyWindow)
@@ -3423,8 +3423,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         inspector.setFrontendWebView(frontendWebView)
         defer { closeWindow(inspectorWindow) }
 
-        inspectorWindow.makeKeyAndOrderFront(nil)
-        inspectorWindow.makeKey()
+        makeWindowKeyForNilTargetAction(inspectorWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertEqual(inspector.closeCount, 0)
         XCTAssertTrue(inspectorWindow.isKeyWindow)
@@ -3484,8 +3483,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         contentView.addSubview(frontendWebView)
         inspector.setFrontendWebView(frontendWebView)
 
-        mainWindow.makeKeyAndOrderFront(nil)
-        mainWindow.makeKey()
+        makeWindowKeyForNilTargetAction(mainWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertTrue(browserPanel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.closeCount, 0)
@@ -3560,7 +3558,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, inspector) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertTrue(panel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.showCount, 1)
 
@@ -3722,7 +3720,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, inspector) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertEqual(inspector.showCount, 1)
 
         // Simulate user closing inspector before detach.
@@ -3738,7 +3736,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, inspector) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertEqual(inspector.showCount, 1)
 
         // Simulate a transient close caused by view detach, not user intent.
@@ -3783,7 +3781,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, inspector) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertTrue(panel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.showCount, 1)
         XCTAssertEqual(inspector.closeCount, 0)
@@ -3805,7 +3803,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, _) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertFalse(panel.hasPendingDeveloperToolsRefreshAfterAttach())
 
         panel.requestDeveloperToolsRefreshAfterNextAttach(reason: "unit-test")
@@ -3852,7 +3850,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let (panel, inspector) = makePanelWithInspector(hideBehavior: .noEffect)
         defer { closeBrowserPanel(panel) }
 
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
         XCTAssertTrue(panel.isDeveloperToolsVisible())
 
         XCTAssertTrue(panel.toggleDeveloperTools())
@@ -4051,7 +4049,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     func testOffWindowReplacementLocalHostDoesNotStealVisibleDevToolsWebView() {
         let (panel, _) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
 
         let paneId = PaneID(id: UUID())
         let representable = WebViewRepresentable(
@@ -4143,7 +4141,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     func testVisibleReplacementLocalHostNormalizesBottomDockedInspectorFrames() {
         let (panel, _) = makePanelWithInspector()
         defer { closeBrowserPanel(panel) }
-        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.showDeveloperTools()); waitForDeveloperToolsTransitions()
 
         let paneId = PaneID(id: UUID())
         let representable = WebViewRepresentable(
@@ -4214,6 +4212,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         narrowHosting.removeFromSuperview()
+        replacementHosting.rootView = representable
         contentView.layoutSubtreeIfNeeded()
         replacementHosting.layoutSubtreeIfNeeded()
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1846,10 +1846,8 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
                 GhosttyNotificationKey.backgroundOpacity: updatedOpacity
             ]
         )
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
-
-        guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
-              let expected = updatedColor.withAlphaComponent(updatedOpacity).usingColorSpace(.sRGB) else {
+        guard let expected = updatedColor.withAlphaComponent(updatedOpacity).usingColorSpace(.sRGB),
+              let actual = cmuxWaitForBrowserBackgroundColorForTesting(panel, matching: expected) else {
             XCTFail("Expected sRGB-convertible under-page background colors")
             return
         }
@@ -1917,10 +1915,8 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
                 GhosttyNotificationKey.backgroundOpacity: NSNumber(value: 0.57),
             ]
         )
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
-
-        guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
-              let expected = updatedColor.withAlphaComponent(0.57).usingColorSpace(.sRGB) else {
+        guard let expected = updatedColor.withAlphaComponent(0.57).usingColorSpace(.sRGB),
+              let actual = cmuxWaitForBrowserBackgroundColorForTesting(panel, matching: expected) else {
             XCTFail("Expected sRGB-convertible under-page background colors")
             return
         }
@@ -2926,6 +2922,7 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
 
 @MainActor
 final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
+    private static var retainedWebKitWindows: [NSWindow] = []
     private final class WKInspectorProbeView: NSView {
         override var acceptsFirstResponder: Bool { true }
     }
@@ -3050,8 +3047,6 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.5))
     }
 
-    private func makeWindowKeyForNilTargetAction(_ window: NSWindow) { NSApp.activate(ignoringOtherApps: true); window.orderFrontRegardless(); window.makeKeyAndOrderFront(nil); window.makeKey(); RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05)) }
-
     private func closeBrowserPanel(_ panel: BrowserPanel) {
         panel.close()
         BrowserWindowPortalRegistry.detach(webView: panel.webView)
@@ -3060,6 +3055,12 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
     }
 
     private func closeWindow(_ window: NSWindow) {
+        if cmuxContainsWebViewForTesting(window.contentView) {
+            window.contentView = nil
+            window.orderOut(nil)
+            Self.retainedWebKitWindows.append(window)
+            return
+        }
         window.contentView = nil
         window.orderOut(nil)
         window.close()
@@ -3366,7 +3367,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         inspector.setFrontendWebView(frontendWebView)
         defer { closeWindow(inspectorWindow) }
 
-        makeWindowKeyForNilTargetAction(inspectorWindow)
+        cmuxMakeWindowKeyForTesting(inspectorWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertEqual(inspector.closeCount, 0)
         XCTAssertTrue(inspectorWindow.isKeyWindow)
@@ -3423,7 +3424,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         inspector.setFrontendWebView(frontendWebView)
         defer { closeWindow(inspectorWindow) }
 
-        makeWindowKeyForNilTargetAction(inspectorWindow)
+        cmuxMakeWindowKeyForTesting(inspectorWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertEqual(inspector.closeCount, 0)
         XCTAssertTrue(inspectorWindow.isKeyWindow)
@@ -3483,7 +3484,7 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         contentView.addSubview(frontendWebView)
         inspector.setFrontendWebView(frontendWebView)
 
-        makeWindowKeyForNilTargetAction(mainWindow)
+        cmuxMakeWindowKeyForTesting(mainWindow)
         XCTAssertTrue(browserPanel.showDeveloperTools())
         XCTAssertTrue(browserPanel.isDeveloperToolsVisible())
         XCTAssertEqual(inspector.closeCount, 0)

--- a/cmuxTests/HeadlessWindowTestHelpers.swift
+++ b/cmuxTests/HeadlessWindowTestHelpers.swift
@@ -39,7 +39,6 @@ func cmuxWaitForBrowserBackgroundColorForTesting(_ panel: BrowserPanel, matching
             return actual
         }
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
-        OperationQueue.main.waitUntilAllOperationsAreFinished()
         actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB)
     }
     return actual

--- a/cmuxTests/HeadlessWindowTestHelpers.swift
+++ b/cmuxTests/HeadlessWindowTestHelpers.swift
@@ -1,0 +1,46 @@
+import AppKit
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+func cmuxMakeWindowKeyForTesting(_ window: NSWindow) {
+    let deadline = Date(timeIntervalSinceNow: 1.0)
+    repeat {
+        NSApp.activate(ignoringOtherApps: true)
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+        window.makeMain()
+        window.makeKey()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+    } while !window.isKeyWindow && Date() < deadline
+}
+
+@MainActor
+func cmuxContainsWebViewForTesting(_ view: NSView?) -> Bool {
+    guard let view else { return false }
+    if view is WKWebView { return true }
+    return view.subviews.contains { cmuxContainsWebViewForTesting($0) }
+}
+
+@MainActor
+func cmuxWaitForBrowserBackgroundColorForTesting(_ panel: BrowserPanel, matching expected: NSColor) -> NSColor? {
+    let deadline = Date(timeIntervalSinceNow: 1.0)
+    var actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB)
+    while actual != nil, Date() < deadline {
+        if abs((actual?.redComponent ?? 0) - expected.redComponent) < 0.005,
+           abs((actual?.greenComponent ?? 0) - expected.greenComponent) < 0.005,
+           abs((actual?.blueComponent ?? 0) - expected.blueComponent) < 0.005,
+           abs((actual?.alphaComponent ?? 0) - expected.alphaComponent) < 0.005 {
+            return actual
+        }
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+        OperationQueue.main.waitUntilAllOperationsAreFinished()
+        actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB)
+    }
+    return actual
+}

--- a/scripts/build-command-palette-nucleo-ffi.sh
+++ b/scripts/build-command-palette-nucleo-ffi.sh
@@ -50,6 +50,23 @@ ensure_rust_target() {
   fi
 }
 
+cargo_build_with_retry() {
+  local target="$1"
+  local attempt
+  local status=0
+  for attempt in 1 2 3; do
+    if cargo build --manifest-path "${CRATE_DIR}/Cargo.toml" --release --target "$target"; then
+      return 0
+    else
+      status=$?
+    fi
+    if [ "$attempt" -eq 3 ]; then
+      return "$status"
+    fi
+    echo "warning: cargo build for ${target} failed on attempt ${attempt}; retrying immediately" >&2
+  done
+}
+
 requested_targets="${CMUX_NUCLEO_FFI_TARGETS:-}"
 if [ -z "${requested_targets}" ] && [ -n "${TARGET_TRIPLE:-}" ]; then
   requested_targets="$(rust_target_for_triple "${TARGET_TRIPLE}")"
@@ -82,7 +99,7 @@ for target in ${requested_targets}; do
   esac
   seen_targets="${seen_targets} ${target}"
   ensure_rust_target "$target"
-  cargo build --manifest-path "${CRATE_DIR}/Cargo.toml" --release --target "$target"
+  cargo_build_with_retry "$target"
   source_lib="${CRATE_DIR}/target/${target}/release/${LIB_NAME}"
   if [ ! -f "${source_lib}" ]; then
     echo "error: expected nucleo FFI library at ${source_lib}" >&2

--- a/scripts/ci/run-unit-tests-with-failure-gate.sh
+++ b/scripts/ci/run-unit-tests-with-failure-gate.sh
@@ -8,16 +8,15 @@ run_unit_tests_once() {
   fi
 
   local source_packages_dir="${SOURCE_PACKAGES_DIR:-$PWD/.ci-source-packages}"
+  local derived_data_path="${CMUX_DERIVED_DATA_PATH:-$PWD/.ci-derived-data/cmux-unit}"
   local command=(
     scripts/ci/xcodebuild_noninteractive.py
     xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug
+    -derivedDataPath "$derived_data_path"
     -clonedSourcePackagesDirPath "$source_packages_dir"
     -disableAutomaticPackageResolution
     -destination "platform=macOS"
   )
-  if [[ -n "${CMUX_DERIVED_DATA_PATH:-}" ]]; then
-    command+=(-derivedDataPath "$CMUX_DERIVED_DATA_PATH")
-  fi
   command+=(test)
 
   "${command[@]}" 2>&1 &
@@ -59,12 +58,9 @@ main() {
     echo "SwiftPM package resolution failed, clearing caches and retrying once"
     rm -rf ~/Library/Caches/org.swift.swiftpm
     mkdir -p ~/Library/Caches/org.swift.swiftpm
-    if [[ -n "${CMUX_DERIVED_DATA_PATH:-}" ]]; then
-      rm -rf "$CMUX_DERIVED_DATA_PATH"
-      mkdir -p "$CMUX_DERIVED_DATA_PATH"
-    else
-      rm -rf ~/Library/Developer/Xcode/DerivedData/cmux-*
-    fi
+    local derived_data_path="${CMUX_DERIVED_DATA_PATH:-$PWD/.ci-derived-data/cmux-unit}"
+    rm -rf "$derived_data_path"
+    mkdir -p "$derived_data_path"
     exit_code=0
     run_with_output_capture "$output_file" || exit_code=$?
   fi

--- a/scripts/ci/run-unit-tests-with-failure-gate.sh
+++ b/scripts/ci/run-unit-tests-with-failure-gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_unit_tests_once() {
+  if [[ -n "${CMUX_UNIT_TEST_FAKE_COMMAND:-}" ]]; then
+    bash -c "$CMUX_UNIT_TEST_FAKE_COMMAND"
+    return
+  fi
+
+  local source_packages_dir="${SOURCE_PACKAGES_DIR:-$PWD/.ci-source-packages}"
+  local command=(
+    scripts/ci/xcodebuild_noninteractive.py
+    xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug
+    -clonedSourcePackagesDirPath "$source_packages_dir"
+    -disableAutomaticPackageResolution
+    -destination "platform=macOS"
+  )
+  if [[ -n "${CMUX_DERIVED_DATA_PATH:-}" ]]; then
+    command+=(-derivedDataPath "$CMUX_DERIVED_DATA_PATH")
+  fi
+  command+=(test)
+
+  "${command[@]}" 2>&1 &
+  local xcodebuild_pid=$!
+  local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-1800}"
+  local deadline=$((SECONDS + timeout_seconds))
+  while kill -0 "$xcodebuild_pid" 2>/dev/null; do
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      echo "xcodebuild unit test timeout after ${timeout_seconds}s; terminating"
+      kill -TERM "$xcodebuild_pid" 2>/dev/null || true
+      sleep 5
+      kill -KILL "$xcodebuild_pid" 2>/dev/null || true
+      wait "$xcodebuild_pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 5
+  done
+  wait "$xcodebuild_pid"
+}
+
+run_with_output_capture() {
+  local output_file="$1"
+  set +e
+  run_unit_tests_once | tee "$output_file"
+  local exit_code=${PIPESTATUS[0]}
+  set -e
+  return "$exit_code"
+}
+
+main() {
+  local output_file="${CMUX_UNIT_TEST_OUTPUT_FILE:-/tmp/test-output.txt}"
+  local exit_code=0
+  local output=""
+
+  run_with_output_capture "$output_file" || exit_code=$?
+  output="$(cat "$output_file")"
+
+  if [[ "$exit_code" -ne 0 ]] && grep -q "Could not resolve package dependencies" <<<"$output"; then
+    echo "SwiftPM package resolution failed, clearing caches and retrying once"
+    rm -rf ~/Library/Caches/org.swift.swiftpm
+    mkdir -p ~/Library/Caches/org.swift.swiftpm
+    if [[ -n "${CMUX_DERIVED_DATA_PATH:-}" ]]; then
+      rm -rf "$CMUX_DERIVED_DATA_PATH"
+      mkdir -p "$CMUX_DERIVED_DATA_PATH"
+    else
+      rm -rf ~/Library/Developer/Xcode/DerivedData/cmux-*
+    fi
+    exit_code=0
+    run_with_output_capture "$output_file" || exit_code=$?
+  fi
+
+  if [[ "$exit_code" -ne 0 ]]; then
+    echo "Unit tests failed"
+    exit "$exit_code"
+  fi
+}
+
+main "$@"

--- a/scripts/ci/run-unit-tests-with-failure-gate.sh
+++ b/scripts/ci/run-unit-tests-with-failure-gate.sh
@@ -19,22 +19,42 @@ run_unit_tests_once() {
   )
   command+=(test)
 
-  "${command[@]}" 2>&1 &
+  local child_pid_file
+  child_pid_file="$(mktemp)"
+  XCODEBUILD_NONINTERACTIVE_CHILD_PID_FILE="$child_pid_file" "${command[@]}" 2>&1 &
   local xcodebuild_pid=$!
   local timeout_seconds="${CMUX_UNIT_TEST_TIMEOUT_SECONDS:-1800}"
   local deadline=$((SECONDS + timeout_seconds))
   while kill -0 "$xcodebuild_pid" 2>/dev/null; do
     if [[ "$SECONDS" -ge "$deadline" ]]; then
       echo "xcodebuild unit test timeout after ${timeout_seconds}s; terminating"
-      kill -TERM "$xcodebuild_pid" 2>/dev/null || true
+      terminate_unit_test_processes "$xcodebuild_pid" "$child_pid_file" TERM
       sleep 5
-      kill -KILL "$xcodebuild_pid" 2>/dev/null || true
+      terminate_unit_test_processes "$xcodebuild_pid" "$child_pid_file" KILL
       wait "$xcodebuild_pid" 2>/dev/null || true
+      rm -f "$child_pid_file"
       return 124
     fi
     sleep 5
   done
   wait "$xcodebuild_pid"
+  local status=$?
+  rm -f "$child_pid_file"
+  return "$status"
+}
+
+terminate_unit_test_processes() {
+  local wrapper_pid="$1"
+  local child_pid_file="$2"
+  local signal="$3"
+  if [[ -s "$child_pid_file" ]]; then
+    local child_pid
+    child_pid="$(cat "$child_pid_file")"
+    if [[ "$child_pid" =~ ^[0-9]+$ ]]; then
+      kill "-$signal" "-$child_pid" 2>/dev/null || kill "-$signal" "$child_pid" 2>/dev/null || true
+    fi
+  fi
+  kill "-$signal" "$wrapper_pid" 2>/dev/null || true
 }
 
 run_with_output_capture() {

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import pty
 import select
+import signal
 import sys
 
 
@@ -30,7 +31,24 @@ def main() -> int:
 
     pid, fd = pty.fork()
     if pid == 0:
+        try:
+            os.setpgrp()
+        except OSError:
+            pass
         os.execvp(sys.argv[1], sys.argv[1:])
+
+    terminating = False
+
+    def forward_signal(signum: int, _frame: object) -> None:
+        nonlocal terminating
+        terminating = True
+        try:
+            os.killpg(pid, signum)
+        except ProcessLookupError:
+            pass
+
+    signal.signal(signal.SIGTERM, forward_signal)
+    signal.signal(signal.SIGINT, forward_signal)
 
     prompt_window = b""
     while True:
@@ -57,6 +75,8 @@ def main() -> int:
             prompt_window = b""
 
     _, status = os.waitpid(pid, 0)
+    if terminating and child_exit_code(status) == 0:
+        return 128 + signal.SIGTERM
     return child_exit_code(status)
 
 

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -37,6 +37,10 @@ def main() -> int:
             pass
         os.execvp(sys.argv[1], sys.argv[1:])
 
+    if pid_file := os.environ.get("XCODEBUILD_NONINTERACTIVE_CHILD_PID_FILE"):
+        with open(pid_file, "w", encoding="utf-8") as handle:
+            handle.write(f"{pid}\n")
+
     terminating = False
 
     def forward_signal(signum: int, _frame: object) -> None:

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -223,6 +223,23 @@ check_tmux_terminal_nightly_isolation() {
   echo "PASS: tmux corpus terminal-nightly uses isolated DerivedData, noninteractive xcodebuild, and expected-failure handling"
 }
 
+check_unit_tests_do_not_mask_xctest_assertion_failures() {
+  local file
+  for file in "$CI_FILE" "$COMPAT_FILE" "$ROOT_DIR/.github/workflows/test-depot.yml"; do
+    if grep -Fq "All failures are expected, treating as pass" "$file"; then
+      echo "FAIL: $(basename "$file") must not treat XCTest assertion failures as a passing unit-test run"
+      exit 1
+    fi
+
+    if grep -Fq "(0 unexpected)" "$file"; then
+      echo "FAIL: $(basename "$file") must not use XCTest '(0 unexpected)' summaries as a unit-test pass condition"
+      exit 1
+    fi
+  done
+
+  echo "PASS: unit-test workflows fail on XCTest assertion failures"
+}
+
 # ci.yml jobs
 check_macos_runner "$CI_FILE" "tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
@@ -247,3 +264,4 @@ check_no_ci_xctest_skips
 check_no_ci_swift_package_skips
 check_web_db_behavior_tests
 check_tmux_terminal_nightly_isolation
+check_unit_tests_do_not_mask_xctest_assertion_failures

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -226,6 +226,11 @@ check_tmux_terminal_nightly_isolation() {
 check_unit_tests_do_not_mask_xctest_assertion_failures() {
   local file
   for file in "$CI_FILE" "$COMPAT_FILE" "$ROOT_DIR/.github/workflows/test-depot.yml"; do
+    if ! grep -Fq "scripts/ci/run-unit-tests-with-failure-gate.sh" "$file"; then
+      echo "FAIL: $(basename "$file") must run unit tests through the shared failure gate"
+      exit 1
+    fi
+
     if grep -Fq "All failures are expected, treating as pass" "$file"; then
       echo "FAIL: $(basename "$file") must not treat XCTest assertion failures as a passing unit-test run"
       exit 1
@@ -238,6 +243,33 @@ check_unit_tests_do_not_mask_xctest_assertion_failures() {
   done
 
   echo "PASS: unit-test workflows fail on XCTest assertion failures"
+}
+
+check_unit_test_failure_gate_behavior() {
+  local temp_dir output_file log_file status
+  temp_dir="$(mktemp -d)"
+  output_file="$temp_dir/test-output.txt"
+  log_file="$temp_dir/gate.log"
+  set +e
+  CMUX_UNIT_TEST_OUTPUT_FILE="$output_file" \
+    CMUX_UNIT_TEST_FAKE_COMMAND='printf "%s\n" "Test Suite '\''cmuxTests.xctest'\'' failed" "** TEST FAILED **"; exit 65' \
+    "$ROOT_DIR/scripts/ci/run-unit-tests-with-failure-gate.sh" >"$log_file" 2>&1
+  status=$?
+  set -e
+  if [ "$status" -ne 65 ]; then
+    echo "FAIL: unit-test failure gate must preserve nonzero XCTest exit status, got $status"
+    cat "$log_file"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+  if ! grep -Fq "Unit tests failed" "$log_file"; then
+    echo "FAIL: unit-test failure gate must report nonzero XCTest failures"
+    cat "$log_file"
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+  rm -rf "$temp_dir"
+  echo "PASS: unit-test failure gate preserves XCTest failure exit status"
 }
 
 # ci.yml jobs
@@ -265,3 +297,4 @@ check_no_ci_swift_package_skips
 check_web_db_behavior_tests
 check_tmux_terminal_nightly_isolation
 check_unit_tests_do_not_mask_xctest_assertion_failures
+check_unit_test_failure_gate_behavior

--- a/tests/test_ci_unit_test_spm_retry.sh
+++ b/tests/test_ci_unit_test_spm_retry.sh
@@ -3,20 +3,32 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-WORKFLOW_FILE="$ROOT_DIR/.github/workflows/ci.yml"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
-REQUIRED_PATTERNS=(
-  "run_unit_tests()"
-  "Could not resolve package dependencies"
-  "rm -rf ~/Library/Caches/org.swift.swiftpm"
-  "run_unit_tests | tee /tmp/test-output.txt"
-)
+mkdir -p "$TEMP_DIR/home"
+MARKER="$TEMP_DIR/retried"
+LOG_FILE="$TEMP_DIR/retry.log"
+OUTPUT_FILE="$TEMP_DIR/test-output.txt"
+DERIVED_DATA="$TEMP_DIR/DerivedData"
 
-for pattern in "${REQUIRED_PATTERNS[@]}"; do
-  if ! grep -Fq "$pattern" "$WORKFLOW_FILE"; then
-    echo "FAIL: Missing pattern in ci.yml: $pattern"
-    exit 1
-  fi
-done
+HOME="$TEMP_DIR/home" \
+CMUX_FAKE_RETRY_MARKER="$MARKER" \
+CMUX_UNIT_TEST_OUTPUT_FILE="$OUTPUT_FILE" \
+CMUX_DERIVED_DATA_PATH="$DERIVED_DATA" \
+CMUX_UNIT_TEST_FAKE_COMMAND='if [ ! -f "$CMUX_FAKE_RETRY_MARKER" ]; then touch "$CMUX_FAKE_RETRY_MARKER"; echo "Could not resolve package dependencies"; exit 74; fi; echo "Retry succeeded"; exit 0' \
+  "$ROOT_DIR/scripts/ci/run-unit-tests-with-failure-gate.sh" >"$LOG_FILE" 2>&1
+
+if ! grep -Fq "SwiftPM package resolution failed, clearing caches and retrying once" "$LOG_FILE"; then
+  echo "FAIL: unit-test gate did not report SwiftPM retry"
+  cat "$LOG_FILE"
+  exit 1
+fi
+
+if ! grep -Fq "Retry succeeded" "$LOG_FILE"; then
+  echo "FAIL: unit-test gate did not rerun after SwiftPM failure"
+  cat "$LOG_FILE"
+  exit 1
+fi
 
 echo "PASS: CI unit-test SwiftPM retry guard is present"

--- a/tests/test_ci_xcodebuild_noninteractive_helper.py
+++ b/tests/test_ci_xcodebuild_noninteractive_helper.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 import textwrap
+import time
 from pathlib import Path
 
 
@@ -14,7 +16,7 @@ HELPER = ROOT / "scripts" / "ci" / "xcodebuild_noninteractive.py"
 PROMPT = "Press space to interact, D to debug, or any other key to quit"
 
 
-def main() -> int:
+def test_prompt_dismissal() -> bool:
     child = textwrap.dedent(
         f"""
         import sys
@@ -48,13 +50,84 @@ def main() -> int:
         print(result.stdout, end="")
         print(result.stderr, end="", file=sys.stderr)
         print(f"FAIL: expected wrapped command exit 7, got {result.returncode}")
-        return 1
+        return False
     if result.stdout.count("received=q") != 2:
         print(result.stdout, end="")
         print("FAIL: helper did not answer each crash prompt with q")
-        return 1
+        return False
 
     print("PASS: xcodebuild noninteractive helper dismisses crash prompts")
+    return True
+
+
+def test_signal_forwarding() -> bool:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        marker = Path(temp_dir) / "terminated"
+        child = textwrap.dedent(
+            f"""
+            import signal
+            import sys
+            import time
+            from pathlib import Path
+
+            marker = Path({str(marker)!r})
+
+            def handle_term(_signum, _frame):
+                marker.write_text("terminated", encoding="utf-8")
+                raise SystemExit(0)
+
+            signal.signal(signal.SIGTERM, handle_term)
+            print("ready", flush=True)
+            while True:
+                time.sleep(0.1)
+            """
+        )
+        process = subprocess.Popen(
+            [sys.executable, str(HELPER), sys.executable, "-c", child],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            assert process.stdout is not None
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if "ready" in process.stdout.readline():
+                    break
+            else:
+                process.kill()
+                print("FAIL: wrapped command did not become ready")
+                return False
+
+            process.terminate()
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+            print(stdout, end="")
+            print(stderr, end="", file=sys.stderr)
+            print("FAIL: helper did not exit after SIGTERM")
+            return False
+
+        if process.returncode != 143:
+            print(stdout, end="")
+            print(stderr, end="", file=sys.stderr)
+            print(f"FAIL: expected helper exit 143 after SIGTERM, got {process.returncode}")
+            return False
+        if marker.read_text(encoding="utf-8") != "terminated":
+            print("FAIL: helper did not forward SIGTERM to wrapped command")
+            return False
+
+    print("PASS: xcodebuild noninteractive helper forwards termination")
+    return True
+
+
+def main() -> int:
+    if not test_prompt_dismissal():
+        return 1
+    if not test_signal_forwarding():
+        return 1
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a CI self-test that forbids broad XCTest expected-failure masking in unit-test workflows
- make unit-test workflow failures exit nonzero instead of treating `(0 unexpected)` assertion failures as a pass
- fix hidden BrowserPanel and responder-repair unit failures exposed by the restored gate

## Verification
- `tests/test_ci_self_hosted_guard.sh`

## Evidence
- previous masked unit failure: https://github.com/manaflow-ai/cmux/actions/runs/27205632078/job/80320587882

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783601489&installation_id=133855650&pr_number=5701&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5701&signature=55e214f016955309e818471e0ae0ca2827d923ea1d7af78227f9465106f8c6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior change removes a broad pass override so previously masked unit failures will fail builds; BrowserPanel DevTools and lifecycle edits affect WebKit UI paths but are mostly test- and edge-case-driven.
> 
> **Overview**
> **CI unit tests now fail on real XCTest failures** instead of treating runs with `(0 unexpected)` as green. `ci.yml`, `ci-macos-compat.yml`, and `test-depot.yml` call **`scripts/ci/run-unit-tests-with-failure-gate.sh`**, which runs `cmux-unit` via the noninteractive xcodebuild wrapper with a configurable timeout, one SwiftPM cache-clear retry, and **no** expected-failure pass override. **`tests/test_ci_self_hosted_guard.sh`** and related scripts assert workflows cannot reintroduce that masking.
> 
> **Supporting CI hardening:** `xcodebuild_noninteractive.py` puts the child in its own process group and forwards **SIGTERM/SIGINT**; the nucleo FFI build script retries **`cargo build`** up to three times; **`tests-build-and-lag`** creates the virtual display **before** the CoreAnimation regression.
> 
> **App and test fixes** exposed once failures were no longer masked: **`BrowserPanel`** refreshes web-view lifecycle when initial navigation is skipped, observes Ghostty background on the main thread, and tightens DevTools visibility/refresh state; **`HeadlessWindowTestHelpers.swift`** adds stable key-window and background-color waits; shortcut, clipboard, terminal search, and browser DevTools tests swap fixed sleeps for **`waitUntil`/`waitFor`** and safer WebKit teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6d201f08c01bdbf0272f2507826a24b30a33c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make unit tests fail CI on real XCTest errors by routing all unit-test jobs through a shared failure gate with a watchdog that can kill the whole test process group on timeout and a one-time SwiftPM retry. Also tighten BrowserPanel/DevTools lifecycle, apply Ghostty background updates on the main thread, improve `xcodebuild` signal handling, and deflake headless tests.

- **Bug Fixes**
  - BrowserPanel: refresh lifecycle when initial navigation is skipped; DevTools respect hidden/visible intent, avoid redundant show if already visible, clear last-known-visible on hide, and allow refresh requests when recently visible; apply Ghostty background changes on the main thread with a safe `NotificationCenter` observer.
  - Headless tests: new `HeadlessWindowTestHelpers.swift` adds a reliable make-key helper and background-color waits; retain WebKit windows and inspector frontend webviews; replace sleeps with deterministic waits.

- **CI**
  - All unit-test workflows call `scripts/ci/run-unit-tests-with-failure-gate.sh` (watchdog with kill-on-timeout of the wrapper and child process group, one SwiftPM cache-clear retry, preserves nonzero exit).
  - Guards: `tests/test_ci_self_hosted_guard.sh` enforces gate usage and nonzero exit preservation; `tests/test_ci_unit_test_spm_retry.sh` verifies the SwiftPM retry; `tests/test_ci_xcodebuild_noninteractive_helper.py` checks SIGTERM forwarding.
  - `scripts/ci/xcodebuild_noninteractive.py` puts `xcodebuild` in its own process group, writes the child PID, forwards SIGTERM/SIGINT to the group, and returns nonzero on termination.
  - Create the virtual display before the CoreAnimation main-thread regression; `scripts/build-command-palette-nucleo-ffi.sh` retries `cargo build` up to 3 times.

<sup>Written for commit fb6d201f08c01bdbf0272f2507826a24b30a33c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web-view lifecycle when initial navigation is disabled.
  * Fixed background-theme observation and developer-tools refresh behavior.
  * Made focus/first-responder tests deterministic to reduce flakiness.
  * Adjusted inspector tests for more reliable teardown and timing.

* **Chores**
  * Simplified CI unit-test failure handling to avoid masking assertion failures.
  * Increased unit-test timeout fallback.
  * Added CI validation to detect workflows that treat test failures as passing.
  * Added retrying Rust build helper in the build script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->