### PR TITLE
Add cmux-custom-sidebar agent skill

### DIFF
--- a/skills/cmux-custom-sidebar/SKILL.md
+++ b/skills/cmux-custom-sidebar/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cmux-custom-sidebar
+description: "Build a custom cmux sidebar from a plain-language request. Use when the user asks for a custom sidebar, a sidebar that shows their workspaces/tabs/PRs/clock, a vibe-coded sidebar, or anything involving files in ~/.config/cmux/sidebars/. Covers authoring the interpreted SwiftUI-style file, enabling the beta flag, selecting it, and iterating with hot reload."
+---
+
+# cmux Custom Sidebar
+
+cmux renders custom sidebars from a small SwiftUI-style file at runtime: no Xcode, no build step, no signing. The file hot-reloads on save, binds to live cmux state (workspaces, tabs, git, PRs, clock), and can run real cmux commands on tap.
+
+The person asking is usually describing a result ("a sidebar that shows my workspaces and lets me jump between them"), not an implementation. Turn that into a clean, native-looking sidebar and make the engineering decisions for them. Do not ask them about SwiftUI, files, or syntax.
+
+## Full reference
+
+This skill is the workflow summary. The complete authoring contract (every supported view, modifier, language feature, and data field) is one command away; read it before writing a non-trivial sidebar:
+
+```bash
+cmux docs sidebars
+curl -fsSL https://raw.githubusercontent.com/manaflow-ai/cmux/main/docs/custom-sidebars.md
+```
+
+## Workflow
+
+1. **Enable the beta** (once). Custom sidebars are behind Settings → Beta features → Custom sidebars (`customSidebars.beta.enabled`). If a written sidebar does not appear in the picker, this flag is the first thing to check.
+2. **Write a named file.** The name becomes the menu label; use short kebab-case:
+   ```
+   ~/.config/cmux/sidebars/<name>.swift
+   ```
+   The file is a single SwiftUI-style view expression (no `struct`, no `var body`, no imports). A `.json` variant exists for static layouts; prefer `.swift` for anything dynamic.
+3. **Validate and select it:**
+   ```bash
+   cmux sidebar validate <name>   # parse/interpret check with real data shapes
+   cmux sidebar select <name>     # switch the sidebar to it
+   ```
+   The user can also pick it manually: right-click the sidebar toggle button.
+4. **Iterate.** Saving the file hot-reloads the sidebar in place (`cmux sidebar reload` forces it). Look at the result, fix what looks off, and verify rows show real data and taps do the right thing before declaring it done.
+
+## Authoring rules
+
+- **Default to live data.** Bind to the `workspaces` context instead of hard-coding text so the sidebar stays correct on its own.
+- **Make it interactive by default.** Rows that represent something openable should run the matching `cmux(...)` action on tap. A list that just displays text is rarely what they wanted.
+- **Prefer `Reorderable` for workspace-like lists.** It gives persisted drag-and-drop reordering for free.
+- **Keep it native and uncluttered:** a title, a divider, then the content.
+- **Cap long lists** (`.prefix(20)`, filter/sort before rendering). The sidebar re-evaluates about once a second; do not render hundreds of rows.
+- **Stay inside the supported subset.** Unsupported syntax is skipped gracefully (never crashes), but choose the closest supported approach rather than shipping a half-blank sidebar.
+
+## Quick start
+
+```bash
+cat > ~/.config/cmux/sidebars/mine.swift <<'SWIFT'
+VStack(alignment: .leading, spacing: 8) {
+    Text("My sidebar").font(.title3).bold()
+    Text(clock.time).font(.caption).foregroundColor(.secondary)
+    Divider()
+    Reorderable(workspaces, move: "workspace.reorder") { w in
+        Button(action: { cmux("workspace.select", workspace_id: w.id) }) {
+            HStack {
+                Text(w.selected ? "●" : "○").foregroundColor(w.selected ? "#FF8800" : .secondary)
+                Text(w.title)
+                Spacer()
+            }.padding(4)
+        }
+    }
+}
+SWIFT
+cmux sidebar validate mine && cmux sidebar select mine
+```
+
+## Live data context (read-only, refreshes ~1s)
+
+- `workspaces`: array with `id`, `title`, `selected`, `pinned`, `index`, `directory`, `ports` + `portCount`, `unread`, `tabs` + `tabCount`; plus, when present: `description`, `color`, `branch` + `dirty`, `pr` / `prs` (`{number, label, url, status, stale, branch}`), `progress` (`{value, label}`), `latestMessage`, `latestPrompt`, `latestAt`, `remote` (`{target, state, connected}`).
+- `workspaces[i].tabs`: `id`, `title`, `focused`, `pinned`; plus `directory`, `branch` + `dirty`, `ports` when available.
+- `clock`: `{time, hour, minute, second, weekday, epoch}`.
+- Scalars: `workspaceCount`, `selectedTitle`, `selectedId`, `unreadTotal`.
+
+Optional fields are omitted when absent; guard with `if let b = w.branch { ... }` or `w.pr != nil ? ... : ...`.
+
+## Actions
+
+A button or `.onTapGesture` body calls `cmux("<method>", param: value)`, dispatched through the same surface as the `cmux` CLI. Common methods: `workspace.select` (`workspace_id`), `surface.focus` (`surface_id`), `workspace.reorder` (`workspace_id` + `index`). `openURL("https://...")` opens links. Discover the full command surface with `cmux docs api`.
+
+## Supported subset at a glance
+
+Containers: stacks (incl. lazy), `Group`, `List`, `Section`, grids, `ViewThatFits`, `ScrollView`, `HSplitView` (two resizable columns). Content: `Text`, `Label`, `Image(systemName:)`, `Button` (title and label form), `Menu`, `ProgressView`, `Gauge`, `Spacer`, `Divider`, shapes, gradients via `.background`. Modifiers: full typography set, colors as hex strings or tokens, `.padding`/`.frame`/layout, `.background`/`.overlay`/`.mask`/`.contextMenu` with arbitrary nested views, shadows/borders/opacity/effects, `.onTapGesture`, `.help`, `.disabled`. Language: `let`, user `func` helpers, `for`/`ForEach`, `if/else`, ternary, string interpolation, arithmetic, array methods (`filter`/`map`/`sorted`/`prefix`/...), string and number formatting.
+
+Not yet supported (write the natural Swift anyway; it degrades gracefully): `@State` and input controls (`TextField`, `Toggle`, `Slider`, `Picker`), custom `struct`/`View` definitions, navigation (`sheet`/`popover`), `AsyncImage`. Two-way editing does not work yet; taps that run `cmux(...)` do.
+
+## Troubleshooting
+
+- Sidebar missing from the right-click picker: the beta flag is off, or the file is not directly under `~/.config/cmux/sidebars/`.
+- Blank or partial render: run `cmux sidebar validate <name>`; errors show inline in the sidebar with the failing location. A broken save keeps the last working render on screen, so re-save after fixing.
+- Rows not tappable: wrap the row in `Button(action: { cmux(...) }) { ... }` or add `.onTapGesture { cmux(...) }`.
+- Reorder not persisting: use `Reorderable(data, move: "workspace.reorder")`, not `List`/`.onMove`/`.draggable`.


### PR DESCRIPTION
Adds an installable agent skill so a user's Claude Code / Codex immediately knows how to author a cmux custom sidebar from a plain-language request.

There was previously no skill for this: `cmux-customization` covers settings/metadata only, and the full authoring contract lives in `docs/custom-sidebars.md` (reachable via `cmux docs sidebars`), which agents don't discover on their own. The skill condenses that contract into the agent workflow: enable the `customSidebars.beta.enabled` flag, write `~/.config/cmux/sidebars/<name>.swift`, `cmux sidebar validate/select/reload`, iterate with hot reload, plus the data context, action dispatch, supported-subset summary, and troubleshooting. It defers to `cmux docs sidebars` for the full reference so the skill stays small and the doc stays canonical.

Install: `./skills.sh --skill cmux-custom-sidebar` or `npx skills add manaflow-ai/cmux --skill cmux-custom-sidebar` (discovery is automatic from the `skills/` directory).

Deliberately not added to the web docs skills page: that list is curated and custom sidebars are still behind a beta flag.

Skill-only change, no app/runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783726166&installation_id=133855650&pr_number=5851&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5851&signature=c53a3e79aafa5ca357f515c21db9beccd57c51d95d08f221e8befb3acc4e81c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an installable `cmux-custom-sidebar` agent skill that turns plain-language requests into working `cmux` custom sidebars. Speeds up sidebar creation with a clear workflow and hot-reload loop; no app/runtime changes.

- New Features
  - Encodes the workflow: enable `customSidebars.beta.enabled`, write `~/.config/cmux/sidebars/<name>.swift`, run `cmux sidebar validate/select/reload`, iterate with hot reload.
  - Summarizes data context, action dispatch (`cmux("<method>")`), supported subset, and troubleshooting; defers to `cmux docs sidebars` for the full reference.
  - Install via `./skills.sh --skill cmux-custom-sidebar` or `npx skills add manaflow-ai/cmux --skill cmux-custom-sidebar`. Not listed on the web docs skills page while the feature is in beta.

<sup>Written for commit e72bcea4d3890d04b18139c54cb2eced1cec875e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for building and customizing sidebars with SwiftUI-style syntax, including setup instructions, usage examples, supported features, and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->