### PR TITLE
Let user SSH options override the daemon-transport keepalive defaults

### DIFF
--- a/Packages/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
+++ b/Packages/CmuxCore/Sources/CmuxCore/Remote/WorkspaceRemoteConfiguration+SSHBatchCommands.swift
@@ -84,11 +84,22 @@ extension WorkspaceRemoteConfiguration {
     // ControlMaster/ControlPersist.
     private func batchSSHArguments() -> [String] {
         let effectiveSSHOptions = backgroundSSHOptions()
-        var args: [String] = [
-            "-o", "ConnectTimeout=6",
-            "-o", "ServerAliveInterval=20",
-            "-o", "ServerAliveCountMax=2",
-        ]
+        var args: [String] = []
+        // Supervision keepalive defaults. These must be emitted only when the
+        // configuration does not already set them: OpenSSH applies the first
+        // value seen for an option, and the user's options are appended after
+        // these, so an unconditional default would silently win over the user.
+        // ServerAliveCountMax defaults to 6 (≈120s with the 20s interval) so a
+        // brief network blip no longer tears the daemon connection down.
+        if !Self.hasSSHOptionKey(effectiveSSHOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=6"]
+        }
+        if !Self.hasSSHOptionKey(effectiveSSHOptions, key: "ServerAliveInterval") {
+            args += ["-o", "ServerAliveInterval=20"]
+        }
+        if !Self.hasSSHOptionKey(effectiveSSHOptions, key: "ServerAliveCountMax") {
+            args += ["-o", "ServerAliveCountMax=6"]
+        }
         if !Self.hasSSHOptionKey(effectiveSSHOptions, key: "StrictHostKeyChecking") {
             args += ["-o", "StrictHostKeyChecking=accept-new"]
         }

--- a/Packages/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
+++ b/Packages/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
@@ -160,4 +160,35 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
         )
         #expect(configuration().reverseRelayControlMasterCancelArguments(relayPort: 0) == nil)
     }
+
+    @Test("supervision keepalive default tolerates longer outages (ServerAliveCountMax=6)")
+    func keepaliveDefaultCountMaxIsSix() {
+        let arguments = configuration().daemonTransportArguments(remotePath: "/remote/cmuxd-remote")
+        #expect(arguments.contains("ServerAliveCountMax=6"))
+        #expect(!arguments.contains("ServerAliveCountMax=2"))
+    }
+
+    @Test("user-supplied keepalive options override the supervision defaults")
+    func userKeepaliveOptionsOverrideDefaults() {
+        let arguments = configuration(
+            sshOptions: [
+                "ControlPath=/tmp/cmux-ssh-%C",
+                "StrictHostKeyChecking=accept-new",
+                "ServerAliveInterval=15",
+                "ServerAliveCountMax=12",
+                "ConnectTimeout=30",
+            ]
+        ).daemonTransportArguments(remotePath: "/remote/cmuxd-remote")
+        // Defaults must yield to the user's values (OpenSSH is first-value-wins,
+        // so emitting both the default and the user option silently ignores the
+        // user). The default tokens must be absent entirely.
+        #expect(!arguments.contains("ServerAliveCountMax=6"))
+        #expect(!arguments.contains("ServerAliveCountMax=2"))
+        #expect(!arguments.contains("ServerAliveInterval=20"))
+        #expect(!arguments.contains("ConnectTimeout=6"))
+        // The user's values survive exactly once each.
+        #expect(arguments.filter { $0 == "ServerAliveCountMax=12" }.count == 1)
+        #expect(arguments.filter { $0 == "ServerAliveInterval=15" }.count == 1)
+        #expect(arguments.filter { $0 == "ConnectTimeout=30" }.count == 1)
+    }
 }

--- a/Packages/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
+++ b/Packages/CmuxCore/Tests/CmuxCoreTests/WorkspaceRemoteConfigurationSSHBatchCommandsTests.swift
@@ -36,7 +36,7 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
     private let expectedBatchArguments: [String] = [
         "-o", "ConnectTimeout=6",
         "-o", "ServerAliveInterval=20",
-        "-o", "ServerAliveCountMax=2",
+        "-o", "ServerAliveCountMax=6",
         "-o", "BatchMode=yes",
         "-o", "ControlMaster=no",
         "-p", "2222",
@@ -85,7 +85,7 @@ struct WorkspaceRemoteConfigurationSSHBatchCommandsTests {
                 "-T",
                 "-o", "ConnectTimeout=6",
                 "-o", "ServerAliveInterval=20",
-                "-o", "ServerAliveCountMax=2",
+                "-o", "ServerAliveCountMax=6",
                 "-o", "StrictHostKeyChecking=accept-new",
                 "-o", "BatchMode=yes",
                 "-o", "ControlMaster=no",

--- a/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
+++ b/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+SSHArguments.swift
@@ -13,11 +13,22 @@ extension RemoteSessionCoordinator {
             }
             return normalizedSSHOptions(configuration.sshOptions)
         }()
-        var args: [String] = [
-            "-o", "ConnectTimeout=6",
-            "-o", "ServerAliveInterval=20",
-            "-o", "ServerAliveCountMax=2",
-        ]
+        var args: [String] = []
+        // Supervision keepalive defaults, emitted only when the configuration
+        // does not already set them: OpenSSH applies the first value seen and
+        // the user's options are appended after these, so an unconditional
+        // default would silently win over the user. ServerAliveCountMax
+        // defaults to 6 (≈120s with the 20s interval) so a brief network blip
+        // no longer tears the connection down.
+        if !hasSSHOptionKey(effectiveSSHOptions, key: "ConnectTimeout") {
+            args += ["-o", "ConnectTimeout=6"]
+        }
+        if !hasSSHOptionKey(effectiveSSHOptions, key: "ServerAliveInterval") {
+            args += ["-o", "ServerAliveInterval=20"]
+        }
+        if !hasSSHOptionKey(effectiveSSHOptions, key: "ServerAliveCountMax") {
+            args += ["-o", "ServerAliveCountMax=6"]
+        }
         if !hasSSHOptionKey(effectiveSSHOptions, key: "StrictHostKeyChecking") {
             args += ["-o", "StrictHostKeyChecking=accept-new"]
         }


### PR DESCRIPTION
## Summary

**What:** The daemon-transport SSH command builders emitted `ConnectTimeout`, `ServerAliveInterval`, and `ServerAliveCountMax` unconditionally at the **front** of the `ssh` argv, before appending the configuration's own SSH options. OpenSSH applies the **first** value it sees for an option, so:

1. A user could never override these keepalives via their SSH options - the hardcoded defaults always won.
2. The default budget (`ServerAliveInterval=20` x `ServerAliveCountMax=2` = ~40s) tore the supervision connection down on brief network blips, producing the "attempt N/20" reconnect flapping.

**Why / fix:** Guard each default with `hasSSHOptionKey` so it is emitted only when the configuration has not already set it (matching the existing `StrictHostKeyChecking` guard right below it), and raise the default `ServerAliveCountMax` from 2 to 6 (~120s budget) so a short outage no longer kills the connection.

Applied to both daemon-transport builders:
- `CmuxCore` - `WorkspaceRemoteConfiguration.batchSSHArguments()` (`daemonTransportArguments` / `daemonSocketForwardArguments` / reverse-relay).
- `CmuxRemoteSession` - `RemoteSessionCoordinator.sshCommonArguments(batchMode:)`.

## Testing

`swift test --package-path Packages/CmuxCore --filter WorkspaceRemoteConfigurationSSHBatchCommandsTests` - 9 passed.

Two new regression tests (two-commit red/green):
- `supervision keepalive default tolerates longer outages (ServerAliveCountMax=6)`
- `user-supplied keepalive options override the supervision defaults` - verifies a user's `ServerAliveInterval`/`ServerAliveCountMax`/`ConnectTimeout` survive exactly once and no default token is emitted.

Verified locally that both fail on the test-only commit (the argv contains both the hardcoded `=2` and the user's value) and pass on the fix commit. `CmuxRemoteSession` builds clean.

## Demo Video

Terminal-only argv change; before/after is the argument list asserted in the tests above. Before: `-o ServerAliveCountMax=2 ... -o ServerAliveCountMax=12` (user value ignored, first-wins). After: `-o ServerAliveCountMax=12` only (user value honored), default `=6` when unset.

## Review Trigger

Override semantics for daemon-transport keepalives + default budget change.

## Checklist

- [x] Defaults overridable by user SSH options
- [x] Regression tests (red without fix, green with fix)
- [x] Both daemon-transport builders covered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH connection reliability for remote workspace operations by applying more robust keepalive defaults (including a higher `ServerAliveCountMax`) when those options aren’t already set. User-supplied SSH keepalive settings continue to fully override the defaults.

* **Tests**
  * Updated and expanded SSH batch-argument expectations to cover the new default keepalive behavior and verify that user-provided values replace defaults as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->