### PR TITLE
Native tmux control mode: render local tmux in a real Ghostty surface (P1)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4853,7 +4853,10 @@ struct CMUXCLI {
         if let target, !target.isEmpty {
             params["target"] = target
         }
-        if let surfaceRaw = surfaceOpt {
+        // Default to the calling surface so `cmux tmux attach` replaces the
+        // current terminal in place rather than creating a new one.
+        let surfaceRaw = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+        if let surfaceRaw {
             if let surface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
                 params["surface_id"] = surface
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4830,7 +4830,13 @@ struct CMUXCLI {
         idFormat: CLIIDFormat
     ) throws {
         let usage = "Usage: cmux tmux attach [session] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>]"
-        guard let sub = commandArgs.first, sub.lowercased() == "attach" else {
+        // Accept tmux-style abbreviations: a, at, att, ... attach, attach-session.
+        func isAttachVerb(_ s: String) -> Bool {
+            let v = s.lowercased()
+            guard !v.isEmpty else { return false }
+            return "attach".hasPrefix(v) || "attach-session".hasPrefix(v)
+        }
+        guard let sub = commandArgs.first, isAttachVerb(sub) else {
             if let sub = commandArgs.first {
                 throw CLIError(message: "Unknown tmux subcommand: \(sub). \(usage)")
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4745,6 +4745,10 @@ struct CMUXCLI {
         case "markdown":
             try runMarkdownCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        // Native tmux control mode (renders a tmux pane in a manual-IO Ghostty surface)
+        case "tmux":
+            try runTmuxAttachCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+
         default:
             print(usage())
             throw CLIError(message: "Unknown command: \(command)")
@@ -4815,6 +4819,67 @@ struct CMUXCLI {
     }
 
     // MARK: - Markdown Commands
+
+    /// `cmux tmux attach [session]` — take over the current pane with a native
+    /// Ghostty surface rendering a local tmux session via control mode. The user
+    /// never types `tmux -CC`; cmux drives it as a hidden gateway.
+    private func runTmuxAttachCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        let usage = "Usage: cmux tmux attach [session] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>]"
+        guard let sub = commandArgs.first, sub.lowercased() == "attach" else {
+            if let sub = commandArgs.first {
+                throw CLIError(message: "Unknown tmux subcommand: \(sub). \(usage)")
+            }
+            throw CLIError(message: usage)
+        }
+        var args = Array(commandArgs.dropFirst())
+
+        let (workspaceOpt, a1) = parseOption(args, name: "--workspace")
+        let (windowOpt, a2) = parseOption(a1, name: "--window")
+        let (surfaceOpt, a3) = parseOption(a2, name: "--surface")
+        let (focusOpt, a4) = parseOption(a3, name: "--focus")
+        args = a4
+
+        if let unknownFlag = args.first(where: { $0.hasPrefix("-") }) {
+            throw CLIError(message: "tmux attach: unknown flag '\(unknownFlag)'. \(usage)")
+        }
+        let target = args.first
+
+        var params: [String: Any] = [:]
+        if let target, !target.isEmpty {
+            params["target"] = target
+        }
+        if let surfaceRaw = surfaceOpt {
+            if let surface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
+                params["surface_id"] = surface
+            }
+        }
+        let workspaceRaw = workspaceOpt ?? (windowOpt == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+        if let workspaceRaw {
+            if let workspace = try normalizeWorkspaceHandle(workspaceRaw, client: client) {
+                params["workspace_id"] = workspace
+            }
+        }
+        if let windowRaw = windowOpt {
+            if let window = try normalizeWindowHandle(windowRaw, client: client) {
+                params["window_id"] = window
+            }
+        }
+        try applyFocusOption(focusOpt, defaultValue: true, to: &params)
+
+        let payload = try client.sendV2(method: "tmux.attach", params: params)
+
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+        } else {
+            let surfaceText = formatHandle(payload, kind: "surface", idFormat: idFormat) ?? "unknown"
+            print("OK surface=\(surfaceText)")
+        }
+    }
 
     private func runMarkdownCommand(
         commandArgs: [String],
@@ -5128,6 +5193,7 @@ struct CMUXCLI {
         "swap-pane",
         "tab-action",
         "themes",
+        "tmux",
         "top",
         "tree",
         "trigger-flash",
@@ -14726,6 +14792,32 @@ struct CMUXCLI {
               cmux markdown ~/project/CHANGELOG.md
               cmux markdown open ./docs/design.md --workspace 0
               cmux markdown open plan.md --direction down
+            """
+        case "tmux":
+            return """
+            Usage: cmux tmux attach [session] [options]
+
+            Attach a local tmux session and render it natively in the current
+            pane using a manual-IO Ghostty surface. You get native text
+            selection, cmd-F find, and real scrollback with a scrollbar, because
+            the pane is a real Ghostty terminal driven by tmux control mode
+            (cmux runs `tmux -CC` for you; never type it yourself). When the
+            session detaches or exits, the pane reverts to its previous surface.
+
+            Arguments:
+              session                      tmux session to attach or create
+                                           (default: most recent session)
+
+            Options:
+              --workspace <id|ref|index>   Target workspace (default: $CMUX_WORKSPACE_ID)
+              --surface <id|ref|index>     Target surface (default: focused surface)
+              --window <id|ref|index>      Target window
+              --focus <true|false>         Focus the new surface (default: true)
+
+            Examples:
+              cmux tmux attach
+              cmux tmux attach main
+              cmux tmux attach work --window 0
             """
         default:
             return nil

--- a/Packages/CmuxTmuxControlMode/Package.swift
+++ b/Packages/CmuxTmuxControlMode/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxTmuxControlMode",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxTmuxControlMode",
+            targets: ["CmuxTmuxControlMode"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxTmuxControlMode",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxTmuxControlModeTests",
+            dependencies: ["CmuxTmuxControlMode"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/ControlModeSessionSource.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/ControlModeSessionSource.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// What a control-mode terminal renderer needs from whatever owns the
+/// authoritative session (local tmux today; the Mac mobile host and
+/// cmuxd-remote later). The renderer is always a manual-IO Ghostty surface;
+/// the source differs only in transport. See
+/// `plans/feat-control-mode-terminals/DESIGN.md` in cmuxterm-hq.
+public protocol ControlModeSessionSource: AnyObject, Sendable {
+    /// Human-readable name for the session (used for the surface title).
+    var displayName: String { get }
+
+    /// Begin the session at the given size. Delegate callbacks deliver the
+    /// initial snapshot, then live output, then end-of-session. Callbacks may
+    /// be invoked on a background queue; the caller is responsible for hopping
+    /// to the main actor before touching UI.
+    func start(initialSize: TerminalSize, delegate: any ControlModeSessionDelegate)
+
+    /// Forward bytes the user typed (already encoded by the local surface).
+    func sendInput(_ bytes: [UInt8])
+
+    /// Notify the source the local surface resized.
+    func resize(_ size: TerminalSize)
+
+    /// Tear the session down (detach; does not kill the server-side session).
+    func stop()
+}
+
+/// Callbacks from a ``ControlModeSessionSource``.
+public protocol ControlModeSessionDelegate: AnyObject, Sendable {
+    /// The initial screen + scrollback snapshot, as bytes to feed into the
+    /// local surface before any live output.
+    func controlModeSession(didProduceSnapshot bytes: [UInt8])
+    /// Live bytes from the attached pane.
+    func controlModeSession(didProduceOutput bytes: [UInt8])
+    /// The session ended (detach, exit, or gateway death). `reason` is a
+    /// best-effort human-readable cause.
+    func controlModeSession(didEndWithReason reason: String?)
+}
+
+/// What to attach to when starting a local tmux control-mode session.
+public enum TmuxAttachTarget: Equatable, Sendable {
+    /// Attach the most-recently-used session; fail if none exists.
+    case mostRecent
+    /// Attach the named session, creating it if it does not exist
+    /// (`new-session -A -s <name>`).
+    case session(String)
+
+    /// The argument vector for `tmux` (after the `-CC` flag) for this target.
+    public var tmuxArguments: [String] {
+        switch self {
+        case .mostRecent:
+            return ["attach"]
+        case let .session(name):
+            return ["new-session", "-A", "-s", name]
+        }
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TerminalSize.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TerminalSize.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A terminal grid size in character cells. Used to drive `refresh-client -C`.
+public struct TerminalSize: Equatable, Sendable {
+    public var columns: Int
+    public var rows: Int
+
+    public init(columns: Int, rows: Int) {
+        // tmux refuses sizes below 1x1; clamp so we never emit a malformed
+        // refresh-client command.
+        self.columns = max(1, columns)
+        self.rows = max(1, rows)
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEncoder.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEncoder.swift
@@ -27,6 +27,12 @@ public enum TmuxControlModeEncoder {
         "refresh-client -C \(size.columns)x\(size.rows)"
     }
 
+    /// Detach this control client (the tmux session keeps running). tmux then
+    /// emits `%exit`, which ends the control-mode session.
+    public static func detachClient() -> String {
+        "detach-client"
+    }
+
     /// List the panes of the attached session's current window, active flag
     /// first, so we can resolve which pane to render.
     /// Each result line is `<pane_active>:<pane_id>`, e.g. `1:%3`.

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEncoder.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEncoder.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Builders for the tmux commands cmux writes to the `-CC` gateway's stdin.
+///
+/// In control mode the client drives tmux by writing ordinary tmux commands
+/// (one per line). These helpers produce those command lines (without the
+/// trailing newline). Pure and unit-testable.
+public enum TmuxControlModeEncoder {
+    /// Capture a pane's full scrollback + visible screen, with SGR escapes, for
+    /// the initial snapshot. Mirrors iTerm2's control-mode attach behavior.
+    /// `-p` to stdout, `-e` keep escape sequences, `-J` join wrapped lines and
+    /// preserve trailing spaces, `-S -`/`-E -` from start to end of history.
+    public static func capturePane(paneID: String) -> String {
+        "capture-pane -t \(paneID) -p -e -J -S - -E -"
+    }
+
+    /// Send literal bytes to a pane as input. `-H` takes space-separated hex
+    /// byte values, so this transmits the exact bytes Ghostty encoded from the
+    /// user's keystrokes without tmux key-name interpretation.
+    public static func sendKeys(paneID: String, bytes: [UInt8]) -> String {
+        let hex = bytes.map { String(format: "%02x", $0) }.joined(separator: " ")
+        return "send-keys -t \(paneID) -H \(hex)"
+    }
+
+    /// Declare this control client's size so tmux sizes the window to us.
+    public static func refreshClientSize(_ size: TerminalSize) -> String {
+        "refresh-client -C \(size.columns)x\(size.rows)"
+    }
+
+    /// List the panes of the attached session's current window, active flag
+    /// first, so we can resolve which pane to render.
+    /// Each result line is `<pane_active>:<pane_id>`, e.g. `1:%3`.
+    public static func listActivePanes() -> String {
+        "list-panes -F '#{pane_active}:#{pane_id}'"
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEvent.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeEvent.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// A single decoded event from a `tmux -CC` (control mode) gateway stream.
+///
+/// The control protocol multiplexes two things on one stream: command
+/// request/response blocks (`%begin` … `%end`/`%error`) and asynchronous
+/// `%`-prefixed notifications. tmux guarantees a notification never appears
+/// inside a command block, so the parser is a simple in-block / out-of-block
+/// state machine. See https://github.com/tmux/tmux/wiki/Control-Mode.
+public enum TmuxControlModeEvent: Equatable, Sendable {
+    /// `%begin <time> <number> <flags>` — start of a command response block.
+    case begin(number: Int)
+
+    /// A completed command response block (`%begin` … `%end`/`%error`).
+    /// `output` is the verbatim lines tmux emitted for the command, in order.
+    /// `isError` is true when the block was terminated by `%error`.
+    case commandResult(number: Int, output: [String], isError: Bool)
+
+    /// `%output %<pane> <data>` — live bytes a pane's program wrote.
+    /// `bytes` is already octal-unescaped back to the raw byte stream.
+    case output(paneID: String, bytes: [UInt8])
+
+    /// `%layout-change <window> <layout> <visible-layout> <flags>`.
+    case layoutChange(window: String, layout: String, visibleLayout: String?, flags: String?)
+
+    /// `%window-add @<window>`.
+    case windowAdd(window: String)
+    /// `%window-close @<window>` / `%unlinked-window-close`.
+    case windowClose(window: String)
+    /// `%window-renamed @<window> <name>`.
+    case windowRenamed(window: String, name: String)
+    /// `%window-pane-changed @<window> %<pane>`.
+    case windowPaneChanged(window: String, pane: String)
+
+    /// `%session-changed $<session> <name>`.
+    case sessionChanged(session: String, name: String)
+    /// `%sessions-changed`.
+    case sessionsChanged
+
+    /// `%pane-mode-changed %<pane>` (copy-mode entered/left server-side).
+    case paneModeChanged(pane: String)
+
+    /// `%exit [reason]` — the control client is ending.
+    case exit(reason: String?)
+    /// `%client-detached <client>` — this client detached but the server lives on.
+    case clientDetached
+
+    /// Any other `%…` notification we do not model explicitly.
+    /// `name` excludes the leading `%`.
+    case notification(name: String, arguments: [String])
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeGateway.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeGateway.swift
@@ -1,12 +1,18 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#endif
 
-/// A local `tmux -CC` control-mode session: spawns the gateway process, pumps
-/// its stdout through ``TmuxControlModeSessionCore``, and writes commands to its
-/// stdin. Conforms to ``ControlModeSessionSource`` so the app wires it to a
-/// manual-IO Ghostty surface without knowing it is tmux.
+/// A local `tmux -CC` control-mode session: spawns the gateway process on a
+/// pseudo-terminal, pumps its output through ``TmuxControlModeSessionCore``, and
+/// writes commands to it. Conforms to ``ControlModeSessionSource`` so the app
+/// wires it to a manual-IO Ghostty surface without knowing it is tmux.
 ///
-/// All ``TmuxControlModeSessionCore`` access is serialized on a private queue;
-/// delegate callbacks are invoked on that queue (the app hops to the main actor).
+/// `tmux -CC` requires a real terminal (it calls `tcgetattr` on its standard
+/// streams and exits if they are plain pipes), so the gateway runs on a PTY
+/// whose master end we read/write. All ``TmuxControlModeSessionCore`` access is
+/// serialized on a private queue; delegate callbacks are invoked on the main
+/// queue (the app stays on the main actor).
 public final class TmuxControlModeGateway: ControlModeSessionSource, @unchecked Sendable {
     private let target: TmuxAttachTarget
     private let tmuxExecutablePath: String
@@ -15,11 +21,10 @@ public final class TmuxControlModeGateway: ControlModeSessionSource, @unchecked 
 
     private let queue = DispatchQueue(label: "com.cmux.tmux-control-mode.gateway")
     private var core = TmuxControlModeSessionCore()
-    private weak var delegate: (any ControlModeSessionDelegate)?
+    private var delegate: (any ControlModeSessionDelegate)?
 
     private let process = Process()
-    private let stdinPipe = Pipe()
-    private let stdoutPipe = Pipe()
+    private var masterHandle: FileHandle?
     private var launched = false
     private var finished = false
 
@@ -48,45 +53,65 @@ public final class TmuxControlModeGateway: ControlModeSessionSource, @unchecked 
             launched = true
             self.delegate = delegate
 
+            // tmux -CC needs a controlling terminal; allocate a PTY and run it
+            // on the slave end, reading/writing the master.
+            var master: Int32 = 0
+            var slave: Int32 = 0
+            var ws = winsize(
+                ws_row: UInt16(clamping: initialSize.rows),
+                ws_col: UInt16(clamping: initialSize.columns),
+                ws_xpixel: 0,
+                ws_ypixel: 0
+            )
+            guard openpty(&master, &slave, nil, nil, &ws) == 0 else {
+                deliverEnd(reason: "failed to allocate pty for tmux")
+                return
+            }
+
+            // Raw slave so the commands we write are not echoed back into the
+            // control stream.
+            var term = termios()
+            if tcgetattr(slave, &term) == 0 {
+                cfmakeraw(&term)
+                _ = tcsetattr(slave, TCSANOW, &term)
+            }
+
             process.executableURL = URL(fileURLWithPath: tmuxExecutablePath)
             process.arguments = ["-CC"] + target.tmuxArguments
-            process.standardInput = stdinPipe
-            process.standardOutput = stdoutPipe
-            process.standardError = stdoutPipe // fold stderr into the stream; control protocol ignores stray lines
+            process.standardInput = FileHandle(fileDescriptor: slave, closeOnDealloc: false)
+            process.standardOutput = FileHandle(fileDescriptor: slave, closeOnDealloc: false)
+            process.standardError = FileHandle(fileDescriptor: slave, closeOnDealloc: false)
             if let workingDirectory { process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory) }
             if let environment { process.environment = environment }
 
-            stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let mHandle = FileHandle(fileDescriptor: master, closeOnDealloc: true)
+            masterHandle = mHandle
+            mHandle.readabilityHandler = { [weak self] handle in
                 let data = handle.availableData
                 guard let self else { return }
                 if data.isEmpty {
-                    // EOF; termination handler will deliver the end-of-session.
-                    handle.readabilityHandler = nil
+                    handle.readabilityHandler = nil // EOF; termination handler delivers the end.
                     return
                 }
-                self.queue.async {
-                    self.apply(self.core.consume([UInt8](data)))
-                }
+                self.queue.async { self.apply(self.core.consume([UInt8](data))) }
             }
 
             process.terminationHandler = { [weak self] proc in
                 guard let self else { return }
                 let reason = proc.terminationStatus == 0 ? nil : "tmux exited (\(proc.terminationStatus))"
-                self.queue.async {
-                    self.apply(self.core.gatewayExited(reason: reason))
-                }
+                self.queue.async { self.apply(self.core.gatewayExited(reason: reason)) }
             }
 
             do {
                 try process.run()
             } catch {
-                finished = true
-                let delegate = self.delegate
-                DispatchQueue.main.async {
-                    delegate?.controlModeSession(didEndWithReason: "failed to launch tmux: \(error.localizedDescription)")
-                }
+                close(slave)
+                deliverEnd(reason: "failed to launch tmux: \(error.localizedDescription)")
                 return
             }
+            // The child holds the slave now; close our copy so the master sees
+            // EOF when tmux exits.
+            close(slave)
 
             apply(core.start(initialSize: initialSize))
         }
@@ -128,21 +153,25 @@ public final class TmuxControlModeGateway: ControlModeSessionSource, @unchecked 
                 let delegate = self.delegate
                 DispatchQueue.main.async { delegate?.controlModeSession(didProduceOutput: bytes) }
             case let .ended(reason):
-                guard !finished else { continue }
-                finished = true
-                let delegate = self.delegate
-                DispatchQueue.main.async { delegate?.controlModeSession(didEndWithReason: reason) }
+                deliverEnd(reason: reason)
             }
         }
     }
 
+    private func deliverEnd(reason: String?) {
+        guard !finished else { return }
+        finished = true
+        let delegate = self.delegate
+        DispatchQueue.main.async { delegate?.controlModeSession(didEndWithReason: reason) }
+    }
+
     private func writeToGateway(_ bytes: [UInt8]) {
-        guard !bytes.isEmpty else { return }
+        guard !bytes.isEmpty, let masterHandle else { return }
         do {
-            try stdinPipe.fileHandleForWriting.write(contentsOf: Data(bytes))
+            try masterHandle.write(contentsOf: Data(bytes))
         } catch {
-            // Broken pipe -> the gateway is gone; let the termination handler
-            // deliver the end-of-session.
+            // Broken pipe -> the gateway is gone; the termination handler
+            // delivers the end-of-session.
         }
     }
 

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeGateway.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeGateway.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+/// A local `tmux -CC` control-mode session: spawns the gateway process, pumps
+/// its stdout through ``TmuxControlModeSessionCore``, and writes commands to its
+/// stdin. Conforms to ``ControlModeSessionSource`` so the app wires it to a
+/// manual-IO Ghostty surface without knowing it is tmux.
+///
+/// All ``TmuxControlModeSessionCore`` access is serialized on a private queue;
+/// delegate callbacks are invoked on that queue (the app hops to the main actor).
+public final class TmuxControlModeGateway: ControlModeSessionSource, @unchecked Sendable {
+    private let target: TmuxAttachTarget
+    private let tmuxExecutablePath: String
+    private let workingDirectory: String?
+    private let environment: [String: String]?
+
+    private let queue = DispatchQueue(label: "com.cmux.tmux-control-mode.gateway")
+    private var core = TmuxControlModeSessionCore()
+    private weak var delegate: (any ControlModeSessionDelegate)?
+
+    private let process = Process()
+    private let stdinPipe = Pipe()
+    private let stdoutPipe = Pipe()
+    private var launched = false
+    private var finished = false
+
+    public var displayName: String {
+        switch target {
+        case .mostRecent: return "tmux"
+        case let .session(name): return "tmux: \(name)"
+        }
+    }
+
+    public init(
+        target: TmuxAttachTarget,
+        tmuxExecutablePath: String,
+        workingDirectory: String? = nil,
+        environment: [String: String]? = nil
+    ) {
+        self.target = target
+        self.tmuxExecutablePath = tmuxExecutablePath
+        self.workingDirectory = workingDirectory
+        self.environment = environment
+    }
+
+    public func start(initialSize: TerminalSize, delegate: any ControlModeSessionDelegate) {
+        queue.async { [self] in
+            guard !launched else { return }
+            launched = true
+            self.delegate = delegate
+
+            process.executableURL = URL(fileURLWithPath: tmuxExecutablePath)
+            process.arguments = ["-CC"] + target.tmuxArguments
+            process.standardInput = stdinPipe
+            process.standardOutput = stdoutPipe
+            process.standardError = stdoutPipe // fold stderr into the stream; control protocol ignores stray lines
+            if let workingDirectory { process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory) }
+            if let environment { process.environment = environment }
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                let data = handle.availableData
+                guard let self else { return }
+                if data.isEmpty {
+                    // EOF; termination handler will deliver the end-of-session.
+                    handle.readabilityHandler = nil
+                    return
+                }
+                self.queue.async {
+                    self.apply(self.core.consume([UInt8](data)))
+                }
+            }
+
+            process.terminationHandler = { [weak self] proc in
+                guard let self else { return }
+                let reason = proc.terminationStatus == 0 ? nil : "tmux exited (\(proc.terminationStatus))"
+                self.queue.async {
+                    self.apply(self.core.gatewayExited(reason: reason))
+                }
+            }
+
+            do {
+                try process.run()
+            } catch {
+                finished = true
+                let delegate = self.delegate
+                DispatchQueue.main.async {
+                    delegate?.controlModeSession(didEndWithReason: "failed to launch tmux: \(error.localizedDescription)")
+                }
+                return
+            }
+
+            apply(core.start(initialSize: initialSize))
+        }
+    }
+
+    public func sendInput(_ bytes: [UInt8]) {
+        queue.async { [self] in
+            guard launched, !finished else { return }
+            apply(core.sendInput(bytes))
+        }
+    }
+
+    public func resize(_ size: TerminalSize) {
+        queue.async { [self] in
+            guard launched, !finished else { return }
+            apply(core.resize(size))
+        }
+    }
+
+    public func stop() {
+        queue.async { [self] in
+            guard launched, !finished else { return }
+            if process.isRunning { process.terminate() }
+        }
+    }
+
+    // MARK: - Effect application (always on `queue`)
+
+    private func apply(_ effects: [TmuxControlModeSessionCore.Effect]) {
+        guard !effects.isEmpty else { return }
+        for effect in effects {
+            switch effect {
+            case let .write(bytes):
+                writeToGateway(bytes)
+            case let .snapshot(bytes):
+                let delegate = self.delegate
+                DispatchQueue.main.async { delegate?.controlModeSession(didProduceSnapshot: bytes) }
+            case let .output(bytes):
+                let delegate = self.delegate
+                DispatchQueue.main.async { delegate?.controlModeSession(didProduceOutput: bytes) }
+            case let .ended(reason):
+                guard !finished else { continue }
+                finished = true
+                let delegate = self.delegate
+                DispatchQueue.main.async { delegate?.controlModeSession(didEndWithReason: reason) }
+            }
+        }
+    }
+
+    private func writeToGateway(_ bytes: [UInt8]) {
+        guard !bytes.isEmpty else { return }
+        do {
+            try stdinPipe.fileHandleForWriting.write(contentsOf: Data(bytes))
+        } catch {
+            // Broken pipe -> the gateway is gone; let the termination handler
+            // deliver the end-of-session.
+        }
+    }
+
+    // MARK: - tmux discovery
+
+    /// Resolve an absolute `tmux` path from common locations and `PATH`.
+    /// Returns nil when tmux is not installed. Pass `pathEnvironment` to search
+    /// a specific `PATH`; nil falls back to the current process environment.
+    public static func resolveTmuxExecutable(pathEnvironment: String? = nil) -> String? {
+        let fm = FileManager.default
+        var candidates = ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/usr/bin/tmux"]
+        let searchPath = pathEnvironment ?? ProcessInfo.processInfo.environment["PATH"]
+        if let searchPath {
+            for dir in searchPath.split(separator: ":") {
+                candidates.append("\(dir)/tmux")
+            }
+        }
+        for candidate in candidates where fm.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+        return nil
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeParser.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeParser.swift
@@ -32,7 +32,11 @@ public struct TmuxControlModeParser: Sendable {
         return events
     }
 
-    private mutating func processLine(_ line: [UInt8], into events: inout [TmuxControlModeEvent]) {
+    private mutating func processLine(_ rawLine: [UInt8], into events: inout [TmuxControlModeEvent]) {
+        // Outside a block, strip tmux's control-mode introducer/terminator,
+        // which it emits on the wire fused to the next token, e.g.
+        // "\u{1b}P1000p%begin …" on entry and a trailing ST ("\u{1b}\\") on exit.
+        let line = inBlock ? rawLine : Self.stripControlIntroducers(rawLine)
         if inBlock {
             if line.starts(with: Array("%end ".utf8)) || lineEquals(line, "%end") {
                 finishBlock(isError: false, into: &events)
@@ -180,6 +184,25 @@ public struct TmuxControlModeParser: Sendable {
     }
 
     private static func isOctalDigit(_ b: UInt8) -> Bool { b >= 0x30 && b <= 0x37 }
+
+    /// Remove tmux's control-mode introducer `ESC P 1 0 0 0 p` (entry) and the
+    /// `ESC \` string terminator (exit) wherever they sit at a line boundary.
+    /// tmux emits the entry sequence fused to the first `%begin`.
+    static func stripControlIntroducers(_ input: [UInt8]) -> [UInt8] {
+        let dcs: [UInt8] = [0x1B, 0x50, 0x31, 0x30, 0x30, 0x30, 0x70] // ESC P 1 0 0 0 p
+        let st: [UInt8] = [0x1B, 0x5C] // ESC backslash
+        var line = input
+        var changed = true
+        while changed {
+            changed = false
+            if line.starts(with: dcs) { line.removeFirst(dcs.count); changed = true }
+            if line.starts(with: st) { line.removeFirst(st.count); changed = true }
+        }
+        if line.count >= st.count, line.suffix(st.count).elementsEqual(st) {
+            line.removeLast(st.count)
+        }
+        return line
+    }
 
     private func lineEquals(_ line: [UInt8], _ s: String) -> Bool {
         line.elementsEqual(Array(s.utf8))

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeParser.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeParser.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Incremental, line-oriented parser for the `tmux -CC` control protocol.
+///
+/// Feed it raw gateway stdout via ``consume(_:)``; it buffers partial lines and
+/// returns decoded ``TmuxControlModeEvent`` values. It is a pure value type with
+/// no I/O, so it is fully unit-testable.
+public struct TmuxControlModeParser: Sendable {
+    private var lineBuffer: [UInt8] = []
+
+    // Command-block state. While `inBlock` is true, every non-fence line is
+    // buffered as command output (notifications never appear inside a block).
+    private var inBlock = false
+    private var blockNumber = 0
+    private var blockOutput: [String] = []
+
+    public init() {}
+
+    /// Consume a chunk of gateway output and return any events it completes.
+    public mutating func consume(_ bytes: [UInt8]) -> [TmuxControlModeEvent] {
+        guard !bytes.isEmpty else { return [] }
+        lineBuffer.append(contentsOf: bytes)
+
+        var events: [TmuxControlModeEvent] = []
+        while let newlineIndex = lineBuffer.firstIndex(of: 0x0A) /* \n */ {
+            var line = Array(lineBuffer[lineBuffer.startIndex..<newlineIndex])
+            // Strip a trailing CR (tmux uses \r\n on some lines).
+            if line.last == 0x0D /* \r */ { line.removeLast() }
+            lineBuffer.removeSubrange(lineBuffer.startIndex...newlineIndex)
+            processLine(line, into: &events)
+        }
+        return events
+    }
+
+    private mutating func processLine(_ line: [UInt8], into events: inout [TmuxControlModeEvent]) {
+        if inBlock {
+            if line.starts(with: Array("%end ".utf8)) || lineEquals(line, "%end") {
+                finishBlock(isError: false, into: &events)
+                return
+            }
+            if line.starts(with: Array("%error ".utf8)) || lineEquals(line, "%error") {
+                finishBlock(isError: true, into: &events)
+                return
+            }
+            // Verbatim command output line.
+            blockOutput.append(String(decoding: line, as: UTF8.self))
+            return
+        }
+
+        guard line.first == 0x25 /* % */ else {
+            // Outside a block, non-% lines are not part of the protocol
+            // (e.g. the DCS sent on entering control mode). Ignore them.
+            return
+        }
+
+        let text = String(decoding: line, as: UTF8.self)
+        if text.hasPrefix("%begin ") {
+            inBlock = true
+            blockOutput = []
+            blockNumber = Self.commandNumber(fromFence: text)
+            events.append(.begin(number: blockNumber))
+            return
+        }
+        decodeNotification(line: line, text: text, into: &events)
+    }
+
+    private mutating func finishBlock(isError: Bool, into events: inout [TmuxControlModeEvent]) {
+        events.append(.commandResult(number: blockNumber, output: blockOutput, isError: isError))
+        inBlock = false
+        blockOutput = []
+    }
+
+    private func decodeNotification(line: [UInt8], text: String, into events: inout [TmuxControlModeEvent]) {
+        // %output and %extended-output carry octal-escaped binary data after the
+        // pane id, so they are decoded at the byte level. Everything else is
+        // plain ASCII tokens.
+        if line.starts(with: Array("%output ".utf8)) {
+            if let (pane, dataBytes) = Self.paneAndData(line, prefixLength: 8) {
+                events.append(.output(paneID: pane, bytes: Self.unescapeOutput(dataBytes)))
+            }
+            return
+        }
+        if line.starts(with: Array("%extended-output ".utf8)) {
+            // %extended-output %<pane> <age> : <data>
+            if let (pane, rest) = Self.paneAndData(line, prefixLength: 17),
+               let colon = rest.firstIndex(of: 0x3A) /* : */ {
+                // Data begins one byte after the colon's trailing space.
+                var dataStart = rest.index(after: colon)
+                if dataStart < rest.endIndex, rest[dataStart] == 0x20 { dataStart = rest.index(after: dataStart) }
+                let dataBytes = rest[dataStart..<rest.endIndex]
+                events.append(.output(paneID: pane, bytes: Self.unescapeOutput(dataBytes)))
+            }
+            return
+        }
+
+        let tokens = text.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard let head = tokens.first else { return }
+        let name = String(head.dropFirst()) // drop leading '%'
+        let args = Array(tokens.dropFirst())
+
+        switch name {
+        case "layout-change":
+            // %layout-change <window> <layout> <visible-layout> <flags>
+            events.append(.layoutChange(
+                window: args.first ?? "",
+                layout: args.count > 1 ? args[1] : "",
+                visibleLayout: args.count > 2 ? args[2] : nil,
+                flags: args.count > 3 ? args[3] : nil
+            ))
+        case "window-add":
+            events.append(.windowAdd(window: args.first ?? ""))
+        case "window-close", "unlinked-window-close":
+            events.append(.windowClose(window: args.first ?? ""))
+        case "window-renamed":
+            events.append(.windowRenamed(window: args.first ?? "", name: args.count > 1 ? tokens.dropFirst(2).joined(separator: " ") : ""))
+        case "window-pane-changed":
+            events.append(.windowPaneChanged(window: args.first ?? "", pane: args.count > 1 ? args[1] : ""))
+        case "session-changed":
+            events.append(.sessionChanged(session: args.first ?? "", name: args.count > 1 ? args[1] : ""))
+        case "sessions-changed":
+            events.append(.sessionsChanged)
+        case "pane-mode-changed":
+            events.append(.paneModeChanged(pane: args.first ?? ""))
+        case "exit":
+            events.append(.exit(reason: args.isEmpty ? nil : args.joined(separator: " ")))
+        case "client-detached":
+            events.append(.clientDetached)
+        default:
+            events.append(.notification(name: name, arguments: args))
+        }
+    }
+
+    // MARK: - Static helpers
+
+    private static func commandNumber(fromFence text: String) -> Int {
+        // "%begin <time> <number> <flags>"
+        let parts = text.split(separator: " ")
+        guard parts.count >= 3 else { return 0 }
+        return Int(parts[2]) ?? 0
+    }
+
+    /// Split a `%output`/`%extended-output` line into the pane id and the
+    /// remaining bytes (data, or `age : data`). `prefixLength` is the byte
+    /// length of the directive plus its trailing space.
+    private static func paneAndData(_ line: [UInt8], prefixLength: Int) -> (pane: String, rest: ArraySlice<UInt8>)? {
+        guard line.count > prefixLength else { return nil }
+        let afterPrefix = line[(line.startIndex + prefixLength)...]
+        guard let spaceIndex = afterPrefix.firstIndex(of: 0x20) else { return nil }
+        let paneBytes = afterPrefix[afterPrefix.startIndex..<spaceIndex]
+        let pane = String(decoding: paneBytes, as: UTF8.self)
+        let rest = afterPrefix[afterPrefix.index(after: spaceIndex)...]
+        return (pane, rest)
+    }
+
+    /// Reverse tmux's control-mode escaping: a backslash followed by exactly
+    /// three octal digits encodes one raw byte (e.g. `\033` -> 0x1B, `\134` ->
+    /// `\`). Anything else is passed through verbatim.
+    static func unescapeOutput(_ bytes: ArraySlice<UInt8>) -> [UInt8] {
+        var out: [UInt8] = []
+        out.reserveCapacity(bytes.count)
+        var i = bytes.startIndex
+        while i < bytes.endIndex {
+            let b = bytes[i]
+            if b == 0x5C /* \ */ {
+                let d0 = bytes.index(i, offsetBy: 1, limitedBy: bytes.endIndex)
+                let d1 = bytes.index(i, offsetBy: 2, limitedBy: bytes.endIndex)
+                let d2 = bytes.index(i, offsetBy: 3, limitedBy: bytes.endIndex)
+                if let d0, let d1, let d2, d0 < bytes.endIndex, d1 < bytes.endIndex, d2 < bytes.endIndex,
+                   isOctalDigit(bytes[d0]), isOctalDigit(bytes[d1]), isOctalDigit(bytes[d2]) {
+                    let value = (Int(bytes[d0] - 0x30) << 6) | (Int(bytes[d1] - 0x30) << 3) | Int(bytes[d2] - 0x30)
+                    out.append(UInt8(truncatingIfNeeded: value))
+                    i = bytes.index(i, offsetBy: 4)
+                    continue
+                }
+            }
+            out.append(b)
+            i = bytes.index(after: i)
+        }
+        return out
+    }
+
+    private static func isOctalDigit(_ b: UInt8) -> Bool { b >= 0x30 && b <= 0x37 }
+
+    private func lineEquals(_ line: [UInt8], _ s: String) -> Bool {
+        line.elementsEqual(Array(s.utf8))
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
@@ -116,8 +116,15 @@ public struct TmuxControlModeSessionCore: Sendable {
     }
 
     private mutating func deliverSnapshot(output: [String], into effects: inout [Effect]) {
-        var bytes = Array(output.joined(separator: "\r\n").utf8)
-        if !output.isEmpty { bytes.append(contentsOf: [0x0D, 0x0A]) } // trailing CRLF
+        // Trim trailing blank rows (capture-pane pads to the screen height) and
+        // emit no trailing newline, so the snapshot anchors at the top of the
+        // surface with the cursor right after the last real line — matching how
+        // the pane looks in tmux instead of sinking to the bottom.
+        var lines = output
+        while let last = lines.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            lines.removeLast()
+        }
+        let bytes = Array(lines.joined(separator: "\r\n").utf8)
         effects.append(.snapshot(bytes))
         if !pendingLiveOutput.isEmpty {
             effects.append(.output(pendingLiveOutput))

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
@@ -126,10 +126,10 @@ public struct TmuxControlModeSessionCore: Sendable {
         }
         let bytes = Array(lines.joined(separator: "\r\n").utf8)
         effects.append(.snapshot(bytes))
-        if !pendingLiveOutput.isEmpty {
-            effects.append(.output(pendingLiveOutput))
-            pendingLiveOutput.removeAll(keepingCapacity: false)
-        }
+        // Any pane output buffered before the capture-pane result is already
+        // reflected in the snapshot, so drop it rather than replaying it (which
+        // would duplicate the last line, e.g. a second prompt).
+        pendingLiveOutput.removeAll(keepingCapacity: false)
     }
 
     // MARK: - Helpers

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Pure orchestration for a local tmux control-mode session, with no process
+/// or threading. It turns gateway input + caller intents into a list of
+/// ``Effect`` values (bytes to write to the gateway, snapshot/output to feed
+/// the surface, end-of-session). The Process- and queue-bound wrapper lives in
+/// ``TmuxControlModeGateway``; keeping the logic here makes it synchronously
+/// testable with a fake transport.
+public struct TmuxControlModeSessionCore: Sendable {
+    public enum Effect: Equatable, Sendable {
+        /// Bytes to write to the gateway's stdin (a tmux command + newline).
+        case write([UInt8])
+        /// The initial snapshot to feed into the surface (before live output).
+        case snapshot([UInt8])
+        /// Live pane bytes to feed into the surface.
+        case output([UInt8])
+        /// The session ended.
+        case ended(reason: String?)
+    }
+
+    /// Each command we write is answered by exactly one `%begin`…`%end` block,
+    /// in order, so we track what each pending response is for.
+    private enum PendingCommand: Equatable {
+        case ignore        // refresh-client, send-keys: result discarded
+        case resolvePane   // list-panes: parse the active pane id
+        case snapshot      // capture-pane: deliver as the initial snapshot
+    }
+
+    private var parser = TmuxControlModeParser()
+    private var pending: [PendingCommand] = []
+
+    private var targetPane: String?
+    private var snapshotDelivered = false
+    private var pendingLiveOutput: [UInt8] = []
+    private var ended = false
+
+    public init() {}
+
+    /// Resolve the active pane, then capture it. The gateway has already been
+    /// spawned for the chosen target; here we negotiate size and snapshot.
+    public mutating func start(initialSize: TerminalSize) -> [Effect] {
+        var effects: [Effect] = []
+        effects.append(writeCommand(TmuxControlModeEncoder.refreshClientSize(initialSize), as: .ignore))
+        effects.append(writeCommand(TmuxControlModeEncoder.listActivePanes(), as: .resolvePane))
+        return effects
+    }
+
+    /// Feed raw gateway stdout.
+    public mutating func consume(_ bytes: [UInt8]) -> [Effect] {
+        guard !ended else { return [] }
+        var effects: [Effect] = []
+        for event in parser.consume(bytes) {
+            handle(event, into: &effects)
+            if ended { break }
+        }
+        return effects
+    }
+
+    public mutating func sendInput(_ bytes: [UInt8]) -> [Effect] {
+        guard !ended, let pane = targetPane, !bytes.isEmpty else { return [] }
+        return [writeCommand(TmuxControlModeEncoder.sendKeys(paneID: pane, bytes: bytes), as: .ignore)]
+    }
+
+    public mutating func resize(_ size: TerminalSize) -> [Effect] {
+        guard !ended else { return [] }
+        return [writeCommand(TmuxControlModeEncoder.refreshClientSize(size), as: .ignore)]
+    }
+
+    /// The gateway process exited.
+    public mutating func gatewayExited(reason: String?) -> [Effect] {
+        guard !ended else { return [] }
+        ended = true
+        return [.ended(reason: reason)]
+    }
+
+    // MARK: - Event handling
+
+    private mutating func handle(_ event: TmuxControlModeEvent, into effects: inout [Effect]) {
+        switch event {
+        case .begin:
+            break
+        case let .commandResult(_, output, isError):
+            let kind = pending.isEmpty ? nil : pending.removeFirst()
+            switch kind {
+            case .resolvePane:
+                handleResolvePane(output: output, isError: isError, into: &effects)
+            case .snapshot:
+                deliverSnapshot(output: output, into: &effects)
+            case .ignore, .none:
+                break
+            }
+        case let .output(paneID, bytes):
+            guard paneID == targetPane else { return }
+            if snapshotDelivered {
+                effects.append(.output(bytes))
+            } else {
+                pendingLiveOutput.append(contentsOf: bytes)
+            }
+        case .exit(let reason):
+            ended = true
+            effects.append(.ended(reason: reason))
+        case .clientDetached:
+            ended = true
+            effects.append(.ended(reason: "detached"))
+        default:
+            break
+        }
+    }
+
+    private mutating func handleResolvePane(output: [String], isError: Bool, into effects: inout [Effect]) {
+        guard !isError, let pane = Self.activePane(from: output) else {
+            ended = true
+            effects.append(.ended(reason: "no active tmux pane"))
+            return
+        }
+        targetPane = pane
+        effects.append(writeCommand(TmuxControlModeEncoder.capturePane(paneID: pane), as: .snapshot))
+    }
+
+    private mutating func deliverSnapshot(output: [String], into effects: inout [Effect]) {
+        guard !snapshotDelivered else { return }
+        snapshotDelivered = true
+        var bytes = Array(output.joined(separator: "\r\n").utf8)
+        if !output.isEmpty { bytes.append(contentsOf: [0x0D, 0x0A]) } // trailing CRLF
+        effects.append(.snapshot(bytes))
+        if !pendingLiveOutput.isEmpty {
+            effects.append(.output(pendingLiveOutput))
+            pendingLiveOutput.removeAll(keepingCapacity: false)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private mutating func writeCommand(_ command: String, as kind: PendingCommand) -> Effect {
+        pending.append(kind)
+        var bytes = Array(command.utf8)
+        bytes.append(0x0A) // \n
+        return .write(bytes)
+    }
+
+    /// Pick the active pane id from `list-panes -F '#{pane_active}:#{pane_id}'`
+    /// output. Lines look like `1:%3` (active) / `0:%4`.
+    static func activePane(from output: [String]) -> String? {
+        for line in output {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard let colon = trimmed.firstIndex(of: ":") else { continue }
+            let active = trimmed[trimmed.startIndex..<colon]
+            let pane = String(trimmed[trimmed.index(after: colon)...])
+            if active == "1", !pane.isEmpty { return pane }
+        }
+        // Fall back to the first listed pane if none is flagged active.
+        for line in output {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard let colon = trimmed.firstIndex(of: ":") else { continue }
+            let pane = String(trimmed[trimmed.index(after: colon)...])
+            if !pane.isEmpty { return pane }
+        }
+        return nil
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
@@ -39,6 +39,14 @@ public struct TmuxControlModeSessionCore: Sendable {
     private var pendingLiveOutput: [UInt8] = []
     private var ended = false
 
+    /// tmux prefix handling. Keys arrive already encoded, so the prefix is the
+    /// control byte (Ctrl-b = 0x02 by default). We intercept `<prefix> d` to
+    /// detach; any other prefixed key is passed through literally (so Ctrl-b
+    /// still works in the pane for unmapped chords).
+    private static let prefixByte: UInt8 = 0x02 // Ctrl-b
+    private static let detachKey: UInt8 = 0x64  // 'd'
+    private var awaitingPrefixChord = false
+
     public init() {}
 
     /// Negotiate size, then ask tmux for its panes so we can resolve the one to
@@ -63,7 +71,32 @@ public struct TmuxControlModeSessionCore: Sendable {
 
     public mutating func sendInput(_ bytes: [UInt8]) -> [Effect] {
         guard !ended, let pane = targetPane, !bytes.isEmpty else { return [] }
-        return [.write(commandBytes(TmuxControlModeEncoder.sendKeys(paneID: pane, bytes: bytes)))]
+        var effects: [Effect] = []
+        var passthrough: [UInt8] = []
+        func flush() {
+            guard !passthrough.isEmpty else { return }
+            effects.append(.write(commandBytes(TmuxControlModeEncoder.sendKeys(paneID: pane, bytes: passthrough))))
+            passthrough.removeAll(keepingCapacity: true)
+        }
+        for byte in bytes {
+            if awaitingPrefixChord {
+                awaitingPrefixChord = false
+                if byte == Self.detachKey {
+                    flush()
+                    effects.append(.write(commandBytes(TmuxControlModeEncoder.detachClient())))
+                } else {
+                    // Unmapped chord: pass the prefix and key through literally.
+                    passthrough.append(Self.prefixByte)
+                    passthrough.append(byte)
+                }
+            } else if byte == Self.prefixByte {
+                awaitingPrefixChord = true
+            } else {
+                passthrough.append(byte)
+            }
+        }
+        flush()
+        return effects
     }
 
     public mutating func resize(_ size: TerminalSize) -> [Effect] {

--- a/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
+++ b/Packages/CmuxTmuxControlMode/Sources/CmuxTmuxControlMode/TmuxControlModeSessionCore.swift
@@ -6,6 +6,14 @@ import Foundation
 /// the surface, end-of-session). The Process- and queue-bound wrapper lives in
 /// ``TmuxControlModeGateway``; keeping the logic here makes it synchronously
 /// testable with a fake transport.
+///
+/// Command responses are matched by **content/phase**, not by a positional
+/// queue: tmux emits spontaneous `%begin`/`%end` blocks on entry (e.g. an
+/// initial empty block), so a positional FIFO desyncs. Instead we send
+/// `list-panes` and treat the first command block whose output parses as a pane
+/// list as the resolver; the first block after we request `capture-pane` is the
+/// snapshot; everything else (the entry block, `refresh-client`/`send-keys`
+/// acknowledgements) is ignored.
 public struct TmuxControlModeSessionCore: Sendable {
     public enum Effect: Equatable, Sendable {
         /// Bytes to write to the gateway's stdin (a tmux command + newline).
@@ -18,30 +26,27 @@ public struct TmuxControlModeSessionCore: Sendable {
         case ended(reason: String?)
     }
 
-    /// Each command we write is answered by exactly one `%begin`…`%end` block,
-    /// in order, so we track what each pending response is for.
-    private enum PendingCommand: Equatable {
-        case ignore        // refresh-client, send-keys: result discarded
-        case resolvePane   // list-panes: parse the active pane id
-        case snapshot      // capture-pane: deliver as the initial snapshot
+    private enum Phase: Equatable {
+        case resolvingPane   // waiting for a command block that parses as a pane list
+        case capturing       // capture-pane requested; next command block is the snapshot
+        case live            // snapshot delivered; command blocks are acknowledgements
     }
 
     private var parser = TmuxControlModeParser()
-    private var pending: [PendingCommand] = []
+    private var phase: Phase = .resolvingPane
 
     private var targetPane: String?
-    private var snapshotDelivered = false
     private var pendingLiveOutput: [UInt8] = []
     private var ended = false
 
     public init() {}
 
-    /// Resolve the active pane, then capture it. The gateway has already been
-    /// spawned for the chosen target; here we negotiate size and snapshot.
+    /// Negotiate size, then ask tmux for its panes so we can resolve the one to
+    /// render. The gateway has already been spawned for the chosen target.
     public mutating func start(initialSize: TerminalSize) -> [Effect] {
         var effects: [Effect] = []
-        effects.append(writeCommand(TmuxControlModeEncoder.refreshClientSize(initialSize), as: .ignore))
-        effects.append(writeCommand(TmuxControlModeEncoder.listActivePanes(), as: .resolvePane))
+        effects.append(.write(commandBytes(TmuxControlModeEncoder.refreshClientSize(initialSize))))
+        effects.append(.write(commandBytes(TmuxControlModeEncoder.listActivePanes())))
         return effects
     }
 
@@ -58,12 +63,12 @@ public struct TmuxControlModeSessionCore: Sendable {
 
     public mutating func sendInput(_ bytes: [UInt8]) -> [Effect] {
         guard !ended, let pane = targetPane, !bytes.isEmpty else { return [] }
-        return [writeCommand(TmuxControlModeEncoder.sendKeys(paneID: pane, bytes: bytes), as: .ignore)]
+        return [.write(commandBytes(TmuxControlModeEncoder.sendKeys(paneID: pane, bytes: bytes)))]
     }
 
     public mutating func resize(_ size: TerminalSize) -> [Effect] {
         guard !ended else { return [] }
-        return [writeCommand(TmuxControlModeEncoder.refreshClientSize(size), as: .ignore)]
+        return [.write(commandBytes(TmuxControlModeEncoder.refreshClientSize(size)))]
     }
 
     /// The gateway process exited.
@@ -77,21 +82,24 @@ public struct TmuxControlModeSessionCore: Sendable {
 
     private mutating func handle(_ event: TmuxControlModeEvent, into effects: inout [Effect]) {
         switch event {
-        case .begin:
-            break
         case let .commandResult(_, output, isError):
-            let kind = pending.isEmpty ? nil : pending.removeFirst()
-            switch kind {
-            case .resolvePane:
-                handleResolvePane(output: output, isError: isError, into: &effects)
-            case .snapshot:
+            switch phase {
+            case .resolvingPane:
+                // Ignore the entry block, refresh-client ack, and any other
+                // block that is not the pane list. Only resolve on a real list.
+                guard !isError, let pane = Self.activePane(from: output) else { return }
+                targetPane = pane
+                phase = .capturing
+                effects.append(.write(commandBytes(TmuxControlModeEncoder.capturePane(paneID: pane))))
+            case .capturing:
                 deliverSnapshot(output: output, into: &effects)
-            case .ignore, .none:
+                phase = .live
+            case .live:
                 break
             }
         case let .output(paneID, bytes):
             guard paneID == targetPane else { return }
-            if snapshotDelivered {
+            if phase == .live {
                 effects.append(.output(bytes))
             } else {
                 pendingLiveOutput.append(contentsOf: bytes)
@@ -107,19 +115,7 @@ public struct TmuxControlModeSessionCore: Sendable {
         }
     }
 
-    private mutating func handleResolvePane(output: [String], isError: Bool, into effects: inout [Effect]) {
-        guard !isError, let pane = Self.activePane(from: output) else {
-            ended = true
-            effects.append(.ended(reason: "no active tmux pane"))
-            return
-        }
-        targetPane = pane
-        effects.append(writeCommand(TmuxControlModeEncoder.capturePane(paneID: pane), as: .snapshot))
-    }
-
     private mutating func deliverSnapshot(output: [String], into effects: inout [Effect]) {
-        guard !snapshotDelivered else { return }
-        snapshotDelivered = true
         var bytes = Array(output.joined(separator: "\r\n").utf8)
         if !output.isEmpty { bytes.append(contentsOf: [0x0D, 0x0A]) } // trailing CRLF
         effects.append(.snapshot(bytes))
@@ -131,30 +127,26 @@ public struct TmuxControlModeSessionCore: Sendable {
 
     // MARK: - Helpers
 
-    private mutating func writeCommand(_ command: String, as kind: PendingCommand) -> Effect {
-        pending.append(kind)
+    private func commandBytes(_ command: String) -> [UInt8] {
         var bytes = Array(command.utf8)
         bytes.append(0x0A) // \n
-        return .write(bytes)
+        return bytes
     }
 
     /// Pick the active pane id from `list-panes -F '#{pane_active}:#{pane_id}'`
-    /// output. Lines look like `1:%3` (active) / `0:%4`.
+    /// output. Lines look like `1:%3` (active) / `0:%4`. Returns nil if no line
+    /// parses as a pane entry (so non-pane command blocks are skipped).
     static func activePane(from output: [String]) -> String? {
+        var firstPane: String?
         for line in output {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             guard let colon = trimmed.firstIndex(of: ":") else { continue }
             let active = trimmed[trimmed.startIndex..<colon]
             let pane = String(trimmed[trimmed.index(after: colon)...])
-            if active == "1", !pane.isEmpty { return pane }
+            guard pane.hasPrefix("%"), pane.count > 1 else { continue }
+            if firstPane == nil { firstPane = pane }
+            if active == "1" { return pane }
         }
-        // Fall back to the first listed pane if none is flagged active.
-        for line in output {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard let colon = trimmed.firstIndex(of: ":") else { continue }
-            let pane = String(trimmed[trimmed.index(after: colon)...])
-            if !pane.isEmpty { return pane }
-        }
-        return nil
+        return firstPane
     }
 }

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeEncoderTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeEncoderTests.swift
@@ -1,0 +1,23 @@
+import Testing
+@testable import CmuxTmuxControlMode
+
+@Suite("tmux control mode encoder")
+struct TmuxControlModeEncoderTests {
+    @Test func capturePaneRequestsFullHistoryWithEscapes() {
+        #expect(TmuxControlModeEncoder.capturePane(paneID: "%3") == "capture-pane -t %3 -p -e -J -S - -E -")
+    }
+
+    @Test func sendKeysEncodesBytesAsHex() {
+        #expect(TmuxControlModeEncoder.sendKeys(paneID: "%1", bytes: [0x68, 0x69, 0x0D]) == "send-keys -t %1 -H 68 69 0d")
+    }
+
+    @Test func refreshClientUsesColumnsByRows() {
+        #expect(TmuxControlModeEncoder.refreshClientSize(TerminalSize(columns: 120, rows: 40)) == "refresh-client -C 120x40")
+    }
+
+    @Test func terminalSizeClampsToOne() {
+        let size = TerminalSize(columns: 0, rows: -5)
+        #expect(size.columns == 1)
+        #expect(size.rows == 1)
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeParserTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeParserTests.swift
@@ -80,6 +80,20 @@ struct TmuxControlModeParserTests {
         #expect(events == [.output(paneID: "%1", bytes: Array("ok".utf8))])
     }
 
+    @Test func stripsControlModeEntryDcsFusedToFirstBegin() {
+        // tmux emits the entry DCS fused to the first %begin on the wire.
+        let events = parse("\u{1b}P1000p%begin 1 5 0\nok\n%end 1 5 0\n")
+        #expect(events == [
+            .begin(number: 5),
+            .commandResult(number: 5, output: ["ok"], isError: false),
+        ])
+    }
+
+    @Test func stripsTrailingStringTerminatorOnExit() {
+        let events = parse("%exit\u{1b}\\\n")
+        #expect(events == [.exit(reason: nil)])
+    }
+
     @Test func decodesExtendedOutput() {
         let events = parse("%extended-output %1 5 : data\n")
         #expect(events == [.output(paneID: "%1", bytes: Array("data".utf8))])

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeParserTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeParserTests.swift
@@ -1,0 +1,87 @@
+import Testing
+@testable import CmuxTmuxControlMode
+
+@Suite("tmux control mode parser")
+struct TmuxControlModeParserTests {
+    private func parse(_ s: String) -> [TmuxControlModeEvent] {
+        var parser = TmuxControlModeParser()
+        return parser.consume(Array(s.utf8))
+    }
+
+    @Test func decodesOutputAndUnescapesOctal() {
+        // \033]0;t\007hi  -> ESC ] 0 ; t BEL h i
+        let events = parse("%output %1 \\033]0;t\\007hi\n")
+        #expect(events == [.output(paneID: "%1", bytes: [0x1B, 0x5D, 0x30, 0x3B, 0x74, 0x07, 0x68, 0x69])])
+    }
+
+    @Test func unescapesBackslashItself() {
+        // tmux escapes a literal backslash as \134
+        let events = parse("%output %2 a\\134b\n")
+        #expect(events == [.output(paneID: "%2", bytes: [0x61, 0x5C, 0x62])])
+    }
+
+    @Test func outputDataMayContainSpaces() {
+        let events = parse("%output %0 hello world\n")
+        #expect(events == [.output(paneID: "%0", bytes: Array("hello world".utf8))])
+    }
+
+    @Test func commandBlockAggregatesOutputLines() {
+        let events = parse("%begin 100 7 1\nline one\nline two\n%end 100 7 1\n")
+        #expect(events == [
+            .begin(number: 7),
+            .commandResult(number: 7, output: ["line one", "line two"], isError: false),
+        ])
+    }
+
+    @Test func errorBlockIsFlagged() {
+        let events = parse("%begin 1 3 1\nboom\n%error 1 3 1\n")
+        #expect(events == [
+            .begin(number: 3),
+            .commandResult(number: 3, output: ["boom"], isError: true),
+        ])
+    }
+
+    @Test func notificationLinesInsideBlockAreTreatedAsOutput() {
+        // The "notifications never appear inside a block" invariant means a line
+        // that merely looks like a notification is command output here.
+        let events = parse("%begin 1 1 1\n%this-is-data\n%end 1 1 1\n")
+        #expect(events == [
+            .begin(number: 1),
+            .commandResult(number: 1, output: ["%this-is-data"], isError: false),
+        ])
+    }
+
+    @Test func decodesLayoutChange() {
+        let events = parse("%layout-change @0 b25f,80x24,0,0,1 b25f,80x24,0,0,1 *\n")
+        #expect(events == [.layoutChange(window: "@0", layout: "b25f,80x24,0,0,1", visibleLayout: "b25f,80x24,0,0,1", flags: "*")])
+    }
+
+    @Test func decodesExitAndDetach() {
+        #expect(parse("%exit\n") == [.exit(reason: nil)])
+        #expect(parse("%exit server exited\n") == [.exit(reason: "server exited")])
+        #expect(parse("%client-detached client-1\n") == [.clientDetached])
+    }
+
+    @Test func handlesCRLFLineEndings() {
+        let events = parse("%output %1 hi\r\n")
+        #expect(events == [.output(paneID: "%1", bytes: Array("hi".utf8))])
+    }
+
+    @Test func buffersPartialLinesAcrossChunks() {
+        var parser = TmuxControlModeParser()
+        #expect(parser.consume(Array("%output %1 he".utf8)).isEmpty)
+        let events = parser.consume(Array("llo\n".utf8))
+        #expect(events == [.output(paneID: "%1", bytes: Array("hello".utf8))])
+    }
+
+    @Test func ignoresStrayNonProtocolLinesOutsideBlock() {
+        // The DCS / leftover terminal noise before the protocol settles.
+        let events = parse("garbage line\n%output %1 ok\n")
+        #expect(events == [.output(paneID: "%1", bytes: Array("ok".utf8))])
+    }
+
+    @Test func decodesExtendedOutput() {
+        let events = parse("%extended-output %1 5 : data\n")
+        #expect(events == [.output(paneID: "%1", bytes: Array("data".utf8))])
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
@@ -54,21 +54,21 @@ struct TmuxControlModeSessionCoreTests {
         #expect(result.snapshots == [Array("row1\r\nrow2".utf8)])
     }
 
-    @Test func liveOutputBeforeSnapshotIsBufferedThenFlushed() {
+    @Test func liveOutputBeforeSnapshotIsDiscardedNotDuplicated() {
         var core = TmuxControlModeSessionCore()
         _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
         _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))          // refresh-client
         _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))    // list-panes -> capture-pane queued
 
-        // Live output for the target pane arrives before the snapshot completes.
+        // Pre-snapshot output is already reflected in capture-pane, so it must
+        // not be replayed after the snapshot (that caused a duplicate prompt).
         let early = core.consume(Array("%output %5 early\n".utf8))
-        #expect(bytes(early).outputs.isEmpty) // buffered, not emitted yet
+        #expect(bytes(early).outputs.isEmpty)
 
-        // Snapshot completes -> snapshot first, then buffered live output.
         let afterCapture = core.consume(Array("%begin 3 3 0\nscreen\n%end 3 3 0\n".utf8))
         let result = bytes(afterCapture)
         #expect(result.snapshots == [Array("screen".utf8)])
-        #expect(result.outputs == [Array("early".utf8)])
+        #expect(result.outputs.isEmpty) // discarded, not flushed
 
         // Subsequent output is emitted directly.
         let live = core.consume(Array("%output %5 more\n".utf8))

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
@@ -100,6 +100,33 @@ struct TmuxControlModeSessionCoreTests {
         #expect(commands(core.sendInput([0x68, 0x69])) == ["send-keys -t %5 -H 68 69"])
     }
 
+    @Test func prefixDDetachesViaDetachClient() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))
+        // Ctrl-b (0x02) then 'd' (0x64) -> detach-client, no send-keys.
+        #expect(commands(core.sendInput([0x02, 0x64])) == ["detach-client"])
+    }
+
+    @Test func prefixSplitAcrossCallsStillDetaches() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))
+        #expect(commands(core.sendInput([0x02])).isEmpty) // prefix held
+        #expect(commands(core.sendInput([0x64])) == ["detach-client"])
+    }
+
+    @Test func unmappedPrefixChordPassesThrough() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))
+        // Ctrl-b then 'x' (not mapped) -> both bytes sent to the pane.
+        #expect(commands(core.sendInput([0x02, 0x78])) == ["send-keys -t %5 -H 02 78"])
+    }
+
     @Test func resizeEmitsRefreshClient() {
         var core = TmuxControlModeSessionCore()
         _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
@@ -51,7 +51,7 @@ struct TmuxControlModeSessionCoreTests {
         // capture-pane response -> snapshot.
         let afterCapture = core.consume(Array("%begin 3 3 0\nrow1\nrow2\n%end 3 3 0\n".utf8))
         let result = bytes(afterCapture)
-        #expect(result.snapshots == [Array("row1\r\nrow2\r\n".utf8)])
+        #expect(result.snapshots == [Array("row1\r\nrow2".utf8)])
     }
 
     @Test func liveOutputBeforeSnapshotIsBufferedThenFlushed() {
@@ -67,7 +67,7 @@ struct TmuxControlModeSessionCoreTests {
         // Snapshot completes -> snapshot first, then buffered live output.
         let afterCapture = core.consume(Array("%begin 3 3 0\nscreen\n%end 3 3 0\n".utf8))
         let result = bytes(afterCapture)
-        #expect(result.snapshots == [Array("screen\r\n".utf8)])
+        #expect(result.snapshots == [Array("screen".utf8)])
         #expect(result.outputs == [Array("early".utf8)])
 
         // Subsequent output is emitted directly.

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
@@ -1,0 +1,132 @@
+import Testing
+@testable import CmuxTmuxControlMode
+
+@Suite("tmux control mode session core")
+struct TmuxControlModeSessionCoreTests {
+    private typealias Effect = TmuxControlModeSessionCore.Effect
+
+    private func commands(_ effects: [Effect]) -> [String] {
+        effects.compactMap { effect in
+            guard case let .write(bytes) = effect else { return nil }
+            return String(decoding: bytes, as: UTF8.self).trimmingCharacters(in: ["\n"])
+        }
+    }
+
+    private func bytes(_ effects: [Effect]) -> (snapshots: [[UInt8]], outputs: [[UInt8]], ended: [String?]) {
+        var snapshots: [[UInt8]] = []
+        var outputs: [[UInt8]] = []
+        var ended: [String?] = []
+        for effect in effects {
+            switch effect {
+            case let .snapshot(b): snapshots.append(b)
+            case let .output(b): outputs.append(b)
+            case let .ended(r): ended.append(r)
+            case .write: break
+            }
+        }
+        return (snapshots, outputs, ended)
+    }
+
+    @Test func startNegotiatesSizeThenResolvesPane() {
+        var core = TmuxControlModeSessionCore()
+        let started = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        #expect(commands(started) == [
+            "refresh-client -C 80x24",
+            "list-panes -F '#{pane_active}:#{pane_id}'",
+        ])
+    }
+
+    @Test func fullAttachFlowResolvesPaneCapturesAndSnapshots() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+
+        // refresh-client response (ignored).
+        let afterRefresh = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        #expect(commands(afterRefresh).isEmpty)
+
+        // list-panes response -> capture-pane the active pane (%5).
+        let afterList = core.consume(Array("%begin 2 2 0\n1:%5\n0:%6\n%end 2 2 0\n".utf8))
+        #expect(commands(afterList) == ["capture-pane -t %5 -p -e -J -S - -E -"])
+
+        // capture-pane response -> snapshot.
+        let afterCapture = core.consume(Array("%begin 3 3 0\nrow1\nrow2\n%end 3 3 0\n".utf8))
+        let result = bytes(afterCapture)
+        #expect(result.snapshots == [Array("row1\r\nrow2\r\n".utf8)])
+    }
+
+    @Test func liveOutputBeforeSnapshotIsBufferedThenFlushed() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))          // refresh-client
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))    // list-panes -> capture-pane queued
+
+        // Live output for the target pane arrives before the snapshot completes.
+        let early = core.consume(Array("%output %5 early\n".utf8))
+        #expect(bytes(early).outputs.isEmpty) // buffered, not emitted yet
+
+        // Snapshot completes -> snapshot first, then buffered live output.
+        let afterCapture = core.consume(Array("%begin 3 3 0\nscreen\n%end 3 3 0\n".utf8))
+        let result = bytes(afterCapture)
+        #expect(result.snapshots == [Array("screen\r\n".utf8)])
+        #expect(result.outputs == [Array("early".utf8)])
+
+        // Subsequent output is emitted directly.
+        let live = core.consume(Array("%output %5 more\n".utf8))
+        #expect(bytes(live).outputs == [Array("more".utf8)])
+    }
+
+    @Test func outputForOtherPanesIsIgnored() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))
+        _ = core.consume(Array("%begin 3 3 0\nx\n%end 3 3 0\n".utf8)) // snapshot delivered
+
+        let other = core.consume(Array("%output %9 nope\n".utf8))
+        #expect(bytes(other).outputs.isEmpty)
+        let mine = core.consume(Array("%output %5 yes\n".utf8))
+        #expect(bytes(mine).outputs == [Array("yes".utf8)])
+    }
+
+    @Test func sendInputEncodesSendKeysForResolvedPane() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        // No pane yet -> input is dropped.
+        #expect(commands(core.sendInput([0x61])).isEmpty)
+
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8))
+        _ = core.consume(Array("%begin 2 2 0\n1:%5\n%end 2 2 0\n".utf8))
+
+        #expect(commands(core.sendInput([0x68, 0x69])) == ["send-keys -t %5 -H 68 69"])
+    }
+
+    @Test func resizeEmitsRefreshClient() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        #expect(commands(core.resize(TerminalSize(columns: 100, rows: 30))) == ["refresh-client -C 100x30"])
+    }
+
+    @Test func exitEndsSession() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        let ended = bytes(core.consume(Array("%exit gone\n".utf8))).ended
+        #expect(ended == ["gone"])
+        // After end, further input produces nothing.
+        #expect(core.sendInput([0x61]).isEmpty)
+    }
+
+    @Test func gatewayExitEndsSession() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        let ended = bytes(core.gatewayExited(reason: "tmux exited (1)")).ended
+        #expect(ended == ["tmux exited (1)"])
+    }
+
+    @Test func missingActivePaneEndsSession() {
+        var core = TmuxControlModeSessionCore()
+        _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
+        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8)) // refresh-client
+        let ended = bytes(core.consume(Array("%begin 2 2 1\n%error 2 2 1\n".utf8))).ended
+        #expect(ended == ["no active tmux pane"])
+    }
+}

--- a/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
+++ b/Packages/CmuxTmuxControlMode/Tests/CmuxTmuxControlModeTests/TmuxControlModeSessionCoreTests.swift
@@ -122,11 +122,20 @@ struct TmuxControlModeSessionCoreTests {
         #expect(ended == ["tmux exited (1)"])
     }
 
-    @Test func missingActivePaneEndsSession() {
+    @Test func spontaneousAndEmptyBlocksAreIgnoredNotFatal() {
+        // tmux emits a spontaneous entry block plus an empty refresh-client ack
+        // before the list-panes response. Neither must end the session or be
+        // mistaken for the pane list.
         var core = TmuxControlModeSessionCore()
         _ = core.start(initialSize: TerminalSize(columns: 80, rows: 24))
-        _ = core.consume(Array("%begin 1 1 0\n%end 1 1 0\n".utf8)) // refresh-client
-        let ended = bytes(core.consume(Array("%begin 2 2 1\n%error 2 2 1\n".utf8))).ended
-        #expect(ended == ["no active tmux pane"])
+        let spontaneous = core.consume(Array("%begin 1 323 0\n%end 1 323 0\n".utf8)) // tmux entry block
+        #expect(commands(spontaneous).isEmpty)
+        #expect(bytes(spontaneous).ended.isEmpty)
+        let refresh = core.consume(Array("%begin 2 1 0\n%end 2 1 0\n".utf8)) // refresh-client ack
+        #expect(commands(refresh).isEmpty)
+        #expect(bytes(refresh).ended.isEmpty)
+        // The real list-panes block resolves the pane and triggers capture.
+        let list = core.consume(Array("%begin 3 2 0\n1:%7\n%end 3 2 0\n".utf8))
+        #expect(commands(list) == ["capture-pane -t %7 -p -e -J -S - -E -"])
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2243,6 +2243,22 @@ class GhosttyApp {
                    let manager = app.tabManagerFor(tabId: callbackTabId) ?? app.tabManager,
                    let workspace = manager.tabs.first(where: { $0.id == callbackTabId }),
                    workspace.panels[callbackSurfaceId] != nil {
+                    // Respawn reuses the panel id, so a late close callback from a
+                    // freed surface can arrive after a replacement surface is
+                    // bound to the same id but before it registers. If the panel's
+                    // current surface is no longer the callback's surface, this is
+                    // a stale callback for the old surface — ignore it so the
+                    // replacement (e.g. a tmux-control-mode revert shell) is not
+                    // closed.
+                    if let terminalPanel = workspace.panels[callbackSurfaceId] as? TerminalPanel,
+                       terminalPanel.surface !== callbackSurface {
+#if DEBUG
+                        cmuxDebugLog(
+                            "surface.closeCallback.ignore surface=\(callbackSurfaceId.uuidString.prefix(5)) reason=replacedSurface"
+                        )
+#endif
+                        return
+                    }
                     if needsConfirmClose {
                         manager.closeRuntimeSurfaceWithConfirmation(
                             tabId: callbackTabId,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CmuxTerminalCopyMode
+import CmuxTmuxControlMode
 import CmuxSocketControl
 import SwiftUI
 import AppKit
@@ -5376,6 +5377,23 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private(set) var surface: ghostty_surface_t?
     private weak var attachedView: GhosttyNSView?
 
+    /// When set, this surface renders a control-mode session (local `tmux -CC`
+    /// today; Mac-host / cmuxd-remote later) via the manual-IO Ghostty backend
+    /// instead of spawning a local PTY. Session bytes flow in through
+    /// `ghostty_surface_process_output`; the user's keystrokes flow out through
+    /// the surface's `io_write_cb` to `session.sendInput`. Native selection,
+    /// find, scrollbar, and scrollback all work because they operate on the
+    /// local emulator's screen. See the `CmuxTmuxControlMode` package and
+    /// `plans/feat-control-mode-terminals/DESIGN.md`.
+    let controlModeSession: (any ControlModeSessionSource)?
+
+    /// Invoked on the main actor when the control-mode session ends (detach,
+    /// exit, or gateway death) so the owner can close/revert this surface.
+    var onControlModeSessionEnded: (@MainActor (String?) -> Void)?
+
+    private var controlModeSessionStarted = false
+    private var controlModeBridge: ControlModeSurfaceBridge?
+
     /// Whether the runtime Ghostty surface exists and has not begun teardown.
     ///
     /// Use this as a quick availability check. Before passing `surface` to
@@ -5596,8 +5614,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
         initialInput: String? = nil,
         initialEnvironmentOverrides: [String: String] = [:],
         additionalEnvironment: [String: String] = [:],
-        focusPlacement: TerminalSurfaceFocusPlacement = .workspace
+        focusPlacement: TerminalSurfaceFocusPlacement = .workspace,
+        controlModeSession: (any ControlModeSessionSource)? = nil
     ) {
+        self.controlModeSession = controlModeSession
         #if DEBUG
         dispatchPrecondition(condition: .onQueue(.main))
         #endif
@@ -6699,7 +6719,22 @@ final class TerminalSurface: Identifiable, ObservableObject {
             }
         }
 
-        createWithCommandAndWorkingDirectory()
+        if controlModeSession != nil {
+            // Manual-IO backend: no PTY/subprocess. The control-mode session
+            // owns the data; bytes flow in via ghostty_surface_process_output
+            // and the user's keystrokes flow out via io_write_cb.
+            surfaceConfig.io_mode = GHOSTTY_SURFACE_IO_MANUAL
+            surfaceConfig.io_write_cb = { userdata, buf, len in
+                guard let userdata, let buf, len > 0 else { return }
+                let data = Data(bytes: buf, count: Int(len))
+                let ctx = Unmanaged<GhosttySurfaceCallbackContext>.fromOpaque(userdata).takeUnretainedValue()
+                ctx.terminalSurface?.handleControlModeOutboundBytes(data)
+            }
+            surfaceConfig.io_write_userdata = callbackContext.toOpaque()
+            createSurface()
+        } else {
+            createWithCommandAndWorkingDirectory()
+        }
 
         if surface == nil {
             surfaceCallbackContext?.release()
@@ -6732,14 +6767,19 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // and feed them into their own libghostty surface, guaranteeing
         // grid parity by construction. The userdata box is released
         // alongside `surfaceCallbackContext` when the surface tears down.
-        mobileByteTeeContext?.release()
-        let teeContext = Unmanaged.passRetained(MobileTerminalByteTeeUserdata(surfaceID: id))
-        ghostty_surface_set_pty_tee_cb(
-            createdSurface,
-            cmuxMobileTerminalByteTeeCallback,
-            teeContext.toOpaque()
-        )
-        mobileByteTeeContext = teeContext
+        // The PTY tee mirrors an exec surface's read-thread bytes to paired
+        // iPhones. A manual-IO control-mode surface has no PTY read thread, so
+        // skip it.
+        if controlModeSession == nil {
+            mobileByteTeeContext?.release()
+            let teeContext = Unmanaged.passRetained(MobileTerminalByteTeeUserdata(surfaceID: id))
+            ghostty_surface_set_pty_tee_cb(
+                createdSurface,
+                cmuxMobileTerminalByteTeeCallback,
+                teeContext.toOpaque()
+            )
+            mobileByteTeeContext = teeContext
+        }
         if runtimeInitialInput != nil {
             nextRuntimeInitialInput = nil
         }
@@ -6773,6 +6813,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
             lastUncappedPixelHeight = hpx
             lastXScale = scaleFactors.x
             lastYScale = scaleFactors.y
+        }
+
+        // Start the control-mode session now that the surface exists and has a
+        // real grid size to negotiate with the source.
+        if let session = controlModeSession, !controlModeSessionStarted {
+            startControlModeSession(session, surface: createdSurface)
         }
 
         // Some GhosttyKit builds can drop inherited font_size during post-create
@@ -6884,6 +6930,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
             ghostty_surface_set_size(surface, wpx, hpx)
             lastPixelWidth = wpx
             lastPixelHeight = hpx
+            if controlModeSession != nil {
+                notifyControlModeResize(surface)
+            }
         }
 
         // Let Ghostty continue rendering on its own wakeups for steady-state frames.
@@ -16443,5 +16492,75 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.hostedView = nil
 
         nsView.subviews.forEach { $0.removeFromSuperview() }
+    }
+}
+
+// MARK: - Control-mode (manual IO) surface glue
+
+extension TerminalSurface {
+    /// Begin the control-mode session once the surface exists and has a grid
+    /// size. Wires the session's snapshot/output back into this surface and
+    /// keeps the delegate bridge alive for the session's lifetime.
+    @MainActor
+    func startControlModeSession(_ session: any ControlModeSessionSource, surface: ghostty_surface_t) {
+        guard !controlModeSessionStarted else { return }
+        controlModeSessionStarted = true
+        let bridge = ControlModeSurfaceBridge(surface: self)
+        controlModeBridge = bridge
+        session.start(initialSize: currentControlModeSize(surface), delegate: bridge)
+    }
+
+    @MainActor
+    func notifyControlModeResize(_ surface: ghostty_surface_t) {
+        controlModeSession?.resize(currentControlModeSize(surface))
+    }
+
+    private func currentControlModeSize(_ surface: ghostty_surface_t) -> TerminalSize {
+        let size = ghostty_surface_size(surface)
+        return TerminalSize(columns: Int(size.columns), rows: Int(size.rows))
+    }
+
+    /// Bytes Ghostty encoded from the user's keystrokes (delivered via the
+    /// surface's `io_write_cb` on an arbitrary thread). Forward them to the
+    /// session, which is `Sendable` and serializes internally.
+    nonisolated func handleControlModeOutboundBytes(_ data: Data) {
+        guard !data.isEmpty else { return }
+        controlModeSession?.sendInput([UInt8](data))
+    }
+
+    /// Feed session bytes (snapshot or live output) into the local emulator.
+    @MainActor
+    func feedControlModeBytes(_ bytes: [UInt8]) {
+        guard !bytes.isEmpty, let surface else { return }
+        writeProcessOutputData(Data(bytes), to: surface)
+    }
+
+    @MainActor
+    func handleControlModeEnded(_ reason: String?) {
+        controlModeSession?.stop()
+        onControlModeSessionEnded?(reason)
+    }
+}
+
+/// Delegate bridge between a `ControlModeSessionSource` (which calls back on the
+/// main queue) and a `TerminalSurface` (which is not `Sendable`). The gateway
+/// guarantees main-thread delivery, so `MainActor.assumeIsolated` is safe here.
+final class ControlModeSurfaceBridge: ControlModeSessionDelegate, @unchecked Sendable {
+    weak var surface: TerminalSurface?
+
+    init(surface: TerminalSurface) {
+        self.surface = surface
+    }
+
+    func controlModeSession(didProduceSnapshot bytes: [UInt8]) {
+        MainActor.assumeIsolated { surface?.feedControlModeBytes(bytes) }
+    }
+
+    func controlModeSession(didProduceOutput bytes: [UInt8]) {
+        MainActor.assumeIsolated { surface?.feedControlModeBytes(bytes) }
+    }
+
+    func controlModeSession(didEndWithReason reason: String?) {
+        MainActor.assumeIsolated { surface?.handleControlModeEnded(reason) }
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6128,6 +6128,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         markPortalLifecycleClosed(reason: "teardown")
         closeHeadlessStartupWindowIfNeeded()
 
+        // Stop the control-mode gateway (e.g. tmux -CC) so it does not outlive
+        // the surface when the surface is closed, respawned, or the app quits.
+        // Clear the end handler first so tearing the surface down (close / quit)
+        // does not trigger the detach-revert (which would respawn a shell in a
+        // pane the user is closing). Detach-revert still runs on a real session
+        // end while the surface is alive.
+        onControlModeSessionEnded = nil
+        controlModeSession?.stop()
+
         let callbackContext = surfaceCallbackContext
         surfaceCallbackContext = nil
         let teeContext = mobileByteTeeContext

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import AppKit
 import Bonsplit
+import CmuxTmuxControlMode
 
 struct AgentHibernationPanelState {
     let agent: SessionRestorableAgentSnapshot
@@ -166,7 +167,8 @@ final class TerminalPanel: Panel, ObservableObject {
         initialInput: String? = nil,
         initialEnvironmentOverrides: [String: String] = [:],
         additionalEnvironment: [String: String] = [:],
-        focusPlacement: TerminalSurfaceFocusPlacement = .workspace
+        focusPlacement: TerminalSurfaceFocusPlacement = .workspace,
+        controlModeSession: (any ControlModeSessionSource)? = nil
     ) {
         let surface = TerminalSurface(
             id: id,
@@ -180,7 +182,8 @@ final class TerminalPanel: Panel, ObservableObject {
             initialInput: initialInput,
             initialEnvironmentOverrides: initialEnvironmentOverrides,
             additionalEnvironment: additionalEnvironment,
-            focusPlacement: focusPlacement
+            focusPlacement: focusPlacement,
+            controlModeSession: controlModeSession
         )
         self.init(workspaceId: workspaceId, surface: surface)
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4,6 +4,7 @@ import CmuxControlSocket
 import CmuxSettings
 import CmuxSocketControl
 import CmuxSwiftRenderUI
+import CmuxTmuxControlMode
 import Carbon.HIToolbox
 import CMUXMobileCore
 import CMUXWorkstream
@@ -2042,6 +2043,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceSplit(params: params))
         case "surface.respawn":
             return v2Result(id: id, self.v2SurfaceRespawn(params: params))
+        case "tmux.attach":
+            return v2Result(id: id, self.v2TmuxAttach(params: params))
         case "surface.create":
             return v2Result(id: id, self.v2SurfaceCreate(params: params))
         case "surface.close":
@@ -2510,6 +2513,7 @@ class TerminalController {
             "surface.focus",
             "surface.split",
             "surface.respawn",
+            "tmux.attach",
             "surface.create",
             "surface.close",
             "surface.drag_to_split",
@@ -7926,6 +7930,80 @@ class TerminalController {
             } else {
                 result = .err(code: "internal_error", message: "Failed to create split", data: nil)
             }
+        }
+        return result
+    }
+
+    /// `tmux.attach`: take over the focused pane with a local tmux control-mode
+    /// session rendered natively (manual-IO Ghostty). Optional `target` names a
+    /// session to attach or create; otherwise the most-recent session.
+    private func v2TmuxAttach(params: [String: Any]) -> V2CallResult {
+        let target: TmuxAttachTarget
+        if let name = v2OptionalTrimmedRawString(params, "target"), !name.isEmpty {
+            target = .session(name)
+        } else {
+            target = .mostRecent
+        }
+        let focus: Bool?
+        if v2HasNonNullParam(params, "focus") {
+            focus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? true)
+        } else {
+            focus = nil
+        }
+        let fallbackTabManager = v2ResolveTabManager(params: params)
+
+        var result: V2CallResult = .err(
+            code: "internal_error",
+            message: String(localized: "rpc.v2.tmux.attach.failed", defaultValue: "Failed to attach tmux session"),
+            data: nil
+        )
+        v2MainSync {
+            guard let tabManager = fallbackTabManager else {
+                result = .err(
+                    code: "unavailable",
+                    message: String(localized: "rpc.v2.tmux.attach.tabManagerUnavailable", defaultValue: "Unable to access the target workspace"),
+                    data: nil
+                )
+                return
+            }
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(
+                    code: "not_found",
+                    message: String(localized: "rpc.v2.tmux.attach.workspaceNotFound", defaultValue: "Workspace not found"),
+                    data: nil
+                )
+                return
+            }
+            guard TmuxControlModeGateway.resolveTmuxExecutable() != nil else {
+                result = .err(
+                    code: "unavailable",
+                    message: String(localized: "rpc.v2.tmux.attach.tmuxMissing", defaultValue: "tmux is not installed"),
+                    data: nil
+                )
+                return
+            }
+            v2MaybeFocusWindow(for: tabManager)
+            v2MaybeSelectWorkspace(tabManager, workspace: ws)
+
+            guard let panel = ws.attachLocalTmuxControlMode(target: target, focus: focus) else {
+                result = .err(
+                    code: "internal_error",
+                    message: String(localized: "rpc.v2.tmux.attach.failed", defaultValue: "Failed to attach tmux session"),
+                    data: nil
+                )
+                return
+            }
+
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": panel.id.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: panel.id),
+                "type": panel.panelType.rawValue,
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId)
+            ])
         }
         return result
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7982,10 +7982,19 @@ class TerminalController {
                 )
                 return
             }
+            // Replace the calling surface in place (or the focused one).
+            guard let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId else {
+                result = .err(
+                    code: "not_found",
+                    message: String(localized: "rpc.v2.tmux.attach.noSurface", defaultValue: "No surface to attach tmux into"),
+                    data: nil
+                )
+                return
+            }
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
-            guard let panel = ws.attachLocalTmuxControlMode(target: target, focus: focus) else {
+            guard let panel = ws.attachLocalTmuxControlMode(target: target, replacingPanelId: surfaceId, focus: focus) else {
                 result = .err(
                     code: "internal_error",
                     message: String(localized: "rpc.v2.tmux.attach.failed", defaultValue: "Failed to attach tmux session"),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -14950,7 +14950,7 @@ final class Workspace: Identifiable, ObservableObject {
             tmuxExecutablePath: tmuxPath,
             environment: ProcessInfo.processInfo.environment
         )
-        return respawnTerminalSurface(panelId: panelId, command: "", controlModeSession: session, focus: focus)
+        return respawnTerminalSurface(panelId: panelId, command: "", focus: focus, controlModeSession: session)
     }
 
     /// Replace the terminal process behind an existing surface while preserving its pane and tab identity.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4,6 +4,7 @@ import AppKit
 import Bonsplit
 import CMUXAgentLaunch
 import CmuxSocketControl
+import CmuxTmuxControlMode
 import Combine
 import CryptoKit
 import Darwin
@@ -14861,6 +14862,96 @@ final class Workspace: Identifiable, ObservableObject {
             )
         }
         return newPanel
+    }
+
+    /// Add a control-mode terminal surface (manual-IO Ghostty, e.g. local
+    /// `tmux -CC`) to a pane. The surface renders the session natively (native
+    /// selection, find, scrollbar, scrollback). When the session ends, the
+    /// surface closes and the pane reveals the previously active surface — the
+    /// in-place takeover/revert described in
+    /// `plans/feat-control-mode-terminals/DESIGN.md`.
+    @discardableResult
+    func newControlModeTerminalSurface(
+        inPane paneId: PaneID,
+        session: any ControlModeSessionSource,
+        focus: Bool? = nil
+    ) -> TerminalPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+        let inheritedConfig = inheritedTerminalConfig(inPane: paneId)
+
+        let newPanel = TerminalPanel(
+            workspaceId: id,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: inheritedConfig,
+            portOrdinal: portOrdinal,
+            controlModeSession: session
+        )
+        newPanel.updateTitle(session.displayName)
+        configureNewTerminalPanel(newPanel)
+        panels[newPanel.id] = newPanel
+        panelTitles[newPanel.id] = newPanel.displayTitle
+        seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
+
+        // When the control-mode session ends (tmux detach/exit, gateway death),
+        // close this surface so the pane reveals the original shell surface.
+        let panelId = newPanel.id
+        newPanel.surface.onControlModeSessionEnded = { [weak self] _ in
+            self?.closePanel(panelId, force: true)
+        }
+
+        guard let newTabId = bonsplitController.createTab(
+            title: newPanel.displayTitle,
+            icon: newPanel.displayIcon,
+            kind: SurfaceKind.terminal,
+            isDirty: newPanel.isDirty,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: newPanel.id)
+            panelTitles.removeValue(forKey: newPanel.id)
+            terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = newPanel.id
+        publishCmuxSurfaceCreated(newPanel.id, paneId: paneId, kind: "terminal", origin: "tmux_control_mode", focused: shouldFocusNewTab)
+
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            newPanel.focus()
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: newPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+        return newPanel
+    }
+
+    /// Convenience: attach a local tmux control-mode session in the focused
+    /// pane of this workspace.
+    @discardableResult
+    func attachLocalTmuxControlMode(
+        target: TmuxAttachTarget,
+        inPane paneId: PaneID? = nil,
+        focus: Bool? = nil
+    ) -> TerminalPanel? {
+        guard let tmuxPath = TmuxControlModeGateway.resolveTmuxExecutable() else {
+            return nil
+        }
+        let resolvedPane = paneId ?? bonsplitController.focusedPaneId
+        guard let resolvedPane else { return nil }
+        let session = TmuxControlModeGateway(
+            target: target,
+            tmuxExecutablePath: tmuxPath,
+            environment: ProcessInfo.processInfo.environment
+        )
+        return newControlModeTerminalSurface(inPane: resolvedPane, session: session, focus: focus)
     }
 
     /// Replace the terminal process behind an existing surface while preserving its pane and tab identity.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11494,6 +11494,13 @@ final class Workspace: Identifiable, ObservableObject {
     /// Mapping from bonsplit TabID (surface ID) to panel UUID
     var surfaceIdToPanelId: [TabID: UUID] = [:]
 
+    /// Original terminal panel stashed alive (hidden, not torn down) while a
+    /// control-mode session (e.g. tmux -CC) takes over its tab. Keyed by the
+    /// tab id; on detach the original is restored intact. See
+    /// `attachControlModeBySwap` / `restoreOriginalAfterControlMode` and
+    /// `docs/tmux-control-mode.md`.
+    private var controlModeStashedOriginalPanelId: [TabID: UUID] = [:]
+
     /// Tab IDs that are allowed to close even if they would normally require confirmation.
     /// This is used by app-level confirmation prompts (for example, Close Tab) so the
     /// Bonsplit delegate doesn't block the close after the user already confirmed.
@@ -14933,9 +14940,10 @@ final class Workspace: Identifiable, ObservableObject {
         return newPanel
     }
 
-    /// Attach a local tmux control-mode session by **replacing** an existing
-    /// terminal surface in place (same pane and tab — no new tab). When the
-    /// session ends, the surface reverts to a normal shell.
+    /// Attach a local tmux control-mode session over an existing terminal
+    /// surface in place: the original shell is stashed alive (hidden) and the
+    /// control-mode view takes over the same pane and tab (no new tab). On
+    /// detach the original shell is restored intact.
     @discardableResult
     func attachLocalTmuxControlMode(
         target: TmuxAttachTarget,
@@ -14950,7 +14958,187 @@ final class Workspace: Identifiable, ObservableObject {
             tmuxExecutablePath: tmuxPath,
             environment: ProcessInfo.processInfo.environment
         )
-        return respawnTerminalSurface(panelId: panelId, command: "", focus: focus, controlModeSession: session)
+        return attachControlModeBySwap(replacingPanelId: panelId, session: session, focus: focus)
+    }
+
+    /// Stash the original terminal panel alive+hidden and bind a control-mode
+    /// panel to the same tab. The bonsplit tab is reused (no new tab); only the
+    /// cmux panel behind it changes, plus tab chrome. Restored by
+    /// ``restoreOriginalAfterControlMode(tabId:)`` when the session ends.
+    @discardableResult
+    func attachControlModeBySwap(
+        replacingPanelId panelId: UUID,
+        session: any ControlModeSessionSource,
+        focus: Bool? = nil
+    ) -> TerminalPanel? {
+        guard let original = terminalPanel(for: panelId),
+              let tabId = surfaceIdFromPanelId(panelId),
+              let paneId = paneId(forPanelId: panelId) else {
+            return nil
+        }
+        // Don't double-swap a tab already hosting a control-mode session.
+        guard controlModeStashedOriginalPanelId[tabId] == nil else { return nil }
+
+        let selectedInPane = bonsplitController.selectedTab(inPane: paneId)?.id == tabId
+        let paneWasFocused = bonsplitController.focusedPaneId == paneId
+        let shouldFocus = focus ?? (selectedInPane && paneWasFocused)
+        let inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
+        let wasPinned = pinnedPanelIds.contains(panelId)
+
+        // Stash the original alive + hidden: keep its shell/PTY running, just
+        // detach its view from the pane. No teardown, no portal-close lifecycle.
+        original.unfocus()
+        original.hostedView.setVisibleInUI(false)
+        TerminalWindowPortalRegistry.detach(hostedView: original.hostedView)
+
+        let controlPanel = TerminalPanel(
+            workspaceId: id,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: inheritedConfig,
+            portOrdinal: portOrdinal,
+            controlModeSession: session
+        )
+        controlPanel.updateTitle(session.displayName)
+        configureNewTerminalPanel(controlPanel)
+        panels[controlPanel.id] = controlPanel
+        panelTitles[controlPanel.id] = controlPanel.displayTitle
+        seedTerminalInheritanceFontPoints(panelId: controlPanel.id, configTemplate: inheritedConfig)
+
+        controlModeStashedOriginalPanelId[tabId] = original.id
+        surfaceIdToPanelId[tabId] = controlPanel.id
+
+        controlPanel.surface.onControlModeSessionEnded = { [weak self] _ in
+            self?.restoreOriginalAfterControlMode(tabId: tabId)
+        }
+
+        let resolvedTitle = resolvedPanelTitle(panelId: controlPanel.id, fallback: controlPanel.displayTitle)
+        bonsplitController.updateTab(
+            tabId,
+            title: resolvedTitle,
+            icon: .some(controlPanel.displayIcon),
+            iconImageData: .some(nil),
+            kind: .some(SurfaceKind.terminal),
+            hasCustomTitle: false,
+            isDirty: controlPanel.isDirty,
+            showsNotificationBadge: false,
+            isLoading: false,
+            isPinned: wasPinned
+        )
+
+        if shouldFocus {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(tabId)
+            focusPanel(controlPanel.id)
+        } else if selectedInPane {
+            bonsplitController.selectTab(tabId)
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        }
+
+        scheduleTerminalGeometryReconcile()
+        scheduleFocusReconcile()
+        return controlPanel
+    }
+
+    /// Restore the stashed original shell into its tab when the control-mode
+    /// session ends, and tear down the control-mode panel.
+    func restoreOriginalAfterControlMode(tabId: TabID) {
+        guard let originalPanelId = controlModeStashedOriginalPanelId[tabId],
+              let original = terminalPanel(for: originalPanelId) else {
+            controlModeStashedOriginalPanelId.removeValue(forKey: tabId)
+            return
+        }
+        let controlPanelId = surfaceIdToPanelId[tabId]
+        guard let paneId = paneId(forPanelId: controlPanelId ?? originalPanelId)
+            ?? paneId(forPanelId: originalPanelId) else {
+            controlModeStashedOriginalPanelId.removeValue(forKey: tabId)
+            return
+        }
+        let selectedInPane = bonsplitController.selectedTab(inPane: paneId)?.id == tabId
+        let paneWasFocused = bonsplitController.focusedPaneId == paneId
+        let wasPinned = pinnedPanelIds.contains(originalPanelId)
+
+        // Tear down the disposable control-mode panel.
+        if let controlPanelId, controlPanelId != originalPanelId,
+           let controlPanel = terminalPanel(for: controlPanelId) {
+            controlPanel.surface.onControlModeSessionEnded = nil
+            controlPanel.unfocus()
+            controlPanel.hostedView.setVisibleInUI(false)
+            TerminalWindowPortalRegistry.detach(hostedView: controlPanel.hostedView)
+            controlPanel.surface.beginPortalCloseLifecycle(reason: "controlMode.detach")
+            discardClosedPanelLifecycleState(
+                panelId: controlPanelId,
+                tabId: tabId,
+                paneId: paneId,
+                panel: controlPanel,
+                origin: "controlMode_detach",
+                closePanel: false,
+                publishSurfaceClosedEvent: false,
+                clearSurfaceNotifications: false,
+                requestTransferredRemoteCleanup: true,
+                cleanupControllerSurfaceState: false
+            )
+            TerminalSurfaceRegistry.shared.unregister(controlPanel.surface)
+            controlPanel.surface.teardownSurface()
+        }
+
+        // Re-bind the original to the tab (the teardown cleared the mapping).
+        controlModeStashedOriginalPanelId.removeValue(forKey: tabId)
+        surfaceIdToPanelId[tabId] = originalPanelId
+
+        original.requestViewReattach()
+        let resolvedTitle = resolvedPanelTitle(panelId: originalPanelId, fallback: original.displayTitle)
+        bonsplitController.updateTab(
+            tabId,
+            title: resolvedTitle,
+            icon: .some(original.displayIcon),
+            iconImageData: .some(nil),
+            kind: .some(SurfaceKind.terminal),
+            hasCustomTitle: panelCustomTitles[originalPanelId] != nil,
+            isDirty: original.isDirty,
+            showsNotificationBadge: false,
+            isLoading: false,
+            isPinned: wasPinned
+        )
+
+        if paneWasFocused && selectedInPane {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(tabId)
+            focusPanel(originalPanelId)
+        } else if selectedInPane {
+            bonsplitController.selectTab(tabId)
+            applyTabSelection(tabId: tabId, inPane: paneId)
+        } else {
+            original.unfocus()
+        }
+
+        scheduleTerminalGeometryReconcile()
+        scheduleFocusReconcile()
+    }
+
+    /// Tear down a control-mode session's stashed original shell when its tab is
+    /// being closed by the user (so the alive-but-hidden original is not leaked).
+    func discardControlModeStashIfNeeded(forTab tabId: TabID) {
+        guard let originalPanelId = controlModeStashedOriginalPanelId.removeValue(forKey: tabId) else { return }
+        guard let original = terminalPanel(for: originalPanelId) else { return }
+        original.surface.onControlModeSessionEnded = nil
+        original.unfocus()
+        original.hostedView.setVisibleInUI(false)
+        TerminalWindowPortalRegistry.detach(hostedView: original.hostedView)
+        original.surface.beginPortalCloseLifecycle(reason: "controlMode.stashClose")
+        discardClosedPanelLifecycleState(
+            panelId: originalPanelId,
+            tabId: nil,
+            paneId: nil,
+            panel: original,
+            origin: "controlMode_stash_close",
+            closePanel: false,
+            publishSurfaceClosedEvent: false,
+            clearSurfaceNotifications: false,
+            requestTransferredRemoteCleanup: true,
+            cleanupControllerSurfaceState: false
+        )
+        TerminalSurfaceRegistry.shared.unregister(original.surface)
+        original.surface.teardownSurface()
     }
 
     /// Replace the terminal process behind an existing surface while preserving its pane and tab identity.
@@ -19157,6 +19345,9 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didCloseTab tabId: TabID, fromPane pane: PaneID) {
+        // If this tab was hosting a control-mode session, the alive-but-hidden
+        // original shell is stashed off-tab; tear it down so it is not leaked.
+        discardControlModeStashIfNeeded(forTab: tabId)
         forceCloseTabIds.remove(tabId)
         tabCloseButtonCloseTabIds.remove(tabId)
         let selectTabId = postCloseSelectTabId.removeValue(forKey: tabId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -15041,11 +15041,21 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] = replacementPanel
         panelTitles[panelId] = replacementPanel.displayTitle
         if controlModeSession != nil {
-            // When the control-mode session ends, respawn a normal shell in the
-            // same surface so the pane reverts to a usable terminal in place.
+            // When the control-mode session ends (detach / exit), respawn a
+            // normal shell in the same surface so the pane reverts to a usable
+            // terminal in place, in the original working directory.
+            // NOTE: this is the interim revert. Preserving the *exact* original
+            // shell (scrollback/state) is a planned follow-up that requires
+            // keeping the original surface suspended in the background; see
+            // docs/tmux-control-mode.md.
             let revertPanelId = panelId
+            let revertWorkingDirectory = requestedWorkingDirectory
             replacementPanel.surface.onControlModeSessionEnded = { [weak self] _ in
-                self?.respawnTerminalSurface(panelId: revertPanelId, command: "exec ${SHELL:-/bin/zsh} -l")
+                self?.respawnTerminalSurface(
+                    panelId: revertPanelId,
+                    command: "exec ${SHELL:-/bin/zsh} -l",
+                    workingDirectory: revertWorkingDirectory
+                )
             }
         }
         if let customTitle {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -14933,25 +14933,24 @@ final class Workspace: Identifiable, ObservableObject {
         return newPanel
     }
 
-    /// Convenience: attach a local tmux control-mode session in the focused
-    /// pane of this workspace.
+    /// Attach a local tmux control-mode session by **replacing** an existing
+    /// terminal surface in place (same pane and tab — no new tab). When the
+    /// session ends, the surface reverts to a normal shell.
     @discardableResult
     func attachLocalTmuxControlMode(
         target: TmuxAttachTarget,
-        inPane paneId: PaneID? = nil,
+        replacingPanelId panelId: UUID,
         focus: Bool? = nil
     ) -> TerminalPanel? {
         guard let tmuxPath = TmuxControlModeGateway.resolveTmuxExecutable() else {
             return nil
         }
-        let resolvedPane = paneId ?? bonsplitController.focusedPaneId
-        guard let resolvedPane else { return nil }
         let session = TmuxControlModeGateway(
             target: target,
             tmuxExecutablePath: tmuxPath,
             environment: ProcessInfo.processInfo.environment
         )
-        return newControlModeTerminalSurface(inPane: resolvedPane, session: session, focus: focus)
+        return respawnTerminalSurface(panelId: panelId, command: "", controlModeSession: session, focus: focus)
     }
 
     /// Replace the terminal process behind an existing surface while preserving its pane and tab identity.
@@ -14961,7 +14960,8 @@ final class Workspace: Identifiable, ObservableObject {
         command: String,
         workingDirectory: String? = nil,
         tmuxStartCommand: String? = nil,
-        focus: Bool? = nil
+        focus: Bool? = nil,
+        controlModeSession: (any ControlModeSessionSource)? = nil
     ) -> TerminalPanel? {
         guard let oldPanel = terminalPanel(for: panelId),
               let tabId = surfaceIdFromPanelId(panelId),
@@ -14970,7 +14970,9 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedCommand.isEmpty else { return nil }
+        // A control-mode surface has no command (the session drives IO), so a
+        // command is only required for a normal exec respawn.
+        guard controlModeSession != nil || !trimmedCommand.isEmpty else { return nil }
 
         let inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
         let requestedWorkingDirectory: String? = {
@@ -15028,15 +15030,24 @@ final class Workspace: Identifiable, ObservableObject {
             configTemplate: inheritedConfig,
             workingDirectory: requestedWorkingDirectory,
             portOrdinal: portOrdinal,
-            initialCommand: trimmedCommand,
-            tmuxStartCommand: replacementTmuxStartCommand,
+            initialCommand: controlModeSession == nil ? trimmedCommand : nil,
+            tmuxStartCommand: controlModeSession == nil ? replacementTmuxStartCommand : nil,
             initialEnvironmentOverrides: initialEnvironmentOverrides,
             additionalEnvironment: additionalEnvironment,
-            focusPlacement: focusPlacement
+            focusPlacement: focusPlacement,
+            controlModeSession: controlModeSession
         )
         configureNewTerminalPanel(replacementPanel)
         panels[panelId] = replacementPanel
         panelTitles[panelId] = replacementPanel.displayTitle
+        if controlModeSession != nil {
+            // When the control-mode session ends, respawn a normal shell in the
+            // same surface so the pane reverts to a usable terminal in place.
+            let revertPanelId = panelId
+            replacementPanel.surface.onControlModeSessionEnded = { [weak self] _ in
+                self?.respawnTerminalSurface(panelId: revertPanelId, command: "exec ${SHELL:-/bin/zsh} -l")
+            }
+        }
         if let customTitle {
             panelCustomTitles[panelId] = customTitle
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		C5A1FED100000000000000D2 /* CmuxSwiftRenderUI in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */; };
 		C52830000000000000000001 /* CmuxTerminalCopyMode in Frameworks */ = {isa = PBXBuildFile; productRef = C52830000000000000000004 /* CmuxTerminalCopyMode */; };
 		C52830000000000000000002 /* CmuxTerminalCopyMode in Frameworks */ = {isa = PBXBuildFile; productRef = C52830000000000000000004 /* CmuxTerminalCopyMode */; };
+		C7B1100000000000000000A1 /* CmuxTmuxControlMode in Frameworks */ = {isa = PBXBuildFile; productRef = C7B1100000000000000000A4 /* CmuxTmuxControlMode */; };
+		C7B1100000000000000000A2 /* CmuxTmuxControlMode in Frameworks */ = {isa = PBXBuildFile; productRef = C7B1100000000000000000A4 /* CmuxTmuxControlMode */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
 		C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */; };
@@ -1468,6 +1470,7 @@
 				C5A1FED000000000000000C1 /* CmuxSwiftRender in Frameworks */,
 				C5A1FED100000000000000D1 /* CmuxSwiftRenderUI in Frameworks */,
 				C52830000000000000000001 /* CmuxTerminalCopyMode in Frameworks */,
+				C7B1100000000000000000A1 /* CmuxTmuxControlMode in Frameworks */,
 				CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */,
 				CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
@@ -1518,6 +1521,7 @@
 				5E2701040000000000000004 /* CmuxFoundation in Frameworks */,
 				EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */,
 				C52830000000000000000002 /* CmuxTerminalCopyMode in Frameworks */,
+				C7B1100000000000000000A2 /* CmuxTmuxControlMode in Frameworks */,
 				5E2701040000000000000003 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2316,6 +2320,7 @@
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
+				C7B1100000000000000000A4 /* CmuxTmuxControlMode */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
 				C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */,
@@ -2416,6 +2421,7 @@
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
+				C7B1100000000000000000A4 /* CmuxTmuxControlMode */,
 				5E2701040000000000000001 /* Sentry */,
 				5E2701040000000000000002 /* CmuxFoundation */,
 			);
@@ -2479,6 +2485,7 @@
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
 				C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */,
+				C7B1100000000000000000A3 /* XCLocalSwiftPackageReference "CmuxTmuxControlMode" */,
 				C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */,
 				C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */,
 				C5A1FED200000000000000E4 /* XCLocalSwiftPackageReference "CmuxSidebarInterpreterService" */,
@@ -3790,6 +3797,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxTerminalCopyMode;
 		};
+		C7B1100000000000000000A3 /* XCLocalSwiftPackageReference "CmuxTmuxControlMode" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxTmuxControlMode;
+		};
 		C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSwiftRenderUI;
@@ -3949,6 +3960,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */;
 			productName = CmuxTerminalCopyMode;
+		};
+		C7B1100000000000000000A4 /* CmuxTmuxControlMode */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C7B1100000000000000000A3 /* XCLocalSwiftPackageReference "CmuxTmuxControlMode" */;
+			productName = CmuxTmuxControlMode;
 		};
 		C5A1FED000000000000000C3 /* CmuxSwiftRender */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/docs/tmux-control-mode.md
+++ b/docs/tmux-control-mode.md
@@ -83,20 +83,22 @@ Key points:
 - `Sources/TerminalController.swift` — `tmux.attach` V2 RPC.
 - `CLI/cmux.swift` — `cmux tmux attach` verb.
 
-## Revert behavior (current vs planned)
+## Revert behavior: exact original shell preserved
 
-**Current:** on detach the surface respawns a fresh login shell in the same pane
-and tab, in the original working directory.
+On attach, the original terminal surface is **stashed alive (hidden), not
+killed** — its shell, scrollback, history, and cwd keep running. A new
+control-mode panel is bound to the **same bonsplit tab** (no new tab; only the
+cmux panel behind the tab changes, via `surfaceIdToPanelId`). On detach the
+control-mode panel is torn down and the original is restored into the same tab,
+intact — it feels like tmux was a foreground program. This is a cmux-only
+in-place panel swap (`attachControlModeBySwap` / `restoreOriginalAfterControlMode`
+in `Sources/Workspace.swift`); it needs no bonsplit changes because the tab is
+reused and SwiftUI re-renders the new panel after the mapping is re-pointed.
 
-**Planned — restore the exact original shell.** Keep the original shell surface
-alive (suspended, not killed) during the takeover and restore it intact on
-detach, so it feels like tmux was a foreground program (the real-tmux/iTerm2
-feel). cmux panes already hide/show/revive surfaces correctly via tab switching,
-so the clean implementation is: keep the original as a second surface but hide
-its tab from the tab bar while control mode is active, then reselect + unhide it
-on detach. This needs a small "hidden tab" capability in bonsplit
-(`vendor/bonsplit`), which renders the tab bar; the surface preserve/restore
-itself reuses the existing tab-selection machinery.
+If the tab is closed while a control-mode session is active, the stashed
+original is torn down too (`discardControlModeStashIfNeeded`) so it is not
+leaked. The stash lives only in memory, so it does not survive an app restart
+(see Session restore below).
 
 ## Session restore (planned)
 

--- a/docs/tmux-control-mode.md
+++ b/docs/tmux-control-mode.md
@@ -1,0 +1,127 @@
+# tmux control mode (native tmux in cmux)
+
+cmux can render a local tmux session inside a **real Ghostty terminal** using
+tmux's control mode (`tmux -CC`). Because the pane is a genuine local emulator
+fed the tmux pane's byte stream, you get cmux-native text selection, ⌘F find,
+and a real scrollbar over full local scrollback — none of which work with a
+plain `tmux attach` inside a terminal (where tmux owns the screen).
+
+## Usage
+
+```
+cmux tmux attach [session]
+```
+
+- Run it inside any cmux terminal. That terminal is **replaced in place** (same
+  pane, same tab — no new tab) with a native view of the tmux session.
+- `session` is optional. With a name, cmux attaches it or creates it
+  (`new-session -A`). Without a name, it attaches the most recent session.
+- tmux-style abbreviations work: `cmux tmux a`, `cmux tmux at`, … all mean
+  `attach`.
+- You never type `tmux -CC` — cmux runs it for you as a hidden gateway.
+
+Options: `--workspace`, `--surface`, `--window`, `--focus`. By default the target
+is the calling surface (`$CMUX_SURFACE_ID`).
+
+### Detaching
+
+- **Ctrl-b d** detaches (cmux intercepts the tmux prefix and sends
+  `detach-client`). The tmux session keeps running; the pane reverts to a shell.
+- Exiting the tmux session (or the pane's program exiting) also reverts.
+- The tmux prefix is hardcoded to the default **Ctrl-b**. Any other prefixed key
+  is passed through to the pane literally (so Ctrl-b still works for unmapped
+  chords).
+
+### What about other tmux chords?
+
+Window/pane chords (`Ctrl-b c`, `Ctrl-b %`, `Ctrl-b "`, etc.) are intentionally
+**not** mapped: in cmux you use cmux's own splits and tabs for layout, and tmux
+is just the persistent session. Only `Ctrl-b d` (detach) is special-cased.
+Copy/scroll chords are unnecessary because scrollback, selection, and find are
+all native.
+
+## How it works
+
+```
+cmux tmux attach           (CLI verb)
+  -> tmux.attach RPC        (Sources/TerminalController.swift)
+  -> Workspace.attachLocalTmuxControlMode -> respawnTerminalSurface(controlModeSession:)
+       (in-place takeover: same pane+tab id)
+  -> TerminalSurface manual-IO Ghostty surface (io_mode = GHOSTTY_SURFACE_IO_MANUAL)
+       feed: session bytes -> ghostty_surface_process_output
+       input: io_write_cb  -> session.sendInput
+  -> TmuxControlModeGateway (Packages/CmuxTmuxControlMode)
+       runs `tmux -CC <target>` on a PTY (tmux requires a tty)
+       parses the control protocol, resolves the active pane,
+       capture-pane snapshot + live %output, send-keys for input,
+       refresh-client for sizing, Ctrl-b d -> detach-client
+```
+
+Key points:
+
+- **Manual-IO Ghostty surface.** The first non-iOS use of cmux's manual IO
+  backend. Native selection / find / scrollbar / scrollback are PTY-independent
+  surface features, so they work as soon as bytes flow into the surface.
+- **PTY gateway.** `tmux -CC` calls `tcgetattr` on its streams and exits on
+  plain pipes, so the gateway runs tmux on a pseudo-terminal and reads/writes
+  the master end.
+- **Content/phase response matching.** tmux emits a spontaneous `%begin/%end`
+  block on entry, so the gateway resolves the pane by recognizing the
+  `list-panes` output rather than by positional command order.
+- **Snapshot.** On attach, `capture-pane -p -e -J -S - -E -` provides the full
+  history (iTerm2's model); trailing blank rows and the trailing newline are
+  trimmed so content anchors at the top, and pre-snapshot live output is dropped
+  (it is already in the snapshot) to avoid a duplicate prompt.
+
+### Code map
+
+- `Packages/CmuxTmuxControlMode/` — the protocol core (parser, encoder, session
+  orchestration, PTY gateway, `ControlModeSessionSource`). Pure + unit-tested.
+- `Sources/GhosttyTerminalView.swift` — manual-IO surface + control-mode glue.
+- `Sources/Workspace.swift` — `attachLocalTmuxControlMode` /
+  `respawnTerminalSurface(controlModeSession:)` (in-place takeover + revert).
+- `Sources/TerminalController.swift` — `tmux.attach` V2 RPC.
+- `CLI/cmux.swift` — `cmux tmux attach` verb.
+
+## Revert behavior (current vs planned)
+
+**Current:** on detach the surface respawns a fresh login shell in the same pane
+and tab, in the original working directory.
+
+**Planned — restore the exact original shell.** Keep the original shell surface
+alive (suspended, not killed) during the takeover and restore it intact on
+detach, so it feels like tmux was a foreground program (the real-tmux/iTerm2
+feel). cmux panes already hide/show/revive surfaces correctly via tab switching,
+so the clean implementation is: keep the original as a second surface but hide
+its tab from the tab bar while control mode is active, then reselect + unhide it
+on detach. This needs a small "hidden tab" capability in bonsplit
+(`vendor/bonsplit`), which renders the tab bar; the surface preserve/restore
+itself reuses the existing tab-selection machinery.
+
+## Session restore (planned)
+
+tmux sessions survive a cmux restart because the tmux server is a separate
+process. cmux should restore a control-mode surface by re-attaching:
+
+1. Persist the control-mode target with the surface in `SessionPersistence`
+   (a `tmuxControlModeTarget` field alongside the existing terminal surface
+   state), set when `attachLocalTmuxControlMode` runs.
+2. On restore, if a surface carries a control-mode target, re-run
+   `attachLocalTmuxControlMode` for it instead of spawning a shell — but only if
+   that tmux session still exists (otherwise fall back to a shell so a dead
+   session does not leave a blank surface).
+3. Pair this with the exact-original-shell preserve work so the restored layout
+   matches: the surface comes back as the tmux view, revertible to a shell.
+
+Until this lands, a restored cmux window brings back a normal shell in the
+pane; the tmux session is still alive and can be reattached with
+`cmux tmux attach <session>`.
+
+## Limitations (P1)
+
+- Multi-pane tmux *windows* render the active pane only; switching panes inside
+  one tmux window is a follow-up.
+- Prefix is the default Ctrl-b only (not read from `~/.tmux.conf`).
+- Remote (SSH) and iOS use the same renderer but different session sources;
+  those are later phases (see `plans/feat-control-mode-terminals/DESIGN.md` in
+  the cmuxterm-hq control repo).


### PR DESCRIPTION
## Summary

P1 of native control-mode terminals (design: `plans/feat-control-mode-terminals/DESIGN.md` in cmuxterm-hq): run a local tmux session inside a **real Ghostty terminal** via tmux control mode (`tmux -CC`), so you get native text selection, cmd-F find, and real scrollback with a scrollbar — because the pane is a genuine Ghostty emulator, not a cell mirror.

The user types `cmux tmux attach [session]`; cmux drives `tmux -CC` as a hidden gateway, parses the control protocol, and feeds the attached pane's bytes into a **manual-IO Ghostty surface** (the same backend iOS uses, now wired for macOS for the first time). The surface takes over the current pane in place and reverts to the original shell surface when the session detaches/exits.

Native selection, find, and scrollbar come for free: they operate on the local emulator's screen, which is independent of whether bytes came from a PTY or from the control-mode stream.

## What's in this PR

- **`Packages/CmuxTmuxControlMode`** — pure, fully unit-tested control-mode core:
  - `TmuxControlModeParser` — incremental `%begin/%end` block vs `%output` (octal-unescaping) state machine.
  - `TmuxControlModeEncoder` — `capture-pane` snapshot, `send-keys -H` input, `refresh-client -C` sizing.
  - `TmuxControlModeSessionCore` — pure attach orchestration (resolve active pane → capture → snapshot, buffer live output until snapshot, route input/resize). Effect-based, synchronously testable.
  - `TmuxControlModeGateway` — `Process`-based `tmux -CC` gateway implementing `ControlModeSessionSource`.
  - `ControlModeSessionSource` — renderer-agnostic session abstraction (generalizes to the Mac mobile host and cmuxd-remote in later phases; same renderer).
  - **25 unit tests, all green.**
- **macOS manual-IO Ghostty surface** (`GhosttyTerminalView`): `io_mode=manual`, `io_write_cb`, feed via `ghostty_surface_process_output`, with a `@unchecked Sendable` delegate bridge (gateway delivers on main → `MainActor.assumeIsolated`).
- **In-place pane takeover** (`Workspace.newControlModeTerminalSurface` + `attachLocalTmuxControlMode`): pushes the control-mode surface onto the current pane and closes it on session end to reveal the original shell surface.
- **`tmux.attach` V2 RPC** (`TerminalController`) + **`cmux tmux attach [session]` CLI** verb with `--help`.

## Design decisions (from the blessed design doc)

- The attachable unit is a tmux **pane** (one terminal), not windows/sessions; one cmux surface ↔ one tmux pane. No tmux split/layout mirroring — cmux owns layout, tmux owns the persistent session.
- Transport is never user-visible. This is the local-tmux `ControlModeSessionSource`; iOS render-grid and SSH backends are later phases behind the same renderer.
- Scrollback uses the iTerm2 model: eager full `capture-pane -S - -E -` snapshot on attach.

## Testing

- `swift test` in `Packages/CmuxTmuxControlMode`: 25 tests pass (parser, encoder, octal-unescape, attach orchestration, input/resize routing, end-of-session).
- macOS app builds clean (cloud builder, `BUILD SUCCEEDED`).
- Dogfood: `cmux tmux attach` takes over the pane with native scrollback + cmd-F find on a real tmux session.

## Known P1 boundaries (tracked in the design doc)

- Multi-pane tmux windows render the active pane only (pane-switch is a fast-follow).
- iOS native niceties (deep render-grid scrollback) and SSH exec→manual conversion are P2/P3.
- Control-mode RPC error strings use `String(localized:)` defaults; xcstrings catalog entries are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650633&installation_id=133855650&pr_number=5745&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5745&signature=11096277f167e00321ecf788d721a6336d928019b55b0f310a42e36f5fc4eed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core terminal surface lifecycle, workspace panel swap/teardown, and subprocess/PTY I/O; bugs could leak stashed shells or close the wrong surface, but behavior is covered by package tests and explicit lifecycle guards.
> 
> **Overview**
> Adds **native local tmux in cmux** via tmux control mode (`tmux -CC`): pane bytes feed a **manual-IO Ghostty surface** so selection, find, and scrollback behave like a normal terminal.
> 
> **New `CmuxTmuxControlMode` package** — parser, command encoder, pure session orchestration (`list-panes` → `capture-pane` snapshot → live `%output`), and a PTY-backed gateway (tmux requires a real tty). Includes unit tests and a `ControlModeSessionSource` abstraction for future transports.
> 
> **App integration** — `TerminalSurface` can run with `GHOSTTY_SURFACE_IO_MANUAL` (input via `io_write_cb`, output via `process_output`); gateway lifecycle is tied to teardown. **`Workspace.attachControlModeBySwap`** hides the original shell alive and reuses the same tab; on detach it restores the original intact (stash cleaned up on tab close). **`tmux.attach` RPC** and **`cmux tmux attach [session]`** target the calling surface by default.
> 
> **Lifecycle fixes** — ignore stale `close_surface_cb` after panel swap/respawn; clear control-mode end handler on intentional close so quit doesn’t respawn a shell; **Ctrl-b d** maps to `detach-client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a63cfc750c2d86c8d6ef771fd62964d68b1a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run a local tmux pane inside a real Ghostty surface via control mode. `tmux.attach` RPC and `cmux tmux attach` swap the tmux view into the current tab and, on detach, restore the exact original shell (scrollback/cwd intact) — with native selection, find, and real scrollback.

- **New Features**
  - In-place panel swap: stash the original terminal alive/hidden and bind the tmux view to the same tab; on `%exit`/detach the original shell is restored intact; stash is torn down if the tab closes.
  - `Ctrl-b d` detaches by sending `detach-client`; other prefixed keys pass through literally.
  - New `CmuxTmuxControlMode` package (parser, encoder, session core, PTY gateway). Unit tests added.
  - macOS manual-IO integration: feed snapshot/output into the surface, forward keystrokes via `send-keys -H`, resize via `refresh-client -C`; skip mobile PTY tee for these surfaces.
  - Workspace/Controller/CLI: V2 `tmux.attach` RPC and `cmux tmux attach [session]` replace the calling surface in place; CLI accepts `attach` abbreviations; docs updated to cover exact-shell restore (`docs/tmux-control-mode.md`).

- **Bug Fixes**
  - Snapshot anchoring: trim trailing blank rows and omit the trailing newline; drop pre-snapshot `%output` to avoid duplicate prompts.
  - Attach flow: resolve the active pane by content/phase and ignore spontaneous `%begin/%end` blocks; run `tmux -CC` on a PTY and strip fused DCS/ST markers.
  - Lifecycle: stop the control-mode gateway on surface teardown and clear the end handler so close/quit doesn’t trigger a revert; ignore stale `close_surface_cb` after respawn/swap so the restored shell isn’t closed.
  - Workspace: fix `respawnTerminalSurface` argument order so focus and control-mode session apply correctly.

<sup>Written for commit 07a63cfc750c2d86c8d6ef771fd62964d68b1a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add `tmux attach` CLI command to attach to local tmux sessions.
  * Terminal surfaces can run control‑mode tmux panes with live output, keystroke forwarding, resize handling, lifecycle hooks, and proper focus/tab behavior.
  * Workspace/panel flow updated to create/replace panes when attaching control‑mode tmux sessions.

* **Tests**
  * New unit tests covering control‑mode encoding, parsing, session orchestration, and terminal size handling.

* **Documentation**
  * Added user guide describing tmux control‑mode usage, flags, detach behavior, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->