### PR TITLE
Pixel-align sidebar content height to hide the phantom scrollbar (#3241)

### DIFF
--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -76,15 +76,17 @@ enum SidebarWorkspaceScrollLayout {
         viewportHeight: CGFloat,
         insets: SidebarWorkspaceScrollInsets
     ) -> CGFloat {
-        // Pixel-align (floor) the available height. The scroll content is sized
-        // to fill exactly `viewportHeight - insets.total`, but on Retina/scaled
-        // displays the viewport is frequently fractional and AppKit rounds the
-        // laid-out document view UP to the next backing-store pixel. A fractional
-        // value would round up past the viewport by a sub-pixel, making the
-        // content barely scrollable and showing the auto-hiding overlay scroller
-        // even with a single workspace. Flooring keeps `content + insets <=
-        // viewportHeight` after the round-up, so the phantom scrollbar stays
-        // hidden when content fits (https://github.com/manaflow-ai/cmux/issues/3241).
+        // Floor the available height to a whole point. The scroll content is
+        // sized to fill exactly `viewportHeight - insets.total`, but on
+        // Retina/scaled displays the viewport is frequently fractional and
+        // AppKit aligns the laid-out document view's frame to the backing store
+        // (rounding up), so a fractional value can land just past the viewport.
+        // That sub-point overflow makes the content barely scrollable and shows
+        // the auto-hiding overlay scroller even with a single workspace.
+        // Flooring to a whole point keeps `content + insets <= viewportHeight`
+        // regardless of the display's backing scale, so the phantom scrollbar
+        // stays hidden when content fits
+        // (https://github.com/manaflow-ai/cmux/issues/3241).
         return max(0, (viewportHeight - insets.total).rounded(.down))
     }
 

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -76,7 +76,16 @@ enum SidebarWorkspaceScrollLayout {
         viewportHeight: CGFloat,
         insets: SidebarWorkspaceScrollInsets
     ) -> CGFloat {
-        return max(0, viewportHeight - insets.total)
+        // Pixel-align (floor) the available height. The scroll content is sized
+        // to fill exactly `viewportHeight - insets.total`, but on Retina/scaled
+        // displays the viewport is frequently fractional and AppKit rounds the
+        // laid-out document view UP to the next backing-store pixel. A fractional
+        // value would round up past the viewport by a sub-pixel, making the
+        // content barely scrollable and showing the auto-hiding overlay scroller
+        // even with a single workspace. Flooring keeps `content + insets <=
+        // viewportHeight` after the round-up, so the phantom scrollbar stays
+        // hidden when content fits (https://github.com/manaflow-ai/cmux/issues/3241).
+        return max(0, (viewportHeight - insets.total).rounded(.down))
     }
 
     /// Height of the empty drop/tap area placed below the last workspace row.

--- a/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
+++ b/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
@@ -92,8 +92,10 @@ struct SidebarWorkspaceScrollLayoutTests {
                 viewportHeight: viewportHeight,
                 insets: insets
             )
-            // Simulate AppKit rounding the laid-out document view up to a whole
-            // backing-store pixel.
+            // Simulate AppKit rounding the laid-out document view up to the next
+            // whole point. This is conservative (AppKit aligns to backing-store
+            // pixels, which are <= 1 pt on Retina displays), so the assertion
+            // holds regardless of the display scale factor.
             let roundedDocumentHeight = contentMinHeight.rounded(.up)
             #expect(roundedDocumentHeight + insets.total <= viewportHeight)
         }

--- a/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
+++ b/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
@@ -71,17 +71,19 @@ struct SidebarWorkspaceScrollLayoutTests {
     @Test func contentHeightStaysWithinViewportAfterPixelRounding() {
         // Real sidebar viewport heights are frequently fractional on
         // Retina/scaled displays and with fractional window heights. SwiftUI
-        // lays the scroll content out to `contentMinHeight`, but AppKit rounds
-        // the document view's frame UP to the next backing-store pixel. If
+        // lays the scroll content out to `contentMinHeight`, but AppKit aligns
+        // the document view's frame to the backing store (rounding up). If
         // `contentMinHeight` is fractional, that round-up pushes
-        // `document + insets` a sub-pixel past the viewport, so the content
+        // `document + insets` a sub-point past the viewport, so the content
         // becomes (barely) scrollable and the auto-hiding overlay scroller is
         // shown even when only a single workspace is present — the phantom
         // sidebar scrollbar (https://github.com/manaflow-ai/cmux/issues/3241).
         //
-        // Guard the invariant directly: the content height must stay pixel
-        // aligned so that, even after AppKit rounds it up to a whole pixel,
-        // `content + insets` never exceeds the viewport.
+        // Guard the invariant directly: the content height must stay point
+        // aligned. Rounding up to a whole point is a conservative
+        // over-approximation of AppKit's backing-store alignment (which is
+        // finer on Retina), so if `content + insets` survives a whole-point
+        // round-up it survives the real, finer one too.
         let insets = SidebarWorkspaceScrollInsets(top: 28, bottom: 48)
         let fractionalViewportHeights: [CGFloat] = [948.7, 720.5, 1033.25, 600.999]
 

--- a/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
+++ b/cmuxTests/SidebarWorkspaceScrollLayoutTests.swift
@@ -68,6 +68,35 @@ struct SidebarWorkspaceScrollLayoutTests {
         #expect(abs((rowsHeight + emptyAreaHeight) - contentMinHeight) <= 0.001)
     }
 
+    @Test func contentHeightStaysWithinViewportAfterPixelRounding() {
+        // Real sidebar viewport heights are frequently fractional on
+        // Retina/scaled displays and with fractional window heights. SwiftUI
+        // lays the scroll content out to `contentMinHeight`, but AppKit rounds
+        // the document view's frame UP to the next backing-store pixel. If
+        // `contentMinHeight` is fractional, that round-up pushes
+        // `document + insets` a sub-pixel past the viewport, so the content
+        // becomes (barely) scrollable and the auto-hiding overlay scroller is
+        // shown even when only a single workspace is present — the phantom
+        // sidebar scrollbar (https://github.com/manaflow-ai/cmux/issues/3241).
+        //
+        // Guard the invariant directly: the content height must stay pixel
+        // aligned so that, even after AppKit rounds it up to a whole pixel,
+        // `content + insets` never exceeds the viewport.
+        let insets = SidebarWorkspaceScrollInsets(top: 28, bottom: 48)
+        let fractionalViewportHeights: [CGFloat] = [948.7, 720.5, 1033.25, 600.999]
+
+        for viewportHeight in fractionalViewportHeights {
+            let contentMinHeight = SidebarWorkspaceScrollLayout.contentMinHeight(
+                viewportHeight: viewportHeight,
+                insets: insets
+            )
+            // Simulate AppKit rounding the laid-out document view up to a whole
+            // backing-store pixel.
+            let roundedDocumentHeight = contentMinHeight.rounded(.up)
+            #expect(roundedDocumentHeight + insets.total <= viewportHeight)
+        }
+    }
+
     @Test func emptyAreaCollapsesWhenRowsAlreadyOverflowViewport() {
         let contentMinHeight: CGFloat = 300
         let rowsHeight: CGFloat = 420


### PR DESCRIPTION
## Problem

The workspace sidebar shows a scrollbar even when the content fits the viewport — a single workspace still gets a permanent/phantom scroller. Re-reported today.

Fixes #3241

## Root cause

The sidebar scroll content is sized to **exactly** fill the viewport:

```swift
// SidebarWorkspaceScrollLayout.contentMinHeight
return max(0, viewportHeight - insets.total)
```

and the empty drop area below the rows fills the remainder so that `rows + emptyArea == viewportHeight - insets.total` exactly (the existing test even asserts "rows + empty area **exactly equals** the viewport").

On Retina/scaled displays the sidebar viewport height is frequently **fractional** (e.g. `948.7`). SwiftUI lays the document view out to that fractional height, but **AppKit rounds the document view's frame UP to the next backing-store pixel**. That round-up pushes `document + insets` a sub-pixel past the viewport, so the content becomes *barely* scrollable and the auto-hiding overlay scroller is shown — even with a single workspace. Constant agent-driven sidebar re-renders then re-tile the scroller every frame so it never fades, which reads as "always showing."

This is why the previously-shipped overlay + `autohidesScrollers` + empty-area work (already on `main`) was insufficient: from AppKit's point of view the content genuinely (sub-pixel) overflows, so auto-hide correctly keeps the scroller visible.

## Fix

Pixel-align (`floor`) the available content height in `SidebarWorkspaceScrollLayout.contentMinHeight`:

```swift
return max(0, (viewportHeight - insets.total).rounded(.down))
```

Because `floor(V - T) + T <= V`, the document view stays at or below the viewport even after AppKit rounds it up to a whole pixel, so the content is never marginally scrollable when the rows fit. The floored value is also stable frame-to-frame, so sub-pixel viewport jitter no longer flips scrollability. Both sidebar scroll paths (`workspaceScrollArea` and `extensionSidebarScrollArea`) go through this single function, so both are covered. Scrollability for genuinely overflowing content is unchanged.

## Testing

Scroller visibility is AppKit layout behavior and is not cleanly unit-testable end-to-end, so the regression test guards the **testable seam**: the pure `contentMinHeight` layout function. `contentHeightStaysWithinViewportAfterPixelRounding` feeds fractional viewport heights, simulates AppKit's whole-pixel round-up (`.rounded(.up)`), and asserts `content + insets <= viewport`. It fails on the old fractional value and passes after flooring.

Two-commit structure (failing test → fix) proves CI catches the bug.

Repro: this was investigated from code plus a read-only screenshot of the running production app (which has many workspaces, so it legitimately scrolls — the empty/fits case is the fractional-overflow path above). The fix is to the shared pure layout function; no sidebar data-flow changes, keeping the diff minimal and clear of #5832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783725142&installation_id=133855650&pr_number=5846&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5846&signature=5996c9b95166f09b4245ba20558440ce4198a2d0b678a268d1251b22a7b27e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pixel-align the sidebar scroll content height to prevent the phantom scrollbar when content fits the viewport. Fixes #3241 and keeps the scroller hidden on Retina/scaled displays.

- **Bug Fixes**
  - Floor `viewportHeight - insets.total` in `SidebarWorkspaceScrollLayout.contentMinHeight` so `content + insets <= viewport` after AppKit rounds up, eliminating the phantom scrollbar.
  - Applies to both sidebar scroll areas; adds a test that simulates whole-point round-up (conservative) and updates comments to explicitly describe whole-point rounding (not backing-store pixels).

<sup>Written for commit 941433108a735b75c0eaeb19e5fa93708cbaaa7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar scroll layout height computation to use pixel-aligned values, preventing small overflows that could reveal the overlay scroller.

* **Tests**
  * Added a test ensuring content height remains within the viewport after pixel rounding across a range of fractional viewport sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->