### PR TITLE
Fix cmux ssh resize freezing: reconnect dead cached control-socket connections in the CLI

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1679,7 +1679,6 @@ final class SocketClient {
     private var lastConfiguredReceiveTimeout: TimeInterval?
     private var lastOperationTelemetry: CLISocketOperationTelemetry.State?
     private var reconnectAuthCommand: String?
-    private var isReplayingReconnectAuth = false
     private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
     private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
     private static let maxSocketTimeoutSeconds: TimeInterval = 9_007_199_254_740_991
@@ -1836,14 +1835,14 @@ final class SocketClient {
     /// Re-establish the connection — and replay password auth when configured
     /// — before sending instead of failing the request on a dead socket.
     /// Clients that were never connected still surface "Not connected".
-    private func reestablishConnectionIfPeerClosed() throws {
+    /// The auth replay goes through `performSend` directly (not `send`), so
+    /// this never re-enters itself and needs no reentrancy sentinel.
+    private func reestablishConnectionIfPeerClosed(responseTimeout: TimeInterval? = nil) throws {
         guard socketFD >= 0, !connectionAppearsOpen() else { return }
         close()
         try connect()
-        guard let authCommand = reconnectAuthCommand, !isReplayingReconnectAuth else { return }
-        isReplayingReconnectAuth = true
-        defer { isReplayingReconnectAuth = false }
-        let response = try send(command: authCommand)
+        guard let authCommand = reconnectAuthCommand else { return }
+        let response = try performSend(command: authCommand, responseTimeout: responseTimeout)
         if response.hasPrefix("ERROR:") {
             throw CLIError(message: response)
         }
@@ -1853,7 +1852,12 @@ final class SocketClient {
         if relayEndpoint != nil, socketFD < 0 {
             try connect()
         }
-        try reestablishConnectionIfPeerClosed()
+        try reestablishConnectionIfPeerClosed(responseTimeout: responseTimeout)
+        guard socketFD >= 0 else { throw CLIError(message: "Not connected") }
+        return try performSend(command: command, responseTimeout: responseTimeout)
+    }
+
+    private func performSend(command: String, responseTimeout: TimeInterval? = nil) throws -> String {
         guard socketFD >= 0 else { throw CLIError(message: "Not connected") }
         let shouldCloseAfterSend = relayEndpoint != nil
         defer {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1678,6 +1678,8 @@ final class SocketClient {
     private var socketFD: Int32 = -1
     private var lastConfiguredReceiveTimeout: TimeInterval?
     private var lastOperationTelemetry: CLISocketOperationTelemetry.State?
+    private var reconnectAuthCommand: String?
+    private var isReplayingReconnectAuth = false
     private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
     private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
     private static let maxSocketTimeoutSeconds: TimeInterval = 9_007_199_254_740_991
@@ -1820,10 +1822,38 @@ final class SocketClient {
         lastConfiguredReceiveTimeout = nil
     }
 
+    /// Remembers the auth line to replay when a dead cached connection is
+    /// transparently re-established: the server authenticates each socket
+    /// connection independently, so a reconnect must repeat the login.
+    func rememberReconnectAuth(command: String) {
+        reconnectAuthCommand = command
+    }
+
+    /// The control socket server applies a receive timeout to each accepted
+    /// connection and closes it once idle, so for a long-lived cached client
+    /// (such as the ssh-pty-attach SIGWINCH resize source) a peer-closed
+    /// connection is the expected steady state rather than an error.
+    /// Re-establish the connection — and replay password auth when configured
+    /// — before sending instead of failing the request on a dead socket.
+    /// Clients that were never connected still surface "Not connected".
+    private func reestablishConnectionIfPeerClosed() throws {
+        guard socketFD >= 0, !connectionAppearsOpen() else { return }
+        close()
+        try connect()
+        guard let authCommand = reconnectAuthCommand, !isReplayingReconnectAuth else { return }
+        isReplayingReconnectAuth = true
+        defer { isReplayingReconnectAuth = false }
+        let response = try send(command: authCommand)
+        if response.hasPrefix("ERROR:") {
+            throw CLIError(message: response)
+        }
+    }
+
     func send(command: String, responseTimeout: TimeInterval? = nil) throws -> String {
         if relayEndpoint != nil, socketFD < 0 {
             try connect()
         }
+        try reestablishConnectionIfPeerClosed()
         guard socketFD >= 0 else { throw CLIError(message: "Not connected") }
         let shouldCloseAfterSend = relayEndpoint != nil
         defer {
@@ -5612,6 +5642,9 @@ struct CMUXCLI {
             if authResponse.hasPrefix("ERROR:"),
                !authResponse.contains("Unknown command 'auth'") {
                 throw CLIError(message: authResponse)
+            }
+            if !authResponse.hasPrefix("ERROR:") {
+                client.rememberReconnectAuth(command: "auth \(socketPassword)")
             }
         }
     }
@@ -10897,7 +10930,15 @@ struct CMUXCLI {
                 params["surface_id"] = surfaceID
                 params["allow_moved_surface"] = true
             }
-            _ = try? client.sendV2(method: "workspace.remote.pty_resize", params: params)
+            // SocketClient.send() transparently re-establishes a peer-closed
+            // cached connection (the server times out idle clients), so the
+            // only errors left here are real failures — log them instead of
+            // silently freezing the remote PTY at its previous size.
+            do {
+                _ = try client.sendV2(method: "workspace.remote.pty_resize", params: params)
+            } catch {
+                self.cliDebugLog("ssh-pty-attach: failed to propagate terminal resize (\(size.cols)x\(size.rows)): \(error)")
+            }
         }
         source.resume()
         return source

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -4609,6 +4609,21 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             targetResizes,
             "Each SIGWINCH must reconnect and issue a resize RPC; reusing one connection froze resizes after the first (delivered=\(delivered))"
         )
+
+        // The bridge close must also complete cleanly end-to-end: the EOF
+        // cleanup path runs on the same cached client, so a stale connection
+        // there would surface as a non-zero exit.
+        let exited = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exited.signal()
+        }
+        XCTAssertEqual(exited.wait(timeout: .now() + 5), .success, "ssh-pty-attach did not exit after bridge close")
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, stderr)
+        XCTAssertTrue(stdout.isEmpty, stdout)
+        XCTAssertTrue(stderr.isEmpty, stderr)
     }
 
     func testSSHSessionAttachCreatesSurfaceWithPersistedPTYSessionID() throws {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -4444,6 +4444,173 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         ])
     }
 
+    /// Regression: the cmux control socket serves a single request per connection
+    /// (it closes the connection once it has replied). `ssh-pty-attach` reused one
+    /// long-lived SocketClient for every SIGWINCH-driven resize, so after the first
+    /// resize the connection was dead and all later resizes failed silently — the
+    /// remote PTY froze at its initial width. Drive several SIGWINCH signals against
+    /// a one-request-per-connection server and assert each is delivered as its own
+    /// resize RPC (i.e. the handler reconnects). Pre-fix this server would receive
+    /// only the bridge request and zero resizes.
+    func testSSHPTYAttachReconnectsResizeForEachSIGWINCH() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("sshptyresizereconnect")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let bridge = try bindLoopbackTCP()
+        let state = MockSocketServerState()
+        let workspaceId = "44444444-4444-4444-4444-444444444444"
+        let surfaceId = "55555555-5555-5555-5555-555555555555"
+        let sessionId = "ssh-\(workspaceId)-\(surfaceId)"
+        let token = "bridge-token"
+        let bridgeReady = DispatchSemaphore(value: 0)
+        let closeBridge = DispatchSemaphore(value: 0)
+
+        defer {
+            Darwin.close(listenerFD)
+            Darwin.close(bridge.fd)
+            unlink(socketPath)
+        }
+
+        // One request per connection: accept, answer a single request, then close —
+        // mirroring the real cmux control socket. The accept loop ends when the
+        // listener is closed in `defer`.
+        DispatchQueue.global(qos: .userInitiated).async {
+            while true {
+                var clientAddr = sockaddr_un()
+                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                    }
+                }
+                if clientFD < 0 { return }
+                var pending = Data()
+                var buffer = [UInt8](repeating: 0, count: 4096)
+                var answered = false
+                while !answered {
+                    let count = Darwin.read(clientFD, &buffer, buffer.count)
+                    if count <= 0 { break }
+                    pending.append(buffer, count: count)
+                    guard let newlineRange = pending.firstRange(of: Data([0x0A])) else { continue }
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { break }
+                    state.append(line)
+                    let response: String
+                    if let payload = self.jsonObject(line),
+                       let id = payload["id"] as? String,
+                       let method = payload["method"] as? String {
+                        switch method {
+                        case "workspace.remote.pty_bridge":
+                            response = self.v2Response(
+                                id: id,
+                                ok: true,
+                                result: [
+                                    "host": "127.0.0.1",
+                                    "port": bridge.port,
+                                    "token": token,
+                                    "session_id": sessionId,
+                                    "attachment_id": surfaceId,
+                                ]
+                            )
+                        default:
+                            response = self.v2Response(id: id, ok: true, result: [:])
+                        }
+                    } else {
+                        response = self.malformedRequestResponse(raw: line)
+                    }
+                    _ = (response + "\n").withCString { Darwin.write(clientFD, $0, strlen($0)) }
+                    answered = true
+                }
+                Darwin.close(clientFD)
+            }
+        }
+
+        // Bridge loopback: complete the attach handshake and hand back the token.
+        DispatchQueue.global(qos: .userInitiated).async {
+            var clientAddr = sockaddr_in()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(bridge.fd, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 1024)
+            while !pending.contains(0x0A) {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 { if errno == EINTR { continue }; return }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+            }
+            let ready = #"{"type":"ready","attachment_token":"attach-token"}"# + "\n"
+            _ = ready.withCString { Darwin.write(clientFD, $0, strlen($0)) }
+            bridgeReady.signal()
+            _ = closeBridge.wait(timeout: .now() + 10)
+        }
+
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: cliPath)
+        process.arguments = [
+            "ssh-pty-attach",
+            "--workspace", workspaceId,
+            "--session-id", sessionId,
+            "--attachment-id", surfaceId,
+        ]
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        defer {
+            if process.isRunning { process.terminate() }
+        }
+        XCTAssertEqual(bridgeReady.wait(timeout: .now() + 5), .success)
+
+        // Count only resizes that carry the full attach context the remote PTY
+        // requires; a resize that drops workspace/session/attachment ids or the
+        // token would be rejected by the real daemon, so it must not count here.
+        func resizeCount() -> Int {
+            state.snapshot()
+                .compactMap { self.jsonObject($0) }
+                .filter { ($0["method"] as? String) == "workspace.remote.pty_resize" }
+                .filter { request in
+                    guard let params = request["params"] as? [String: Any] else { return false }
+                    return params["workspace_id"] as? String == workspaceId
+                        && params["session_id"] as? String == sessionId
+                        && params["attachment_id"] as? String == surfaceId
+                        && params["attachment_token"] as? String == "attach-token"
+                        && params["cols"] as? Int != nil
+                        && params["rows"] as? Int != nil
+                }
+                .count
+        }
+
+        // Each SIGWINCH must reconnect and deliver its own resize RPC. Pre-fix the
+        // first dead-connection resize would abort the chain at zero.
+        let targetResizes = 3
+        let deadline = Date().addingTimeInterval(10)
+        while resizeCount() < targetResizes, Date() < deadline {
+            Darwin.kill(process.processIdentifier, SIGWINCH)
+            usleep(200_000)
+        }
+        let delivered = resizeCount()
+        closeBridge.signal()
+
+        XCTAssertGreaterThanOrEqual(
+            delivered,
+            targetResizes,
+            "Each SIGWINCH must reconnect and issue a resize RPC; reusing one connection froze resizes after the first (delivered=\(delivered))"
+        )
+    }
+
     func testSSHSessionAttachCreatesSurfaceWithPersistedPTYSessionID() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("sshattach")

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -4618,7 +4618,13 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             process.waitUntilExit()
             exited.signal()
         }
-        XCTAssertEqual(exited.wait(timeout: .now() + 5), .success, "ssh-pty-attach did not exit after bridge close")
+        // Guard-and-return rather than assert-and-continue: reading
+        // terminationStatus on a still-running Process raises an ObjC
+        // exception, which would crash the test run instead of failing it.
+        guard exited.wait(timeout: .now() + 5) == .success else {
+            XCTFail("ssh-pty-attach did not exit after bridge close")
+            return
+        }
         let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         XCTAssertEqual(process.terminationStatus, 0, stderr)


### PR DESCRIPTION
## Summary

- **What changed?** `SocketClient.send()` now detects a peer-closed cached connection before writing (`connectionAppearsOpen()`), transparently re-establishes it, and replays password auth when configured. The `ssh-pty-attach` SIGWINCH resize handler logs real failures instead of discarding them with `try?`.
- **Why?** The control socket server applies a **30s receive timeout** to every accepted connection (`SocketTransport.clientReadTimeout`, default 30) and closes it once idle — `handleClient`'s read loop treats the timeout as EOF. Any long-lived cached `SocketClient` is therefore usually talking to a dead socket by the time it next sends. The resize handler swallowed that failure, so **every `cmux ssh` window resize issued more than ~30s after attach silently never reached the remote PTY**, freezing the remote at its previous size (local PTY reflows, remote doesn't — the TUI then renders garbled at the stale width).
- This is the same user-visible bug as #4960. That PR was closed as "fixed by #4807", but #4807 only made the server serve multiple requests per connection — resize works for ~30s after attach and then breaks, which is why the earlier verification passed. Reproduced on v0.64.14 against a live session: the attached CLI's control-socket fd shows peer `(none)` in `lsof` while the data bridge stays healthy, and the daemon never receives the resize RPC.
- Fixing it inside `SocketClient.send()` (rather than at the resize call site as #4960 did) also heals the other long-lived users of a cached client — e.g. `handleSSHPTYBridgeEOF`, which could misreport "bridge closed before remote PTY exit could be confirmed" (exit 255) on a stale connection. The relay-backed path already treats reconnect-per-send as steady state; this extends the same honesty to the unix-socket path. Per-connection password auth is replayed on reconnect (registered by `authenticateSocketClientIfNeeded`), which a call-site-only fix would miss.

## Testing

- **Two commits per the regression policy:** commit 1 = failing test only (CI red), commit 2 = fix (CI green).
- Regression test `testSSHPTYAttachReconnectsResizeForEachSIGWINCH` (ported from #4960, kays0x authorship): drives several SIGWINCH signals against a one-request-per-connection control-socket mock and asserts each is delivered as its own `workspace.remote.pty_resize` RPC.
  - Without the fix: **fails with `delivered=0`** (10.7s, exhausts the poll window).
  - With the fix: **passes in 0.8s**.
- Adjacent SSH PTY tests pass unchanged: `testSSHPTYAttachSerializesResizeBeforeEOFLocalCleanup`, `testSSHPTYAttachBridgeEOFWhileSessionRunsExitsWithoutSSHRetryStatus`, `testSSHPTYAttachBridgeEOFWhenSessionGoneClearsLocalState`, `testSSHPTYAttachWaitUsesCurrentTerminalSizeForBridgeHandshake`.
- `xcodebuild test -scheme cmux-unit ... -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/...` → **TEST SUCCEEDED** (5 tests, 0 failures).
- Manual root-cause verification on a live v0.64.14 session against a real remote (ovh VPS): local PTY resized 88x55 → 60x37 while remote stayed 88x55; manual `SIGWINCH` no-op; `lsof` showed the CLI's cached unix socket with peer gone while the bridge TCP connection stayed ESTABLISHED; daemon-side `pty_sessions` still reported the attachment at 88x55 — resize RPCs were being silently dropped.

## Demo Video

- Terminal-only change; before/after evidence above (live-session `TIOCGWINSZ` reads + `lsof` fd state + daemon `pty_sessions` output).

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed — behavior fix)
- [x] Bot reviews run automatically on every push
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783707230&installation_id=133855650&pr_number=5808&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5808&signature=381276c43f0acfc328d7ddb773fd282d984e38ae996a3ea53807ffe17dc77c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux ssh` resize freezes by auto-reconnecting stale control-socket connections and replaying auth safely. Resizes now reach the remote PTY after idle timeouts; real errors are logged and EOF cleanup exits cleanly.

- **Bug Fixes**
  - Detect peer-closed cached connections in `SocketClient.send()` and reconnect before sending; replay per-connection password auth via a remembered `auth` command, routed through `performSend` to avoid re-entering `send()`.
  - `ssh-pty-attach` resize handler now logs failures (with size and error) instead of swallowing them.
  - Regression test simulates a one-request-per-connection control socket: asserts each `SIGWINCH` delivers a `workspace.remote.pty_resize` with full attach context and that the process exits 0 after the bridge closes; exit wait is guarded to fail instead of crash if hung.

<sup>Written for commit b6cc12a9f8d382fed367f520e947b33c27b3bc19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Socket connections now transparently reconnect after peer-closed idle sessions and automatically replay the last successful authentication.
* **Bug Fixes**
  * SSH PTY resize propagation now reports failures instead of silently ignoring them, improving troubleshooting when resize forwarding fails.
* **Tests**
  * Added a regression test verifying `ssh-pty-attach` reconnects and continues sending PTY resize requests across repeated `SIGWINCH` signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
