### PR TITLE
iOS: turnkey cloud TestFlight lane (fleet unsigned archive + local re-sign/verify)

### DIFF
--- a/ios/Config/cmux-release.entitlements
+++ b/ios/Config/cmux-release.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+
+	<!-- APNs remote push. "production" targets the production APNs host
+	     (api.push.apple.com), which is the gateway TestFlight and App Store
+	     builds run against. This Release entitlement is selected per-config via
+	     CODE_SIGN_ENTITLEMENTS in Release.xcconfig; the Debug build uses
+	     cmux.entitlements ("development", sandbox host) so local dev push keeps
+	     working. The reported apnsEnvironment in MobileAuthComposition
+	     ("production" for non-DEBUG) must stay in lockstep with this value so the
+	     backend routes the device token to the matching APNs host. -->
+	<key>aps-environment</key>
+	<string>production</string>
+
+	<!-- Allows the .time-sensitive interruption level used by agent push. -->
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/README.md
+++ b/ios/README.md
@@ -24,3 +24,36 @@ Run package tests:
 ```bash
 swift test --package-path ios/cmuxPackage
 ```
+
+## TestFlight beta (cloud lane)
+
+`ios/scripts/cloud-testflight.sh` is the turnkey lane for cutting a TestFlight
+beta. It builds the heavy GhosttyKit + Swift Release compile on a leased fleet
+Mac (same maclease pool as the device cloud reload, m1ultra excluded), so the
+build stays off this Mac's CPU. The fleet produces an UNSIGNED Release archive
+for the beta bundle id `dev.cmux.app.beta` (no signing material ever lands on
+the shared Macs), downloads it locally, then hands it to
+`ios/scripts/upload-testflight.sh --archive-path`, which does the local export,
+re-sign with the Apple Distribution cert (re-adding `aps-environment=production`),
+strict codesign verification, and TestFlight upload.
+
+```bash
+# Dry run: build + export + re-sign + verify aps-environment=production, NO upload
+ios/scripts/cloud-testflight.sh --no-upload
+
+# Full lane: build on the fleet and upload to TestFlight (internal "cmux beta" group)
+ios/scripts/cloud-testflight.sh
+
+# Also make the build eligible for external testers
+ios/scripts/cloud-testflight.sh --external
+```
+
+A standalone cmux clone with no cmuxterm-hq checkout transparently falls back to
+a LOCAL Release archive (`--local` forces it), then takes the same export path.
+
+Internal testers (the `cmux beta` group) get every uploaded build instantly with
+no review. An `--external` build is different: the FIRST external build of a new
+`MARKETING_VERSION` must pass a one-time Apple Beta App Review (~24h) before any
+external tester can install it. Subsequent external builds of the same version
+ship without re-review. Plan a version bump's first external cut around that
+~24h gate.

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Turnkey cloud TestFlight lane for the cmux iOS beta.
+#
+#   ios/scripts/cloud-testflight.sh --no-upload          # dry run: archive + export + re-sign + verify, NO upload
+#   ios/scripts/cloud-testflight.sh                       # full lane: build on the fleet, upload to TestFlight
+#   ios/scripts/cloud-testflight.sh --external            # also make the build external-tester eligible
+#
+# The heavy GhosttyKit + Swift Release compile runs on a leased fleet Mac (the
+# same maclease pool/exclusions reload-cloud-ios uses, m1ultra excluded). The
+# fleet builds an UNSIGNED Release archive for the beta bundle id
+# (dev.cmux.app.beta): no signing material ever lands on the shared Macs (they
+# also run GitHub Actions, i.e. arbitrary PR code). The archive is downloaded
+# locally and handed to ios/scripts/upload-testflight.sh --archive-path, which
+# does the local export, re-sign with the Apple Distribution cert (re-adding
+# aps-environment=production), strict codesign verification, and TestFlight
+# upload.
+#
+# The cloud build is provided by the cmuxterm-hq script scripts/reload-cloud-ios.sh
+# (located the same way the worktree shim ios/scripts/reload-cloud.sh finds it).
+# That script also owns builder resilience: an unreachable leased slot is released
+# and the next builder is tried, and beta-archive mode applies a pre-build disk
+# floor (RELOAD_CLOUD_IOS_MIN_FREE_GB, default 20G) so a nearly-full fleet host
+# (cmux-aws-m4pro routinely sits ~99.7% APFS-full) is skipped instead of dying
+# mid-archive; it also prunes its remote work dir after the download. A standalone
+# cmux clone with no hq checkout transparently falls back to a LOCAL Release
+# archive on this Mac. Either way the archive is then handed to
+# upload-testflight.sh, so the export/re-sign/verify/upload path is identical.
+#
+# Relies on the upload-testflight.sh re-sign + aps-environment=production gate
+# (shipped with this lane; a superset of the copy in PR
+# https://github.com/manaflow-ai/cmux/pull/5647 with the same re-sign/gates plus
+# main's --external support preserved) to make a push-working beta. This lane
+# only feeds the archive in; it deliberately does NOT duplicate that signing
+# logic. Without the re-sign, the export still runs but the unsigned archive's
+# export carries NO aps-environment at all (profile-baseline entitlements
+# only), so push would be silently dead; the --no-upload gate below catches
+# exactly that.
+#
+# FIRST EXTERNAL BUILD OF A VERSION: an --external build must pass a one-time
+# Apple Beta App Review (~24h) before external testers can install it. Internal
+# testers (the "cmux beta" group) get every build instantly with no review.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$IOS_DIR/.." && pwd)"
+
+LANE="beta"
+TAG="beta"
+NO_UPLOAD=0
+EXTERNAL=0
+KEEP_ARTIFACTS=0
+HOST_FILTER=""
+# When the fleet is busy, wait for a cloud slot rather than degrading to a local
+# Release archive on this Mac (which is slow and eats the user's CPU). Mirrors
+# reload-cloud-ios.sh's --wait. Set to 0 to fail/fallback fast.
+WAIT_SECONDS="${CLOUD_TESTFLIGHT_WAIT:-1200}"
+# Force a local Release archive on this Mac instead of the fleet (offline cloud,
+# or deliberate). Also the automatic fallback when no hq cloud script is found.
+FORCE_LOCAL="${CLOUD_TESTFLIGHT_FORCE_LOCAL:-0}"
+BETA_BUNDLE_ID="${IOS_BETA_BUNDLE_ID:-dev.cmux.app.beta}"
+
+err() { printf 'cloud-testflight: %s\n' "$*" >&2; }
+die() { err "$*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: ios/scripts/cloud-testflight.sh [--no-upload] [--external] [--tag <tag>]
+                                       [--host <name>] [--wait <seconds>]
+                                       [--local] [--keep-artifacts]
+
+Build an UNSIGNED Release archive for the cmux iOS beta on a leased fleet Mac,
+download it, then export/re-sign/verify/upload via upload-testflight.sh.
+
+  --no-upload        Dry run. Stop after the local export + re-sign + strict
+                     codesign verification (aps-environment=production); do NOT
+                     upload to TestFlight. Maps to upload-testflight.sh
+                     --export-only.
+  --external         Make the build eligible for EXTERNAL TestFlight testers
+                     (requires a one-time Apple Beta App Review per version).
+                     Default is internal-only (instant for the "cmux beta" group).
+  --tag <tag>        Build tag for the lease description / remote work dir
+                     (default: beta). Does not change the bundle id.
+  --host <name>      Force a specific fleet builder (skips host preference).
+  --wait <seconds>   Block up to this long for a free cloud builder before
+                     falling back to a local build (default 1200).
+  --local            Build the Release archive locally on this Mac instead of the
+                     fleet. Used automatically when no hq cloud script is present.
+  --keep-artifacts   Keep the downloaded archive + export dir.
+
+Signing/upload credentials are resolved by upload-testflight.sh (ASC API key via
+ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH or
+ios/Config/AppStoreConnect.local.plist; the Apple Distribution cert in the local
+keychain for the re-sign).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-upload) NO_UPLOAD=1; shift ;;
+    --external) EXTERNAL=1; shift ;;
+    --tag) TAG="${2:-}"; shift 2 ;;
+    --host) HOST_FILTER="${2:-}"; shift 2 ;;
+    --wait) WAIT_SECONDS="${2:-}"; shift 2 ;;
+    --local) FORCE_LOCAL=1; shift ;;
+    --keep-artifacts) KEEP_ARTIFACTS=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; die "unknown argument: $1" ;;
+  esac
+done
+
+[[ "$LANE" == "beta" ]] || die "only the beta lane is supported"
+[[ "$TAG" =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid tag: $TAG"
+[[ -d "$IOS_DIR/cmux.xcworkspace" ]] || die "run from a cmux checkout containing ios/cmux.xcworkspace"
+
+# --- locate the hq cloud build script (mirrors ios/scripts/reload-cloud.sh) ---
+# scripts/reload-cloud-ios.sh lives in the cmuxterm-hq checkout, two levels up
+# from the worktree's git common dir (.../cmuxterm-hq/repo/.git -> cmuxterm-hq).
+# A standalone cmux clone has no such file; we fall back to a local build.
+find_hq_cloud_ios() {
+  local git_common_dir hq_root real
+  git_common_dir="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+  [[ -n "$git_common_dir" ]] || return 1
+  case "$git_common_dir" in
+    /*) ;;
+    *) git_common_dir="$(cd "$REPO_ROOT/$git_common_dir" 2>/dev/null && pwd || true)" ;;
+  esac
+  [[ -n "$git_common_dir" ]] || return 1
+  hq_root="$(cd "$git_common_dir/../.." 2>/dev/null && pwd || true)"
+  [[ -n "$hq_root" ]] || return 1
+  real="$hq_root/scripts/reload-cloud-ios.sh"
+  [[ -x "$real" ]] || return 1
+  printf '%s\n' "$real"
+}
+
+ARTIFACT_ROOT="${CLOUD_TESTFLIGHT_ARTIFACT_ROOT:-$REPO_ROOT/artifacts/cloud-testflight}"
+mkdir -p "$ARTIFACT_ROOT"
+
+ARCHIVE_PATH=""
+
+build_archive_cloud() {
+  local hq_cloud="$1" log line
+  # BSD mktemp only expands trailing Xs, so the template must END with XXXXXX.
+  log="$(mktemp "${TMPDIR:-/tmp}/cloud-testflight-cloud.XXXXXX")"
+  err "building UNSIGNED Release beta archive on the fleet via $hq_cloud"
+  local args=( --mode beta-archive --tag "$TAG" --keep-artifacts --beta-bundle-id "$BETA_BUNDLE_ID" )
+  [[ -n "$HOST_FILTER" ]] && args+=( --host "$HOST_FILTER" )
+  [[ "$WAIT_SECONDS" =~ ^[0-9]+$ && "$WAIT_SECONDS" -gt 0 ]] && args+=( --wait "$WAIT_SECONDS" )
+  # Run from the repo root so the hq script's "run from a cmux checkout" check and
+  # its dirty-tree rsync pick up THIS worktree.
+  #
+  # RELOAD_CLOUD_IOS_FALLBACK_LOCAL=0 pins the hq script's no-cloud-slot behavior
+  # to FAIL CLOSED. Its beta-archive mode already refuses its own device fallback
+  # by design (`ios/scripts/reload.sh --device-only` would do a Debug DEVICE
+  # build+install, exit 0, and never print BETA_ARCHIVE_PATH, i.e. silently the
+  # wrong thing), but that guard lives in the hq checkout, whose version this
+  # wrapper does not control. Exporting the kill switch makes the contract
+  # self-enforcing against any hq version: the subprocess either prints
+  # BETA_ARCHIVE_PATH or fails, and THIS script owns the only legitimate
+  # fallback (build_archive_local).
+  if ! ( cd "$REPO_ROOT" && RELOAD_CLOUD_IOS_FALLBACK_LOCAL=0 "$hq_cloud" "${args[@]}" ) 2>&1 | tee "$log"; then
+    err "cloud beta-archive build failed (see $log)"
+    return 1
+  fi
+  line="$(grep -E '^BETA_ARCHIVE_PATH=' "$log" | tail -n 1 || true)"
+  ARCHIVE_PATH="${line#BETA_ARCHIVE_PATH=}"
+  [[ -n "$ARCHIVE_PATH" && -d "$ARCHIVE_PATH" ]] || { err "cloud build did not report a usable BETA_ARCHIVE_PATH"; return 1; }
+  return 0
+}
+
+build_archive_local() {
+  err "building UNSIGNED Release beta archive LOCALLY on this Mac (uses local CPU)"
+  local out build_number
+  out="$ARTIFACT_ROOT/$TAG-$(date -u +%Y%m%d%H%M%S)"
+  mkdir -p "$out"
+  build_number="$(date -u +%Y%m%d%H%M%S)"
+  ARCHIVE_PATH="$out/cmux-ios-beta.xcarchive"
+  [[ -x "$REPO_ROOT/scripts/ensure-ghosttykit.sh" ]] && ( cd "$REPO_ROOT" && ./scripts/ensure-ghosttykit.sh ) || true
+  # Same UNSIGNED Release archive the fleet builds, so the downstream export/
+  # re-sign/upload path is identical. CODE_SIGNING_ALLOWED=NO keeps signing out of
+  # the archive; upload-testflight.sh does all signing.
+  ( cd "$REPO_ROOT" && xcodebuild archive \
+      -workspace ios/cmux.xcworkspace \
+      -scheme cmux-ios \
+      -configuration Release \
+      -destination 'generic/platform=iOS' \
+      -archivePath "$ARCHIVE_PATH" \
+      -derivedDataPath "$out/DerivedData" \
+      PRODUCT_BUNDLE_IDENTIFIER="$BETA_BUNDLE_ID" \
+      CURRENT_PROJECT_VERSION="$build_number" \
+      CODE_SIGNING_ALLOWED=NO \
+      CODE_SIGNING_REQUIRED=NO \
+      CODE_SIGN_IDENTITY="" \
+      | tee "$out/archive.log" )
+  [[ -d "$ARCHIVE_PATH" ]] || die "local archive not produced: $ARCHIVE_PATH"
+}
+
+# --- build the archive (cloud preferred, local fallback) --------------------
+if [[ "$FORCE_LOCAL" == "1" ]]; then
+  build_archive_local
+else
+  if hq_cloud="$(find_hq_cloud_ios)"; then
+    build_archive_cloud "$hq_cloud" || {
+      err "falling back to a LOCAL Release archive"
+      build_archive_local
+    }
+  else
+    err "no cmuxterm-hq cloud build script found; building locally"
+    build_archive_local
+  fi
+fi
+
+[[ -d "$ARCHIVE_PATH" ]] || die "no archive to hand off"
+err "archive ready: $ARCHIVE_PATH"
+
+# Verify an exported/re-signed IPA's single .app is strictly signed AND carries
+# aps-environment == production in its ACTUAL signature. The dry run promises this
+# check, so the LANE enforces it independently of upload-testflight.sh: even if
+# that script's re-sign were ever lost or skipped (an unsigned archive's export
+# carries NO aps-environment at all), this gate FAILS the dry run instead of
+# silently "passing". On the real upload path upload-testflight.sh runs its own
+# pre-altool gate, so this is the dry-run-only backstop.
+verify_ipa_aps_environment_production() {
+  local ipa="$1" workdir app ent aps rc
+  [[ -f "$ipa" ]] || { err "verify: IPA not found: $ipa"; return 1; }
+  workdir="$(mktemp -d)"
+  if ! ( cd "$workdir" && unzip -q "$ipa" ); then err "verify: could not unzip $ipa"; rm -rf "$workdir"; return 1; fi
+  app="$(find "$workdir/Payload" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n 1)"
+  if [[ -z "$app" || ! -d "$app" ]]; then err "verify: IPA has no Payload/*.app: $ipa"; rm -rf "$workdir"; return 1; fi
+  if ! codesign --verify --strict --verbose=2 "$app" >&2; then rm -rf "$workdir"; return 1; fi
+  ent="$workdir/signed-entitlements.plist"
+  if ! codesign -d --entitlements :- --xml "$app" > "$ent" 2>/dev/null; then
+    err "verify: could not read entitlements from signed app: $app"; rm -rf "$workdir"; return 1
+  fi
+  aps="$(/usr/libexec/PlistBuddy -c 'Print :aps-environment' "$ent" 2>/dev/null)"; rc=$?
+  if [[ $rc -ne 0 || "$aps" != "production" ]]; then
+    err "verify: signed app aps-environment is '${aps:-<absent>}', expected 'production' (push would silently fail): $app"
+    plutil -p "$ent" >&2 || true
+    rm -rf "$workdir"; return 1
+  fi
+  rm -rf "$workdir"
+  return 0
+}
+
+# --- hand off to upload-testflight.sh (export + re-sign + verify + upload) ----
+UPLOAD="$IOS_DIR/scripts/upload-testflight.sh"
+[[ -x "$UPLOAD" ]] || die "missing $UPLOAD"
+
+upload_args=( --lane "$LANE" --archive-path "$ARCHIVE_PATH" )
+[[ "$EXTERNAL" -eq 1 ]] && upload_args+=( --external )
+# --no-upload maps to --export-only: upload-testflight.sh exports the IPA,
+# re-signs it with the full Release entitlements, and gates it on
+# aps-environment=production before exiting ahead of altool. The re-sign +
+# verify live in upload-testflight.sh, NOT here, so this lane does not
+# duplicate them; the dry-run gate below independently confirms the result.
+RESIGNED_IPA=""
+if [[ "$NO_UPLOAD" -eq 1 ]]; then
+  upload_args+=( --export-only )
+  err "DRY RUN: export + re-sign then verify, no TestFlight upload"
+  # BSD mktemp only expands trailing Xs, so the template must END with XXXXXX.
+  upload_log="$(mktemp "${TMPDIR:-/tmp}/cloud-testflight-export.XXXXXX")"
+  # `if !` so a failing upload-testflight.sh dies with a pointer to the log
+  # instead of set -e/pipefail killing the script before any message.
+  if ! ( cd "$REPO_ROOT" && "$UPLOAD" "${upload_args[@]}" ) 2>&1 | tee "$upload_log"; then
+    die "upload-testflight.sh --export-only failed (see $upload_log)"
+  fi
+  # upload-testflight.sh prints IPA_PATH=<final ipa> (the re-signed IPA on the
+  # manual signing path).
+  RESIGNED_IPA="$(grep -E '^IPA_PATH=' "$upload_log" | tail -n 1 | sed 's/^IPA_PATH=//')"
+  rm -f "$upload_log"
+  [[ -n "$RESIGNED_IPA" ]] || die "dry run did not produce an IPA to verify"
+  err "verifying exported IPA is strictly signed with aps-environment=production"
+  verify_ipa_aps_environment_production "$RESIGNED_IPA" \
+    || die "DRY RUN FAILED: exported IPA is not a valid production-push build (see above). If the upload-testflight.sh re-sign was skipped or lost, the unsigned archive's export carries no aps-environment at all; that is the gap this gate catches."
+else
+  ( cd "$REPO_ROOT" && "$UPLOAD" "${upload_args[@]}" )
+fi
+
+if [[ "$KEEP_ARTIFACTS" -ne 1 ]]; then
+  # Prune the heavy archive + DerivedData unless --keep-artifacts. A local Release
+  # archive + DerivedData is tens of GB, so leaking it on every --local dry run
+  # would fill the disk. We only remove the .xcarchive's PARENT dir, and only when
+  # it is recognisably one of our artifact dirs: this lane's own root
+  # ($ARTIFACT_ROOT/<tag>-<ts>/) or the hq cloud download
+  # (.../artifacts/reload-cloud-ios/<tag>-<ts>/, which we asked to --keep so we
+  # own the cleanup). Belt-and-suspenders so a returned path can never rm an
+  # unexpected directory.
+  archive_dir="$(dirname "$ARCHIVE_PATH")"
+  case "$archive_dir" in
+    "$ARTIFACT_ROOT"/*-[0-9]*|*/artifacts/reload-cloud-ios/*-[0-9]*)
+      rm -rf "$archive_dir" 2>/dev/null || true ;;
+  esac
+fi
+
+if [[ "$NO_UPLOAD" -eq 1 ]]; then
+  echo
+  echo "==> Cloud TestFlight DRY RUN complete (no upload)"
+  echo "Archive:      $ARCHIVE_PATH"
+  echo "Verified IPA: $RESIGNED_IPA"
+  echo "The exported IPA passed the lane's strict codesign verify and carries"
+  echo "aps-environment=production in its signed entitlements. No TestFlight upload."
+else
+  echo
+  echo "==> Cloud TestFlight upload complete"
+  if [[ "$EXTERNAL" -eq 1 ]]; then
+    echo "Lane:     $LANE (external-eligible; first external build of a version needs Apple Beta App Review)"
+  else
+    echo "Lane:     $LANE (internal-only)"
+  fi
+fi

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -1,6 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Verify a built/exported IPA's single .app is strictly signed AND carries
+# aps-environment == "production" in its actual code signature. A config-level
+# entitlement only delivers push if it survives into the SIGNED binary; only
+# `codesign -d --entitlements` on the .app proves it (see the #5496 regression
+# note below). The VALUE matters, not just presence: a "development" value
+# registers a sandbox token that the production APNs host (which TestFlight runs
+# against) rejects with BadDeviceToken, which is the exact failure this guards.
+# Returns 0 only when production push is genuinely wired; non-zero otherwise.
+# One shared check used by both signing paths (manual post-re-sign gate,
+# automatic pre-upload gate) so the two paths can't drift.
+verify_ipa_aps_environment_production() {
+  local ipa="$1"
+  local workdir app ent aps rc
+  workdir="$(mktemp -d)"
+  if ! ( cd "$workdir" && unzip -q "$ipa" ); then
+    echo "error: could not unzip IPA to verify entitlements: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  app="$(find "$workdir/Payload" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n 1)"
+  if [[ -z "$app" || ! -d "$app" ]]; then
+    echo "error: IPA has no Payload/*.app to verify: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  # --verify --strict catches a corrupt bundle (e.g. a bad re-zip).
+  if ! codesign --verify --strict --verbose=2 "$app" >&2; then
+    rm -rf "$workdir"
+    return 1
+  fi
+  # Read the signed entitlements and assert aps-environment == production.
+  ent="$workdir/signed-entitlements.plist"
+  if ! codesign -d --entitlements :- --xml "$app" > "$ent" 2>/dev/null; then
+    echo "error: could not read entitlements from signed app: $app" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  # PlistBuddy exits non-zero (and prints to stdout) when the key is absent, so
+  # capture rc and require an exact "production" match.
+  aps="$(/usr/libexec/PlistBuddy -c 'Print :aps-environment' "$ent" 2>/dev/null)"
+  rc=$?
+  if [[ $rc -ne 0 || "$aps" != "production" ]]; then
+    echo "error: signed app aps-environment is '${aps:-<absent>}', expected 'production' (push would silently fail): $app" >&2
+    plutil -p "$ent" >&2 || true
+    rm -rf "$workdir"
+    return 1
+  fi
+  rm -rf "$workdir"
+  return 0
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -13,6 +64,17 @@ TestFlight. The default lane is beta:
 
   bundle id: dev.cmux.app.beta
   profile:   cmux Beta Distribution
+
+On the manual signing path the exported app is RE-SIGNED with the full
+entitlements before upload. The archive is built unsigned (to avoid
+distribution-cert churn), so -exportArchive re-adds only the profile baseline
+and silently DROPS app-capability entitlements like aps-environment. That is
+the https://github.com/manaflow-ai/cmux/pull/5496 regression that killed
+beta/prod push. A config-level entitlements file alone does not prove the
+entitlement reaches the signed binary; only codesign -d --entitlements on the
+exported app does. So the re-sign merges Config/cmux-release.entitlements into
+the export baseline and signs with the local distribution cert, gated on
+codesign showing aps-environment and a strict signature verify.
 
 Authentication uses one of:
 
@@ -387,6 +449,131 @@ IPA_PATH="$EXPORT_PATH/cmux.ipa"
 if [[ ! -f "$IPA_PATH" ]]; then
   echo "error: IPA was not exported at $IPA_PATH" >&2
   exit 1
+fi
+
+# Re-sign the exported app with the FULL entitlements (production aps-environment
+# et al.), then point $IPA_PATH at the re-signed IPA so the upload below ships it.
+#
+# Why this is necessary: the archive is built UNSIGNED (CODE_SIGNING_ALLOWED=NO,
+# see above) to avoid distribution-cert churn on ephemeral runners. An unsigned
+# archive carries NO entitlements, so `-exportArchive` re-adds only the profile
+# baseline (application-identifier, com.apple.developer.team-identifier,
+# get-task-allow, beta-reports-active) and SILENTLY DROPS app-capability
+# entitlements such as aps-environment. This regressed in
+# https://github.com/manaflow-ai/cmux/pull/5496 (June 2026): the signed beta IPA
+# had aps-environment absent entirely, so the device registered no push token and
+# beta/prod push was dead. The per-config entitlements file fix
+# (Config/cmux-release.entitlements) is necessary but NOT sufficient on its own:
+# a config-level entitlement only ships if it survives into the signed binary,
+# and only `codesign -d --entitlements` on the EXPORTED app proves that. So we
+# re-sign here with the export baseline MERGED with the Release entitlements file.
+#
+# This runs on the MANUAL signing path only: it re-signs with the named
+# distribution cert from the local keychain ("Apple Distribution: Manaflow,
+# Inc."), which is present for local/fleet-archive beta cuts. The cmux iOS app is
+# a single self-contained bundle (no Frameworks/, no PlugIns/, GhosttyKit is
+# static), so only the top-level .app is signed; there is no nested code to
+# re-sign. Two alternatives were ruled out: an ad-hoc archive (CODE_SIGN_IDENTITY
+# "-") is rejected by the iOS SDK for an entitled app, and signing on the shared
+# fleet would put distribution material on shared Macs.
+if [[ "$SIGNING" == "manual" ]]; then
+  # Resolve the Release entitlements file. Release.xcconfig statically sets
+  # CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements, so default to that
+  # path rather than parsing xcodebuild -showBuildSettings (slower, more brittle).
+  RELEASE_ENTITLEMENTS="${IOS_RELEASE_ENTITLEMENTS:-$IOS_DIR/Config/cmux-release.entitlements}"
+  RESIGN_IDENTITY="${IOS_DISTRIBUTION_IDENTITY:-Apple Distribution: Manaflow, Inc. (7WLXT3NR37)}"
+
+  if [[ ! -f "$RELEASE_ENTITLEMENTS" ]]; then
+    echo "error: re-sign needs the Release entitlements file but it is missing: $RELEASE_ENTITLEMENTS (set IOS_RELEASE_ENTITLEMENTS to override)" >&2
+    exit 1
+  fi
+  if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$RESIGN_IDENTITY"; then
+    echo "error: re-sign needs the distribution identity '$RESIGN_IDENTITY' in the keychain, but it was not found (security find-identity -v -p codesigning). Set IOS_DISTRIBUTION_IDENTITY, or run on a Mac with the Apple Distribution cert." >&2
+    exit 1
+  fi
+
+  RESIGN_DIR="$OUT_DIR/resign"
+  rm -rf "$RESIGN_DIR"
+  mkdir -p "$RESIGN_DIR"
+  ( cd "$RESIGN_DIR" && unzip -q "$IPA_PATH" )
+  RESIGN_APP="$(find "$RESIGN_DIR/Payload" -maxdepth 1 -name '*.app' -type d | head -n 1)"
+  if [[ -z "$RESIGN_APP" || ! -d "$RESIGN_APP" ]]; then
+    echo "error: could not find Payload/*.app inside the exported IPA to re-sign" >&2
+    exit 1
+  fi
+
+  # Start from the exported app's current (profile-baseline) entitlements, then
+  # MERGE every key from the Release entitlements file. The merge is GENERIC:
+  # PlistBuddy Merge copies all keys from the Release file and skips any that
+  # already exist in the baseline, so future entitlements survive automatically
+  # and existing baseline values (e.g. get-task-allow=false) are preserved.
+  MERGED_ENTITLEMENTS="$RESIGN_DIR/entitlements.plist"
+  codesign -d --entitlements :- --xml "$RESIGN_APP" > "$MERGED_ENTITLEMENTS" 2>/dev/null || {
+    echo "error: could not read current entitlements from the exported app: $RESIGN_APP" >&2
+    exit 1
+  }
+  # `|| true`: PlistBuddy Merge prints "Duplicate Entry Was Skipped" if a future
+  # Release key ever overlaps a baseline key. That is the intended behavior
+  # (baseline wins), but its exit code on that path is not contractually 0 across
+  # OS versions, and a stray non-zero would kill the script under `set -e`. The
+  # exit code is non-load-bearing anyway: a genuinely failed merge produces no
+  # aps-environment and is caught by the hard gate below with a clear error.
+  /usr/libexec/PlistBuddy -c "Merge $RELEASE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null || true
+  plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
+
+  codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"
+
+  # HARD GATES on the signed .app: the entitlement we are fixing must be present,
+  # and the signature must be strictly valid. A config-level check cannot prove
+  # either; only codesign on the actual binary does.
+  if ! codesign -d --entitlements :- --xml "$RESIGN_APP" 2>/dev/null | plutil -p - | grep -q '"aps-environment"'; then
+    echo "error: re-signed app is still missing aps-environment; refusing to upload a push-broken build" >&2
+    codesign -d --entitlements :- --xml "$RESIGN_APP" 2>/dev/null | plutil -p - >&2 || true
+    exit 1
+  fi
+  codesign --verify --strict --verbose=2 "$RESIGN_APP"
+
+  # Re-zip with the exact IPA layout (Payload/ at archive root) and repoint
+  # $IPA_PATH so the existing upload step ships the re-signed IPA.
+  RESIGNED_IPA="$EXPORT_PATH/cmux-resigned.ipa"
+  rm -f "$RESIGNED_IPA"
+  ( cd "$RESIGN_DIR" && zip -qrX "$RESIGNED_IPA" Payload )
+
+  # Post-zip gate: a wrong Payload root or stripped attributes corrupts the bundle
+  # silently, and the whole point is that aps-environment survives. Re-verify the
+  # produced IPA (strict signature + aps-environment) so altool is not the first
+  # thing to notice. Same shared check the automatic path uses.
+  if ! verify_ipa_aps_environment_production "$RESIGNED_IPA"; then
+    echo "error: re-signed IPA failed verification (corrupt bundle, or aps-environment not production); refusing to upload" >&2
+    exit 1
+  fi
+
+  IPA_PATH="$RESIGNED_IPA"
+  echo "re-signed IPA with full entitlements (aps-environment=production): $IPA_PATH"
+else
+  # Automatic (cloud-managed) signing: there is no named distribution cert in the
+  # keychain to re-sign with, so we cannot re-add a dropped entitlement here. The
+  # archive is unsigned and -exportArchive does NOT mine the profile's
+  # app-capability entitlements (verified: even a manual export with the
+  # push-capable "cmux Beta Distribution" profile produced only the 4-key baseline
+  # with no aps-environment), so an automatic export almost certainly drops it too.
+  #
+  # Rather than upload a known-push-broken build with only a warning (CI warnings
+  # are effectively silent, and ios-testflight.yml drives the PRIMARY beta cut with
+  # --signing automatic), FAIL CLOSED: verify the exported IPA actually carries
+  # aps-environment, and refuse the upload if it does not. If automatic ever does
+  # preserve it, the gate passes and upload proceeds.
+  #
+  # To make CI cut a push-WORKING beta, ios-testflight.yml must import the iOS
+  # distribution cert and call this script with --signing manual (nightly.yml /
+  # release.yml already import a signing cert on ephemeral runners, so the pattern
+  # exists). That is a security-relevant workflow + secrets decision, deliberately
+  # out of scope here; this gate just stops shipping a broken artifact until then.
+  if ! verify_ipa_aps_environment_production "$IPA_PATH"; then
+    echo "error: --signing automatic produced an IPA without aps-environment=production; refusing to upload a push-broken beta. Cut the beta via --signing manual (import the iOS distribution cert in CI), or re-sign with the distribution cert." >&2
+    exit 1
+  fi
+  echo "automatic-signed IPA verified to carry aps-environment=production: $IPA_PATH"
 fi
 
 echo "IPA_PATH=$IPA_PATH"


### PR DESCRIPTION
Turnkey cloud TestFlight lane for the cmux iOS beta, scripts only.

`ios/scripts/cloud-testflight.sh` builds an UNSIGNED Release archive for `dev.cmux.app.beta` on a leased fleet Mac (same maclease pool as the device cloud reload, m1ultra excluded), downloads it, and hands it to `ios/scripts/upload-testflight.sh --archive-path` for the local export, re-sign with the Apple Distribution cert, strict verification, and TestFlight upload. No signing material ever lands on the shared builders (they also run GitHub Actions, i.e. arbitrary PR code). `--no-upload` is a verified dry run; `--external` makes the build external-tester eligible; a standalone clone with no hq checkout falls back to a local Release archive.

`upload-testflight.sh` changes (a superset of the copy in https://github.com/manaflow-ai/cmux/pull/5647: same re-sign and gates, plus this branch preserves main's existing `--external` support, which that PR's older base accidentally reverts; whichever lands second takes a trivial rebase on this file):

- Manual path: after `-exportArchive`, re-sign the exported app with `Config/cmux-release.entitlements` merged into the export's profile baseline. The archive is unsigned, so the export re-adds only the profile baseline and silently drops app-capability entitlements like `aps-environment`; that is the https://github.com/manaflow-ai/cmux/pull/5496 regression that killed beta push. Hard gates: `codesign -d --entitlements` must show `aps-environment`, `codesign --verify --strict` must pass, and the re-zipped IPA is re-verified (shared `verify_ipa_aps_environment_production` check, asserting the value is exactly `production`).
- Automatic path: fail closed before `altool` when the exported IPA does not carry `aps-environment=production`, instead of uploading a push-broken beta with a warning nobody reads.
- The re-sign and gates run before the `--export-only` exit, so a dry run verifies exactly what it claims.

Review notes from the dual-review pass, both deliberate:

- The automatic-signing gate means `.github/workflows/ios-testflight.yml` (which uses `--signing automatic`) will fail closed at the pre-upload gate until CI imports the iOS distribution cert and switches to `--signing manual`. That cert/secrets decision is open on https://github.com/manaflow-ai/cmux/pull/5647 and is intentionally not made here. Until then a red workflow replaces silently push-dead beta uploads.
- `ios/Config/cmux-release.entitlements` is carried byte-identical from https://github.com/manaflow-ai/cmux/pull/5647 and is not wired into `Release.xcconfig` here; that wiring (plus the gateway/version changes it depends on) stays in that PR. This lane does not need it: the fleet archive is unsigned, so `CODE_SIGN_ENTITLEMENTS` never applies to it, and entitlements enter only via the re-sign, which reads the file directly.

Cloud-failure ordering: the hq-side `reload-cloud-ios.sh --mode beta-archive` fails closed when no cloud builder is usable (it never degrades to its Debug device-install fallback), and the wrapper additionally pins that with `RELOAD_CLOUD_IOS_FALLBACK_LOCAL=0` in the subprocess env so the contract holds against any hq checkout version. The wrapper owns the only legitimate fallback, a local Release archive that feeds the same export/re-sign path.

Dry run executed end to end (maclease on aws-m4pro-4, fleet UNSIGNED Release archive for `dev.cmux.app.beta`, download, local export, re-sign, verification, no upload), exit 0:

```
reload-cloud-ios: leased aws-m4pro-4 (host aws-m4pro-4, lease 20260609163...)
reload-cloud-ios: aws-m4pro-4 has 25G free (>= 20G floor)
** ARCHIVE SUCCEEDED **
reload-cloud-ios: remote archive build finished in 32s
==> Cloud iOS beta archive ready (UNSIGNED)
Bundle id:     dev.cmux.app.beta
BETA_ARCHIVE_PATH=.../artifacts/reload-cloud-ios/betadry-1781048415/cmux-ios-betadry.xcarchive
cloud-testflight: DRY RUN: export + re-sign then verify, no TestFlight upload
** EXPORT SUCCEEDED **
/tmp/cmux-ios-testflight-20260609234022/resign/Payload/cmux.app: valid on disk
/tmp/cmux-ios-testflight-20260609234022/resign/Payload/cmux.app: satisfies its Designated Requirement
re-signed IPA with full entitlements (aps-environment=production): .../export/cmux-resigned.ipa
cloud-testflight: verifying exported IPA is strictly signed with aps-environment=production
==> Cloud TestFlight DRY RUN complete (no upload)
The exported IPA passed the lane's strict codesign verify and carries
aps-environment=production in its signed entitlements. No TestFlight upload.
```

Signed entitlements read back from the re-signed IPA with `codesign -d --entitlements`:

```
"application-identifier" => "7WLXT3NR37.dev.cmux.app.beta"
"aps-environment" => "production"
"beta-reports-active" => true
"com.apple.developer.applesignin" => [ "Default" ]
"com.apple.developer.team-identifier" => "7WLXT3NR37"
"com.apple.developer.usernotifications.time-sensitive" => true
"get-task-allow" => false
```

Autoreview (codex, branch vs origin/main) is clean apart from the two scoped boundaries above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783640524&installation_id=133855650&pr_number=5729&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5729&signature=6f886549e62fa8134a0c33b2716059f5bb43cf4c9977ff228218b6eec26c1abc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary TestFlight publish scripts and will block CI automatic-signing uploads until manual cert wiring; incorrect signing/entitlements would break beta push or releases.
> 
> **Overview**
> Adds a **turnkey cloud TestFlight lane** for the iOS beta (`dev.cmux.app.beta`): `ios/scripts/cloud-testflight.sh` builds an **unsigned** Release archive on leased fleet Macs (or locally when hq cloud / `--local`), then delegates export, re-sign, verification, and upload to `upload-testflight.sh --archive-path`. Supports `--no-upload` dry runs, `--external`, and documents the flow in `ios/README.md`.
> 
> **Fixes silent broken push on TestFlight** by extending `upload-testflight.sh`: after export, the **manual** path re-signs the IPA with `Config/cmux-release.entitlements` merged into the profile baseline (restoring `aps-environment=production`), with strict `codesign` gates and a shared `verify_ipa_aps_environment_production` check. The **automatic** path now **fails closed** if the exported IPA lacks production `aps-environment` instead of uploading a push-dead build. Adds `ios/Config/cmux-release.entitlements` (production APNs, Sign in with Apple, time-sensitive notifications) for that re-sign step.
> 
> **Operational note:** `ios-testflight.yml` still uses `--signing automatic`, so CI beta uploads will fail at the new gate until the workflow switches to manual signing with a distribution cert in the keychain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7127b28e74ada987de16717746406470fbcd0a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turnkey cloud TestFlight lane for the iOS beta: builds an UNSIGNED Release archive on a fleet Mac, then locally exports, re-signs with the Distribution cert to restore `aps-environment=production`, strictly verifies, and uploads. Prevents push‑broken beta uploads with fail‑closed gates and supports a verified `--no-upload` dry run.

- New Features
  - Added `ios/scripts/cloud-testflight.sh` to build on a leased Mac, download the archive, and hand off to `ios/scripts/upload-testflight.sh`; supports `--no-upload`, `--external`, wait/host selection, and local fallback.
  - `ios/scripts/upload-testflight.sh` now enforces a strict re-sign/verify step and prints `IPA_PATH` on `--export-only`; bundled `ios/Config/cmux-release.entitlements` supplies `aps-environment=production`.
  - README documents the lane and usage.

- Migration
  - CI using `--signing automatic` will now fail closed before upload if the IPA lacks `aps-environment=production`. Import the iOS Distribution cert in CI and switch to `--signing manual` in `.github/workflows/ios-testflight.yml` to cut push‑working betas.

<sup>Written for commit 7127b28e74ada987de16717746406470fbcd0a0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

