### PR TITLE
Fix light themes rendering white-on-white terminals (#3459)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -6,7 +6,7 @@
 19820	Sources/Workspace.swift
 19209	Sources/ContentView.swift
 18044	Sources/AppDelegate.swift
-16537	Sources/GhosttyTerminalView.swift
+16539	Sources/GhosttyTerminalView.swift
 13589	Sources/Panels/BrowserPanel.swift
 11916	cmuxTests/AppDelegateShortcutRoutingTests.swift
 9939	Sources/TabManager.swift
@@ -14,7 +14,7 @@
 7737	Sources/Panels/BrowserPanelView.swift
 7198	cmuxTests/WorkspaceUnitTests.swift
 6948	cmuxTests/WorkspaceRemoteConnectionTests.swift
-6521	cmuxTests/GhosttyConfigTests.swift
+6542	cmuxTests/GhosttyConfigTests.swift
 6299	cmuxTests/TerminalAndGhosttyTests.swift
 6220	cmuxTests/SessionPersistenceTests.swift
 6119	CLI/cmux_open.swift
@@ -79,7 +79,7 @@
 1084	cmuxTests/AgentHibernationTests.swift
 1068	cmuxTests/FileExplorerStoreTests.swift
 1058	cmuxUITests/BonsplitTabDragUITests.swift
-1070	Sources/GhosttyConfig.swift
+1096	Sources/GhosttyConfig.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift
 1000	cmuxTests/CmuxTopSnapshotScopeTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -14,7 +14,7 @@
 7737	Sources/Panels/BrowserPanelView.swift
 7198	cmuxTests/WorkspaceUnitTests.swift
 6948	cmuxTests/WorkspaceRemoteConnectionTests.swift
-6469	cmuxTests/GhosttyConfigTests.swift
+6521	cmuxTests/GhosttyConfigTests.swift
 6299	cmuxTests/TerminalAndGhosttyTests.swift
 6220	cmuxTests/SessionPersistenceTests.swift
 6119	CLI/cmux_open.swift
@@ -79,7 +79,7 @@
 1084	cmuxTests/AgentHibernationTests.swift
 1068	cmuxTests/FileExplorerStoreTests.swift
 1058	cmuxUITests/BonsplitTabDragUITests.swift
-1048	Sources/GhosttyConfig.swift
+1070	Sources/GhosttyConfig.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift
 1000	cmuxTests/CmuxTopSnapshotScopeTests.swift

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -809,6 +809,28 @@ struct GhosttyConfig {
         return rawThemeValue.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Returns true when the raw `theme` value uses ghostty's conditional
+    /// `light:...`/`dark:...` syntax. cmux must resolve and inject a plain
+    /// `theme = X` override for these values because ghostty mis-applies the
+    /// conditional form (background lands but the foreground/palette stay at the
+    /// default colors). See https://github.com/manaflow-ai/cmux/issues/3459.
+    static func themeValueUsesConditionalThemeSyntax(_ rawThemeValue: String) -> Bool {
+        for token in rawThemeValue.split(separator: ",").map(String.init) {
+            let entry = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !entry.isEmpty else { continue }
+
+            let parts = entry.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if (key == "light" || key == "dark"), !value.isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+
     static func themeValueUsesSameResolvedThemeInBothColorSchemes(_ rawThemeValue: String) -> Bool {
         let lightTheme = resolveThemeName(from: rawThemeValue, preferredColorScheme: .light)
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -809,12 +809,25 @@ struct GhosttyConfig {
         return rawThemeValue.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    /// Returns true when the raw `theme` value uses ghostty's conditional
-    /// `light:...`/`dark:...` syntax. cmux must resolve and inject a plain
-    /// `theme = X` override for these values because ghostty mis-applies the
-    /// conditional form (background lands but the foreground/palette stay at the
-    /// default colors). See https://github.com/manaflow-ai/cmux/issues/3459.
-    static func themeValueUsesConditionalThemeSyntax(_ rawThemeValue: String) -> Bool {
+    /// Returns the theme name that the raw `theme` value *explicitly* assigns to
+    /// `preferredColorScheme` via ghostty's conditional `light:...`/`dark:...`
+    /// syntax, or `nil` when that side is not conditionally specified.
+    ///
+    /// Unlike ``resolveThemeName(from:preferredColorScheme:)``, this performs no
+    /// cross-side fallback: `light:X` (with no `dark:` token) returns `X` for
+    /// `.light` and `nil` for `.dark`. cmux injects a resolved plain `theme = X`
+    /// override only for explicitly specified sides, because ghostty mis-applies
+    /// the conditional form (the background lands but the foreground/palette stay
+    /// at the default colors — see
+    /// https://github.com/manaflow-ai/cmux/issues/3459). Injecting for an unset
+    /// side would clobber the user's inherited/default theme for that appearance.
+    static func explicitConditionalThemeName(
+        from rawThemeValue: String,
+        preferredColorScheme: ColorSchemePreference
+    ) -> String? {
+        var lightTheme: String?
+        var darkTheme: String?
+
         for token in rawThemeValue.split(separator: ",").map(String.init) {
             let entry = token.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !entry.isEmpty else { continue }
@@ -824,11 +837,24 @@ struct GhosttyConfig {
 
             let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            if (key == "light" || key == "dark"), !value.isEmpty {
-                return true
+            guard !value.isEmpty else { continue }
+
+            switch key {
+            case "light":
+                if lightTheme == nil { lightTheme = value }
+            case "dark":
+                if darkTheme == nil { darkTheme = value }
+            default:
+                continue
             }
         }
-        return false
+
+        switch preferredColorScheme {
+        case .light:
+            return lightTheme
+        case .dark:
+            return darkTheme
+        }
     }
 
     static func themeValueUsesSameResolvedThemeInBothColorSchemes(_ rawThemeValue: String) -> Bool {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2859,17 +2859,16 @@ class GhosttyApp {
         let summary = userAppearanceConfigSummary(configPaths: configPaths)
         guard let rawThemeValue = summary.lastThemeDirective else { return nil }
 
-        let lightTheme = GhosttyConfig.resolveThemeName(
-            from: rawThemeValue,
-            preferredColorScheme: .light
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
-        let darkTheme = GhosttyConfig.resolveThemeName(
-            from: rawThemeValue,
-            preferredColorScheme: .dark
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !lightTheme.isEmpty,
-              !darkTheme.isEmpty,
-              lightTheme.caseInsensitiveCompare(darkTheme) != .orderedSame else {
+        // Inject a resolved plain theme whenever the value uses ghostty's
+        // conditional `light:...`/`dark:...` syntax, even when both sides resolve
+        // to the same theme. `cmux themes set` always encodes the selection with
+        // this syntax (a single theme becomes `light:X,dark:X`), and ghostty
+        // mis-applies the conditional form — the background lands but the
+        // foreground/palette stay at the default white colors, producing the
+        // white-on-light terminals reported in
+        // https://github.com/manaflow-ai/cmux/issues/3459. Plain (non-conditional)
+        // theme values are applied correctly by ghostty, so they need no override.
+        guard GhosttyConfig.themeValueUsesConditionalThemeSyntax(rawThemeValue) else {
             return nil
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2859,23 +2859,26 @@ class GhosttyApp {
         let summary = userAppearanceConfigSummary(configPaths: configPaths)
         guard let rawThemeValue = summary.lastThemeDirective else { return nil }
 
-        // Inject a resolved plain theme whenever the value uses ghostty's
-        // conditional `light:...`/`dark:...` syntax, even when both sides resolve
-        // to the same theme. `cmux themes set` always encodes the selection with
-        // this syntax (a single theme becomes `light:X,dark:X`), and ghostty
-        // mis-applies the conditional form — the background lands but the
-        // foreground/palette stay at the default white colors, producing the
-        // white-on-light terminals reported in
-        // https://github.com/manaflow-ai/cmux/issues/3459. Plain (non-conditional)
-        // theme values are applied correctly by ghostty, so they need no override.
-        guard GhosttyConfig.themeValueUsesConditionalThemeSyntax(rawThemeValue) else {
+        // Inject a resolved plain theme whenever the requested appearance side is
+        // explicitly named via ghostty's conditional `light:...`/`dark:...`
+        // syntax, even when both sides resolve to the same theme. `cmux themes
+        // set` always encodes the selection with this syntax (a single theme
+        // becomes `light:X,dark:X`), and ghostty mis-applies the conditional form
+        // — the background lands but the foreground/palette stay at the default
+        // white colors, producing the white-on-light terminals reported in
+        // https://github.com/manaflow-ai/cmux/issues/3459. Only override sides the
+        // value explicitly specifies: a one-sided `light:X` must not force the
+        // light theme onto dark appearances (which would clobber the inherited or
+        // default dark theme). Plain (non-conditional) theme values are applied
+        // correctly by ghostty, so they need no override.
+        guard let explicitTheme = GhosttyConfig.explicitConditionalThemeName(
+            from: rawThemeValue,
+            preferredColorScheme: preferredColorScheme
+        ) else {
             return nil
         }
 
-        let resolvedTheme = GhosttyConfig.resolveThemeName(
-            from: rawThemeValue,
-            preferredColorScheme: preferredColorScheme
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTheme = explicitTheme.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !resolvedTheme.isEmpty,
               resolvedTheme.rangeOfCharacter(from: .newlines) == nil else {
             return nil

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4501,13 +4501,65 @@ final class GhosttyMouseFocusTests: XCTestCase {
         }
     }
 
-    func testConditionalThemeOverrideSkipsSameThemePair() throws {
+    // Regression: https://github.com/manaflow-ai/cmux/issues/3459
+    // `cmux themes set` always encodes the selection with conditional
+    // `light:...,dark:...` syntax, even when both sides are identical. Ghostty
+    // mis-applies that conditional syntax (background lands but foreground/palette
+    // stay at the white defaults), so cmux must inject the resolved plain theme
+    // even when the light and dark sides resolve to the same theme.
+    func testConditionalThemeOverrideResolvesSameThemePair() throws {
         try withTempConfig("theme = light:Catppuccin Mocha,dark:Catppuccin Mocha\n") { path in
-            XCTAssertNil(
+            XCTAssertEqual(
                 GhosttyApp.conditionalThemeOverrideConfigContents(
                     preferredColorScheme: .dark,
                     configPaths: [path]
-                )
+                ),
+                "theme = Catppuccin Mocha"
+            )
+        }
+    }
+
+    // Regression: https://github.com/manaflow-ai/cmux/issues/3459
+    // Exact repro from the issue body: selecting a single light theme for both
+    // sides must force ghostty to apply the light theme's dark-on-light
+    // foreground instead of leaving the default white foreground.
+    func testConditionalThemeOverrideResolvesIdenticalLightThemePairFromCLIEncoding() throws {
+        try withTempConfig("theme = light:GitHub Light Default,dark:GitHub Light Default\n") { path in
+            XCTAssertEqual(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .light,
+                    configPaths: [path]
+                ),
+                "theme = GitHub Light Default"
+            )
+            XCTAssertEqual(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .dark,
+                    configPaths: [path]
+                ),
+                "theme = GitHub Light Default"
+            )
+        }
+    }
+
+    // Regression: https://github.com/manaflow-ai/cmux/issues/3459
+    // `cmux themes set --light X` encodes `theme = light:X`, which ghostty treats
+    // as conditional config. cmux must still inject the resolved plain theme.
+    func testConditionalThemeOverrideResolvesLightOnlyConditionalTheme() throws {
+        try withTempConfig("theme = light:Catppuccin Latte\n") { path in
+            XCTAssertEqual(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .light,
+                    configPaths: [path]
+                ),
+                "theme = Catppuccin Latte"
+            )
+            XCTAssertEqual(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .dark,
+                    configPaths: [path]
+                ),
+                "theme = Catppuccin Latte"
             )
         }
     }

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4544,8 +4544,10 @@ final class GhosttyMouseFocusTests: XCTestCase {
 
     // Regression: https://github.com/manaflow-ai/cmux/issues/3459
     // `cmux themes set --light X` encodes `theme = light:X`, which ghostty treats
-    // as conditional config. cmux must still inject the resolved plain theme.
-    func testConditionalThemeOverrideResolvesLightOnlyConditionalTheme() throws {
+    // as conditional config. cmux injects the resolved plain theme for the
+    // explicitly named light side, but must NOT force it onto dark appearances
+    // (the dark side is unset and should keep the inherited/default dark theme).
+    func testConditionalThemeOverrideResolvesExplicitSideOnlyForOneSidedTheme() throws {
         try withTempConfig("theme = light:Catppuccin Latte\n") { path in
             XCTAssertEqual(
                 GhosttyApp.conditionalThemeOverrideConfigContents(
@@ -4554,12 +4556,31 @@ final class GhosttyMouseFocusTests: XCTestCase {
                 ),
                 "theme = Catppuccin Latte"
             )
+            XCTAssertNil(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .dark,
+                    configPaths: [path]
+                )
+            )
+        }
+    }
+
+    // Regression: https://github.com/manaflow-ai/cmux/issues/3459
+    // Mirror of the one-sided case for `theme = dark:Y` (only the dark side set).
+    func testConditionalThemeOverrideResolvesExplicitSideOnlyForDarkOnlyTheme() throws {
+        try withTempConfig("theme = dark:Catppuccin Mocha\n") { path in
             XCTAssertEqual(
                 GhosttyApp.conditionalThemeOverrideConfigContents(
                     preferredColorScheme: .dark,
                     configPaths: [path]
                 ),
-                "theme = Catppuccin Latte"
+                "theme = Catppuccin Mocha"
+            )
+            XCTAssertNil(
+                GhosttyApp.conditionalThemeOverrideConfigContents(
+                    preferredColorScheme: .light,
+                    configPaths: [path]
+                )
             )
         }
     }


### PR DESCRIPTION
Fixes #3459

## Problem

Switching to a light theme via `cmux themes set` (e.g. `GitHub Light Default`, `Xcode Light`) produced unreadable terminals: a light background with white/near-white foreground text. The background applied but the default foreground and most of the ANSI palette stayed white. This symptom has recurred repeatedly (#3511, #3523, #3827, #5165).

## Root cause

`cmux themes set` **always** encodes the selection with ghostty's conditional `light:...,dark:...` syntax — even a single theme is encoded as `theme = light:X,dark:X` (see `encodedThemeValue` in `CLI/CMUXCLI+Themes.swift`).

Ghostty mis-applies the conditional form: the **background** lands but the default **foreground and palette stay at ghostty's white defaults**. Because cmux *also* paints the terminal background via its own host layer — resolved correctly by the Swift config parser (`GhosttyConfig.load`) — the user sees a correctly-light background with white-on-white text rendered by ghostty's renderer.

cmux already works around ghostty's conditional-theme bug by injecting a resolved **plain** `theme = X` override (`conditionalThemeOverrideConfigContents`, added for #2922). But that injection was gated on the light and dark sides *differing*:

```swift
guard ..., lightTheme.caseInsensitiveCompare(darkTheme) != .orderedSame else { return nil }
```

The overwhelmingly common case — picking one theme for both sides — yields identical sides, so the override was **skipped** and ghostty was left to mis-render the conditional syntax. An explicit test (`testConditionalThemeOverrideSkipsSameThemePair`) even codified this incorrect behavior.

## Fix

Inject the resolved plain `theme = X` whenever the value uses conditional `light:`/`dark:` syntax, regardless of whether the two sides match. Plain (non-conditional) theme values are applied correctly by ghostty and still need no override.

- New `GhosttyConfig.themeValueUsesConditionalThemeSyntax(_:)` helper detects `light:`/`dark:` keys in the raw value.
- `conditionalThemeOverrideConfigContents` now gates on conditional-syntax presence instead of side equality.

The override runs in the shared config-load path (`loadDefaultConfigFilesWithLegacyFallback`), so the fix covers **new surfaces**, **already-open surfaces** (`reloadConfiguration` / `reloadSurfaceConfiguration`), and **post-restart** loads. Dark themes and plain single-theme values are unchanged.

## Tests (two-commit red/green)

1. Commit 1 adds regression tests asserting the resolved plain theme is injected for identical `light:X,dark:X` pairs and `light:X`-only values — these **fail** against `main`.
2. Commit 2 applies the fix — tests **pass**.

Tests live in `cmuxTests/GhosttyConfigTests.swift` (already wired into the `cmuxTests` target).

## Localization

No user-facing strings added or changed (code comments and an internal ghostty `theme = X` directive only). No localization audit entries required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783717248&installation_id=133855650&pr_number=5826&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5826&signature=d13fb8ce5e9d49936dff15b68b75797cdc5a4a0a171ead758412f04681bfab90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes white-on-white text in light themes by injecting a resolved plain `theme = X` for appearance sides explicitly set via `light:`/`dark:` conditional syntax. Applies to new and existing terminals and after restart; fixes #3459.

- **Bug Fixes**
  - Added `GhosttyConfig.explicitConditionalThemeName(...)` to read the theme explicitly assigned to the requested side.
  - Inject a resolved plain `theme = X` only for explicitly specified sides in `conditionalThemeOverrideConfigContents`; identical pairs still resolve, and unset sides are not forced.
  - Plain (non-conditional) values and dark themes remain unchanged.
  - Added regression tests for identical `light:X,dark:X`, `light:X`-only (light overrides, dark not), and `dark:Y`-only.

- **Dependencies**
  - Updated `.github/swift-file-length-budget.tsv` for `Sources/GhosttyConfig.swift`, `Sources/GhosttyTerminalView.swift`, and `cmuxTests/GhosttyConfigTests.swift`.

<sup>Written for commit a6cde874cce453aef3efcb84d5b925206ac078c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of conditional themes (light:/dark:) so the explicitly specified side now yields a plain resolved theme instead of being rejected—ensures consistent theme application for the active color-scheme and when both variants resolve to the same theme.
* **Tests**
  * Expanded regression tests to cover one-sided and paired conditional theme scenarios and their resolved outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->