### PR TITLE
Deflake control-socket ping UI tests: wait for listener bind, then ping

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		C3408A000000000000000005 /* ContentView+ViewCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */; };
 		A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 		C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */; };
+		D10000000000000000B00000 /* ControlSocketReadinessUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000B00001 /* ControlSocketReadinessUITestSupport.swift */; };
 		DEBDADADADADADADAD000001 /* DebugDogfoodCredentialResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */; };
 		DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
@@ -1018,6 +1019,7 @@
 		C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+ViewCommandPalette.swift"; sourceTree = "<group>"; };
 		A5001012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewIdentifierCopyCommands.swift; sourceTree = "<group>"; };
+		D10000000000000000B00001 /* ControlSocketReadinessUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSocketReadinessUITestSupport.swift; sourceTree = "<group>"; };
 		DEBDADADADADADADAD000002 /* DebugDogfoodCredentialResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolver.swift; sourceTree = "<group>"; };
 		DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolverTests.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
@@ -1601,6 +1603,7 @@
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 				C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */,
 				D10000000000000000A00011 /* SettingsUITestSupport.swift */,
+				D10000000000000000B00001 /* ControlSocketReadinessUITestSupport.swift */,
 				D10000000000000000A00013 /* SettingsAppBehaviorUITests.swift */,
 				D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */,
 				D10000000000000000A00017 /* SettingsSidebarBetaBehaviorUITests.swift */,
@@ -3156,6 +3159,7 @@
 				B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
 				B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */,
 				C0DE32470000000000000005 /* CommandPaletteIdentifierClipboardUITests.swift in Sources */,
+				D10000000000000000B00000 /* ControlSocketReadinessUITestSupport.swift in Sources */,
 				B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,
 				D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */,

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -210,8 +210,10 @@ final class AutomationSocketUITests: XCTestCase {
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
         var resolvedPath: String?
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in
+        let ready = waitForControlSocketReady(
+            pingTimeout: timeout,
+            socketFileExists: { self.socketCandidates().contains { FileManager.default.fileExists(atPath: $0) } },
+            pingReturnsPong: {
                 let originalPath = self.socketPath
                 for candidate in self.socketCandidates() {
                     guard FileManager.default.fileExists(atPath: candidate) else { continue }
@@ -223,14 +225,10 @@ final class AutomationSocketUITests: XCTestCase {
                     self.socketPath = originalPath
                 }
                 return false
-            },
-            object: NSObject()
+            }
         )
-        let completed = XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
-        if let resolvedPath {
-            socketPath = resolvedPath
-        }
-        return completed
+        if let resolvedPath { socketPath = resolvedPath }
+        return ready
     }
 
     private func socketCandidates() -> [String] {

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1345,7 +1345,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
     }
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
-        waitForCondition(timeout: timeout) {
+        waitForControlSocketReady(socketPath: socketPath, pingTimeout: timeout) {
             self.socketCommand("ping") == "PONG"
         }
     }

--- a/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
+++ b/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
@@ -204,8 +204,10 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
         var resolvedPath: String?
-        let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in
+        let ready = waitForControlSocketReady(
+            pingTimeout: timeout,
+            socketFileExists: { self.socketCandidates().contains { FileManager.default.fileExists(atPath: $0) } },
+            pingReturnsPong: {
                 let originalPath = self.socketPath
                 for candidate in self.socketCandidates() {
                     guard FileManager.default.fileExists(atPath: candidate) else { continue }
@@ -217,14 +219,10 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
                     self.socketPath = originalPath
                 }
                 return false
-            },
-            object: NSObject()
+            }
         )
-        let completed = XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
-        if let resolvedPath {
-            socketPath = resolvedPath
-        }
-        return completed
+        if let resolvedPath { socketPath = resolvedPath }
+        return ready
     }
 
     private func socketCandidates() -> [String] {

--- a/cmuxUITests/ControlSocketReadinessUITestSupport.swift
+++ b/cmuxUITests/ControlSocketReadinessUITestSupport.swift
@@ -1,0 +1,85 @@
+import XCTest
+import Foundation
+
+extension XCTestCase {
+    /// Waits for a cmux control socket listener to become ready in two
+    /// decoupled phases, then returns whether it answered a `ping` with `PONG`.
+    ///
+    /// The two phases exist to keep a slow app cold-launch on hosted CI runners
+    /// from starving the ping budget:
+    ///
+    /// 1. **Listener bound.** Wait up to `listenerBindTimeout` for the listener
+    ///    to bind, observed as the Unix-domain socket file appearing on disk.
+    ///    The server creates that file with `bind(2)` before it accepts, so the
+    ///    file appearing is a real readiness signal, not a fixed sleep. Each UI
+    ///    test binds a unique per-run socket path and removes it in `setUp`, so
+    ///    the file can only appear because *this* app instance bound it.
+    /// 2. **Accepting and responsive.** With the listener bound, wait up to
+    ///    `pingTimeout` (a *fresh* budget that only starts once phase 1
+    ///    completes) for it to accept a connection and answer `ping` with
+    ///    `PONG`.
+    ///
+    /// Splitting the wait this way is the fix for the flake in
+    /// https://github.com/manaflow-ai/cmux/issues/5414: previously a single
+    /// fixed `pingTimeout` had to cover *both* the time for the listener to
+    /// bind and the time to answer, so a slow cold-launch could exhaust the
+    /// whole budget before the listener even existed. Now a slow launch is
+    /// absorbed by `listenerBindTimeout` and the ping confirmation always gets
+    /// its full budget.
+    ///
+    /// Both phases poll observable conditions through `XCTNSPredicateExpectation`
+    /// instead of a hand-rolled deadline loop, so each waits only as long as it
+    /// needs to and never longer than its bound.
+    ///
+    /// - Parameters:
+    ///   - listenerBindTimeout: Maximum time to wait for the socket file to
+    ///     appear (the listener-bound signal). Generous on purpose so a slow
+    ///     launch does not eat the ping budget; only hit on a genuine bind
+    ///     failure.
+    ///   - pingTimeout: Fresh budget for the `ping` -> `PONG` round trip once
+    ///     the listener has bound.
+    ///   - socketFileExists: Returns true once the listener's socket file is on
+    ///     disk. A closure (not a path) so callers that resolve among several
+    ///     candidate paths can report "any candidate exists".
+    ///   - pingReturnsPong: Returns true when a `ping` to the listener answered
+    ///     `PONG`.
+    /// - Returns: `true` only when both phases complete.
+    func waitForControlSocketReady(
+        listenerBindTimeout: TimeInterval = 60.0,
+        pingTimeout: TimeInterval,
+        socketFileExists: @escaping () -> Bool,
+        pingReturnsPong: @escaping () -> Bool
+    ) -> Bool {
+        let bound = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in socketFileExists() },
+            object: nil
+        )
+        guard XCTWaiter().wait(for: [bound], timeout: listenerBindTimeout) == .completed else {
+            return false
+        }
+
+        let responsive = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in pingReturnsPong() },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [responsive], timeout: pingTimeout) == .completed
+    }
+
+    /// Convenience wrapper of ``waitForControlSocketReady(listenerBindTimeout:pingTimeout:socketFileExists:pingReturnsPong:)``
+    /// for the common single-path case: the listener-bound signal is simply the
+    /// file at `socketPath` appearing. `pingReturnsPong` is a trailing closure
+    /// so call sites stay as terse as the previous single-budget poll.
+    func waitForControlSocketReady(
+        socketPath: String,
+        listenerBindTimeout: TimeInterval = 60.0,
+        pingTimeout: TimeInterval,
+        pingReturnsPong: @escaping () -> Bool
+    ) -> Bool {
+        waitForControlSocketReady(
+            listenerBindTimeout: listenerBindTimeout,
+            pingTimeout: pingTimeout,
+            socketFileExists: { FileManager.default.fileExists(atPath: socketPath) },
+            pingReturnsPong: pingReturnsPong
+        )
+    }
+}

--- a/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
+++ b/cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
@@ -1245,7 +1245,7 @@ final class SplitCloseRightBlankRegressionUITests: XCTestCase {
     // MARK: - Automation Socket Client (UI Tests)
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
-        waitForCondition(timeout: timeout) {
+        waitForControlSocketReady(socketPath: socketPath, pingTimeout: timeout) {
             self.socketCommand("ping") == "PONG"
         }
     }

--- a/cmuxUITests/SidebarHelpMenuUITests.swift
+++ b/cmuxUITests/SidebarHelpMenuUITests.swift
@@ -980,8 +980,8 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
     }
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
-        sidebarHelpPollUntil(timeout: timeout) {
-            socketCommand("ping") == "PONG"
+        waitForControlSocketReady(socketPath: socketPath, pingTimeout: timeout) {
+            self.socketCommand("ping") == "PONG"
         }
     }
 

--- a/cmuxUITests/SidebarPullRequestInteractivityUITests.swift
+++ b/cmuxUITests/SidebarPullRequestInteractivityUITests.swift
@@ -171,8 +171,8 @@ final class SidebarPullRequestInteractivityUITests: XCTestCase {
     }
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
-        pollUntil(timeout: timeout) {
-            socketCommand("ping") == "PONG"
+        waitForControlSocketReady(socketPath: socketPath, pingTimeout: timeout) {
+            self.socketCommand("ping") == "PONG"
         }
     }
 


### PR DESCRIPTION
## Problem

The XCUITest control-socket readiness helper `waitForSocketPong` polled `ping -> PONG` under a single fixed timeout (usually 12s) that had to cover **both** the time for the app's control listener to bind **and** the time for it to answer. On hosted EC2 runners a slow app cold-launch consumed most of that budget before the listener bound, so the poll timed out and the test failed with `Expected control socket at <path>` even though nothing was broken (a same-commit rerun passed). Most recently flaked `BrowserPaneNavigationKeybindUITests/testCmdFOpensBrowserFindAfterCmdDCmdLNavigation` on 2026-06-10.

The failure is a timing race, not a missing condition: the wait for the app to come up and the wait for the socket to be ready competed for one budget.

## Fix (event-based, not a bigger number)

Split readiness into two event-driven phases in a shared `XCTestCase.waitForControlSocketReady` helper (`cmuxUITests/ControlSocketReadinessUITestSupport.swift`):

1. **Listener bound.** Wait (generous bound, default 60s) for the listener to bind, observed as the Unix-domain socket **file appearing on disk**. The server creates that file with `bind(2)` before it accepts, and each test binds a unique per-run socket path that it removes in `setUp`, so the file appearing is a real "this app instance bound" signal, not a sleep.
2. **Accepting and responsive.** With the listener bound, wait with a **fresh** ping budget for `ping -> PONG`.

A slow launch is now absorbed by the bind phase instead of starving the ping budget, and the ping confirmation always gets its full timeout. Both phases poll observable conditions through `XCTNSPredicateExpectation`, so each waits only as long as it needs.

## Scope

All `waitForSocketPong` call sites route through the one shared helper, so every test benefits rather than just the one that flaked:

- Simple ping pollers (`BrowserPaneNavigationKeybindUITests`, `MenuKeyEquivalentRoutingUITests`, `SidebarHelpMenuUITests`, `SidebarPullRequestInteractivityUITests`) now use the two-phase helper directly.
- Candidate-path resolvers (`AutomationSocketUITests`, `CloseWorkspacesConfirmDialogUITests`) keep their multi-path resolution but gain the same two-phase budget. `AutomationSocketUITests`' socket-recreation test in particular is now more robust: it waits for the recreated file, then pings.
- `MultiWindowNotificationsUITests` is intentionally left as-is: it already gates on `resolveSocketPath` (file-exists + ping) first, and its `waitForSocketPong` is a `String`-returning short re-probe, not the racing readiness gate.

No assertions weakened, no sleeps added, no timeout merely inflated. The assertions still fail (just after a longer, bounded wait) if the listener genuinely never binds, so the test still catches a real regression.

## Reliability

Before/after targeted hosted runs of the flaky test are recorded in a comment below.

Closes https://github.com/manaflow-ai/cmux/issues/5414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783709385&installation_id=133855650&pr_number=5812&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5812&signature=dfb88943a79dbb84d91525ffd2491aedc5fe2ed45e4a9befd7b8e21ee1f7ee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes control-socket UI tests by splitting readiness into two phases: wait for the listener to bind (socket file appears), then ping with a fresh timeout. Adds a shared `waitForControlSocketReady` and updates ping call sites for consistent, reliable waits. Closes #5414.

- **Bug Fixes**
  - Two-phase readiness with separate timeouts; slow CI cold launches no longer exhaust the ping budget.
  - New `XCTestCase.waitForControlSocketReady`; candidate-path tests now resolve on bind, then ping.
  - Uses `XCTNSPredicateExpectation`; no sleeps or inflated timeouts; assertions unchanged.

<sup>Written for commit 5c0cac3f91a31805efd52891c1653d910b3a24b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new shared UI test helper for control-socket readiness and updated multiple UI tests to use it.
* **Chores**
  * Project/test configuration updated to include the new test support file.

Note: No user-facing changes; updates are limited to internal test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->