### PR TITLE
web: bypass next/image optimizer for hero logo (Safari broken-image fix)

### DIFF
--- a/web/app/[locale]/components/download-confirmation.tsx
+++ b/web/app/[locale]/components/download-confirmation.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { DOWNLOAD_URL, DOWNLOAD_INTENT_PARAM } from "../../lib/download";
 import { OfficialLinks } from "./official-links";
@@ -50,7 +49,17 @@ export function DownloadConfirmation() {
     <main className="mx-auto w-full max-w-6xl px-6 py-16 sm:py-20">
       {/* Hero */}
       <div className="flex flex-col items-center text-center">
-        <Image
+        {/* Plain <img> (raw PNG), not next/image, on purpose. The 34 KB
+            256×256 logo shown at 48px gains nothing from the optimizer, and
+            routing it through /_next/image broke this hero in Safari while
+            Chrome rendered it (issue #5819): WebKit's HTTP cache mishandles the
+            optimizer's `Vary: Accept` responses (compounded by the `priority`
+            preload and `?dpl=`-pinned URLs across deploys), surfacing the
+            broken-image glyph. The site header already serves /logo.png as a
+            plain <img> and renders fine in Safari — this matches it.
+            fetchPriority="high" preserves the above-the-fold load hint that
+            `priority` provided. */}
+        <img
           // Decorative: the heading below already names the product, so an
           // empty alt avoids an untranslated string for screen readers.
           src="/logo.png"
@@ -58,7 +67,7 @@ export function DownloadConfirmation() {
           width={48}
           height={48}
           className="rounded-xl"
-          priority
+          fetchPriority="high"
         />
         <h1 className="mt-6 text-2xl sm:text-3xl font-semibold tracking-tight">
           {t("heading")}

--- a/web/app/[locale]/deeplink/[kind]/page.tsx
+++ b/web/app/[locale]/deeplink/[kind]/page.tsx
@@ -1,5 +1,4 @@
 import { getTranslations } from "next-intl/server";
-import Image from "next/image";
 import { notFound } from "next/navigation";
 import { buildAlternates } from "../../../../i18n/seo";
 import { Link } from "../../../../i18n/navigation";
@@ -326,7 +325,12 @@ export default async function DeeplinkPage({
       <SiteHeader section={t("section")} />
       <main className="mx-auto w-full max-w-2xl px-6 py-12">
         <div className="mb-8 flex items-center gap-4">
-          <Image
+          {/* Plain <img> (raw PNG), not next/image, on purpose — same
+              optimizer-bypass as the download confirmation hero (issue #5819).
+              The small logo gains nothing from /_next/image, and the optimizer
+              indirection broke the logo in Safari (WebKit `Vary: Accept` cache
+              mishandling). Matches the plain <img> the site header uses. */}
+          <img
             src="/logo.png"
             alt=""
             width={44}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5819

## Problem

On `https://cmux.com/download/confirmation` ("Thanks for downloading cmux!"), the hero cmux logo rendered as Safari's broken-image placeholder (blue "?" glyph) while Chrome rendered it fine.

The logo was served via `next/image` with `priority`, producing a `/_next/image?url=%2Flogo.png&…&dpl=…` optimizer URL with a `srcset` and a `<link rel=preload>`. The server output is healthy — per the issue's diagnostics (and re-confirmed below), the optimizer returns a valid `200 image/webp` for both Chrome's and Safari's `Accept` profiles. The failure is in the **optimizer-indirection / cache layer**, specific to Safari/WebKit:

- WebKit's HTTP cache mishandles `Vary: Accept` image responses,
- compounded by the `priority` preload matching and `?dpl=`-pinned URLs that go stale across deploys.

Strong supporting evidence already in the issue: the site header on the *same page* serves `/logo.png` as a **plain `<img>`** and renders fine in Safari — so the asset is fine; the optimizer indirection is the failing layer.

## Fix

Bypass the optimizer for the hero logo: render the raw `/logo.png` as a plain `<img>`, matching what the site header already does. A 34 KB 256×256 PNG shown at 48px gains nothing from `/_next/image`, and bypassing it eliminates the entire `Vary`/preload/`dpl` failure class in one move. `fetchPriority="high"` preserves the above-the-fold load hint that `priority` provided.

Applied to the two `next/image`-on-`/logo.png` small-logo instances:
- `web/app/[locale]/components/download-confirmation.tsx` (the reported page)
- `web/app/[locale]/deeplink/[kind]/page.tsx` (identical pattern, same exposure)

Preserved exactly: rendered size (48 / 44 px), `rounded-xl` corners, decorative empty `alt`, and the auto-download `useEffect` logic (untouched).

Other `next/image priority` usages on the site (`page.tsx`, `docs/changelog`, `assets`) render large static-imported screenshots, not the small `/logo.png` hero — they are a different class and genuinely benefit from optimization, so they are intentionally left alone. A broader image-pipeline review is out of scope here.

## Reproduction / characterization

Per the issue, this is a Safari **cache-poisoning-dependent** bug: a clean profile won't reproduce the poisoned state. I drove a headless WebKit (Playwright) against production `https://cmux.com/download/confirmation`:

- WebKit loaded the optimizer image fine: `/_next/image?url=%2Flogo.png&w=48…` → `200 image/webp`, `naturalWidth=48`, `complete=true`.

This confirms the issue's caveat — clean-profile WebKit can't reproduce the cache-poisoned failure, but it confirms the **server output is healthy** and the failure lives in the optimizer/cache indirection layer. The defensive bypass removes that layer for the logo entirely, so the failure class cannot recur regardless of cache state.

## Tests

web/ has no Playwright/e2e infrastructure (the `test` script is `bun test`, unit only). Adding e2e infra solely to assert this logo loads would be disproportionate, so no failing-test-first commit is included — stating that plainly rather than faking a test. Verification is done on the Vercel preview in a WebKit engine (evidence to follow in a comment).

## Verification

- `tsc --noEmit`: clean.
- `eslint` on changed files: no errors (the `@next/next/no-img-element` warning is the same pre-existing, accepted warning the site header's `<img>` already produces — no new error class).
- Vercel preview WebKit verification: to be attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716049&installation_id=133855650&pr_number=5820&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5820&signature=6ef83a4c04dbd6f1677d3e308322b5a1680936310f999fab18e5fa6ddff7d2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass the `next/image` optimizer for the hero logo to fix Safari showing a broken image on the download confirmation and deeplink pages. Serve `/logo.png` as a plain <img> to avoid WebKit `Vary: Accept` cache issues while keeping the load hint. Fixes #5819.

- **Bug Fixes**
  - Replaced `next/image` with `<img src="/logo.png" fetchPriority="high">` on both pages.
  - Kept sizes (48/44), `rounded-xl`, and empty `alt`.
  - Left other `next/image` usages (large screenshots) unchanged.

<sup>Written for commit eb577ebdf62569f811ebf84b70b3c9aacc6987f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized logo rendering in download confirmation and deeplink pages to improve cross-browser compatibility and display reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->