### PR TITLE
macOS pairing window: replace "Download via TestFlight" with "Get cmux for iPhone"

### DIFF
--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -16,7 +16,8 @@ struct MobilePairingView: View {
     private let browserSignIn: HostBrowserSignInFlow? = AppDelegate.shared?.auth?.browserSignIn
 
     private static let tailscaleDownloadURL = URL(string: "https://tailscale.com/download")!
-    private static let testFlightURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
+    /// Where a Mac user goes to get cmux for iPhone while the beta is invite-only.
+    private static let iphoneAppURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
 
     var body: some View {
         ScrollView {
@@ -269,12 +270,12 @@ struct MobilePairingView: View {
             step(1, String(localized: "mobile.pairing.step.install", defaultValue: "Install cmux on your iPhone and open it."))
             HStack(spacing: 4) {
                 Spacer(minLength: 30)
-                Text(String(localized: "mobile.pairing.testflight.prompt", defaultValue: "Don't have it yet?"))
+                Text(String(localized: "mobile.pairing.getApp.prompt", defaultValue: "Don't have it yet?"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Link(
-                    String(localized: "mobile.pairing.testflight.link", defaultValue: "Download via TestFlight"),
-                    destination: Self.testFlightURL
+                    String(localized: "mobile.pairing.getApp.link", defaultValue: "Get cmux for iPhone"),
+                    destination: Self.iphoneAppURL
                 )
                 .font(.caption)
                 Spacer(minLength: 0)


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/5593 (which removed TestFlight wording from the iOS screens). The macOS Mobile Connect pairing window still showed "Don't have it yet? Download via TestFlight" under step 1.

Wording-only change. The link still points at the Founders Edition page; the label is now "Get cmux for iPhone" (ja: "iPhone 版 cmux を入手"). String keys renamed `mobile.pairing.testflight.*` to `mobile.pairing.getApp.*` so the key names match the wording; both en and ja localizations updated. With this, no user-facing surface (macOS, iOS, web) mentions TestFlight; the only remaining hit is the historical changelog media caption describing how the beta shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783690822&installation_id=133855650&pr_number=5795&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5795&signature=cb3e5f4b96d47cd633d9b494253f511ad74eb7d8d222a1d785ac21de98a602e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and localization key rename only; no pairing logic or URL changes beyond naming.
> 
> **Overview**
> Updates the macOS **Pair your iPhone** flow so step 1 no longer says **Download via TestFlight**. The helper link under “Install cmux on your iPhone” now reads **Get cmux for iPhone** (Japanese: **iPhone 版 cmux を入手**); the URL is unchanged (Founders Edition on GitHub).
> 
> Localization keys are renamed from `mobile.pairing.testflight.*` to `mobile.pairing.getApp.*`, and `MobilePairingView` uses `iphoneAppURL` instead of `testFlightURL` for the same destination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8779282b1d4444fb125345676ba35806dee490cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace "Download via TestFlight" with "Get cmux for iPhone" in the macOS Mobile Connect pairing window. Renames strings to `mobile.pairing.getApp.*` with EN/JA updates and keeps the Founders Edition link, removing the last TestFlight reference from the UI.

<sup>Written for commit 8779282b1d4444fb125345676ba35806dee490cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated mobile app pairing instructions with new localized messaging.
  * Modified iPhone app access link to direct users to the new distribution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->