### PR TITLE
Sidebar: memoize VerticalTabsSidebar derived dictionaries to stop per-tick O(N) rebuilds (#5832)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11006,11 +11006,17 @@ struct VerticalTabsSidebar: View {
         let canCloseWorkspace = workspaceCount > 1
         let workspaceNumberShortcut = self.workspaceNumberShortcut
         let tabItemSettings = tabItemSettingsStore.snapshot
-        let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
-            ($0.element.id, $0.offset)
-        })
-        let workspaceById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
-        let workspaceGroupIdByWorkspaceId = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0.groupId) })
+        // The workspace identity / order / grouping derived structures are
+        // memoized in `TabManager`, so the frequent unrelated ticks that
+        // re-evaluate this body (unread-count churn, config changes, parent
+        // re-renders) read cached values instead of rebuilding five O(N)
+        // dictionaries each time. See #5832.
+        let derived = tabManager.sidebarWorkspaceListDerived()
+        let tabIndexById = derived.tabIndexById
+        let workspaceById = derived.workspaceById
+        let workspaceGroupIdByWorkspaceId = derived.workspaceGroupIdByWorkspaceId
+        // Selection-derived values depend on the view-local `selectedTabIds`
+        // binding (not on `tabs`/`workspaceGroups`), so they stay in body.
         let orderedSelectedTabs = tabs.filter { selectedTabIds.contains($0.id) }
         let selectedContextTargetIds = orderedSelectedTabs.map(\.id)
         let selectedRemoteContextMenuTargets = orderedSelectedTabs.filter { $0.isRemoteWorkspace }
@@ -11022,15 +11028,10 @@ struct VerticalTabsSidebar: View {
         let allSelectedRemoteContextMenuTargetsDisconnected = !selectedRemoteContextMenuTargets.isEmpty &&
             selectedRemoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
         let workspaceGroups = tabManager.workspaceGroups
-        let workspaceGroupById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
-        let workspaceGroupMenuSnapshot = WorkspaceGroupMenuSnapshot(
-            items: workspaceGroups.map { WorkspaceGroupMenuSnapshot.Item(id: $0.id, name: $0.name) }
-        )
-        let workspaceRenderItems = SidebarWorkspaceRenderItem.renderItems(
-            tabs: tabs,
-            groupsById: workspaceGroupById
-        )
-        let visibleWorkspaceRowIds = workspaceRenderItems.map(\.rowWorkspaceId)
+        let workspaceGroupById = derived.workspaceGroupById
+        let workspaceGroupMenuSnapshot = derived.workspaceGroupMenuSnapshot
+        let workspaceRenderItems = derived.workspaceRenderItems
+        let visibleWorkspaceRowIds = derived.visibleWorkspaceRowIds
         let draggedSidebarTabId = dragState.draggedTabId
         let sidebarReorderIds = draggedSidebarTabId.map {
             tabManager.sidebarReorderWorkspaceIds(
@@ -11040,7 +11041,7 @@ struct VerticalTabsSidebar: View {
         } ?? []
         let renderContext = WorkspaceListRenderContext(
             tabs: tabs,
-            tabIds: tabs.map(\.id),
+            tabIds: derived.tabIds,
             sidebarReorderIds: sidebarReorderIds,
             workspaceCount: workspaceCount,
             canCloseWorkspace: canCloseWorkspace,

--- a/Sources/SidebarWorkspaceListDerivedCache.swift
+++ b/Sources/SidebarWorkspaceListDerivedCache.swift
@@ -61,6 +61,9 @@ final class SidebarWorkspaceListDerivedCache {
             workspaceGroupIds: tabs.map(\.groupId),
             groups: workspaceGroups
         )
+        if let cachedDerived, cachedFingerprint == fingerprint {
+            return cachedDerived
+        }
         let derived = Self.build(tabs: tabs, workspaceGroups: workspaceGroups)
         cachedFingerprint = fingerprint
         cachedDerived = derived

--- a/Sources/SidebarWorkspaceListDerivedCache.swift
+++ b/Sources/SidebarWorkspaceListDerivedCache.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Memoizes the O(N) lookup dictionaries and render items that the workspace
+/// sidebar's `body` would otherwise rebuild on every observable tick.
+///
+/// `VerticalTabsSidebar.body` re-evaluates whenever any of its observed stores
+/// publish — `notificationStore` (unread counts churn continuously while agents
+/// run), `cmuxConfigStore`, the parent `ContentView`, etc. Most of those ticks
+/// are orthogonal to the inputs these structures actually depend on (workspace
+/// identity + order, per-workspace `groupId`, and the `workspaceGroups` value
+/// array). Rebuilding five O(N) dictionaries plus the render-item traversal on
+/// each unrelated tick is steady main-thread churn that, with 130+ workspaces
+/// and ~10 concurrent agents, turns into visible sidebar jank.
+///
+/// This cache keys the derived structures on a cheap value fingerprint of those
+/// inputs, so an unrelated tick is a fingerprint comparison instead of five
+/// fresh allocations. See https://github.com/manaflow-ai/cmux/issues/5832 (and
+/// the per-`Workspace` memoization in #4621, which is complementary).
+@MainActor
+final class SidebarWorkspaceListDerivedCache {
+    /// Captures exactly the inputs the derived structures depend on. Equality is
+    /// the memo key: anything not represented here (title, status entries,
+    /// badges, git branch, unread counts, …) is correctly ignored.
+    struct Fingerprint: Equatable {
+        /// Workspace identity + order. Membership or reorder changes this.
+        let workspaceIds: [UUID]
+        /// Per-workspace `groupId`, parallel to `workspaceIds`. Grouping a
+        /// workspace changes this even when membership/order does not.
+        let workspaceGroupIds: [UUID?]
+        /// Value-type group state (name, collapse, anchor, color, icon). Any
+        /// group mutation reassigns the `@Published` array and lands here.
+        let groups: [WorkspaceGroup]
+    }
+
+    /// The cached, ready-to-read structures consumed by the sidebar body.
+    struct Derived {
+        let tabIds: [UUID]
+        let tabIndexById: [UUID: Int]
+        let workspaceById: [UUID: Workspace]
+        let workspaceGroupIdByWorkspaceId: [UUID: UUID?]
+        let workspaceGroupById: [UUID: WorkspaceGroup]
+        let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
+        let workspaceRenderItems: [SidebarWorkspaceRenderItem]
+        let visibleWorkspaceRowIds: [UUID]
+    }
+
+    private var cachedFingerprint: Fingerprint?
+    private var cachedDerived: Derived?
+
+    /// Number of times the derived structures were actually (re)built. Exposed so
+    /// regression tests can assert that an unrelated observable tick does not
+    /// trigger a rebuild of all five structures. Not `@Published`; reading or
+    /// writing it never invalidates a SwiftUI view.
+    private(set) var rebuildCount: Int = 0
+
+    /// Returns the derived structures for the given inputs, rebuilding only when
+    /// the fingerprint changed since the last call.
+    func derived(tabs: [Workspace], workspaceGroups: [WorkspaceGroup]) -> Derived {
+        let fingerprint = Fingerprint(
+            workspaceIds: tabs.map(\.id),
+            workspaceGroupIds: tabs.map(\.groupId),
+            groups: workspaceGroups
+        )
+        let derived = Self.build(tabs: tabs, workspaceGroups: workspaceGroups)
+        cachedFingerprint = fingerprint
+        cachedDerived = derived
+        rebuildCount += 1
+        return derived
+    }
+
+    private static func build(
+        tabs: [Workspace],
+        workspaceGroups: [WorkspaceGroup]
+    ) -> Derived {
+        let tabIds = tabs.map(\.id)
+        let tabIndexById = Dictionary(
+            uniqueKeysWithValues: tabs.enumerated().map { ($0.element.id, $0.offset) }
+        )
+        let workspaceById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
+        let workspaceGroupIdByWorkspaceId = Dictionary(
+            uniqueKeysWithValues: tabs.map { ($0.id, $0.groupId) }
+        )
+        let workspaceGroupById = Dictionary(
+            uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) }
+        )
+        let workspaceGroupMenuSnapshot = WorkspaceGroupMenuSnapshot(
+            items: workspaceGroups.map { WorkspaceGroupMenuSnapshot.Item(id: $0.id, name: $0.name) }
+        )
+        let workspaceRenderItems = SidebarWorkspaceRenderItem.renderItems(
+            tabs: tabs,
+            groupsById: workspaceGroupById
+        )
+        let visibleWorkspaceRowIds = workspaceRenderItems.map(\.rowWorkspaceId)
+        return Derived(
+            tabIds: tabIds,
+            tabIndexById: tabIndexById,
+            workspaceById: workspaceById,
+            workspaceGroupIdByWorkspaceId: workspaceGroupIdByWorkspaceId,
+            workspaceGroupById: workspaceGroupById,
+            workspaceGroupMenuSnapshot: workspaceGroupMenuSnapshot,
+            workspaceRenderItems: workspaceRenderItems,
+            visibleWorkspaceRowIds: visibleWorkspaceRowIds
+        )
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1065,6 +1065,13 @@ class TabManager: ObservableObject {
     weak var window: NSWindow?
 
     @Published var tabs: [Workspace] = []
+    /// Memoizes the sidebar's O(N) lookup dictionaries / render items so they
+    /// rebuild only when their inputs (workspace identity + order, per-workspace
+    /// `groupId`, `workspaceGroups`) actually change — not on every unrelated
+    /// observable tick that re-evaluates `VerticalTabsSidebar.body`. See #5832.
+    /// Plain (non-`@Published`) storage: reading/updating it must never
+    /// invalidate a SwiftUI view.
+    let sidebarWorkspaceListDerivedCache = SidebarWorkspaceListDerivedCache()
     /// Named groupings of workspaces shown as collapsible sections in the sidebar.
     /// Group order in this array defines section order in the sidebar.
     /// Each member workspace stores its `groupId` on the `Workspace` model.
@@ -3682,6 +3689,13 @@ class TabManager: ObservableObject {
         }
         postWorkspaceOrderDidChange(movedWorkspaceIds: [tabId])
         return true
+    }
+
+    /// Sidebar lookup dictionaries / render items derived from the current
+    /// `tabs` and `workspaceGroups`, memoized so unrelated observable ticks that
+    /// re-evaluate `VerticalTabsSidebar.body` don't rebuild them. See #5832.
+    func sidebarWorkspaceListDerived() -> SidebarWorkspaceListDerivedCache.Derived {
+        sidebarWorkspaceListDerivedCache.derived(tabs: tabs, workspaceGroups: workspaceGroups)
     }
 
     func sidebarReorderWorkspaceIds(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -578,6 +578,8 @@
 		C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */; };
 		C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */; };
 		C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */; };
+		5832CA0E00000000000000A1 /* SidebarWorkspaceListDerivedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5832CA0E00000000000000A2 /* SidebarWorkspaceListDerivedCache.swift */; };
+		5832CA0E00000000000000B1 /* SidebarWorkspaceListDerivedCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5832CA0E00000000000000B2 /* SidebarWorkspaceListDerivedCacheTests.swift */; };
 		C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */; };
 		D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */; };
 		C9A57501C9A57501C9A57501 /* SidebarWorkspaceRowsHeightPreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57502C9A57502C9A57502 /* SidebarWorkspaceRowsHeightPreferenceKey.swift */; };
@@ -1318,6 +1320,8 @@
 		C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderMetricsTests.swift; sourceTree = "<group>"; };
 		C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupHeaderView.swift; sourceTree = "<group>"; };
 		C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupingMetrics.swift; sourceTree = "<group>"; };
+		5832CA0E00000000000000A2 /* SidebarWorkspaceListDerivedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceListDerivedCache.swift; sourceTree = "<group>"; };
+		5832CA0E00000000000000B2 /* SidebarWorkspaceListDerivedCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceListDerivedCacheTests.swift; sourceTree = "<group>"; };
 		C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItem.swift; sourceTree = "<group>"; };
 		D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTracker.swift; sourceTree = "<group>"; };
 		C9A57502C9A57502C9A57502 /* SidebarWorkspaceRowsHeightPreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowsHeightPreferenceKey.swift; sourceTree = "<group>"; };
@@ -1736,6 +1740,7 @@
 				C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */,
 				D5037010000000000000002 /* RenderableSystemSymbol.swift */,
 				C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */,
+				5832CA0E00000000000000A2 /* SidebarWorkspaceListDerivedCache.swift */,
 				C9A57512C9A57512C9A57512 /* SidebarScrollViewConfigurator.swift */,
 				C9A57502C9A57502C9A57502 /* SidebarWorkspaceRowsHeightPreferenceKey.swift */,
 				C9A57504C9A57504C9A57504 /* SidebarWorkspaceRowsMeasurement.swift */,
@@ -2238,6 +2243,7 @@
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				5832CA0E00000000000000B2 /* SidebarWorkspaceListDerivedCacheTests.swift */,
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
 				42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */,
@@ -3005,6 +3011,7 @@
 				C9A57301C9A57301C9A57301 /* SidebarWorkspaceGroupHeaderMetrics.swift in Sources */,
 				C9A57101C9A57101C9A57101 /* SidebarWorkspaceGroupHeaderView.swift in Sources */,
 				C9A57109C9A57109C9A57109 /* SidebarWorkspaceGroupingMetrics.swift in Sources */,
+				5832CA0E00000000000000A1 /* SidebarWorkspaceListDerivedCache.swift in Sources */,
 				C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */,
 				D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */,
 				C9A57501C9A57501C9A57501 /* SidebarWorkspaceRowsHeightPreferenceKey.swift in Sources */,
@@ -3337,6 +3344,7 @@
 				D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */,
 				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
+				5832CA0E00000000000000B1 /* SidebarWorkspaceListDerivedCacheTests.swift in Sources */,
 				C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */,
 				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 				62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceListDerivedCacheTests.swift
+++ b/cmuxTests/SidebarWorkspaceListDerivedCacheTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5832.
+///
+/// `VerticalTabsSidebar.body` used to rebuild ~5 O(N) lookup dictionaries plus
+/// the render-item traversal on every observable tick that re-evaluated the
+/// body — including ticks orthogonal to the inputs those structures depend on
+/// (workspace title, status entries, unread counts, …). The fix memoizes them
+/// in `SidebarWorkspaceListDerivedCache`, keyed on a fingerprint of the inputs
+/// that actually matter. These tests assert the cache rebuilds once per relevant
+/// change and *not* on unrelated workspace state churn.
+@MainActor
+final class SidebarWorkspaceListDerivedCacheTests: XCTestCase {
+
+    private func makeManagerWithWorkspaces(_ count: Int) -> TabManager {
+        let manager = TabManager()
+        // TabManager seeds one workspace; add the rest.
+        while manager.tabs.count < count {
+            _ = manager.addWorkspace()
+        }
+        return manager
+    }
+
+    func testFirstCallBuildsDerivedStructures() {
+        let manager = makeManagerWithWorkspaces(3)
+        let cache = SidebarWorkspaceListDerivedCache()
+
+        let derived = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+
+        XCTAssertEqual(cache.rebuildCount, 1)
+        XCTAssertEqual(derived.tabIds, manager.tabs.map(\.id))
+        XCTAssertEqual(derived.tabIndexById.count, 3)
+        XCTAssertEqual(derived.workspaceById.count, 3)
+        for (offset, tab) in manager.tabs.enumerated() {
+            XCTAssertEqual(derived.tabIndexById[tab.id], offset)
+            XCTAssertTrue(derived.workspaceById[tab.id] === tab)
+        }
+    }
+
+    /// The core regression: an unrelated workspace state change (title) must NOT
+    /// trigger a rebuild of the derived structures. Without memoization this
+    /// rebuilds every call and `rebuildCount` climbs to 2.
+    func testUnrelatedWorkspaceStateChangeDoesNotRebuild() {
+        let manager = makeManagerWithWorkspaces(3)
+        let cache = SidebarWorkspaceListDerivedCache()
+
+        _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(cache.rebuildCount, 1)
+
+        // Simulate an orthogonal observable tick: a workspace's title changes.
+        // None of the cache's fingerprint inputs (ids, order, groupId, groups)
+        // are affected, so the cache must serve the memoized value.
+        manager.tabs[0].title = "changed-title"
+        manager.tabs[1].customTitle = "custom"
+
+        _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(
+            cache.rebuildCount, 1,
+            "An unrelated workspace state change must not rebuild the sidebar derived structures (#5832)"
+        )
+    }
+
+    func testRepeatedIdenticalCallsDoNotRebuild() {
+        let manager = makeManagerWithWorkspaces(4)
+        let cache = SidebarWorkspaceListDerivedCache()
+
+        for _ in 0..<10 {
+            _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        }
+        XCTAssertEqual(cache.rebuildCount, 1)
+    }
+
+    func testAddingWorkspaceRebuilds() {
+        let manager = makeManagerWithWorkspaces(3)
+        let cache = SidebarWorkspaceListDerivedCache()
+
+        _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(cache.rebuildCount, 1)
+
+        _ = manager.addWorkspace()
+
+        let derived = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(cache.rebuildCount, 2)
+        XCTAssertEqual(derived.tabIndexById.count, 4)
+    }
+
+    func testGroupIdChangeRebuilds() {
+        let manager = makeManagerWithWorkspaces(2)
+        let cache = SidebarWorkspaceListDerivedCache()
+
+        _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(cache.rebuildCount, 1)
+
+        // A grouping change mutates per-workspace `groupId` even when membership
+        // and order are unchanged; the fingerprint must catch it.
+        let newGroupId = UUID()
+        manager.tabs[0].groupId = newGroupId
+
+        _ = cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups)
+        XCTAssertEqual(cache.rebuildCount, 2)
+        XCTAssertEqual(cache.derived(tabs: manager.tabs, workspaceGroups: manager.workspaceGroups).rebuildSentinelGroupId(newGroupId), newGroupId)
+        // Still only two rebuilds — the last identical call was memoized.
+        XCTAssertEqual(cache.rebuildCount, 2)
+    }
+}
+
+private extension SidebarWorkspaceListDerivedCache.Derived {
+    /// Tiny helper to read back the mapped groupId for the assertion above
+    /// without leaking dictionary-access noise into the test body.
+    func rebuildSentinelGroupId(_ expected: UUID) -> UUID? {
+        for (_, gid) in workspaceGroupIdByWorkspaceId where gid == expected {
+            return gid
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Problem

`VerticalTabsSidebar.body` rebuilt ~5 O(N) lookup dictionaries plus the render-item traversal on **every** observable tick that re-evaluated the body — and most of those ticks are orthogonal to the inputs those structures actually depend on. The body observes `tabManager`, `notificationStore` (unread counts churn continuously while agents run), `cmuxConfigStore`, `fileExplorerState`, and re-evaluates on parent `ContentView` re-renders. Each such tick rebuilt:

- `tabIndexById`, `workspaceById`, `workspaceGroupIdByWorkspaceId`, `workspaceGroupById` — 4 × O(N) dictionary allocations
- `workspaceGroupMenuSnapshot`, `SidebarWorkspaceRenderItem.renderItems(...)` — O(N) traversal
- `tabIds` / `visibleWorkspaceRowIds` maps

With 130+ workspaces and ~10 concurrent agents mutating workspace state continuously, this is constant main-thread churn even when layout converges (distinct from the #5764 / #2586 non-converging-layout loop — same hot path, different fix).

## Fix

Introduce `SidebarWorkspaceListDerivedCache`, owned by `TabManager`, which memoizes those derived structures keyed on a cheap value **fingerprint** of the inputs that actually matter:

- workspace identity + order (`tabs.map(\.id)`)
- per-workspace `groupId` (so a grouping change is caught even when membership/order is unchanged)
- the `workspaceGroups` value array (name/collapse/anchor/color/icon)

An unrelated tick (title, status entry, unread count, git branch) leaves the fingerprint unchanged, so the body reads the memoized structures instead of rebuilding them. The cache lives on `TabManager` so it persists across body evaluations, and uses plain (non-`@Published`) storage so reads/updates never invalidate a SwiftUI view (respects the no-mutation-in-body and snapshot-boundary rules).

Selection-derived values (`orderedSelectedTabs`, remote-context-menu targets) depend on the view-local `selectedTabIds` binding rather than `tabs`/`workspaceGroups`, so they intentionally stay in `body`.

This complements #4621 (per-`Workspace` memoization): that reduces cost *inside* a row; this reduces the eager *body setup* cost.

## Tests

Two-commit red/green structure:
1. Adds `SidebarWorkspaceListDerivedCacheTests` + a non-memoized cache (rebuilds every call) → the memoization tests fail (CI red).
2. Adds the fingerprint memo → tests pass (CI green).

Structural assertions via a `rebuildCount` counter (no wall-clock timing):
- an unrelated workspace state change (title/customTitle) does **not** rebuild the derived structures
- repeated identical calls rebuild once
- adding a workspace / changing a `groupId` rebuilds

SwiftUI `body` itself isn't unit-testable; the refactor extracts the cache into a plain `@MainActor` object so the behavior is tested directly.

Fixes #5832

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783722894&installation_id=133855650&pr_number=5840&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5840&signature=463fa346accea86e578af325ba4ab091e9187f0958011fd018df2d30a6028b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes `VerticalTabsSidebar` lookup dictionaries, tab ids, and render items to stop per-tick O(N) rebuilds and cut sidebar jank with many workspaces. Adds a fingerprinted cache and routes reads through it. Fixes #5832.

- **Refactors**
  - Added `SidebarWorkspaceListDerivedCache` keyed on workspace ids/order, per-workspace `groupId`, and `workspaceGroups`.
  - Stored the cache on `TabManager` (non-`@Published`) with `sidebarWorkspaceListDerived()` accessor.
  - Updated `VerticalTabsSidebar.body` to read cached `tabIndexById`, `workspaceById`, `workspaceGroupIdByWorkspaceId`, `workspaceGroupById`, `workspaceGroupMenuSnapshot`, `workspaceRenderItems`, `visibleWorkspaceRowIds`, and `tabIds`; kept selection-derived values local.
  - Added regression tests to ensure no rebuild on unrelated state changes and rebuild only on workspace add or `groupId` change.

<sup>Written for commit 31d5b461f22c6f4604e3a0dd35a3e747d1cc8caf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined workspace sidebar list computation and management for improved efficiency.

* **Tests**
  * Added comprehensive test coverage for workspace list operations and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->