### PR TITLE
Add a persistent default display for dev builds

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,11 +1,11 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-32873	CLI/cmux.swift
+32949	CLI/cmux.swift
 22426	Sources/TerminalController.swift
 19955	Sources/Workspace.swift
 19245	Sources/ContentView.swift
-18044	Sources/AppDelegate.swift
+18056	Sources/AppDelegate.swift
 16539	Sources/GhosttyTerminalView.swift
 13589	Sources/Panels/BrowserPanel.swift
 11916	cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -20,7 +20,7 @@
 6119	CLI/cmux_open.swift
 5948	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
-5439	Sources/cmuxApp.swift
+5448	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3016,6 +3016,17 @@ struct CMUXCLI {
             return
         }
 
+        // `window default-display` only reads/writes the shared dev setting file;
+        // it must work with no cmux running, so handle it before socket resolution.
+        if command == "window",
+           commandArgs.first?.lowercased() == "default-display" {
+            try runWindowDefaultDisplayCommand(
+                commandArgs: Array(commandArgs.dropFirst()),
+                jsonOutput: jsonOutput
+            )
+            return
+        }
+
         // Keep no-socket config subcommands on the early path. Socket-backed
         // config subcommands fall through to the resolved-socket dispatch below.
         if command == "config",
@@ -7126,6 +7137,56 @@ struct CMUXCLI {
     /// same v2 socket methods that legacy verbs use (`new-workspace`,
     /// `list-workspaces`, etc.) so behavior matches. Legacy verbs keep working
     /// unchanged for backwards compatibility.
+    /// `cmux window default-display [<name>|--clear]` — read/write the shared,
+    /// cross-tag default display that DEBUG cmux builds open new windows on
+    /// (file: ~/.config/cmux/dev-window-display). No running app required.
+    private func runWindowDefaultDisplayCommand(commandArgs: [String], jsonOutput: Bool) throws {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/cmux/dev-window-display")
+
+        func currentValue() -> String? {
+            guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        if commandArgs.contains("--clear") {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+            if jsonOutput { print(jsonString(["default_display": NSNull()])) }
+            else { print("Cleared dev window display default.") }
+            return
+        }
+
+        let positional = commandArgs.filter { !$0.hasPrefix("-") }
+        if let raw = positional.first {
+            let name = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else {
+                throw CLIError(message: "window default-display requires a display name, or --clear")
+            }
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try (name + "\n").write(to: url, atomically: true, encoding: .utf8)
+            if jsonOutput { print(jsonString(["default_display": name])) }
+            else { print("Dev builds will open on \"\(name)\" (DEBUG builds, applied at window creation).") }
+            return
+        }
+
+        let current = currentValue()
+        if jsonOutput {
+            if let current {
+                print(jsonString(["default_display": current]))
+            } else {
+                print(jsonString(["default_display": NSNull()]))
+            }
+        } else {
+            print(current ?? "(unset)")
+        }
+    }
+
     private func runWindowNamespace(
         commandArgs: [String],
         client: SocketClient,
@@ -7134,7 +7195,7 @@ struct CMUXCLI {
         windowOverride: String?
     ) throws {
         guard let sub = commandArgs.first?.lowercased() else {
-            throw CLIError(message: "window requires a subcommand. Try: display, displays")
+            throw CLIError(message: "window requires a subcommand. Try: display, displays, default-display")
         }
         let rest = Array(commandArgs.dropFirst())
         switch sub {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CMUXAgentLaunch
 import CmuxFoundation
+import CmuxSettings
 import CmuxSocketControl
 import CoreFoundation
 import CryptoKit
@@ -7138,22 +7139,40 @@ struct CMUXCLI {
     /// `list-workspaces`, etc.) so behavior matches. Legacy verbs keep working
     /// unchanged for backwards compatibility.
     /// `cmux window default-display [<name>|--clear]` — read/write the shared,
-    /// cross-tag default display that DEBUG cmux builds open new windows on
-    /// (file: ~/.config/cmux/dev-window-display). No running app required.
+    /// cross-tag default display that DEBUG cmux builds open new windows on.
+    ///
+    /// Persisted through ``CmuxSettings/JSONConfigStore`` in the shared
+    /// `cmux.json` under `app.devWindowDisplay`, so it applies to every tagged
+    /// dev build regardless of bundle id. No running app required: the value is
+    /// read/written directly on disk via the store on this no-socket early path.
     private func runWindowDefaultDisplayCommand(commandArgs: [String], jsonOutput: Bool) throws {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/cmux/dev-window-display")
+        let store = JSONConfigStore(fileURL: CmuxConfigLocation().userConfigFile)
+        let key = SettingCatalog().app.devWindowDisplay
 
-        func currentValue() -> String? {
-            guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return nil }
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Bridge the actor-backed store to this synchronous CLI: run the async
+        // store call on the cooperative pool and block this thread until it
+        // signals. The semaphore establishes the happens-before that makes the
+        // `nonisolated(unsafe)` result hand-off race-free.
+        func runBlocking<T: Sendable>(_ work: @escaping @Sendable () async throws -> T) throws -> T {
+            let semaphore = DispatchSemaphore(value: 0)
+            nonisolated(unsafe) var output: Result<T, Error>!
+            Task {
+                do { output = .success(try await work()) }
+                catch { output = .failure(error) }
+                semaphore.signal()
+            }
+            semaphore.wait()
+            return try output.get()
+        }
+
+        func currentValue() throws -> String? {
+            let trimmed = try runBlocking { await store.value(for: key) }
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }
 
         if commandArgs.contains("--clear") {
-            if FileManager.default.fileExists(atPath: url.path) {
-                try FileManager.default.removeItem(at: url)
-            }
+            try runBlocking { try await store.reset(key) }
             if jsonOutput { print(jsonString(["default_display": NSNull()])) }
             else { print("Cleared dev window display default.") }
             return
@@ -7165,17 +7184,13 @@ struct CMUXCLI {
             guard !name.isEmpty else {
                 throw CLIError(message: "window default-display requires a display name, or --clear")
             }
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try (name + "\n").write(to: url, atomically: true, encoding: .utf8)
+            try runBlocking { try await store.set(name, for: key) }
             if jsonOutput { print(jsonString(["default_display": name])) }
             else { print("Dev builds will open on \"\(name)\" (DEBUG builds, applied at window creation).") }
             return
         }
 
-        let current = currentValue()
+        let current = try currentValue()
         if jsonOutput {
             if let current {
                 print(jsonString(["default_display": current]))

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -178,5 +178,18 @@ public struct AppCatalogSection: SettingCatalogSection {
         userDefaultsKey: "systemWideHotkey.enabled"
     )
 
+    /// Shared, cross-tag default display that DEBUG cmux builds open new
+    /// windows on, identified by the display's `localizedName` (e.g.
+    /// `"LG HDR 4K"`). Empty means the system default placement.
+    ///
+    /// JSON-backed (`JSONKey`) on purpose: `cmux.json` lives at a fixed path
+    /// shared by every bundle id, so one value is honored by every tagged dev
+    /// build and every launch path. `UserDefaults` is per-bundle and would not
+    /// be shared. Release builds never read it.
+    public let devWindowDisplay = JSONKey<String>(
+        id: "app.devWindowDisplay",
+        defaultValue: ""
+    )
+
     public init() {}
 }

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/JSONConfigStoreTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/JSONConfigStoreTests.swift
@@ -125,6 +125,24 @@ struct JSONConfigStoreTests {
         try Data(#"{"app":{"devWindowDisplay":"LG HDR 4K"}}"#.utf8).write(to: fileURL)
         #expect(store.snapshotValue(for: key) == "LG HDR 4K")
     }
+
+    @Test func devWindowDisplayCatalogKeyRoundTripsToSharedPath() async throws {
+        let (store, fileURL, catalog) = makeStore()
+        try await store.set("LG HDR 4K", for: catalog.app.devWindowDisplay)
+
+        // Async and sync reads agree on the catalog key.
+        #expect(await store.value(for: catalog.app.devWindowDisplay) == "LG HDR 4K")
+        #expect(store.snapshotValue(for: catalog.app.devWindowDisplay) == "LG HDR 4K")
+
+        // It lands at app.devWindowDisplay in cmux.json — the shared on-disk
+        // shape the CLI, the app's window hook, and the Debug menu all read.
+        let parsed = try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        let app = parsed?["app"] as? [String: Any]
+        #expect(app?["devWindowDisplay"] as? String == "LG HDR 4K")
+
+        try await store.reset(catalog.app.devWindowDisplay)
+        #expect(store.snapshotValue(for: catalog.app.devWindowDisplay) == "")
+    }
 }
 
 private func withTimeout<T: Sendable>(seconds: Double, _ work: @escaping @Sendable () async -> T) async -> T {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1977,6 +1977,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isRunningUnderXCTest(env) || env["CMUX_UI_TEST_MODE"] == "1" {
             scheduleUITestSocketSanityCheckIfNeeded()
         }
+        // Best-effort one-time migration: a value previously stored in the
+        // legacy ~/.config/cmux/dev-window-display file moves into the shared
+        // cmux.json (app.devWindowDisplay) so an existing dev-display default
+        // keeps working. No-op when already set or the legacy file is absent.
+        Task { await DevWindowDisplayDefault.migrateLegacyFileIfNeeded(runtime: settingsRuntime) }
 #endif
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8270,6 +8270,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
 #endif
         }
+#if DEBUG
+        // Honor the shared dev-only default display (set via `cmux window
+        // default-display` or the Debug menu) so every dev build, any tag and
+        // any launch path, opens on the chosen monitor. Focus-safe and a no-op
+        // when unset. See DevWindowDisplayDefault.
+        DevWindowDisplayDefault.applyToNewWindow(window)
+#endif
         return windowId
     }
 
@@ -17983,7 +17990,7 @@ extension AppDelegate {
     /// Resolve a display from a query: case-insensitive exact name, then
     /// case-insensitive substring, then a zero-based index string. Returns nil
     /// when nothing matches so callers can report the available names.
-    private func screenMatching(_ query: String) -> NSScreen? {
+    func screenMatching(_ query: String) -> NSScreen? {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let screens = NSScreen.screens
@@ -18031,7 +18038,7 @@ extension AppDelegate {
     /// size (clamped to the display) and centering it. Deliberately does NOT
     /// raise, key, or activate the window: `window.display` is not a focus-intent
     /// command, so it must never steal macOS focus (see `focusIntentV2Methods`).
-    private func repositionPreservingSize(_ window: NSWindow, onto screen: NSScreen) {
+    func repositionPreservingSize(_ window: NSWindow, onto screen: NSScreen) {
         let visible = screen.visibleFrame
         let width = min(window.frame.width, visible.width)
         let height = min(window.frame.height, visible.height)

--- a/Sources/DevWindowDisplayDebugWindow.swift
+++ b/Sources/DevWindowDisplayDebugWindow.swift
@@ -1,0 +1,111 @@
+import AppKit
+import SwiftUI
+
+/// Debug-menu window for the shared, cross-tag default display that new DEBUG
+/// cmux windows open on.
+///
+/// Reads and writes ``DevWindowDisplayDefault`` (a shared file rather than
+/// `@AppStorage`, so the value applies to every tagged dev build, not just this
+/// one). The same value is also settable from `cmux window default-display`.
+final class DevWindowDisplayDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = DevWindowDisplayDebugWindowController()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 360),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "debug.devWindowDisplay.title", defaultValue: "Dev Window Display")
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.devWindowDisplay")
+        window.center()
+        window.contentView = NSHostingView(rootView: DevWindowDisplayDebugView())
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @MainActor
+    func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+private struct DevWindowDisplayDebugView: View {
+    @State private var current: String? = DevWindowDisplayDefault.read()
+    @State private var displays: [String] = NSScreen.screens.map(\.localizedName)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(String(localized: "debug.devWindowDisplay.title", defaultValue: "Dev Window Display"))
+                .font(.headline)
+            Text(String(
+                localized: "debug.devWindowDisplay.description",
+                defaultValue: "New DEBUG cmux windows open on the selected display. Shared across all tagged dev builds; applied at window creation."
+            ))
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            GroupBox {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(displays, id: \.self) { name in
+                        Button {
+                            DevWindowDisplayDefault.write(name)
+                            current = name
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: current == name ? "checkmark.circle.fill" : "circle")
+                                    .foregroundStyle(current == name ? Color.accentColor : Color.secondary)
+                                Text(name)
+                                Spacer()
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(6)
+            }
+
+            HStack {
+                Button(String(localized: "debug.devWindowDisplay.refresh", defaultValue: "Refresh displays")) {
+                    displays = NSScreen.screens.map(\.localizedName)
+                    current = DevWindowDisplayDefault.read()
+                }
+                Spacer()
+                Button(String(localized: "debug.devWindowDisplay.clear", defaultValue: "Clear (system default)")) {
+                    DevWindowDisplayDefault.write(nil)
+                    current = nil
+                }
+            }
+
+            Text(currentLabel)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(16)
+        .frame(minWidth: 380, minHeight: 300)
+    }
+
+    private var currentLabel: String {
+        if let current {
+            return String(
+                format: String(localized: "debug.devWindowDisplay.current", defaultValue: "Current: %@"),
+                current
+            )
+        }
+        return String(localized: "debug.devWindowDisplay.currentNone", defaultValue: "Current: (system default)")
+    }
+}

--- a/Sources/DevWindowDisplayDebugWindow.swift
+++ b/Sources/DevWindowDisplayDebugWindow.swift
@@ -4,9 +4,10 @@ import SwiftUI
 /// Debug-menu window for the shared, cross-tag default display that new DEBUG
 /// cmux windows open on.
 ///
-/// Reads and writes ``DevWindowDisplayDefault`` (a shared file rather than
-/// `@AppStorage`, so the value applies to every tagged dev build, not just this
-/// one). The same value is also settable from `cmux window default-display`.
+/// Reads and writes ``DevWindowDisplayDefault`` (persisted in the shared
+/// `cmux.json` via ``CmuxSettings``, not `@AppStorage`, so the value applies to
+/// every tagged dev build, not just this one). The same value is also settable
+/// from `cmux window default-display`.
 final class DevWindowDisplayDebugWindowController: NSWindowController, NSWindowDelegate {
     static let shared = DevWindowDisplayDebugWindowController()
 
@@ -43,7 +44,8 @@ final class DevWindowDisplayDebugWindowController: NSWindowController, NSWindowD
 }
 
 private struct DevWindowDisplayDebugView: View {
-    @State private var current: String? = DevWindowDisplayDefault.read()
+    @State private var current: String? =
+        AppDelegate.shared?.settingsRuntime.flatMap(DevWindowDisplayDefault.current)
     @State private var displays: [String] = NSScreen.screens.map(\.localizedName)
 
     var body: some View {
@@ -61,8 +63,7 @@ private struct DevWindowDisplayDebugView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(displays, id: \.self) { name in
                         Button {
-                            DevWindowDisplayDefault.write(name)
-                            current = name
+                            write(name)
                         } label: {
                             HStack(spacing: 8) {
                                 Image(systemName: current == name ? "checkmark.circle.fill" : "circle")
@@ -81,12 +82,11 @@ private struct DevWindowDisplayDebugView: View {
             HStack {
                 Button(String(localized: "debug.devWindowDisplay.refresh", defaultValue: "Refresh displays")) {
                     displays = NSScreen.screens.map(\.localizedName)
-                    current = DevWindowDisplayDefault.read()
+                    current = AppDelegate.shared?.settingsRuntime.flatMap(DevWindowDisplayDefault.current)
                 }
                 Spacer()
                 Button(String(localized: "debug.devWindowDisplay.clear", defaultValue: "Clear (system default)")) {
-                    DevWindowDisplayDefault.write(nil)
-                    current = nil
+                    write(nil)
                 }
             }
 
@@ -97,6 +97,14 @@ private struct DevWindowDisplayDebugView: View {
         }
         .padding(16)
         .frame(minWidth: 380, minHeight: 300)
+    }
+
+    /// Optimistically reflect the selection, then persist it through the shared
+    /// settings store. `nil` clears the value (system-default placement).
+    private func write(_ name: String?) {
+        current = name
+        guard let runtime = AppDelegate.shared?.settingsRuntime else { return }
+        Task { await DevWindowDisplayDefault.set(name, runtime: runtime) }
     }
 
     private var currentLabel: String {

--- a/Sources/DevWindowDisplayDefault.swift
+++ b/Sources/DevWindowDisplayDefault.swift
@@ -1,54 +1,69 @@
 import AppKit
+import CmuxSettings
+import CmuxSettingsUI
 
 /// Shared, cross-tag default for which display new cmux DEV windows open on.
 ///
-/// The value is a display's `localizedName` (e.g. `"LG HDR 4K"`), stored as a
-/// single line in `~/.config/cmux/dev-window-display`.
+/// The value is a display's `localizedName` (e.g. `"LG HDR 4K"`), persisted in
+/// the shared `cmux.json` under `app.devWindowDisplay` through ``CmuxSettings``.
 ///
-/// It lives in a fixed-path file rather than `UserDefaults` on purpose: every
-/// tagged dev build has its own bundle id and therefore its own defaults domain,
-/// but we want one value honored by *every* dev build and *every* launch path
-/// (`reload.sh`, an agent, or cmd-clicking a Tag Opener link). A shared file is
-/// the only store all of those read.
+/// It lives in `cmux.json` (a fixed path shared across bundle ids) rather than
+/// per-bundle `UserDefaults` on purpose: every tagged dev build has its own
+/// bundle id and therefore its own defaults domain, but we want one value
+/// honored by *every* dev build and *every* launch path (`reload.sh`, an agent,
+/// or cmd-clicking a Tag Opener link). The shared config file is the only store
+/// all of those read. Release builds never apply it.
+///
+/// This is a thin wrapper over ``CmuxSettings/JSONConfigStore``: the
+/// window-creation hook reads it synchronously via the store's `snapshotValue`
+/// seam, and the Debug menu / CLI write through the store's async `set`.
 enum DevWindowDisplayDefault {
-    /// Path to the shared setting file under the cmux config directory.
-    static var fileURL: URL {
+    /// Legacy single-line file the value used to live in, before it moved into
+    /// `cmux.json`. Read for migration and as a first-launch fallback, then
+    /// ignored.
+    static var legacyFileURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config", isDirectory: true)
-            .appendingPathComponent("cmux", isDirectory: true)
-            .appendingPathComponent("dev-window-display", isDirectory: false)
+            .appendingPathComponent(".config/cmux/dev-window-display")
     }
 
-    /// The configured display name, or `nil` when unset or empty.
-    static func read() -> String? {
-        guard let raw = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+    /// The trimmed display name in the legacy file, or `nil` when absent/empty.
+    static func legacyFileName() -> String? {
+        guard let raw = try? String(contentsOf: legacyFileURL, encoding: .utf8) else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// Persist `name`, or clear the setting when `name` is `nil`/empty.
-    ///
-    /// - Returns: `true` on success.
-    @discardableResult
-    static func write(_ name: String?) -> Bool {
-        let url = fileURL
+    /// The configured display name from settings, or `nil` when unset/empty.
+    /// Reads the store's synchronous snapshot, so it is safe to call on the
+    /// main actor before any suspension point.
+    static func current(_ runtime: SettingsRuntime) -> String? {
+        let value = runtime.jsonStore
+            .snapshotValue(for: runtime.catalog.app.devWindowDisplay)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    /// Persist `name`, or clear the setting when `name` is `nil`/empty, through
+    /// the shared settings store. Clearing removes the key (and prunes the empty
+    /// parent), matching `cmux window default-display --clear`.
+    static func set(_ name: String?, runtime: SettingsRuntime) async {
         let value = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        do {
-            if value.isEmpty {
-                if FileManager.default.fileExists(atPath: url.path) {
-                    try FileManager.default.removeItem(at: url)
-                }
-            } else {
-                try FileManager.default.createDirectory(
-                    at: url.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try (value + "\n").write(to: url, atomically: true, encoding: .utf8)
-            }
-            return true
-        } catch {
-            return false
+        if value.isEmpty {
+            try? await runtime.jsonStore.reset(runtime.catalog.app.devWindowDisplay)
+        } else {
+            try? await runtime.jsonStore.set(value, for: runtime.catalog.app.devWindowDisplay)
         }
+    }
+
+    /// One-time best-effort migration of the pre-`cmux.json` file value into
+    /// `app.devWindowDisplay`. No-op when the settings value is already set or
+    /// the legacy file is absent. Leaves the legacy file untouched so an older
+    /// build that still reads it keeps working too.
+    static func migrateLegacyFileIfNeeded(runtime: SettingsRuntime) async {
+        let existing = await runtime.jsonStore.value(for: runtime.catalog.app.devWindowDisplay)
+        guard existing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard let name = legacyFileName() else { return }
+        try? await runtime.jsonStore.set(name, for: runtime.catalog.app.devWindowDisplay)
     }
 
 #if DEBUG
@@ -58,8 +73,12 @@ enum DevWindowDisplayDefault {
     /// never steals focus. DEBUG-only: production cmux is never auto-moved.
     @MainActor
     static func applyToNewWindow(_ window: NSWindow) {
-        guard let name = read(),
-              let app = AppDelegate.shared,
+        guard let app = AppDelegate.shared,
+              let runtime = app.settingsRuntime else { return }
+        // Prefer the settings value; fall back to the legacy file so an existing
+        // pre-migration default still places the very first window before the
+        // async one-time migration has committed to cmux.json.
+        guard let name = current(runtime) ?? legacyFileName(),
               let screen = app.screenMatching(name) else { return }
         app.repositionPreservingSize(window, onto: screen)
     }

--- a/Sources/DevWindowDisplayDefault.swift
+++ b/Sources/DevWindowDisplayDefault.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+/// Shared, cross-tag default for which display new cmux DEV windows open on.
+///
+/// The value is a display's `localizedName` (e.g. `"LG HDR 4K"`), stored as a
+/// single line in `~/.config/cmux/dev-window-display`.
+///
+/// It lives in a fixed-path file rather than `UserDefaults` on purpose: every
+/// tagged dev build has its own bundle id and therefore its own defaults domain,
+/// but we want one value honored by *every* dev build and *every* launch path
+/// (`reload.sh`, an agent, or cmd-clicking a Tag Opener link). A shared file is
+/// the only store all of those read.
+enum DevWindowDisplayDefault {
+    /// Path to the shared setting file under the cmux config directory.
+    static var fileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("dev-window-display", isDirectory: false)
+    }
+
+    /// The configured display name, or `nil` when unset or empty.
+    static func read() -> String? {
+        guard let raw = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Persist `name`, or clear the setting when `name` is `nil`/empty.
+    ///
+    /// - Returns: `true` on success.
+    @discardableResult
+    static func write(_ name: String?) -> Bool {
+        let url = fileURL
+        let value = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            if value.isEmpty {
+                if FileManager.default.fileExists(atPath: url.path) {
+                    try FileManager.default.removeItem(at: url)
+                }
+            } else {
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try (value + "\n").write(to: url, atomically: true, encoding: .utf8)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+#if DEBUG
+    /// Place a newly-created window on the configured display, if one is set and
+    /// currently connected. No-ops otherwise. Repositions without raising or
+    /// activating the window (it reuses the focus-safe placement helper), so it
+    /// never steals focus. DEBUG-only: production cmux is never auto-moved.
+    @MainActor
+    static func applyToNewWindow(_ window: NSWindow) {
+        guard let name = read(),
+              let app = AppDelegate.shared,
+              let screen = app.screenMatching(name) else { return }
+        app.repositionPreservingSize(window, onto: screen)
+    }
+#endif
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1438,6 +1438,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.startupAppearanceDebug",
     "cmux.bonsplitTabBarDebug",
     "cmux.titlebarLayoutDebug",
+    "cmux.devWindowDisplay",
 ]
 
 /// Returns whether the given window should handle the standard close shortcut

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -561,6 +561,14 @@ struct cmuxApp: App {
                     Button("Debug Window Controls…") {
                         DebugWindowControlsWindowController.shared.show()
                     }
+                    Button(
+                        String(
+                            localized: "debug.menu.devWindowDisplay",
+                            defaultValue: "Dev Window Display…"
+                        )
+                    ) {
+                        DevWindowDisplayDebugWindowController.shared.show()
+                    }
                     Button("Feed Preview…") {
                         FeedPreviewWindowController.shared.show()
                     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 		A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001F000000000000000002 /* DetachedFolderDragIcon.swift */; };
 		DE71CE000000000000000004 /* DeviceRegistryClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000003 /* DeviceRegistryClient.swift */; };
 		DE71CE000000000000000002 /* DeviceRegistryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000001 /* DeviceRegistryClientTests.swift */; };
+		DE000A020000000000000001 /* DevWindowDisplayDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE000A020000000000000002 /* DevWindowDisplayDebugWindow.swift */; };
+		DE000A010000000000000001 /* DevWindowDisplayDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE000A010000000000000002 /* DevWindowDisplayDefault.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
@@ -1035,6 +1037,8 @@
 		A5001F000000000000000002 /* DetachedFolderDragIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedFolderDragIcon.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000003 /* DeviceRegistryClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeviceRegistryClient.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000001 /* DeviceRegistryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegistryClientTests.swift; sourceTree = "<group>"; };
+		DE000A020000000000000002 /* DevWindowDisplayDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevWindowDisplayDebugWindow.swift; sourceTree = "<group>"; };
+		DE000A010000000000000002 /* DevWindowDisplayDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevWindowDisplayDefault.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
@@ -1701,6 +1705,8 @@
 				C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */,
 				C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */,
 				C4160A070000000000000002 /* TitlebarLayoutDebugWindow.swift */,
+				DE000A010000000000000002 /* DevWindowDisplayDefault.swift */,
+				DE000A020000000000000002 /* DevWindowDisplayDebugWindow.swift */,
 				DC5DC5DC0000000000000002 /* CmuxSidebarActionDispatch.swift */,
 				F50030020000000000000002 /* TitlebarInteractiveControlModifier.swift */,
 				C0DE34020000000000000003 /* CmuxHelpCommands.swift */,
@@ -2845,6 +2851,8 @@
 				A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */,
 				A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */,
 				DE71CE000000000000000004 /* DeviceRegistryClient.swift in Sources */,
+				DE000A020000000000000001 /* DevWindowDisplayDebugWindow.swift in Sources */,
+				DE000A010000000000000001 /* DevWindowDisplayDefault.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		A9F20000000000000000001A /* CmuxRuntimeDebugCaptureSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000001A /* CmuxRuntimeDebugCaptureSender.swift */; };
 		A9F200000000000000000007 /* CmuxRuntimeDebugCaptureSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000007 /* CmuxRuntimeDebugCaptureSequence.swift */; };
 		CD0CFE5300000000CD0CFE53 /* CmuxSettings in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5200000000CD0CFE52 /* CmuxSettings */; };
+		CD0CFE5700000000CD0CFE57 /* CmuxSettings in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5200000000CD0CFE52 /* CmuxSettings */; };
 		D3610C010000000000000001 /* CmuxSettingsJSONPathSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */; };
 		CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */; };
 		DC5DC5DC0000000000000001 /* CmuxSidebarActionDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5DC5DC0000000000000002 /* CmuxSidebarActionDispatch.swift */; };
@@ -1535,6 +1536,7 @@
 				C8000314C8000314C8000314 /* CmuxFileWatch in Frameworks */,
 				CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */,
 				C8000304C8000304C8000304 /* CmuxProcess in Frameworks */,
+				CD0CFE5700000000CD0CFE57 /* CmuxSettings in Frameworks */,
 				C5A1FED200000000000000E2 /* CmuxSidebarInterpreterClient in Frameworks */,
 				B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */,
 				C5A1FED000000000000000C2 /* CmuxSwiftRender in Frameworks */,
@@ -2417,6 +2419,7 @@
 				C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */,
 				C8000302C8000302C8000302 /* CmuxProcess */,
 				C8000312C8000312C8000312 /* CmuxFileWatch */,
+				CD0CFE5200000000CD0CFE52 /* CmuxSettings */,
 				CF00F00000000000000000A2 /* CmuxFoundation */,
 			);
 			productName = cmux;

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -93,6 +93,7 @@ Environment:
 | `close-window` | Close a window by handle. |
 | `window displays` | List connected displays (name, index, main flag). |
 | `window display <name\|index>` | Move the instance's window(s) onto a display by name (exact, substring) or index, preserving size. Does not steal focus. With `--window`, targets that window; otherwise moves all main windows. `--list` aliases `window displays`. |
+| `window default-display [<name>\|--clear]` | Set, show (no arg), or clear (`--clear`) the shared, cross-tag default display that DEBUG dev builds open new windows on, stored in `~/.config/cmux/dev-window-display`. No running app required; applied at window creation. Also settable in Debug > Debug Windows > Dev Window Display. |
 | `move-workspace-to-window` | Move a workspace into a target window. |
 | `reorder-workspace` | Reorder a workspace inside a window. |
 | `reorder-workspaces` | Atomically reorder workspaces inside pinned and unpinned groups. |

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -93,7 +93,7 @@ Environment:
 | `close-window` | Close a window by handle. |
 | `window displays` | List connected displays (name, index, main flag). |
 | `window display <name\|index>` | Move the instance's window(s) onto a display by name (exact, substring) or index, preserving size. Does not steal focus. With `--window`, targets that window; otherwise moves all main windows. `--list` aliases `window displays`. |
-| `window default-display [<name>\|--clear]` | Set, show (no arg), or clear (`--clear`) the shared, cross-tag default display that DEBUG dev builds open new windows on, stored in `~/.config/cmux/dev-window-display`. No running app required; applied at window creation. Also settable in Debug > Debug Windows > Dev Window Display. |
+| `window default-display [<name>\|--clear]` | Set, show (no arg), or clear (`--clear`) the shared, cross-tag default display that DEBUG dev builds open new windows on, stored in `~/.config/cmux/cmux.json` under `app.devWindowDisplay`. No running app required; applied at window creation. Also settable in Debug > Debug Windows > Dev Window Display. |
 | `move-workspace-to-window` | Move a workspace into a target window. |
 | `reorder-workspace` | Reorder a workspace inside a window. |
 | `reorder-workspaces` | Atomically reorder workspaces inside pinned and unpinned groups. |


### PR DESCRIPTION
Persist the shared, cross-tag "which display do dev builds open on" default through the existing settings system (`CmuxSettings` / `cmux.json`) instead of a bespoke `~/.config/cmux/dev-window-display` file. Behavior is identical to the original version of this PR: opt-in, no-op when unset, `#if DEBUG` only, focus-safe, cross-tag, settable via CLI and Debug menu, applied at window creation.

**Stacked on https://github.com/manaflow-ai/cmux/pull/5838** (the `CmuxSettings` synchronous read seam). The first commit here is that seam; until #5838 merges, this PR's diff includes it. Review #5838 first.

What changed:
- **Catalog key**: `JSONKey<String> app.devWindowDisplay`. `cmux.json` is a fixed path shared across bundle ids, so one value is honored by every tagged dev build; `UserDefaults` is per-bundle and would not be shared.
- **App**: the `#if DEBUG` window-creation hook reads the value synchronously via the store's new `snapshotValue` seam (no actor hop on the main actor), with a read-only fallback to the legacy file so an existing default still places the very first window before the async one-time migration commits. Placement reuses the existing focus-safe `repositionPreservingSize`.
- **CLI**: `cmux-cli` now links `CmuxSettings`; `window default-display` get/set/clear go through `JSONConfigStore` on the no-socket early path (works with no app running), bridging the actor with a `DispatchSemaphore`. The bespoke file read/write is gone.
- **Debug menu**: reads/writes through the settings store.
- **Migration**: best-effort one-time read of the legacy file into `cmux.json` at app startup, so the existing `LG HDR 4K` default keeps working. The legacy file is left in place.
- **Tests**: catalog-key round-trip through `JSONConfigStore` asserting the value lands at `app.devWindowDisplay` in `cmux.json` (the on-disk shape the CLI, app hook, and Debug menu all share).
- **Docs**: `cli-contract.md` now points at `cmux.json` / `app.devWindowDisplay`.

Verified: `cmux DEV devdisp` builds clean (app + `cmux-cli` linking `CmuxSettings`); `window default-display` get → `(unset)`, set → writes `app.devWindowDisplay` preserving other keys, clear → removes it and prunes the empty `app` parent. pbxproj check, swift-file-length budget, and localization audit all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `window default-display` CLI to view, set, or clear a DEBUG default display (supports JSON or human output).
  * Added a “Dev Window Display…” debug panel and menu item to pick, refresh, or clear the default display; choice is applied to new windows.

* **Localization**
  * Added localized strings for the debug menu, panel title, description, refresh/clear actions, and current-display text.

* **Documentation**
  * Added CLI contract entry for `window default-display`.

* **Tests**
  * Added tests verifying the shared setting persists and resets correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->