### PR TITLE
Custom sidebars: project PR context from per-panel state, not the focused-panel mirror

### DIFF
--- a/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarValidator.swift
+++ b/Packages/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Sidebar/CustomSidebarValidator.swift
@@ -157,6 +157,7 @@ public struct CustomSidebarValidator {
                 "branch": .string("main"),
                 "dirty": .bool(false),
                 "pr": .string(""),
+                "prs": .array([]),
                 "progress": .string(""),
                 "latestMessage": .string(""),
                 "latestPrompt": .string(""),

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10737,16 +10737,10 @@ struct VerticalTabsSidebar: View {
             fields["branch"] = .string(git.branch)
             fields["dirty"] = .bool(git.isDirty)
         }
-        if let pr = workspace.pullRequest {
-            var prFields: [String: SwiftValue] = [
-                "number": .int(pr.number),
-                "label": .string(pr.label),
-                "url": .string(pr.url.absoluteString),
-                "status": .string(pr.status.rawValue),
-                "stale": .bool(pr.isStale),
-            ]
-            if let prBranch = pr.branch { prFields["branch"] = .string(prBranch) }
-            fields["pr"] = .object(prFields)
+        let pullRequestValues = workspace.customSidebarPullRequestValues()
+        if let firstPullRequest = pullRequestValues.first {
+            fields["pr"] = firstPullRequest
+            fields["prs"] = .array(pullRequestValues)
         }
         if let progress = workspace.progress {
             var progressFields: [String: SwiftValue] = ["value": .double(progress.value)]

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10733,7 +10733,7 @@ struct VerticalTabsSidebar: View {
         ]
         if let description = workspace.customDescription, !description.isEmpty { fields["description"] = .string(description) }
         if let color = workspace.customColor, !color.isEmpty { fields["color"] = .string(color) }
-        if let git = workspace.gitBranch {
+        if let git = workspace.sidebarGitBranchesInDisplayOrder().first {
             fields["branch"] = .string(git.branch)
             fields["dirty"] = .bool(git.isDirty)
         }
@@ -11868,7 +11868,7 @@ struct VerticalTabsSidebar: View {
             isPinned: workspace.isPinned,
             rootPath: rootPath,
             projectRootPath: workspace.extensionSidebarProjectRootPath,
-            branchSummary: workspace.gitBranch?.branch,
+            branchSummary: workspace.sidebarGitBranchesInDisplayOrder().first?.branch,
             remoteDisplayTarget: workspace.remoteDisplayTarget,
             remoteConnectionState: workspace.remoteConnectionState.rawValue,
             unreadCount: notificationStore.unreadCount(forTabId: workspace.id),

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4372,7 +4372,7 @@ class TerminalController {
             "pinned": workspace.isPinned,
             "root_path": v2OrNull(rootPath),
             "project_root_path": v2OrNull(projectRootPath),
-            "branch_summary": v2OrNull(workspace.gitBranch?.branch),
+            "branch_summary": v2OrNull(workspace.sidebarGitBranchesInDisplayOrder().first?.branch),
             "remote_display_target": v2OrNull(workspace.remoteDisplayTarget),
             "remote_connection_state": workspace.remoteConnectionState.rawValue,
             "remote": workspace.remoteStatusPayload(),

--- a/Sources/Workspace+CustomSidebarPullRequests.swift
+++ b/Sources/Workspace+CustomSidebarPullRequests.swift
@@ -3,21 +3,22 @@ import Foundation
 
 extension Workspace {
     /// Pull-request values projected for the custom-sidebar interpreter
-    /// context (`workspaces[i].pr` / `workspaces[i].prs`).
+    /// context (`workspaces[i].pr` / `workspaces[i].prs`). Reads the per-panel
+    /// pull-request state in sidebar display order rather than the
+    /// focused-panel `pullRequest` mirror: the mirror only refreshes while its
+    /// panel is focused, so it is routinely nil for background workspaces that
+    /// do have a known open PR.
     func customSidebarPullRequestValues() -> [SwiftValue] {
-        guard let pullRequest else { return [] }
-        return [Self.customSidebarPullRequestValue(pullRequest)]
-    }
-
-    private static func customSidebarPullRequestValue(_ pullRequest: SidebarPullRequestState) -> SwiftValue {
-        var fields: [String: SwiftValue] = [
-            "number": .int(pullRequest.number),
-            "label": .string(pullRequest.label),
-            "url": .string(pullRequest.url.absoluteString),
-            "status": .string(pullRequest.status.rawValue),
-            "stale": .bool(pullRequest.isStale),
-        ]
-        if let branch = pullRequest.branch { fields["branch"] = .string(branch) }
-        return .object(fields)
+        sidebarPullRequestsInDisplayOrder().map { pullRequest in
+            var fields: [String: SwiftValue] = [
+                "number": .int(pullRequest.number),
+                "label": .string(pullRequest.label),
+                "url": .string(pullRequest.url.absoluteString),
+                "status": .string(pullRequest.status.rawValue),
+                "stale": .bool(pullRequest.isStale),
+            ]
+            if let branch = pullRequest.branch { fields["branch"] = .string(branch) }
+            return .object(fields)
+        }
     }
 }

--- a/Sources/Workspace+CustomSidebarPullRequests.swift
+++ b/Sources/Workspace+CustomSidebarPullRequests.swift
@@ -1,0 +1,23 @@
+import CmuxSwiftRender
+import Foundation
+
+extension Workspace {
+    /// Pull-request values projected for the custom-sidebar interpreter
+    /// context (`workspaces[i].pr` / `workspaces[i].prs`).
+    func customSidebarPullRequestValues() -> [SwiftValue] {
+        guard let pullRequest else { return [] }
+        return [Self.customSidebarPullRequestValue(pullRequest)]
+    }
+
+    private static func customSidebarPullRequestValue(_ pullRequest: SidebarPullRequestState) -> SwiftValue {
+        var fields: [String: SwiftValue] = [
+            "number": .int(pullRequest.number),
+            "label": .string(pullRequest.label),
+            "url": .string(pullRequest.url.absoluteString),
+            "status": .string(pullRequest.status.rawValue),
+            "stale": .bool(pullRequest.isStale),
+        ]
+        if let branch = pullRequest.branch { fields["branch"] = .string(branch) }
+        return .object(fields)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 		807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */; };
 		D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */; };
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
+		9FC97DA1B422776BB1EEC821 /* Workspace+CustomSidebarPullRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */; };
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
@@ -697,6 +698,7 @@
 		D7AB3605C10DEF0000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
 		F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
+		281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */; };
 		E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 		C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */; };
 		C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */; };
@@ -1419,6 +1421,7 @@
 		0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowGlassEffect.swift; sourceTree = "<group>"; };
 		D0B10025A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowInputRoutingContext.swift; sourceTree = "<group>"; };
 		A5001219 /* WindowToolbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowToolbarController.swift; sourceTree = "<group>"; };
+		42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPullRequests.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
@@ -1433,6 +1436,7 @@
 		D7AB3605C10DEF0000000002 /* WorkspaceCloseTabsContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCloseTabsContextMenuTests.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+		CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomSidebarPullRequestContextTests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFinderDirectoryResolver.swift; sourceTree = "<group>"; };
 		C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupMenuSnapshot.swift; sourceTree = "<group>"; };
@@ -1805,6 +1809,7 @@
 				5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */,
 				D7AB3605C10DEF0000000004 /* WorkspaceCloseTabsBatching.swift */,
 				C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */,
+				42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */,
 				E30780000000000000000001 /* WorkspaceRemoteConfiguration.swift */,
 				D0C0D0C0D0C0D0C0D0C00002 /* RemoteLoopbackProxyAlias.swift */,
 				D0C0D0C0D0C0D0C0D0C00004 /* RemoteLoopbackRuntimeBridge.swift */,
@@ -2189,6 +2194,7 @@
 				D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */,
 				C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */,
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
+				CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */,
 				71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */,
 				EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */,
 				F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */,
@@ -3075,6 +3081,7 @@
 				807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */,
 				D0B10024A1B2C3D4E5F60001 /* WindowInputRoutingContext.swift in Sources */,
 				A5001209 /* WindowToolbarController.swift in Sources */,
+				9FC97DA1B422776BB1EEC821 /* Workspace+CustomSidebarPullRequests.swift in Sources */,
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
@@ -3359,6 +3366,7 @@
 				A11EAE000000000000000000 /* WorkspaceAppearanceConfigResolutionTests.swift in Sources */,
 				D7AB3605C10DEF0000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */,
 				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+				281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */,
 				C9A57001C9A57001C9A57001 /* WorkspaceGroupTests.swift in Sources */,
 				0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,

--- a/cmuxTests/WorkspaceCustomSidebarPullRequestContextTests.swift
+++ b/cmuxTests/WorkspaceCustomSidebarPullRequestContextTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+import CmuxSwiftRender
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class WorkspaceCustomSidebarPullRequestContextTests: XCTestCase {
+    @MainActor
+    func testValuesIncludePanelPullRequestWhenFocusedPanelMirrorIsNil() throws {
+        let workspace = Workspace(
+            title: "Tests",
+            workingDirectory: FileManager.default.currentDirectoryPath,
+            portOrdinal: 0
+        )
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        workspace.updatePanelPullRequest(
+            panelId: panelId,
+            number: 5314,
+            label: "PR",
+            url: URL(string: "https://github.com/manaflow-ai/cmux/pull/5314")!,
+            status: .open
+        )
+        // The focused-panel `pullRequest` mirror only refreshes while its panel
+        // is focused, so live sessions routinely hold panel pull requests with a
+        // nil mirror. The interpreter context must project from the per-panel
+        // state, not the mirror.
+        workspace.pullRequest = nil
+
+        let values = workspace.customSidebarPullRequestValues()
+        XCTAssertEqual(values.count, 1)
+        guard case .object(let fields)? = values.first else {
+            XCTFail("Expected object pull-request value, got \(String(describing: values.first))")
+            return
+        }
+        XCTAssertEqual(fields["number"], .int(5314))
+        XCTAssertEqual(fields["status"], .string("open"))
+        XCTAssertEqual(fields["url"], .string("https://github.com/manaflow-ai/cmux/pull/5314"))
+        XCTAssertEqual(fields["stale"], .bool(false))
+    }
+
+    @MainActor
+    func testValuesEmptyWhenWorkspaceHasNoPullRequests() {
+        let workspace = Workspace(
+            title: "Tests",
+            workingDirectory: FileManager.default.currentDirectoryPath,
+            portOrdinal: 0
+        )
+
+        XCTAssertEqual(workspace.customSidebarPullRequestValues(), [])
+    }
+}

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -77,7 +77,9 @@ Then right-click the sidebar button and choose **mine**.
   (array of Int) + `portCount`, `unread` (Int notifications), `tabs` + `tabCount`.
   Present when the workspace has them (use `if let` / ternary): `description`,
   `color` (hex), `branch` + `dirty` (Bool) from git, `pr`
-  (`{ number, label, url, status: open|merged|closed, stale, branch }`),
+  (`{ number, label, url, status: open|merged|closed, stale, branch }`, the
+  workspace's first pull request in sidebar display order) + `prs` (array of
+  the same shape with every pull request cmux knows for the workspace),
   `progress` (`{ value: 0..1, label }`), `latestMessage` (last agent message),
   `latestPrompt` (last submitted prompt), `latestAt` (epoch), `remote`
   (`{ target, state, connected }`).


### PR DESCRIPTION
Custom-sidebar templates read `workspaces[i].pr` to know a workspace's pull-request state, but the interpreter context projected it from `Workspace.pullRequest`, a focused-panel mirror that only refreshes while its panel is focused. In live sessions the mirror is routinely nil for background workspaces whose `panelPullRequests` hold a known open PR, so status-style sidebars (e.g. a review-lane board) silently miss workspaces that are in review. The native sidebar pills and `cmux sidebar-state` already read the per-panel list and disagree with the interpreter context on the same workspace.

Fix: project the context from `sidebarPullRequestsInDisplayOrder()` (the same per-panel, display-ordered, branch-validated list the native pills use). `pr` stays the first entry for backward compatibility, and a new `prs` array exposes every PR cmux knows for the workspace. The projection lives in a new `Workspace.customSidebarPullRequestValues()` seam so it is unit-testable; the validator's representative context and `docs/custom-sidebars.md` are updated for `prs`.

Two-commit structure: the first commit adds the extraction seam (behavior unchanged, still mirror-based) plus the regression test, which fails red on CI; the second commit switches the seam to the per-panel list and goes green.

Localization audit: no user-facing strings changed (interpreter data fields, validator sample context, and an engineering doc only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716836&installation_id=133855650&pr_number=5823&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5823&signature=f7fc46ad2699536d59945af3b40144a547c4787ce90a1218c690ecc2b0601342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom sidebar PR and branch context to use per-panel state in display order, matching the native sidebar and preventing missed PRs or stale branch info in background workspaces. Adds `prs` to the interpreter context while keeping `pr` as the first entry for compatibility.

- **Bug Fixes**
  - Project PRs from `sidebarPullRequestsInDisplayOrder()` instead of the focused-panel mirror.
  - Read git branch from `sidebarGitBranchesInDisplayOrder().first` for custom-sidebar `branch`/`dirty`, provider `branchSummary`, and v2 `branch_summary`.
  - Add `Workspace.customSidebarPullRequestValues()` seam with tests; update validator sample context and `docs/custom-sidebars.md`.

<sup>Written for commit 0c264c6e4f9eb774366fcd510ea5580698a8c462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar now exposes an ordered list of pull requests (prs) and a primary pr for display, including number, status, URL, branch when present, and staleness.

* **Tests**
  * Added tests covering sidebar pull-request values, including focused-panel nil and no-pull-request scenarios.

* **Documentation**
  * Clarified workspace pr and prs data shape.

* **Chores**
  * Validation defaults now include an empty prs array.

* **Bug Fixes**
  * Workspace branch summary and serialized payload now derive from sidebar branch ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Verification note:** the hosted `tests` job cannot prove the red/green structure: its full-suite step hits the 900s `CMUX_UNIT_TEST_TIMEOUT_SECONDS` around the alphabetically-early suites and passes anyway, so `cmuxTests/Workspace*` classes (including this PR's regression test) never execute there. The red/green proof for `WorkspaceCustomSidebarPullRequestContextTests` was run as targeted `xcodebuild test -only-testing:` invocations on the AWS M4 Pro builder against both commits; results posted in a PR comment. The suite-truncation gap itself is being filed separately.
