### PR TITLE
Fix sidebar PR badge for reftable repos and non-github origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to cmux are documented here.
 
+## [Unreleased]
+
+### Fixed
+- Fix the sidebar PR badge not appearing (or going stale on branch switch) in repos using git's reftable ref backend or whose `origin` is not a github.com remote ([#5702](https://github.com/manaflow-ai/cmux/pull/5702))
+
 ## [0.64.14] - 2026-06-06
 
 ### Added

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -469,17 +469,41 @@ _cmux_git_head_signature() {
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
     local line
     IFS= read -r line < "$head_path" || return 1
+    # See the zsh integration: git's reftable backend pins HEAD to the constant
+    # placeholder "ref: refs/heads/.invalid", so the live ref state lives in
+    # reftable/tables.list (rewritten on every ref update). Fold that into the
+    # signature so the HEAD watch still detects branch switches.
+    if [[ "$line" == "ref: refs/heads/.invalid" ]]; then
+        local reftable_list="${head_path%/*}/reftable/tables.list"
+        if [[ -r "$reftable_list" ]]; then
+            local stack=""
+            stack="$(<"$reftable_list")"
+            printf 'reftable:%s\n' "${stack//$'\n'/,}"
+            return 0
+        fi
+    fi
     printf '%s\n' "$line"
 }
 
 _cmux_git_branch_for_path() {
     local repo_path="$1"
-    local head_path="" head_line="" prefix="ref: refs/heads/"
+    local head_path="" head_line="" branch="" prefix="ref: refs/heads/"
     head_path="$(_cmux_git_resolve_head_path "$repo_path" 2>/dev/null || true)"
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
-    IFS= read -r head_line < "$head_path" || return 1
-    [[ "$head_line" == "$prefix"* ]] || return 1
-    printf '%s\n' "${head_line#$prefix}"
+    IFS= read -r head_line < "$head_path" || head_line=""
+    if [[ "$head_line" == "$prefix"* ]]; then
+        branch="${head_line#$prefix}"
+        # See the zsh integration: git's reftable backend pins HEAD to the
+        # placeholder "ref: refs/heads/.invalid"; the real branch lives in the
+        # reftable stack, so fall through to git only in that case.
+        if [[ "$branch" != ".invalid" ]]; then
+            printf '%s\n' "$branch"
+            return 0
+        fi
+    fi
+    branch="$(command git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+    [[ -n "$branch" ]] || return 1
+    printf '%s\n' "$branch"
 }
 
 _cmux_set_git_active_pwd() {
@@ -896,9 +920,12 @@ _cmux_git_origin_url_read_config_file() {
         {
             line = strip_inline_comment($0)
             trimmed = trim(line)
-            if (trimmed ~ /^\[remote[[:space:]]+"origin"\][[:space:]]*$/) {
+            if (trimmed ~ /^\[remote[[:space:]]+"/) {
                 section = "remote"
                 condition = ""
+                remote_name = trimmed
+                sub(/^\[remote[[:space:]]+"/, "", remote_name)
+                sub(/"\][[:space:]]*$/, "", remote_name)
                 next
             }
             if (trimmed == "[include]") {
@@ -919,7 +946,7 @@ _cmux_git_origin_url_read_config_file() {
                 next
             }
             if (section == "remote" && line ~ /^[[:space:]]*url[[:space:]]*=/) {
-                print "remote\t" path_value(line) "\t"
+                print "remote\t" remote_name "\t" path_value(line)
             }
             if (section == "include" && line ~ /^[[:space:]]*path[[:space:]]*=/) {
                 print "include\t" path_value(line) "\t"
@@ -933,7 +960,8 @@ _cmux_git_origin_url_read_config_file() {
     while IFS=$'\t' read -r kind entry_payload entry_value; do
         case "$kind" in
             remote)
-                [[ -n "$entry_payload" ]] && _cmux_git_origin_url_result="$entry_payload" ;;
+                [[ -n "$entry_payload" && -n "$entry_value" ]] && \
+                    _cmux_git_remote_urls+="$entry_payload"$'\t'"$entry_value"$'\n' ;;
             include)
                 include_path="$(_cmux_git_config_resolve_include_path "$entry_payload" "$config_dir")"
                 [[ -r "$include_path" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$include_path" ;;
@@ -946,15 +974,54 @@ _cmux_git_origin_url_read_config_file() {
     done <<< "$output"
 }
 
+# Pick the best GitHub remote URL from accumulated "<name>\t<url>" lines on
+# stdin. Mirrors the app-side GitMetadataService ordering (upstream > origin >
+# other, ties broken alphabetically), keeps only github.com remotes, and takes
+# the last URL seen per remote name (git's last-one-wins). Implemented in awk so
+# the zsh and bash integrations share identical logic without associative arrays
+# (macOS /bin/bash is 3.2 and has none).
+_cmux_select_github_remote_url() {
+    awk -F'\t' '
+        function is_github(u) {
+            return (u ~ /^git@github\.com:/ ||
+                    u ~ /^ssh:\/\/git@github\.com\// ||
+                    u ~ /^https:\/\/github\.com\// ||
+                    u ~ /^http:\/\/github\.com\// ||
+                    u ~ /^git:\/\/github\.com\//)
+        }
+        function priority(name,   lower) {
+            lower = tolower(name)
+            if (lower == "upstream") return 0
+            if (lower == "origin") return 1
+            return 2
+        }
+        {
+            if ($1 == "" || $2 == "" || !is_github($2)) next
+            last_url[$1] = $2
+            seen[$1] = 1
+        }
+        END {
+            best = ""; best_priority = 99
+            for (name in seen) {
+                p = priority(name)
+                if (best == "" || p < best_priority || (p == best_priority && name < best)) {
+                    best = name; best_priority = p
+                }
+            }
+            if (best != "") print last_url[best]
+        }
+    '
+}
+
 _cmux_git_origin_url_from_config_files() {
     local repo_path="$1" git_dir="$2" common_dir="$3"
     local _cmux_git_origin_url_seen=$'\n'
     local _cmux_git_origin_url_depth=0
-    local _cmux_git_origin_url_result=""
+    local _cmux_git_remote_urls=""
 
     [[ -r "$common_dir/config" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$common_dir/config"
     [[ "$git_dir" != "$common_dir" && -r "$git_dir/config" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$git_dir/config"
-    [[ -n "$_cmux_git_origin_url_result" ]] && printf '%s\n' "$_cmux_git_origin_url_result"
+    printf '%s' "$_cmux_git_remote_urls" | _cmux_select_github_remote_url
 }
 
 _cmux_github_repo_slug_for_path() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -665,21 +665,45 @@ _cmux_git_head_signature() {
     local head_path="$1"
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
     local line=""
-    if IFS= read -r line < "$head_path"; then
-        print -r -- "$line"
-        return 0
+    IFS= read -r line < "$head_path" || return 1
+    # Under git's reftable backend, $GIT_DIR/HEAD is a fixed placeholder that
+    # always reads "ref: refs/heads/.invalid"; the live ref state (including
+    # which branch HEAD points at) lives in reftable/tables.list, which git
+    # rewrites on every ref update. Fold that stack list into the signature so
+    # the HEAD watch still detects branch switches instead of polling an
+    # unchanging placeholder.
+    if [[ "$line" == "ref: refs/heads/.invalid" ]]; then
+        local reftable_list="${head_path:h}/reftable/tables.list"
+        if [[ -r "$reftable_list" ]]; then
+            local stack=""
+            stack="$(<"$reftable_list")"
+            print -r -- "reftable:${stack//$'\n'/,}"
+            return 0
+        fi
     fi
-    return 1
+    print -r -- "$line"
 }
 
 _cmux_git_branch_for_path() {
     local repo_path="$1"
-    local head_path="" head_line="" prefix="ref: refs/heads/"
+    local head_path="" head_line="" branch="" prefix="ref: refs/heads/"
     head_path="$(_cmux_git_resolve_head_path "$repo_path" 2>/dev/null || true)"
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
     head_line="$(<"$head_path")"
-    [[ "$head_line" == "$prefix"* ]] || return 1
-    print -r -- "${head_line#$prefix}"
+    if [[ "$head_line" == "$prefix"* ]]; then
+        branch="${head_line#$prefix}"
+        # Git's reftable backend pins $GIT_DIR/HEAD to the placeholder
+        # "ref: refs/heads/.invalid"; the real branch lives in the reftable
+        # stack and can't be read as text. Only in that case fall through to
+        # git (normal loose-ref repos keep the fast no-subprocess path).
+        if [[ "$branch" != ".invalid" ]]; then
+            print -r -- "$branch"
+            return 0
+        fi
+    fi
+    branch="$(command git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+    [[ -n "$branch" ]] || return 1
+    print -r -- "$branch"
 }
 
 _cmux_set_git_active_pwd() {
@@ -1058,9 +1082,12 @@ _cmux_git_origin_url_read_config_file() {
         {
             line = strip_inline_comment($0)
             trimmed = trim(line)
-            if (trimmed ~ /^\[remote[[:space:]]+"origin"\][[:space:]]*$/) {
+            if (trimmed ~ /^\[remote[[:space:]]+"/) {
                 section = "remote"
                 condition = ""
+                remote_name = trimmed
+                sub(/^\[remote[[:space:]]+"/, "", remote_name)
+                sub(/"\][[:space:]]*$/, "", remote_name)
                 next
             }
             if (trimmed == "[include]") {
@@ -1081,7 +1108,7 @@ _cmux_git_origin_url_read_config_file() {
                 next
             }
             if (section == "remote" && line ~ /^[[:space:]]*url[[:space:]]*=/) {
-                print "remote\t" path_value(line) "\t"
+                print "remote\t" remote_name "\t" path_value(line)
             }
             if (section == "include" && line ~ /^[[:space:]]*path[[:space:]]*=/) {
                 print "include\t" path_value(line) "\t"
@@ -1095,7 +1122,8 @@ _cmux_git_origin_url_read_config_file() {
     while IFS=$'\t' read -r kind entry_payload entry_value; do
         case "$kind" in
             remote)
-                [[ -n "$entry_payload" ]] && _cmux_git_origin_url_result="$entry_payload" ;;
+                [[ -n "$entry_payload" && -n "$entry_value" ]] && \
+                    _cmux_git_remote_urls+="$entry_payload"$'\t'"$entry_value"$'\n' ;;
             include)
                 include_path="$(_cmux_git_config_resolve_include_path "$entry_payload" "$config_dir")"
                 [[ -r "$include_path" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$include_path" ;;
@@ -1108,15 +1136,54 @@ _cmux_git_origin_url_read_config_file() {
     done <<< "$output"
 }
 
+# Pick the best GitHub remote URL from accumulated "<name>\t<url>" lines on
+# stdin. Mirrors the app-side GitMetadataService ordering (upstream > origin >
+# other, ties broken alphabetically), keeps only github.com remotes, and takes
+# the last URL seen per remote name (git's last-one-wins). Implemented in awk so
+# the zsh and bash integrations share identical logic without associative arrays
+# (macOS /bin/bash is 3.2 and has none).
+_cmux_select_github_remote_url() {
+    awk -F'\t' '
+        function is_github(u) {
+            return (u ~ /^git@github\.com:/ ||
+                    u ~ /^ssh:\/\/git@github\.com\// ||
+                    u ~ /^https:\/\/github\.com\// ||
+                    u ~ /^http:\/\/github\.com\// ||
+                    u ~ /^git:\/\/github\.com\//)
+        }
+        function priority(name,   lower) {
+            lower = tolower(name)
+            if (lower == "upstream") return 0
+            if (lower == "origin") return 1
+            return 2
+        }
+        {
+            if ($1 == "" || $2 == "" || !is_github($2)) next
+            last_url[$1] = $2
+            seen[$1] = 1
+        }
+        END {
+            best = ""; best_priority = 99
+            for (name in seen) {
+                p = priority(name)
+                if (best == "" || p < best_priority || (p == best_priority && name < best)) {
+                    best = name; best_priority = p
+                }
+            }
+            if (best != "") print last_url[best]
+        }
+    '
+}
+
 _cmux_git_origin_url_from_config_files() {
     local repo_path="$1" git_dir="$2" common_dir="$3"
     local _cmux_git_origin_url_seen=$'\n'
     local _cmux_git_origin_url_depth=0
-    local _cmux_git_origin_url_result=""
+    local _cmux_git_remote_urls=""
 
     [[ -r "$common_dir/config" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$common_dir/config"
     [[ "$git_dir" != "$common_dir" && -r "$git_dir/config" ]] && _cmux_git_origin_url_read_config_file "$repo_path" "$git_dir" "$common_dir" "$git_dir/config"
-    [[ -n "$_cmux_git_origin_url_result" ]] && printf '%s\n' "$_cmux_git_origin_url_result"
+    printf '%s' "$_cmux_git_remote_urls" | _cmux_select_github_remote_url
 }
 
 _cmux_github_repo_slug_for_path() {

--- a/tests/test_shell_pr_probe_reftable_and_multi_remote.py
+++ b/tests/test_shell_pr_probe_reftable_and_multi_remote.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for the shell-side sidebar PR probe in two repo shapes the
+old probe could not handle:
+
+1) git's reftable ref backend. With `extensions.refStorage=reftable`, git keeps
+   `$GIT_DIR/HEAD` as a fixed placeholder ("ref: refs/heads/.invalid") and stores
+   the live ref state in `reftable/tables.list`. The probe read HEAD as text (no
+   git, for speed), so it saw ".invalid" and probed `gh pr view .invalid` -> no
+   PR. The branch detector now falls back to `git symbolic-ref` only for that
+   placeholder, and the HEAD-watch signature folds in `reftable/tables.list` so
+   branch switches are still detected (the placeholder alone never changes).
+
+2) repos whose `origin` is not a github.com remote (e.g. a push/proxy mirror)
+   but which DO have another github.com remote. The probe only read
+   `[remote "origin"]`, so it derived no `--repo` slug. It now scans every
+   remote and picks the best github.com URL (upstream > origin > other,
+   alphabetical), mirroring the app-side GitMetadataService ordering.
+
+Each case drives the real integration functions in both zsh and bash. The
+reftable cases are hermetic: they write the placeholder HEAD and a fake
+`reftable/tables.list` directly and stub `git` on PATH, so they don't depend on
+the test machine's git supporting reftable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SHELLS = [
+    ("zsh", ["-f", "-c"], ROOT / "Resources/shell-integration/cmux-zsh-integration.zsh"),
+    ("bash", ["--noprofile", "--norc", "-c"], ROOT / "Resources/shell-integration/cmux-bash-integration.bash"),
+]
+INVALID_HEAD = "ref: refs/heads/.invalid\n"
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _git_stub() -> str:
+    # Only `symbolic-ref --quiet --short HEAD` is expected; record every call so
+    # the loose-ref fast path can assert git was never spawned.
+    return textwrap.dedent(
+        """\
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "$CMUX_TEST_GIT_LOG"
+        if [ "$1" = "-C" ]; then shift 2; fi
+        if [ "$1" = "symbolic-ref" ]; then
+          printf '%s\\n' "$CMUX_TEST_BRANCH"
+          exit 0
+        fi
+        exit 0
+        """
+    )
+
+
+def _run(shell: str, shell_args: list[str], script: Path, body: str, env: dict[str, str]) -> tuple[int, str, str]:
+    command = f'source "$CMUX_TEST_SCRIPT"\n{body}'
+    full_env = dict(os.environ)
+    full_env.update(env)
+    full_env["CMUX_TEST_SCRIPT"] = str(script)
+    result = subprocess.run(
+        [shell, *shell_args, command],
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _reftable_branch_case(base: Path, shell: str, shell_args: list[str], script: Path) -> list[str]:
+    failures: list[str] = []
+    work = base / shell / "reftable-branch"
+    bindir = work / "bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    _write_executable(bindir / "git", _git_stub())
+    git_log = work / "git.log"
+
+    # reftable repo: placeholder HEAD + a reftable/ stack list.
+    rt = work / "reftable-repo"
+    (rt / ".git" / "reftable").mkdir(parents=True, exist_ok=True)
+    (rt / ".git" / "HEAD").write_text(INVALID_HEAD, encoding="utf-8")
+    (rt / ".git" / "reftable" / "tables.list").write_text("0x01-0x02-aaaa.ref\n", encoding="utf-8")
+
+    env = {
+        "PATH": f"{bindir}:{os.environ.get('PATH', '')}",
+        "CMUX_TEST_GIT_LOG": str(git_log),
+        "CMUX_TEST_BRANCH": "feature/reftable-branch",
+    }
+    rc, out, err = _run(shell, shell_args, script, f'_cmux_git_branch_for_path "{rt}"', env)
+    if rc != 0 or out.strip() != "feature/reftable-branch":
+        failures.append(f"{shell}: reftable branch fallback expected feature/reftable-branch, got rc={rc} out={out!r} err={err!r}")
+    git_log_text = git_log.read_text(encoding="utf-8") if git_log.exists() else ""
+    if "symbolic-ref" not in git_log_text:
+        failures.append(f"{shell}: reftable branch detection did not invoke git symbolic-ref")
+
+    # loose-ref repo: must resolve from HEAD text WITHOUT spawning git.
+    loose = work / "loose-repo"
+    (loose / ".git").mkdir(parents=True, exist_ok=True)
+    (loose / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    loose_log = work / "git-loose.log"
+    env2 = dict(env)
+    env2["CMUX_TEST_GIT_LOG"] = str(loose_log)
+    rc, out, err = _run(shell, shell_args, script, f'_cmux_git_branch_for_path "{loose}"', env2)
+    if rc != 0 or out.strip() != "main":
+        failures.append(f"{shell}: loose-ref branch expected main, got rc={rc} out={out!r} err={err!r}")
+    if loose_log.exists() and "symbolic-ref" in loose_log.read_text(encoding="utf-8"):
+        failures.append(f"{shell}: loose-ref branch detection spawned git (should stay on the fast text path)")
+    return failures
+
+
+def _reftable_signature_case(base: Path, shell: str, shell_args: list[str], script: Path) -> list[str]:
+    failures: list[str] = []
+    work = base / shell / "reftable-signature"
+    gitdir = work / ".git"
+    (gitdir / "reftable").mkdir(parents=True, exist_ok=True)
+    (gitdir / "HEAD").write_text(INVALID_HEAD, encoding="utf-8")
+    tables = gitdir / "reftable" / "tables.list"
+    head = gitdir / "HEAD"
+
+    tables.write_text("0x01-0x02-aaaa.ref\n", encoding="utf-8")
+    rc, sig1, err = _run(shell, shell_args, script, f'_cmux_git_head_signature "{head}"', {})
+    if rc != 0 or not sig1.strip().startswith("reftable:"):
+        failures.append(f"{shell}: reftable signature should be reftable-derived, got rc={rc} out={sig1!r} err={err!r}")
+
+    # A branch switch rewrites tables.list; the signature must change so the
+    # HEAD watch refreshes the badge (the placeholder HEAD never changes).
+    tables.write_text("0x01-0x02-aaaa.ref\n0x03-0x03-bbbb.ref\n", encoding="utf-8")
+    rc, sig2, _ = _run(shell, shell_args, script, f'_cmux_git_head_signature "{head}"', {})
+    if sig1.strip() == sig2.strip():
+        failures.append(f"{shell}: reftable signature did not change after tables.list changed ({sig1.strip()!r})")
+
+    # Loose-ref HEAD keeps its plain text signature.
+    loose_head = work / "loose-HEAD"
+    loose_head.write_text("ref: refs/heads/main\n", encoding="utf-8")
+    rc, sig3, _ = _run(shell, shell_args, script, f'_cmux_git_head_signature "{loose_head}"', {})
+    if sig3.strip() != "ref: refs/heads/main":
+        failures.append(f"{shell}: loose-ref signature expected the HEAD line, got {sig3!r}")
+    return failures
+
+
+def _multi_remote_slug_case(base: Path, shell: str, shell_args: list[str], script: Path) -> list[str]:
+    failures: list[str] = []
+    cases = {
+        # origin is a non-github proxy; a separate github remote must be used.
+        "non-github-origin": (
+            textwrap.dedent(
+                """\
+                [remote "origin"]
+                    url = https://gitstream.example.com/acme/widgets.git
+                [remote "github"]
+                    url = https://github.com/acme/widgets.git
+                """
+            ),
+            "acme/widgets",
+        ),
+        # upstream outranks origin.
+        "upstream-beats-origin": (
+            textwrap.dedent(
+                """\
+                [remote "origin"]
+                    url = git@github.com:me/fork.git
+                [remote "upstream"]
+                    url = https://github.com/acme/widgets.git
+                """
+            ),
+            "acme/widgets",
+        ),
+        # origin outranks an arbitrarily named remote.
+        "origin-beats-other": (
+            textwrap.dedent(
+                """\
+                [remote "zzz"]
+                    url = https://github.com/other/repo.git
+                [remote "origin"]
+                    url = https://github.com/acme/widgets.git
+                """
+            ),
+            "acme/widgets",
+        ),
+    }
+    for name, (config, expected) in cases.items():
+        repo = base / shell / "slug" / name / "repo"
+        (repo / ".git").mkdir(parents=True, exist_ok=True)
+        (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+        (repo / ".git" / "config").write_text(config, encoding="utf-8")
+        rc, out, err = _run(shell, shell_args, script, f'_cmux_github_repo_slug_for_path "{repo}"', {})
+        if rc != 0 or out.strip() != expected:
+            failures.append(f"{shell}: slug {name} expected {expected}, got rc={rc} out={out!r} err={err!r}")
+    return failures
+
+
+def main() -> int:
+    base = Path("/tmp") / f"cmux_pr_probe_reftable_multi_remote_{os.getpid()}"
+    failures: list[str] = []
+    ran = 0
+    try:
+        shutil.rmtree(base, ignore_errors=True)
+        base.mkdir(parents=True, exist_ok=True)
+        for shell, shell_args, script in SHELLS:
+            if not script.exists():
+                failures.append(f"{shell}: integration script missing at {script}")
+                continue
+            if shutil.which(shell) is None:
+                print(f"SKIP: {shell} not available")
+                continue
+            ran += 1
+            failures += _reftable_branch_case(base, shell, shell_args, script)
+            failures += _reftable_signature_case(base, shell, shell_args, script)
+            failures += _multi_remote_slug_case(base, shell, shell_args, script)
+
+        if ran == 0:
+            failures.append("no shell integration cases executed - regression coverage is a no-op")
+
+        if failures:
+            print("FAIL:")
+            for failure in failures:
+                print(f"  {failure}")
+            return 1
+        print(f"PASS: {ran} shell integration(s) handle reftable HEAD and multi-remote GitHub slug detection")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The shell-side sidebar PR probe (`_cmux_report_pr_for_path`) resolves the current branch by reading `$GIT_DIR/HEAD` as text and derives the GitHub `--repo` slug by parsing only `[remote "origin"]` from git config. Both shortcuts (deliberately avoiding `git` for speed) fail in two real repo shapes, so the PR badge never appears in the sidebar:

1. **git reftable backend** (`extensions.refStorage=reftable`). git keeps `$GIT_DIR/HEAD` as a fixed placeholder that always reads `ref: refs/heads/.invalid` and stores the live ref state in `reftable/tables.list`. The probe saw `.invalid` and ran `gh pr view .invalid` → no PR. Worse, `_cmux_git_head_signature` read the unchanging placeholder, so the HEAD watch **never detected branch switches** (the badge went stale until the next slow poll, if at all).
2. **Non-github `origin`.** Repos whose `origin` is a push/proxy mirror (not `github.com`) but which have another github.com remote derived no slug, so the probe fell back to a bare `gh pr view` that errors with *"could not resolve remote origin"*.

### What changed (both the zsh and bash integrations)

- **`_cmux_git_branch_for_path`** — keep the fast no-subprocess text path for normal loose-ref repos; only when HEAD is the reftable placeholder (`ref: refs/heads/.invalid`) fall back to `git symbolic-ref --quiet --short HEAD`.
- **`_cmux_git_head_signature`** — under reftable, fold `reftable/tables.list` (rewritten on every ref update) into the signature so the HEAD watch still detects branch switches.
- **`_cmux_git_origin_url_from_config_files`** — scan every `[remote "..."]` section and pick the best github.com URL (upstream > origin > other, alphabetical), mirroring the app-side `GitMetadataService` ordering and keeping git's last-one-wins per remote. Selection runs in `awk` so zsh and bash share identical logic without associative arrays (macOS `/bin/bash` is 3.2 and has none).

No app-side change is needed — `GitMetadataService` already scans all remotes; this brings the shell probe in line with it.

## Testing

- `zsh -n` / `bash -n` clean on both integration scripts.
- New `tests/test_shell_pr_probe_reftable_and_multi_remote.py` drives the real integration functions in both shells. The reftable cases are hermetic — they write the placeholder HEAD and a fake `reftable/tables.list` and stub `git` on PATH — so they don't depend on the test machine's git supporting reftable.
- Existing shell-integration regression tests still pass:
  - `tests/test_shell_git_config_remote_url_parsing.py`
  - `tests/test_shell_git_branch_stale_cwd.py`
  - `tests/test_issue_1138_sidebar_pr_polling.py`
- Manually verified end-to-end on a real reftable repo (`git init --ref-format=reftable`) with a non-github `origin` plus a `github` remote: the probe resolves the true branch, derives the correct `owner/repo` slug, and the HEAD signature changes on `git checkout` to another branch.

## Demo Video

N/A — shell-integration only (no UI surface). Behavior is covered by the automated tests above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar PR badge not appearing or becoming stale when switching branches in repositories using Git's reftable ref backend or where `origin` is not a GitHub remote.

* **Tests**
  * Added regression tests for Git reftable backend handling and multi-remote repository configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->