### PR TITLE
Fix top-row clicks and find overlay close button in compact mode

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -205,7 +205,15 @@ final class WindowTerminalHostView: NSView {
     private func shouldPassThroughToTitlebar(at point: NSPoint) -> Bool {
         guard let window else { return false }
         let windowPoint = convert(point, to: nil)
-        return windowPoint.y >= BonsplitTabBarPassThrough.titlebarInteractionBandMinY(in: window)
+        guard windowPoint.y >= BonsplitTabBarPassThrough.titlebarInteractionBandMinY(in: window) else {
+            return false
+        }
+        // Compact mode removes the unifiedCompact toolbar, so the bonsplit
+        // tab strip sits flush at the top of content and hosted terminal
+        // pixels (including the SurfaceSearchOverlay close button) can land
+        // inside the titlebar interaction band. Defer to the hosted terminal
+        // before swallowing the hit, mirroring shouldPassThroughToPaneTabBar.
+        return hostedTerminalHitView(at: point) == nil
     }
 
     private func shouldPassThroughToPaneTabBar(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3800,6 +3800,67 @@ final class WindowTerminalHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewKeepsTerminalTopRowClickableInsideTitlebarInteractionBand() {
+        // Compact (minimal) mode removes the unifiedCompact toolbar, so the
+        // bonsplit tab strip sits flush at the top of content and hosted
+        // terminal pixels (plus the SurfaceSearchOverlay close button parked
+        // at .topRight) end up inside the 28-72pt titlebar interaction band
+        // computed by BonsplitTabBarPassThrough.titlebarInteractionBandMinY.
+        // Without a hosted-terminal guard in shouldPassThroughToTitlebar, the
+        // host swallows those clicks the same way it did before #3720 for the
+        // tab-strip pass-through.
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowTerminalHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+
+        // Mount the hosted terminal flush to the top of the host, modeling
+        // compact mode where there is no chrome between the system titlebar
+        // and the terminal pixels.
+        let hostedView = makeHostedTerminalView(frame: host.bounds)
+        host.addSubview(hostedView)
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        // Pick a point a few points below the top of content — well inside
+        // the titlebar interaction band (>= 28pt deep) but still over the
+        // hosted terminal view.
+        let titlebarBandHeight = max(
+            28,
+            min(72, window.frame.height - window.contentLayoutRect.height)
+        )
+        let depthInsideBand: CGFloat = 4
+        XCTAssertLessThan(
+            depthInsideBand,
+            titlebarBandHeight,
+            "Test point must be inside the titlebar interaction band"
+        )
+        let pointInContent = NSPoint(
+            x: contentView.bounds.midX,
+            y: contentView.bounds.maxY - depthInsideBand
+        )
+        let pointInWindow = contentView.convert(pointInContent, to: nil)
+        let pointInHost = host.convert(pointInWindow, from: nil)
+        let event = makeMouseDownEvent(at: pointInWindow, window: window)
+
+        assertHitFallsInsideHostedTerminal(
+            host.performHitTest(at: pointInHost, currentEvent: event),
+            hostedView: hostedView,
+            message: "Terminal top-row clicks (and the find overlay close button in compact mode) must reach the hosted terminal even when the titlebar interaction band overlaps it"
+        )
+    }
+
     func testHostViewPassesThroughWhenNoTerminalSubviewIsHit() {
         let host = WindowTerminalHostView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
 


### PR DESCRIPTION
## Summary

Compact (minimal) mode broke two terminal interactions: dragging to select text in the top row, and clicking the `x` close button on the cmd+f find overlay.

Both have the same root cause as #3709 / #3720 but in a sibling code path that PR didn't cover.

`WindowTerminalHostView.shouldPassThroughToTitlebar` returned `true` for any point inside the 28-72pt titlebar interaction band — without checking whether a visible hosted terminal actually sits there. In compact mode the `unifiedCompact` toolbar is removed (`WindowToolbarController` only attaches it when `!WorkspacePresentationModeSettings.isMinimal()`), so terminal pixels and the `SurfaceSearchOverlay` close button (parked at `.topRight` corner with 8pt padding) end up inside that band. The host swallowed the click and returned `nil` from `hitTest`, so neither the terminal nor the SwiftUI close button ever received the mouse-down.

`shouldPassThroughToPaneTabBar` already had the right protection — added in #3720. This PR mirrors it for the titlebar pass-through: defer to `hostedTerminalHitView(at:)` before returning true.

Test followed CLAUDE.md's two-commit red/green pattern: failing test first, fix second.

## Test plan

- [ ] CI builds clean
- [ ] `testHostViewKeepsTerminalTopRowClickableInsideTitlebarInteractionBand` fails on the first commit (test-only) and passes on the second commit (fix)
- [ ] Manual repro in compact mode: top-row drag-select works; find overlay `x` button closes the overlay
- [ ] Manual regression check in non-compact mode: window dragging via the titlebar strip still works where there is no terminal underneath

Fixes the symptoms originally reported around #3709 that persisted in compact mode after #3720.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783673106&installation_id=133855650&pr_number=5777&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5777&signature=b669b4216a0572b104bb10dd2120d92c253d923c632a7c98fe23062542553d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken clicks in compact mode by stopping the titlebar pass-through from swallowing hits over visible terminal pixels. Top-row text selection and the Cmd+F find overlay close button now work again.

- **Bug Fixes**
  - Updated WindowTerminalHostView.shouldPassThroughToTitlebar to only pass through when hostedTerminalHitView(at:) is nil, mirroring the pane tab bar path.
  - Added a regression test to ensure terminal top-row clicks inside the titlebar interaction band reach the terminal; non-compact window dragging remains unchanged.

<sup>Written for commit 541f59fc7009f32b4435e433c346785f8adf8d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mouse clicks in the titlebar area weren't properly routing to the terminal view underneath, preventing interaction with the top rows of the terminal window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->