### PR TITLE
Post one banner and one sound for blocking agent prompts

### DIFF
--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -156,19 +156,25 @@ final class FeedCoordinator: @unchecked Sendable {
             }
         }
 
+        // While this decision is pending, this banner is the canonical
+        // desktop alert for the surface: the same prompt also fires the
+        // agent's notification hook, which would otherwise post a second
+        // banner (and second sound) through TerminalNotificationStore
+        // (manaflow-ai/cmux#2322). Claim the surface for the decision's
+        // lifetime so the store keeps its sidebar record but stands down
+        // from desktop alerts.
+        let deliveryGateKey = resolvedAttentionTarget.map {
+            TerminalNotificationDeliveryGate.key(workspaceId: $0.workspaceId, surfaceId: $0.surfaceId)
+        }
+        TerminalNotificationDeliveryGate.shared.beginBlockingDecision(forKey: deliveryGateKey)
+
         // If this is a blocking actionable event and the app window isn't
         // focused, post a native notification banner with inline action
         // buttons so the user can respond without switching windows.
-        // The sound-gate key lets the banner share its sound window with the
-        // agent-hook notification the same prompt routes through
-        // TerminalNotificationStore, so one decision never dings twice.
-        let soundGateKey = resolvedAttentionTarget.map {
-            TerminalNotificationSoundGate.key(workspaceId: $0.workspaceId, surfaceId: $0.surfaceId)
-        }
         postNotificationIfStillAwaiting(
             event: event,
             requestId: requestId,
-            soundGateKey: soundGateKey
+            deliveryGateKey: deliveryGateKey
         )
 
         let deadline: DispatchTime = .now() + waitTimeout
@@ -177,6 +183,7 @@ final class FeedCoordinator: @unchecked Sendable {
         waiterLock.lock()
         let w = waiters.removeValue(forKey: requestId)
         waiterLock.unlock()
+        TerminalNotificationDeliveryGate.shared.endBlockingDecision(forKey: deliveryGateKey)
 
         switch waitResult {
         case .success:
@@ -721,7 +728,7 @@ private extension FeedCoordinator {
     func postNotificationIfStillAwaiting(
         event: WorkstreamEvent,
         requestId: String,
-        soundGateKey: String? = nil
+        deliveryGateKey: String? = nil
     ) {
         Task { @MainActor [weak self] in
             guard let self, self.isAwaitingDecision(requestId: requestId) else {
@@ -803,7 +810,7 @@ private extension FeedCoordinator {
                     subtitle: "",
                     body: body,
                     effects: policyContext.envelope.effects,
-                    soundGateKey: soundGateKey
+                    deliveryGateKey: deliveryGateKey
                 )
             }
 
@@ -838,7 +845,7 @@ private extension FeedCoordinator {
                     subtitle: payload.subtitle,
                     body: payload.body,
                     effects: envelope.effects,
-                    soundGateKey: soundGateKey
+                    deliveryGateKey: deliveryGateKey
                 )
             case .failure(let failure):
                 deliverDefault()
@@ -877,19 +884,21 @@ private extension FeedCoordinator {
         subtitle: String,
         body: String,
         effects: TerminalNotificationPolicyEffects,
-        soundGateKey: String? = nil
+        deliveryGateKey: String? = nil
     ) {
         var effects = effects
         guard isAwaitingDecision(requestId: requestId),
               effects.desktop || effects.sound || effects.command
         else { return }
 
-        // One blocking prompt also fires the agent's notification hook, which
-        // posts a separate banner through TerminalNotificationStore. Share the
-        // per-surface sound window with that path so the prompt dings once no
-        // matter which banner lands first (manaflow-ai/cmux#2322).
+        // One blocking prompt also fires the agent's notification hook. The
+        // delivery gate makes this banner the canonical alert: the store
+        // stands down while the decision is pending, any agent-hook banner
+        // that raced ahead of the claim is withdrawn below, and the shared
+        // sound window guarantees a single ding either way
+        // (manaflow-ai/cmux#2322).
         if effects.sound,
-           !TerminalNotificationSoundGate.shared.shouldPlaySound(forKey: soundGateKey) {
+           !TerminalNotificationDeliveryGate.shared.claimSound(forKey: deliveryGateKey) {
             effects.sound = false
         }
 
@@ -902,6 +911,16 @@ private extension FeedCoordinator {
                 effects: effects
             )
             return
+        }
+
+        // This banner supersedes any agent-hook banner that raced ahead of
+        // the blocking-decision claim — withdraw it so exactly one banner
+        // remains visible for the prompt.
+        if let deliveryGateKey {
+            TerminalNotificationStore.shared.withdrawRecentDeliveredDesktopNotifications(
+                forGateKey: deliveryGateKey,
+                since: Date().addingTimeInterval(-5)
+            )
         }
 
         let content = UNMutableNotificationContent()

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -159,7 +159,17 @@ final class FeedCoordinator: @unchecked Sendable {
         // If this is a blocking actionable event and the app window isn't
         // focused, post a native notification banner with inline action
         // buttons so the user can respond without switching windows.
-        postNotificationIfStillAwaiting(event: event, requestId: requestId)
+        // The sound-gate key lets the banner share its sound window with the
+        // agent-hook notification the same prompt routes through
+        // TerminalNotificationStore, so one decision never dings twice.
+        let soundGateKey = resolvedAttentionTarget.map {
+            TerminalNotificationSoundGate.key(workspaceId: $0.workspaceId, surfaceId: $0.surfaceId)
+        }
+        postNotificationIfStillAwaiting(
+            event: event,
+            requestId: requestId,
+            soundGateKey: soundGateKey
+        )
 
         let deadline: DispatchTime = .now() + waitTimeout
         let waitResult = semaphore.wait(timeout: deadline)
@@ -708,7 +718,11 @@ private extension FeedCoordinator {
     /// Notification eligibility is derived only from the waiter table so
     /// resolved/timed-out requests cannot enqueue stale banners while the main
     /// queue, policy hooks, or notification center catches up.
-    func postNotificationIfStillAwaiting(event: WorkstreamEvent, requestId: String) {
+    func postNotificationIfStillAwaiting(
+        event: WorkstreamEvent,
+        requestId: String,
+        soundGateKey: String? = nil
+    ) {
         Task { @MainActor [weak self] in
             guard let self, self.isAwaitingDecision(requestId: requestId) else {
                 return
@@ -788,7 +802,8 @@ private extension FeedCoordinator {
                     title: title,
                     subtitle: "",
                     body: body,
-                    effects: policyContext.envelope.effects
+                    effects: policyContext.envelope.effects,
+                    soundGateKey: soundGateKey
                 )
             }
 
@@ -822,7 +837,8 @@ private extension FeedCoordinator {
                     title: payload.title,
                     subtitle: payload.subtitle,
                     body: payload.body,
-                    effects: envelope.effects
+                    effects: envelope.effects,
+                    soundGateKey: soundGateKey
                 )
             case .failure(let failure):
                 deliverDefault()
@@ -860,11 +876,22 @@ private extension FeedCoordinator {
         title: String,
         subtitle: String,
         body: String,
-        effects: TerminalNotificationPolicyEffects
+        effects: TerminalNotificationPolicyEffects,
+        soundGateKey: String? = nil
     ) {
+        var effects = effects
         guard isAwaitingDecision(requestId: requestId),
               effects.desktop || effects.sound || effects.command
         else { return }
+
+        // One blocking prompt also fires the agent's notification hook, which
+        // posts a separate banner through TerminalNotificationStore. Share the
+        // per-surface sound window with that path so the prompt dings once no
+        // matter which banner lands first (manaflow-ai/cmux#2322).
+        if effects.sound,
+           !TerminalNotificationSoundGate.shared.shouldPlaySound(forKey: soundGateKey) {
+            effects.sound = false
+        }
 
         if !effects.desktop {
             runFallbackEffectsIfStillAwaiting(

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -770,6 +770,59 @@ enum TerminalNotificationClickAction: Codable, Hashable, Sendable {
     }
 }
 
+/// Deduplicates notification sounds across independent banner paths.
+///
+/// A single blocking agent prompt can legitimately post two desktop banners
+/// almost at once: the agent's notification hook (`cmux hooks <agent>
+/// notification`) routes through ``TerminalNotificationStore`` while the feed
+/// decision bridge posts its own actionable banner straight to
+/// `UNUserNotificationCenter` (`FeedCoordinator.postNotificationIfStillAwaiting`).
+/// The banners carry different content, so they cannot be deduplicated by
+/// identity — but both request a sound, and the user hears a double ding for
+/// one event (manaflow-ai/cmux#2322).
+///
+/// The gate grants the sound to the first banner per surface inside a short
+/// window and silences follow-ups. Banner visibility is unaffected; denied
+/// attempts do not extend the window.
+final class TerminalNotificationSoundGate: @unchecked Sendable {
+    static let shared = TerminalNotificationSoundGate()
+
+    let suppressionWindow: TimeInterval
+
+    private let lock = NSLock()
+    private var lastGrantDateByKey: [String: Date] = [:]
+    private let maxTrackedKeys = 128
+
+    init(suppressionWindow: TimeInterval = 2.0) {
+        self.suppressionWindow = suppressionWindow
+    }
+
+    /// The dedupe key for a notification target. Keyed by surface when known
+    /// so prompts on different panes of one workspace stay independent.
+    static func key(workspaceId: UUID, surfaceId: UUID?) -> String {
+        (surfaceId ?? workspaceId).uuidString
+    }
+
+    /// Returns whether a sound may play for the given key, recording a grant
+    /// when it does. `nil` keys are never deduplicated.
+    func shouldPlaySound(forKey key: String?, now: Date = Date()) -> Bool {
+        guard let key, !key.isEmpty else { return true }
+        lock.lock()
+        defer { lock.unlock() }
+        if let lastGrant = lastGrantDateByKey[key],
+           abs(now.timeIntervalSince(lastGrant)) < suppressionWindow {
+            return false
+        }
+        if lastGrantDateByKey.count >= maxTrackedKeys {
+            lastGrantDateByKey = lastGrantDateByKey.filter {
+                abs(now.timeIntervalSince($0.value)) < suppressionWindow
+            }
+        }
+        lastGrantDateByKey[key] = now
+        return true
+    }
+}
+
 struct TerminalNotification: Identifiable, Hashable {
     let id: UUID
     let tabId: UUID
@@ -1987,6 +2040,7 @@ final class TerminalNotificationStore: ObservableObject {
         _ notification: TerminalNotification,
         effects: TerminalNotificationPolicyEffects
     ) {
+        let effects = effectsAfterSoundGate(effects, for: notification)
         guard effects.desktop else {
             playLocalNotificationFeedback(
                 title: resolvedNotificationTitle(for: notification),
@@ -2057,10 +2111,30 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
 
+    /// Strips the sound effect when another banner for the same surface was
+    /// granted a sound moments ago (see ``TerminalNotificationSoundGate``).
+    private func effectsAfterSoundGate(
+        _ effects: TerminalNotificationPolicyEffects,
+        for notification: TerminalNotification
+    ) -> TerminalNotificationPolicyEffects {
+        guard effects.sound else { return effects }
+        let key = TerminalNotificationSoundGate.key(
+            workspaceId: notification.tabId,
+            surfaceId: notification.surfaceId
+        )
+        guard !TerminalNotificationSoundGate.shared.shouldPlaySound(forKey: key) else {
+            return effects
+        }
+        var silenced = effects
+        silenced.sound = false
+        return silenced
+    }
+
     private func playSuppressedNotificationFeedback(
         for notification: TerminalNotification,
         effects: TerminalNotificationPolicyEffects
     ) {
+        let effects = effectsAfterSoundGate(effects, for: notification)
         playLocalNotificationFeedback(
             title: resolvedNotificationTitle(for: notification),
             subtitle: notification.subtitle,

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -770,55 +770,116 @@ enum TerminalNotificationClickAction: Codable, Hashable, Sendable {
     }
 }
 
-/// Deduplicates notification sounds across independent banner paths.
+/// Coordinates desktop alerts for one logical agent prompt across the two
+/// independent banner paths.
 ///
-/// A single blocking agent prompt can legitimately post two desktop banners
-/// almost at once: the agent's notification hook (`cmux hooks <agent>
-/// notification`) routes through ``TerminalNotificationStore`` while the feed
-/// decision bridge posts its own actionable banner straight to
-/// `UNUserNotificationCenter` (`FeedCoordinator.postNotificationIfStillAwaiting`).
-/// The banners carry different content, so they cannot be deduplicated by
-/// identity — but both request a sound, and the user hears a double ding for
-/// one event (manaflow-ai/cmux#2322).
+/// A blocking agent decision (PermissionRequest / ExitPlanMode /
+/// AskUserQuestion) legitimately reaches the user twice: the agent's
+/// notification hook (`cmux hooks <agent> notification`) posts through
+/// ``TerminalNotificationStore`` while the feed decision bridge posts its own
+/// actionable banner straight to `UNUserNotificationCenter`
+/// (`FeedCoordinator.postNotificationIfStillAwaiting`). Without coordination
+/// the user gets two banners and two sounds for one prompt
+/// (manaflow-ai/cmux#2322).
 ///
-/// The gate grants the sound to the first banner per surface inside a short
-/// window and silences follow-ups. Banner visibility is unaffected; denied
-/// attempts do not extend the window.
-final class TerminalNotificationSoundGate: @unchecked Sendable {
-    static let shared = TerminalNotificationSoundGate()
+/// The gate makes the feed's actionable banner the canonical desktop alert
+/// for blocking decisions, deterministically — not "whichever path wins":
+/// - While a blocking decision is pending for a surface
+///   (``beginBlockingDecision(forKey:)`` / ``endBlockingDecision(forKey:)``),
+///   the store keeps recording sidebar notifications but stands down from
+///   desktop banners, sounds, and notification commands for that surface.
+/// - If the store's banner raced ahead of the decision registration, the feed
+///   withdraws it from Notification Center when posting its own
+///   (`TerminalNotificationStore.withdrawRecentDeliveredDesktopNotifications`).
+/// - ``claimSound(forKey:now:)`` additionally guarantees at most one sound
+///   per surface inside a short window no matter which banner landed first.
+final class TerminalNotificationDeliveryGate: @unchecked Sendable {
+    static let shared = TerminalNotificationDeliveryGate()
 
-    let suppressionWindow: TimeInterval
+    let soundWindow: TimeInterval
+    let blockingClaimWindow: TimeInterval
 
     private let lock = NSLock()
-    private var lastGrantDateByKey: [String: Date] = [:]
+    private var lastSoundGrantDateByKey: [String: Date] = [:]
+    private var blockingClaimsByKey: [String: (count: Int, latestBeginDate: Date)] = [:]
     private let maxTrackedKeys = 128
 
-    init(suppressionWindow: TimeInterval = 2.0) {
-        self.suppressionWindow = suppressionWindow
+    init(soundWindow: TimeInterval = 2.0, blockingClaimWindow: TimeInterval = 5.0) {
+        self.soundWindow = soundWindow
+        self.blockingClaimWindow = blockingClaimWindow
     }
 
-    /// The dedupe key for a notification target. Keyed by surface when known
-    /// so prompts on different panes of one workspace stay independent.
+    /// The coordination key for a notification target. Keyed by surface when
+    /// known so prompts on different panes of one workspace stay independent.
     static func key(workspaceId: UUID, surfaceId: UUID?) -> String {
         (surfaceId ?? workspaceId).uuidString
     }
 
+    // MARK: Blocking decisions
+
+    /// Marks a blocking decision as pending for the surface. Refcounted, so
+    /// overlapping decisions on one surface stay claimed until the last one
+    /// concludes. `nil` keys (unresolvable targets) are ignored.
+    func beginBlockingDecision(forKey key: String?, now: Date = Date()) {
+        guard let key, !key.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let count = blockingClaimsByKey[key]?.count ?? 0
+        blockingClaimsByKey[key] = (count: count + 1, latestBeginDate: now)
+    }
+
+    /// Concludes one pending blocking decision for the surface. Unbalanced
+    /// calls are a no-op.
+    func endBlockingDecision(forKey key: String?) {
+        guard let key, !key.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let claim = blockingClaimsByKey[key] else { return }
+        if claim.count <= 1 {
+            blockingClaimsByKey.removeValue(forKey: key)
+        } else {
+            blockingClaimsByKey[key] = (count: claim.count - 1, latestBeginDate: claim.latestBeginDate)
+        }
+    }
+
+    /// Whether a blocking decision currently claims desktop alerts for the
+    /// surface.
+    ///
+    /// The claim is time-boxed: the agent-hook banner for the same prompt
+    /// arrives within moments of the decision event, while the decision
+    /// itself can stay pending for minutes (e.g. the user answers in the
+    /// terminal, which the app only observes as a timeout). Suppressing for
+    /// the whole pendency would swallow legitimate later alerts on the
+    /// surface — like a completion banner right after an approval — so the
+    /// claim only suppresses near its start and unrelated alerts pass
+    /// through afterwards.
+    func hasActiveBlockingDecision(forKey key: String?, now: Date = Date()) -> Bool {
+        guard let key, !key.isEmpty else { return false }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let claim = blockingClaimsByKey[key] else { return false }
+        return abs(now.timeIntervalSince(claim.latestBeginDate)) < blockingClaimWindow
+    }
+
+    // MARK: Sound window
+
     /// Returns whether a sound may play for the given key, recording a grant
-    /// when it does. `nil` keys are never deduplicated.
-    func shouldPlaySound(forKey key: String?, now: Date = Date()) -> Bool {
+    /// when it does. `nil` keys are never silenced; denied attempts do not
+    /// extend the window.
+    func claimSound(forKey key: String?, now: Date = Date()) -> Bool {
         guard let key, !key.isEmpty else { return true }
         lock.lock()
         defer { lock.unlock() }
-        if let lastGrant = lastGrantDateByKey[key],
-           abs(now.timeIntervalSince(lastGrant)) < suppressionWindow {
+        if let lastGrant = lastSoundGrantDateByKey[key],
+           abs(now.timeIntervalSince(lastGrant)) < soundWindow {
             return false
         }
-        if lastGrantDateByKey.count >= maxTrackedKeys {
-            lastGrantDateByKey = lastGrantDateByKey.filter {
-                abs(now.timeIntervalSince($0.value)) < suppressionWindow
+        if lastSoundGrantDateByKey.count >= maxTrackedKeys {
+            lastSoundGrantDateByKey = lastSoundGrantDateByKey.filter {
+                abs(now.timeIntervalSince($0.value)) < soundWindow
             }
         }
-        lastGrantDateByKey[key] = now
+        lastSoundGrantDateByKey[key] = now
         return true
     }
 }
@@ -2040,6 +2101,13 @@ final class TerminalNotificationStore: ObservableObject {
         _ notification: TerminalNotification,
         effects: TerminalNotificationPolicyEffects
     ) {
+        // While a blocking decision is pending for this surface, the feed's
+        // actionable banner is the canonical desktop alert: keep the sidebar
+        // record but stand down from the banner, sound, and command
+        // (manaflow-ai/cmux#2322).
+        guard !TerminalNotificationDeliveryGate.shared.hasActiveBlockingDecision(
+            forKey: Self.deliveryGateKey(for: notification)
+        ) else { return }
         let effects = effectsAfterSoundGate(effects, for: notification)
         guard effects.desktop else {
             playLocalNotificationFeedback(
@@ -2111,29 +2179,60 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
 
+    nonisolated private static func deliveryGateKey(for notification: TerminalNotification) -> String {
+        TerminalNotificationDeliveryGate.key(
+            workspaceId: notification.tabId,
+            surfaceId: notification.surfaceId
+        )
+    }
+
     /// Strips the sound effect when another banner for the same surface was
-    /// granted a sound moments ago (see ``TerminalNotificationSoundGate``).
+    /// granted a sound moments ago (see ``TerminalNotificationDeliveryGate``).
     private func effectsAfterSoundGate(
         _ effects: TerminalNotificationPolicyEffects,
         for notification: TerminalNotification
     ) -> TerminalNotificationPolicyEffects {
         guard effects.sound else { return effects }
-        let key = TerminalNotificationSoundGate.key(
-            workspaceId: notification.tabId,
-            surfaceId: notification.surfaceId
-        )
-        guard !TerminalNotificationSoundGate.shared.shouldPlaySound(forKey: key) else {
-            return effects
-        }
+        guard !TerminalNotificationDeliveryGate.shared.claimSound(
+            forKey: Self.deliveryGateKey(for: notification)
+        ) else { return effects }
         var silenced = effects
         silenced.sound = false
         return silenced
+    }
+
+    /// Withdraws recently delivered desktop banners for a surface from
+    /// Notification Center without touching the sidebar record or unread
+    /// state. Called by the feed decision bridge when its actionable banner
+    /// supersedes an agent-hook banner that raced ahead of the
+    /// blocking-decision registration.
+    func withdrawRecentDeliveredDesktopNotifications(forGateKey key: String, since: Date) {
+        let ids = Self.withdrawableNotificationIds(in: notifications, gateKey: key, since: since)
+        guard !ids.isEmpty else { return }
+        center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
+        center.removePendingNotificationRequestsOffMain(withIdentifiers: ids)
+    }
+
+    nonisolated static func withdrawableNotificationIds(
+        in notifications: [TerminalNotification],
+        gateKey: String,
+        since: Date
+    ) -> [String] {
+        notifications.compactMap { notification in
+            guard notification.createdAt >= since,
+                  deliveryGateKey(for: notification) == gateKey
+            else { return nil }
+            return notification.id.uuidString
+        }
     }
 
     private func playSuppressedNotificationFeedback(
         for notification: TerminalNotification,
         effects: TerminalNotificationPolicyEffects
     ) {
+        guard !TerminalNotificationDeliveryGate.shared.hasActiveBlockingDecision(
+            forKey: Self.deliveryGateKey(for: notification)
+        ) else { return }
         let effects = effectsAfterSoundGate(effects, for: notification)
         playLocalNotificationFeedback(
             title: resolvedNotificationTitle(for: notification),

--- a/cmuxTests/NotificationSoundSettingsTests.swift
+++ b/cmuxTests/NotificationSoundSettingsTests.swift
@@ -36,3 +36,75 @@ import Testing
         #expect(NotificationSoundSettings.stagedSystemSoundName(for: NotificationSoundSettings.customFileValue) == nil)
     }
 }
+
+@Suite struct TerminalNotificationSoundGateTests {
+    private let workspaceId = UUID()
+    private let surfaceId = UUID()
+
+    @Test func firstSoundForAKeyIsGranted() {
+        let gate = TerminalNotificationSoundGate()
+        #expect(gate.shouldPlaySound(forKey: "surface-a"))
+    }
+
+    @Test func secondSoundWithinTheWindowIsSilenced() {
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
+        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(0.05)))
+        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(1.95)))
+    }
+
+    @Test func soundIsGrantedAgainAfterTheWindowElapses() {
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
+    }
+
+    @Test func deniedAttemptsDoNotExtendTheWindow() {
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
+        // A silenced banner at t+1.5 must not push the next grant to t+3.5.
+        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(1.5)))
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
+    }
+
+    @Test func distinctKeysDoNotShareAWindow() {
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
+        #expect(gate.shouldPlaySound(forKey: "surface-b", now: start.addingTimeInterval(0.1)))
+    }
+
+    @Test func missingKeysAreNeverSilenced() {
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: nil, now: start))
+        #expect(gate.shouldPlaySound(forKey: nil, now: start.addingTimeInterval(0.1)))
+        #expect(gate.shouldPlaySound(forKey: "", now: start.addingTimeInterval(0.2)))
+    }
+
+    @Test func keyPrefersTheSurfaceAndFallsBackToTheWorkspace() {
+        #expect(
+            TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: surfaceId)
+                == surfaceId.uuidString
+        )
+        #expect(
+            TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: nil)
+                == workspaceId.uuidString
+        )
+    }
+
+    @Test func bothBannerPathsForOnePromptShareTheWindow() {
+        // The agent-hook banner (TerminalNotificationStore) and the feed
+        // decision banner (FeedCoordinator) compute the same key for one
+        // surface, so whichever posts first wins the sound and the other is
+        // silenced — regardless of arrival order.
+        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let key = TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: surfaceId)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        #expect(gate.shouldPlaySound(forKey: key, now: start))
+        #expect(!gate.shouldPlaySound(forKey: key, now: start.addingTimeInterval(0.3)))
+    }
+}

--- a/cmuxTests/NotificationSoundSettingsTests.swift
+++ b/cmuxTests/NotificationSoundSettingsTests.swift
@@ -37,74 +37,158 @@ import Testing
     }
 }
 
-@Suite struct TerminalNotificationSoundGateTests {
+@Suite struct TerminalNotificationDeliveryGateTests {
     private let workspaceId = UUID()
     private let surfaceId = UUID()
 
+    // MARK: Sound window
+
     @Test func firstSoundForAKeyIsGranted() {
-        let gate = TerminalNotificationSoundGate()
-        #expect(gate.shouldPlaySound(forKey: "surface-a"))
+        let gate = TerminalNotificationDeliveryGate()
+        #expect(gate.claimSound(forKey: "surface-a"))
     }
 
     @Test func secondSoundWithinTheWindowIsSilenced() {
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let gate = TerminalNotificationDeliveryGate(soundWindow: 2.0)
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
-        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(0.05)))
-        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(1.95)))
+        #expect(gate.claimSound(forKey: "surface-a", now: start))
+        #expect(!gate.claimSound(forKey: "surface-a", now: start.addingTimeInterval(0.05)))
+        #expect(!gate.claimSound(forKey: "surface-a", now: start.addingTimeInterval(1.95)))
     }
 
     @Test func soundIsGrantedAgainAfterTheWindowElapses() {
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let gate = TerminalNotificationDeliveryGate(soundWindow: 2.0)
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
+        #expect(gate.claimSound(forKey: "surface-a", now: start))
+        #expect(gate.claimSound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
     }
 
     @Test func deniedAttemptsDoNotExtendTheWindow() {
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let gate = TerminalNotificationDeliveryGate(soundWindow: 2.0)
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
+        #expect(gate.claimSound(forKey: "surface-a", now: start))
         // A silenced banner at t+1.5 must not push the next grant to t+3.5.
-        #expect(!gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(1.5)))
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
+        #expect(!gate.claimSound(forKey: "surface-a", now: start.addingTimeInterval(1.5)))
+        #expect(gate.claimSound(forKey: "surface-a", now: start.addingTimeInterval(2.05)))
     }
 
     @Test func distinctKeysDoNotShareAWindow() {
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let gate = TerminalNotificationDeliveryGate(soundWindow: 2.0)
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: "surface-a", now: start))
-        #expect(gate.shouldPlaySound(forKey: "surface-b", now: start.addingTimeInterval(0.1)))
+        #expect(gate.claimSound(forKey: "surface-a", now: start))
+        #expect(gate.claimSound(forKey: "surface-b", now: start.addingTimeInterval(0.1)))
     }
 
     @Test func missingKeysAreNeverSilenced() {
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
+        let gate = TerminalNotificationDeliveryGate(soundWindow: 2.0)
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: nil, now: start))
-        #expect(gate.shouldPlaySound(forKey: nil, now: start.addingTimeInterval(0.1)))
-        #expect(gate.shouldPlaySound(forKey: "", now: start.addingTimeInterval(0.2)))
+        #expect(gate.claimSound(forKey: nil, now: start))
+        #expect(gate.claimSound(forKey: nil, now: start.addingTimeInterval(0.1)))
+        #expect(gate.claimSound(forKey: "", now: start.addingTimeInterval(0.2)))
     }
 
     @Test func keyPrefersTheSurfaceAndFallsBackToTheWorkspace() {
         #expect(
-            TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: surfaceId)
+            TerminalNotificationDeliveryGate.key(workspaceId: workspaceId, surfaceId: surfaceId)
                 == surfaceId.uuidString
         )
         #expect(
-            TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: nil)
+            TerminalNotificationDeliveryGate.key(workspaceId: workspaceId, surfaceId: nil)
                 == workspaceId.uuidString
         )
     }
 
-    @Test func bothBannerPathsForOnePromptShareTheWindow() {
-        // The agent-hook banner (TerminalNotificationStore) and the feed
-        // decision banner (FeedCoordinator) compute the same key for one
-        // surface, so whichever posts first wins the sound and the other is
-        // silenced — regardless of arrival order.
-        let gate = TerminalNotificationSoundGate(suppressionWindow: 2.0)
-        let key = TerminalNotificationSoundGate.key(workspaceId: workspaceId, surfaceId: surfaceId)
+    // MARK: Blocking-decision claims
+
+    @Test func blockingDecisionClaimsTheSurfaceUntilConcluded() {
+        let gate = TerminalNotificationDeliveryGate()
         let start = Date(timeIntervalSinceReferenceDate: 1_000)
-        #expect(gate.shouldPlaySound(forKey: key, now: start))
-        #expect(!gate.shouldPlaySound(forKey: key, now: start.addingTimeInterval(0.3)))
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-a", now: start))
+        gate.beginBlockingDecision(forKey: "surface-a", now: start)
+        #expect(gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(0.5)))
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-b", now: start.addingTimeInterval(0.5)))
+        gate.endBlockingDecision(forKey: "surface-a")
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(1.0)))
+    }
+
+    @Test func blockingClaimIsTimeBoxedWhileStillPending() {
+        // A decision the user answers in the terminal stays pending app-side
+        // until the hook timeout. The claim must stop suppressing unrelated
+        // alerts (e.g. the completion banner) long before that.
+        let gate = TerminalNotificationDeliveryGate(blockingClaimWindow: 5.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        gate.beginBlockingDecision(forKey: "surface-a", now: start)
+        #expect(gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(4.9)))
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(5.1)))
+    }
+
+    @Test func overlappingBlockingDecisionsAreRefcounted() {
+        let gate = TerminalNotificationDeliveryGate(blockingClaimWindow: 5.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        gate.beginBlockingDecision(forKey: "surface-a", now: start)
+        gate.beginBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(1.0))
+        gate.endBlockingDecision(forKey: "surface-a")
+        #expect(gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(2.0)))
+        gate.endBlockingDecision(forKey: "surface-a")
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(2.0)))
+    }
+
+    @Test func aFreshOverlappingDecisionExtendsTheClaimWindow() {
+        let gate = TerminalNotificationDeliveryGate(blockingClaimWindow: 5.0)
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+        gate.beginBlockingDecision(forKey: "surface-a", now: start)
+        gate.beginBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(4.0))
+        #expect(gate.hasActiveBlockingDecision(forKey: "surface-a", now: start.addingTimeInterval(7.0)))
+    }
+
+    @Test func unbalancedEndAndNilKeysAreNoOps() {
+        let gate = TerminalNotificationDeliveryGate()
+        gate.endBlockingDecision(forKey: "surface-a")
+        #expect(!gate.hasActiveBlockingDecision(forKey: "surface-a"))
+        gate.beginBlockingDecision(forKey: nil)
+        gate.beginBlockingDecision(forKey: "")
+        #expect(!gate.hasActiveBlockingDecision(forKey: nil))
+        #expect(!gate.hasActiveBlockingDecision(forKey: ""))
+    }
+
+    // MARK: Raced-banner withdrawal selection
+
+    @Test func withdrawalSelectsOnlyRecentBannersForTheSurface() {
+        let now = Date(timeIntervalSinceReferenceDate: 10_000)
+        let recentMatch = makeNotification(surfaceId: surfaceId, createdAt: now.addingTimeInterval(-1))
+        let staleMatch = makeNotification(surfaceId: surfaceId, createdAt: now.addingTimeInterval(-30))
+        let otherSurface = makeNotification(surfaceId: UUID(), createdAt: now.addingTimeInterval(-1))
+
+        let ids = TerminalNotificationStore.withdrawableNotificationIds(
+            in: [recentMatch, staleMatch, otherSurface],
+            gateKey: TerminalNotificationDeliveryGate.key(workspaceId: workspaceId, surfaceId: surfaceId),
+            since: now.addingTimeInterval(-5)
+        )
+        #expect(ids == [recentMatch.id.uuidString])
+    }
+
+    @Test func withdrawalFallsBackToTheWorkspaceKeyForSurfacelessBanners() {
+        let now = Date(timeIntervalSinceReferenceDate: 10_000)
+        let surfaceless = makeNotification(surfaceId: nil, createdAt: now)
+
+        let ids = TerminalNotificationStore.withdrawableNotificationIds(
+            in: [surfaceless],
+            gateKey: TerminalNotificationDeliveryGate.key(workspaceId: workspaceId, surfaceId: nil),
+            since: now.addingTimeInterval(-5)
+        )
+        #expect(ids == [surfaceless.id.uuidString])
+    }
+
+    private func makeNotification(surfaceId: UUID?, createdAt: Date) -> TerminalNotification {
+        TerminalNotification(
+            id: UUID(),
+            tabId: workspaceId,
+            surfaceId: surfaceId,
+            title: "Claude",
+            subtitle: "Permission",
+            body: "Bash needs approval",
+            createdAt: createdAt,
+            isRead: false
+        )
     }
 }


### PR DESCRIPTION
## Problem

When a Claude Code session hits a blocking decision (tool permission request, `ExitPlanMode`, `AskUserQuestion`) while cmux is in the background, the user gets **two desktop banners and two sounds for one prompt**. This is one concrete, reproducible slice of the notification flakiness tracked in #2322.

## Root cause

A single blocking prompt fires **two independent hooks**, and each posts its own desktop banner with its own sound:

1. The agent's `Notification` hook (`cmux hooks claude notification`) classifies the permission message as `.needsInput` (`classifyAgentHookNotification`, `CLI/cmux.swift`) and posts through `TerminalNotificationStore.scheduleUserNotification`.
2. The `PermissionRequest` hook (`cmux hooks feed --source claude`) routes through `FeedCoordinator.ingestBlocking → postNotificationIfStillAwaiting → deliverFeedNotificationIfStillAwaiting`, which posts its own actionable banner (`feed.<requestId>`) directly to `UNUserNotificationCenter`.

There is no shared state between the paths: the store's `cooldownKey` is per-call-site opt-in and the CLI's `notificationFingerprint` dedup is per-hook-handler only. The feed path also runs regardless of whether the feed sidebar beta is enabled, so every user with Claude hooks gets the duplicate on blocking prompts.

## Fix — one event, one banner, one ding (deterministically)

`TerminalNotificationDeliveryGate` makes the **feed's actionable banner the canonical desktop alert** for blocking decisions — not "whichever banner wins the race":

- **Claim:** `FeedCoordinator.ingestBlocking` claims the surface for the decision's lifetime (`beginBlockingDecision` / `endBlockingDecision`, keyed by `surfaceId ?? workspaceId`). While claimed, the store keeps recording sidebar notifications (history/unread untouched) but stands down from desktop banners, sounds, and notification commands for that surface.
- **Withdraw:** if the agent-hook banner raced ahead of the claim, the feed withdraws it from Notification Center when posting its own (`withdrawRecentDeliveredDesktopNotifications`, 5s lookback, sidebar record untouched) — exactly one banner remains visible.
- **Sound window:** `claimSound` guarantees at most one sound per surface within 2s regardless of arrival order, covering the withdraw case where the raced banner already dinged.
- **Time-boxed claims:** a decision the user answers in the terminal stays pending app-side until the hook timeout (the app only observes a timeout), so an unbounded claim would swallow legitimate later alerts — e.g. the completion banner right after an approval. Claims therefore only suppress within 5s of registration; refcounted and window-extended for overlapping decisions.

Net behavior: blocking prompt while backgrounded → **one actionable banner + one ding**. Blocking prompt while focused → in-app attention only (existing #5313 path). Completions and idle "waiting for input" notifications are unchanged: one banner, one ding, as before.

Degenerate case: if the decision's target can't be resolved from the hook-session store (`nil` key), nothing is claimed and behavior falls back to today's.

## Tests

`TerminalNotificationDeliveryGateTests` (Swift Testing, appended to the already-wired `NotificationSoundSettingsTests.swift` to avoid `project.pbxproj` edits per the CLAUDE.md test-wiring pitfall): sound-window grant/silence/expiry, denied attempts not extending the window, per-key independence, nil-key passthrough, claim begin/end/refcount/time-box/extension, unbalanced-end no-ops, and the withdrawal id-selection logic (recent + matching surface only, workspace-key fallback).

Note on the two-commit red/green policy: these are unit tests of a new type, so a failing-first commit cannot compile; an end-to-end repro would need a `UNUserNotificationCenter` seam that doesn't exist today.

## Verification

- `swiftc -parse` clean on all three touched files.
- Authored on a machine without the full Xcode toolchain, so I could not run `reload.sh` / `xcodebuild test` locally — relying on CI for build + test. Happy to iterate on any failures.
- Localization audit: no user-facing strings added or changed.

Fixes one source of #2322 (related: #942, #5286).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now coordinate to ensure only a single banner remains visible for the same prompt and to pause banner side-effects while a blocking decision is pending.

* **Bug Fixes**
  * Eliminated duplicate notification sounds across delivery paths and ensured suppressed notifications honor sound deduplication.

* **Tests**
  * Added comprehensive tests covering sound-suppression windows, blocking-decision gating, and banner withdrawal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->