### PR TITLE
CLI: drop expected broken-pipe write failures from Sentry (kills ~87% of error ingestion)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -142,6 +142,11 @@ private final class CLISocketSentryTelemetry {
 
     func captureError(stage: String, error: Error, data: [String: Any] = [:]) {
         guard shouldEmit else { return }
+        // Writes to a peer that has gone away (broken pipe / reset / closed fd)
+        // are expected disconnects, not bugs. Drop them before capture so they
+        // do not flood Sentry (this signature was the large majority of all
+        // error events) and so we skip the 2s flush below on the hot path.
+        if SentryNoiseFilter.isExpectedPeerDisconnect(String(describing: error)) { return }
 #if canImport(Sentry)
         Self.ensureStarted()
         flushPendingBreadcrumbs()
@@ -283,6 +288,23 @@ private final class CLISocketSentryTelemetry {
     }
 
 #if canImport(Sentry)
+    /// True when an outgoing event is an expected broken-pipe / peer-disconnect
+    /// write failure, so `beforeSend` can drop it. Inspects the human-readable
+    /// message and exception values (grouping fields are left untouched).
+    private static func isExpectedPeerDisconnectEvent(_ event: Event) -> Bool {
+        if let message = event.message?.formatted,
+           SentryNoiseFilter.isExpectedPeerDisconnect(message) {
+            return true
+        }
+        for exception in event.exceptions ?? [] {
+            if let value = exception.value,
+               SentryNoiseFilter.isExpectedPeerDisconnect(value) {
+                return true
+            }
+        }
+        return false
+    }
+
     private static func ensureStarted() {
         startupLock.lock()
         defer { startupLock.unlock() }
@@ -309,7 +331,12 @@ private final class CLISocketSentryTelemetry {
             // Redact file paths, emails, and secrets from every outgoing event
             // and breadcrumb before it leaves the device.
             let scrubber = SentryEventScrubber()
-            options.beforeSend = { event in scrubber.scrub(event) }
+            options.beforeSend = { event in
+                // Net for any capture path that bypasses captureError: drop
+                // expected broken-pipe/peer-disconnect write failures entirely.
+                if Self.isExpectedPeerDisconnectEvent(event) { return nil }
+                return scrubber.scrub(event)
+            }
             options.beforeBreadcrumb = { breadcrumb in scrubber.scrub(breadcrumb) }
         }
         started = true

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/SentryNoiseFilter.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/SentryNoiseFilter.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Classifies Sentry-bound error text so expected, non-actionable noise can be
+/// dropped before it is captured or sent.
+///
+/// The CLI writes to Unix sockets and to stdout/stderr pipes whose peer (the
+/// cmux app, a parent agent process, or a closed terminal) can disappear
+/// mid-write. A write to a peer that has gone away is an expected disconnect,
+/// not a bug, yet each one was being captured and flushed to Sentry. At fleet
+/// scale that single signature accounted for the large majority of all error
+/// events. This filter recognizes that signature so both the capture site and
+/// `beforeSend` can discard it.
+///
+/// The match is intentionally narrow: only writes that failed with a
+/// broken-pipe / connection-reset / bad-descriptor errno are treated as noise.
+/// Every other write failure (timeouts, permission errors, missing socket, and
+/// so on) still reports normally, so a genuinely new failure mode is not
+/// silently hidden.
+public enum SentryNoiseFilter {
+    /// Returns `true` when `text` describes a write to a peer that has already
+    /// gone away (a broken pipe, a reset connection, or a closed descriptor).
+    ///
+    /// `text` is typically `String(describing: error)` or a Sentry exception
+    /// value such as `"Failed to write to socket (Broken pipe, errno 32)"`.
+    public static func isExpectedPeerDisconnect(_ text: String) -> Bool {
+        let t = text.lowercased()
+
+        // Scope to write/send failures so an unrelated error that merely
+        // mentions one of these tokens is not swallowed.
+        let isWriteFailure =
+            t.contains("write to socket")
+            || t.contains("failed to write")
+            || t.contains("broken pipe")
+            || t.contains("sigpipe")
+        guard isWriteFailure else { return false }
+
+        return t.contains("broken pipe")
+            || t.contains("errno 32")        // EPIPE
+            || t.contains("sigpipe")
+            || t.contains("connection reset")
+            || t.contains("errno 54")        // ECONNRESET
+            || t.contains("errno 9")         // EBADF (peer closed, fd reused)
+    }
+}

--- a/Packages/CmuxFoundation/Tests/CmuxFoundationTests/SentryNoiseFilterTests.swift
+++ b/Packages/CmuxFoundation/Tests/CmuxFoundationTests/SentryNoiseFilterTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import CmuxFoundation
+
+final class SentryNoiseFilterTests: XCTestCase {
+    func testDropsBrokenPipeSocketWrite() {
+        // The exact production signature behind the ~10.9M-event flood.
+        XCTAssertTrue(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to write to socket (Broken pipe, errno 32)"))
+        XCTAssertTrue(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "CLIError: Failed to write to socket (Broken pipe, errno 32) (Code: 1)"))
+    }
+
+    func testDropsSigpipeAndResetAndBadDescriptorWrites() {
+        XCTAssertTrue(SentryNoiseFilter.isExpectedPeerDisconnect("SIGPIPE: Signal 13, Code 0"))
+        XCTAssertTrue(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to write to socket (Connection reset by peer, errno 54)"))
+        XCTAssertTrue(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to write to socket (Bad file descriptor, errno 9)"))
+    }
+
+    func testKeepsActionableWriteFailures() {
+        // Other write failures are real bugs and must still report.
+        XCTAssertFalse(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to write to socket (Operation timed out, errno 60)"))
+        XCTAssertFalse(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to write to socket (Permission denied, errno 13)"))
+    }
+
+    func testDoesNotMatchUnrelatedErrorsThatMentionTokens() {
+        // "errno 32" outside a write context, or an unrelated message, stays.
+        XCTAssertFalse(SentryNoiseFilter.isExpectedPeerDisconnect(
+            "Failed to connect to socket at /tmp/x (No such file or directory, errno 2)"))
+        XCTAssertFalse(SentryNoiseFilter.isExpectedPeerDisconnect("Event stream closed"))
+        XCTAssertFalse(SentryNoiseFilter.isExpectedPeerDisconnect("Command timed out"))
+    }
+}


### PR DESCRIPTION
## Problem
Writes to a peer that has gone away (the cmux app, a parent agent process, or a closed terminal) fail with `EPIPE` / broken pipe. These are expected disconnects, not bugs, but the CLI captured and flushed every one to Sentry. As a result `cmux_cli.CLIError: Failed to write to socket (Broken pipe, errno 32)` is the single largest source of Sentry events for `cmuxterm-macos`: **~10.9M events / ~30k users over 14 days, roughly 87% of all error ingestion.**

## Fix
A pure, testable predicate `SentryNoiseFilter.isExpectedPeerDisconnect` (in `CmuxFoundation`) recognizes the broken-pipe / connection-reset / closed-descriptor write signature, applied in two layers in the CLI Sentry path (`CLI/cmux.swift`):

1. `captureError` returns early for these errors, which also skips the 2s `SentrySDK.flush` on the hot disconnect path.
2. `beforeSend` drops any matching event that reaches it by another capture path (defense in depth).

The match is scoped to write/send failures with a broken-pipe / reset / bad-descriptor errno, so genuinely actionable write failures (timeouts, permission denied, missing socket) still report normally. A new failure mode is not silently hidden.

## Why this is principled, not a hack
It does not suppress a symptom of a bug; it stops reporting a non-event (an expected disconnect) while leaving all real errors intact. The narrow scoping is the safety margin. The companion crash work (unconditional `SIGPIPE` ignore + EPIPE-safe stdout/stderr writes) is tracked in https://github.com/manaflow-ai/cmux/issues/5750; this PR is the ingestion-cost half and lands independently.

## Tests
`swift test --package-path Packages/CmuxFoundation --filter SentryNoiseFilterTests` (4 cases, green): drops the exact production signature + SIGPIPE/reset/EBADF writes; keeps timeout/permission write failures and unrelated errors that merely mention a token.

## Impact
Removes ~96% of CLI error-event ingestion (broken-pipe + the related socket noise it gates) without losing real signal.

Refs https://github.com/manaflow-ai/cmux/issues/5750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783656975&installation_id=133855650&pr_number=5754&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5754&signature=449596c77bd613a3246bc77ce3a2cb46e152f5b7862bb68bfd05f8c49836ce4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow string-based filter with tests; only suppresses known disconnect signatures and leaves other errors reporting unchanged.
> 
> **Overview**
> Adds **`SentryNoiseFilter.isExpectedPeerDisconnect`** in `CmuxFoundation` to classify expected peer-disconnect write failures (broken pipe, ECONNRESET, EBADF) so they are not treated as actionable bugs.
> 
> The CLI Sentry path applies it in two places: **`captureError`** returns early (avoiding the heavy flush on disconnect), and **`beforeSend`** drops matching events from any other capture path. Other write failures (timeouts, permission errors, etc.) still report.
> 
> Unit tests cover the production broken-pipe signature, related disconnect errno cases, and false-positive guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e3b784fca28a4b60f95b631364196dac859e676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop expected broken-pipe/peer-disconnect write failures from Sentry in the CLI to stop noise and cut error ingestion by ~87%. Also skips the 2s `SentrySDK.flush` on disconnects.

- **Bug Fixes**
  - Added `CmuxFoundation` `SentryNoiseFilter.isExpectedPeerDisconnect` to detect EPIPE/ECONNRESET/EBADF/SIGPIPE write/send failures.
  - Applied in `CLI/cmux.swift` via early return in `captureError` and event drop in `beforeSend`.
  - Kept actionable write failures (timeouts, permission denied, missing socket) reporting.
  - Added unit tests for drop/keep cases.

<sup>Written for commit 4e3b784fca28a4b60f95b631364196dac859e676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent error filtering to automatically identify and exclude expected peer-disconnect and broken-pipe errors from monitoring, reducing noise in error reports.

* **Tests**
  * Added comprehensive unit tests to validate peer-disconnect error detection and classification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->