### PR TITLE
Retain Settings window for reliable reopen

### DIFF
--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -1,52 +1,83 @@
 import AppKit
 
 @MainActor
-enum SettingsWindowPresenter {
+struct SettingsWindowPresenter {
     static let windowID = "settings"
     static let windowIdentifier = "cmux.settings"
     static let minimumSize = NSSize(width: 820, height: 540)
     private static let visibleAreaInset: CGFloat = 18
+    private static let sharedPresenter = SettingsWindowPresenter()
 
-    private static var openWindow: (@MainActor () -> Void)?
-    private static var parentWindowProvider: (@MainActor () -> NSWindow?)?
-    private static weak var settingsWindow: NSWindow?
-    private static var pendingNavigationTarget: SettingsNavigationTarget?
-    private static var pendingContentNavigationTarget: SettingsNavigationTarget?
-    private static var shouldOpenWhenConfigured = false
-#if DEBUG
-    private static var focusHandlerForTests: (@MainActor (NSWindow) -> Void)?
-#endif
+    private final class State {
+        var openWindow: (@MainActor () -> Void)?
+        var parentWindowProvider: (@MainActor () -> NSWindow?)?
+        var settingsWindow: NSWindow?
+        var pendingNavigationTarget: SettingsNavigationTarget?
+        var pendingContentNavigationTarget: SettingsNavigationTarget?
+        var shouldOpenWhenConfigured = false
+    }
+
+    private let state: State
+
+    init() {
+        state = State()
+    }
 
     static func configure(
         openWindow: @escaping @MainActor () -> Void,
         parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }
     ) {
-        self.openWindow = openWindow
-        self.parentWindowProvider = parentWindowProvider
-        if shouldOpenWhenConfigured {
-            shouldOpenWhenConfigured = false
+        sharedPresenter.configure(
+            openWindow: openWindow,
+            parentWindowProvider: parentWindowProvider
+        )
+    }
+
+    func configure(
+        openWindow: @escaping @MainActor () -> Void,
+        parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }
+    ) {
+        state.openWindow = openWindow
+        state.parentWindowProvider = parentWindowProvider
+        if state.shouldOpenWhenConfigured {
+            state.shouldOpenWhenConfigured = false
             openWindow()
         }
     }
 
     static func configure(window: NSWindow) {
-        let shouldFocusAfterConfiguration = settingsWindow !== window
-        settingsWindow = window
-        window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
+        sharedPresenter.configure(window: window)
+    }
+
+    func configure(window: NSWindow) {
+        let shouldFocusAfterConfiguration = state.settingsWindow !== window
+        state.settingsWindow = window
+        window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
+        window.isReleasedWhenClosed = false
         window.isRestorable = false
-        window.minSize = minimumSize
-        window.contentMinSize = minimumSize
+        window.minSize = Self.minimumSize
+        window.contentMinSize = Self.minimumSize
         window.adoptCmuxPeerWindowLevel()
         clampToVisibleAreaIfNeeded(window)
         if shouldFocusAfterConfiguration {
             Task { @MainActor in
-                guard settingsWindow === window else { return }
+                guard state.settingsWindow === window else { return }
                 focus(window)
             }
         }
     }
 
     static func show(
+        navigationTarget: SettingsNavigationTarget? = nil,
+        openWindowOverride: (@MainActor () -> Void)? = nil
+    ) {
+        sharedPresenter.show(
+            navigationTarget: navigationTarget,
+            openWindowOverride: openWindowOverride
+        )
+    }
+
+    func show(
         navigationTarget: SettingsNavigationTarget? = nil,
         openWindowOverride: (@MainActor () -> Void)? = nil
     ) {
@@ -60,14 +91,14 @@ enum SettingsWindowPresenter {
             payload["used_open_window_override"] = openWindowOverride != nil
         }
 #endif
-        pendingNavigationTarget = navigationTarget
-        pendingContentNavigationTarget = navigationTarget
+        state.pendingNavigationTarget = navigationTarget
+        state.pendingContentNavigationTarget = navigationTarget
 
         if let window = existingWindow() {
             let shouldDeferNavigation = window.isMiniaturized
             if !shouldDeferNavigation {
-                pendingNavigationTarget = nil
-                pendingContentNavigationTarget = nil
+                state.pendingNavigationTarget = nil
+                state.pendingContentNavigationTarget = nil
             }
             focus(window)
             if let navigationTarget, !shouldDeferNavigation {
@@ -81,47 +112,43 @@ enum SettingsWindowPresenter {
             return
         }
 
-        guard let openWindow else {
-            shouldOpenWhenConfigured = true
+        guard let openWindow = state.openWindow else {
+            state.shouldOpenWhenConfigured = true
             return
         }
         openWindow()
     }
 
     static func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
-        let target = pendingNavigationTarget
-        pendingNavigationTarget = nil
+        sharedPresenter.consumePendingNavigationTarget()
+    }
+
+    func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
+        let target = state.pendingNavigationTarget
+        state.pendingNavigationTarget = nil
         return target
     }
 
     static func consumePendingContentNavigationTarget() -> SettingsNavigationTarget? {
-        let target = pendingContentNavigationTarget
-        pendingContentNavigationTarget = nil
+        sharedPresenter.consumePendingContentNavigationTarget()
+    }
+
+    func consumePendingContentNavigationTarget() -> SettingsNavigationTarget? {
+        let target = state.pendingContentNavigationTarget
+        state.pendingContentNavigationTarget = nil
         return target
     }
 
     static func refocusIfVisible() {
+        sharedPresenter.refocusIfVisible()
+    }
+
+    func refocusIfVisible() {
         guard let window = existingWindow() else { return }
         focus(window)
     }
 
-#if DEBUG
-    static func resetForTests() {
-        openWindow = nil
-        parentWindowProvider = nil
-        settingsWindow = nil
-        pendingNavigationTarget = nil
-        pendingContentNavigationTarget = nil
-        shouldOpenWhenConfigured = false
-        focusHandlerForTests = nil
-    }
-
-    static func setFocusHandlerForTests(_ handler: @escaping @MainActor (NSWindow) -> Void) {
-        focusHandlerForTests = handler
-    }
-#endif
-
-    private static func existingWindow() -> NSWindow? {
+    private func existingWindow() -> NSWindow? {
         // Return the settings window whenever it still exists, even if it
         // is currently ordered out (closed). SwiftUI's single `Window`
         // scene does not destroy the window on close — it just hides it
@@ -130,25 +157,19 @@ enum SettingsWindowPresenter {
         // made every reopen-after-close fall through to a dead `openWindow`
         // call and the window never came back. Reusing the hidden window
         // lets `show()` re-front it via `makeKeyAndOrderFront`.
-        if let settingsWindow {
+        if let settingsWindow = state.settingsWindow {
             return settingsWindow
         }
         return NSApp.windows.first {
-            $0.identifier?.rawValue == windowIdentifier
+            $0.identifier?.rawValue == Self.windowIdentifier
         }
     }
 
-    private static func focus(_ window: NSWindow) {
-#if DEBUG
-        if let focusHandlerForTests {
-            focusHandlerForTests(window)
-            return
-        }
-#endif
+    private func focus(_ window: NSWindow) {
         performFocus(window)
     }
 
-    private static func performFocus(_ window: NSWindow) {
+    private func performFocus(_ window: NSWindow) {
         if window.isMiniaturized {
             window.deminiaturize(nil)
         }
@@ -163,7 +184,7 @@ enum SettingsWindowPresenter {
         // https://github.com/manaflow-ai/cmux/issues/5081). One-time front
         // ordering gives the same initial layering while leaving normal
         // click-to-raise window ordering fully intact afterwards.
-        if let parentWindow = parentWindowProvider?(), parentWindow !== window {
+        if let parentWindow = state.parentWindowProvider?(), parentWindow !== window {
             if parentWindow.isMiniaturized {
                 parentWindow.deminiaturize(nil)
             }
@@ -174,7 +195,7 @@ enum SettingsWindowPresenter {
         window.orderFrontRegardless()
     }
 
-    private static func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
+    private func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
         guard let screen = window.screen ?? NSScreen.main else { return }
         var frame = window.frame
         let originalFrame = frame
@@ -184,15 +205,15 @@ enum SettingsWindowPresenter {
             height: max(window.minSize.height, window.contentMinSize.height)
         )
         let maxVisibleSize = NSSize(
-            width: max(minimumFrameSize.width, visibleFrame.width - 2 * visibleAreaInset),
-            height: max(minimumFrameSize.height, visibleFrame.height - 2 * visibleAreaInset)
+            width: max(minimumFrameSize.width, visibleFrame.width - 2 * Self.visibleAreaInset),
+            height: max(minimumFrameSize.height, visibleFrame.height - 2 * Self.visibleAreaInset)
         )
         frame.size.width = min(frame.size.width, maxVisibleSize.width)
         frame.size.height = min(frame.size.height, maxVisibleSize.height)
-        let minX = visibleFrame.minX + visibleAreaInset
-        let minY = visibleFrame.minY + visibleAreaInset
-        let maxX = max(minX, visibleFrame.maxX - visibleAreaInset - frame.width)
-        let maxY = max(minY, visibleFrame.maxY - visibleAreaInset - frame.height)
+        let minX = visibleFrame.minX + Self.visibleAreaInset
+        let minY = visibleFrame.minY + Self.visibleAreaInset
+        let maxX = max(minX, visibleFrame.maxX - Self.visibleAreaInset - frame.width)
+        let maxY = max(minY, visibleFrame.maxY - Self.visibleAreaInset - frame.height)
         frame.origin = NSPoint(
             x: min(max(frame.origin.x, minX), maxX),
             y: min(max(frame.origin.y, minY), maxY)

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -16,7 +16,7 @@ final class SettingsWindowPresenterTests: XCTestCase {
     }
 
     func testConfigureWindowLeavesPendingNavigationForSettingsViews() {
-        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        let settingsWindow = makeWindow(identifier: "cmux.unconfiguredSettings.\(UUID().uuidString)")
         var didOpen = false
         defer {
             settingsWindow.orderOut(nil)
@@ -77,6 +77,34 @@ final class SettingsWindowPresenterTests: XCTestCase {
         XCTAssertFalse(didOpen)
         XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
         XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
+    }
+
+    func testPresenterRetainsConfiguredSettingsWindowForReopen() async {
+        var settingsWindow: NSWindow? = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        weak var weakSettingsWindow = settingsWindow
+        var didOpen = false
+        var focusedWindows: [NSWindow] = []
+
+        SettingsWindowPresenter.setFocusHandlerForTests { window in
+            focusedWindows.append(window)
+        }
+
+        SettingsWindowPresenter.configure(window: settingsWindow!)
+        await Task.yield()
+        settingsWindow?.orderOut(nil)
+        settingsWindow = nil
+        await Task.yield()
+
+        XCTAssertNotNil(weakSettingsWindow)
+
+        SettingsWindowPresenter.show(
+            openWindowOverride: { didOpen = true }
+        )
+
+        XCTAssertFalse(didOpen)
+        XCTAssertEqual(focusedWindows.count, 2)
+        XCTAssertTrue(focusedWindows.last === weakSettingsWindow)
+        weakSettingsWindow?.orderOut(nil)
     }
 
     // Settings is a top-level *peer* window, not a child of the main window.

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -10,86 +10,87 @@ import XCTest
 #if DEBUG
 @MainActor
 final class SettingsWindowPresenterTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        closeSettingsWindows()
+    }
+
     override func tearDown() {
-        SettingsWindowPresenter.resetForTests()
+        closeSettingsWindows()
         super.tearDown()
     }
 
     func testConfigureWindowLeavesPendingNavigationForSettingsViews() {
+        let presenter = SettingsWindowPresenter()
         let settingsWindow = makeWindow(identifier: "cmux.unconfiguredSettings.\(UUID().uuidString)")
         var didOpen = false
         defer {
             settingsWindow.orderOut(nil)
+            settingsWindow.close()
         }
 
-        SettingsWindowPresenter.show(
+        presenter.show(
             navigationTarget: .browserImport,
             openWindowOverride: { didOpen = true }
         )
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
 
         XCTAssertTrue(didOpen)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
-        XCTAssertNil(SettingsWindowPresenter.consumePendingNavigationTarget())
-        XCTAssertNil(SettingsWindowPresenter.consumePendingContentNavigationTarget())
+        XCTAssertEqual(presenter.consumePendingNavigationTarget(), .browserImport)
+        XCTAssertEqual(presenter.consumePendingContentNavigationTarget(), .browserImport)
+        XCTAssertNil(presenter.consumePendingNavigationTarget())
+        XCTAssertNil(presenter.consumePendingContentNavigationTarget())
     }
 
     func testRepeatedConfigureForSameSettingsWindowDoesNotRefocus() async {
+        let presenter = SettingsWindowPresenter()
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-        var focusedWindows: [NSWindow] = []
         defer {
             settingsWindow.orderOut(nil)
+            settingsWindow.close()
         }
 
-        SettingsWindowPresenter.setFocusHandlerForTests { window in
-            focusedWindows.append(window)
-        }
-
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
         await Task.yield()
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
         await Task.yield()
 
-        XCTAssertEqual(focusedWindows.count, 1)
-        XCTAssertTrue(focusedWindows.first === settingsWindow)
+        XCTAssertEqual(settingsWindow.makeKeyAndOrderFrontCallCount, 1)
     }
 
     func testShowPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async {
+        let presenter = SettingsWindowPresenter()
         let settingsWindow = makeWindow(
             identifier: SettingsWindowPresenter.windowIdentifier,
-            isMiniaturizedForTests: true
+            forcedMiniaturized: true
         )
         var didOpen = false
         defer {
             settingsWindow.orderOut(nil)
+            settingsWindow.close()
         }
 
-        SettingsWindowPresenter.setFocusHandlerForTests { _ in }
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
         await Task.yield()
 
-        SettingsWindowPresenter.show(
+        presenter.show(
             navigationTarget: .browserImport,
             openWindowOverride: { didOpen = true }
         )
 
         XCTAssertFalse(didOpen)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingNavigationTarget(), .browserImport)
-        XCTAssertEqual(SettingsWindowPresenter.consumePendingContentNavigationTarget(), .browserImport)
+        XCTAssertEqual(presenter.consumePendingNavigationTarget(), .browserImport)
+        XCTAssertEqual(presenter.consumePendingContentNavigationTarget(), .browserImport)
     }
 
     func testPresenterRetainsConfiguredSettingsWindowForReopen() async {
-        var settingsWindow: NSWindow? = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        let presenter = SettingsWindowPresenter()
+        let testWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        var settingsWindow: TestSettingsWindow? = testWindow
         weak var weakSettingsWindow = settingsWindow
         var didOpen = false
-        var focusedWindows: [NSWindow] = []
 
-        SettingsWindowPresenter.setFocusHandlerForTests { window in
-            focusedWindows.append(window)
-        }
-
-        SettingsWindowPresenter.configure(window: settingsWindow!)
+        presenter.configure(window: settingsWindow!)
         await Task.yield()
         settingsWindow?.orderOut(nil)
         settingsWindow = nil
@@ -97,14 +98,15 @@ final class SettingsWindowPresenterTests: XCTestCase {
 
         XCTAssertNotNil(weakSettingsWindow)
 
-        SettingsWindowPresenter.show(
+        presenter.show(
             openWindowOverride: { didOpen = true }
         )
 
         XCTAssertFalse(didOpen)
-        XCTAssertEqual(focusedWindows.count, 2)
-        XCTAssertTrue(focusedWindows.last === weakSettingsWindow)
+        XCTAssertEqual(testWindow.makeKeyAndOrderFrontCallCount, 2)
+        XCTAssertTrue(testWindow === weakSettingsWindow)
         weakSettingsWindow?.orderOut(nil)
+        weakSettingsWindow?.close()
     }
 
     // Settings is a top-level *peer* window, not a child of the main window.
@@ -114,18 +116,21 @@ final class SettingsWindowPresenterTests: XCTestCase {
     // These tests pin the peer invariant: configuring/focusing Settings must
     // never create a parent-child relationship and must leave it at `.normal`.
     func testDoesNotAttachSettingsAsChildOfPreferredMainWindow() {
+        let presenter = SettingsWindowPresenter()
         let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
             settingsWindow.orderOut(nil)
             parentWindow.orderOut(nil)
+            settingsWindow.close()
+            parentWindow.close()
         }
 
-        SettingsWindowPresenter.configure(
+        presenter.configure(
             openWindow: {},
             parentWindowProvider: { parentWindow }
         )
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
 
         XCTAssertNil(settingsWindow.parent)
         XCTAssertFalse(parentWindow.childWindows?.contains(where: { $0 === settingsWindow }) == true)
@@ -133,6 +138,7 @@ final class SettingsWindowPresenterTests: XCTestCase {
     }
 
     func testFocusingSettingsKeepsItAsPeerWhenPreferredMainWindowChanges() {
+        let presenter = SettingsWindowPresenter()
         let firstParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let secondParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
@@ -141,19 +147,22 @@ final class SettingsWindowPresenterTests: XCTestCase {
             settingsWindow.orderOut(nil)
             firstParent.orderOut(nil)
             secondParent.orderOut(nil)
+            settingsWindow.close()
+            firstParent.close()
+            secondParent.close()
         }
 
-        SettingsWindowPresenter.configure(
+        presenter.configure(
             openWindow: {},
             parentWindowProvider: { preferredParent }
         )
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
         XCTAssertNil(settingsWindow.parent)
 
         preferredParent = secondParent
         settingsWindow.orderFront(nil)
         // refocusIfVisible() runs the real performFocus ordering path.
-        SettingsWindowPresenter.refocusIfVisible()
+        presenter.refocusIfVisible()
 
         XCTAssertNil(settingsWindow.parent)
         XCTAssertFalse(firstParent.childWindows?.contains(where: { $0 === settingsWindow }) == true)
@@ -162,18 +171,21 @@ final class SettingsWindowPresenterTests: XCTestCase {
     }
 
     func testSettingsSurvivesPreferredMainWindowCloseAsIndependentPeer() {
+        let presenter = SettingsWindowPresenter()
         let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
         let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
         defer {
             settingsWindow.orderOut(nil)
             parentWindow.orderOut(nil)
+            settingsWindow.close()
+            parentWindow.close()
         }
 
-        SettingsWindowPresenter.configure(
+        presenter.configure(
             openWindow: {},
             parentWindowProvider: { parentWindow }
         )
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
         settingsWindow.orderFront(nil)
         XCTAssertNil(settingsWindow.parent)
 
@@ -187,7 +199,10 @@ final class SettingsWindowPresenterTests: XCTestCase {
 
     func testAdoptCmuxPeerWindowLevelBringsFloatingWindowToNormal() {
         let window = makeWindow(identifier: "cmux.peer.\(UUID().uuidString)")
-        defer { window.orderOut(nil) }
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
 
         window.level = .floating
         XCTAssertEqual(window.level, .floating)
@@ -198,6 +213,7 @@ final class SettingsWindowPresenterTests: XCTestCase {
     }
 
     func testConfigureClampsOversizedSettingsFrameToVisibleArea() throws {
+        let presenter = SettingsWindowPresenter()
         guard let screen = NSScreen.main else {
             throw XCTSkip("No screen available for Settings frame clamping")
         }
@@ -214,9 +230,10 @@ final class SettingsWindowPresenterTests: XCTestCase {
         )
         defer {
             settingsWindow.orderOut(nil)
+            settingsWindow.close()
         }
 
-        SettingsWindowPresenter.configure(window: settingsWindow)
+        presenter.configure(window: settingsWindow)
 
         let inset: CGFloat = 18
         let availableWidth = max(
@@ -242,25 +259,39 @@ final class SettingsWindowPresenterTests: XCTestCase {
 
     private func makeWindow(
         identifier: String,
-        isMiniaturizedForTests: Bool? = nil
-    ) -> NSWindow {
+        forcedMiniaturized: Bool? = nil
+    ) -> TestSettingsWindow {
         let window = TestSettingsWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 220),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.isMiniaturizedForTests = isMiniaturizedForTests
+        window.forcedMiniaturized = forcedMiniaturized
         window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier(identifier)
         return window
     }
 
+    private func closeSettingsWindows() {
+        for window in NSApp.windows where window.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier {
+            window.orderOut(nil)
+            window.identifier = nil
+            window.close()
+        }
+    }
+
     private final class TestSettingsWindow: NSWindow {
-        var isMiniaturizedForTests: Bool?
+        var forcedMiniaturized: Bool?
+        var makeKeyAndOrderFrontCallCount = 0
 
         override var isMiniaturized: Bool {
-            isMiniaturizedForTests ?? super.isMiniaturized
+            forcedMiniaturized ?? super.isMiniaturized
+        }
+
+        override func makeKeyAndOrderFront(_ sender: Any?) {
+            makeKeyAndOrderFrontCallCount += 1
+            super.makeKeyAndOrderFront(sender)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add regression coverage for reopening the Settings window after its local strong reference is dropped.
- Retain the configured Settings NSWindow and disable release-on-close so Command+, and the app menu can reliably re-front the hidden SwiftUI window.
- Clean up retained Settings windows in DEBUG test reset.

## Root Cause
SettingsWindowPresenter kept the configured Settings window weakly. After closing Settings, reopen behavior depended on incidental SwiftUI/AppKit retention. When the weak reference went nil, show() fell through to openWindow(id:), which can no-op for the existing single SwiftUI Window scene and leave no visible Settings window.

## Validation
- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/abdulazizalbahar/Library/Developer/Xcode/DerivedData/cmux-issue-5245-settings-window-open -only-testing:cmuxTests/SettingsWindowPresenterTests
- ./scripts/reload.sh --tag issue-5245-settings-window-open --launch
- Computer Use: Command+, opens Settings; Command+W then Command+, reopens Settings; app menu Settings… opens Settings.

## Localization
No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698718&installation_id=133855650&pr_number=5801&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5801&signature=f9e2250489966af404431a0e93b2945ab4291dbfc705a16c09fc98fb9a27b159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Settings window reliably reopen via Command+, and the app menu, by retaining and re-fronting the existing SwiftUI window. Also reduces backdrop flicker by only applying the latest plan. Addresses issue 5245.

- **Bug Fixes**
  - Retain the configured Settings `NSWindow` and set `isReleasedWhenClosed = false` so reopen re-fronts the existing window instead of falling through to a dead `openWindow`.
  - Added a regression test that drops the last strong reference, hides the window, and verifies reopen reuses it without calling `openWindow`.
  - Tests now close and clear retained Settings windows in setUp/tearDown.

- **Refactors**
  - Converted `SettingsWindowPresenter` from a static enum to an instance-backed struct with internal state and a shared singleton; static APIs forward to it.
  - Introduced `WindowBackdropApplyScheduler` to coalesce backdrop applies by mutation ID; switched `ContentView` and `GhosttyTerminalView` to it and moved overlay/titlebar updates into apply completion.

<sup>Written for commit f92cc7fc7e9c5cdff0fd19510744d3af384253c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

