### PR TITLE
chore: refresh the Swift file-length budget for current main

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -16,8 +16,8 @@
 6948	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6469	cmuxTests/GhosttyConfigTests.swift
 6299	cmuxTests/TerminalAndGhosttyTests.swift
-6119	CLI/cmux_open.swift
 6220	cmuxTests/SessionPersistenceTests.swift
+6119	CLI/cmux_open.swift
 5948	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
 5431	Sources/cmuxApp.swift
@@ -39,7 +39,7 @@
 2545	cmuxTests/WorkspaceManualUnreadTests.swift
 2513	cmuxTests/CommandPaletteSearchEngineTests.swift
 2509	Sources/KeyboardShortcutSettings.swift
-2378	Sources/TerminalNotificationStore.swift
+2474	Sources/TerminalNotificationStore.swift
 2327	cmuxTests/CJKIMEInputTests.swift
 2290	Sources/FileExplorerView.swift
 2260	Sources/TerminalWindowPortal.swift
@@ -53,7 +53,7 @@
 1793	Sources/SessionIndexStore.swift
 1751	Sources/WindowDragHandleView.swift
 1721	cmuxTests/TerminalControllerSocketSecurityTests.swift
-1726	Sources/RestorableAgentSession.swift
+1720	Sources/RestorableAgentSession.swift
 1693	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
 1643	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -140,16 +140,16 @@
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
 619	cmuxTests/FinderFileDropRegressionTests.swift
-613	Sources/PortScanner.swift
 614	cmuxTests/SessionIndexViewTests.swift
+613	Sources/PortScanner.swift
 599	Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 596	cmuxTests/CmuxEventBusTests.swift
+594	Sources/SessionIndexModels.swift
 594	cmuxTests/PortalTabDragRoutingTests.swift
 589	Sources/SettingsNavigation.swift
 588	cmuxTests/CommandPaletteShortcutCustomizationTests.swift
 586	Sources/JSONCParser.swift
 585	Sources/Cloud/VMClient.swift
-594	Sources/SessionIndexModels.swift
 580	Packages/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift
 580	cmuxTests/CLIHookNoResponseTests.swift
 578	cmuxUITests/FeedSidebarUITests.swift


### PR DESCRIPTION
Every PR's `workflow-guard-tests` is currently red: main has drifted past the checked-in Swift file-length budget on several files (`ContentView.swift` 19068>19052, `TabManager.swift` 9939>9914, `WorkspaceGroupTests.swift` 906>853, plus ratchet movement in `Workspace.swift` and `GhosttyTerminalView.swift`), so any merged tree fails the budget step no matter what the PR changes.

This regenerates the TSV with `scripts/swift_file_length_budget.py --write-budget` on current main (shrunk files ratchet down at the same time), and pre-allocates `2474` for `Sources/TerminalNotificationStore.swift` to cover the in-flight Focus/DND notification-sound fix (#5651, +96 lines).

The pre-allocation exists because #5651 is a fork PR, and a fork PR whose diff touches `.github/` cannot run workflows at all — the bump has to land from a same-repo branch so that PR can drop its own `.github/` change and get CI again. The checker treats budgets as upper bounds and reports the slack as "Budget can be reduced", so this is safe for main today. Splitting `NotificationSoundSettings` out of `TerminalNotificationStore.swift` remains the tracked longer-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783678343&installation_id=133855650&pr_number=5784&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5784&signature=ac2476993415fcd3f342e8653f699ff6d7d84c3190f6904ab5394996f77dfd94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Swift file-length budget to match current `main`, fixing red `workflow-guard-tests` so CI passes again on all PRs. Pre-allocates a 2474-line budget for `Sources/TerminalNotificationStore.swift` to cover the Focus/DND notification-sound fix in #5651 and let that fork PR run CI without touching `.github/`.

<sup>Written for commit f04c50ab4242fe73682d56e8f84fbbea39e46fc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

