### PR TITLE
Per-workspace pictures (iMessage-style avatars) with iOS sync

### DIFF
--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -18,6 +18,10 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         /// Whether this workspace is pinned, if the Mac reported it. `nil` when
         /// connected to a Mac old enough not to emit `is_pinned`.
         public let isPinned: Bool?
+        /// Content hash of the workspace picture (iMessage-style avatar), or `nil`
+        /// when the workspace has no picture or the Mac is old enough not to emit
+        /// `picture_hash`. The bytes are fetched on demand keyed by this hash.
+        public let pictureHash: String?
         /// Terminals belonging to this workspace.
         public let terminals: [Terminal]
 
@@ -27,6 +31,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             case currentDirectory = "current_directory"
             case isSelected = "is_selected"
             case isPinned = "is_pinned"
+            case pictureHash = "picture_hash"
             case terminals
         }
     }

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePictureResponse.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePictureResponse.swift
@@ -1,0 +1,36 @@
+public import Foundation
+
+/// Typed decoder for the `mobile.workspace.picture.get` RPC result.
+///
+/// The Mac returns the workspace id, the hash that was requested, and the avatar
+/// PNG as base64 (or null when the workspace has no picture or the hash no longer
+/// matches). The phone caches the decoded bytes by hash so an unchanged avatar is
+/// never refetched.
+public struct MobileWorkspacePictureResponse: Decodable, Sendable {
+    /// The workspace the picture belongs to.
+    public let workspaceID: String
+    /// The hash that was requested (echoed back).
+    public let hash: String
+    /// The avatar PNG as base64, or `nil` when there is no matching picture.
+    public let imageBase64: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case workspaceID = "workspace_id"
+        case hash
+        case imageBase64 = "image_base64"
+    }
+
+    /// Decode a picture response from raw JSON data.
+    /// - Parameter data: The RPC result payload.
+    /// - Returns: The decoded response.
+    /// - Throws: A decoding error if the payload is malformed.
+    public static func decode(_ data: Data) throws -> MobileWorkspacePictureResponse {
+        try JSONDecoder().decode(Self.self, from: data)
+    }
+
+    /// The decoded avatar bytes, or `nil` when absent/invalid.
+    public var imageData: Data? {
+        guard let imageBase64, !imageBase64.isEmpty else { return nil }
+        return Data(base64Encoded: imageBase64)
+    }
+}

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -8,6 +8,7 @@ extension MobileWorkspacePreview {
             id: ID(rawValue: remote.id),
             name: remote.title,
             isPinned: remote.isPinned ?? false,
+            pictureHash: remote.pictureHash,
             terminals: remote.terminals.map { terminal in
                 MobileTerminalPreview(remote: terminal)
             }

--- a/Packages/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileWorkspacePictureDecodeTests.swift
+++ b/Packages/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileWorkspacePictureDecodeTests.swift
@@ -1,0 +1,71 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+
+@testable import CmuxMobileRPC
+
+/// Decode tests for the workspace-picture (iMessage-style avatar) wire shapes:
+/// the `picture_hash` field on the workspace-list payload and the
+/// `mobile.workspace.picture.get` fetch-by-hash response.
+@Suite struct MobileWorkspacePictureDecodeTests {
+    @Test func workspaceListDecodesPictureHash() throws {
+        let json = #"""
+        {"workspaces":[{"id":"ws-1","title":"Build","current_directory":null,"is_selected":true,"is_pinned":false,"picture_hash":"a1b2c3d4e5f60718","terminals":[]}]}
+        """#
+        let response = try MobileSyncWorkspaceListResponse.decode(Data(json.utf8))
+        let workspace = try #require(response.workspaces.first)
+        #expect(workspace.pictureHash == "a1b2c3d4e5f60718")
+    }
+
+    @Test func workspaceListToleratesMissingAndNullPictureHash() throws {
+        let json = #"""
+        {"workspaces":[
+            {"id":"ws-1","title":"NoField","is_selected":false,"terminals":[]},
+            {"id":"ws-2","title":"NullField","is_selected":false,"picture_hash":null,"terminals":[]}
+        ]}
+        """#
+        let response = try MobileSyncWorkspaceListResponse.decode(Data(json.utf8))
+        #expect(response.workspaces.count == 2)
+        #expect(response.workspaces[0].pictureHash == nil)
+        #expect(response.workspaces[1].pictureHash == nil)
+    }
+
+    @Test func remoteMappingCarriesPictureHashIntoPreview() throws {
+        let json = #"""
+        {"workspaces":[{"id":"ws-1","title":"Build","is_selected":false,"picture_hash":"deadbeef00112233","terminals":[]}]}
+        """#
+        let response = try MobileSyncWorkspaceListResponse.decode(Data(json.utf8))
+        let remote = try #require(response.workspaces.first)
+        let preview = MobileWorkspacePreview(remote: remote)
+        #expect(preview.pictureHash == "deadbeef00112233")
+        #expect(preview.pictureData == nil)
+    }
+
+    @Test func pictureResponseDecodesImageBytes() throws {
+        let pngBytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        let json = """
+        {"workspace_id":"ws-1","hash":"a1b2c3d4e5f60718","image_base64":"\(pngBytes.base64EncodedString())"}
+        """
+        let response = try MobileWorkspacePictureResponse.decode(Data(json.utf8))
+        #expect(response.workspaceID == "ws-1")
+        #expect(response.hash == "a1b2c3d4e5f60718")
+        #expect(response.imageData == pngBytes)
+    }
+
+    @Test func pictureResponseTreatsNullImageAsAbsent() throws {
+        let json = #"{"workspace_id":"ws-1","hash":"a1b2c3d4e5f60718","image_base64":null}"#
+        let response = try MobileWorkspacePictureResponse.decode(Data(json.utf8))
+        #expect(response.imageData == nil)
+    }
+
+    @Test func pictureResponseTreatsEmptyAndInvalidBase64AsAbsent() throws {
+        let empty = try MobileWorkspacePictureResponse.decode(
+            Data(#"{"workspace_id":"ws-1","hash":"h","image_base64":""}"#.utf8)
+        )
+        #expect(empty.imageData == nil)
+        let invalid = try MobileWorkspacePictureResponse.decode(
+            Data(#"{"workspace_id":"ws-1","hash":"h","image_base64":"%%%not-base64%%%"}"#.utf8)
+        )
+        #expect(invalid.imageData == nil)
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspacePictures.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspacePictures.swift
@@ -1,0 +1,126 @@
+import CmuxMobileRPC
+import Foundation
+internal import OSLog
+
+private let mobileShellLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "mobile-shell"
+)
+
+/// Workspace-picture (iMessage-style avatar) fetch and cache for the mobile
+/// shell. The workspace-list payload carries only a content hash per workspace;
+/// the bytes are fetched once per hash via `mobile.workspace.picture.get` and
+/// cached (stored state lives in `MobileShellComposite.swift`), so an unchanged
+/// avatar is never re-sent and the per-frame stream stays untouched.
+extension MobileShellComposite {
+    /// Hard cap on accepted avatar bytes, mirroring the Mac store's stored-PNG
+    /// cap. Enforced client-side so a buggy or hostile host can't grow the
+    /// cache with oversized payloads.
+    nonisolated static var maxWorkspacePictureBytes: Int { 512 * 1024 }
+
+    /// Kick off fetches for any workspace picture whose hash is not yet cached.
+    /// Idempotent and de-duplicated: each hash fetches at most once. The bytes are
+    /// fetched on demand (not in the list payload) so `workspace.updated` stays
+    /// small and an unchanged avatar is never re-sent.
+    func fetchMissingWorkspacePictures() {
+        guard let client = remoteClient else { return }
+        var pending: [(workspaceID: String, hash: String)] = []
+        var seenHashes: Set<String> = []
+        for workspace in workspaces {
+            guard let hash = workspace.pictureHash,
+                  workspacePictureBytesByHash[hash] == nil,
+                  !workspacePictureFetchInFlight.contains(hash),
+                  seenHashes.insert(hash).inserted else {
+                continue
+            }
+            pending.append((workspace.id.rawValue, hash))
+        }
+        guard !pending.isEmpty else { return }
+        for entry in pending {
+            workspacePictureFetchInFlight.insert(entry.hash)
+        }
+        Task { @MainActor [weak self] in
+            for entry in pending {
+                await self?.fetchWorkspacePicture(
+                    client: client,
+                    workspaceID: entry.workspaceID,
+                    hash: entry.hash
+                )
+            }
+        }
+    }
+
+    private func fetchWorkspacePicture(
+        client: MobileCoreRPCClient,
+        workspaceID: String,
+        hash: String
+    ) async {
+        defer { workspacePictureFetchInFlight.remove(hash) }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "mobile.workspace.picture.get",
+                params: [
+                    "workspace_id": workspaceID,
+                    "hash": hash,
+                    "client_id": clientID,
+                ]
+            )
+            let data = try await client.sendRequest(request)
+            guard self.remoteClient === client else { return }
+            let response = try MobileWorkspacePictureResponse.decode(data)
+            guard response.hash == hash, let imageData = response.imageData else { return }
+            // Enforce the avatar size contract client-side; treat an oversized
+            // response as absent rather than caching attacker-sized blobs.
+            guard imageData.count <= Self.maxWorkspacePictureBytes else {
+                mobileShellLog.error("workspace picture oversized hash=\(hash, privacy: .public) bytes=\(imageData.count, privacy: .public)")
+                return
+            }
+            cacheWorkspacePicture(imageData, forHash: hash)
+            applyCachedWorkspacePictures()
+        } catch {
+            mobileShellLog.info("workspace picture fetch failed hash=\(hash, privacy: .public) error=\(String(describing: error), privacy: .private)")
+        }
+    }
+
+    private func cacheWorkspacePicture(_ data: Data, forHash hash: String) {
+        if workspacePictureBytesByHash[hash] == nil {
+            workspacePictureHashLRU.append(hash)
+        }
+        workspacePictureBytesByHash[hash] = data
+        guard workspacePictureHashLRU.count > Self.maxCachedWorkspacePictures else { return }
+        // Single bounded pass, oldest first: evict unreferenced hashes until the
+        // cache fits. A hash still referenced by a live workspace is never
+        // evicted, so when every cached avatar is live the cache simply stays
+        // over budget for this round (bounded by the live workspace count).
+        let liveHashes = Set(workspaces.compactMap(\.pictureHash))
+        var overflow = workspacePictureHashLRU.count - Self.maxCachedWorkspacePictures
+        var retained: [String] = []
+        retained.reserveCapacity(workspacePictureHashLRU.count)
+        for candidate in workspacePictureHashLRU {
+            if overflow > 0, !liveHashes.contains(candidate) {
+                workspacePictureBytesByHash.removeValue(forKey: candidate)
+                overflow -= 1
+            } else {
+                retained.append(candidate)
+            }
+        }
+        workspacePictureHashLRU = retained
+    }
+
+    /// Re-stamp `pictureData` on each workspace from the cache (after a fetch
+    /// resolved new bytes), publishing the change so rows pick up the avatar.
+    private func applyCachedWorkspacePictures() {
+        var didChange = false
+        let updated = workspaces.map { workspace -> MobileWorkspacePreview in
+            let resolved = workspace.pictureHash.flatMap { workspacePictureBytesByHash[$0] }
+            guard workspace.pictureData != resolved else { return workspace }
+            var copy = workspace
+            copy.pictureData = resolved
+            didChange = true
+            return copy
+        }
+        if didChange {
+            workspaces = updated
+        }
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3074,15 +3074,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             workspacePictureHashLRU.append(hash)
         }
         workspacePictureBytesByHash[hash] = data
-        while workspacePictureHashLRU.count > Self.maxCachedWorkspacePictures {
-            let evicted = workspacePictureHashLRU.removeFirst()
-            // Never evict a hash still referenced by a live workspace.
-            if workspaces.contains(where: { $0.pictureHash == evicted }) {
-                workspacePictureHashLRU.append(evicted)
-                continue
+        guard workspacePictureHashLRU.count > Self.maxCachedWorkspacePictures else { return }
+        // Single bounded pass, oldest first: evict unreferenced hashes until the
+        // cache fits. A hash still referenced by a live workspace is never
+        // evicted, so when every cached avatar is live the cache simply stays
+        // over budget for this round (bounded by the live workspace count).
+        let liveHashes = Set(workspaces.compactMap(\.pictureHash))
+        var overflow = workspacePictureHashLRU.count - Self.maxCachedWorkspacePictures
+        var retained: [String] = []
+        retained.reserveCapacity(workspacePictureHashLRU.count)
+        for candidate in workspacePictureHashLRU {
+            if overflow > 0, !liveHashes.contains(candidate) {
+                workspacePictureBytesByHash.removeValue(forKey: candidate)
+                overflow -= 1
+            } else {
+                retained.append(candidate)
             }
-            workspacePictureBytesByHash.removeValue(forKey: evicted)
         }
+        workspacePictureHashLRU = retained
     }
 
     /// Re-stamp `pictureData` on each workspace from the cache (after a fetch

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -208,7 +208,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private let identityProvider: (any MobileIdentityProviding)?
     private let reachability: any ReachabilityProviding
     private let pairingHintDefaults: UserDefaults
-    private let clientID: String
+    /// Internal (not private) so the workspace-pictures extension file can
+    /// build RPC params with it.
+    let clientID: String
     /// The injected, fire-and-forget product-analytics emitter. Defaults to
     /// ``NoopAnalytics`` so previews/tests inject nothing.
     private let analytics: any AnalyticsEmitting
@@ -241,7 +243,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// `public` so the DEV feedback-submit affordance can ``DiagnosticLog/export()``
     /// it.
     public let diagnosticLog: DiagnosticLog?
-    private var remoteClient: MobileCoreRPCClient? {
+    /// Internal (not private) so the workspace-pictures extension file can
+    /// guard fetch results against reconnects.
+    var remoteClient: MobileCoreRPCClient? {
         didSet {
             if remoteClient == nil {
                 stopTerminalRefreshPolling()
@@ -273,12 +277,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Mac changes the hash whenever the picture changes, so a stale avatar is
     /// never served. Bounded by `maxCachedWorkspacePictures` so a long-lived
     /// session with many edited avatars can't grow it without limit.
-    private var workspacePictureBytesByHash: [String: Data] = [:]
+    var workspacePictureBytesByHash: [String: Data] = [:]
     /// LRU order of cached picture hashes (oldest first) for bounded eviction.
-    private var workspacePictureHashLRU: [String] = []
+    var workspacePictureHashLRU: [String] = []
     /// Hashes with an in-flight fetch, so overlapping list refreshes don't kick
     /// off duplicate picture requests for the same avatar.
-    private var workspacePictureFetchInFlight: Set<String> = []
+    var workspacePictureFetchInFlight: Set<String> = []
     nonisolated static let maxCachedWorkspacePictures = 128
     private var createWorkspaceTaskID: UUID?
     private var createTerminalTaskID: UUID?
@@ -3008,106 +3012,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return terminal
             }
             return workspace
-        }
-    }
-
-    /// Kick off fetches for any workspace picture whose hash is not yet cached.
-    /// Idempotent and de-duplicated: each hash fetches at most once. The bytes are
-    /// fetched on demand (not in the list payload) so `workspace.updated` stays
-    /// small and an unchanged avatar is never re-sent.
-    private func fetchMissingWorkspacePictures() {
-        guard let client = remoteClient else { return }
-        var pending: [(workspaceID: String, hash: String)] = []
-        var seenHashes: Set<String> = []
-        for workspace in workspaces {
-            guard let hash = workspace.pictureHash,
-                  workspacePictureBytesByHash[hash] == nil,
-                  !workspacePictureFetchInFlight.contains(hash),
-                  seenHashes.insert(hash).inserted else {
-                continue
-            }
-            pending.append((workspace.id.rawValue, hash))
-        }
-        guard !pending.isEmpty else { return }
-        for entry in pending {
-            workspacePictureFetchInFlight.insert(entry.hash)
-        }
-        Task { @MainActor [weak self] in
-            for entry in pending {
-                await self?.fetchWorkspacePicture(
-                    client: client,
-                    workspaceID: entry.workspaceID,
-                    hash: entry.hash
-                )
-            }
-        }
-    }
-
-    private func fetchWorkspacePicture(
-        client: MobileCoreRPCClient,
-        workspaceID: String,
-        hash: String
-    ) async {
-        defer { workspacePictureFetchInFlight.remove(hash) }
-        do {
-            let request = try MobileCoreRPCClient.requestData(
-                method: "mobile.workspace.picture.get",
-                params: [
-                    "workspace_id": workspaceID,
-                    "hash": hash,
-                    "client_id": clientID,
-                ]
-            )
-            let data = try await client.sendRequest(request)
-            guard self.remoteClient === client else { return }
-            let response = try MobileWorkspacePictureResponse.decode(data)
-            guard response.hash == hash, let imageData = response.imageData else { return }
-            cacheWorkspacePicture(imageData, forHash: hash)
-            applyCachedWorkspacePictures()
-        } catch {
-            mobileShellLog.info("workspace picture fetch failed hash=\(hash, privacy: .public) error=\(String(describing: error), privacy: .private)")
-        }
-    }
-
-    private func cacheWorkspacePicture(_ data: Data, forHash hash: String) {
-        if workspacePictureBytesByHash[hash] == nil {
-            workspacePictureHashLRU.append(hash)
-        }
-        workspacePictureBytesByHash[hash] = data
-        guard workspacePictureHashLRU.count > Self.maxCachedWorkspacePictures else { return }
-        // Single bounded pass, oldest first: evict unreferenced hashes until the
-        // cache fits. A hash still referenced by a live workspace is never
-        // evicted, so when every cached avatar is live the cache simply stays
-        // over budget for this round (bounded by the live workspace count).
-        let liveHashes = Set(workspaces.compactMap(\.pictureHash))
-        var overflow = workspacePictureHashLRU.count - Self.maxCachedWorkspacePictures
-        var retained: [String] = []
-        retained.reserveCapacity(workspacePictureHashLRU.count)
-        for candidate in workspacePictureHashLRU {
-            if overflow > 0, !liveHashes.contains(candidate) {
-                workspacePictureBytesByHash.removeValue(forKey: candidate)
-                overflow -= 1
-            } else {
-                retained.append(candidate)
-            }
-        }
-        workspacePictureHashLRU = retained
-    }
-
-    /// Re-stamp `pictureData` on each workspace from the cache (after a fetch
-    /// resolved new bytes), publishing the change so rows pick up the avatar.
-    private func applyCachedWorkspacePictures() {
-        var didChange = false
-        let updated = workspaces.map { workspace -> MobileWorkspacePreview in
-            let resolved = workspace.pictureHash.flatMap { workspacePictureBytesByHash[$0] }
-            guard workspace.pictureData != resolved else { return workspace }
-            var copy = workspace
-            copy.pictureData = resolved
-            didChange = true
-            return copy
-        }
-        if didChange {
-            workspaces = updated
         }
     }
 

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -268,6 +268,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var createWorkspaceTask: Task<Void, Never>?
     private var createTerminalTask: Task<Void, Never>?
     private var workspaceListRefreshTask: Task<Void, Never>?
+    /// Cache of fetched workspace-picture (avatar) bytes keyed by content hash.
+    /// A picture is fetched once per hash and reused across list refreshes; the
+    /// Mac changes the hash whenever the picture changes, so a stale avatar is
+    /// never served. Bounded by `maxCachedWorkspacePictures` so a long-lived
+    /// session with many edited avatars can't grow it without limit.
+    private var workspacePictureBytesByHash: [String: Data] = [:]
+    /// LRU order of cached picture hashes (oldest first) for bounded eviction.
+    private var workspacePictureHashLRU: [String] = []
+    /// Hashes with an in-flight fetch, so overlapping list refreshes don't kick
+    /// off duplicate picture requests for the same avatar.
+    private var workspacePictureFetchInFlight: Set<String> = []
+    nonisolated static let maxCachedWorkspacePictures = 128
     private var createWorkspaceTaskID: UUID?
     private var createTerminalTaskID: UUID?
     private var connectionGeneration: UUID
@@ -2956,6 +2968,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } else {
             workspaces = remoteWorkspaces
         }
+        // Resolve any avatars whose hash isn't cached yet (independent of which
+        // selection branch returns below).
+        fetchMissingWorkspacePictures()
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return
         }
@@ -2977,6 +2992,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) -> [MobileWorkspacePreview] {
         response.workspaces.map { remoteWorkspace in
             var workspace = MobileWorkspacePreview(remote: remoteWorkspace)
+            // Stamp cached avatar bytes for the reported hash (if any) so the row
+            // renders the picture without holding the store. A new/unknown hash
+            // leaves `pictureData` nil until the fetch below resolves it.
+            workspace.pictureData = workspace.pictureHash.flatMap { workspacePictureBytesByHash[$0] }
             guard let existingWorkspace = workspaces.first(where: { $0.id == workspace.id }) else {
                 return workspace
             }
@@ -2989,6 +3008,97 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return terminal
             }
             return workspace
+        }
+    }
+
+    /// Kick off fetches for any workspace picture whose hash is not yet cached.
+    /// Idempotent and de-duplicated: each hash fetches at most once. The bytes are
+    /// fetched on demand (not in the list payload) so `workspace.updated` stays
+    /// small and an unchanged avatar is never re-sent.
+    private func fetchMissingWorkspacePictures() {
+        guard let client = remoteClient else { return }
+        var pending: [(workspaceID: String, hash: String)] = []
+        var seenHashes: Set<String> = []
+        for workspace in workspaces {
+            guard let hash = workspace.pictureHash,
+                  workspacePictureBytesByHash[hash] == nil,
+                  !workspacePictureFetchInFlight.contains(hash),
+                  seenHashes.insert(hash).inserted else {
+                continue
+            }
+            pending.append((workspace.id.rawValue, hash))
+        }
+        guard !pending.isEmpty else { return }
+        for entry in pending {
+            workspacePictureFetchInFlight.insert(entry.hash)
+        }
+        Task { @MainActor [weak self] in
+            for entry in pending {
+                await self?.fetchWorkspacePicture(
+                    client: client,
+                    workspaceID: entry.workspaceID,
+                    hash: entry.hash
+                )
+            }
+        }
+    }
+
+    private func fetchWorkspacePicture(
+        client: MobileCoreRPCClient,
+        workspaceID: String,
+        hash: String
+    ) async {
+        defer { workspacePictureFetchInFlight.remove(hash) }
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "mobile.workspace.picture.get",
+                params: [
+                    "workspace_id": workspaceID,
+                    "hash": hash,
+                    "client_id": clientID,
+                ]
+            )
+            let data = try await client.sendRequest(request)
+            guard self.remoteClient === client else { return }
+            let response = try MobileWorkspacePictureResponse.decode(data)
+            guard response.hash == hash, let imageData = response.imageData else { return }
+            cacheWorkspacePicture(imageData, forHash: hash)
+            applyCachedWorkspacePictures()
+        } catch {
+            mobileShellLog.info("workspace picture fetch failed hash=\(hash, privacy: .public) error=\(String(describing: error), privacy: .private)")
+        }
+    }
+
+    private func cacheWorkspacePicture(_ data: Data, forHash hash: String) {
+        if workspacePictureBytesByHash[hash] == nil {
+            workspacePictureHashLRU.append(hash)
+        }
+        workspacePictureBytesByHash[hash] = data
+        while workspacePictureHashLRU.count > Self.maxCachedWorkspacePictures {
+            let evicted = workspacePictureHashLRU.removeFirst()
+            // Never evict a hash still referenced by a live workspace.
+            if workspaces.contains(where: { $0.pictureHash == evicted }) {
+                workspacePictureHashLRU.append(evicted)
+                continue
+            }
+            workspacePictureBytesByHash.removeValue(forKey: evicted)
+        }
+    }
+
+    /// Re-stamp `pictureData` on each workspace from the cache (after a fetch
+    /// resolved new bytes), publishing the change so rows pick up the avatar.
+    private func applyCachedWorkspacePictures() {
+        var didChange = false
+        let updated = workspaces.map { workspace -> MobileWorkspacePreview in
+            let resolved = workspace.pictureHash.flatMap { workspacePictureBytesByHash[$0] }
+            guard workspace.pictureData != resolved else { return workspace }
+            var copy = workspace
+            copy.pictureData = resolved
+            didChange = true
+            return copy
+        }
+        if didChange {
+            workspaces = updated
         }
     }
 

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 /// A lightweight, `Sendable` snapshot of a remote workspace shown in the mobile shell.
 ///
@@ -32,6 +32,16 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// Whether the workspace is pinned on the Mac. Pinned workspaces sort to the
     /// top of the mobile list.
     public var isPinned: Bool
+    /// Content hash of the workspace picture (iMessage-style avatar) reported by
+    /// the Mac, or `nil` when the workspace has no picture. The avatar bytes are
+    /// fetched on demand keyed by this hash and stamped into ``pictureData``; the
+    /// hash itself is what drives a refetch when the picture changes.
+    public var pictureHash: String?
+    /// Resolved avatar image bytes (a small PNG) once fetched and cached by hash,
+    /// or `nil` until fetched (or when the workspace has no picture). Carried in
+    /// the value snapshot so list rows can render the avatar without holding the
+    /// shell store (snapshot-boundary rule).
+    public var pictureData: Data?
     /// The terminals contained in the workspace, in display order.
     public var terminals: [MobileTerminalPreview]
 
@@ -40,11 +50,22 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     ///   - id: The workspace's stable identifier.
     ///   - name: The workspace's user-facing display name.
     ///   - isPinned: Whether the workspace is pinned on the Mac. Defaults to `false`.
+    ///   - pictureHash: Content hash of the workspace picture, or `nil` for none.
+    ///   - pictureData: Resolved avatar bytes once fetched, or `nil`.
     ///   - terminals: The terminals contained in the workspace, in display order.
-    public init(id: ID, name: String, isPinned: Bool = false, terminals: [MobileTerminalPreview]) {
+    public init(
+        id: ID,
+        name: String,
+        isPinned: Bool = false,
+        pictureHash: String? = nil,
+        pictureData: Data? = nil,
+        terminals: [MobileTerminalPreview]
+    ) {
         self.id = id
         self.name = name
         self.isPinned = isPinned
+        self.pictureHash = pictureHash
+        self.pictureData = pictureData
         self.terminals = terminals
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -1,6 +1,11 @@
 import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
+#if os(iOS)
+@preconcurrency import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 struct WorkspaceRow: View {
     let workspace: MobileWorkspacePreview
@@ -71,14 +76,37 @@ struct WorkspaceAvatar: View {
 
     var body: some View {
         ZStack {
-            Circle()
-                .fill(workspace.avatarGradient)
-                .frame(width: 48, height: 48)
+            if let pictureImage {
+                pictureImage
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill(workspace.avatarGradient)
+                    .frame(width: 48, height: 48)
 
-            Image(systemName: workspace.avatarSymbolName)
-                .font(.headline)
-                .foregroundStyle(.white)
-                .accessibilityHidden(true)
+                Image(systemName: workspace.avatarSymbolName)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .accessibilityHidden(true)
+            }
         }
+    }
+
+    /// Resolved avatar image when the workspace has a fetched picture, else nil
+    /// so the gradient + symbol fallback renders.
+    private var pictureImage: Image? {
+        guard let data = workspace.pictureData else { return nil }
+        #if os(iOS)
+        guard let uiImage = UIImage(data: data) else { return nil }
+        return Image(uiImage: uiImage)
+        #elseif os(macOS)
+        guard let nsImage = NSImage(data: data) else { return nil }
+        return Image(nsImage: nsImage)
+        #else
+        return nil
+        #endif
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15062,6 +15062,10 @@ struct SidebarWorkspaceSnapshotBuilder {
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
+        /// Content hash of the workspace picture, or nil for none. Carried as a
+        /// value in the row snapshot so the leading avatar re-renders when the
+        /// picture changes without the row holding the picture store.
+        let pictureHash: String?
         let remoteWorkspaceSidebarText: String?
         let remoteConnectionStatusText: String
         let remoteStateHelpText: String
@@ -15500,6 +15504,14 @@ struct TabItemView: View, Equatable {
                         .font(.system(size: scaledFontSize(9), weight: .semibold))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(protectedWorkspaceTooltip)
+                }
+
+                if let pictureHash = workspaceSnapshot.pictureHash {
+                    SidebarWorkspaceAvatarView(
+                        workspaceId: tab.id,
+                        pictureHash: pictureHash,
+                        size: max(16, 18 * fontScale)
+                    )
                 }
 
                 Text(workspaceSnapshot.title)
@@ -16113,6 +16125,43 @@ struct TabItemView: View, Equatable {
             }
         }
 
+        if !isMulti {
+            Menu(String(localized: "contextMenu.workspacePicture", defaultValue: "Workspace Picture")) {
+                Button {
+                    chooseWorkspacePictureFromFile()
+                } label: {
+                    Label(
+                        tab.pictureHash == nil
+                            ? String(localized: "contextMenu.setWorkspacePicture", defaultValue: "Choose Picture…")
+                            : String(localized: "contextMenu.changeWorkspacePicture", defaultValue: "Change Picture…"),
+                        systemImage: "photo"
+                    )
+                }
+
+                if WorkspacePicturePasteboardSupport.hasImage {
+                    Button {
+                        pasteWorkspacePicture()
+                    } label: {
+                        Label(
+                            String(localized: "contextMenu.pasteWorkspacePicture", defaultValue: "Paste Picture"),
+                            systemImage: "doc.on.clipboard"
+                        )
+                    }
+                }
+
+                if tab.pictureHash != nil {
+                    Button {
+                        tabManager.removeWorkspacePicture(tabId: tab.id)
+                    } label: {
+                        Label(
+                            String(localized: "contextMenu.removeWorkspacePicture", defaultValue: "Remove Picture"),
+                            systemImage: "xmark.circle"
+                        )
+                    }
+                }
+            }
+        }
+
         if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
             Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
                 WorkspaceSurfaceIdentifierClipboardText.copy(copyableSidebarSSHError)
@@ -16524,6 +16573,7 @@ struct TabItemView: View, Equatable {
             customDescription: settings.showsWorkspaceDescription ? sidebarVisibleCustomDescription : nil,
             isPinned: tab.isPinned,
             customColorHex: tab.customColor,
+            pictureHash: tab.pictureHash,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
@@ -16939,6 +16989,45 @@ struct TabItemView: View, Equatable {
         applyTabColor(normalized, targetIds: targetIds)
     }
 
+    /// Shared set/change path: pick an image file via NSOpenPanel, then route it
+    /// through the single `TabManager.setWorkspacePicture` mutation. The store
+    /// downscales and persists; the published hash change updates the sidebar
+    /// avatar and pushes to any paired phone.
+    private func chooseWorkspacePictureFromFile() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.prompt = String(localized: "panel.workspacePicture.choose", defaultValue: "Choose")
+        panel.message = String(
+            localized: "panel.workspacePicture.message",
+            defaultValue: "Choose an image to use as this workspace's picture."
+        )
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let image = NSImage(contentsOf: url) else {
+            return
+        }
+        applyWorkspacePicture(image)
+    }
+
+    /// Shared paste path: read an image off the general pasteboard and apply it
+    /// through the same mutation as the file pick.
+    private func pasteWorkspacePicture() {
+        guard let image = WorkspacePicturePasteboardSupport.imageFromPasteboard() else {
+            NSSound.beep()
+            return
+        }
+        applyWorkspacePicture(image)
+    }
+
+    private func applyWorkspacePicture(_ image: NSImage) {
+        if !tabManager.setWorkspacePicture(tabId: tab.id, image: image) {
+            NSSound.beep()
+        }
+    }
+
     private func showInvalidColorAlert(_ value: String) {
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -16980,6 +17069,48 @@ struct TabItemView: View, Equatable {
         tabManager.selectTab(tab)
         setSelectionToTabs()
         _ = AppDelegate.shared?.requestEditWorkspaceDescriptionViaCommandPalette()
+    }
+}
+
+/// Small leading avatar for a workspace that has a picture set. Loads the image
+/// from `WorkspacePictureStore` keyed by the immutable `(workspaceId,
+/// pictureHash)` value passed in, so the row holds no store reference (snapshot-
+/// boundary rule) and the cached `NSImage` only reloads when the hash changes.
+private struct SidebarWorkspaceAvatarView: View {
+    let workspaceId: UUID
+    let pictureHash: String
+    let size: CGFloat
+
+    @State private var image: NSImage?
+    @State private var loadedHash: String?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(width: size, height: size)
+            }
+        }
+        .accessibilityHidden(true)
+        .task(id: pictureHash) {
+            guard loadedHash != pictureHash else { return }
+            if let data = WorkspacePictureStore.shared.pictureData(
+                for: workspaceId,
+                matchingHash: pictureHash
+            ) {
+                image = NSImage(data: data)
+            } else {
+                image = nil
+            }
+            loadedHash = pictureHash
+        }
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -16126,40 +16126,7 @@ struct TabItemView: View, Equatable {
         }
 
         if !isMulti {
-            Menu(String(localized: "contextMenu.workspacePicture", defaultValue: "Workspace Picture")) {
-                Button {
-                    chooseWorkspacePictureFromFile()
-                } label: {
-                    Label(
-                        tab.pictureHash == nil
-                            ? String(localized: "contextMenu.setWorkspacePicture", defaultValue: "Choose Picture…")
-                            : String(localized: "contextMenu.changeWorkspacePicture", defaultValue: "Change Picture…"),
-                        systemImage: "photo"
-                    )
-                }
-
-                if WorkspacePicturePasteboardSupport.hasImage {
-                    Button {
-                        pasteWorkspacePicture()
-                    } label: {
-                        Label(
-                            String(localized: "contextMenu.pasteWorkspacePicture", defaultValue: "Paste Picture"),
-                            systemImage: "doc.on.clipboard"
-                        )
-                    }
-                }
-
-                if tab.pictureHash != nil {
-                    Button {
-                        tabManager.removeWorkspacePicture(tabId: tab.id)
-                    } label: {
-                        Label(
-                            String(localized: "contextMenu.removeWorkspacePicture", defaultValue: "Remove Picture"),
-                            systemImage: "xmark.circle"
-                        )
-                    }
-                }
-            }
+            workspacePictureMenu
         }
 
         if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
@@ -16989,45 +16956,6 @@ struct TabItemView: View, Equatable {
         applyTabColor(normalized, targetIds: targetIds)
     }
 
-    /// Shared set/change path: pick an image file via NSOpenPanel, then route it
-    /// through the single `TabManager.setWorkspacePicture` mutation. The store
-    /// downscales and persists; the published hash change updates the sidebar
-    /// avatar and pushes to any paired phone.
-    private func chooseWorkspacePictureFromFile() {
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.image]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.prompt = String(localized: "panel.workspacePicture.choose", defaultValue: "Choose")
-        panel.message = String(
-            localized: "panel.workspacePicture.message",
-            defaultValue: "Choose an image to use as this workspace's picture."
-        )
-        guard panel.runModal() == .OK,
-              let url = panel.url,
-              let image = NSImage(contentsOf: url) else {
-            return
-        }
-        applyWorkspacePicture(image)
-    }
-
-    /// Shared paste path: read an image off the general pasteboard and apply it
-    /// through the same mutation as the file pick.
-    private func pasteWorkspacePicture() {
-        guard let image = WorkspacePicturePasteboardSupport.imageFromPasteboard() else {
-            NSSound.beep()
-            return
-        }
-        applyWorkspacePicture(image)
-    }
-
-    private func applyWorkspacePicture(_ image: NSImage) {
-        if !tabManager.setWorkspacePicture(tabId: tab.id, image: image) {
-            NSSound.beep()
-        }
-    }
-
     private func showInvalidColorAlert(_ value: String) {
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -17069,48 +16997,6 @@ struct TabItemView: View, Equatable {
         tabManager.selectTab(tab)
         setSelectionToTabs()
         _ = AppDelegate.shared?.requestEditWorkspaceDescriptionViaCommandPalette()
-    }
-}
-
-/// Small leading avatar for a workspace that has a picture set. Loads the image
-/// from `WorkspacePictureStore` keyed by the immutable `(workspaceId,
-/// pictureHash)` value passed in, so the row holds no store reference (snapshot-
-/// boundary rule) and the cached `NSImage` only reloads when the hash changes.
-private struct SidebarWorkspaceAvatarView: View {
-    let workspaceId: UUID
-    let pictureHash: String
-    let size: CGFloat
-
-    @State private var image: NSImage?
-    @State private var loadedHash: String?
-
-    var body: some View {
-        Group {
-            if let image {
-                Image(nsImage: image)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: size, height: size)
-                    .clipShape(Circle())
-            } else {
-                Circle()
-                    .fill(Color.secondary.opacity(0.2))
-                    .frame(width: size, height: size)
-            }
-        }
-        .accessibilityHidden(true)
-        .task(id: pictureHash) {
-            guard loadedHash != pictureHash else { return }
-            if let data = WorkspacePictureStore.shared.pictureData(
-                for: workspaceId,
-                matchingHash: pictureHash
-            ) {
-                image = NSImage(data: data)
-            } else {
-                image = nil
-            }
-            loadedHash = pictureHash
-        }
     }
 }
 

--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -84,6 +84,10 @@ final class MobileWorkspaceListObserver {
                 // a pure pin toggle need not change the panel set or title, so
                 // without this the phone never learns the workspace was pinned.
                 workspace.$isPinned.map { _ in () }.eraseToAnyPublisher(),
+                // The picture (iMessage-style avatar) is iOS-facing: a set/change/
+                // remove must push `workspace.updated` so the phone refetches the
+                // avatar by its new hash. The hash, not the bytes, rides the list.
+                workspace.$pictureHash.map { _ in () }.eraseToAnyPublisher(),
                 workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
                 workspace.$panelDirectories.map { _ in () }.eraseToAnyPublisher(),
                 // Pure drag-reorders change spatial order without changing the panel
@@ -135,6 +139,8 @@ final class MobileWorkspaceListObserver {
             hasher.combine(workspace.id)
             hasher.combine(workspace.title)
             hasher.combine(workspace.isPinned)
+            // Picture-hash change must re-emit so the phone refetches the avatar.
+            hasher.combine(workspace.pictureHash)
             // Spatial order is significant: hash the ordered id sequence so a
             // reorder of the same panel set changes the hash.
             let panelIDs = workspace.orderedPanelIds

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1794,6 +1794,11 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customTitle: String?
     var customDescription: String?
     var customColor: String?
+    /// Content hash of the workspace's picture (iMessage-style avatar). The image
+    /// bytes live on disk in `WorkspacePictureStore` keyed by workspace id; only
+    /// this small hash is persisted here. `nil` for workspaces with no picture and
+    /// for older snapshots.
+    var pictureHash: String? = nil
     var isPinned: Bool
     var groupId: UUID? = nil
     var isManuallyUnread: Bool? = nil

--- a/Sources/Sidebar/SidebarWorkspacePictureUI.swift
+++ b/Sources/Sidebar/SidebarWorkspacePictureUI.swift
@@ -1,0 +1,128 @@
+import AppKit
+import SwiftUI
+
+/// Sidebar UI for per-workspace pictures (iMessage-style avatars): the context
+/// menu entrypoints on a workspace row and the small leading avatar. All
+/// mutations route through the one shared `TabManager.setWorkspacePicture` /
+/// `removeWorkspacePicture` path.
+extension TabItemView {
+    /// "Workspace Picture" submenu for the workspace context menu.
+    @ViewBuilder
+    var workspacePictureMenu: some View {
+        Menu(String(localized: "contextMenu.workspacePicture", defaultValue: "Workspace Picture")) {
+            Button {
+                chooseWorkspacePictureFromFile()
+            } label: {
+                Label(
+                    tab.pictureHash == nil
+                        ? String(localized: "contextMenu.setWorkspacePicture", defaultValue: "Choose Picture…")
+                        : String(localized: "contextMenu.changeWorkspacePicture", defaultValue: "Change Picture…"),
+                    systemImage: "photo"
+                )
+            }
+
+            if WorkspacePicturePasteboardSupport.hasImage {
+                Button {
+                    pasteWorkspacePicture()
+                } label: {
+                    Label(
+                        String(localized: "contextMenu.pasteWorkspacePicture", defaultValue: "Paste Picture"),
+                        systemImage: "doc.on.clipboard"
+                    )
+                }
+            }
+
+            if tab.pictureHash != nil {
+                Button {
+                    tabManager.removeWorkspacePicture(tabId: tab.id)
+                } label: {
+                    Label(
+                        String(localized: "contextMenu.removeWorkspacePicture", defaultValue: "Remove Picture"),
+                        systemImage: "xmark.circle"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Shared set/change path: pick an image file via NSOpenPanel, then route it
+    /// through the single `TabManager.setWorkspacePicture` mutation. The store
+    /// downscales and persists; the published hash change updates the sidebar
+    /// avatar and pushes to any paired phone.
+    private func chooseWorkspacePictureFromFile() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.prompt = String(localized: "panel.workspacePicture.choose", defaultValue: "Choose")
+        panel.message = String(
+            localized: "panel.workspacePicture.message",
+            defaultValue: "Choose an image to use as this workspace's picture."
+        )
+        guard panel.runModal() == .OK,
+              let url = panel.url,
+              let image = NSImage(contentsOf: url) else {
+            return
+        }
+        applyWorkspacePicture(image)
+    }
+
+    /// Shared paste path: read an image off the general pasteboard and apply it
+    /// through the same mutation as the file pick.
+    private func pasteWorkspacePicture() {
+        guard let image = WorkspacePicturePasteboardSupport.imageFromPasteboard() else {
+            NSSound.beep()
+            return
+        }
+        applyWorkspacePicture(image)
+    }
+
+    private func applyWorkspacePicture(_ image: NSImage) {
+        if !tabManager.setWorkspacePicture(tabId: tab.id, image: image) {
+            NSSound.beep()
+        }
+    }
+}
+
+/// Small leading avatar for a workspace that has a picture set. Loads the image
+/// from `WorkspacePictureStore` keyed by the immutable `(workspaceId,
+/// pictureHash)` value passed in, so the row holds no store reference (snapshot-
+/// boundary rule) and the cached `NSImage` only reloads when the hash changes.
+struct SidebarWorkspaceAvatarView: View {
+    let workspaceId: UUID
+    let pictureHash: String
+    let size: CGFloat
+
+    @State private var image: NSImage?
+    @State private var loadedHash: String?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: size, height: size)
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(width: size, height: size)
+            }
+        }
+        .accessibilityHidden(true)
+        .task(id: pictureHash) {
+            guard loadedHash != pictureHash else { return }
+            if let data = WorkspacePictureStore.shared.pictureData(
+                for: workspaceId,
+                matchingHash: pictureHash
+            ) {
+                image = NSImage(data: data)
+            } else {
+                image = nil
+            }
+            loadedHash = pictureHash
+        }
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -4,6 +4,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
+        let pictureHash: String?
     }
 
     var contextMenuImmediateFields: ContextMenuImmediateFields {
@@ -11,7 +12,8 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             title: title,
             customDescription: customDescription,
             isPinned: isPinned,
-            customColorHex: customColorHex
+            customColorHex: customColorHex,
+            pictureHash: pictureHash
         )
     }
 
@@ -23,6 +25,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             customDescription: snapshot.customDescription,
             isPinned: snapshot.isPinned,
             customColorHex: snapshot.customColorHex,
+            pictureHash: snapshot.pictureHash,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4024,6 +4024,22 @@ class TabManager: ObservableObject {
         tab.setCustomColor(color)
     }
 
+    /// Shared set/change path for a workspace picture (iMessage-style avatar).
+    /// Routes every entrypoint (context menu, paste, future CLI/phone) through the
+    /// one `Workspace.setPicture` mutation, which persists the downscaled image and
+    /// publishes the new hash. Returns `false` if the image can't be encoded.
+    @discardableResult
+    func setWorkspacePicture(tabId: UUID, image: NSImage) -> Bool {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return false }
+        return tab.setPicture(image)
+    }
+
+    /// Shared remove path for a workspace picture.
+    func removeWorkspacePicture(tabId: UUID) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        tab.clearPicture()
+    }
+
     func applyWorkspaceColor(_ color: String?, toWorkspaceIds workspaceIds: [UUID]) {
         guard !workspaceIds.isEmpty else { return }
         if workspaceIds.count == 1, let workspaceId = workspaceIds.first {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20805,6 +20805,8 @@ class TerminalController {
             result = await v2MobileAttachTicketCreate(params: request.params)
         case "mobile.workspace.list", "workspace.list":
             result = v2MobileWorkspaceList(params: request.params)
+        case "mobile.workspace.picture.get", "workspace.picture.get":
+            result = v2MobileWorkspacePicture(params: request.params)
         case "workspace.create":
             result = v2MobileWorkspaceCreate(params: request.params)
         case "mobile.terminal.create", "terminal.create":
@@ -21358,8 +21360,52 @@ class TerminalController {
             "current_directory": v2OrNull(mobileNonEmpty(workspace.currentDirectory)),
             "is_selected": isSelected,
             "is_pinned": workspace.isPinned,
+            // Content hash of the workspace picture (iMessage-style avatar), or
+            // null when it has none. The phone caches the avatar bytes by hash and
+            // fetches them on demand via `mobile.workspace.picture.get`, so the
+            // list payload stays tiny and never base64-bloats `workspace.updated`.
+            "picture_hash": v2OrNull(mobileNonEmpty(workspace.pictureHash)),
             "terminals": terminals
         ]
+    }
+
+    /// Fetch-on-demand handler for a workspace picture (iMessage-style avatar).
+    ///
+    /// The phone learns a picture's content hash from the workspace-list payload
+    /// and asks for the bytes once per hash, caching the result. Keeping the bytes
+    /// out of the list payload (and out of the per-frame render-grid stream) means
+    /// `workspace.updated` stays tiny and an unchanged avatar is never re-sent.
+    ///
+    /// Params: `workspace_id` (required) and `hash` (required, the hash the phone
+    /// saw in the list). The hash is matched against the workspace's current
+    /// picture before any bytes are returned, so a stale request gets `null`
+    /// rather than a different avatar. The PNG is small (downscaled to 256px and
+    /// hard-capped by `WorkspacePictureStore.maxStoredPictureBytes`) and cached in
+    /// memory by hash, so the synchronous read + base64 here is cheap and bounded.
+    private func v2MobileWorkspacePicture(params: [String: Any]) -> V2CallResult {
+        guard let workspaceID = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        guard let requestedHash = mobileNonEmpty(v2RawString(params, "hash")) else {
+            return .err(code: "invalid_params", message: "Missing or invalid hash", data: nil)
+        }
+        // Hash-gated lookup against the authoritative on-disk store. Returns nil
+        // when the workspace has no picture or its hash no longer matches.
+        guard let png = WorkspacePictureStore.shared.pictureData(
+            for: workspaceID,
+            matchingHash: requestedHash
+        ) else {
+            return .ok([
+                "workspace_id": workspaceID.uuidString,
+                "hash": requestedHash,
+                "image_base64": v2OrNull(nil),
+            ])
+        }
+        return .ok([
+            "workspace_id": workspaceID.uuidString,
+            "hash": requestedHash,
+            "image_base64": png.base64EncodedString(),
+        ])
     }
 
     private enum MobileTerminalAliasUUID {

--- a/Sources/Workspace+Picture.swift
+++ b/Sources/Workspace+Picture.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Per-workspace picture (iMessage-style avatar) mutations. The image bytes live
+/// on disk in `WorkspacePictureStore`; the workspace only carries the small
+/// `@Published` content hash, declared in `Workspace.swift`.
+extension Workspace {
+    /// Set this workspace's picture from an image, persisting the downscaled PNG
+    /// via `WorkspacePictureStore` and publishing the new content hash. Returns
+    /// `false` when the image can't be encoded. The `@Published` hash change is
+    /// what drives the sidebar avatar and the mobile-list push.
+    @discardableResult
+    func setPicture(_ image: NSImage) -> Bool {
+        guard let hash = WorkspacePictureStore.shared.setPicture(image, for: id) else {
+            return false
+        }
+        pictureHash = hash
+        return true
+    }
+
+    /// Remove this workspace's picture from disk and clear the published hash.
+    func clearPicture() {
+        WorkspacePictureStore.shared.removePicture(for: id)
+        pictureHash = nil
+    }
+
+    /// Re-derive the published picture hash from disk (used on restore so a
+    /// persisted hash that no longer has a backing file falls back to no avatar).
+    func reloadPictureHashFromStore() {
+        WorkspacePictureStore.shared.invalidateCache(for: id)
+        pictureHash = WorkspacePictureStore.shared.pictureHash(for: id)
+    }
+
+    /// Restore-time picture adoption. The picture file is named by workspace id,
+    /// but restore rebuilds the workspace under a fresh UUID, so re-home the
+    /// original id's picture onto the new id. Falls back to re-deriving from disk
+    /// so a snapshot hash with no backing file resolves to no avatar instead of a
+    /// dangling hash.
+    func restorePicture(fromSnapshotWorkspaceId originalWorkspaceId: UUID?) {
+        if let originalWorkspaceId,
+           let migratedHash = WorkspacePictureStore.shared.migratePicture(
+               from: originalWorkspaceId,
+               to: id
+           ) {
+            pictureHash = migratedHash
+        } else {
+            reloadPictureHashFromStore()
+        }
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -325,19 +325,7 @@ extension Workspace {
         isPinned = snapshot.isPinned
         groupId = snapshot.groupId
 
-        // The picture file is named by workspace id, but restore rebuilds this
-        // workspace under a fresh UUID, so re-home the original id's picture onto
-        // the new id. Fall back to re-deriving from disk so a snapshot hash with
-        // no backing file resolves to no avatar instead of a dangling hash.
-        if let originalWorkspaceId = snapshot.workspaceId,
-           let migratedHash = WorkspacePictureStore.shared.migratePicture(
-               from: originalWorkspaceId,
-               to: id
-           ) {
-            pictureHash = migratedHash
-        } else {
-            reloadPictureHashFromStore()
-        }
+        restorePicture(fromSnapshotWorkspaceId: snapshot.workspaceId)
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -12355,32 +12343,6 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customColor = nil
         }
-    }
-
-    /// Set this workspace's picture from an image, persisting the downscaled PNG
-    /// via `WorkspacePictureStore` and publishing the new content hash. Returns
-    /// `false` when the image can't be encoded. The `@Published` hash change is
-    /// what drives the sidebar avatar and the mobile-list push.
-    @discardableResult
-    func setPicture(_ image: NSImage) -> Bool {
-        guard let hash = WorkspacePictureStore.shared.setPicture(image, for: id) else {
-            return false
-        }
-        pictureHash = hash
-        return true
-    }
-
-    /// Remove this workspace's picture from disk and clear the published hash.
-    func clearPicture() {
-        WorkspacePictureStore.shared.removePicture(for: id)
-        pictureHash = nil
-    }
-
-    /// Re-derive the published picture hash from disk (used on restore so a
-    /// persisted hash that no longer has a backing file falls back to no avatar).
-    func reloadPictureHashFromStore() {
-        WorkspacePictureStore.shared.invalidateCache(for: id)
-        pictureHash = WorkspacePictureStore.shared.pictureHash(for: id)
     }
 
     func setTerminalScrollBarHidden(_ hidden: Bool) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -240,6 +240,7 @@ extension Workspace {
             customTitle: customTitle,
             customDescription: customDescription,
             customColor: customColor,
+            pictureHash: pictureHash,
             isPinned: isPinned,
             groupId: groupId,
             isManuallyUnread: isWorkspaceManuallyUnread,
@@ -323,6 +324,20 @@ extension Workspace {
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
         groupId = snapshot.groupId
+
+        // The picture file is named by workspace id, but restore rebuilds this
+        // workspace under a fresh UUID, so re-home the original id's picture onto
+        // the new id. Fall back to re-deriving from disk so a snapshot hash with
+        // no backing file resolves to no avatar instead of a dangling hash.
+        if let originalWorkspaceId = snapshot.workspaceId,
+           let migratedHash = WorkspacePictureStore.shared.migratePicture(
+               from: originalWorkspaceId,
+               to: id
+           ) {
+            pictureHash = migratedHash
+        } else {
+            reloadPictureHashFromStore()
+        }
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -10495,6 +10510,11 @@ final class Workspace: Identifiable, ObservableObject {
     /// The group entity itself lives in `TabManager.workspaceGroups`.
     @Published var groupId: UUID?
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    /// Content hash of this workspace's picture (iMessage-style avatar), or nil if
+    /// it has none. The image bytes live on disk in `WorkspacePictureStore`; only
+    /// this small hash is `@Published`/persisted, so a picture change pushes
+    /// `workspace.updated` to the phone and the phone caches the avatar by hash.
+    @Published var pictureHash: String?
     // Legacy in-memory state for old helpers/tests. Product UI, rendering, and
     // session persistence no longer honor per-workspace scrollbar overrides.
     @Published private(set) var terminalScrollBarHidden: Bool = false
@@ -10788,6 +10808,7 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
+            sidebarObservationSignal($pictureHash),
             sidebarObservationSignal($latestConversationMessage),
             sidebarObservationSignal($latestSubmittedMessage),
             sidebarObservationSignal($latestSubmittedAt),
@@ -12334,6 +12355,32 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customColor = nil
         }
+    }
+
+    /// Set this workspace's picture from an image, persisting the downscaled PNG
+    /// via `WorkspacePictureStore` and publishing the new content hash. Returns
+    /// `false` when the image can't be encoded. The `@Published` hash change is
+    /// what drives the sidebar avatar and the mobile-list push.
+    @discardableResult
+    func setPicture(_ image: NSImage) -> Bool {
+        guard let hash = WorkspacePictureStore.shared.setPicture(image, for: id) else {
+            return false
+        }
+        pictureHash = hash
+        return true
+    }
+
+    /// Remove this workspace's picture from disk and clear the published hash.
+    func clearPicture() {
+        WorkspacePictureStore.shared.removePicture(for: id)
+        pictureHash = nil
+    }
+
+    /// Re-derive the published picture hash from disk (used on restore so a
+    /// persisted hash that no longer has a backing file falls back to no avatar).
+    func reloadPictureHashFromStore() {
+        WorkspacePictureStore.shared.invalidateCache(for: id)
+        pictureHash = WorkspacePictureStore.shared.pictureHash(for: id)
     }
 
     func setTerminalScrollBarHidden(_ hidden: Bool) {

--- a/Sources/WorkspacePictureStore.swift
+++ b/Sources/WorkspacePictureStore.swift
@@ -1,0 +1,289 @@
+import AppKit
+import CryptoKit
+import Foundation
+import OSLog
+
+private let workspacePictureLog = Logger(subsystem: "com.cmuxterm.app", category: "workspace-picture")
+
+/// On-disk store for per-workspace pictures (iMessage-style avatars).
+///
+/// The image bytes are deliberately kept out of the session JSON snapshot, which
+/// is a small state-tree file: a per-workspace picture lives as its own PNG under
+/// `<appSupport>/cmux/workspace-pictures-<bundleId>/<workspaceId>.png`, mirroring
+/// the bundle-id scoping of `SessionPersistence`. The session snapshot carries
+/// only the small `pictureHash` string, so restore re-derives the avatar from the
+/// file the same way the live store does.
+///
+/// Pictures are downscaled to a fixed avatar size and re-encoded as PNG before
+/// storage so a multi-megabyte source image never lands on disk or rides the
+/// mobile RPC. The content hash is the SHA-256 of the stored PNG bytes, so the
+/// phone caches by hash and never refetches an unchanged avatar.
+@MainActor
+final class WorkspacePictureStore {
+    static let shared = WorkspacePictureStore()
+
+    /// Square avatar edge, in pixels, that every stored picture is downscaled to.
+    /// 256px is sharp on a Retina sidebar row and on the phone's 48pt avatar while
+    /// keeping the PNG well under the mobile payload cap.
+    static let avatarPixelSize = 256
+
+    /// Hard cap on a stored (already-downscaled) PNG. A normal 256px avatar is a
+    /// few tens of KB; this backstops a pathological encode and bounds the
+    /// base64 the phone ever fetches.
+    static let maxStoredPictureBytes = 512 * 1024
+
+    private let fileManager: FileManager
+    private let bundleIdentifier: String?
+    private let appSupportDirectory: URL?
+
+    /// In-memory cache of the current hash per workspace so reads don't hit disk
+    /// on every mobile-list build. `nil` means "no picture"; absence means
+    /// "not yet probed".
+    private var hashCache: [UUID: String?] = [:]
+    /// In-memory cache of stored PNG bytes keyed by content hash, so repeated
+    /// fetch-by-hash RPCs from the phone don't re-read the file each time.
+    private var bytesByHash: [String: Data] = [:]
+
+    init(
+        fileManager: FileManager = .default,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.bundleIdentifier = bundleIdentifier
+        self.appSupportDirectory = appSupportDirectory
+    }
+
+    // MARK: - Directory resolution
+
+    private func picturesDirectoryURL() -> URL? {
+        let resolvedAppSupport: URL
+        if let appSupportDirectory {
+            resolvedAppSupport = appSupportDirectory
+        } else if let discovered = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            resolvedAppSupport = discovered
+        } else {
+            return nil
+        }
+        let safeBundleId = Self.safeBundleIdentifier(bundleIdentifier)
+        return resolvedAppSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("workspace-pictures-\(safeBundleId)", isDirectory: true)
+    }
+
+    private func pictureFileURL(for workspaceID: UUID) -> URL? {
+        picturesDirectoryURL()?.appendingPathComponent("\(workspaceID.uuidString).png", isDirectory: false)
+    }
+
+    static func safeBundleIdentifier(_ bundleIdentifier: String?) -> String {
+        let bundleId = (bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+            ? bundleIdentifier!
+            : "com.cmuxterm.app"
+        return bundleId.replacingOccurrences(
+            of: "[^A-Za-z0-9._-]",
+            with: "_",
+            options: .regularExpression
+        )
+    }
+
+    // MARK: - Reads
+
+    /// Content hash of the workspace's current picture, or `nil` if it has none.
+    /// Cheap on the hot mobile-list path: cached in memory, re-derived from disk
+    /// only on a cache miss.
+    func pictureHash(for workspaceID: UUID) -> String? {
+        if let cached = hashCache[workspaceID] {
+            return cached
+        }
+        let data = readStoredPNG(for: workspaceID)
+        let hash = data.map { Self.contentHash(of: $0) }
+        hashCache[workspaceID] = hash
+        if let data, let hash {
+            bytesByHash[hash] = data
+        }
+        return hash
+    }
+
+    /// Stored PNG bytes for a workspace whose current picture matches `hash`, or
+    /// `nil` if there is no picture or the hash no longer matches (the phone is
+    /// asking for a stale avatar). Hash-gated so a fetch can never serve bytes the
+    /// caller didn't ask for.
+    func pictureData(for workspaceID: UUID, matchingHash hash: String) -> Data? {
+        guard let currentHash = pictureHash(for: workspaceID), currentHash == hash else {
+            return nil
+        }
+        if let cached = bytesByHash[hash] {
+            return cached
+        }
+        guard let data = readStoredPNG(for: workspaceID) else { return nil }
+        bytesByHash[hash] = data
+        return data
+    }
+
+    private func readStoredPNG(for workspaceID: UUID) -> Data? {
+        guard let url = pictureFileURL(for: workspaceID),
+              fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              !data.isEmpty,
+              data.count <= Self.maxStoredPictureBytes else {
+            return nil
+        }
+        return data
+    }
+
+    // MARK: - Writes
+
+    /// Downscale, re-encode, and persist `image` as this workspace's picture,
+    /// returning the new content hash. Returns `nil` if the image can't be
+    /// encoded (e.g. an empty or corrupt source).
+    @discardableResult
+    func setPicture(_ image: NSImage, for workspaceID: UUID) -> String? {
+        guard let png = Self.normalizedAvatarPNG(from: image) else {
+            workspacePictureLog.error("failed to encode workspace picture")
+            return nil
+        }
+        return setPictureData(png, for: workspaceID)
+    }
+
+    /// Persist already-encoded avatar PNG bytes (used by the image-pick path and
+    /// directly by tests). The bytes are assumed normalized by
+    /// `normalizedAvatarPNG`; oversized blobs are rejected.
+    @discardableResult
+    func setPictureData(_ png: Data, for workspaceID: UUID) -> String? {
+        guard !png.isEmpty, png.count <= Self.maxStoredPictureBytes else { return nil }
+        guard let directory = picturesDirectoryURL(),
+              let url = pictureFileURL(for: workspaceID) else {
+            return nil
+        }
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try png.write(to: url, options: .atomic)
+        } catch {
+            workspacePictureLog.error("failed to persist workspace picture: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+        let hash = Self.contentHash(of: png)
+        hashCache[workspaceID] = hash
+        bytesByHash[hash] = png
+        return hash
+    }
+
+    /// Remove a workspace's picture from disk and caches.
+    func removePicture(for workspaceID: UUID) {
+        if let url = pictureFileURL(for: workspaceID) {
+            try? fileManager.removeItem(at: url)
+        }
+        if case let .some(previousHash) = hashCache[workspaceID], let previousHash {
+            bytesByHash.removeValue(forKey: previousHash)
+        }
+        hashCache[workspaceID] = .some(nil)
+    }
+
+    /// Drop the in-memory hash entry so the next read re-probes disk (used when a
+    /// workspace is closed or restored).
+    func invalidateCache(for workspaceID: UUID) {
+        hashCache.removeValue(forKey: workspaceID)
+    }
+
+    /// On session restore a workspace is rebuilt under a fresh UUID, so its
+    /// picture file (named by the original id) must be re-homed onto the new id.
+    /// Moves `<sourceID>.png` to `<destinationID>.png` and returns the resulting
+    /// content hash, or `nil` if the source has no stored picture. No-op when the
+    /// ids match.
+    @discardableResult
+    func migratePicture(from sourceID: UUID, to destinationID: UUID) -> String? {
+        guard sourceID != destinationID else {
+            return pictureHash(for: destinationID)
+        }
+        guard let sourceURL = pictureFileURL(for: sourceID),
+              let destinationURL = pictureFileURL(for: destinationID),
+              fileManager.fileExists(atPath: sourceURL.path) else {
+            return nil
+        }
+        do {
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.moveItem(at: sourceURL, to: destinationURL)
+        } catch {
+            workspacePictureLog.error("failed to migrate workspace picture: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+        invalidateCache(for: sourceID)
+        invalidateCache(for: destinationID)
+        return pictureHash(for: destinationID)
+    }
+
+    // MARK: - Encoding helpers (pure, testable)
+
+    /// SHA-256 of the bytes, hex-encoded and truncated to 16 chars. A 64-bit
+    /// prefix is collision-safe for a per-user avatar set and keeps the mobile
+    /// payload field tiny.
+    static func contentHash(of data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.joined().prefix(16).description
+    }
+
+    /// Downscale `image` to a centered square `avatarPixelSize` PNG. Returns `nil`
+    /// for an empty/unrenderable image. Pure: no disk or instance state, so the
+    /// store's encoding contract is unit-testable.
+    static func normalizedAvatarPNG(
+        from image: NSImage,
+        pixelSize: Int = avatarPixelSize
+    ) -> Data? {
+        guard pixelSize > 0, image.size.width > 0, image.size.height > 0 else { return nil }
+        let side = CGFloat(pixelSize)
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixelSize,
+            pixelsHigh: pixelSize,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        rep.size = NSSize(width: side, height: side)
+
+        guard let context = NSGraphicsContext(bitmapImageRep: rep) else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        context.imageInterpolation = .high
+
+        // Aspect-fill: scale the source so the shorter edge fills the square, then
+        // center it so a non-square source crops to a square avatar instead of
+        // distorting.
+        let sourceAspect = image.size.width / image.size.height
+        let drawRect: NSRect
+        if sourceAspect >= 1 {
+            let scaledWidth = side * sourceAspect
+            drawRect = NSRect(x: (side - scaledWidth) / 2, y: 0, width: scaledWidth, height: side)
+        } else {
+            let scaledHeight = side / sourceAspect
+            drawRect = NSRect(x: 0, y: (side - scaledHeight) / 2, width: side, height: scaledHeight)
+        }
+        image.draw(in: drawRect, from: .zero, operation: .copy, fraction: 1.0)
+        NSGraphicsContext.restoreGraphicsState()
+
+        return rep.representation(using: .png, properties: [:])
+    }
+}
+
+/// Pasteboard helpers for the "Paste Picture" context-menu affordance, kept
+/// alongside the picture store so all workspace-picture concerns live together.
+enum WorkspacePicturePasteboardSupport {
+    /// Whether the general pasteboard currently holds an image (drives whether the
+    /// "Paste Picture" menu item is shown).
+    static var hasImage: Bool {
+        NSPasteboard.general.canReadObject(forClasses: [NSImage.self], options: nil)
+    }
+
+    /// Read an image off the general pasteboard, or `nil` if it holds none.
+    static func imageFromPasteboard() -> NSImage? {
+        NSPasteboard.general.readObjects(forClasses: [NSImage.self], options: nil)?.first as? NSImage
+    }
+}

--- a/Sources/WorkspacePictureStore.swift
+++ b/Sources/WorkspacePictureStore.swift
@@ -163,9 +163,22 @@ final class WorkspacePictureStore {
             return nil
         }
         let hash = Self.contentHash(of: png)
+        evictCachedBytesForPreviousHash(of: workspaceID, keeping: hash)
         hashCache[workspaceID] = hash
         bytesByHash[hash] = png
         return hash
+    }
+
+    /// Drop the bytes cached under a workspace's previous hash so repeated
+    /// picture changes don't accumulate stale PNGs in the in-memory cache. If
+    /// another workspace happens to share the evicted hash, its next read is a
+    /// cheap cache miss re-served from its own file.
+    private func evictCachedBytesForPreviousHash(of workspaceID: UUID, keeping newHash: String? = nil) {
+        if case let .some(previousHash) = hashCache[workspaceID],
+           let previousHash,
+           previousHash != newHash {
+            bytesByHash.removeValue(forKey: previousHash)
+        }
     }
 
     /// Remove a workspace's picture from disk and caches.
@@ -209,6 +222,9 @@ final class WorkspacePictureStore {
             workspacePictureLog.error("failed to migrate workspace picture: \(String(describing: error), privacy: .public)")
             return nil
         }
+        // The destination's previous picture (if any) was just overwritten on
+        // disk; drop its now-stale cached bytes before re-probing.
+        evictCachedBytesForPreviousHash(of: destinationID)
         invalidateCache(for: sourceID)
         invalidateCache(for: destinationID)
         return pictureHash(for: destinationID)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -569,6 +569,7 @@
 		C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */; };
 		C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */; };
 		C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */; };
+		D35112070000000000000001 /* SidebarWorkspacePictureUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35112070000000000000002 /* SidebarWorkspacePictureUI.swift */; };
 		C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */; };
 		D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */; };
 		C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */; };
@@ -676,6 +677,7 @@
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
+		D35112050000000000000001 /* Workspace+Picture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35112050000000000000002 /* Workspace+Picture.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		7D77A0EBBE3D8E05CDC16229 /* WorkspaceActionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CC15CEAA80B779ADEE78AA /* WorkspaceActionDispatcher.swift */; };
 		7F0A0E04A8CADC84BB4F1DF7 /* WorkspaceActionDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */; };
@@ -1297,6 +1299,7 @@
 		C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderMetricsTests.swift; sourceTree = "<group>"; };
 		C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderView.swift; sourceTree = "<group>"; };
 		C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupingMetrics.swift; sourceTree = "<group>"; };
+		D35112070000000000000002 /* SidebarWorkspacePictureUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspacePictureUI.swift; sourceTree = "<group>"; };
 		C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItem.swift; sourceTree = "<group>"; };
 		D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTracker.swift; sourceTree = "<group>"; };
 		C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSelectionAnchorPolicyTests.swift; sourceTree = "<group>"; };
@@ -1402,6 +1405,7 @@
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
+		D35112050000000000000002 /* Workspace+Picture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+Picture.swift"; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		C5CC15CEAA80B779ADEE78AA /* WorkspaceActionDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceActionDispatcher.swift; sourceTree = "<group>"; };
 		EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceActionDispatcherTests.swift; sourceTree = "<group>"; };
@@ -1702,6 +1706,7 @@
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */,
+				D35112070000000000000002 /* SidebarWorkspacePictureUI.swift */,
 				C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */,
 				C9A57106C9A57106C9A57106 /* SidebarWorkspaceGroupContextMenuRunner.swift */,
 				C9A57108C9A57108C9A57108 /* SidebarWorkspaceGroupDialogs.swift */,
@@ -1996,6 +2001,7 @@
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
 				D35110010000000000000002 /* CmuxApplicationSupportDirectories.swift */,
 				D35112010000000000000002 /* WorkspacePictureStore.swift */,
+				D35112050000000000000002 /* Workspace+Picture.swift */,
 				A5001651 /* CmuxConfig.swift */,
 				C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */,
 				C0DEF0A10000000000000002 /* CmuxConfigUI.swift */,
@@ -2968,6 +2974,7 @@
 				C9A57301C9A57301C9A57301 /* SidebarWorkspaceGroupHeaderMetrics.swift in Sources */,
 				C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */,
 				C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */,
+				D35112070000000000000001 /* SidebarWorkspacePictureUI.swift in Sources */,
 				C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */,
 				D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */,
 				988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,
@@ -3045,6 +3052,7 @@
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
+				D35112050000000000000001 /* Workspace+Picture.swift in Sources */,
 				A5001406 /* Workspace.swift in Sources */,
 				7D77A0EBBE3D8E05CDC16229 /* WorkspaceActionDispatcher.swift in Sources */,
 				A11EAD000000000000000000 /* WorkspaceAppearanceResolution.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -692,6 +692,8 @@
 		C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */; };
 		C9A57001C9A57001C9A57001 /* WorkspaceGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */; };
 		0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */; };
+		D35112010000000000000001 /* WorkspacePictureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35112010000000000000002 /* WorkspacePictureStore.swift */; };
+		D35112030000000000000001 /* WorkspacePictureStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35112030000000000000002 /* WorkspacePictureStoreTests.swift */; };
 		D0B10004A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10005A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift */; };
 		1A1B2C3D4E5F607180000001 /* WorkspacePromptSubmit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F607180000002 /* WorkspacePromptSubmit.swift */; };
 		1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A1B2C3D4E5F607180000004 /* WorkspacePromptSubmitTests.swift */; };
@@ -1416,6 +1418,8 @@
 		C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupMenuSnapshot.swift; sourceTree = "<group>"; };
 		C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupTests.swift; sourceTree = "<group>"; };
 		1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManualUnreadTests.swift; sourceTree = "<group>"; };
+		D35112010000000000000002 /* WorkspacePictureStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePictureStore.swift; sourceTree = "<group>"; };
+		D35112030000000000000002 /* WorkspacePictureStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePictureStoreTests.swift; sourceTree = "<group>"; };
 		D0B10005A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePortalPaneDrop.swift; sourceTree = "<group>"; };
 		1A1B2C3D4E5F607180000002 /* WorkspacePromptSubmit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePromptSubmit.swift; sourceTree = "<group>"; };
 		1A1B2C3D4E5F607180000004 /* WorkspacePromptSubmitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePromptSubmitTests.swift; sourceTree = "<group>"; };
@@ -1991,6 +1995,7 @@
 				A5001642 /* RemoteInteractiveShellBootstrapBuilder.swift */,
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
 				D35110010000000000000002 /* CmuxApplicationSupportDirectories.swift */,
+				D35112010000000000000002 /* WorkspacePictureStore.swift */,
 				A5001651 /* CmuxConfig.swift */,
 				C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */,
 				C0DEF0A10000000000000002 /* CmuxConfigUI.swift */,
@@ -2125,6 +2130,7 @@
 				F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */,
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
+				D35112030000000000000002 /* WorkspacePictureStoreTests.swift */,
 				F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
 				DE71CE000000000000000001 /* DeviceRegistryClientTests.swift */,
 				AA5269A0C0DE0003FACE0003 /* ForeignFirstResponderPolicyTests.swift */,
@@ -3047,6 +3053,7 @@
 				A5001407 /* WorkspaceContentView.swift in Sources */,
 				C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */,
 				C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */,
+				D35112010000000000000001 /* WorkspacePictureStore.swift in Sources */,
 				D0B10004A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift in Sources */,
 				1A1B2C3D4E5F607180000001 /* WorkspacePromptSubmit.swift in Sources */,
 				E30780000000000000000002 /* WorkspaceRemoteConfiguration.swift in Sources */,
@@ -3314,6 +3321,7 @@
 				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 				C9A57001C9A57001C9A57001 /* WorkspaceGroupTests.swift in Sources */,
 				0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
+				D35112030000000000000001 /* WorkspacePictureStoreTests.swift in Sources */,
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,
 				DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -93,6 +93,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         customDescription: String? = nil,
         isPinned: Bool = false,
         customColorHex: String? = nil,
+        pictureHash: String? = nil,
         remoteConnectionStatusText: String = "Disconnected",
         latestConversationMessage: String? = nil,
         listeningPorts: [Int] = []
@@ -103,6 +104,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex,
+            pictureHash: pictureHash,
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: "",

--- a/cmuxTests/WorkspacePictureStoreTests.swift
+++ b/cmuxTests/WorkspacePictureStoreTests.swift
@@ -1,0 +1,177 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Behavior tests for the on-disk per-workspace picture (avatar) store: encode
+/// contract, set/get/remove round-trip, hash gating, restore re-derivation, and
+/// the restore-time id migration.
+@MainActor
+@Suite struct WorkspacePictureStoreTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspacePictureStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    private func makeStore(appSupport: URL) -> WorkspacePictureStore {
+        WorkspacePictureStore(
+            bundleIdentifier: "com.cmuxterm.tests",
+            appSupportDirectory: appSupport
+        )
+    }
+
+    /// A solid-color bitmap-backed NSImage that renders in headless CI.
+    private func makeImage(width: Int, height: Int, color: NSColor) throws -> NSImage {
+        let rep = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ))
+        let context = try #require(NSGraphicsContext(bitmapImageRep: rep))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        color.setFill()
+        NSRect(x: 0, y: 0, width: CGFloat(width), height: CGFloat(height)).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        let image = NSImage(size: NSSize(width: width, height: height))
+        image.addRepresentation(rep)
+        return image
+    }
+
+    @Test func setPictureRoundTripsThroughHashGatedRead() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        let workspaceID = UUID()
+
+        let image = try makeImage(width: 640, height: 480, color: .systemTeal)
+        let hash = try #require(store.setPicture(image, for: workspaceID))
+
+        #expect(store.pictureHash(for: workspaceID) == hash)
+        let data = try #require(store.pictureData(for: workspaceID, matchingHash: hash))
+        #expect(WorkspacePictureStore.contentHash(of: data) == hash)
+        // Hash gating: a stale/wrong hash never serves bytes.
+        #expect(store.pictureData(for: workspaceID, matchingHash: "0000000000000000") == nil)
+    }
+
+    @Test func freshStoreRederivesHashFromDisk() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let workspaceID = UUID()
+
+        let image = try makeImage(width: 100, height: 100, color: .systemRed)
+        let hash = try #require(makeStore(appSupport: appSupport).setPicture(image, for: workspaceID))
+
+        // A cold store (restore path) must re-derive the same hash from the file.
+        let coldStore = makeStore(appSupport: appSupport)
+        #expect(coldStore.pictureHash(for: workspaceID) == hash)
+        #expect(coldStore.pictureData(for: workspaceID, matchingHash: hash) != nil)
+    }
+
+    @Test func removePictureClearsDiskAndReads() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        let workspaceID = UUID()
+
+        let image = try makeImage(width: 64, height: 64, color: .systemBlue)
+        let hash = try #require(store.setPicture(image, for: workspaceID))
+        store.removePicture(for: workspaceID)
+
+        #expect(store.pictureHash(for: workspaceID) == nil)
+        #expect(store.pictureData(for: workspaceID, matchingHash: hash) == nil)
+        // Cold read confirms the file is gone, not just the cache.
+        #expect(makeStore(appSupport: appSupport).pictureHash(for: workspaceID) == nil)
+    }
+
+    @Test func changingPictureChangesHash() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        let workspaceID = UUID()
+
+        let first = try #require(store.setPicture(
+            try makeImage(width: 64, height: 64, color: .systemGreen),
+            for: workspaceID
+        ))
+        let second = try #require(store.setPicture(
+            try makeImage(width: 64, height: 64, color: .systemOrange),
+            for: workspaceID
+        ))
+        #expect(first != second)
+        #expect(store.pictureHash(for: workspaceID) == second)
+        // The old hash no longer matches, so the stale fetch yields nil.
+        #expect(store.pictureData(for: workspaceID, matchingHash: first) == nil)
+    }
+
+    @Test func migratePictureRehomesFileOntoNewWorkspaceID() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        let originalID = UUID()
+        let restoredID = UUID()
+
+        let image = try makeImage(width: 64, height: 64, color: .systemPurple)
+        let hash = try #require(store.setPicture(image, for: originalID))
+
+        let migratedHash = store.migratePicture(from: originalID, to: restoredID)
+        #expect(migratedHash == hash)
+        #expect(store.pictureHash(for: restoredID) == hash)
+        #expect(store.pictureHash(for: originalID) == nil)
+        #expect(store.pictureData(for: restoredID, matchingHash: hash) != nil)
+    }
+
+    @Test func migratePictureWithoutSourceReturnsNil() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        #expect(store.migratePicture(from: UUID(), to: UUID()) == nil)
+    }
+
+    @Test func normalizedAvatarPNGDownscalesToSquareAvatarSize() throws {
+        let image = try makeImage(width: 1200, height: 800, color: .systemIndigo)
+        let png = try #require(WorkspacePictureStore.normalizedAvatarPNG(from: image))
+        let rep = try #require(NSBitmapImageRep(data: png))
+        #expect(rep.pixelsWide == WorkspacePictureStore.avatarPixelSize)
+        #expect(rep.pixelsHigh == WorkspacePictureStore.avatarPixelSize)
+        #expect(png.count <= WorkspacePictureStore.maxStoredPictureBytes)
+    }
+
+    @Test func normalizedAvatarPNGRejectsEmptyImage() {
+        #expect(WorkspacePictureStore.normalizedAvatarPNG(from: NSImage()) == nil)
+    }
+
+    @Test func setPictureDataRejectsEmptyAndOversizedBlobs() throws {
+        let appSupport = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+        let store = makeStore(appSupport: appSupport)
+        let workspaceID = UUID()
+
+        #expect(store.setPictureData(Data(), for: workspaceID) == nil)
+        let oversized = Data(count: WorkspacePictureStore.maxStoredPictureBytes + 1)
+        #expect(store.setPictureData(oversized, for: workspaceID) == nil)
+        #expect(store.pictureHash(for: workspaceID) == nil)
+    }
+
+    @Test func contentHashIsStableAndCompact() {
+        let data = Data("avatar-bytes".utf8)
+        let hash = WorkspacePictureStore.contentHash(of: data)
+        #expect(hash.count == 16)
+        #expect(hash == WorkspacePictureStore.contentHash(of: data))
+        #expect(hash != WorkspacePictureStore.contentHash(of: Data("other".utf8)))
+    }
+}


### PR DESCRIPTION
Lets the user set, change, paste, or remove a picture for a workspace from the sidebar context menu, like iMessage conversation pictures. The avatar syncs to the iOS app and renders in mobile workspace rows.

Data flow: images are downscaled to a 256px square PNG and stored on disk in a new `WorkspacePictureStore` (Application Support, bundle-id scoped, one PNG per workspace id, 512KB hard cap). The session snapshot and the `@Published` workspace state carry only a 16-char content hash, and a hash change is what pushes `workspace.updated` to the phone (same observer pattern as `is_pinned` in https://github.com/manaflow-ai/cmux/pull/5625).

Payload vs RPC: the workspace-list payload carries `picture_hash` only. The phone fetches bytes on demand via a new `mobile.workspace.picture.get` RPC (hash-gated so a stale request returns null instead of a different image) and caches bytes by hash with bounded eviction. Chosen over inlining base64 in the list payload because the list re-sends on every workspace mutation; hashing means an unchanged avatar is never re-sent and the per-frame render-grid stream is untouched.

One shared mutation path: file pick, paste, and remove all route through `TabManager.setWorkspacePicture` / `removeWorkspacePicture` into `Workspace.setPicture` / `clearPicture`. Session restore re-homes the PNG onto the restored workspace's fresh UUID, which also covers reopen-from-closed-history.

Setting the picture from the phone is a follow-up. Picture files for closed workspaces are kept on disk so reopen-from-history restores the avatar; a GC sweep for never-reopened workspaces is a noted follow-up.

Tests: `WorkspacePictureStoreTests` (encode contract, round-trip, hash gating, migration) and `MobileWorkspacePictureDecodeTests` (wire decode for `picture_hash` and the picture RPC). Localized en+ja.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session persistence, mobile RPC, and sidebar/mobile UI; picture bytes stay hash-gated and size-capped, but restore migration and new RPC paths add moderate integration surface.
> 
> **Overview**
> Adds **per-workspace pictures** (iMessage-style avatars) on Mac and syncs them to iOS.
> 
> On **Mac**, a new `WorkspacePictureStore` persists downscaled 256px PNGs on disk; workspaces publish only a **content hash** in session snapshots and sidebar state. The sidebar gets choose/change/paste/remove via context menu, a leading avatar in rows, and `TabManager`/`Workspace` mutations. **Session restore** migrates picture files when workspace UUIDs change.
> 
> **Mobile sync** adds `picture_hash` to the workspace list and a hash-gated **`mobile.workspace.picture.get`** RPC (base64 PNG or null). The phone decodes the wire types, caches bytes by hash with LRU eviction, and shows images in `WorkspaceRow` when `pictureData` is stamped on previews. `MobileWorkspaceListObserver` re-emits on hash changes so phones refetch.
> 
> **Tests** cover store behavior, RPC decode, and snapshot refresh policy; **en+ja** strings for picture UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5a85dc102fde42f1db5c1006af073e27cb52d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-workspace pictures (iMessage-style avatars) with iOS sync. Users can set, paste, change, or remove a picture on Mac; iOS fetches and caches by hash and shows avatars in workspace rows.

- New Features
  - Mac: Sidebar context menu to choose/paste/remove a workspace picture, and show a small avatar in rows. Images are downscaled to a 256px PNG and stored on disk in `WorkspacePictureStore` (512KB cap). Only a 16‑char `picture_hash` is persisted and `@Published` on `Workspace`; session restore migrates the file to the new UUID.
  - iOS: Workspace list includes `picture_hash`. Added `mobile.workspace.picture.get` RPC (hash-gated) that returns a base64 PNG or null; results are cached by hash (LRU, 128 max) in `CmuxMobileShell` and rendered in `WorkspaceRow` with gradient+symbol fallback. Oversized (>512KB) responses are dropped client‑side.
  - Keeps `workspace.updated` and render-grid streams small by sending hashes and fetching bytes on demand.
  - Tests: `WorkspacePictureStoreTests` and `MobileWorkspacePictureDecodeTests`. Localized strings added for the new menu.

- Refactors
  - Extracted code into `SidebarWorkspacePictureUI.swift`, `Workspace+Picture.swift`, and `MobileShellComposite+WorkspacePictures.swift`; also evict stale cached PNG bytes on picture replace and fix avatar-cache eviction to a bounded single pass.

<sup>Written for commit 6c380af3148da9fc5ab3d615906e534462c19adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now set workspace avatars via file selection, paste, or remove from the workspace context menu.
  * Workspace avatars display in the sidebar with automatic image loading when available.
  * Avatars are fetched on-demand and distributed to mobile updates via picture-hash change signals.
  * Added local persistence and an in-memory/disk cache to keep avatar retrieval fast across sessions.
* **Tests**
  * Added decoding coverage and avatar store unit tests for persistence, hashing, and migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->