### PR TITLE
Mac pairing window: drop Download via TestFlight wording

### DIFF
--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -16,7 +16,7 @@ struct MobilePairingView: View {
     private let browserSignIn: HostBrowserSignInFlow? = AppDelegate.shared?.auth?.browserSignIn
 
     private static let tailscaleDownloadURL = URL(string: "https://tailscale.com/download")!
-    private static let testFlightURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
+    private static let iosBetaURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
 
     var body: some View {
         ScrollView {
@@ -269,12 +269,12 @@ struct MobilePairingView: View {
             step(1, String(localized: "mobile.pairing.step.install", defaultValue: "Install cmux on your iPhone and open it."))
             HStack(spacing: 4) {
                 Spacer(minLength: 30)
-                Text(String(localized: "mobile.pairing.testflight.prompt", defaultValue: "Don't have it yet?"))
+                Text(String(localized: "mobile.pairing.getapp.prompt", defaultValue: "Don't have it yet?"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Link(
-                    String(localized: "mobile.pairing.testflight.link", defaultValue: "Download via TestFlight"),
-                    destination: Self.testFlightURL
+                    String(localized: "mobile.pairing.getapp.link", defaultValue: "Get the cmux iOS beta"),
+                    destination: Self.iosBetaURL
                 )
                 .font(.caption)
                 Spacer(minLength: 0)


### PR DESCRIPTION
Companion to https://github.com/manaflow-ai/cmux/pull/5593, which removes the TestFlight wording from the iOS screens. This covers the last user-facing TestFlight download CTA: the macOS Mobile Connect pairing window step list.

Wording-only. The link already pointed at the GitHub Founders Edition anchor, so only the label changes: "Download via TestFlight" becomes "Get the cmux iOS beta". Keys renamed `mobile.pairing.testflight.*` to `mobile.pairing.getapp.*` with English and Japanese values updated.

Localization audit: both changed keys have en and ja entries in `Resources/Localizable.xcstrings`; no new bare string literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783683423&installation_id=133855650&pr_number=5793&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5793&signature=0a2c8a3375217f237a102d44319e095d5ced85004eec4fab471a065e15f42a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and localization key renames only; no URL, pairing logic, or auth changes.
> 
> **Overview**
> Removes **TestFlight** branding from the macOS **Pair your iPhone** pairing flow so the install step matches the iOS copy refresh in the companion PR.
> 
> In `MobilePairingView`, the optional download link under step 1 now uses localization keys `mobile.pairing.getapp.*` instead of `mobile.pairing.testflight.*`, with English/Japanese strings updated to **"Get the cmux iOS beta"** (and the existing **"Don't have it yet?"** prompt). The destination URL is unchanged (Founders Edition anchor on GitHub); only the constant is renamed from `testFlightURL` to `iosBetaURL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d75b550c6d6156aaf810399e89776b08d1d32280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces “Download via TestFlight” with “Get the cmux iOS beta” in the macOS Mobile Connect pairing window to align copy with iOS. Link target remains the GitHub Founders Edition anchor; only wording and localization keys change.

- **Refactors**
  - Renamed keys `mobile.pairing.testflight.*` to `mobile.pairing.getapp.*` and updated en/ja values.
  - Updated string references in the pairing view; renamed URL constant (`testFlightURL` → `iosBetaURL`) without changing the URL.
  - Verified localization coverage (en, ja); no new string literals added.

<sup>Written for commit d75b550c6d6156aaf810399e89776b08d1d32280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS beta access mechanism with new download link and localized instructions for the mobile pairing onboarding flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->