### PR TITLE
Wait for textbox paste before Return

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1737,7 +1737,15 @@ enum TextBoxSubmit {
         }
 
         let pastePayload = TextBoxSubmissionFormatter.formattedText(from: inputParts)
-        return [.pasteText(pastePayload), .namedKey(submitKey)]
+        var events: [DispatchEvent] = [
+            .captureVisibleTextBaseline,
+            .pasteText(pastePayload),
+        ]
+        if let waitNeedle = visibleTextWaitNeedle(for: pastePayload) {
+            events.append(.waitForVisibleText(waitNeedle))
+        }
+        events.append(.namedKey(submitKey))
+        return events
     }
 
     static func send(

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7679,7 +7679,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 terminalAgentContext: "restoredAgent:codex"
             ),
             [
+                .captureVisibleTextBaseline,
                 .pasteText("what is \(imageSubmissionText) now"),
+                .waitForVisibleText("what is \(imageSubmissionText) now"),
                 .namedKey("return")
             ]
         )
@@ -7689,7 +7691,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 terminalAgentContext: "panelTitle:Claude Code"
             ),
             [
+                .captureVisibleTextBaseline,
                 .pasteText("what is \(imageSubmissionText) now"),
+                .waitForVisibleText("what is \(imageSubmissionText) now"),
                 .namedKey("return")
             ]
         )
@@ -7699,7 +7703,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 terminalAgentContext: "initialCommand:echo Claude Code"
             ),
             [
+                .captureVisibleTextBaseline,
                 .pasteText("what is \(imageSubmissionText) now"),
+                .waitForVisibleText("what is \(imageSubmissionText) now"),
                 .namedKey("return")
             ]
         )
@@ -7708,8 +7714,52 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 for: [.text("hello\nworld")],
                 terminalAgentContext: "restoredAgent:claude"
             ),
-            [.pasteText("hello\nworld"), .namedKey("ctrl+enter")]
+            [
+                .captureVisibleTextBaseline,
+                .pasteText("hello\nworld"),
+                .waitForVisibleText("hello\nworld"),
+                .namedKey("ctrl+enter")
+            ]
         )
+    }
+
+    func testTextBoxSubmitWaitsForPastedPromptBeforeReturn() {
+#if DEBUG
+        let surface = FakeTextBoxSubmitSurface()
+        surface.visibleTextValue = "codex ready\n"
+        TextBoxSubmit.debugWaitTimeoutSecondsOverride = 10
+        defer {
+            TextBoxSubmit.debugWaitTimeoutSecondsOverride = nil
+            TextBoxSubmit.debugResetForTesting()
+        }
+
+        var completionContext: TextBoxSubmit.CompletionContext?
+        TextBoxSubmit.debugRunDispatchEvents(
+            TextBoxSubmit.dispatchEvents(
+                for: [.text("fix the home prompt")],
+                terminalAgentContext: "restoredAgent:codex"
+            ),
+            via: surface
+        ) { context in
+            completionContext = context
+        }
+
+        XCTAssertEqual(surface.sentText, ["fix the home prompt"])
+        XCTAssertEqual(surface.sentKeys, [])
+        XCTAssertNil(completionContext)
+
+        surface.visibleTextValue = "codex ready\nfix the home prompt"
+        NotificationCenter.default.post(name: .ghosttyDidTick, object: nil)
+        let deadline = Date().addingTimeInterval(1)
+        while surface.sentKeys.isEmpty, Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
+        XCTAssertEqual(surface.sentKeys, ["return"])
+        XCTAssertEqual(completionContext, .empty)
+#else
+        throw XCTSkip("debugRunDispatchEvents is only available in DEBUG")
+#endif
     }
 
     func testTextBoxSubmitStagesClaudeImagePromptWithMultilineTail() throws {


### PR DESCRIPTION
Summary
- Make terminal text-box submissions wait until pasted prompt text is visible before sending Return.
- Covers the Codex/home race where Return could reach the terminal before slow prompt paste/render finished, producing a blank newline instead of submitting.

Testing
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-hsub test -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testTextBoxSubmitWaitsForPastedPromptBeforeReturn
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-hsub test -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testTextBoxSubmitUsesPastePayloadAndSeparateReturn

Dogfood
- Tagged cloud reload: hsub
- Tag opener: http://127.0.0.1:17320/hsub

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783666890&installation_id=133855650&pr_number=5771&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5771&signature=890721f03a7442d66ec0034b90c0591e06674f520f905a3223a640696c9fba98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core submit timing for all paste-based text-box sends; wrong wait logic could delay or skip submission, though timeouts fall through to continue the event chain.
> 
> **Overview**
> Terminal text-box submissions no longer fire **Return** immediately after paste. **`TextBoxSubmit.dispatchEvents`** now records visible terminal text, pastes the prompt, optionally **`waitForVisibleText`** until the pasted content appears (via **`visibleTextWaitNeedle`**), and only then sends Return—addressing races where Codex/home could submit a blank newline before slow paste/render finished.
> 
> Unit expectations in **`AppDelegateShortcutRoutingTests`** were updated for the new event sequences, and a DEBUG test **`testTextBoxSubmitWaitsForPastedPromptBeforeReturn`** asserts Return is deferred until terminal visible text updates (e.g. on **`ghosttyDidTick`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c222405d036f22b96b9b609c3537e7bbc2f8817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure terminal text-box submissions wait until the pasted prompt is visible before sending Return, preventing blank lines caused by the Codex/home race. Adds a visible-text baseline and wait step to the dispatch sequence.

- Bug Fixes
  - Inserted `.captureVisibleTextBaseline` and `.waitForVisibleText(...)` between paste and Return to avoid premature submits.
  - Added unit tests for paste readiness and separate Return dispatch.

<sup>Written for commit 9c222405d036f22b96b9b609c3537e7bbc2f8817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text submission handling with improved validation. The system now ensures text appears correctly before finalizing submission, resulting in more reliable input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->