### PR TITLE
Refresh Swift file-length budget for three files grown on main

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,12 +4,12 @@
 32553	CLI/cmux.swift
 21996	Sources/TerminalController.swift
 19875	Sources/Workspace.swift
-19052	Sources/ContentView.swift
+19068	Sources/ContentView.swift
 17920	Sources/AppDelegate.swift
 16522	Sources/GhosttyTerminalView.swift
 13589	Sources/Panels/BrowserPanel.swift
 11916	cmuxTests/AppDelegateShortcutRoutingTests.swift
-9914	Sources/TabManager.swift
+9939	Sources/TabManager.swift
 8494	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7737	Sources/Panels/BrowserPanelView.swift
 7214	cmuxTests/WorkspaceUnitTests.swift
@@ -97,7 +97,7 @@
 866	Sources/CommandPalette/CommandPaletteSettingsToggle.swift
 863	Sources/Panels/TerminalPanel.swift
 856	Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
-853	cmuxTests/WorkspaceGroupTests.swift
+906	cmuxTests/WorkspaceGroupTests.swift
 846	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
 842	Sources/Panels/MarkdownWebRenderer.swift


### PR DESCRIPTION
Same failure class as https://github.com/manaflow-ai/cmux/pull/5751: commits on main grew `cmuxTests/WorkspaceGroupTests.swift` (906 > 853), `Sources/TabManager.swift` (9939 > 9914), and `Sources/ContentView.swift` (19068 > 19052) without budget refreshes, so every PR's merge-ref `workflow-guard-tests` run is red. This records the accepted debt at current lengths; `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv` passes on this tree. Metadata-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783659504&installation_id=133855650&pr_number=5762&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5762&signature=be7381f1d656892d532b755c455c7cc33c39882579f8d2c51870ea3db92c2fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the Swift file-length budget to match current sizes on main so `workflow-guard-tests` passes again. Updates `.github/swift-file-length-budget.tsv` for `Sources/ContentView.swift`, `Sources/TabManager.swift`, and `cmuxTests/WorkspaceGroupTests.swift`.

- **Bug Fixes**
  - Accepts current file lengths (19068, 9939, 906) to unblock CI.
  - Metadata only; `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv` passes.

<sup>Written for commit e556fdfc88aeefdf27ff64058d747fe269b0a3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

