### PR TITLE
Set FD_CLOEXEC on control-socket descriptors

### DIFF
--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketControlServer+Startup.swift
@@ -168,9 +168,9 @@ extension SocketControlServer {
         }
 
         // Create socket
-        let newServerSocket = socket(AF_UNIX, SOCK_STREAM, 0)
+        let (newServerSocket, createSocketErrno) = transport.makeListenerSocket()
         guard newServerSocket >= 0 else {
-            let errnoCode = errno
+            let errnoCode = createSocketErrno ?? EIO
             print("SocketControlServer: Failed to create socket")
             reportSocketListenerFailure(
                 message: "socket.listener.start.failed",

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
@@ -2,7 +2,8 @@ internal import Foundation
 internal import Darwin
 
 extension SocketTransport {
-    /// Creates the listener socket (`AF_UNIX`/`SOCK_STREAM`).
+    /// Creates the listener socket (`AF_UNIX`/`SOCK_STREAM`) with `FD_CLOEXEC`
+    /// set so it is not inherited by PTY-child forks.
     ///
     /// - Returns: The descriptor and a nil errno on success, or `-1` and the
     ///   failing `errno`.
@@ -10,6 +11,10 @@ extension SocketTransport {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             return (-1, errno)
+        }
+        if let errnoCode = configureCloseOnExec(fd) {
+            close(fd)
+            return (-1, errnoCode)
         }
         return (fd, nil)
     }

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
@@ -2,6 +2,18 @@ internal import Foundation
 internal import Darwin
 
 extension SocketTransport {
+    /// Creates the listener socket (`AF_UNIX`/`SOCK_STREAM`).
+    ///
+    /// - Returns: The descriptor and a nil errno on success, or `-1` and the
+    ///   failing `errno`.
+    public func makeListenerSocket() -> (fd: Int32, errnoCode: Int32?) {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            return (-1, errno)
+        }
+        return (fd, nil)
+    }
+
     /// Binds `socket` as the listener at `path`, preparing the path first.
     ///
     /// On success the bound socket inode's identity is captured for later

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+Bind.swift
@@ -2,23 +2,6 @@ internal import Foundation
 internal import Darwin
 
 extension SocketTransport {
-    /// Creates the listener socket (`AF_UNIX`/`SOCK_STREAM`) with `FD_CLOEXEC`
-    /// set so it is not inherited by PTY-child forks.
-    ///
-    /// - Returns: The descriptor and a nil errno on success, or `-1` and the
-    ///   failing `errno`.
-    public func makeListenerSocket() -> (fd: Int32, errnoCode: Int32?) {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else {
-            return (-1, errno)
-        }
-        if let errnoCode = configureCloseOnExec(fd) {
-            close(fd)
-            return (-1, errnoCode)
-        }
-        return (fd, nil)
-    }
-
     /// Binds `socket` as the listener at `path`, preparing the path first.
     ///
     /// On success the bound socket inode's identity is captured for later

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
@@ -2,6 +2,23 @@ public import Foundation
 internal import Darwin
 
 extension SocketTransport {
+    /// Creates the listener socket (`AF_UNIX`/`SOCK_STREAM`) with `FD_CLOEXEC`
+    /// set so it is not inherited by PTY-child forks.
+    ///
+    /// - Returns: The descriptor and a nil errno on success, or `-1` and the
+    ///   failing `errno`.
+    public func makeListenerSocket() -> (fd: Int32, errnoCode: Int32?) {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            return (-1, errno)
+        }
+        if let errnoCode = configureCloseOnExec(fd) {
+            close(fd)
+            return (-1, errnoCode)
+        }
+        return (fd, nil)
+    }
+
     /// Sets `O_NONBLOCK` on `fd`.
     ///
     /// - Parameter fd: The socket descriptor to configure.

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+ClientSocket.swift
@@ -17,6 +17,30 @@ extension SocketTransport {
         return nil
     }
 
+    /// Sets `FD_CLOEXEC` on `fd` so it is not inherited across `fork`/`exec`.
+    ///
+    /// Read-modify-write via `F_GETFD` to preserve any existing descriptor
+    /// flags; a no-op when the flag is already set. macOS has no `accept4`/
+    /// `SOCK_CLOEXEC`, so control-socket descriptors must be marked explicitly
+    /// to keep them out of PTY-child forks (see the path-lock fd, which uses
+    /// the same pattern).
+    ///
+    /// - Parameter fd: The descriptor to mark close-on-exec.
+    /// - Returns: Nil on success, the failing `errno` otherwise.
+    public func configureCloseOnExec(_ fd: Int32) -> Int32? {
+        let flags = fcntl(fd, F_GETFD, 0)
+        guard flags >= 0 else {
+            return errno
+        }
+        if flags & FD_CLOEXEC != 0 {
+            return nil
+        }
+        guard fcntl(fd, F_SETFD, flags | FD_CLOEXEC) >= 0 else {
+            return errno
+        }
+        return nil
+    }
+
     /// Clears `O_NONBLOCK` on `fd`; returns the failing `errno` otherwise.
     func configureBlocking(_ fd: Int32) -> Int32? {
         let flags = fcntl(fd, F_GETFL, 0)
@@ -109,6 +133,12 @@ extension SocketTransport {
     /// - Parameter fd: The freshly accepted client socket descriptor.
     /// - Returns: Nil on success, or the failing ``SocketStageFailure``.
     public func configureAcceptedClientSocket(_ fd: Int32) -> SocketStageFailure? {
+        // Set close-on-exec first, before any later configuration step can
+        // fail and before a concurrent PTY fork can inherit the descriptor
+        // (macOS has no `accept4`/`SOCK_CLOEXEC`).
+        if let errnoCode = configureCloseOnExec(fd) {
+            return SocketStageFailure(stage: "accept_client_configure_cloexec", errnoCode: errnoCode)
+        }
         if let errnoCode = configureBlocking(fd) {
             return SocketStageFailure(stage: "accept_client_configure_blocking", errnoCode: errnoCode)
         }

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+IO.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+IO.swift
@@ -54,6 +54,7 @@ extension SocketTransport {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return nil }
         defer { close(fd) }
+        _ = configureCloseOnExec(fd)
         configureSocketTimeouts(fd, timeout: timeout)
 
         _ = configureNoSigPipe(fd)

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathIdentity.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketTransport+PathIdentity.swift
@@ -65,6 +65,7 @@ extension SocketTransport {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return .occupiedOrIndeterminate }
         defer { close(fd) }
+        _ = configureCloseOnExec(fd)
 
         let originalFlags = fcntl(fd, F_GETFL, 0)
         guard originalFlags >= 0 else { return .occupiedOrIndeterminate }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportHardeningTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketTransportHardeningTests.swift
@@ -39,4 +39,43 @@ import Testing
         #expect(flags >= 0)
         #expect(flags & FD_CLOEXEC != 0, "lock fd must not leak across fork/exec")
     }
+
+    @Test func listenerSocketIsCloseOnExec() {
+        let (fd, errnoCode) = transport.makeListenerSocket()
+        #expect(errnoCode == nil)
+        guard fd >= 0 else {
+            Issue.record("expected listener socket creation to succeed")
+            return
+        }
+        defer { Darwin.close(fd) }
+
+        let flags = fcntl(fd, F_GETFD)
+        #expect(flags >= 0)
+        #expect(flags & FD_CLOEXEC != 0, "listener fd must not leak into PTY-child forks")
+    }
+
+    @Test func acceptedClientSocketIsCloseOnExec() throws {
+        let path = UnixSocketFixture.makeTempSocketPath()
+        let listenerFD = try UnixSocketFixture.bindListeningSocket(at: path)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(path)
+        }
+
+        let clientFD = try UnixSocketFixture.connectClient(to: path)
+        defer { Darwin.close(clientFD) }
+
+        let acceptedFD = accept(listenerFD, nil, nil)
+        guard acceptedFD >= 0 else {
+            Issue.record("expected accept to return a client descriptor")
+            return
+        }
+        defer { Darwin.close(acceptedFD) }
+
+        #expect(transport.configureAcceptedClientSocket(acceptedFD) == nil)
+
+        let flags = fcntl(acceptedFD, F_GETFD)
+        #expect(flags >= 0)
+        #expect(flags & FD_CLOEXEC != 0, "accepted client fd must not leak into PTY-child forks")
+    }
 }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/UnixSocketFixture.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/UnixSocketFixture.swift
@@ -53,6 +53,44 @@ enum UnixSocketFixture {
         return fd
     }
 
+    /// Connects a blocking client to the Unix socket at `path`.
+    static func connectClient(to path: String) throws -> Int32 {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw posixError("socket(client)")
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let didFit = path.withCString { ptr -> Bool in
+            guard strlen(ptr) < maxLength else { return false }
+            withUnsafeMutablePointer(to: &addr.sun_path) { pathPtr in
+                let pathBuf = UnsafeMutableRawPointer(pathPtr).assumingMemoryBound(to: CChar.self)
+                memset(pathBuf, 0, maxLength)
+                strncpy(pathBuf, ptr, maxLength - 1)
+            }
+            return true
+        }
+        guard didFit else {
+            Darwin.close(fd)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(ENAMETOOLONG))
+        }
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            let error = posixError("connect(\(path))")
+            Darwin.close(fd)
+            throw error
+        }
+
+        return fd
+    }
+
     /// Accepts a single client on a background thread and runs `handler` with
     /// the client fd. Returns after the handler finishes via the continuation
     /// stored in the returned closure-waitable.


### PR DESCRIPTION
## Problem

`lsof -U | grep cmux-501.sock` on a live system shows `zsh`, `sleep`, and `claude` PTY-child processes holding open connections to the app's control socket (`~/.local/state/cmux/cmux-501.sock`). They inherited the app's socket FDs across fork/exec because neither the listening socket nor the FDs returned by `accept()` set `FD_CLOEXEC` (macOS has no `accept4`/`SOCK_CLOEXEC`). The only existing CLOEXEC handling was on the path-lock file.

Observed (before): app + many `zsh`/`sleep`/`claude` PIDs hold `cmux-501.sock`.
Expected: only the `cmux` app process holds it.

Why it matters:
- A leaked **accepted** FD also held by a long-lived child never reads EOF, so per-connection handler threads (`spawnClientHandler`, one detached thread per client) linger past the real client's death.
- A leaked **listener** FD held by a child keeps the socket bound after the app exits/restarts (interferes with rebind/recovery, manaflow-ai/cmux#4325 territory).
- Every spawned shell gets ambient access to a privileged control-channel FD.

ghostty's PTY spawn (`Command.zig` → `posix.fork()` + exec) does not close arbitrary FDs, so the correct general fix is to mark the socket FDs close-on-exec at creation rather than to enumerate FDs at spawn time.

## Fix

- New `SocketTransport.configureCloseOnExec(_:)` helper — read-modify-write via `F_GETFD` to preserve existing flags, idempotent. Mirrors the path-lock CLOEXEC pattern.
- `makeListenerSocket()` (extracted from startup) sets `FD_CLOEXEC` immediately after `socket()`; startup aborts if it fails.
- `configureAcceptedClientSocket()` sets `FD_CLOEXEC` first, before any other config step and before a concurrent fork can inherit the FD.
- Short-lived probe FDs (`probeCommand`, `pathProbeResult`) set it best-effort.

## Tests

Two-commit red/green structure:
1. Failing regression tests (`listenerSocketIsCloseOnExec`, `acceptedClientSocketIsCloseOnExec`) — assert `fcntl(fd, F_GETFD) & FD_CLOEXEC != 0` on the listener FD and an accepted client FD. Both fail on the pre-fix commit.
2. The fix — all 112 CmuxControlSocket package tests pass (`swift test`).

Closes https://github.com/manaflow-ai/cmux/issues/5835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783721843&installation_id=133855650&pr_number=5837&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5837&signature=732c856d70ed3076a6159b4d0c63bc097d0b6566ffd9812d34a80f213aad8624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the control-socket listener and accepted client sockets close-on-exec to stop leaking FDs into child processes, preventing stale connections, rebinding failures on restart, and unintended access to the control channel.

- **Bug Fixes**
  - Added `SocketTransport.configureCloseOnExec(_:)` (uses `fcntl(F_GETFD)` to set `FD_CLOEXEC`, idempotent).
  - Listener creation uses `transport.makeListenerSocket()` to set `FD_CLOEXEC` immediately after `socket()`; startup fails fast on error.
  - Accepted client sockets set `FD_CLOEXEC` right after `accept()` and before any further config.
  - Short-lived probe FDs mark close-on-exec best-effort.
  - New tests assert `FD_CLOEXEC` on listener and accepted sockets.

- **Refactors**
  - Moved `makeListenerSocket()` next to the socket primitives (`SocketTransport+ClientSocket.swift`); no behavior change.

<sup>Written for commit 563c370b6f41178c3cf23814c2ff0bedb5a943ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced socket file descriptor lifecycle and resource management to ensure automatic cleanup when child processes spawn, reducing security risks and preventing resource leaks across all socket operations including listener creation, client connections, and diagnostic command probes.

* **Tests**
  * Added comprehensive test coverage for socket descriptor configuration and lifecycle validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->