### PR TITLE
Force overlay scrollers process-wide so browser panes stop showing a legacy scrollbar (part of #3241)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -20,7 +20,7 @@
 6119	CLI/cmux_open.swift
 5948	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
-5439	Sources/cmuxApp.swift
+5441	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -20,7 +20,7 @@
 6119	CLI/cmux_open.swift
 5948	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
-5441	Sources/cmuxApp.swift
+5443	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -63,10 +63,11 @@ enum AppScrollerStylePolicy {
     /// Running first makes the contract self-enforcing rather than relying on
     /// the ordering of unrelated `init` steps.
     static func applyAtLaunch(defaults: UserDefaults = .standard) {
-        // `string(forKey:)` resolves across domains, so once cmux's own
-        // application domain holds `WhenScrolling` this is a no-op on every
-        // subsequent launch — no redundant write, no spurious change
-        // notification.
+        // `string(forKey:)` resolves across domains (app domain before
+        // global), so this is a no-op whenever the *effective* value is
+        // already `WhenScrolling` — whether the app domain holds it from a
+        // previous launch or the global domain already provides it. No
+        // redundant write, no spurious change notification.
         if defaults.string(forKey: scrollBarsDefaultsKey) != overlayValue {
             defaults.set(overlayValue, forKey: scrollBarsDefaultsKey)
         }

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -41,8 +41,12 @@ import AppKit
 /// `AppleShowScrollBars` key from cmux's application domain (e.g. a one-shot
 /// `defaults.removeObject(forKey:)` migration) so stale installs stop forcing
 /// overlay. Accessibility note: this overrides a deliberate system-wide
-/// "Always" choice for cmux only; it intentionally matches the no-opt-out
-/// overlay forcing the terminal/sidebar/text-input surfaces already apply.
+/// "Always" choice for cmux only, matching the overlay forcing the
+/// terminal/sidebar/text-input surfaces already apply. There is, however, a
+/// per-app escape hatch — an explicit `AppleShowScrollBars` value in cmux's own
+/// defaults domain (`defaults write <cmux-bundle-id> AppleShowScrollBars
+/// Always`) is honored, because the override is written only when the app
+/// domain has no value of its own.
 enum AppScrollerStylePolicy {
     /// `AppleShowScrollBars` selects overlay vs. legacy scrollers app-wide.
     static let scrollBarsDefaultsKey = "AppleShowScrollBars"
@@ -73,10 +77,16 @@ enum AppScrollerStylePolicy {
         // a later system switch to "Always" (which posts the distributed
         // settings-changed notification) would then re-resolve AppKit to legacy
         // scrollers for the rest of the session, reintroducing #3241 until the
-        // next launch. Persisting to the app domain whenever it is absent makes
-        // the override deterministic while still avoiding redundant writes.
-        let appDomainValue = defaults.persistentDomain(forName: bundleIdentifier)?[scrollBarsDefaultsKey] as? String
-        if appDomainValue != overlayValue {
+        // next launch.
+        //
+        // Write only when the app domain has *no* explicit value. A fresh
+        // install gets the deterministic override and the mid-session gap stays
+        // closed, but a deliberate per-app escape hatch is honored across
+        // launches: `defaults write <cmux-bundle-id> AppleShowScrollBars Always`
+        // (or `Automatic`) survives because the key is then present and we leave
+        // it untouched. This also avoids redundant writes on later launches.
+        let appDomainValue = defaults.persistentDomain(forName: bundleIdentifier)?[scrollBarsDefaultsKey]
+        if appDomainValue == nil {
             defaults.set(overlayValue, forKey: scrollBarsDefaultsKey)
         }
     }

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -32,6 +32,17 @@ import AppKit
 /// app-domain write (which posts `UserDefaults.didChangeNotification` and can
 /// nudge AppKit to re-evaluate scroller style mid-fade), the override is
 /// written only when the resolved value is not already `WhenScrolling`.
+///
+/// Caveat: because the registration domain ranks *below* `NSGlobalDomain`, a
+/// non-persistent `register(defaults:)` cannot beat a user's `Always`
+/// preference — the override must live in the persistent application domain.
+/// That value therefore outlives this code: if this policy is ever removed or
+/// replaced with a user-facing opt-out, that change must also delete the
+/// `AppleShowScrollBars` key from cmux's application domain (e.g. a one-shot
+/// `defaults.removeObject(forKey:)` migration) so stale installs stop forcing
+/// overlay. Accessibility note: this overrides a deliberate system-wide
+/// "Always" choice for cmux only; it intentionally matches the no-opt-out
+/// overlay forcing the terminal/sidebar/text-input surfaces already apply.
 enum AppScrollerStylePolicy {
     /// `AppleShowScrollBars` selects overlay vs. legacy scrollers app-wide.
     static let scrollBarsDefaultsKey = "AppleShowScrollBars"

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -50,9 +50,18 @@ enum AppScrollerStylePolicy {
     /// The value AppKit maps to the modern overlay (auto-fading) scroller style.
     static let overlayValue = "WhenScrolling"
 
-    /// Registers the per-app overlay-scroller override. Must run during launch
-    /// before any scroll view (terminal, sidebar, browser pane) is created so
-    /// `NSScroller.preferredScrollerStyle` resolves to overlay from the start.
+    /// Registers the per-app overlay-scroller override.
+    ///
+    /// Call this as early as possible in app launch — **before any
+    /// AppKit-adjacent work** (appearance, language, scroll-view creation).
+    /// AppKit resolves `NSScroller.preferredScrollerStyle` lazily and caches
+    /// it; it only re-resolves when System Settings posts the distributed
+    /// `AppleShowScrollBarsSettingChanged` notification. A local
+    /// `UserDefaults.set` does **not** post that notification, so on the first
+    /// launch after this ships (before the value is persisted) the override
+    /// only takes effect if nothing has queried `preferredScrollerStyle` yet.
+    /// Running first makes the contract self-enforcing rather than relying on
+    /// the ordering of unrelated `init` steps.
     static func applyAtLaunch(defaults: UserDefaults = .standard) {
         // `string(forKey:)` resolves across domains, so once cmux's own
         // application domain holds `WhenScrolling` this is a no-op on every

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -1,0 +1,49 @@
+import AppKit
+
+/// Forces overlay (auto-fading) scrollers across all of cmux's AppKit and
+/// WKWebView scroll views by overriding a system-wide "Show scroll bars:
+/// Always" (legacy) preference for cmux's process only.
+///
+/// In legacy-scroller environments — a mouse connected, or System Settings →
+/// Appearance → Show scroll bars → Always (`defaults write -g
+/// AppleShowScrollBars Always`) — macOS draws persistent, always-visible
+/// scrollbars in every scroll view app-wide, including the page content of
+/// `WKWebView`. That reserves a permanent bright track over browser panes and
+/// other cmux chrome, which is the persistent-scrollbar symptom reported in
+/// https://github.com/manaflow-ai/cmux/issues/3241.
+///
+/// AppKit resolves `NSScroller.preferredScrollerStyle` from the
+/// `AppleShowScrollBars` default. Writing `WhenScrolling` into cmux's *own*
+/// application defaults domain takes precedence over `NSGlobalDomain` for this
+/// process only, so every cmux scroll view (the sidebar list, browser-pane web
+/// content, settings panes, the file explorer) adopts the overlay style while
+/// the user's system-wide preference is left untouched for every other app.
+///
+/// This is the same intent already applied surface-by-surface elsewhere
+/// (terminals, the sidebar, text inputs all force `scrollerStyle = .overlay`);
+/// this policy makes overlay the process default so AppKit-created scrollers
+/// that cmux does not directly own — most importantly `WKWebView` page
+/// scrollers — match instead of inheriting the legacy style.
+///
+/// It composes with `SidebarScrollViewConfigurator`: that type still forces
+/// `.overlay` directly on the sidebar scroll view and tolerates no same-value
+/// rewrites; this policy only changes the *default* AppKit reads when it
+/// creates a scroller, so the two never fight. To avoid a redundant
+/// app-domain write (which posts `UserDefaults.didChangeNotification` and can
+/// nudge AppKit to re-evaluate scroller style mid-fade), the override is
+/// written only when the resolved value is not already `WhenScrolling`.
+enum AppScrollerStylePolicy {
+    /// `AppleShowScrollBars` selects overlay vs. legacy scrollers app-wide.
+    static let scrollBarsDefaultsKey = "AppleShowScrollBars"
+
+    /// The value AppKit maps to the modern overlay (auto-fading) scroller style.
+    static let overlayValue = "WhenScrolling"
+
+    /// Registers the per-app overlay-scroller override. Must run during launch
+    /// before any scroll view (terminal, sidebar, browser pane) is created so
+    /// `NSScroller.preferredScrollerStyle` resolves to overlay from the start.
+    static func applyAtLaunch(defaults: UserDefaults = .standard) {
+        // Intentionally unimplemented in this commit so the regression test
+        // fails (red). The override is added in the following commit (green).
+    }
+}

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -68,16 +68,16 @@ enum AppScrollerStylePolicy {
     /// the ordering of unrelated `init` steps.
     static func applyAtLaunch(
         defaults: UserDefaults = .standard,
-        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? ""
+        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? "",
+        appDomainValue: (_ key: String, _ bundleIdentifier: String) -> Any? = AppScrollerStylePolicy.copyAppDomainValue
     ) {
         // Decide by inspecting cmux's *application domain specifically*, not the
-        // cross-domain `string(forKey:)` resolution. If the user's global
-        // preference already resolves to `WhenScrolling`, a cross-domain check
-        // would skip the write and leave cmux with no app-domain override — and
-        // a later system switch to "Always" (which posts the distributed
-        // settings-changed notification) would then re-resolve AppKit to legacy
-        // scrollers for the rest of the session, reintroducing #3241 until the
-        // next launch.
+        // cross-domain resolution. If the user's global preference already
+        // resolves to `WhenScrolling`, a cross-domain check would skip the write
+        // and leave cmux with no app-domain override — and a later system switch
+        // to "Always" (which posts the distributed settings-changed
+        // notification) would then re-resolve AppKit to legacy scrollers for the
+        // rest of the session, reintroducing #3241 until the next launch.
         //
         // Write only when the app domain has *no* explicit value. A fresh
         // install gets the deterministic override and the mid-session gap stays
@@ -85,9 +85,28 @@ enum AppScrollerStylePolicy {
         // launches: `defaults write <cmux-bundle-id> AppleShowScrollBars Always`
         // (or `Automatic`) survives because the key is then present and we leave
         // it untouched. This also avoids redundant writes on later launches.
-        let appDomainValue = defaults.persistentDomain(forName: bundleIdentifier)?[scrollBarsDefaultsKey]
-        if appDomainValue == nil {
+        if appDomainValue(scrollBarsDefaultsKey, bundleIdentifier) == nil {
             defaults.set(overlayValue, forKey: scrollBarsDefaultsKey)
         }
+    }
+
+    /// Reads one key from an application's *own* defaults domain only.
+    ///
+    /// `CFPreferencesCopyValue` with an explicit `(key, appID, currentUser,
+    /// anyHost)` reads exactly the named domain — it does **not** merge
+    /// `NSGlobalDomain`. `UserDefaults.persistentDomain(forName:)` returns
+    /// app-domain-only keys on current Darwin, but Apple *documents* it as the
+    /// merged search list (FB8742683); relying on that undocumented behavior
+    /// would silently no-op this fix for exactly the #3241 population if
+    /// Foundation ever matched its docs — and this repo has direct precedent for
+    /// such silent Foundation shifts across macOS majors (issue #4529). Reading
+    /// the named domain contractually removes that fragility.
+    static func copyAppDomainValue(_ key: String, _ bundleIdentifier: String) -> Any? {
+        CFPreferencesCopyValue(
+            key as CFString,
+            bundleIdentifier as CFString,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        )
     }
 }

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -28,10 +28,10 @@ import AppKit
 /// It composes with `SidebarScrollViewConfigurator`: that type still forces
 /// `.overlay` directly on the sidebar scroll view and tolerates no same-value
 /// rewrites; this policy only changes the *default* AppKit reads when it
-/// creates a scroller, so the two never fight. To avoid a redundant
-/// app-domain write (which posts `UserDefaults.didChangeNotification` and can
-/// nudge AppKit to re-evaluate scroller style mid-fade), the override is
-/// written only when the resolved value is not already `WhenScrolling`.
+/// creates a scroller, so the two never fight. To avoid a redundant write
+/// (which posts `UserDefaults.didChangeNotification` and can nudge AppKit to
+/// re-evaluate scroller style mid-fade), the override is written only when
+/// cmux's *application domain* does not already hold `WhenScrolling`.
 ///
 /// Caveat: because the registration domain ranks *below* `NSGlobalDomain`, a
 /// non-persistent `register(defaults:)` cannot beat a user's `Always`
@@ -62,13 +62,21 @@ enum AppScrollerStylePolicy {
     /// only takes effect if nothing has queried `preferredScrollerStyle` yet.
     /// Running first makes the contract self-enforcing rather than relying on
     /// the ordering of unrelated `init` steps.
-    static func applyAtLaunch(defaults: UserDefaults = .standard) {
-        // `string(forKey:)` resolves across domains (app domain before
-        // global), so this is a no-op whenever the *effective* value is
-        // already `WhenScrolling` — whether the app domain holds it from a
-        // previous launch or the global domain already provides it. No
-        // redundant write, no spurious change notification.
-        if defaults.string(forKey: scrollBarsDefaultsKey) != overlayValue {
+    static func applyAtLaunch(
+        defaults: UserDefaults = .standard,
+        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? ""
+    ) {
+        // Decide by inspecting cmux's *application domain specifically*, not the
+        // cross-domain `string(forKey:)` resolution. If the user's global
+        // preference already resolves to `WhenScrolling`, a cross-domain check
+        // would skip the write and leave cmux with no app-domain override — and
+        // a later system switch to "Always" (which posts the distributed
+        // settings-changed notification) would then re-resolve AppKit to legacy
+        // scrollers for the rest of the session, reintroducing #3241 until the
+        // next launch. Persisting to the app domain whenever it is absent makes
+        // the override deterministic while still avoiding redundant writes.
+        let appDomainValue = defaults.persistentDomain(forName: bundleIdentifier)?[scrollBarsDefaultsKey] as? String
+        if appDomainValue != overlayValue {
             defaults.set(overlayValue, forKey: scrollBarsDefaultsKey)
         }
     }

--- a/Sources/AppScrollerStylePolicy.swift
+++ b/Sources/AppScrollerStylePolicy.swift
@@ -43,7 +43,12 @@ enum AppScrollerStylePolicy {
     /// before any scroll view (terminal, sidebar, browser pane) is created so
     /// `NSScroller.preferredScrollerStyle` resolves to overlay from the start.
     static func applyAtLaunch(defaults: UserDefaults = .standard) {
-        // Intentionally unimplemented in this commit so the regression test
-        // fails (red). The override is added in the following commit (green).
+        // `string(forKey:)` resolves across domains, so once cmux's own
+        // application domain holds `WhenScrolling` this is a no-op on every
+        // subsequent launch — no redundant write, no spurious change
+        // notification.
+        if defaults.string(forKey: scrollBarsDefaultsKey) != overlayValue {
+            defaults.set(overlayValue, forKey: scrollBarsDefaultsKey)
+        }
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -164,6 +164,10 @@ struct cmuxApp: App {
             Self.terminateForMissingLaunchTag()
         }
 
+        // Force overlay scrollers before any AppKit code resolves and caches
+        // NSScroller.preferredScrollerStyle (appearance/language work below). See #3241.
+        AppScrollerStylePolicy.applyAtLaunch()
+        StartupBreadcrumbLog.append("app.init.scrollerStyle.forced")
         Self.configureGhosttyEnvironment()
         StartupBreadcrumbLog.append("app.init.ghosttyEnvironment.configured")
         _ = KeyboardShortcutSettings.settingsFileStore
@@ -177,8 +181,6 @@ struct cmuxApp: App {
         Self.applyAppearance(startupAppearance, duringLaunch: true)
         StartupBreadcrumbLog.append("app.init.appearance.applied", fields: ["mode": startupAppearance.rawValue])
         let defaults = UserDefaults.standard
-        // Force overlay scrollers process-wide before any scroll view exists. See #3241.
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
         AppBundleIconPersistencePolicy.updateDisableDefault(
             defaults: defaults,
             launchArguments: ProcessInfo.processInfo.arguments

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -177,6 +177,11 @@ struct cmuxApp: App {
         Self.applyAppearance(startupAppearance, duringLaunch: true)
         StartupBreadcrumbLog.append("app.init.appearance.applied", fields: ["mode": startupAppearance.rawValue])
         let defaults = UserDefaults.standard
+        // Force overlay (auto-fading) scrollers process-wide before any scroll
+        // view is created, so browser-pane WKWebViews and other cmux chrome
+        // stop drawing a persistent legacy scrollbar in "Show scroll bars:
+        // Always" / mouse-connected environments. See #3241.
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
         AppBundleIconPersistencePolicy.updateDisableDefault(
             defaults: defaults,
             launchArguments: ProcessInfo.processInfo.arguments

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -177,10 +177,7 @@ struct cmuxApp: App {
         Self.applyAppearance(startupAppearance, duringLaunch: true)
         StartupBreadcrumbLog.append("app.init.appearance.applied", fields: ["mode": startupAppearance.rawValue])
         let defaults = UserDefaults.standard
-        // Force overlay (auto-fading) scrollers process-wide before any scroll
-        // view is created, so browser-pane WKWebViews and other cmux chrome
-        // stop drawing a persistent legacy scrollbar in "Show scroll bars:
-        // Always" / mouse-connected environments. See #3241.
+        // Force overlay scrollers process-wide before any scroll view exists. See #3241.
         AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
         AppBundleIconPersistencePolicy.updateDisableDefault(
             defaults: defaults,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAA000000000000000001 /* AppearanceSettingsTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
+		C9A57517C9A57517C9A57517 /* AppScrollerStylePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57518C9A57518C9A57518 /* AppScrollerStylePolicy.swift */; };
+		C9A57515C9A57515C9A57515 /* AppScrollerStylePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57516C9A57516C9A57516 /* AppScrollerStylePolicyTests.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000002 /* AuthEnvironmentTests.swift */; };
@@ -856,6 +858,8 @@
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
+		C9A57518C9A57518C9A57518 /* AppScrollerStylePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScrollerStylePolicy.swift; sourceTree = "<group>"; };
+		C9A57516C9A57516C9A57516 /* AppScrollerStylePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScrollerStylePolicyTests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		A47E00010000000000000002 /* AuthEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -1749,6 +1753,7 @@
 				D5037010000000000000002 /* RenderableSystemSymbol.swift */,
 				C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */,
 				C9A57512C9A57512C9A57512 /* SidebarScrollViewConfigurator.swift */,
+				C9A57518C9A57518C9A57518 /* AppScrollerStylePolicy.swift */,
 				C9A57502C9A57502C9A57502 /* SidebarWorkspaceRowsHeightPreferenceKey.swift */,
 				C9A57504C9A57504C9A57504 /* SidebarWorkspaceRowsMeasurement.swift */,
 				C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */,
@@ -2216,6 +2221,7 @@
 				EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */,
 				F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */,
 				C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */,
+				C9A57516C9A57516C9A57516 /* AppScrollerStylePolicyTests.swift */,
 				C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */,
 				C0DEF0B30000000000000002 /* KeyboardShortcutSettingsFileStoreMigrationTests.swift */,
 				E3337002E3337002E3337002 /* KeyboardShortcutSettingsFileStoreStartupTests.swift */,
@@ -2753,6 +2759,7 @@
 				A5001093 /* AppDelegate.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
+				C9A57517C9A57517C9A57517 /* AppScrollerStylePolicy.swift in Sources */,
 				D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */,
 				C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */,
 				A50012F1 /* Backport.swift in Sources */,
@@ -3231,6 +3238,7 @@
 				C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
 				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
+				C9A57515C9A57515C9A57515 /* AppScrollerStylePolicyTests.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
 				D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */,
 				BCBC0A0E0000000000000D01 /* BrowserChromeMetricsTests.swift in Sources */,

--- a/cmuxTests/AppScrollerStylePolicyTests.swift
+++ b/cmuxTests/AppScrollerStylePolicyTests.swift
@@ -10,32 +10,44 @@ import Testing
 @MainActor
 @Suite("App scroller style policy")
 struct AppScrollerStylePolicyTests {
-    /// In-memory `UserDefaults` that records writes. A same-value or redundant
+    /// In-memory `UserDefaults` that models two layers of the search list: the
+    /// app's own persistent domain (what `persistentDomain(forName:)` returns
+    /// and what `set(_:forKey:)` writes) and a simulated `NSGlobalDomain` value
+    /// that is only visible through cross-domain `string(forKey:)` resolution.
+    ///
+    /// The split lets the tests prove the policy decides from the *app domain
+    /// specifically*: a global `WhenScrolling` must not suppress the app-domain
+    /// write. `setCount` guards the no-redundant-write contract — a same-value
     /// write to `AppleShowScrollBars` posts `UserDefaults.didChangeNotification`
-    /// and can prompt AppKit to re-evaluate the scroller style mid-fade, so the
-    /// policy must write the override only when it actually changes — this
-    /// counter guards that no-redundant-write contract.
+    /// and can prompt AppKit to re-evaluate the scroller style mid-fade.
     private final class RecordingDefaults: UserDefaults {
-        private var store: [String: Any] = [:]
+        private var appDomain: [String: Any] = [:]
+        private var globalValue: String?
         var setCount = 0
 
         // `init()` returns an instance backed by the standard search list, but
-        // every primitive accessor below is overridden to use `store`, so the
-        // real on-disk domains are never touched.
-        convenience init(seed: [String: Any] = [:]) {
+        // every primitive accessor below is overridden to use the in-memory
+        // layers, so the real on-disk domains are never touched.
+        convenience init(appDomain: [String: Any] = [:], global: String? = nil) {
             self.init()
-            store = seed
+            self.appDomain = appDomain
+            self.globalValue = global
         }
 
-        override func object(forKey defaultName: String) -> Any? { store[defaultName] }
+        override func persistentDomain(forName domainName: String) -> [String: Any]? { appDomain }
+
+        override func object(forKey defaultName: String) -> Any? {
+            if let value = appDomain[defaultName] { return value }
+            return defaultName == AppScrollerStylePolicy.scrollBarsDefaultsKey ? globalValue : nil
+        }
 
         override func string(forKey defaultName: String) -> String? {
-            store[defaultName] as? String
+            object(forKey: defaultName) as? String
         }
 
         override func set(_ value: Any?, forKey defaultName: String) {
             setCount += 1
-            store[defaultName] = value
+            appDomain[defaultName] = value
         }
     }
 
@@ -50,11 +62,9 @@ struct AppScrollerStylePolicyTests {
     }
 
     @Test func applyOverridesLegacyAlwaysPreference() {
-        // Simulates a user with the system-wide "Show scroll bars: Always"
-        // (legacy) preference — the #3241 reproduction environment.
-        let defaults = RecordingDefaults(seed: [
-            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Always"
-        ])
+        // System-wide "Show scroll bars: Always" (legacy), app domain empty —
+        // the #3241 reproduction environment.
+        let defaults = RecordingDefaults(global: "Always")
 
         AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
 
@@ -64,12 +74,10 @@ struct AppScrollerStylePolicyTests {
     }
 
     @Test func applyOverridesAutomaticPreference() {
-        // Simulates the "Automatic" setting with a mouse connected — the other
-        // #3241 reproduction path. AppKit draws legacy scrollers whenever the
+        // The "Automatic" setting with a mouse connected — the other #3241
+        // reproduction path. AppKit draws legacy scrollers whenever the
         // input-device heuristic fires; forcing WhenScrolling removes that.
-        let defaults = RecordingDefaults(seed: [
-            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Automatic"
-        ])
+        let defaults = RecordingDefaults(global: "Automatic")
 
         AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
 
@@ -78,9 +86,24 @@ struct AppScrollerStylePolicyTests {
         #expect(defaults.setCount == 1)
     }
 
+    @Test func persistsOverrideEvenWhenGlobalAlreadyResolvesWhenScrolling() {
+        // Regression guard: the global preference already resolves WhenScrolling,
+        // but the app domain is empty. A cross-domain check would skip the write
+        // and leave cmux with no app-domain override — so a later switch to
+        // "Always" would revert cmux to legacy scrollers mid-session. The policy
+        // must still persist the override to the app domain.
+        let defaults = RecordingDefaults(global: AppScrollerStylePolicy.overlayValue)
+
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.persistentDomain(forName: "any")?[AppScrollerStylePolicy.scrollBarsDefaultsKey] as? String
+            == AppScrollerStylePolicy.overlayValue)
+        #expect(defaults.setCount == 1)
+    }
+
     @Test func reapplyWritesNothing() {
         // Launch runs this once per process; a re-run (or any later launch with
-        // the override already resolved) must not re-write the key.
+        // the app-domain override already in place) must not re-write the key.
         let defaults = RecordingDefaults()
         AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
 

--- a/cmuxTests/AppScrollerStylePolicyTests.swift
+++ b/cmuxTests/AppScrollerStylePolicyTests.swift
@@ -10,119 +10,90 @@ import Testing
 @MainActor
 @Suite("App scroller style policy")
 struct AppScrollerStylePolicyTests {
-    /// In-memory `UserDefaults` that models two layers of the search list: the
-    /// app's own persistent domain (what `persistentDomain(forName:)` returns
-    /// and what `set(_:forKey:)` writes) and a simulated `NSGlobalDomain` value
-    /// that is only visible through cross-domain `string(forKey:)` resolution.
-    ///
-    /// The split lets the tests prove the policy decides from the *app domain
-    /// specifically*: a global `WhenScrolling` must not suppress the app-domain
-    /// write. `setCount` guards the no-redundant-write contract — a same-value
+    /// In-memory `UserDefaults` that records writes. A same-value or redundant
     /// write to `AppleShowScrollBars` posts `UserDefaults.didChangeNotification`
-    /// and can prompt AppKit to re-evaluate the scroller style mid-fade.
+    /// and can prompt AppKit to re-evaluate the scroller style mid-fade, so the
+    /// policy must write the override only when it actually needs to — this
+    /// counter guards that contract. The decision input (the app-domain value)
+    /// is injected separately, so this fake only models the write side.
     private final class RecordingDefaults: UserDefaults {
-        private var appDomain: [String: Any] = [:]
-        private var globalValue: String?
+        private var store: [String: Any] = [:]
         var setCount = 0
 
-        // `init()` returns an instance backed by the standard search list, but
-        // every primitive accessor below is overridden to use the in-memory
-        // layers, so the real on-disk domains are never touched.
-        convenience init(appDomain: [String: Any] = [:], global: String? = nil) {
-            self.init()
-            self.appDomain = appDomain
-            self.globalValue = global
-        }
-
-        override func persistentDomain(forName domainName: String) -> [String: Any]? { appDomain }
-
-        override func object(forKey defaultName: String) -> Any? {
-            if let value = appDomain[defaultName] { return value }
-            return defaultName == AppScrollerStylePolicy.scrollBarsDefaultsKey ? globalValue : nil
-        }
+        override func object(forKey defaultName: String) -> Any? { store[defaultName] }
 
         override func string(forKey defaultName: String) -> String? {
-            object(forKey: defaultName) as? String
+            store[defaultName] as? String
         }
 
         override func set(_ value: Any?, forKey defaultName: String) {
             setCount += 1
-            appDomain[defaultName] = value
+            store[defaultName] = value
         }
     }
 
-    @Test func applyForcesOverlayWhenUnset() {
+    private let key = AppScrollerStylePolicy.scrollBarsDefaultsKey
+    private let overlay = AppScrollerStylePolicy.overlayValue
+
+    @Test func forcesOverlayWhenAppDomainUnset() {
+        // The app domain has no value of its own — true for a fresh install
+        // regardless of the system-wide setting (Always, Automatic with a mouse,
+        // or even a global WhenScrolling). Because the decision reads cmux's app
+        // domain *only*, the override is written deterministically in every one
+        // of those #3241 environments.
         let defaults = RecordingDefaults()
 
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+        AppScrollerStylePolicy.applyAtLaunch(
+            defaults: defaults,
+            bundleIdentifier: "com.cmux.test",
+            appDomainValue: { _, _ in nil }
+        )
 
-        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
-            == AppScrollerStylePolicy.overlayValue)
+        #expect(defaults.string(forKey: key) == overlay)
         #expect(defaults.setCount == 1)
     }
 
-    @Test func applyOverridesLegacyAlwaysPreference() {
-        // System-wide "Show scroll bars: Always" (legacy), app domain empty —
-        // the #3241 reproduction environment.
-        let defaults = RecordingDefaults(global: "Always")
+    @Test func passesScrollBarsKeyAndBundleToAppDomainLookup() {
+        // The decision must query the AppleShowScrollBars key in cmux's own
+        // bundle domain, not some other key/domain.
+        let defaults = RecordingDefaults()
+        var queried: (key: String, bundle: String)?
 
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+        AppScrollerStylePolicy.applyAtLaunch(
+            defaults: defaults,
+            bundleIdentifier: "com.cmux.test",
+            appDomainValue: { k, b in queried = (k, b); return nil }
+        )
 
-        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
-            == AppScrollerStylePolicy.overlayValue)
-        #expect(defaults.setCount == 1)
-    }
-
-    @Test func applyOverridesAutomaticPreference() {
-        // The "Automatic" setting with a mouse connected — the other #3241
-        // reproduction path. AppKit draws legacy scrollers whenever the
-        // input-device heuristic fires; forcing WhenScrolling removes that.
-        let defaults = RecordingDefaults(global: "Automatic")
-
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
-
-        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
-            == AppScrollerStylePolicy.overlayValue)
-        #expect(defaults.setCount == 1)
-    }
-
-    @Test func persistsOverrideEvenWhenGlobalAlreadyResolvesWhenScrolling() {
-        // Regression guard: the global preference already resolves WhenScrolling,
-        // but the app domain is empty. A cross-domain check would skip the write
-        // and leave cmux with no app-domain override — so a later switch to
-        // "Always" would revert cmux to legacy scrollers mid-session. The policy
-        // must still persist the override to the app domain.
-        let defaults = RecordingDefaults(global: AppScrollerStylePolicy.overlayValue)
-
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
-
-        #expect(defaults.persistentDomain(forName: "any")?[AppScrollerStylePolicy.scrollBarsDefaultsKey] as? String
-            == AppScrollerStylePolicy.overlayValue)
-        #expect(defaults.setCount == 1)
+        #expect(queried?.key == key)
+        #expect(queried?.bundle == "com.cmux.test")
     }
 
     @Test func honorsExplicitPerAppOptOut() {
         // A user who deliberately sets a per-app value in cmux's own domain
         // (`defaults write <cmux-bundle-id> AppleShowScrollBars Always`) keeps
         // it — the override only writes when the app domain has no value.
-        let defaults = RecordingDefaults(appDomain: [
-            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Always"
-        ])
+        let defaults = RecordingDefaults()
 
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+        AppScrollerStylePolicy.applyAtLaunch(
+            defaults: defaults,
+            bundleIdentifier: "com.cmux.test",
+            appDomainValue: { _, _ in "Always" }
+        )
 
-        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey) == "Always")
         #expect(defaults.setCount == 0)
     }
 
-    @Test func reapplyWritesNothing() {
-        // Launch runs this once per process; a re-run (or any later launch with
-        // the app-domain override already in place) must not re-write the key.
+    @Test func reapplyIsNoOpWhenOverrideAlreadyPresent() {
+        // A later launch (or re-run) where cmux's app domain already holds the
+        // override must not re-write the key.
         let defaults = RecordingDefaults()
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
 
-        defaults.setCount = 0
-        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+        AppScrollerStylePolicy.applyAtLaunch(
+            defaults: defaults,
+            bundleIdentifier: "com.cmux.test",
+            appDomainValue: { _, _ in overlay }
+        )
 
         #expect(defaults.setCount == 0)
     }

--- a/cmuxTests/AppScrollerStylePolicyTests.swift
+++ b/cmuxTests/AppScrollerStylePolicyTests.swift
@@ -63,6 +63,21 @@ struct AppScrollerStylePolicyTests {
         #expect(defaults.setCount == 1)
     }
 
+    @Test func applyOverridesAutomaticPreference() {
+        // Simulates the "Automatic" setting with a mouse connected — the other
+        // #3241 reproduction path. AppKit draws legacy scrollers whenever the
+        // input-device heuristic fires; forcing WhenScrolling removes that.
+        let defaults = RecordingDefaults(seed: [
+            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Automatic"
+        ])
+
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
+            == AppScrollerStylePolicy.overlayValue)
+        #expect(defaults.setCount == 1)
+    }
+
     @Test func reapplyWritesNothing() {
         // Launch runs this once per process; a re-run (or any later launch with
         // the override already resolved) must not re-write the key.

--- a/cmuxTests/AppScrollerStylePolicyTests.swift
+++ b/cmuxTests/AppScrollerStylePolicyTests.swift
@@ -1,0 +1,77 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("App scroller style policy")
+struct AppScrollerStylePolicyTests {
+    /// In-memory `UserDefaults` that records writes. A same-value or redundant
+    /// write to `AppleShowScrollBars` posts `UserDefaults.didChangeNotification`
+    /// and can prompt AppKit to re-evaluate the scroller style mid-fade, so the
+    /// policy must write the override only when it actually changes — this
+    /// counter guards that no-redundant-write contract.
+    private final class RecordingDefaults: UserDefaults {
+        private var store: [String: Any] = [:]
+        var setCount = 0
+
+        // `init()` returns an instance backed by the standard search list, but
+        // every primitive accessor below is overridden to use `store`, so the
+        // real on-disk domains are never touched.
+        convenience init(seed: [String: Any] = [:]) {
+            self.init()
+            store = seed
+        }
+
+        override func object(forKey defaultName: String) -> Any? { store[defaultName] }
+
+        override func string(forKey defaultName: String) -> String? {
+            store[defaultName] as? String
+        }
+
+        override func set(_ value: Any?, forKey defaultName: String) {
+            setCount += 1
+            store[defaultName] = value
+        }
+    }
+
+    @Test func applyForcesOverlayWhenUnset() {
+        let defaults = RecordingDefaults()
+
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
+            == AppScrollerStylePolicy.overlayValue)
+        #expect(defaults.setCount == 1)
+    }
+
+    @Test func applyOverridesLegacyAlwaysPreference() {
+        // Simulates a user with the system-wide "Show scroll bars: Always"
+        // (legacy) preference — the #3241 reproduction environment.
+        let defaults = RecordingDefaults(seed: [
+            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Always"
+        ])
+
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey)
+            == AppScrollerStylePolicy.overlayValue)
+        #expect(defaults.setCount == 1)
+    }
+
+    @Test func reapplyWritesNothing() {
+        // Launch runs this once per process; a re-run (or any later launch with
+        // the override already resolved) must not re-write the key.
+        let defaults = RecordingDefaults()
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        defaults.setCount = 0
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.setCount == 0)
+    }
+}

--- a/cmuxTests/AppScrollerStylePolicyTests.swift
+++ b/cmuxTests/AppScrollerStylePolicyTests.swift
@@ -101,6 +101,20 @@ struct AppScrollerStylePolicyTests {
         #expect(defaults.setCount == 1)
     }
 
+    @Test func honorsExplicitPerAppOptOut() {
+        // A user who deliberately sets a per-app value in cmux's own domain
+        // (`defaults write <cmux-bundle-id> AppleShowScrollBars Always`) keeps
+        // it — the override only writes when the app domain has no value.
+        let defaults = RecordingDefaults(appDomain: [
+            AppScrollerStylePolicy.scrollBarsDefaultsKey: "Always"
+        ])
+
+        AppScrollerStylePolicy.applyAtLaunch(defaults: defaults)
+
+        #expect(defaults.string(forKey: AppScrollerStylePolicy.scrollBarsDefaultsKey) == "Always")
+        #expect(defaults.setCount == 0)
+    }
+
     @Test func reapplyWritesNothing() {
         // Launch runs this once per process; a re-run (or any later launch with
         // the app-domain override already in place) must not re-write the key.


### PR DESCRIPTION
## Summary

Part of https://github.com/manaflow-ai/cmux/issues/3241 (browser-pane / legacy-scroller scope; sidebar scroller config is handled in a parallel PR).

In legacy-scroller environments — a mouse connected (`AppleShowScrollBars = Automatic`), or **System Settings → Appearance → Show scroll bars → Always** (`defaults write -g AppleShowScrollBars Always`) — macOS draws persistent, always-visible scrollbars in *every* scroll view app-wide, including the page content of `WKWebView`. That is the surface in the reopen screenshot: a bright persistent vertical scrollbar over a YouTube page in a **browser pane**, which `SidebarScrollViewConfigurator` (PR #4767) never covered because it only configures the sidebar list scroll view.

## Mechanism

`AppScrollerStylePolicy.applyAtLaunch` (called from `cmuxApp.init`, **before any AppKit appearance/scroll-view work**) writes `AppleShowScrollBars = WhenScrolling` into **cmux's own application defaults domain**. AppKit resolves `NSScroller.preferredScrollerStyle` from that key, and the per-app value out-ranks `NSGlobalDomain` for this process only — so every cmux scroll view (sidebar, **browser-pane web content**, settings, file explorer) adopts the overlay (auto-fading) style while the user's **system-wide preference is untouched for every other app**. This extends to the remaining surfaces the same overlay intent cmux already forces per-surface in the terminal, sidebar, and text inputs.

### Design details (hardened over review)
- **Ordering:** runs first in `init`. AppKit lazily resolves *and caches* the scroller style, and a local `UserDefaults.set` does **not** post the distributed `AppleShowScrollBarsSettingChanged` notification that would force re-resolution — so the write must land before anything queries the style.
- **App-domain-specific decision via `CFPreferencesCopyValue`:** the override is written only when cmux's *application domain* has no explicit value. We read it with `CFPreferencesCopyValue(key, bundleID, currentUser, anyHost)`, which contractually reads the named domain **without merging `NSGlobalDomain`** — deliberately avoiding `persistentDomain(forName:)`, whose app-domain-only behavior is undocumented (FB8742683) and could silently flip on a future macOS (cf. the Foundation behavior shift in #4529).
- **Closes a mid-session revert gap:** because the decision ignores the global value, a later system switch to "Always" cannot leave cmux without its own override.
- **Per-app escape hatch (accessibility):** because the override only writes when the app domain is *unset*, a user who deliberately runs `defaults write <cmux-bundle-id> AppleShowScrollBars Always` keeps legacy scrollers in cmux across launches. This preserves an accessibility opt-out at zero cost without a new Settings surface.
- **Composes with `SidebarScrollViewConfigurator`** (still forces `.overlay` directly on the sidebar; this only changes the process default). No sidebar code is modified here.
- **Persistence caveat documented:** the override lives in the persistent app domain (the registration domain ranks below `NSGlobalDomain`, so `register(defaults:)` cannot win). If this policy is ever removed/replaced, that change must also delete the key from cmux's domain — noted in the source.

## Tests
Two-commit red/green per repo policy (commit 1 adds the failing test with an unimplemented policy; commit 2 implements it). `cmuxTests/AppScrollerStylePolicyTests.swift` (wired into `project.pbxproj`) injects all seams (defaults, bundle id, app-domain lookup) and asserts: app-domain-unset forces overlay (covers Always / Automatic / global-WhenScrolling alike, since the read is app-domain-only), the correct key+bundle are queried, the per-app opt-out is honored, and re-apply writes nothing (the no-redundant-write / no-fade-churn contract).

The **overlay fade itself is video-verifiable only** (it lives in the private `NSScrollerImp`, not observable from `NSScroller.alphaValue`), so the unit tests cover the configuration lever and empirical before/after is captured on a legacy-scroller macOS.

## Empirical verification
Reproduction recipe: macOS 15.x with `defaults write -g AppleShowScrollBars Always`, restart cmux, open a browser pane on a long page (e.g. YouTube).
- [ ] Browser-pane before/after video (persistent legacy scrollbar → overlay/fade) — **VM capture in progress; the cmux-loader lease repeatedly timed out on Tailscale device discovery (infra), pursuing an AWS M4 Pro builder.** Will attach.
- [ ] Sidebar fix (#4767) verified to still hold in legacy mode (report only; sidebar code unchanged here).
- [ ] Audit: settings panes / file explorer in legacy mode (the same process-default lever should fix them for free; any remainder filed as follow-ups).

## Localization
No new user-facing strings (no Settings UI added). Localization audit: nothing to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
