### PR TITLE
Add regression test: shift+click extends terminal selection (Ghostty parity)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11477,6 +11477,56 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         return payload
     }
+
+    /// Synthesize a left-button mouse event through the view's real NSEvent
+    /// handlers (mouseDown/mouseDragged/mouseUp) so selection behavior such as
+    /// drag-select and shift+click extension can be exercised from socket
+    /// tests. `point` is view-local with a top-left origin.
+    func debugSynthesizeMouseEventForTesting(
+        action: String,
+        at point: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags,
+        clickCount: Int
+    ) -> Bool {
+        guard let window else { return false }
+        let clamped = clampedDebugPoint(NSPoint(x: point.x, y: bounds.height - point.y))
+        let locationInWindow = convert(clamped, to: nil)
+
+        let type: NSEvent.EventType
+        switch action {
+        case "down": type = .leftMouseDown
+        case "up": type = .leftMouseUp
+        case "drag": type = .leftMouseDragged
+        default: return false
+        }
+
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: locationInWindow,
+            modifierFlags: modifierFlags,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: clickCount,
+            pressure: type == .leftMouseUp ? 0 : 1
+        ) else { return false }
+
+        switch type {
+        case .leftMouseDown: mouseDown(with: event)
+        case .leftMouseUp: mouseUp(with: event)
+        case .leftMouseDragged: mouseDragged(with: event)
+        default: return false
+        }
+        return true
+    }
+
+    func debugSelectionInfoForTesting() -> (active: Bool, text: String) {
+        guard let surface else { return (false, "") }
+        let active = ghostty_surface_has_selection(surface)
+        guard active, let snapshot = readSelectionSnapshot() else { return (active, "") }
+        return (active, snapshot.string)
+    }
 #endif
 
     override func rightMouseDown(with event: NSEvent) {
@@ -12519,6 +12569,29 @@ final class GhosttySurfaceScrollView: NSView {
 
     func debugSimulateCommandClick(at point: NSPoint) -> [String: Any] {
         surfaceView.debugSimulateCommandClick(at: debugPointInSurface(point))
+    }
+
+    func debugSynthesizeMouseEventForTesting(
+        action: String,
+        atSurfaceFraction fraction: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags,
+        clickCount: Int
+    ) -> Bool {
+        let surfaceBounds = surfaceView.bounds
+        let point = NSPoint(
+            x: fraction.x * surfaceBounds.width,
+            y: fraction.y * surfaceBounds.height
+        )
+        return surfaceView.debugSynthesizeMouseEventForTesting(
+            action: action,
+            at: point,
+            modifierFlags: modifierFlags,
+            clickCount: clickCount
+        )
+    }
+
+    func debugSelectionInfoForTesting() -> (active: Bool, text: String) {
+        surfaceView.debugSelectionInfoForTesting()
     }
 #endif
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1728,6 +1728,12 @@ class TerminalController {
         case "read_terminal_text":
             return readTerminalText(args)
 
+        case "terminal_mouse":
+            return terminalMouseDebug(args)
+
+        case "terminal_selection":
+            return terminalSelectionDebug(args)
+
         case "render_stats":
             return renderStats(args)
 
@@ -2384,6 +2390,10 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugReadTerminalText(params: params))
         case "debug.terminal.render_stats":
             return v2Result(id: id, self.v2DebugRenderStats(params: params))
+        case "debug.terminal.mouse":
+            return v2Result(id: id, self.v2DebugTerminalMouse(params: params))
+        case "debug.terminal.selection":
+            return v2Result(id: id, self.v2DebugTerminalSelection(params: params))
         case "debug.layout":
             return v2Result(id: id, self.v2DebugLayout())
         case "debug.portal.stats":
@@ -2664,6 +2674,8 @@ class TerminalController {
             "debug.terminal.is_focused",
             "debug.terminal.read_text",
             "debug.terminal.render_stats",
+            "debug.terminal.mouse",
+            "debug.terminal.selection",
             "debug.layout",
             "debug.portal.stats",
             "debug.bonsplit_underflow.count",
@@ -15852,6 +15864,39 @@ class TerminalController {
         return .ok(["stats": obj])
     }
 
+    private func v2DebugTerminalMouse(params: [String: Any]) -> V2CallResult {
+        guard let action = v2String(params, "action"),
+              let fx = (params["fx"] as? NSNumber)?.doubleValue,
+              let fy = (params["fy"] as? NSNumber)?.doubleValue else {
+            return .err(code: "invalid_params", message: "debug.terminal.mouse requires action, fx, fy", data: nil)
+        }
+        let mods = v2String(params, "mods") ?? "none"
+        let clicks = (params["clicks"] as? NSNumber)?.intValue ?? 1
+        let surfaceArg = v2String(params, "surface_id") ?? ""
+        var command = "\(action) \(fx) \(fy) \(mods) \(clicks)"
+        if !surfaceArg.isEmpty {
+            command += " \(surfaceArg)"
+        }
+        let resp = terminalMouseDebug(command)
+        guard resp.hasPrefix("OK") else {
+            return .err(code: "invalid_params", message: resp, data: nil)
+        }
+        return .ok(["delivered": true])
+    }
+
+    private func v2DebugTerminalSelection(params: [String: Any]) -> V2CallResult {
+        let surfaceArg = v2String(params, "surface_id") ?? ""
+        let resp = terminalSelectionDebug(surfaceArg)
+        guard resp.hasPrefix("OK ") else {
+            return .err(code: "internal_error", message: resp, data: nil)
+        }
+        let payload = String(resp.dropFirst(3))
+        let parts = payload.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: false)
+        let active = parts.first == "1"
+        let b64 = parts.count > 1 ? String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines) : ""
+        return .ok(["active": active, "base64": b64])
+    }
+
     private func v2DebugLayout() -> V2CallResult {
         let resp = layoutDebug()
         guard resp.hasPrefix("OK ") else {
@@ -16211,6 +16256,8 @@ class TerminalController {
           send_workspace <workspace_id> <text> - Send text to a workspace's selected terminal (test-only)
           is_terminal_focused <id|idx>    - Return true/false if terminal surface is first responder (test-only)
           read_terminal_text [id|idx]     - Read visible terminal text (base64, test-only)
+          terminal_mouse <down|up|drag> <fx 0-1> <fy 0-1> [mods] [clicks] [id|idx] - Synthesize a left-button mouse event on the terminal (test-only)
+          terminal_selection [id|idx]     - Read selection state: "OK <0|1> <base64 text>" (test-only)
           render_stats [id|idx]           - Read terminal render stats (draw counters, test-only)
           layout_debug                    - Dump bonsplit layout + selected panel bounds (test-only)
           bonsplit_underflow_count        - Count bonsplit arranged-subview underflow events (test-only)
@@ -16873,6 +16920,93 @@ class TerminalController {
 
     private func readTerminalText(_ args: String) -> String {
         readTerminalTextBase64(surfaceArg: args)
+    }
+
+    /// `terminal_mouse <down|up|drag> <fx> <fy> [mods] [clicks] [panel]`
+    /// fx/fy are 0-1 fractions of the surface bounds with a top-left origin.
+    /// mods is a |-separated list of shift/ctrl/alt/cmd, or "none". Events are
+    /// delivered through the terminal view's real mouse handlers so selection
+    /// behavior (drag-select, shift+click extension) is exercised end to end.
+    private func terminalMouseDebug(_ args: String) -> String {
+        guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
+        let parts = args.split(separator: " ").map(String.init)
+        guard parts.count >= 3,
+              let fx = Double(parts[1]),
+              let fy = Double(parts[2]),
+              (0...1).contains(fx),
+              (0...1).contains(fy) else {
+            return "ERROR: Usage: terminal_mouse <down|up|drag> <fx 0-1> <fy 0-1> [mods] [clicks] [panel]"
+        }
+        let action = parts[0]
+        var flags: NSEvent.ModifierFlags = []
+        if parts.count >= 4, parts[3] != "none" {
+            for token in parts[3].lowercased().split(separator: "|") {
+                switch token {
+                case "shift": flags.insert(.shift)
+                case "ctrl", "control": flags.insert(.control)
+                case "alt", "option": flags.insert(.option)
+                case "cmd", "command": flags.insert(.command)
+                default: return "ERROR: Unknown modifier: \(token)"
+                }
+            }
+        }
+        let clicks = parts.count >= 5 ? (Int(parts[4]) ?? 1) : 1
+        let panelArg = parts.count >= 6 ? parts[5] : ""
+
+        var result = "ERROR: No tab selected"
+        v2MainSync {
+            guard let tabId = tabManager.selectedTabId,
+                  let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
+                return
+            }
+            let panelId: UUID?
+            if panelArg.isEmpty {
+                panelId = tab.focusedPanelId
+            } else {
+                panelId = resolveSurfaceId(from: panelArg, tab: tab)
+            }
+            guard let panelId,
+                  let terminalPanel = tab.terminalPanel(for: panelId) else {
+                result = "ERROR: Terminal surface not found"
+                return
+            }
+            let delivered = terminalPanel.hostedView.debugSynthesizeMouseEventForTesting(
+                action: action,
+                atSurfaceFraction: NSPoint(x: fx, y: fy),
+                modifierFlags: flags,
+                clickCount: clicks
+            )
+            result = delivered ? "OK delivered" : "ERROR: Event not delivered"
+        }
+        return result
+    }
+
+    /// `terminal_selection [panel]` -> `OK <active 0|1> <base64 selection text>`
+    private func terminalSelectionDebug(_ args: String) -> String {
+        guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
+        let panelArg = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        var result = "ERROR: No tab selected"
+        v2MainSync {
+            guard let tabId = tabManager.selectedTabId,
+                  let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
+                return
+            }
+            let panelId: UUID?
+            if panelArg.isEmpty {
+                panelId = tab.focusedPanelId
+            } else {
+                panelId = resolveSurfaceId(from: panelArg, tab: tab)
+            }
+            guard let panelId,
+                  let terminalPanel = tab.terminalPanel(for: panelId) else {
+                result = "ERROR: Terminal surface not found"
+                return
+            }
+            let info = terminalPanel.hostedView.debugSelectionInfoForTesting()
+            let b64 = Data(info.text.utf8).base64EncodedString()
+            result = "OK \(info.active ? 1 : 0) \(b64)"
+        }
+        return result
     }
 
     private struct RenderStatsResponse: Codable {

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -1030,6 +1030,42 @@ class cmux:
         # Server wraps the underlying stats object under "stats".
         return dict(res.get("stats") or {})
 
+    def terminal_mouse(
+        self,
+        action: str,
+        fx: float,
+        fy: float,
+        mods: str = "none",
+        clicks: int = 1,
+        panel: Union[str, int, None] = None,
+    ) -> None:
+        """
+        Synthesize a left-button mouse event on a terminal surface.
+        action is down/up/drag; fx/fy are 0-1 fractions of the surface bounds
+        with a top-left origin; mods is a |-separated list of shift/ctrl/alt/cmd.
+        """
+        params: Dict[str, Any] = {
+            "action": action,
+            "fx": fx,
+            "fy": fy,
+            "mods": mods,
+            "clicks": clicks,
+        }
+        if panel is not None:
+            params["surface_id"] = self._resolve_surface_id(panel)
+        self._call("debug.terminal.mouse", params)
+
+    def terminal_selection(self, panel: Union[str, int, None] = None) -> Tuple[bool, str]:
+        """Return (selection_active, selected_text) for a terminal surface."""
+        params: Dict[str, Any] = {}
+        if panel is not None:
+            params["surface_id"] = self._resolve_surface_id(panel)
+        res = self._call("debug.terminal.selection", params) or {}
+        active = bool(res.get("active"))
+        b64 = str(res.get("base64") or "")
+        raw = base64.b64decode(b64) if b64 else b""
+        return active, raw.decode("utf-8", errors="replace")
+
     def layout_debug(self) -> dict:
         res = self._call("debug.layout") or {}
         # Server wraps LayoutDebugResponse under "layout".

--- a/tests_v2/test_terminal_shift_click_extend_selection.py
+++ b/tests_v2/test_terminal_shift_click_extend_selection.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Regression: shift+click must extend an existing terminal selection (Ghostty parity).
+
+Ghostty core extends the current selection when a left click lands with shift
+held, an earlier click recorded, and more than mouse-interval (500ms) elapsed.
+cmux heavily customizes the macOS event path around GhosttyNSView, so this
+guards the whole chain view-handlers -> ghostty_surface_mouse_* -> core
+selection state via the debug.terminal.mouse / debug.terminal.selection
+socket methods.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+# Core refuses to extend within its mouse-interval (default 500ms) so a fast
+# second click can still count as a double-click. Stay safely above it.
+MOUSE_INTERVAL_GRACE_S = 0.8
+
+ROW_Y = 0.5
+DRAG_START_X = 0.10
+DRAG_END_X = 0.30
+EXTEND_X = 0.60
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _fill_viewport(c: cmux) -> None:
+    c.send("clear; seq -f 'ROW%02g aaaa bbbb cccc dddd eeee ffff gggg hhhh' 1 40\\n")
+    deadline = time.time() + 8.0
+    while time.time() < deadline:
+        if "ROW20" in c.read_terminal_text():
+            return
+        time.sleep(0.2)
+    raise cmuxError("Timed out waiting for test rows to render")
+
+
+def _drag_select(c: cmux) -> None:
+    c.terminal_mouse("down", DRAG_START_X, ROW_Y)
+    steps = 8
+    for i in range(1, steps + 1):
+        x = DRAG_START_X + (DRAG_END_X - DRAG_START_X) * i / steps
+        c.terminal_mouse("drag", x, ROW_Y)
+        time.sleep(0.02)
+    c.terminal_mouse("up", DRAG_END_X, ROW_Y)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        _fill_viewport(c)
+
+        # Baseline: plain drag-select produces a selection.
+        _drag_select(c)
+        time.sleep(0.3)
+        active, base_text = c.terminal_selection()
+        _must(active, "drag-select did not produce a selection")
+        _must(bool(base_text.strip()), f"drag-select produced empty text: {base_text!r}")
+
+        time.sleep(MOUSE_INTERVAL_GRACE_S)
+
+        # Shift+click further right on the same row must extend, not replace.
+        c.terminal_mouse("down", EXTEND_X, ROW_Y, mods="shift")
+        c.terminal_mouse("up", EXTEND_X, ROW_Y, mods="shift")
+        time.sleep(0.3)
+        active, extended_text = c.terminal_selection()
+        _must(active, "selection vanished after shift+click")
+        _must(
+            len(extended_text) > len(base_text),
+            f"shift+click did not extend selection: base={base_text!r} after={extended_text!r}",
+        )
+        _must(
+            base_text.strip()[:6] in extended_text,
+            f"extended selection lost the original anchor: base={base_text!r} after={extended_text!r}",
+        )
+
+        # Plain click clears the selection again (no sticky extend state).
+        c.terminal_mouse("down", DRAG_START_X, 0.9)
+        c.terminal_mouse("up", DRAG_START_X, 0.9)
+        time.sleep(0.3)
+        active, _ = c.terminal_selection()
+        _must(not active, "plain click after shift+click extension should clear the selection")
+
+    print("PASS: shift+click extends terminal selection")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except cmuxError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests_v2/test_terminal_shift_click_extend_selection.py
+++ b/tests_v2/test_terminal_shift_click_extend_selection.py
@@ -61,9 +61,10 @@ def main() -> int:
     with cmux(SOCKET_PATH) as c:
         _fill_viewport(c)
 
-        # Baseline: plain drag-select produces a selection.
+        # Baseline: plain drag-select produces a selection. terminal_mouse and
+        # terminal_selection both run synchronously on the app's main thread,
+        # so selection state is settled as soon as each call returns.
         _drag_select(c)
-        time.sleep(0.3)
         active, base_text = c.terminal_selection()
         _must(active, "drag-select did not produce a selection")
         _must(bool(base_text.strip()), f"drag-select produced empty text: {base_text!r}")
@@ -73,7 +74,6 @@ def main() -> int:
         # Shift+click further right on the same row must extend, not replace.
         c.terminal_mouse("down", EXTEND_X, ROW_Y, mods="shift")
         c.terminal_mouse("up", EXTEND_X, ROW_Y, mods="shift")
-        time.sleep(0.3)
         active, extended_text = c.terminal_selection()
         _must(active, "selection vanished after shift+click")
         _must(
@@ -88,7 +88,6 @@ def main() -> int:
         # Plain click clears the selection again (no sticky extend state).
         c.terminal_mouse("down", DRAG_START_X, 0.9)
         c.terminal_mouse("up", DRAG_START_X, 0.9)
-        time.sleep(0.3)
         active, _ = c.terminal_selection()
         _must(not active, "plain click after shift+click extension should clear the selection")
 


### PR DESCRIPTION
## Summary

Adds regression coverage for **shift+click extending an existing terminal selection** (Ghostty parity), plus the debug-socket plumbing needed to drive terminal mouse input from socket tests.

While investigating a "shift+click doesn't extend the selection" report against cmux, I traced the full chain (`GhosttyNSView` mouse handlers → `ghostty_surface_mouse_pos`/`ghostty_surface_mouse_button` → core `Surface.zig` shift-extend path) and confirmed the behavior **works correctly on current main**, including with `terminal.copyOnSelect` enabled (the extended selection is re-copied on release, as expected). However, the behavior had zero test coverage — and since cmux customizes the macOS event path heavily (window `sendEvent` swizzles, portal hit-testing, overlay forwarding), a future refactor could silently regress it.

## What's included

- **`debug.terminal.mouse`** (v2) / **`terminal_mouse`** (v1, documented in help): synthesize left-button down/drag/up on a terminal surface through the view's real `mouseDown`/`mouseDragged`/`mouseUp` handlers, with modifier support (`shift|ctrl|alt|cmd`) and clickCount. Fills the terminal-mouse gap in the existing test-only command family (`simulate_type`, `simulate_shortcut`, `debug.sidebar.simulate_drag`, …). DEBUG builds only.
- **`debug.terminal.selection`** (v2) / **`terminal_selection`** (v1): read selection state + selected text (base64), built on the existing `readSelectionSnapshot()`.
- **`tests_v2/test_terminal_shift_click_extend_selection.py`**: drag-select → wait past core `mouse-interval` → shift+click further right ⇒ selection must extend (and keep its anchor); a plain click afterwards must clear it.
- `tests_v2/cmux.py`: `terminal_mouse()` / `terminal_selection()` client helpers.

## Why in-process synthesis (not CGEvent/XCUI)

Real-HID CGEvent injection needs Accessibility/TCC and a quiescent pointer; `NSApp.postEvent`/`window.sendEvent` synthesis is unreliable here because portal hit-testing reads `NSApp.currentEvent` and AppKit rewrites `clickCount` on posted events. Driving the view handlers directly exercises everything from cmux's Swift layer down through libghostty selection state, deterministically and CI/VM-safe.

## Validation

- Built with `./scripts/reload.sh --tag shiftsel`; ran the new test against the tagged Debug app — passes.
- Manually verified in the Debug app: real shift+click extends a drag selection, with and without `terminal.copyOnSelect` (clipboard updates to the extended text on release).
- Negative check: the test fails if the shift mods are dropped from the press (verified by temporarily forcing `GHOSTTY_MODS_NONE` in `mouseDown`).

## Localization audit

No user-facing UI strings added. The only text changes are entries in the socket protocol `help` output, which follows the existing convention of unlocalized English for that surface (all sibling entries are plain strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783681734&installation_id=133855650&pr_number=5790&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5790&signature=a8a4d569d4229b82bb7f8de3eb9bb47d43807540811706bd2e2b68b73abd9a84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test to verify Shift+Click extends an existing terminal selection (Ghostty parity). Adds debug socket commands to synthesize terminal mouse input and read selection through the full macOS event path.

- **New Features**
  - `debug.terminal.mouse` (v2) / `terminal_mouse` (v1): synthesize left-button down/drag/up via real view handlers with `shift|ctrl|alt|cmd` and click count. DEBUG builds only.
  - `debug.terminal.selection` (v2) / `terminal_selection` (v1): return selection active state and base64 text.
  - Test `tests_v2/test_terminal_shift_click_extend_selection.py`: drag-select → wait past mouse interval → Shift+Click extends (anchor kept) → plain click clears.
  - Helpers in `tests_v2/cmux.py`: `terminal_mouse()` and `terminal_selection()`.

- **Refactors**
  - Removed redundant post-mouse-up sleeps in the test; rely on synchronous dispatch of `debug.terminal.mouse`/`debug.terminal.selection` and keep only the mouse-interval grace wait.

<sup>Written for commit 3e690534fe9fc5024db3c36fdfcf84bf9972affa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New (Debug)**
  * Added debug/test-only terminal commands to synthesize mouse input and inspect selection state for end-to-end testing.

* **Tests**
  * Enhanced testing infrastructure with helpers to simulate terminal mouse events and verify selections.
  * Added a regression test verifying shift+click extends a terminal selection and that plain click clears it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->