### PR TITLE
Cache negative cmux-scope results so system.top stops re-probing every process per poll

### DIFF
--- a/Sources/CmuxTopProcessEnumeration.swift
+++ b/Sources/CmuxTopProcessEnumeration.swift
@@ -89,7 +89,7 @@ nonisolated extension CmuxTopProcessSnapshot {
         let path = includeProcessDetails ? processPath(pid: pid) : nil
         let rawTTY = Int64(bsdInfo.e_tdev)
         let ttyDevice = rawTTY > 0 ? rawTTY : nil
-        let cmuxScope = cachedCMUXScope(for: pid, cacheKey: cacheKey)
+        let cmuxScope = cachedCMUXScope(for: pid, cacheKey: cacheKey, nowNanoseconds: sampledAtNanoseconds)
         let rawProcessGroupID = Int(bsdInfo.pbi_pgid)
         let processGroupID = rawProcessGroupID > 0 ? rawProcessGroupID : nil
         let rawTerminalProcessGroupID = Int(bsdInfo.e_tpgid)

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -117,7 +117,7 @@ nonisolated struct CmuxTopProcessInfo: Sendable {
     }
 }
 
-nonisolated struct CmuxTopProcessScope: Sendable {
+nonisolated struct CmuxTopProcessScope: Sendable, Equatable {
     let workspaceID: UUID?
     let surfaceID: UUID?
     let attributionReason: String

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -84,19 +84,27 @@ nonisolated extension CmuxTopProcessSnapshot {
 
         switch probe(pid, cacheKey) {
         case .resolved(let scope):
-            guard let scope else {
-                // BUG (issue 5756): a resolved "no cmux scope" is not cached, so
-                // every poll re-probes every non-cmux process. Fixed in the next
-                // commit by caching the negative result under a TTL.
-                return nil
-            }
-            cmuxTopScopeCache.withLock { cache in
+            // Cache the resolved result. Positive scopes are kept indefinitely;
+            // negative scopes are kept only until the TTL elapses so a later exec
+            // is eventually attributed. The key is pruned to live pids each
+            // capture, so a recycled pid gets a fresh key.
+            //
+            // capture() runs concurrently (async task-manager sampling and sync
+            // system.top socket handling), and the probe happened outside the
+            // lock. Never let a stale negative from an older capture clobber a
+            // positive scope a newer capture already discovered for the same
+            // process: if we probed nil but a positive entry now exists, keep and
+            // return it.
+            return cmuxTopScopeCache.withLock { cache -> CmuxTopProcessScope? in
+                if scope == nil, let existing = cache[cacheKey], let existingScope = existing.scope {
+                    return existingScope
+                }
                 cache[cacheKey] = CmuxTopProcessScopeCacheValue(
                     scope: scope,
                     negativeExpiresAtNanos: nowNanoseconds &+ cmuxTopNegativeScopeTTLNanoseconds
                 )
+                return scope
             }
-            return scope
         case .unavailable:
             // Transient failure: do not cache, retry on the next poll.
             return nil

--- a/Sources/CmuxTopSnapshotScopeCache.swift
+++ b/Sources/CmuxTopSnapshotScopeCache.swift
@@ -9,7 +9,32 @@ nonisolated struct CmuxTopProcessScopeCacheKey: Hashable {
 }
 
 private nonisolated struct CmuxTopProcessScopeCacheValue {
-    let scope: CmuxTopProcessScope
+    // nil means "this process was probed and has no cmux scope". A negative entry
+    // is honored as a hit only until `negativeExpiresAtNanos`, so a non-cmux
+    // process is re-probed at most once per TTL window instead of on every
+    // system.top poll. Positive entries never expire (`negativeExpiresAtNanos` is
+    // ignored when `scope != nil`): a cmux scope comes from inherited environment
+    // or a stable argv and does not disappear for the process lifetime.
+    let scope: CmuxTopProcessScope?
+    let negativeExpiresAtNanos: UInt64
+}
+
+// How long a "no cmux scope" result stays cached before the process is probed
+// again. The scope is derived from argv/environment, which an `exec` can change
+// without changing the pid or process start time (the cache key), so a process
+// first sampled in its fork-before-exec window, or one that execs into a
+// `cmux hooks … monitor` later, must be re-probed eventually or it would never
+// be attributed. The TTL bounds that attribution latency while still collapsing
+// the per-poll sysctl storm for the steady-state majority of non-cmux processes.
+private nonisolated let cmuxTopNegativeScopeTTLNanoseconds: UInt64 = 15 * 1_000_000_000
+
+// Result of probing a single process for its cmux scope. `resolved` means the
+// probe completed (the scope may legitimately be absent) and is safe to cache.
+// `unavailable` means a transient failure (process exited mid-probe, pid reuse,
+// or a failed sysctl) and must NOT be cached so the next poll retries.
+nonisolated enum CmuxTopProcessScopeProbeResult: Equatable {
+    case resolved(CmuxTopProcessScope?)
+    case unavailable
 }
 
 // CmuxTopProcessSnapshot.capture is intentionally synchronous because it backs
@@ -40,21 +65,42 @@ nonisolated extension CmuxTopProcessSnapshot {
 
     static func cachedCMUXScope(
         for pid: Int,
-        cacheKey: CmuxTopProcessScopeCacheKey
+        cacheKey: CmuxTopProcessScopeCacheKey,
+        nowNanoseconds: UInt64,
+        probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = CmuxTopProcessSnapshot.cmuxScopeProbe
     ) -> CmuxTopProcessScope? {
         if let cached = cmuxTopScopeCache.withLock({ cache in cache[cacheKey] }) {
-            return cached.scope
+            if let scope = cached.scope {
+                // Positive results never expire: a discovered cmux scope is stable.
+                return scope
+            }
+            if nowNanoseconds < cached.negativeExpiresAtNanos {
+                // Negative result still within its TTL: honor the cached miss.
+                return nil
+            }
+            // Negative TTL expired: fall through and re-probe in case the process
+            // execed into a cmux-scoped command since it was last sampled.
         }
 
-        guard let scope = cmuxScope(for: pid, expectedCacheKey: cacheKey) else {
+        switch probe(pid, cacheKey) {
+        case .resolved(let scope):
+            guard let scope else {
+                // BUG (issue 5756): a resolved "no cmux scope" is not cached, so
+                // every poll re-probes every non-cmux process. Fixed in the next
+                // commit by caching the negative result under a TTL.
+                return nil
+            }
+            cmuxTopScopeCache.withLock { cache in
+                cache[cacheKey] = CmuxTopProcessScopeCacheValue(
+                    scope: scope,
+                    negativeExpiresAtNanos: nowNanoseconds &+ cmuxTopNegativeScopeTTLNanoseconds
+                )
+            }
+            return scope
+        case .unavailable:
+            // Transient failure: do not cache, retry on the next poll.
             return nil
         }
-
-        cmuxTopScopeCache.withLock { cache in
-            cache[cacheKey] = CmuxTopProcessScopeCacheValue(scope: scope)
-        }
-
-        return scope
     }
 
     static func pruneCMUXScopeCache(activeKeys: Set<CmuxTopProcessScopeCacheKey>) {
@@ -63,33 +109,58 @@ nonisolated extension CmuxTopProcessSnapshot {
         }
     }
 
-    private static func cmuxScope(
+    // Probes a single process for its cmux scope via sysctl.
+    //
+    // `KERN_PROCARGS2` can fail two very different ways: transiently, because the
+    // process exited mid-probe or its pid was reused (then `kinfoProc` no longer
+    // matches the expected start-time key), or permanently, because the process
+    // belongs to another user / is protected (the kernel denies procargs for the
+    // process's whole life). We must cache the permanent case as a definitive
+    // "no readable cmux scope" — those processes are not cmux-scoped and stay in
+    // `activeKeys`, so leaving them uncached would re-run this sysctl fan-out on
+    // every poll. We must NOT cache the transient case, so a process that is
+    // simply mid-exec is retried.
+    //
+    // The discriminator is liveness: if a procargs read fails but the process is
+    // still alive with the same start time, the failure is a permanent denial and
+    // resolves to nil; otherwise it raced with exit/reuse and is `.unavailable`.
+    static func cmuxScopeProbe(
         for pid: Int,
         expectedCacheKey: CmuxTopProcessScopeCacheKey
-    ) -> CmuxTopProcessScope? {
-        guard let currentProcess = kinfoProc(for: pid),
-              scopeCacheKey(from: currentProcess) == expectedCacheKey else {
-            return nil
+    ) -> CmuxTopProcessScopeProbeResult {
+        guard processMatchesKey(pid, expectedCacheKey) else {
+            return .unavailable
         }
 
         var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, Int32(pid)]
         var size: size_t = 0
         guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0,
               size > MemoryLayout<Int32>.size else {
-            return nil
+            // Sizing failed: permanent denial if still alive, else exit race.
+            return processMatchesKey(pid, expectedCacheKey) ? .resolved(nil) : .unavailable
         }
 
         var buffer = [UInt8](repeating: 0, count: size)
         let success = buffer.withUnsafeMutableBytes { rawBuffer in
             sysctl(&mib, u_int(mib.count), rawBuffer.baseAddress, &size, nil, 0) == 0
         }
-        guard success else { return nil }
-        guard let currentProcess = kinfoProc(for: pid),
-              scopeCacheKey(from: currentProcess) == expectedCacheKey else {
-            return nil
+        guard success else {
+            return processMatchesKey(pid, expectedCacheKey) ? .resolved(nil) : .unavailable
+        }
+        guard processMatchesKey(pid, expectedCacheKey) else {
+            return .unavailable
         }
 
-        return cmuxScope(fromKernProcArgs: Array(buffer.prefix(Int(size))))
+        return .resolved(cmuxScope(fromKernProcArgs: Array(buffer.prefix(Int(size)))))
+    }
+
+    // True when `pid` is still the same process (same start time) as the key.
+    private static func processMatchesKey(
+        _ pid: Int,
+        _ expectedCacheKey: CmuxTopProcessScopeCacheKey
+    ) -> Bool {
+        guard let process = kinfoProc(for: pid) else { return false }
+        return scopeCacheKey(from: process) == expectedCacheKey
     }
 
     static func cmuxScope(fromKernProcArgs bytes: [UInt8]) -> CmuxTopProcessScope? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */; };
 		C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A501000000000000000001 /* CmuxTopSnapshot.swift */; };
 		C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */; };
+		C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */; };
 		C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */; };
 		CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0200000000CDFEED02 /* CmuxUpdater */; };
 		CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */; };
@@ -979,6 +980,7 @@
 		C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessSnapshotCache.swift; sourceTree = "<group>"; };
 		C7A501000000000000000001 /* CmuxTopSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshot.swift; sourceTree = "<group>"; };
 		C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCache.swift; sourceTree = "<group>"; };
+		C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCacheTests.swift; sourceTree = "<group>"; };
 		C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
@@ -2229,6 +2231,7 @@
 				C7A507000000000000000001 /* TaskManagerResourcesTests.swift */,
 				C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */,
 				C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */,
+				C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */,
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */,
@@ -3213,6 +3216,7 @@
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
+				C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,
 				C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */,
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,

--- a/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeCacheTests.swift
@@ -1,0 +1,190 @@
+import Testing
+import Foundation
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression coverage for the cmux-scope attribution cache used by system.top.
+// See https://github.com/manaflow-ai/cmux/issues/5756.
+//
+// `.serialized` because these tests share the process-global cmux-top scope
+// cache (`CmuxTopProcessSnapshot.cachedCMUXScope` / `pruneCMUXScopeCache`); they
+// must not interleave with each other.
+@Suite(.serialized)
+struct CmuxTopSnapshotScopeCacheTests {
+    // ~1s, well within the negative TTL.
+    static let nowNanoseconds: UInt64 = 1_000_000_000
+    // ~1000s later, beyond any sane negative TTL, so the negative entry expires.
+    static let farFutureNanoseconds: UInt64 = 1_000_000_000_000
+
+    // Before the fix, a process with no cmux scope was a permanent cache miss, so
+    // every system.top poll re-ran the 3-sysctl probe for every non-cmux process
+    // on the machine. The negative result must now be cached within the TTL.
+    @Test func negativeScopeResultIsCachedWithinTTL() {
+        CmuxTopProcessSnapshot.pruneCMUXScopeCache(activeKeys: [])
+        let cacheKey = CmuxTopProcessScopeCacheKey(
+            pid: 901_001,
+            startSeconds: 1_700_000_001,
+            startMicroseconds: 11
+        )
+        var probeCount = 0
+        let probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = { _, _ in
+            probeCount += 1
+            return .resolved(nil)
+        }
+
+        let first = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_001, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        let second = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_001, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+
+        #expect(first == nil)
+        #expect(second == nil)
+        #expect(probeCount == 1, "non-cmux process should be probed once per TTL, not on every poll")
+    }
+
+    @Test func positiveScopeResultIsCachedAcrossPolls() {
+        CmuxTopProcessSnapshot.pruneCMUXScopeCache(activeKeys: [])
+        let cacheKey = CmuxTopProcessScopeCacheKey(
+            pid: 901_002,
+            startSeconds: 1_700_000_002,
+            startMicroseconds: 22
+        )
+        let expected = CmuxTopProcessScope(
+            workspaceID: UUID(uuidString: "99999999-9999-9999-9999-999999999999"),
+            surfaceID: nil,
+            attributionReason: "cmux-environment"
+        )
+        var probeCount = 0
+        let probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = { _, _ in
+            probeCount += 1
+            return .resolved(expected)
+        }
+
+        // A discovered scope is cached indefinitely, even far past the negative TTL.
+        let first = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_002, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        let second = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_002, cacheKey: cacheKey, nowNanoseconds: Self.farFutureNanoseconds, probe: probe)
+
+        #expect(first == expected)
+        #expect(second == expected)
+        #expect(probeCount == 1)
+    }
+
+    // A transient read failure (process exited mid-probe, pid reuse, failed
+    // sysctl) must not be cached as a nil, so the next poll retries and can still
+    // attribute a live cmux process.
+    @Test func transientProbeFailureIsNotCachedAndRetries() {
+        CmuxTopProcessSnapshot.pruneCMUXScopeCache(activeKeys: [])
+        let cacheKey = CmuxTopProcessScopeCacheKey(
+            pid: 901_003,
+            startSeconds: 1_700_000_003,
+            startMicroseconds: 33
+        )
+        let expected = CmuxTopProcessScope(
+            workspaceID: nil,
+            surfaceID: UUID(uuidString: "abababab-abab-abab-abab-abababababab"),
+            attributionReason: "cmux-environment"
+        )
+        var probeCount = 0
+        let probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = { _, _ in
+            probeCount += 1
+            // Fail the first two polls, then resolve.
+            return probeCount < 3 ? .unavailable : .resolved(expected)
+        }
+
+        let first = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_003, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        let second = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_003, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        let third = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_003, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        let fourth = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_003, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+
+        #expect(first == nil)
+        #expect(second == nil)
+        #expect(third == expected)
+        #expect(fourth == expected, "resolved scope should now be cached")
+        #expect(probeCount == 3, "transient failures retry; the resolved result is cached")
+    }
+
+    // The cache key is (pid, process start time), which an `exec` does not change.
+    // A process first sampled in its fork-before-exec window, or one that execs
+    // into a cmux-scoped command later, must be re-probed once the negative TTL
+    // elapses so it is eventually attributed (https://github.com/manaflow-ai/cmux/issues/5756).
+    @Test func negativeScopeIsReprobedAfterTTLExpiry() {
+        CmuxTopProcessSnapshot.pruneCMUXScopeCache(activeKeys: [])
+        let cacheKey = CmuxTopProcessScopeCacheKey(
+            pid: 901_004,
+            startSeconds: 1_700_000_004,
+            startMicroseconds: 44
+        )
+        let postExecScope = CmuxTopProcessScope(
+            workspaceID: UUID(uuidString: "12121212-1212-1212-1212-121212121212"),
+            surfaceID: nil,
+            attributionReason: "cmux-environment"
+        )
+        var probeCount = 0
+        var resolvedScope: CmuxTopProcessScope?
+        let probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = { _, _ in
+            probeCount += 1
+            return .resolved(resolvedScope)
+        }
+
+        // Sampled pre-exec: no scope yet, cached negative.
+        let preExec = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_004, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        // Polled again within the TTL: served from the negative cache, no re-probe.
+        let withinTTL = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_004, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        #expect(preExec == nil)
+        #expect(withinTTL == nil)
+        #expect(probeCount == 1)
+
+        // Process has since execed into a cmux-scoped command; after the TTL the
+        // negative entry expires and the next poll re-probes and attributes it.
+        resolvedScope = postExecScope
+        let afterExpiry = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_004, cacheKey: cacheKey, nowNanoseconds: Self.farFutureNanoseconds, probe: probe)
+        #expect(afterExpiry == postExecScope)
+        #expect(probeCount == 2, "expired negative entry must be re-probed")
+    }
+
+    // capture() runs concurrently. A slower sample that probed a process before
+    // it execed (resolving nil) must not, on its delayed write, clobber a
+    // positive scope that a faster overlapping sample already discovered.
+    @Test func negativeProbeDoesNotClobberConcurrentlyDiscoveredPositive() {
+        CmuxTopProcessSnapshot.pruneCMUXScopeCache(activeKeys: [])
+        let cacheKey = CmuxTopProcessScopeCacheKey(
+            pid: 901_005,
+            startSeconds: 1_700_000_005,
+            startMicroseconds: 55
+        )
+        let positive = CmuxTopProcessScope(
+            workspaceID: UUID(uuidString: "13131313-1313-1313-1313-131313131313"),
+            surfaceID: nil,
+            attributionReason: "cmux-environment"
+        )
+        // This (older) sample resolves nil, but simulates a concurrent capture
+        // discovering and caching the positive scope while the probe is in flight.
+        let probe: (Int, CmuxTopProcessScopeCacheKey) -> CmuxTopProcessScopeProbeResult = { pid, key in
+            _ = CmuxTopProcessSnapshot.cachedCMUXScope(
+                for: pid, cacheKey: key, nowNanoseconds: Self.nowNanoseconds) { _, _ in .resolved(positive) }
+            return .resolved(nil)
+        }
+
+        let result = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_005, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds, probe: probe)
+        #expect(result == positive, "stale negative must not clobber a concurrently discovered positive")
+
+        // The positive entry survives for later polls.
+        let nextPoll = CmuxTopProcessSnapshot.cachedCMUXScope(
+            for: 901_005, cacheKey: cacheKey, nowNanoseconds: Self.nowNanoseconds) { _, _ in .resolved(nil) }
+        #expect(nextPoll == positive)
+    }
+}


### PR DESCRIPTION
## Summary
`system.top` re-probed **every** non-cmux process with up to 3 `sysctl` calls on every poll, because `CmuxTopProcessSnapshot.cachedCMUXScope` only cached positive scope lookups. Under a heavy local agent fleet this was the single largest on-CPU consumer in a live `sample` of a beachballing stable build (v0.64.14) — hundreds of processes × 3 syscalls × poll rate.

This caches negative results too, with the nuance needed to stay correct:

- **Negative TTL (15s), not lifetime.** The cache key is `(pid, process start time)`, which an `exec` does **not** change, while scope is derived from argv/environment, which an exec *can* change. A lifetime negative cache would permanently mis-attribute a process first sampled in its fork-before-exec window, or one that execs into a `cmux hooks … monitor` later (e.g. a launchd-parented monitor). The TTL bounds attribution latency to 15s while still collapsing the steady-state per-poll storm. Positive scopes stay cached indefinitely (inherited-env / stable-argv scope doesn't disappear).
- **Permanent procargs denial is cached.** `KERN_PROCARGS2` fails permanently for other-user / protected processes (not just on exit races). The probe now distinguishes a permanent denial (process still alive → cache nil) from a transient exit/pid-reuse race (stays uncached). Without this, every root/other-user daemon would remain a permanent cache miss and keep the sysctl fan-out unbounded.
- **Concurrency-safe write.** `capture()` runs concurrently (async task-manager sampling and sync `system.top` socket handling) and the probe runs outside the cache lock, so the post-probe write refuses to overwrite a positive scope a concurrent capture already discovered, and returns that positive.

Drops steady-state per-poll cost from O(non-cmux processes × 3 syscalls) to roughly O(non-cmux processes × 3 syscalls ÷ (TTL ÷ poll interval)).

## Testing
New wired Swift Testing suite `cmuxTests/CmuxTopSnapshotScopeCacheTests` (`.serialized`, probe-injection + monotonic-clock seam): negatives cached within the TTL (probed once per window, not per poll), positives cached indefinitely, transient failures retried, an expired negative re-probed after exec, and a stale negative never clobbering a concurrently discovered positive. Two-commit red/green: commit 1 adds the seam + tests with the buggy behavior; commit 2 enables the TTL negative caching.

Three Codex autoreview rounds drove the design: a lifetime negative cache (exec problem) → 15s TTL; an unconditional write (concurrency clobber) → conditional write; transient-only failure classification (procargs denial leak) → permanent-denial caching.

## Notes
The only `workflow-guard-tests` failure is the pre-existing `AgentLaunchSanitizer.swift` file-length-budget overflow on `main` (untouched here; `main`'s own CI already fails this step). This PR's additions stay within budget in a separate wired test file.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/5756
- Related (architectural umbrella): https://github.com/manaflow-ai/cmux/issues/5757
