### PR TITLE
perf: drop redundant disk I/O on browser-availability checks and bg logging

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -156,6 +156,7 @@
 668	cmuxTests/FeedCoordinatorTests.swift
 574	Sources/Feed/FeedTextEditorDebugWindowController.swift
 568	Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
+566	Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
 562	cmuxTests/AgentExecutableResolverTests.swift
 560	cmuxTests/GhosttyConfigPathResolverTests.swift
 558	Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5059,6 +5059,10 @@ class GhosttyApp {
     }
 
     func logBackground(_ message: String) {
+        // Skip all work (string formatting and disk I/O) unless background logging is
+        // explicitly enabled via env/defaults. Without this guard, direct callers wrote
+        // to /tmp/cmux-bg.log on every theme/OSC color event even in normal runs.
+        guard backgroundLogEnabled else { return }
         let timestamp = Self.backgroundLogTimestampFormatter.string(from: Date())
         let uptimeMs = (ProcessInfo.processInfo.systemUptime - backgroundLogStartUptime) * 1000
         let frame60 = Int((CACurrentMediaTime() * 60.0).rounded(.down))

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -960,7 +960,7 @@ enum BrowserAvailabilitySettings {
     static let defaultDisabled = false
 
     static func isDisabled(defaults: UserDefaults = .standard) -> Bool {
-        defaults.synchronize()
+        // No synchronize() on read: it forces a blocking prefs-plist reload on a path hit from link-open/pane-create; UserDefaults stays coherent in-process and via cfprefsd.
         if defaults.object(forKey: disabledKey) == nil {
             return defaultDisabled
         }
@@ -972,8 +972,8 @@ enum BrowserAvailabilitySettings {
     }
 
     static func setDisabled(_ disabled: Bool, defaults: UserDefaults = .standard) {
+        // `set` already persists; `synchronize()` is a deprecated no-op-style fsync.
         defaults.set(disabled, forKey: disabledKey)
-        defaults.synchronize()
         NotificationCenter.default.post(name: didChangeNotification, object: nil)
     }
 }


### PR DESCRIPTION
## Summary

Followed up on a reported regression where switching between left/right split panes felt laggy after many switches on the main release build, and audited synchronous disk access on interactive paths.

**Pane-switch lag could not be reproduced on current `main`/nightly.** Profiled a tagged build under driven pane-switch loops (real keyboard `cmd+option+arrow` path, not just the socket) at several scales:

- 1 workspace, 2 panes; 41 workspaces, 2 panes; 41 workspaces with 8 panes in the focused workspace.
- In every case steady-state pane switching is cheap: `ContentView.body` re-evaluations ≈ idle (≈1 `sample` hit), no full-window SwiftUI re-render, no per-switch process scan, and per-switch latency is flat (no accumulation across 800+ switches).

The release-build regression appears already fixed by prior perf work (snapshot-boundary rules, equatable `TabItemView`, deferred focus broadcast). The one heavy cost captured in profiling was a coincidental 30s background agent-hibernation process scan, slow only because this dev machine has a very large process table; it is background CPU, not a per-switch main-thread cost. The residual scale-dependent layout-sync case under heavy real sessions is tracked separately in https://github.com/manaflow-ai/cmux/issues/1188.

## Disk-access fixes

- `BrowserAvailabilitySettings.isDisabled()` called `UserDefaults.synchronize()` on every read, forcing a blocking reload of the preferences plist from disk. It is hit from interactive paths (link open, pane create, browser panel create). Removed from both the read and write paths. On modern macOS `synchronize()` is unnecessary; `UserDefaults.standard` stays coherent with `cfprefsd` across processes, so a `cmux browser disable/enable` from the CLI is still reflected on the app's next on-demand read.
- `GhosttyApp.logBackground()` wrote to `/tmp/cmux-bg.log` (open + append) on every theme/OSC color event even in normal runs; only the coalescing dispatcher path was gated on `backgroundLogEnabled`. Gated `logBackground()` itself so normal runs do no string formatting or disk I/O for these events. Explicit debug logging (`CMUX_DEBUG_BG=1`, `CMUX_DEBUG_LOG`, `cmuxDebugBG`) is unchanged.

Other audited paths were already optimized and left unchanged: `cmux.json` config reads are cached by mtime+size (`CmuxConfig.parseConfig`), there is no per-keystroke disk write, and session-persistence / settings-watcher reads are on discrete events, not interactive hot loops.

## Testing

- `./scripts/reload.sh --tag paneperf` builds clean.
- Profiling methodology: launch tagged build, drive alternating `cmd+option+left/right` via the app's own synthetic-shortcut path, `sample` the process during idle vs switching, compare `ContentView.body` / process-scan / render-flush stack frequencies.

## Issues

- Related: https://github.com/manaflow-ai/cmux/issues/1188

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650230&installation_id=133855650&pr_number=5744&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5744&signature=cb6fe20465316db26aea02b6b51fe5a91f9bde9f0f7d3ffb9822678aa7adbbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance changes with no auth or data-model impact; browser disable state still uses the same keys and notifications.
> 
> **Overview**
> This PR trims **blocking disk I/O** on paths that run during normal UI interaction.
> 
> **Browser availability:** `BrowserAvailabilitySettings` no longer calls `UserDefaults.synchronize()` when reading or writing the browser-disabled override. That call forced a plist reload from disk on every `isDisabled()` check (link open, pane/split creation, command palette context). Writes still post the existing notification; cross-process coherence is expected via `cfprefsd` without explicit sync.
> 
> **Terminal background logging:** `GhosttyApp.logBackground()` now returns immediately when `backgroundLogEnabled` is false, so theme/OSC color paths skip formatting and appends to `/tmp/cmux-bg.log` in normal runs. Debug logging via `CMUX_DEBUG_BG`, `CMUX_DEBUG_LOG`, or `cmuxDebugBG` is unchanged.
> 
> The Swift file-length budget entry for `AgentLaunchSanitizer.swift` is updated to **566** lines (unrelated shrink).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825ccef65be380b576d86d13ab1ad5c69bf701df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant disk I/O on browser-availability checks and background logging to reduce blocking work on interactive paths. Improves responsiveness and avoids unnecessary writes during normal runs.

- **Performance**
  - Browser availability: removed `UserDefaults.synchronize()` from `isDisabled` and `setDisabled`; prefs stay coherent via `cfprefsd`, so CLI toggles are picked up on the next read.
  - Background logging: `GhosttyApp.logBackground` now early-returns when `backgroundLogEnabled` is false, skipping string formatting and appends to `/tmp/cmux-bg.log`; debug logging is unchanged.

<sup>Written for commit 7e9850189b42d9ed6112844212ec266624d45cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Avoids unnecessary background logging work and disk I/O when background logging is disabled, improving responsiveness.
  * Removes redundant preference synchronization calls, reducing pointless operations and streamlining settings updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## CI notes

- Rebased onto current `main`.
- Added one entry to `.github/swift-file-length-budget.tsv` for `AgentLaunchSanitizer.swift` (566 lines): it crossed the 500-line tracking threshold on `main` without a budget entry, which made the required `workflow-guard-tests` budget step fail on every PR merge result. Pre-existing `main` breakage, not from this change.
- The earlier `ui-regressions` red was a launch-readiness flake (`waitForSocketPong(timeout: 12.0)` at `BrowserPaneNavigationKeybindUITests.swift:896`); it passed on re-run. Unrelated to this diff (browser is enabled by default in that test; in-process reads are coherent without `synchronize()`).
