### PR TITLE
Fix macOS 27 crash opening browser panel (zero-size SF Symbol rasterization)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14552,18 +14552,9 @@ private struct SidebarHelpMenuButton: View {
             isPopoverPresented.toggle()
         } label: {
             Image(systemName: "questionmark.circle")
-                .resizable()
-                .scaledToFit()
-                .fontWeight(.medium)
+                .cmuxSymbolPixelSize(iconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                // Drive the symbol's raster size from an explicit frame rather
-                // than font metrics. During the window's pre-visible layout pass
-                // the font metrics aren't resolved yet, so a `.font`-sized symbol
-                // rasterizes at 0×0 — which macOS 26+ rejects with an uncaught
-                // `NSInvalidArgumentException` (targetSizeInPoints.width/height>0),
-                // crashing on launch. A fixed frame keeps the raster size positive.
-                .frame(width: iconSize, height: iconSize, alignment: .center)
                 .frame(width: buttonSize, height: buttonSize, alignment: .center)
         }
         .buttonStyle(SidebarFooterIconButtonStyle())

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -134,26 +134,6 @@ private extension WKWebView {
     }
 }
 
-extension Image {
-    /// Sizes an SF Symbol from an explicit frame rather than font metrics.
-    ///
-    /// A `.font(.system(size:))`-sized symbol can rasterize at 0×0 during a
-    /// transient layout pass (e.g. while a panel's hosting view is first added
-    /// to the hierarchy, before font metrics resolve). macOS 26+ rejects a
-    /// zero raster size with an uncaught `NSInvalidArgumentException`
-    /// (`targetSizeInPoints.width>0 && targetSizeInPoints.height>0`), which
-    /// AppKit turns into a hard crash. Driving the raster size from a fixed
-    /// frame keeps it positive across every layout pass. Mirrors the fix in
-    /// `SidebarHelpMenuButton` (#5670).
-    func cmuxSymbolPixelSize(_ size: CGFloat, weight: Font.Weight = .regular) -> some View {
-        self
-            .resizable()
-            .scaledToFit()
-            .fontWeight(weight)
-            .frame(width: size, height: size, alignment: .center)
-    }
-}
-
 enum BrowserDevToolsIconOption: String, CaseIterable, Identifiable {
     case wrenchAndScrewdriver = "wrench.and.screwdriver"
     case wrenchAndScrewdriverFill = "wrench.and.screwdriver.fill"

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -134,6 +134,26 @@ private extension WKWebView {
     }
 }
 
+extension Image {
+    /// Sizes an SF Symbol from an explicit frame rather than font metrics.
+    ///
+    /// A `.font(.system(size:))`-sized symbol can rasterize at 0×0 during a
+    /// transient layout pass (e.g. while a panel's hosting view is first added
+    /// to the hierarchy, before font metrics resolve). macOS 26+ rejects a
+    /// zero raster size with an uncaught `NSInvalidArgumentException`
+    /// (`targetSizeInPoints.width>0 && targetSizeInPoints.height>0`), which
+    /// AppKit turns into a hard crash. Driving the raster size from a fixed
+    /// frame keeps it positive across every layout pass. Mirrors the fix in
+    /// `SidebarHelpMenuButton` (#5670).
+    func cmuxSymbolPixelSize(_ size: CGFloat, weight: Font.Weight = .regular) -> some View {
+        self
+            .resizable()
+            .scaledToFit()
+            .fontWeight(weight)
+            .frame(width: size, height: size, alignment: .center)
+    }
+}
+
 enum BrowserDevToolsIconOption: String, CaseIterable, Identifiable {
     case wrenchAndScrewdriver = "wrench.and.screwdriver"
     case wrenchAndScrewdriverFill = "wrench.and.screwdriver.fill"
@@ -1265,7 +1285,7 @@ struct BrowserPanelView: View {
                 panel.goBack()
             }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolPixelSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1281,7 +1301,7 @@ struct BrowserPanelView: View {
                 panel.goForward()
             }) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolPixelSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1292,7 +1312,7 @@ struct BrowserPanelView: View {
 
             Button(action: handleReloadOrStopButtonAction) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolPixelSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1316,9 +1336,9 @@ struct BrowserPanelView: View {
     private var screenshotPageButton: some View {
         Button(action: handleScreenshotPageButtonAction) {
             Image(systemName: screenshotPageCopied ? "checkmark" : "camera")
+                .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
                 .foregroundStyle(screenshotPageButtonColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1372,7 +1392,7 @@ struct BrowserPanelView: View {
         Button(action: handleBrowserFocusModeButtonAction) {
             HStack(spacing: 5) {
                 Image(systemName: "keyboard")
-                    .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                    .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                     .scaleEffect(panel.isBrowserFocusModeActive ? 1.08 : 1.0)
                     .animation(.spring(response: 0.18, dampingFraction: 0.82), value: panel.isBrowserFocusModeActive)
                 if panel.isBrowserFocusModeActive {
@@ -1418,9 +1438,9 @@ struct BrowserPanelView: View {
             Task { await panel.toggleOrInjectReactGrab() }
         }) {
             Image(systemName: "cursorarrow.click.2")
+                .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
                 .foregroundStyle(panel.isReactGrabActive ? Color.accentColor : Color.secondary)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1435,9 +1455,9 @@ struct BrowserPanelView: View {
             openDevTools()
         }) {
             Image(systemName: devToolsIconOption.rawValue)
+                .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1452,9 +1472,9 @@ struct BrowserPanelView: View {
             isBrowserProfileMenuPresented.toggle()
         }) {
             Image(systemName: "person.crop.circle")
+                .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1480,9 +1500,9 @@ struct BrowserPanelView: View {
             isBrowserThemeMenuPresented.toggle()
         }) {
             Image(systemName: browserThemeMode.iconName)
+                .cmuxSymbolPixelSize(devToolsButtonIconSize, weight: .medium)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
                 .foregroundStyle(browserThemeModeIconColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1509,7 +1529,7 @@ struct BrowserPanelView: View {
         }) {
             HStack(spacing: 4) {
                 Image(systemName: "square.and.arrow.down.on.square")
-                    .font(.system(size: 10, weight: .medium))
+                    .cmuxSymbolPixelSize(10, weight: .medium)
                 Text(String(localized: "browser.import.hint.toolbar", defaultValue: "Import"))
                     .font(.system(size: 11, weight: .medium))
                     .lineLimit(1)
@@ -1635,7 +1655,7 @@ struct BrowserPanelView: View {
         return HStack(spacing: 4) {
             if showSecureBadge {
                 Image(systemName: "lock.fill")
-                    .font(.system(size: chromeMetrics.secureBadgeFontSize))
+                    .cmuxSymbolPixelSize(chromeMetrics.secureBadgeFontSize)
                     .foregroundColor(.secondary)
             }
 

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -1,4 +1,24 @@
 import AppKit
+import SwiftUI
+
+extension Image {
+    /// Sizes an SF Symbol from an explicit frame rather than font metrics.
+    ///
+    /// A `.font(.system(size:))`-sized symbol can rasterize at 0×0 during a
+    /// transient layout pass (e.g. while a view's hosting layer is first added
+    /// to the window, before font metrics resolve). macOS 26+ rejects a zero
+    /// raster size with an uncaught `NSInvalidArgumentException`
+    /// (`targetSizeInPoints.width>0 && targetSizeInPoints.height>0`), which
+    /// AppKit turns into a hard crash. Driving the raster size from a fixed
+    /// frame keeps it positive across every layout pass (#5670, #5841).
+    func cmuxSymbolPixelSize(_ size: CGFloat, weight: Font.Weight = .regular) -> some View {
+        self
+            .resizable()
+            .scaledToFit()
+            .fontWeight(weight)
+            .frame(width: size, height: size, alignment: .center)
+    }
+}
 
 enum RenderableSystemSymbol {
     static let defaultWorkspaceGroupIcon = "folder.fill"


### PR DESCRIPTION
## Summary

Fixes #5841 — follow-up to #5670. The same macOS 26+ zero-size SF Symbol rasterization crash still fires in the **browser panel toolbar**: cmd-clicking a terminal link (which opens the integrated browser) crashes cmux on macOS 27.0.

## Root cause

Captured under lldb on macOS 27:

```
<CUINamedVectorGlyph: …> 'wrench.and.screwdriver' @2x, 11-points, Medium weight … Width=0; Height=0
*** Invalid parameter not satisfying: targetSizeInPoints.width>0 && targetSizeInPoints.height>0
objc_exception_throw
  -[CUINamedVectorGlyph _rasterizeImageUsingScaleFactor:forTargetSize:renderingMode:colorResolver:]
  … RenderBox RBSymbolUpdateTemplateImage
  … SwiftUI  _ShapeStyle_RenderedShape.renderVectorGlyph(…)
  … AppKit   -[NSView addSubview:] → _setDefaultKeyViewLoop → layoutSubtreeIfNeeded
  … cmux     Workspace.flushWorkspaceWindowLayouts()  (Workspace.swift:17295)
```

`BrowserPanelView`'s toolbar sizes its SF Symbols with `.font(.system(size:weight:))`. When the panel's SwiftUI hosting view is added to the hierarchy during a layout follow-up, font metrics aren't resolved yet, so the symbols rasterize at 0×0 — which macOS 26+ rejects with an uncaught `NSInvalidArgumentException`, crashing the app. The captured glyph is `wrench.and.screwdriver` (the default dev-tools button), but all ~12 `.font`-sized toolbar symbols are exposed.

## Fix

Adds an `Image.cmuxSymbolPixelSize(_:weight:)` helper that drives the symbol's raster size from an explicit frame via `.resizable().scaledToFit()` — the same approach merged for `SidebarHelpMenuButton` in #5670 — and applies it across the browser toolbar (navigation chevrons, reload/stop, screenshot camera, focus keyboard, react-grab cursor, dev-tools, profile, theme, import hint, secure lock badge). Visual output is unchanged.

## Verification

Built with Xcode 27 (macOS 27 SDK) and run on macOS 27.0 (26A5353q): before the fix, cmd-clicking a link crashed within ~1s, every time; after the fix, the browser panel opens and the app stays up (verified by reproducing the exact cmd-click flow under an isolated tagged build).

## Note

The `.font(.system(size:))`-on-symbol pattern exists in other panels app-wide; this PR fixes the browser toolbar (the reported crash). A broader sweep (or the reusable helper applied more widely) would harden the remaining surfaces — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon sizing and rendering consistency across navigation controls, reload/stop, developer tools, profile, theme switcher, import hint, secure badge, screenshot, and focus features.
  * Prevented transient icon rasterization/display issues on recent macOS releases.
  * Preserved existing monochrome and flat appearance for affected toolbar and interface icons.
  * Ensured uniform pixel-aligned sizing for toolbar symbols to reduce visual glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->