### PR TITLE
RFC: keep folder/title fixed when toggling the sidebar in fullscreen

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,7 +4,7 @@
 32562	CLI/cmux.swift
 21996	Sources/TerminalController.swift
 19820	Sources/Workspace.swift
-19209	Sources/ContentView.swift
+19189	Sources/ContentView.swift
 17920	Sources/AppDelegate.swift
 16470	Sources/GhosttyTerminalView.swift
 13589	Sources/Panels/BrowserPanel.swift
@@ -24,7 +24,7 @@
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift
-4031	cmuxTests/WindowAndDragTests.swift
+4005	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -24,7 +24,7 @@
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift
-4009	cmuxTests/WindowAndDragTests.swift
+4031	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2067,17 +2067,16 @@ struct ContentView: View {
         return -max(0, min(titlebarPadding, hostingSafeAreaTop))
     }
 
+    // Fullscreen intentionally has no special case: the title keeps the same
+    // sidebar-edge inset whether or not the window is fullscreen, so toggling the
+    // sidebar at the minimum width never moves the folder/title in either mode.
+    // The fullscreen controls overlay ends well left of the minimum inset.
     nonisolated static func customTitlebarLeadingPadding(
-        isFullScreen: Bool,
         isSidebarVisible: Bool,
         sidebarWidth: CGFloat,
         minimumSidebarWidth: CGFloat,
         titlebarLeadingInset: CGFloat
     ) -> CGFloat {
-        if isFullScreen && !isSidebarVisible {
-            return 8
-        }
-
         let minimumSidebarTitleInset = max(titlebarLeadingInset, minimumSidebarWidth + 12)
         guard isSidebarVisible else {
             return minimumSidebarTitleInset
@@ -2370,14 +2369,6 @@ struct ContentView: View {
         .offset(y: -TitlebarControlsVisualMetrics.verticalLift)
     }
 
-    /// Intrinsic width of ``fullscreenControls`` for the current controls style.
-    /// Used to reserve space in the title row so the title flows to the right of
-    /// the controls, which are themselves mounted once in the band overlay.
-    private var fullscreenControlsWidth: CGFloat {
-        let style = TitlebarControlsStyle(rawValue: titlebarControlsStyleRawValue) ?? .classic
-        return TitlebarControlsLayoutMetrics.contentSize(config: style.config).width
-    }
-
     private var titlebarDebugChromeSnapshot: MinimalModeTitlebarDebugSnapshot {
         MinimalModeTitlebarDebugSnapshot(
             leftControlsLeadingInset: MinimalModeTitlebarDebugSettings.clamped(
@@ -2402,7 +2393,6 @@ struct ContentView: View {
     private func customTitlebar(appearance: WindowAppearanceSnapshot) -> some View {
         let titlebarContentHeight = max(1, WindowChromeMetrics.appTitlebarHeight - 2)
         let leadingPadding = Self.customTitlebarLeadingPadding(
-            isFullScreen: isFullScreen,
             isSidebarVisible: sidebarState.isVisible,
             sidebarWidth: sidebarWidth,
             minimumSidebarWidth: minimumSidebarWidth,
@@ -2417,16 +2407,6 @@ struct ContentView: View {
                 .allowsHitTesting(false)
 
             HStack(spacing: 8) {
-                if isFullScreen && !sidebarState.isVisible {
-                    // Reserve the controls' width so the title flows to their right.
-                    // The visible controls are rendered once in the band overlay (see
-                    // `workspaceTitlebarBand`) so their position never depends on
-                    // sidebar visibility.
-                    Color.clear
-                        .frame(width: fullscreenControlsWidth, height: titlebarContentHeight)
-                        .allowsHitTesting(false)
-                }
-
                 // Draggable folder icon + focused command name
                 if let directory = focusedDirectory {
                     DetachedFolderDragIcon(directory: directory)

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2011,7 +2011,6 @@ struct CustomTitlebarLeadingPaddingTests {
     @Test func hiddenSidebarUsesMinimumSidebarTitleInset() {
         #expect(
             ContentView.customTitlebarLeadingPadding(
-                isFullScreen: false,
                 isSidebarVisible: false,
                 sidebarWidth: 216,
                 minimumSidebarWidth: 216,
@@ -2022,14 +2021,12 @@ struct CustomTitlebarLeadingPaddingTests {
 
     @Test func minimumWidthVisibleSidebarMatchesHiddenSidebarTitleInset() {
         let hidden = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: false,
             sidebarWidth: 216,
             minimumSidebarWidth: 216,
             titlebarLeadingInset: 82
         )
         let visible = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: true,
             sidebarWidth: 216,
             minimumSidebarWidth: 216,
@@ -2041,14 +2038,12 @@ struct CustomTitlebarLeadingPaddingTests {
 
     @Test func widerSidebarPushesTitlebarContentRight() {
         let hidden = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: false,
             sidebarWidth: 216,
             minimumSidebarWidth: 216,
             titlebarLeadingInset: 82
         )
         let visible = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: true,
             sidebarWidth: 320,
             minimumSidebarWidth: 216,
@@ -2059,18 +2054,6 @@ struct CustomTitlebarLeadingPaddingTests {
         #expect(visible == 332)
     }
 
-    @Test func fullscreenHiddenSidebarKeepsCompactInset() {
-        #expect(
-            ContentView.customTitlebarLeadingPadding(
-                isFullScreen: true,
-                isSidebarVisible: false,
-                sidebarWidth: 216,
-                minimumSidebarWidth: 216,
-                titlebarLeadingInset: 82
-            ) == 8
-        )
-    }
-
     // Regression: at the default (== minimum) sidebar width, toggling the sidebar
     // must not move the folder/title. The title tracks the actual width only when
     // the sidebar is wider than the minimum, so the default width must equal the
@@ -2079,14 +2062,12 @@ struct CustomTitlebarLeadingPaddingTests {
         let width = CGFloat(SessionPersistencePolicy.defaultSidebarWidth)
         let minimum = CGFloat(SessionPersistencePolicy.minimumSidebarWidth)
         let visible = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: true,
             sidebarWidth: width,
             minimumSidebarWidth: minimum,
             titlebarLeadingInset: 82
         )
         let hidden = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: false,
             isSidebarVisible: false,
             sidebarWidth: width,
             minimumSidebarWidth: minimum,
@@ -2095,26 +2076,19 @@ struct CustomTitlebarLeadingPaddingTests {
         #expect(visible == hidden)
     }
 
-    // Regression: fullscreen must behave like windowed mode. At the minimum
-    // sidebar width, toggling the sidebar in fullscreen used to jump the
-    // folder/title to a compact 8pt inset when hidden instead of keeping the
-    // sidebar-edge inset it has when visible.
+    // Regression: fullscreen must behave like windowed mode. The hidden-sidebar
+    // inset used to special-case fullscreen to a compact 8pt, jumping the
+    // folder/title left on toggle-off. The function no longer takes a fullscreen
+    // input at all, so windowed/fullscreen parity is structural; this pins the
+    // hidden inset that replaced the compact one.
     @Test func fullscreenToggleAtMinimumWidthDoesNotMoveTitle() {
-        let visible = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: true,
-            isSidebarVisible: true,
-            sidebarWidth: 216,
-            minimumSidebarWidth: 216,
-            titlebarLeadingInset: 82
-        )
         let hidden = ContentView.customTitlebarLeadingPadding(
-            isFullScreen: true,
             isSidebarVisible: false,
             sidebarWidth: 216,
             minimumSidebarWidth: 216,
             titlebarLeadingInset: 82
         )
-        #expect(visible == hidden)
+        #expect(hidden == 228)
     }
 }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2094,6 +2094,28 @@ struct CustomTitlebarLeadingPaddingTests {
         )
         #expect(visible == hidden)
     }
+
+    // Regression: fullscreen must behave like windowed mode. At the minimum
+    // sidebar width, toggling the sidebar in fullscreen used to jump the
+    // folder/title to a compact 8pt inset when hidden instead of keeping the
+    // sidebar-edge inset it has when visible.
+    @Test func fullscreenToggleAtMinimumWidthDoesNotMoveTitle() {
+        let visible = ContentView.customTitlebarLeadingPadding(
+            isFullScreen: true,
+            isSidebarVisible: true,
+            sidebarWidth: 216,
+            minimumSidebarWidth: 216,
+            titlebarLeadingInset: 82
+        )
+        let hidden = ContentView.customTitlebarLeadingPadding(
+            isFullScreen: true,
+            isSidebarVisible: false,
+            sidebarWidth: 216,
+            minimumSidebarWidth: 216,
+            titlebarLeadingInset: 82
+        )
+        #expect(visible == hidden)
+    }
 }
 
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/5707, split out per dogfood feedback. Draft on purpose: this is a behavior question, not a settled fix.

**Current fullscreen behavior (after #5707):** with the sidebar hidden in fullscreen, the folder/title hugs the always-visible controls at a compact 8pt inset, reclaiming ~80pt of title space (there are no traffic lights, and long directory titles benefit). The cost is that toggling the sidebar jumps the folder/title left and back, unlike windowed mode where #5707 made it stable.

**This branch:** removes the fullscreen special case and the `isFullScreen` parameter from `customTitlebarLeadingPadding`, so the title keeps the sidebar-edge inset in fullscreen too and never moves on toggle. Windowed/fullscreen parity becomes structural. Trade-off: the title no longer reclaims the space next to the controls in fullscreen.

**Alternatives considered, if full parity feels too aggressive:**
1. Keep the compact inset but animate the title between the two positions instead of snapping.
2. Use the compact inset only when the title would otherwise truncate, sidebar-edge inset otherwise.

Two-commit red/green regression test (`fullscreenToggleAtMinimumWidthDoesNotMoveTitle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783707144&installation_id=133855650&pr_number=5807&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5807&signature=710398c10c7ec9380ceeadeaa5f1af656bb3c00b63bdb5addf94df7c64122a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the folder/title from moving when toggling the sidebar in fullscreen by removing the fullscreen-specific inset. Windowed and fullscreen now use the same sidebar-edge inset.

- **Bug Fixes**
  - Removed the fullscreen-hidden 8pt inset and the `isFullScreen` parameter from `customTitlebarLeadingPadding`; the title uses the sidebar-edge inset in both modes.
  - Stopped reserving fullscreen controls width in the title row; the minimum inset already clears the overlay controls.
  - Added regression test `fullscreenToggleAtMinimumWidthDoesNotMoveTitle` and updated related tests.

<sup>Written for commit 37d03a3a99dabc46aa55e210e69e3f85149c7493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

