### PR TITLE
Remove sidebar row-ids preference aggregation feeding the layout livelock (#2586)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10864,18 +10864,24 @@ struct VerticalTabsSidebar: View {
         return KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
     }
 
-    private func requestSelectedWorkspaceScroll(_ proxy: ScrollViewProxy, workspaceIds: [UUID]) {
+    private func requestSelectedWorkspaceScroll(
+        _ proxy: ScrollViewProxy,
+        renderContext: WorkspaceListRenderContext
+    ) {
         guard let selectedWorkspaceId = tabManager.selectedTabId,
-              workspaceIds.contains(selectedWorkspaceId) else {
+              renderContext.workspaceIds.contains(selectedWorkspaceId) else {
             pendingSelectedWorkspaceScrollId = nil
             return
         }
 
         pendingSelectedWorkspaceScrollId = selectedWorkspaceId
-        flushPendingSelectedWorkspaceScroll(proxy)
+        flushPendingSelectedWorkspaceScroll(proxy, renderContext: renderContext)
     }
 
-    private func flushPendingSelectedWorkspaceScroll(_ proxy: ScrollViewProxy) {
+    private func flushPendingSelectedWorkspaceScroll(
+        _ proxy: ScrollViewProxy,
+        renderContext: WorkspaceListRenderContext
+    ) {
         guard let selectedWorkspaceId = pendingSelectedWorkspaceScrollId else { return }
 
         // Scroll unconditionally: ScrollViewProxy resolves `.id(_:)` values in
@@ -10888,8 +10894,25 @@ struct VerticalTabsSidebar: View {
         // (https://github.com/manaflow-ai/cmux/issues/2586).
         //
         // No anchor means SwiftUI scrolls the minimum needed to reveal the row.
-        proxy.scrollTo(selectedWorkspaceId)
+        proxy.scrollTo(sidebarScrollTargetId(for: selectedWorkspaceId, renderContext: renderContext))
         pendingSelectedWorkspaceScrollId = nil
+    }
+
+    /// A member of a collapsed group has no row of its own, so its UUID is not
+    /// a scrollable `.id` and `scrollTo` would no-op. Target the group header
+    /// (which carries the anchor workspace id) so the scroll still lands where
+    /// the workspace lives. Decided purely from render-context data, never
+    /// from what the lazy layout happens to have realized.
+    private func sidebarScrollTargetId(
+        for workspaceId: UUID,
+        renderContext: WorkspaceListRenderContext
+    ) -> UUID {
+        guard let tab = renderContext.workspaceById[workspaceId],
+              let groupId = tab.groupId,
+              let group = renderContext.workspaceGroupById[groupId],
+              group.isCollapsed
+        else { return workspaceId }
+        return group.anchorWorkspaceId
     }
 
     private func shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
@@ -11176,20 +11199,20 @@ struct VerticalTabsSidebar: View {
                 .background(Color.clear)
                 .modifier(ClearScrollBackground())
                 .onAppear {
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: renderContext.workspaceIds)
+                    requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
                 }
                 .onChange(of: tabManager.selectedTabId) { _, _ in
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: renderContext.workspaceIds)
+                    requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
                 }
                 .onChange(of: renderContext.workspaceIds) { oldWorkspaceIds, newWorkspaceIds in
                     guard shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
                         from: oldWorkspaceIds,
                         to: newWorkspaceIds
                     ) else {
-                        flushPendingSelectedWorkspaceScroll(scrollProxy)
+                        flushPendingSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
                         return
                     }
-                    requestSelectedWorkspaceScroll(scrollProxy, workspaceIds: newWorkspaceIds)
+                    requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .workspaceOrderDidChange)) { notification in
                     requestSelectedWorkspaceScrollAfterWorkspaceOrderChange(notification)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10887,32 +10887,18 @@ struct VerticalTabsSidebar: View {
         // Scroll unconditionally: ScrollViewProxy resolves `.id(_:)` values in
         // lazy containers without requiring the row to be realized, and an
         // unknown id is a harmless no-op. The previous design gated this on a
-        // per-row "laid-out row ids" PreferenceKey aggregated across every
-        // sidebar row; that preference fed `@State` writes from inside the
-        // layout/preference update cycle and was the surviving cmux-owned edge
-        // in the sidebar layout livelock
-        // (https://github.com/manaflow-ai/cmux/issues/2586).
-        //
-        // No anchor means SwiftUI scrolls the minimum needed to reveal the row.
-        proxy.scrollTo(sidebarScrollTargetId(for: selectedWorkspaceId, renderContext: renderContext))
+        // per-row "laid-out row ids" PreferenceKey whose sidebar-wide reduce
+        // fed `@State` writes from inside the layout/preference update cycle,
+        // the cmux-owned edge in the sidebar layout livelock
+        // (https://github.com/manaflow-ai/cmux/issues/2586). No anchor means
+        // SwiftUI scrolls the minimum needed to reveal the row.
+        let group = renderContext.workspaceById[selectedWorkspaceId]?.groupId
+            .flatMap { renderContext.workspaceGroupById[$0] }
+        proxy.scrollTo(SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
+            selectedWorkspaceId: selectedWorkspaceId,
+            group: group
+        ))
         pendingSelectedWorkspaceScrollId = nil
-    }
-
-    /// A member of a collapsed group has no row of its own, so its UUID is not
-    /// a scrollable `.id` and `scrollTo` would no-op. Target the group header
-    /// (which carries the anchor workspace id) so the scroll still lands where
-    /// the workspace lives. Decided purely from render-context data, never
-    /// from what the lazy layout happens to have realized.
-    private func sidebarScrollTargetId(
-        for workspaceId: UUID,
-        renderContext: WorkspaceListRenderContext
-    ) -> UUID {
-        guard let tab = renderContext.workspaceById[workspaceId],
-              let groupId = tab.groupId,
-              let group = renderContext.workspaceGroupById[groupId],
-              group.isCollapsed
-        else { return workspaceId }
-        return group.anchorWorkspaceId
     }
 
     private func shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10585,7 +10585,6 @@ struct VerticalTabsSidebar: View {
     // row sitting behind the open menu. See `SidebarShortcutHintFreezePolicy`.
     @State private var frozenShortcutHintsTabId: UUID?
     @State private var frozenShortcutHintsValue: Bool = false
-    @State private var laidOutWorkspaceRowIds: Set<UUID> = []
     @State private var pendingSelectedWorkspaceScrollId: UUID?
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
@@ -10876,14 +10875,18 @@ struct VerticalTabsSidebar: View {
         flushPendingSelectedWorkspaceScroll(proxy)
     }
 
-    private func flushPendingSelectedWorkspaceScroll(
-        _ proxy: ScrollViewProxy,
-        laidOutWorkspaceRowIds: Set<UUID>? = nil
-    ) {
+    private func flushPendingSelectedWorkspaceScroll(_ proxy: ScrollViewProxy) {
         guard let selectedWorkspaceId = pendingSelectedWorkspaceScrollId else { return }
-        let rowIds = laidOutWorkspaceRowIds ?? self.laidOutWorkspaceRowIds
-        guard rowIds.contains(selectedWorkspaceId) else { return }
 
+        // Scroll unconditionally: ScrollViewProxy resolves `.id(_:)` values in
+        // lazy containers without requiring the row to be realized, and an
+        // unknown id is a harmless no-op. The previous design gated this on a
+        // per-row "laid-out row ids" PreferenceKey aggregated across every
+        // sidebar row; that preference fed `@State` writes from inside the
+        // layout/preference update cycle and was the surviving cmux-owned edge
+        // in the sidebar layout livelock
+        // (https://github.com/manaflow-ai/cmux/issues/2586).
+        //
         // No anchor means SwiftUI scrolls the minimum needed to reveal the row.
         proxy.scrollTo(selectedWorkspaceId)
         pendingSelectedWorkspaceScrollId = nil
@@ -11235,10 +11238,6 @@ struct VerticalTabsSidebar: View {
                     if let index = tabManager.tabs.firstIndex(where: { $0.id == focusedId }) {
                         lastSidebarSelectionIndex = index
                     }
-                }
-                .onPreferenceChange(SidebarWorkspaceRowIdsPreferenceKey.self) { rowIds in
-                    laidOutWorkspaceRowIds = rowIds
-                    flushPendingSelectedWorkspaceScroll(scrollProxy, laidOutWorkspaceRowIds: rowIds)
                 }
             }
         }
@@ -12625,7 +12624,6 @@ struct VerticalTabsSidebar: View {
         .equatable()
         .id(tab.id)
         .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([tab.id]))
 
         row
             .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)
@@ -12635,14 +12633,6 @@ struct VerticalTabsSidebar: View {
     private func debugShortSidebarTabId(_ id: UUID?) -> String {
         guard let id else { return "nil" }
         return String(id.uuidString.prefix(5))
-    }
-}
-
-struct SidebarWorkspaceRowIdsPreferenceKey: PreferenceKey {
-    static let defaultValue: Set<UUID> = []
-
-    static func reduce(value: inout Set<UUID>, nextValue: () -> Set<UUID>) {
-        value.formUnion(nextValue())
     }
 }
 

--- a/Sources/Sidebar/SidebarState.swift
+++ b/Sources/Sidebar/SidebarState.swift
@@ -1,5 +1,6 @@
 import Combine
 import CoreGraphics
+import Foundation
 
 final class SidebarState: ObservableObject {
     @Published var isVisible: Bool

--- a/Sources/Sidebar/SidebarState.swift
+++ b/Sources/Sidebar/SidebarState.swift
@@ -74,4 +74,17 @@ enum SidebarSelectedWorkspaceScrollPolicy {
 
         return true
     }
+
+    /// A member of a collapsed group has no sidebar row of its own, so its
+    /// UUID is not a scrollable `.id` and `scrollTo` would no-op. Target the
+    /// group header (which carries the anchor workspace id) so the scroll
+    /// still lands where the workspace lives. Decided purely from model data,
+    /// never from what the lazy layout happens to have realized.
+    static func scrollTargetWorkspaceId(
+        selectedWorkspaceId: UUID,
+        group: WorkspaceGroup?
+    ) -> UUID {
+        guard let group, group.isCollapsed else { return selectedWorkspaceId }
+        return group.anchorWorkspaceId
+    }
 }

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -156,7 +156,6 @@ extension VerticalTabsSidebar {
         .equatable()
         .id(group.anchorWorkspaceId)
         .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
-        .preference(key: SidebarWorkspaceRowIdsPreferenceKey.self, value: Set([group.anchorWorkspaceId]))
 
         header
             .sidebarWorkspaceFrameAnchor(

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -206,6 +206,51 @@ final class SidebarSelectedWorkspaceScrollPolicyTests: XCTestCase {
             )
         )
     }
+
+    func testScrollTargetIsSelfWithoutGroup() {
+        let workspaceId = UUID()
+        XCTAssertEqual(
+            SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
+                selectedWorkspaceId: workspaceId,
+                group: nil
+            ),
+            workspaceId
+        )
+    }
+
+    func testScrollTargetIsSelfInExpandedGroup() {
+        let workspaceId = UUID()
+        XCTAssertEqual(
+            SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
+                selectedWorkspaceId: workspaceId,
+                group: makeGroup(isCollapsed: false, anchorWorkspaceId: UUID())
+            ),
+            workspaceId
+        )
+    }
+
+    func testScrollTargetIsGroupAnchorWhenGroupIsCollapsed() {
+        let anchorId = UUID()
+        XCTAssertEqual(
+            SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
+                selectedWorkspaceId: UUID(),
+                group: makeGroup(isCollapsed: true, anchorWorkspaceId: anchorId)
+            ),
+            anchorId
+        )
+    }
+
+    private func makeGroup(isCollapsed: Bool, anchorWorkspaceId: UUID) -> WorkspaceGroup {
+        WorkspaceGroup(
+            id: UUID(),
+            name: "group",
+            isCollapsed: isCollapsed,
+            isPinned: false,
+            anchorWorkspaceId: anchorWorkspaceId,
+            customColor: nil,
+            iconSymbol: nil
+        )
+    }
 }
 
 final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {


### PR DESCRIPTION
## Summary
- Removes `SidebarWorkspaceRowIdsPreferenceKey` entirely: the per-row/per-group-header `.preference` emitters, the sidebar-wide `.onPreferenceChange` aggregation, and the `laidOutWorkspaceRowIds` `@State`.
- Selected-workspace scroll-into-view now calls `ScrollViewProxy.scrollTo` unconditionally for pending requests. `scrollTo` resolves `.id()` values in lazy containers without the target row being realized, and unknown ids are a harmless no-op, so the "wait until the row is laid out" gate was unnecessary.

## Why

This is the surviving cmux-owned edge in the https://github.com/manaflow-ai/cmux/issues/2586 sidebar layout livelock. Fresh evidence from today (0.64.14-nightly, macOS 26.5, 36 workspaces, no groups — well below the 100-workspace scale discussed earlier): scrolling the sidebar pegged the main thread at 100% inside a single `GraphHost.flushTransactions()` that never returned to the run loop. Two `sample` captures minutes apart show the identical signature:

- ~99% of main-thread samples inside one `NSHostingView.beginTransaction` run-loop observer callback, looping `runTransaction` → `LazySubviewPlacements.placeSubviews` over the sidebar `ForEach`.
- `SidebarWorkspaceRowIdsPreferenceKey.reduce` → `Set.formUnion` in the hot loop (the #5325-gated `SidebarWorkspaceRowFramePreferenceKey` is absent, consistent with vlechemin's 0.64.13 table).
- The refill side of the loop is visible too: `LazyLayoutCacheItem.AllItemsPhaseMutation` → `LazyLayoutViewCache.updateItemPhases` → `propagate_dirty`, plus `LazyLayoutViewCache.signalPrefetch` → `NSHostingView.requestUpdate` queuing the next transaction.
- Because the observer callback never returns, the autorelease pool never drains: RSS grew ~10&nbsp;MB/s to 6.1&nbsp;GB before the process was killed (heap: 4.3M `NSCompositeAppearance`, 8.6M `NSMutableDictionary`).

Mechanism: the preference value is the set of currently-realized lazy rows, which changes on essentially every layout pass while scrolling. Each change re-runs the N-row `reduce` and fires `onPreferenceChange`, which writes `@State` from inside the update cycle, scheduling another transaction inside the same `flushTransactions` loop. Once lazy phase churn keeps the realized-row set oscillating, the cycle stops converging and the main thread never escapes.

This is the same class-elimination #5325 applied to the sibling drop-target anchor preference: delete the steady-state per-row preference traffic instead of patching timing. With this PR the workspace sidebar publishes no per-row preferences at rest at all.

## How this is principled vs hacky

Principled: it deletes the feedback mechanism rather than debouncing or gating it, and the replacement (`scrollTo` on lazy-container ids) is the API's intended use. Residual risk: if some macOS build fails to resolve an unrealized row id, scroll-into-view for far-off-screen rows would silently no-op — `cmuxUITests/WorkspaceSidebarScrollUITests` (Cmd+1 from the bottom of a 20-workspace overflow list) covers exactly that path on CI.

## Testing
- `WorkspaceSidebarScrollUITests` via `test-e2e.yml` (covers selected-row scroll-into-view incl. off-screen Cmd+1 and Move-to-Top): run pending below.
- A deterministic automated repro of the livelock itself is not practical — the non-convergence is timing/AttributeGraph-state dependent and has resisted deterministic repro across every report in the issue thread. The meaningful verification is the existing scroll behavior suite plus dogfood under the reporter conditions (select tab + scroll).
- Tagged build `rowids` for dogfood.

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/2586 (do not auto-close; secondary CLI `dispatch_sync` deadlock and any non-cmux-owned residual churn remain tracked there)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783620912&installation_id=133855650&pr_number=5708&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5708&signature=8cdc1d091e9b83d14850e4535d96ee12e13fa5caa5d700381adb2ec0f601ac56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lazy-sidebar scroll behavior (no longer gated on realized rows); collapsed-group targeting is new but model-driven, with UI tests covering off-screen scroll paths.
> 
> **Overview**
> Removes the sidebar **layout feedback loop** that caused main-thread livelock (#2586) by deleting `SidebarWorkspaceRowIdsPreferenceKey`, per-row/group `.preference` emitters, the sidebar `.onPreferenceChange` handler, and `@State laidOutWorkspaceRowIds`.
> 
> **Selected-workspace scroll-into-view** no longer waits for lazy rows to report as laid out. `flushPendingSelectedWorkspaceScroll` always calls `ScrollViewProxy.scrollTo` on an id resolved from model data via `SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId` (selected workspace, or the **group header anchor** when the group is collapsed and the member row has no `.id`). Scroll helpers now take `WorkspaceListRenderContext` instead of raw id lists or preference-derived row sets.
> 
> Unit tests cover the new scroll-target mapping for ungrouped, expanded-group, and collapsed-group cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bab011ac60e4b71d6d48abec1e0ac93cdd8872c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the sidebar row-id preference aggregation and scroll gate to break the #2586 layout livelock. Scrolling now always targets the selected workspace (or its group header when collapsed) via `ScrollViewProxy.scrollTo`.

- **Bug Fixes**
  - Removed the row-id preference pipeline and state: `SidebarWorkspaceRowIdsPreferenceKey`, per-row/group `.preference`s, sidebar `.onPreferenceChange`, and `laidOutWorkspaceRowIds`.
  - Selected-workspace scroll now unconditionally calls `scrollTo` with a policy-resolved id; lazy id resolution handles unrealized rows and unknown ids as a no-op. Collapsed-group selections map to the group header via `SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId`; tests cover no-group/expanded/collapsed cases.
  - Imported `Foundation` in `SidebarState` for `UUID`.

<sup>Written for commit 5bab011ac60e4b71d6d48abec1e0ac93cdd8872c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved workspace sidebar scrolling: selection now scrolls immediately and more reliably, with more consistent handling when navigating into collapsed groups so the correct header is brought into view.
* **Tests**
  * Added unit tests covering scroll behavior for open/closed group scenarios to ensure consistent navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->