### PR TITLE
ci: move Linux jobs off billed GitHub-hosted runners to Blacksmith

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,3 +10,7 @@ self-hosted-runner:
     - warp-macos-26-arm64-6x
     - depot-macos-latest
     - depot-macos-14
+    # Linux jobs default to Blacksmith via the LINUX_RUNNER repo variable
+    # (fallback below). GitHub-hosted ubuntu minutes are billed; Blacksmith is
+    # not. See docs/macos-ci-runners.md.
+    - blacksmith-4vcpu-ubuntu-2204

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   workflow-guard-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -89,7 +89,7 @@ jobs:
         run: python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
 
   remote-daemon-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -108,7 +108,7 @@ jobs:
         run: ./tests/test_remote_daemon_release_assets.sh
 
   web-typecheck:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     defaults:
       run:
         working-directory: web
@@ -131,7 +131,7 @@ jobs:
   # Checks for in-app React webviews (currently the diff viewer; more cmux React
   # surfaces will live alongside it).
   react-apps-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -162,7 +162,7 @@ jobs:
         run: bun run react-doctor:ci
 
   web-db-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     defaults:
       run:
         working-directory: web

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -51,7 +51,7 @@ permissions:
 jobs:
   decide:
     name: Decide whether a TestFlight upload is needed
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     timeout-minutes: 5
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
@@ -109,7 +109,10 @@ jobs:
     # blocks publishing arbitrary code by dispatching the workflow against a
     # feature branch (the ASC secrets are only meant to ship reviewed main).
     if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
-    runs-on: macos-26
+    # Signs and uploads to TestFlight from GitHub-hosted macos-26 by default.
+    # Set the IOS_RUNNER repo variable to move this to a paid macOS runner once
+    # it is confirmed to have the required iOS toolchain and signing support.
+    runs-on: ${{ vars.IOS_RUNNER || 'macos-26' }}
     timeout-minutes: 60
     env:
       ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   decide:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
       head_sha: ${{ steps.decide.outputs.head_sha }}

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   detect-ios-changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     timeout-minutes: 5
     outputs:
       should_run: ${{ steps.detect.outputs.should_run }}
@@ -74,7 +74,7 @@ jobs:
   package-conventions-lint:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     timeout-minutes: 5
     steps:
       - name: Checkout
@@ -95,7 +95,9 @@ jobs:
   mobile-core-package:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
-    runs-on: macos-26
+    # swift test only, no iOS Simulator runtime needed, so this rides the same
+    # paid macOS pool as the rest of CI instead of a 10x GitHub-hosted runner.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -129,7 +131,11 @@ jobs:
   ios-simulator:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
-    runs-on: macos-26
+    # Needs iOS Simulator runtimes (xcrun simctl). GitHub-hosted macos-26 ships
+    # these; Warp/Blacksmith macOS images are not yet verified to. Defaults to
+    # the GitHub-hosted runner; set the IOS_RUNNER repo variable to flip to a
+    # paid runner once it is confirmed to have iOS Simulator runtimes.
+    runs-on: ${{ vars.IOS_RUNNER || 'macos-26' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   remote-daemon-fuzz:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   update-cask:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
     # Only run if the release workflow succeeded (or manual trigger)
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/docs/macos-ci-runners.md
+++ b/docs/macos-ci-runners.md
@@ -39,6 +39,34 @@ gh variable list --repo manaflow-ai/cmux
 
 `perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. `auto` (and the empty `pull_request` case for perf) follows `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable also redirects these workflows. An explicit choice wins over the variable; both dropdowns expose `warp-macos-15-arm64-6x` / `warp-macos-26-arm64-6x` so an operator can pick Warp directly during a Blacksmith outage. `test-e2e.yml` also keeps `depot-macos-*` choices and a Depot identity guard for GUI-activation runs.
 
+## Linux runners
+
+GitHub-hosted `ubuntu-latest` minutes are billed against the org's included Actions allowance; Blacksmith Linux runners are not. Every Linux job routes through the `LINUX_RUNNER` repo variable with a Blacksmith fallback:
+
+```yaml
+runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}
+```
+
+With the variable unset (the default), Linux jobs run on Blacksmith. Fall back to GitHub-hosted runners during a Blacksmith Linux outage:
+
+```bash
+gh variable set LINUX_RUNNER --repo manaflow-ai/cmux -b ubuntu-latest
+# revert to Blacksmith:
+gh variable delete LINUX_RUNNER --repo manaflow-ai/cmux
+```
+
+The `cloud-vm-migrate.yml` and `cloud-vm-smoke.yml` jobs intentionally stay on `ubuntu-latest` because they connect to IP-allowlisted cloud infra (Aurora, provider APIs) and need GitHub-hosted egress ranges. They are the only allowlisted exceptions in the guard below.
+
+## iOS runners
+
+The iOS jobs that need an iOS Simulator runtime (`ios-simulator` in `test-ios.yml`) or TestFlight signing (`upload` in `ios-testflight.yml`) default to GitHub-hosted `macos-26`, which bills at 10x. They route through the `IOS_RUNNER` repo variable so they can move to a paid macOS runner once one is confirmed to ship iOS Simulator runtimes and signing support:
+
+```yaml
+runs-on: ${{ vars.IOS_RUNNER || 'macos-26' }}
+```
+
+`mobile-core-package` (`swift test`, no simulator) already runs on `MACOS_RUNNER_26`. Verify a candidate runner has iOS runtimes with `xcrun simctl list devices available` before setting `IOS_RUNNER`.
+
 ## Guard
 
-`tests/test_ci_self_hosted_guard.sh` (run by the `workflow-guard-tests` job) asserts every paid macOS job references `vars.MACOS_RUNNER_*` or a Blacksmith/Warp label, so a job can never silently fall back to a free GitHub-hosted runner. Keep new labels in `.github/actionlint.yaml`.
+`tests/test_ci_self_hosted_guard.sh` (run by the `workflow-guard-tests` job) asserts every paid macOS job references `vars.MACOS_RUNNER_*` or a Blacksmith/Warp label, and that no Linux job uses GitHub-hosted `ubuntu-latest` outside the `cloud-vm-*` allowlist, so a job can never silently fall back to a billed GitHub-hosted runner. Keep new labels in `.github/actionlint.yaml`.

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -109,10 +109,19 @@ check_linux_runners() {
     case " $allowlist " in
       *" $base "*) continue ;;
     esac
-    if grep -Eq "runs-on:[[:space:]]*ubuntu-latest" "$file"; then
+    # Anchor to the YAML key so a literal "ubuntu-latest" inside a run: shell
+    # block or a comment cannot trip the guard, and catch quoted scalars and the
+    # list form (runs-on:\n  - ubuntu-latest) in both .yml and .yaml files.
+    if awk '
+      /^[[:space:]]*runs-on:[[:space:]]*"?'\''?ubuntu-latest'\''?"?([[:space:]#].*)?$/ { found = 1 }
+      /^[[:space:]]*runs-on:[[:space:]]*(#.*)?$/ { in_ro = 1; next }
+      in_ro && /^[[:space:]]*-[[:space:]]*"?'\''?ubuntu-latest'\''?"?([[:space:]#].*)?$/ { found = 1 }
+      in_ro && /^[[:space:]]*[A-Za-z0-9_-]+:/ { in_ro = 0 }
+      END { exit found ? 0 : 1 }
+    ' "$file"; then
       offenders="$offenders $base"
     fi
-  done < <(find "$ROOT_DIR/.github/workflows" -name '*.yml')
+  done < <(find "$ROOT_DIR/.github/workflows" \( -name '*.yml' -o -name '*.yaml' \))
 
   if [[ -n "$offenders" ]]; then
     echo "FAIL: GitHub-hosted 'runs-on: ubuntu-latest' found in:$offenders"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -96,6 +96,34 @@ check_e2e_runner_fallbacks() {
   echo "PASS: test-e2e.yml exposes Depot runner choices, identity guard, and duplicate-queue cancellation"
 }
 
+check_linux_runners() {
+  # GitHub-hosted ubuntu minutes are billed against the org allowance; Blacksmith
+  # Linux runners are not. Every Linux job routes through the LINUX_RUNNER repo
+  # variable (Blacksmith fallback) EXCEPT the cloud-vm jobs, which stay on
+  # GitHub-hosted runners so their egress IPs match infra allowlists. Any other
+  # `runs-on: ubuntu-latest` is a regression that silently burns paid minutes.
+  local allowlist="cloud-vm-migrate.yml cloud-vm-smoke.yml"
+  local offenders=""
+  while IFS= read -r file; do
+    base="$(basename "$file")"
+    case " $allowlist " in
+      *" $base "*) continue ;;
+    esac
+    if grep -Eq "runs-on:[[:space:]]*ubuntu-latest" "$file"; then
+      offenders="$offenders $base"
+    fi
+  done < <(find "$ROOT_DIR/.github/workflows" -name '*.yml')
+
+  if [[ -n "$offenders" ]]; then
+    echo "FAIL: GitHub-hosted 'runs-on: ubuntu-latest' found in:$offenders"
+    echo "      Route Linux jobs through \${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}."
+    echo "      Only $allowlist may stay on ubuntu-latest; add to the allowlist if intentional."
+    exit 1
+  fi
+
+  echo "PASS: Linux jobs route through LINUX_RUNNER (only cloud-vm jobs stay GitHub-hosted)"
+}
+
 check_xcode_selection() {
   if grep -R -n "ls -d /Applications/Xcode" "$ROOT_DIR/.github/workflows"; then
     echo "FAIL: workflow Xcode selection must use find/sort/tail fallback, not ls/glob ordering"
@@ -240,6 +268,7 @@ check_macos_runner "$COMPAT_FILE" "compat-tests"
 # duplicate queued runs for the same ref/filter/runner.
 check_e2e_runner_fallbacks
 
+check_linux_runners
 check_xcode_selection
 check_release_build_signal
 check_release_helper_upload_retry


### PR DESCRIPTION
The org hit 100% of its included GitHub Actions minutes (3000/3000, resets July 1). Only GitHub-hosted runners bill against that allowance; macOS already runs on Warp/Blacksmith, so the remaining drain is the GitHub-hosted Linux (`ubuntu-latest`, 1x) and iOS (`macos-26`, 10x) jobs.

This routes Linux jobs to Blacksmith and sets up the 10x iOS jobs behind a flip-ready variable.

**Linux → Blacksmith.** Every `ubuntu-latest` job now uses `${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}`, mirroring the existing `MACOS_RUNNER_*` indirection. Variable unset = Blacksmith; set `LINUX_RUNNER=ubuntu-latest` to fall back during a Blacksmith outage, no PR needed. `cloud-vm-migrate` and `cloud-vm-smoke` intentionally stay on `ubuntu-latest` because they hit IP-allowlisted cloud infra (Aurora, provider APIs).

**macOS.** `mobile-core-package` is `swift test` with no simulator, so it moves to `MACOS_RUNNER_26` (off the 10x GitHub-hosted runner). `ios-simulator` and the TestFlight `upload` job need iOS Simulator runtimes / signing that Warp/Blacksmith macOS images are not yet verified to have, so they route through a new `IOS_RUNNER` variable that defaults to `macos-26` (no behavior change today). Flip `IOS_RUNNER` once a paid runner is confirmed to have iOS runtimes (`xcrun simctl list devices available`) — that's where the largest 10x savings land.

**Guard.** `tests/test_ci_self_hosted_guard.sh` now fails on any `runs-on: ubuntu-latest` outside the `cloud-vm-*` allowlist, so billed Linux runners can't silently creep back in. New labels added to `.github/actionlint.yaml`; docs updated in `docs/macos-ci-runners.md`.

Validation: this PR's own `ci.yml` Linux jobs run on Blacksmith, so green checks here confirm Blacksmith Linux is live for the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783678026&installation_id=133855650&pr_number=5783&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5783&signature=6a94a8d48a1bed219f821f6a4bddd75dfbd5133d5bc0a54250c5f08d3714e8cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches runner selection across many workflows; misconfiguration or Blacksmith Linux issues could block CI, though `LINUX_RUNNER=ubuntu-latest` is the documented fallback.
> 
> **Overview**
> Routes **Linux** CI jobs off billed GitHub `ubuntu-latest` onto **`LINUX_RUNNER`** with default **`blacksmith-4vcpu-ubuntu-2204`** (same pattern as existing `MACOS_RUNNER_*`). **`cloud-vm-migrate`** and **`cloud-vm-smoke`** stay on GitHub-hosted Ubuntu for IP-allowlisted egress.
> 
> Adds **`IOS_RUNNER`** (default **`macos-26`**) for simulator and TestFlight upload jobs so they can move to paid macOS later; moves **`mobile-core-package`** to **`MACOS_RUNNER_26`**. Extends **`test_ci_self_hosted_guard.sh`** to reject stray `ubuntu-latest`, documents Linux/iOS switching in **`docs/macos-ci-runners.md`**, and registers the Blacksmith Ubuntu label in **actionlint**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d887f2c4e627388589b217e534d14ebd07f70e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Linux CI jobs to Blacksmith via `LINUX_RUNNER` to stop burning billed GitHub-hosted minutes. Add a flip-ready `IOS_RUNNER`, move `mobile-core-package` to `MACOS_RUNNER_26`, and harden the guard so `ubuntu-latest` can’t sneak back in.

- **Refactors**
  - All Linux jobs now use `runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2204' }}`.
  - Keep `cloud-vm-migrate.yml` and `cloud-vm-smoke.yml` on `ubuntu-latest` (IP-allowlisted egress).
  - `ios-simulator` and TestFlight `upload` use `runs-on: ${{ vars.IOS_RUNNER || 'macos-26' }}`; `mobile-core-package` uses `MACOS_RUNNER_26`.
  - Guard now fails on any `runs-on: ubuntu-latest` outside the cloud-vm allowlist and is hardened to anchor to the YAML key, catch quoted/list forms, and scan `.yml`/`.yaml`; actionlint labels and runner docs updated.

- **Migration**
  - Default: no change needed; Linux jobs run on Blacksmith.
  - Temporary fallback: set repo variable `LINUX_RUNNER=ubuntu-latest`.
  - When a paid macOS runner with iOS runtimes is ready, set `IOS_RUNNER` (verify with `xcrun simctl list devices available`).

<sup>Written for commit 8d887f2c4e627388589b217e534d14ebd07f70e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI runners made configurable with sensible defaults for Linux and macOS to allow easier environment selection.
  * Workflows updated to use configurable runner variables with fallbacks to defaults.

* **Tests**
  * Added automated validation to detect disallowed Linux runner usage and enforce configured defaults.

* **Documentation**
  * Expanded guidance on runner selection, defaults, overrides, and guard expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->