### PR TITLE
Run agent lifecycle hooks in background

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -368,6 +368,14 @@ extension CMUXCLI {
     }
 
     static func hookCommandString(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
+        backgroundAgentHookShellCommand(
+            "cmux hooks \(def.name) \(event.cmuxSubcommand)",
+            for: def,
+            logSlug: "\(def.name)-\(event.cmuxSubcommand)"
+        )
+    }
+
+    static func legacySynchronousHookCommandString(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
         agentHookShellCommand("cmux hooks \(def.name) \(event.cmuxSubcommand)", for: def)
     }
 
@@ -385,6 +393,25 @@ extension CMUXCLI {
 
     private static let grokPinnedHookMarker = "cmux-grok-hook-v2"
     private static let antigravityPinnedHookMarker = "cmux-antigravity-hook-v2"
+    private static let backgroundHookMarker = "cmux-agent-hook-background-v1"
+
+    private static func backgroundAgentHookShellCommand(
+        _ command: String,
+        for def: AgentHookDef,
+        logSlug: String
+    ) -> String {
+        let foregroundCommand = agentHookShellCommand(command, for: def)
+        let workerScript = """
+        payload="${CMUX_HOOK_PAYLOAD:-}"; command="${CMUX_HOOK_COMMAND:-}"; cleanup() { [ -n "$payload" ] && rm -f "$payload"; }; trap cleanup EXIT INT TERM; [ -n "$payload" ] && [ -n "$command" ] || exit 0; ( eval "$command" ) < "$payload" & child=$!; remaining=30; while [ "$remaining" -gt 0 ]; do kill -0 "$child" 2>/dev/null || break; sleep 1; remaining=$((remaining - 1)); done; if kill -0 "$child" 2>/dev/null; then kill "$child" 2>/dev/null || true; fi; wait "$child" 2>/dev/null || true
+        """
+        let prerequisite: String
+        if usesPinnedHookDispatch(def) {
+            prerequisite = "if [ \"$\(def.disableEnvVar)\" != \"1\" ]; then"
+        } else {
+            prerequisite = "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"; if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi; if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then"
+        }
+        return ": \(backgroundHookMarker); \(prerequisite) cmux_hook_payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-\(logSlug).json.XXXXXX\")\" || { echo '{}'; exit 0; }; cat > \"$cmux_hook_payload\" || true; cmux_hook_log_dir=\"${TMPDIR:-/tmp}/cmux-agent-hooks\"; mkdir -p \"$cmux_hook_log_dir\" 2>/dev/null || true; CMUX_HOOK_PAYLOAD=\"$cmux_hook_payload\" CMUX_HOOK_COMMAND=\(shellSingleQuote(foregroundCommand)) nohup sh -c \(shellSingleQuote(workerScript)) >> \"$cmux_hook_log_dir/\(logSlug).log\" 2>&1 & echo '{}'; else echo '{}'; fi"
+    }
 
     private static func agentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         if usesPinnedHookDispatch(def) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27346,6 +27346,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             )
             insertHashes(
                 eventLabel: eventLabel,
+                command: Self.legacySynchronousHookCommandString(for: def, event: event),
+                timeouts: [5_000, 600]
+            )
+            insertHashes(
+                eventLabel: eventLabel,
                 command: "cmux codex-hook \(event.cmuxSubcommand)",
                 timeouts: [hookTimeoutMs, 600]
             )

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1003,6 +1003,96 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertNotNil(hooks["stop"])
     }
 
+    func testLifecycleHookCommandsDispatchInBackgroundWhileFeedHooksStayForeground() throws {
+        let backgroundMarker = "cmux-agent-hook-background-v1"
+        for def in CMUXCLI.agentDefs where !def.events.isEmpty {
+            for event in def.events {
+                let command = CMUXCLI.hookCommandString(for: def, event: event)
+                XCTAssertTrue(
+                    command.contains(backgroundMarker),
+                    "Expected \(def.name) \(event.cmuxSubcommand) to use background dispatch, saw \(command)"
+                )
+                XCTAssertTrue(
+                    command.contains("nohup sh -c"),
+                    "Expected \(def.name) \(event.cmuxSubcommand) to detach from the agent hook process, saw \(command)"
+                )
+                XCTAssertTrue(
+                    command.contains("cmux hooks \(def.name) \(event.cmuxSubcommand)"),
+                    "Expected \(def.name) \(event.cmuxSubcommand) to invoke the real hook handler, saw \(command)"
+                )
+            }
+        }
+
+        for def in CMUXCLI.agentDefs where !def.feedHookEvents.isEmpty {
+            for agentEvent in def.feedHookEvents {
+                let command = CMUXCLI.feedHookCommandString(for: def, agentEvent: agentEvent)
+                XCTAssertFalse(
+                    command.contains(backgroundMarker),
+                    "Feed hook \(def.name) \(agentEvent) must stay foreground so approval responses can propagate, saw \(command)"
+                )
+                XCTAssertTrue(
+                    command.contains("hooks feed --source \(def.name) --event \(agentEvent)"),
+                    "Expected \(def.name) \(agentEvent) to invoke the feed bridge, saw \(command)"
+                )
+            }
+        }
+    }
+
+    func testLifecycleHookCommandReturnsBeforeSlowHandlerFinishes() throws {
+        let def = try XCTUnwrap(CMUXCLI.agentDef(named: "codex"))
+        let event = try XCTUnwrap(def.events.first { $0.cmuxSubcommand == "prompt-submit" })
+        let command = CMUXCLI.hookCommandString(for: def, event: event)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-background-hook-\(UUID().uuidString)", isDirectory: true)
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let tmpDir = root.appendingPathComponent("tmp", isDirectory: true)
+        let markerURL = root.appendingPathComponent("handler-output.txt", isDirectory: false)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fakeCmuxURL = binDir.appendingPathComponent("cmux", isDirectory: false)
+        let fakeCmux = """
+        #!/bin/sh
+        payload="$(cat)"
+        sleep 1
+        printf '%s\\n%s\\n' "$*" "$payload" > "$CMUX_HOOK_TEST_MARKER"
+        printf '{}\\n'
+        """
+        try fakeCmux.write(to: fakeCmuxURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeCmuxURL.path)
+
+        let startedAt = Date()
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", command],
+            environment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SURFACE_ID": "surface-test",
+                "CMUX_BUNDLED_CLI_PATH": fakeCmuxURL.path,
+                "CMUX_HOOK_TEST_MARKER": markerURL.path,
+                "TMPDIR": tmpDir.path,
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: #"{"prompt":"name this workspace"}"#,
+            timeout: 1
+        )
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+        XCTAssertLessThan(elapsed, 0.5, "Lifecycle hook should return before the slow handler completes")
+
+        XCTAssertTrue(
+            waitForFile(at: markerURL, timeout: 3),
+            "Expected detached hook worker to run the real cmux handler"
+        )
+        let marker = try String(contentsOf: markerURL, encoding: .utf8)
+        XCTAssertTrue(marker.contains("hooks codex prompt-submit"), marker)
+        XCTAssertTrue(marker.contains("name this workspace"), marker)
+    }
+
     func testKiroFeedDenyUsesPreToolUseExitCodeTwo() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("kiro-feed-deny")
@@ -3695,5 +3785,16 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 "non-restorable codex exec must not persist an env-only CODEX_HOME record; launchCommand=\(persisted["launchCommand"] ?? "nil")"
             )
         }
+    }
+
+    private func waitForFile(at url: URL, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return true
+            }
+            usleep(50_000)
+        }
+        return FileManager.default.fileExists(atPath: url.path)
     }
 }

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -45,6 +45,10 @@ That writes `.opencode/plugins/cmux-feed.js` in the current directory.
 
 Session hooks write `~/.cmuxterm/<agent>-hook-sessions.json`. Each entry stores the agent session ID, cmux workspace ID, surface ID, cwd, process ID when available, current lifecycle (`running`, `idle`, `needsInput`, or `unknown`), and a sanitized launch command. On app relaunch, cmux rebuilds each workspace and runs the agent's native resume command with the saved session ID.
 
+Lifecycle hook commands installed by cmux are fire-and-forget. They copy the hook payload to a temp file, start `cmux hooks <agent> <event>` in the background, and immediately return `{}` to the agent. This keeps session-start, prompt-submit, stop, notification, and session-end hooks from blocking the agent while cmux updates workspace state, Feed telemetry, notifications, and restore records.
+
+Feed bridge hooks stay foreground. Some Feed events need to return approval decisions or propagate a denial exit code, so cmux gives those hooks a longer timeout instead of detaching them.
+
 The sanitizer preserves model, sandbox, config, and cwd-related flags. It drops prompts, credentials, old session selectors, and noninteractive commands so relaunch resumes the session instead of starting a new task or leaking secrets.
 
 Grok uses its `Notification` hook for user-facing completion messages. cmux records `Stop` as idle state, but leaves the visible notification text to the `Notification` payload so repeated turns keep Grok's own message instead of a generic completion fallback.


### PR DESCRIPTION
## Summary
- install cmux lifecycle hook commands as fire-and-forget background dispatchers for all generic agent hook integrations
- keep Feed bridge hooks foreground so approval responses and deny exit codes still propagate
- retain old synchronous Codex hook trust hashes so setup can replace previously trusted commands

## Verification
- `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -derivedDataPath /tmp/cmux-bghook-cli build`
- installed Codex hooks with the tagged CLI into a temp CODEX_HOME; SessionStart/UserPromptSubmit/Stop all contained `cmux-agent-hook-background-v1` and `nohup sh -c`
- executed the installed UserPromptSubmit command against a fake slow `cmux` handler: hook stdout `{}`, returned in 32ms, handler completed later with the payload
- `./scripts/reload-cloud.sh --tag bghook`
- launched tagged `bghook` app, created a Codex workspace through `scripts/cmux-debug-cli.sh`, and confirmed `BGHOOK_DONE_AUTH` with no hook timeout/exited banners

## Notes
- Local `cmux-unit` build is blocked in this worktree by missing `GhosttyKit.xcframework`; CI should compile and run the full test target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783669843&installation_id=133855650&pr_number=5774&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5774&signature=a9fa973b095a8a4020b86c05febb4376be2a294ad54e8a8509c932195d8e8f93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every integrated agent invokes cmux on lifecycle events (session, prompts, stop); wrong background dispatch could drop telemetry or restore updates, while feed paths remain blocking by design.
> 
> **Overview**
> **Lifecycle agent hooks** now install as **fire-and-forget** shell wrappers (`cmux-agent-hook-background-v1`): they write the hook JSON to a temp file, run the real `cmux hooks <agent> <event>` via `nohup`, immediately print `{}`, and log to `cmux-agent-hooks`. A worker caps detached runs at ~30s.
> 
> **Feed bridge hooks** are unchanged—still synchronous so approvals and deny exit codes (e.g. Kiro `exit 2`) reach the agent.
> 
> For **Codex trust hashes**, setup also registers the previous synchronous lifecycle command strings so reinstall can replace already-trusted hook commands.
> 
> Tests cover background vs foreground split and that lifecycle hooks return before a slow handler finishes; docs describe the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252da29162d5e925066e971c2f5e0946a548859b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run agent lifecycle hooks in the background so agents don’t block, while keeping Feed bridge hooks in the foreground so approval/deny behavior still works.

- **New Features**
  - Lifecycle hooks now fire-and-forget: copy payload to temp, spawn `cmux hooks <agent> <event>` with `nohup`, return `{}` immediately.
  - Feed bridge hooks remain foreground to propagate approvals and denial exit codes; timeouts preserved.
  - Preserve trust for existing installs by inserting hashes for legacy synchronous commands; added tests and docs for the new behavior.

<sup>Written for commit 252da29162d5e925066e971c2f5e0946a548859b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Lifecycle hooks now execute as background processes, returning immediately to avoid blocking agent operations
  * Feed bridge hooks remain foreground with extended timeouts to support approval decisions

* **Tests**
  * Added validation for background hook dispatch behavior and execution timing

* **Documentation**
  * Clarified lifecycle hook execution model and feed hook behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->