### PR TITLE
Chat view: resume-binding fallback for session-restored terminals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,6 +420,7 @@ jobs:
           # is confirmed to resolve standalone.
           PACKAGES=(
             CMUXAuthCore
+            CmuxAgentConversation
             CmuxAuthRuntime
             CmuxControlSocket
             CmuxFileWatch

--- a/Sources/AgentChat/AgentChatPresenter.swift
+++ b/Sources/AgentChat/AgentChatPresenter.swift
@@ -32,13 +32,22 @@ struct AgentChatPresenter {
         }
         let workspaceId = workspace.id
         let resolver = resolver
+        // Capture the panel's persisted resume binding on the main actor so the
+        // resolver can fall back to it when the live index has no entry (a
+        // terminal restored after an app relaunch).
+        let resumeBinding = workspace.surfaceResumeBinding(panelId: panelId)
 
         Task {
             // Loading the index and globbing the filesystem is IO; keep it off
             // the main actor, then present on the main actor.
             let resolution = await Task.detached(priority: .userInitiated) {
                 let index = RestorableAgentSessionIndex.load()
-                return resolver.resolve(index: index, workspaceId: workspaceId, panelId: panelId)
+                return resolver.resolve(
+                    index: index,
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    resumeBinding: resumeBinding
+                )
             }.value
 
             guard let resolution else {

--- a/Sources/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/AgentChat/AgentChatTranscriptResolver.swift
@@ -46,42 +46,106 @@ struct AgentChatTranscriptResolver {
     ///   - index: The loaded restorable-session index.
     ///   - workspaceId: The panel's workspace id.
     ///   - panelId: The panel id.
+    ///   - resumeBinding: The panel's surface resume binding, consulted when
+    ///     the live index has no entry for the panel.
     /// - Returns: The resolution, or `nil` when the panel has no known agent
     ///   session or the agent kind is not a transcript-backed kind P1 supports.
     func resolve(
         index: RestorableAgentSessionIndex,
         workspaceId: UUID,
-        panelId: UUID
+        panelId: UUID,
+        resumeBinding: SurfaceResumeBindingSnapshot? = nil
     ) -> Resolution? {
-        guard let snapshot = index.snapshot(workspaceId: workspaceId, panelId: panelId) else {
+        // Prefer the live index; fall back to the panel's resume binding when
+        // the index has no entry. A session-restored terminal does not
+        // repopulate the live hook index until the agent re-announces, but its
+        // resume binding (kind + session id + cwd + env) was persisted at
+        // restore, so the chat view can still find the transcript. Only give up
+        // (the "No agent conversation" empty state) when neither source
+        // yields a transcript-backed agent session.
+        guard let inputs = indexInputs(index: index, workspaceId: workspaceId, panelId: panelId)
+            ?? resumeBindingInputs(resumeBinding) else {
             return nil
         }
-        let sessionId = snapshot.sessionId
-        guard !sessionId.isEmpty else { return nil }
-        let cwd = snapshot.workingDirectory
+        guard !inputs.sessionId.isEmpty else { return nil }
 
-        switch snapshot.kind {
+        switch inputs.kind {
         case .claude:
-            let configuredRoot = snapshot.launchCommand?.environment?["CLAUDE_CONFIG_DIR"]
             return Resolution(
                 agentKind: .claudeCode,
-                sessionId: sessionId,
+                sessionId: inputs.sessionId,
                 transcriptURL: claudeTranscriptURL(
-                    sessionId: sessionId,
-                    cwd: cwd,
-                    configuredRoot: configuredRoot
+                    sessionId: inputs.sessionId,
+                    cwd: inputs.cwd,
+                    configuredRoot: inputs.environment?["CLAUDE_CONFIG_DIR"]
                 )
             )
         case .codex:
-            let codexHome = snapshot.launchCommand?.environment?["CODEX_HOME"]
             return Resolution(
                 agentKind: .codex,
-                sessionId: sessionId,
-                transcriptURL: codexTranscriptURL(sessionId: sessionId, codexHome: codexHome)
+                sessionId: inputs.sessionId,
+                transcriptURL: codexTranscriptURL(
+                    sessionId: inputs.sessionId,
+                    codexHome: inputs.environment?["CODEX_HOME"]
+                )
             )
         default:
             // Other agents are not transcript-backed in the P1 parsers.
             return nil
+        }
+    }
+
+    /// The transcript-lookup inputs for a panel, from one of the two sources.
+    private struct ResolutionInputs {
+        let kind: RestorableAgentKind
+        let sessionId: String
+        let cwd: String?
+        let environment: [String: String]?
+    }
+
+    /// Inputs from the live restorable-session index, or `nil` when the index
+    /// has no entry for the panel.
+    private func indexInputs(
+        index: RestorableAgentSessionIndex,
+        workspaceId: UUID,
+        panelId: UUID
+    ) -> ResolutionInputs? {
+        guard let snapshot = index.snapshot(workspaceId: workspaceId, panelId: panelId) else {
+            return nil
+        }
+        return ResolutionInputs(
+            kind: snapshot.kind,
+            sessionId: snapshot.sessionId,
+            cwd: snapshot.workingDirectory,
+            environment: snapshot.launchCommand?.environment
+        )
+    }
+
+    /// Inputs reconstructed from a panel's persisted resume binding, used when
+    /// the live index misses (e.g. a terminal restored after an app relaunch).
+    /// The binding's `checkpointId` is the agent session id the resume path
+    /// uses; `kind` is the persisted agent-kind string.
+    private func resumeBindingInputs(_ binding: SurfaceResumeBindingSnapshot?) -> ResolutionInputs? {
+        guard let binding,
+              let sessionId = binding.checkpointId, !sessionId.isEmpty,
+              let kind = restorableKind(fromBindingKind: binding.kind) else {
+            return nil
+        }
+        return ResolutionInputs(
+            kind: kind,
+            sessionId: sessionId,
+            cwd: binding.cwd,
+            environment: binding.environment
+        )
+    }
+
+    /// Maps a resume binding's kind string to a `RestorableAgentKind`, limited
+    /// to the transcript-backed kinds the P1 parsers support.
+    private func restorableKind(fromBindingKind kind: String?) -> RestorableAgentKind? {
+        switch kind?.lowercased() {
+        case "claude": return .claude
+        case "codex": return .codex
+        default: return nil
         }
     }
 

--- a/Sources/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/AgentChat/AgentChatTranscriptResolver.swift
@@ -127,7 +127,8 @@ struct AgentChatTranscriptResolver {
     /// uses; `kind` is the persisted agent-kind string.
     private func resumeBindingInputs(_ binding: SurfaceResumeBindingSnapshot?) -> ResolutionInputs? {
         guard let binding,
-              let sessionId = binding.checkpointId, !sessionId.isEmpty,
+              let sessionId = binding.checkpointId,
+              isSafeSessionFilenameComponent(sessionId),
               let kind = restorableKind(fromBindingKind: binding.kind) else {
             return nil
         }
@@ -137,6 +138,20 @@ struct AgentChatTranscriptResolver {
             cwd: binding.cwd,
             environment: binding.environment
         )
+    }
+
+    /// Whether a session id from a persisted resume binding is safe to use as a
+    /// transcript filename component. The resume binding is a trust boundary
+    /// (it can be created through the public resume path and does not validate
+    /// the checkpoint id), and the session id is later appended to a project /
+    /// sessions directory, so a value containing a path separator or `..` could
+    /// escape into another reachable `.jsonl`. Mirrors the live index path's
+    /// Claude safe-filename invariant.
+    private func isSafeSessionFilenameComponent(_ sessionId: String) -> Bool {
+        !sessionId.isEmpty
+            && sessionId != "."
+            && sessionId != ".."
+            && sessionId.range(of: #"[\\/]"#, options: .regularExpression) == nil
     }
 
     /// Maps a resume binding's kind string to a `RestorableAgentKind`, limited

--- a/Sources/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/AgentChat/AgentChatTranscriptResolver.swift
@@ -194,8 +194,45 @@ struct AgentChatTranscriptResolver {
                     .appending(fileName)
                 if regularFileExists(path) { return URL(fileURLWithPath: path) }
             }
+
+            // Workflow/sub-agent case: the recorded session id is a *container*
+            // directory and the real transcript is a newer sibling `.jsonl`
+            // with a different id in the same project dir. Mirrors the live
+            // index path's `resolvedClaudeWorkflowRecord` so restored workflow
+            // panels resolve their transcript too.
+            for dir in projectDirs {
+                let projectDir = (projectsRoot as NSString).appendingPathComponent(dir)
+                let container = (projectDir as NSString).appendingPathComponent(sessionId)
+                var isDir: ObjCBool = false
+                guard fileManager.fileExists(atPath: container, isDirectory: &isDir), isDir.boolValue else {
+                    continue
+                }
+                if let sibling = newestSiblingTranscript(in: projectDir, excludingSessionId: sessionId) {
+                    return sibling
+                }
+            }
         }
         return nil
+    }
+
+    /// The newest `<id>.jsonl` transcript in `projectDir` whose id is not
+    /// `excludedSessionId`, by file modification time. Used for the Claude
+    /// workflow-container fallback.
+    private func newestSiblingTranscript(in projectDir: String, excludingSessionId excluded: String) -> URL? {
+        guard let children = try? fileManager.contentsOfDirectory(atPath: projectDir) else { return nil }
+        var best: (url: URL, modifiedAt: Date)?
+        for child in children where child.hasSuffix(".jsonl") {
+            let id = String(child.dropLast(".jsonl".count))
+            guard id != excluded, !id.isEmpty else { continue }
+            let path = (projectDir as NSString).appendingPathComponent(child)
+            guard regularFileExists(path) else { continue }
+            let modified = (try? fileManager.attributesOfItem(atPath: path)[.modificationDate] as? Date) ?? nil
+            let when = modified ?? .distantPast
+            if best == nil || when > best!.modifiedAt {
+                best = (URL(fileURLWithPath: path), when)
+            }
+        }
+        return best?.url
     }
 
     /// The ordered Claude config roots to search, mirroring the restore/resume

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
 		A6E710010000000000000002 /* AgentChatPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710010000000000000001 /* AgentChatPresenter.swift */; };
 		A6E710020000000000000002 /* AgentChatTranscriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710020000000000000001 /* AgentChatTranscriptResolver.swift */; };
+		A9E0200000000000000000C7 /* AgentChatTranscriptResolverResumeBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E0100000000000000000C7 /* AgentChatTranscriptResolverResumeBindingTests.swift */; };
 		A6E710030000000000000002 /* AgentChatWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E710030000000000000001 /* AgentChatWindowController.swift */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
 		A9F200000000000000000002 /* AgentExecutableResolverError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000002 /* AgentExecutableResolverError.swift */; };
@@ -780,6 +781,7 @@
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
 		A6E710010000000000000001 /* AgentChatPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatPresenter.swift; sourceTree = "<group>"; };
 		A6E710020000000000000001 /* AgentChatTranscriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatTranscriptResolver.swift; sourceTree = "<group>"; };
+		A9E0100000000000000000C7 /* AgentChatTranscriptResolverResumeBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatTranscriptResolverResumeBindingTests.swift; sourceTree = "<group>"; };
 		A6E710030000000000000001 /* AgentChatWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChat/AgentChatWindowController.swift; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
 		A9F100000000000000000002 /* AgentExecutableResolverError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolverError.swift; sourceTree = "<group>"; };
@@ -2088,6 +2090,7 @@
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
+				A9E0100000000000000000C7 /* AgentChatTranscriptResolverResumeBindingTests.swift */,
 				A9E030000000000000000001 /* AgentSessionSocketSurfaceTests.swift */,
 				A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */,
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
@@ -3140,6 +3143,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9E0200000000000000000C7 /* AgentChatTranscriptResolverResumeBindingTests.swift in Sources */,
 				A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */,
 				D36A00020000000000000001 /* AgentHibernationTests.swift in Sources */,
 				D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,

--- a/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
+++ b/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
@@ -91,6 +91,26 @@ import Testing
         )
     }
 
+    @Test func rejectsResumeBindingCheckpointWithPathSeparator() {
+        let resolver = AgentChatTranscriptResolver(homeDirectory: NSHomeDirectory())
+        for unsafe in ["../other/abc", "a/b", "..", "."] {
+            let binding = SurfaceResumeBindingSnapshot(
+                kind: "claude",
+                command: "claude --resume x",
+                cwd: "/Users/dev/proj",
+                checkpointId: unsafe
+            )
+            #expect(
+                resolver.resolve(
+                    index: .empty,
+                    workspaceId: UUID(),
+                    panelId: UUID(),
+                    resumeBinding: binding
+                ) == nil
+            )
+        }
+    }
+
     @Test func returnsNilForNonTranscriptResumeBindingKind() {
         let resolver = AgentChatTranscriptResolver(homeDirectory: NSHomeDirectory())
         let binding = SurfaceResumeBindingSnapshot(

--- a/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
+++ b/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import cmux
+
+/// Behavior coverage for ``AgentChatTranscriptResolver``'s resume-binding
+/// fallback: a session-restored terminal has no live index entry, but its
+/// persisted resume binding still locates the transcript.
+@Suite struct AgentChatTranscriptResolverResumeBindingTests {
+    private func makeTempHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-chatresolve-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func claudeFallsBackToResumeBindingWhenIndexEmpty() throws {
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let cwd = "/Users/dev/proj"
+        let sessionId = "11112222-3333-4444-5555-666677778888"
+        // Lay down the transcript where the resolver looks: <home>/.claude/projects/<encode(cwd)>/<id>.jsonl
+        let dirName = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd)
+        let projectDir = home
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+            .appendingPathComponent(dirName, isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let transcript = projectDir.appendingPathComponent("\(sessionId).jsonl")
+        try Data("{}\n".utf8).write(to: transcript)
+
+        let resolver = AgentChatTranscriptResolver(homeDirectory: home.path)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "claude --resume \(sessionId)",
+            cwd: cwd,
+            checkpointId: sessionId
+        )
+
+        let resolution = resolver.resolve(
+            index: .empty,
+            workspaceId: UUID(),
+            panelId: UUID(),
+            resumeBinding: binding
+        )
+
+        let result = try #require(resolution)
+        #expect(result.agentKind == .claudeCode)
+        #expect(result.sessionId == sessionId)
+        #expect(result.transcriptURL?.standardizedFileURL == transcript.standardizedFileURL)
+    }
+
+    @Test func codexFallsBackToResumeBindingWhenIndexEmpty() throws {
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let sessionId = "abcd1234-5678-90ab-cdef-1234567890ab"
+        let dayDir = home
+            .appendingPathComponent(".codex/sessions/2026/06/10", isDirectory: true)
+        try FileManager.default.createDirectory(at: dayDir, withIntermediateDirectories: true)
+        let transcript = dayDir.appendingPathComponent("rollout-2026-06-10T00-00-00-\(sessionId).jsonl")
+        try Data("{}\n".utf8).write(to: transcript)
+
+        let resolver = AgentChatTranscriptResolver(homeDirectory: home.path)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume \(sessionId)",
+            cwd: "/Users/dev/proj",
+            checkpointId: sessionId
+        )
+
+        let resolution = resolver.resolve(
+            index: .empty,
+            workspaceId: UUID(),
+            panelId: UUID(),
+            resumeBinding: binding
+        )
+
+        let result = try #require(resolution)
+        #expect(result.agentKind == .codex)
+        #expect(result.sessionId == sessionId)
+        #expect(result.transcriptURL?.standardizedFileURL == transcript.standardizedFileURL)
+    }
+
+    @Test func returnsNilWhenIndexAndResumeBindingAbsent() {
+        let resolver = AgentChatTranscriptResolver(homeDirectory: NSHomeDirectory())
+        #expect(
+            resolver.resolve(
+                index: .empty,
+                workspaceId: UUID(),
+                panelId: UUID(),
+                resumeBinding: nil
+            ) == nil
+        )
+    }
+
+    @Test func returnsNilForNonTranscriptResumeBindingKind() {
+        let resolver = AgentChatTranscriptResolver(homeDirectory: NSHomeDirectory())
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "amp",
+            command: "amp",
+            cwd: "/Users/dev/proj",
+            checkpointId: "sess-1"
+        )
+        #expect(
+            resolver.resolve(
+                index: .empty,
+                workspaceId: UUID(),
+                panelId: UUID(),
+                resumeBinding: binding
+            ) == nil
+        )
+    }
+}

--- a/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
+++ b/cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift
@@ -79,6 +79,48 @@ import Testing
         #expect(result.transcriptURL?.standardizedFileURL == transcript.standardizedFileURL)
     }
 
+    @Test func claudeResumeBindingResolvesWorkflowContainerToNewestSibling() throws {
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let cwd = "/Users/dev/proj"
+        // The resume binding's id is a workflow CONTAINER directory, not a transcript.
+        let containerId = "00000000-0000-0000-0000-000000000000"
+        let dirName = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd)
+        let projectDir = home
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+            .appendingPathComponent(dirName, isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        // The container subdirectory named after the recorded id.
+        try FileManager.default.createDirectory(
+            at: projectDir.appendingPathComponent(containerId, isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        // Two sibling transcripts; the newer one should win.
+        let older = projectDir.appendingPathComponent("aaaaaaaa-1111.jsonl")
+        let newer = projectDir.appendingPathComponent("bbbbbbbb-2222.jsonl")
+        try Data("{}\n".utf8).write(to: older)
+        try Data("{}\n".utf8).write(to: newer)
+        let now = Date()
+        try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-60)], ofItemAtPath: older.path)
+        try FileManager.default.setAttributes([.modificationDate: now], ofItemAtPath: newer.path)
+
+        let resolver = AgentChatTranscriptResolver(homeDirectory: home.path)
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "claude --resume \(containerId)",
+            cwd: cwd,
+            checkpointId: containerId
+        )
+        let resolution = resolver.resolve(
+            index: .empty,
+            workspaceId: UUID(),
+            panelId: UUID(),
+            resumeBinding: binding
+        )
+        let result = try #require(resolution)
+        #expect(result.transcriptURL?.standardizedFileURL == newer.standardizedFileURL)
+    }
+
     @Test func returnsNilWhenIndexAndResumeBindingAbsent() {
         let resolver = AgentChatTranscriptResolver(homeDirectory: NSHomeDirectory())
         #expect(


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/5576. Fixes the dogfood blocker (Lawrence): opening the agent chat view on a **session-restored terminal** showed "No agent conversation" even though it had a real agent session.

## Root cause
`AgentChatTranscriptResolver` resolved a panel's transcript only through the live `RestorableAgentSessionIndex`, which is not repopulated for a terminal restored after an app relaunch (the agent hasn't re-announced via the hook yet). So `index.snapshot(...)` returned nil → empty state.

## Fix
The resolver now reconstructs the `(kind, sessionId, cwd, env)` lookup tuple from the panel's persisted `SurfaceResumeBindingSnapshot` (the same binding cmux uses to resume the agent; `checkpointId` is the agent session id) when the live index misses. It only returns the empty state when **neither** source yields a transcript-backed session. The presenter captures `workspace.surfaceResumeBinding(panelId:)` on the main actor and passes it through. Existing index path is unchanged (preferred when present).

## Tests
Swift Testing in `cmuxTests/AgentChatTranscriptResolverResumeBindingTests.swift` (wired into the test target): Claude and Codex fallback locate the transcript with an empty index + a resume binding (temp-home fixtures); absent binding and a non-transcript kind both return nil.

## Verification
Build-only compile (tagged DerivedData): BUILD SUCCEEDED. pbxproj normalized + checked + test-wiring lint ok. Folds into the `gui` dogfood tag for Lawrence to confirm on a restored terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783682087&installation_id=133855650&pr_number=5791&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5791&signature=b97698cfa3857fc4145d25e0571b2907800889dec94e2bb1514edd2b5e3ca855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem transcript resolution from persisted bindings (path traversal guards added) and changes when chat opens vs shows empty state; scope is localized to Agent Chat resolution.
> 
> **Overview**
> Fixes **“No agent conversation”** on session-restored terminals by letting agent chat resolution use the panel’s **persisted resume binding** when the live `RestorableAgentSessionIndex` has no entry yet (typical after relaunch before the agent re-announces).
> 
> `AgentChatPresenter` now reads `workspace.surfaceResumeBinding(panelId:)` on the main actor and passes it into `AgentChatTranscriptResolver.resolve`. The resolver still **prefers the live index**; otherwise it rebuilds kind, session id, cwd, and env from `SurfaceResumeBindingSnapshot` (`checkpointId` as session id), with **filename safety checks** on binding ids and **Claude/Codex-only** kinds.
> 
> Claude lookup also gains the **workflow-container** path: when the session id is a container directory, it picks the **newest sibling `.jsonl`** in the project dir, matching the live index behavior. New `cmuxTests/AgentChatTranscriptResolverResumeBindingTests` cover fallback, workflow siblings, unsafe ids, and unsupported kinds; CI also adds **`CmuxAgentConversation`** to the headless SwiftPM test list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc82bb638be805ad52bf5a293229a1d20109ba3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat view showing “No agent conversation” on session-restored terminals by falling back to the panel’s persisted resume binding when the live index is empty, with session-id validation and a Claude workflow-container fallback. Restored terminals now load the correct Claude/Codex transcript after relaunch.

- **Bug Fixes**
  - Prefer the live `RestorableAgentSessionIndex`; if missing, rebuild `(kind, sessionId, cwd, env)` from `SurfaceResumeBindingSnapshot` and only show the empty state if both miss.
  - For Claude workflow/sub-agent bindings that point at a container directory, resolve to the newest sibling `.jsonl` in the same project.
  - Validate resume-binding session ids as safe filename components and restrict kinds to Claude/Codex; `AgentChatPresenter` passes `workspace.surfaceResumeBinding(panelId:)` to the resolver; tests cover fallback, unsafe ids, unsupported kinds, and the workflow case.

- **CI**
  - Gate `CmuxAgentConversation` Swift package tests to catch Claude/Codex transcript parser regressions.

<sup>Written for commit dc82bb638be805ad52bf5a293229a1d20109ba3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

