### PR TITLE
Reduce idle CPU for agent session polling

### DIFF
--- a/Packages/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift
+++ b/Packages/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift
@@ -11,6 +11,8 @@ public final class DebugEventLog: @unchecked Sendable {
     private var entries: [String] = []
     private let capacity = 500
     private let queue = DispatchQueue(label: "cmux.debug-event-log")
+    /// Persistent write handle, kept open to avoid per-message open/seek/close overhead.
+    private var fileHandle: FileHandle?
     private static let logPath = resolveLogPath()
     private static let debugFieldPattern = try! NSRegularExpression(
         pattern: "(^| )([A-Za-z][A-Za-z0-9_-]*)=",
@@ -140,12 +142,36 @@ public final class DebugEventLog: @unchecked Sendable {
             let line = entry + "\n"
             guard let data = line.data(using: .utf8) else { return }
 
+            self.appendToFile(data)
+        }
+    }
+
+    /// Appends `data` to the log file, reusing a persistent file handle.
+    /// Must only be called from within `queue`.
+    private func appendToFile(_ data: Data) {
+        // Fast path: try to write on the cached handle.
+        if let handle = fileHandle {
+            do {
+                try handle.write(contentsOf: data)
+                return
+            } catch {
+                // Handle became invalid (file deleted/rotated). Fall through to re-open.
+                try? handle.close()
+                fileHandle = nil
+            }
+        }
+        // Slow path: open (or create) the file and seek to end once.
+        if FileManager.default.fileExists(atPath: Self.logPath) {
             if let handle = FileHandle(forWritingAtPath: Self.logPath) {
-                defer { try? handle.close() }
-                guard (try? handle.seekToEnd()) != nil else { return }
+                _ = try? handle.seekToEnd()
+                fileHandle = handle
                 try? handle.write(contentsOf: data)
-            } else {
-                FileManager.default.createFile(atPath: Self.logPath, contents: data)
+            }
+        } else {
+            FileManager.default.createFile(atPath: Self.logPath, contents: data)
+            if let handle = FileHandle(forWritingAtPath: Self.logPath) {
+                _ = try? handle.seekToEnd()
+                fileHandle = handle
             }
         }
     }
@@ -153,6 +179,8 @@ public final class DebugEventLog: @unchecked Sendable {
     /// Writes the current buffer to disk, replacing the existing log file.
     public func dump() {
         queue.sync {
+            try? self.fileHandle?.close()
+            self.fileHandle = nil
             let content = self.entries.joined(separator: "\n") + "\n"
             try? content.write(toFile: Self.logPath, atomically: true, encoding: .utf8)
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CMUXAgentLaunch
+import os
 
 nonisolated enum TerminalStartupShellQuoting {
     static func singleQuoted(_ value: String) -> String {
@@ -959,17 +960,58 @@ struct RestorableAgentSessionIndex: Sendable {
         homeDirectory: String = NSHomeDirectory(),
         fileManager: FileManager = .default
     ) -> RestorableAgentSessionIndex {
+        // Fast path: if ProcessDetectedResumeIndexes.loadSynchronously() already ran
+        // with the same process snapshot, return its cached restorableAgentIndex
+        // directly, avoiding a redundant CmuxVaultAgentRegistry.load() and
+        // RestorableAgentSessionIndex.load() (expensive hook-store JSON reads).
+        let processSnapshot = CmuxTopProcessSnapshot.captureCached(
+            includeProcessDetails: true,
+            maximumAge: 60
+        )
+        if let cached = cachedProcessDetectedResumeIndexes(
+            for: processSnapshot,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        ) {
+            return cached.restorableAgentIndex
+        }
+
+        let capturedAt = Date().timeIntervalSince1970
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = processDetectedSnapshots(
             registry: registry,
-            fileManager: fileManager
+            fileManager: fileManager,
+            processSnapshot: processSnapshot,
+            capturedAt: capturedAt
         )
-        return load(
+        let restorableAgentIndex = load(
             homeDirectory: homeDirectory,
             fileManager: fileManager,
             registry: registry,
             detectedSnapshots: detectedSnapshots
         )
+        // Also compute and cache the full ProcessDetectedResumeIndexes result so that
+        // subsequent ProcessDetectedResumeIndexes.loadSynchronously() calls (e.g. the
+        // session-autosave at t+8 s) can skip their own expensive disk reads.
+        let detectedBindings = SurfaceResumeBindingIndex.processDetectedTmuxBindings(
+            fileManager: fileManager,
+            processSnapshot: processSnapshot,
+            capturedAt: capturedAt
+        )
+        let fullResult = ProcessDetectedResumeIndexes(
+            restorableAgentIndex: restorableAgentIndex,
+            surfaceResumeBindingIndex: SurfaceResumeBindingIndex(
+                bindingsByPanel: detectedBindings.mapValues(\.binding)
+            )
+        )
+        cacheProcessDetectedResumeIndexes(
+            fullResult,
+            for: processSnapshot,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager,
+            registry: registry
+        )
+        return restorableAgentIndex
     }
 
     static func load(
@@ -1653,6 +1695,203 @@ nonisolated struct SurfaceResumeBindingIndex: Sendable {
     }
 }
 
+// Module-level result cache: when the process snapshot and hook/config source files are
+// unchanged, the derived registry, agent-index, and tmux-bindings are unchanged too.
+// This avoids re-reading hook-store JSON on every 8-second autosave tick while the app is idle.
+private nonisolated struct ProcessDetectedResumeIndexesCacheIdentity: Equatable, Sendable {
+    var sampledAt: Date
+    var homeDirectory: String
+    var fileManagerID: ObjectIdentifier
+    var environmentPWD: String?
+    var hookStateDirectoryOverride: String?
+}
+
+private nonisolated struct ProcessDetectedResumeIndexesFileFingerprint: Equatable, Sendable {
+    var path: String
+    var exists: Bool
+    var modifiedAt: TimeInterval
+    var size: UInt64
+}
+
+private nonisolated struct ProcessDetectedResumeIndexesCacheKey: Sendable {
+    var identity: ProcessDetectedResumeIndexesCacheIdentity
+    var sourcePaths: [String]
+    var sourceFingerprint: [ProcessDetectedResumeIndexesFileFingerprint]
+}
+
+private nonisolated struct ProcessDetectedResumeIndexesCache: @unchecked Sendable {
+    var result: ProcessDetectedResumeIndexes?
+    var key: ProcessDetectedResumeIndexesCacheKey?
+}
+private nonisolated let processDetectedResumeIndexesCache = OSAllocatedUnfairLock(
+    initialState: ProcessDetectedResumeIndexesCache()
+)
+
+private nonisolated func cachedProcessDetectedResumeIndexes(
+    for processSnapshot: CmuxTopProcessSnapshot,
+    homeDirectory: String,
+    fileManager: FileManager
+) -> ProcessDetectedResumeIndexes? {
+    let identity = processDetectedResumeIndexesCacheIdentity(
+        processSnapshot: processSnapshot,
+        homeDirectory: homeDirectory,
+        fileManager: fileManager
+    )
+    guard let candidate = processDetectedResumeIndexesCache.withLock({ state -> (ProcessDetectedResumeIndexesCacheKey, ProcessDetectedResumeIndexes)? in
+        guard let key = state.key,
+              key.identity == identity,
+              let result = state.result else {
+            return nil
+        }
+        return (key, result)
+    }) else {
+        return nil
+    }
+
+    let currentFingerprint = processDetectedResumeIndexesFileFingerprint(
+        paths: candidate.0.sourcePaths,
+        fileManager: fileManager
+    )
+    guard currentFingerprint == candidate.0.sourceFingerprint else {
+        return nil
+    }
+    return candidate.1
+}
+
+private nonisolated func cacheProcessDetectedResumeIndexes(
+    _ result: ProcessDetectedResumeIndexes,
+    for processSnapshot: CmuxTopProcessSnapshot,
+    homeDirectory: String,
+    fileManager: FileManager,
+    registry: CmuxVaultAgentRegistry
+) {
+    let sourcePaths = processDetectedResumeIndexesSourcePaths(
+        homeDirectory: homeDirectory,
+        fileManager: fileManager,
+        registry: registry
+    )
+    let key = ProcessDetectedResumeIndexesCacheKey(
+        identity: processDetectedResumeIndexesCacheIdentity(
+            processSnapshot: processSnapshot,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        ),
+        sourcePaths: sourcePaths,
+        sourceFingerprint: processDetectedResumeIndexesFileFingerprint(
+            paths: sourcePaths,
+            fileManager: fileManager
+        )
+    )
+    processDetectedResumeIndexesCache.withLock { state in
+        state.result = result
+        state.key = key
+    }
+}
+
+private nonisolated func processDetectedResumeIndexesCacheIdentity(
+    processSnapshot: CmuxTopProcessSnapshot,
+    homeDirectory: String,
+    fileManager: FileManager
+) -> ProcessDetectedResumeIndexesCacheIdentity {
+    ProcessDetectedResumeIndexesCacheIdentity(
+        sampledAt: processSnapshot.sampledAt,
+        homeDirectory: (homeDirectory as NSString).standardizingPath,
+        fileManagerID: ObjectIdentifier(fileManager),
+        environmentPWD: normalizedProcessDetectedResumeIndexesEnvironmentPath("PWD"),
+        hookStateDirectoryOverride: normalizedProcessDetectedResumeIndexesEnvironmentPath("CMUX_AGENT_HOOK_STATE_DIR")
+    )
+}
+
+private nonisolated func normalizedProcessDetectedResumeIndexesEnvironmentPath(_ key: String) -> String? {
+    guard let rawValue = ProcessInfo.processInfo.environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !rawValue.isEmpty else {
+        return nil
+    }
+    return ((rawValue as NSString).expandingTildeInPath as NSString).standardizingPath
+}
+
+private nonisolated func processDetectedResumeIndexesSourcePaths(
+    homeDirectory: String,
+    fileManager: FileManager,
+    registry: CmuxVaultAgentRegistry
+) -> [String] {
+    let home = (homeDirectory as NSString).standardizingPath
+    var paths = [(home as NSString).appendingPathComponent(".config/cmux/cmux.json")]
+    if let pwd = normalizedProcessDetectedResumeIndexesEnvironmentPath("PWD") {
+        paths.append(contentsOf: processDetectedResumeIndexesLocalConfigCandidatePaths(
+            startingAt: pwd,
+            fileManager: fileManager
+        ))
+    }
+
+    let builtInKindIDs = Set(RestorableAgentKind.allCases.map(\.rawValue))
+    let hookKinds = RestorableAgentKind.allCases
+        + registry.registrations.compactMap { registration -> RestorableAgentKind? in
+            builtInKindIDs.contains(registration.id) ? nil : .custom(registration.id)
+        }
+    paths.append(contentsOf: hookKinds.map { kind in
+        kind.hookStoreFileURL(homeDirectory: home).path
+    })
+
+    return processDetectedResumeIndexesUniqueStandardizedPaths(paths)
+}
+
+private nonisolated func processDetectedResumeIndexesLocalConfigCandidatePaths(
+    startingAt path: String,
+    fileManager: FileManager
+) -> [String] {
+    var isDirectory: ObjCBool = false
+    let start = fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+        ? path
+        : (path as NSString).deletingLastPathComponent
+    var current = (start as NSString).standardizingPath
+    var paths: [String] = []
+    while true {
+        paths.append(((current as NSString).appendingPathComponent(".cmux") as NSString).appendingPathComponent("cmux.json"))
+        paths.append((current as NSString).appendingPathComponent("cmux.json"))
+        let parent = (current as NSString).deletingLastPathComponent
+        if parent == current { break }
+        current = parent
+    }
+    return paths
+}
+
+private nonisolated func processDetectedResumeIndexesUniqueStandardizedPaths(_ paths: [String]) -> [String] {
+    var result: [String] = []
+    var seen = Set<String>()
+    for path in paths {
+        let standardized = ((path as NSString).expandingTildeInPath as NSString).standardizingPath
+        if seen.insert(standardized).inserted {
+            result.append(standardized)
+        }
+    }
+    return result
+}
+
+private nonisolated func processDetectedResumeIndexesFileFingerprint(
+    paths: [String],
+    fileManager: FileManager
+) -> [ProcessDetectedResumeIndexesFileFingerprint] {
+    paths.map { path in
+        guard let attrs = try? fileManager.attributesOfItem(atPath: path) else {
+            return ProcessDetectedResumeIndexesFileFingerprint(
+                path: path,
+                exists: false,
+                modifiedAt: 0,
+                size: 0
+            )
+        }
+        let modifiedAt = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+        return ProcessDetectedResumeIndexesFileFingerprint(
+            path: path,
+            exists: true,
+            modifiedAt: modifiedAt,
+            size: size
+        )
+    }
+}
+
 struct ProcessDetectedResumeIndexes: Sendable {
     let restorableAgentIndex: RestorableAgentSessionIndex
     let surfaceResumeBindingIndex: SurfaceResumeBindingIndex
@@ -1670,8 +1909,26 @@ struct ProcessDetectedResumeIndexes: Sendable {
         homeDirectory: String = NSHomeDirectory(),
         fileManager: FileManager = .default
     ) -> ProcessDetectedResumeIndexes {
+        // Re-use a recent snapshot when available: the session-autosave fires every 8 s and
+        // the process list rarely changes that fast.  A 60-second TTL covers the first
+        // hibernation repeat at t+35 s while still bounding process-detection staleness.
+        let processSnapshot = CmuxTopProcessSnapshot.captureCached(
+            includeProcessDetails: true,
+            maximumAge: 60
+        )
+
+        // Fast path: if the process snapshot has not changed since the last call (same
+        // sampledAt means the same proc_pidinfo data), the derived agent/binding indexes
+        // are also identical.  Skip the registry JSON read and hook-store JSON reads.
+        if let cached = cachedProcessDetectedResumeIndexes(
+            for: processSnapshot,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager
+        ) {
+            return cached
+        }
+
         let capturedAt = Date().timeIntervalSince1970
-        let processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
         let registry = CmuxVaultAgentRegistry.load(homeDirectory: homeDirectory, fileManager: fileManager)
         let detectedSnapshots = RestorableAgentSessionIndex.processDetectedSnapshots(
             registry: registry,
@@ -1690,10 +1947,18 @@ struct ProcessDetectedResumeIndexes: Sendable {
             processSnapshot: processSnapshot,
             capturedAt: capturedAt
         )
-        return ProcessDetectedResumeIndexes(
+        let result = ProcessDetectedResumeIndexes(
             restorableAgentIndex: restorableAgentIndex,
             surfaceResumeBindingIndex: SurfaceResumeBindingIndex(bindingsByPanel: detectedBindings.mapValues(\.binding))
         )
+        cacheProcessDetectedResumeIndexes(
+            result,
+            for: processSnapshot,
+            homeDirectory: homeDirectory,
+            fileManager: fileManager,
+            registry: registry
+        )
+        return result
     }
 }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3255,8 +3255,17 @@ class TabManager: ObservableObject {
     private func shouldStopWorkspaceGitMetadataRefresh(
         _ snapshot: InitialWorkspaceGitMetadataSnapshot
     ) -> Bool {
+        // Once a git repository is confirmed, the burst has served its purpose: retrying
+        // until the repo is found.  Subsequent changes (dirty flag, rebase, branch rename)
+        // are handled by the DispatchSourceFileSystemObject watcher installed after the
+        // first successful probe.  Continuing to fire probes at 0.5 s, 1.5 s, 3 s, 6 s,
+        // and 10 s re-parses the index and re-stats every tracked file unnecessarily, and
+        // the +10 s probe timing consistently lands inside the idle-CPU sampling window,
+        // creating measurable and avoidable background work.
+        //
+        // PR lookup is not driven by these probes; it uses the independent poll timer.
         if snapshot.isRepository {
-            return false
+            return true
         }
         switch snapshot.pullRequest {
         case .deferred, .transientFailure:

--- a/Sources/VaultAgentProcessScanner.swift
+++ b/Sources/VaultAgentProcessScanner.swift
@@ -34,7 +34,13 @@ extension RestorableAgentSessionIndex {
         fileManager: FileManager
     ) -> [PanelKey: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval, processIDs: Set<Int>)] {
         let capturedAt = Date().timeIntervalSince1970
-        let processSnapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: true)
+        // Re-use a recent snapshot when available; the agent-hibernation poll fires every 30 s
+        // and the full proc_pidinfo sweep for all processes is expensive. A 60-second TTL
+        // covers the first repeat at t+35 s while sharing work with the session-autosave path.
+        let processSnapshot = CmuxTopProcessSnapshot.captureCached(
+            includeProcessDetails: true,
+            maximumAge: 60
+        )
         return processDetectedSnapshots(
             registry: registry,
             fileManager: fileManager,


### PR DESCRIPTION
## Summary

This PR reduces debug-app idle CPU by cutting repeated startup/idle work from agent session restore paths.

Changes:
- keep `DebugEventLog`'s write handle open across appends instead of opening/seeking/closing per log line
- share cached `CmuxTopProcessSnapshot` results across session autosave and agent hibernation paths with a 60s TTL
- cache derived `ProcessDetectedResumeIndexes` while the process snapshot and hook/config source files are unchanged
- stop the startup git metadata retry burst once repository detection succeeds; the watcher and PR poller continue handling later changes

## Autoresearch results

I ran `pi-autoresearch` for about 3h10m on this branch with `idle_cpu_percent` as the objective, using the tagged debug app flow.

Raw autoresearch baseline and best:
- baseline: `5.57%` idle CPU
- Pi best before manual safety cleanup: `0.49-0.60%` idle CPU across the TTL=60 confirmation runs

After the manual audit, I strengthened the result cache key so it also validates home directory, file-manager identity, environment-derived config roots, and hook/config file metadata before reusing the derived index. That safer final code measured:
- `0.765%` idle CPU
- `0.755%` idle CPU

That is still roughly an 86% reduction from the `5.57%` baseline on this machine.

## Validation

- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/check-pbxproj.sh`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag codex-energy`
- `.auto/measure.sh` twice against the final audited commit: `0.765%`, `0.755%`

Note: an unskipped reload currently fails in this environment because `zig` resolves to `0.16.0` while the Ghostty CLI helper script requires `0.15.2`. The tagged app build succeeds with `CMUX_SKIP_ZIG_BUILD=1`, which is also what the measurement harness used.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783612997&installation_id=133855650&pr_number=5706&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5706&signature=3e3efbc2505a34f7520f28cf1e1983f4084c9cea0a5248feeb086603b9ea875b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts idle CPU by reusing process snapshots, caching derived resume indexes, and stopping redundant startup work. On the test machine, idle CPU dropped ~86% (5.57% → ~0.76%).

- **Performance**
  - Reuse `CmuxTopProcessSnapshot` across autosave and hibernation with a 60s TTL (`captureCached`).
  - Cache `ProcessDetectedResumeIndexes` when the process snapshot and hook/config sources are unchanged; key includes home dir, file-manager identity, env paths, and file fingerprints.
  - Keep `DebugEventLog` file handle open across writes to avoid per-line open/seek/close.
  - Stop the startup git metadata retry burst once a repo is detected; watcher and PR poller handle later changes.

<sup>Written for commit 37d90e408136916805d0383ed2b7763438fecfa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed git metadata probes continuing unnecessarily after confirming a repository exists

* **Performance**
  * Introduced process detection result caching to minimize repeated disk I/O operations
  * Enhanced debug logging with persistent file handle management and automatic recovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->