### PR TITLE
Fix glued prompt after scrollback restore (#2823)

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -2005,7 +2005,13 @@ enum SessionScrollbackReplayStore {
         // (issue #5165). Strip them before replay.
         let themePortable = strippingTerminalColorOSCSequences(scrollback)
         guard let truncated = SessionPersistencePolicy.truncatedScrollback(themePortable) else { return nil }
-        return ansiSafeReplayText(truncated)
+        let safe = ansiSafeReplayText(truncated)
+        // The captured scrollback ends at the prompt line where the cursor sat,
+        // which has no trailing newline. A bare replay (`cat`) would then glue the
+        // freshly-restored live prompt onto the end of that old prompt line
+        // ("…$ …$"). Guarantee a trailing newline so the live shell's first prompt
+        // starts on its own line (https://github.com/manaflow-ai/cmux/issues/2823).
+        return safe.hasSuffix("\n") ? safe : safe + "\n"
     }
 
     /// Preserve ANSI color state safely across replay boundaries.

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -2005,13 +2005,15 @@ enum SessionScrollbackReplayStore {
         // (issue #5165). Strip them before replay.
         let themePortable = strippingTerminalColorOSCSequences(scrollback)
         guard let truncated = SessionPersistencePolicy.truncatedScrollback(themePortable) else { return nil }
-        let safe = ansiSafeReplayText(truncated)
         // The captured scrollback ends at the prompt line where the cursor sat,
-        // which has no trailing newline. A bare replay (`cat`) would then glue the
-        // freshly-restored live prompt onto the end of that old prompt line
-        // ("…$ …$"). Guarantee a trailing newline so the live shell's first prompt
-        // starts on its own line (https://github.com/manaflow-ai/cmux/issues/2823).
-        return safe.hasSuffix("\n") ? safe : safe + "\n"
+        // which has no trailing newline; a bare replay would glue the freshly-
+        // restored live prompt onto that line ("…$ …$"). Add the newline BEFORE
+        // ansiSafeReplayText so the (cursor-neutral) ANSI reset wraps the content
+        // and we never emit two newlines. Appending it AFTER would let the trailing
+        // reset defeat a hasSuffix("\n") check and insert a blank line when the
+        // captured buffer already ended in a newline (issue #2823, PR #5853).
+        let withTrailingNewline = truncated.hasSuffix("\n") ? truncated : truncated + "\n"
+        return ansiSafeReplayText(withTrailingNewline)
     }
 
     /// Preserve ANSI color state safely across replay boundaries.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -1,0 +1,114 @@
+# Shell integration
+
+cmux ships a small shell integration that the terminal loads automatically into
+every interactive shell it spawns. It powers several behaviors that feel
+"built in" but actually depend on the shell cooperating:
+
+- **New tabs / splits / windows inherit the current working directory.** The
+  integration reports the shell's cwd to cmux (OSC 7 / `report_pwd`), and cmux
+  uses the last reported directory as the starting directory for the next
+  terminal you open.
+- **Scrollback is restored after you quit and relaunch.** On a clean quit cmux
+  captures each terminal's scrollback; on relaunch the integration replays the
+  saved buffer into the new shell (see [issue #2823][2823]).
+- **Shell activity state is reported** (`prompt` vs. `command-running`). cmux
+  uses this to decide when it is safe to persist scrollback and to show
+  accurate close-confirmation prompts.
+
+If the integration does not load, all three quietly stop working: new tabs open
+in your home directory, terminal contents are lost across restarts, and cmux
+falls back to less reliable heuristics for close confirmation.
+
+## How it loads
+
+The integration files live in the app bundle and are pointed to by the
+`CMUX_SHELL_INTEGRATION_DIR` environment variable that cmux sets for every
+spawned shell:
+
+- `cmux-bash-integration.bash`
+- `cmux-zsh-integration.zsh`
+
+The mechanism differs per shell:
+
+| Shell | How cmux injects the integration |
+| --- | --- |
+| **bash** | cmux exports a `PROMPT_COMMAND` *bootstrap* (`cmux-bash-bootstrap.bash`, marked with `__cmux_bash_bootstrap_marker__`). On the first prompt the bootstrap sources `cmux-bash-integration.bash`, then installs the real prompt hook by **prepending** to `PROMPT_COMMAND`. |
+| **zsh** | cmux injects via `ZDOTDIR` (a wrapper `.zshenv`). It restores your real `ZDOTDIR`, sources your normal startup files, then loads `cmux-zsh-integration.zsh`, which registers hooks with `add-zsh-hook precmd/preexec/chpwd` (additive). |
+
+Both paths are designed to **compose with** your existing prompt setup, not
+replace it.
+
+## How it can break
+
+### bash: overwriting `PROMPT_COMMAND` (the common case)
+
+bash's integration rides on `PROMPT_COMMAND`. If your `~/.bashrc` /
+`~/.bash_profile` **assigns** `PROMPT_COMMAND` instead of appending to it, you
+wipe out cmux's bootstrap and the integration never loads:
+
+```bash
+# ❌ Clobbers cmux's bootstrap — integration never loads.
+PROMPT_COMMAND='history -a; printf "\033]0;%s\007" "$PWD"'
+```
+
+Two safe alternatives:
+
+```bash
+# ✅ Append, preserving whatever was already there (including cmux's bootstrap).
+PROMPT_COMMAND="history -a${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+```
+
+```bash
+# ✅ Or source the integration directly, last, so it composes onto your prompt.
+if [ -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ] \
+   && [ -r "${CMUX_SHELL_INTEGRATION_DIR}/cmux-bash-integration.bash" ]; then
+    source "${CMUX_SHELL_INTEGRATION_DIR}/cmux-bash-integration.bash"
+fi
+```
+
+The direct-source form is the most robust: it survives both a clobbered
+`PROMPT_COMMAND` and prompt frameworks (e.g. `bash-git-prompt`) that wrap
+`PROMPT_COMMAND` in a way that can defeat the bootstrap marker. The
+`CMUX_SHELL_INTEGRATION_DIR` guard means the block is a no-op outside cmux, so
+the same dotfile stays safe in other terminals.
+
+### zsh: yes, an analogous risk exists — but it's rarer
+
+zsh does **not** use `PROMPT_COMMAND`, so the bash failure above does not apply.
+zsh loads the integration through `ZDOTDIR` and registers prompt hooks with
+`add-zsh-hook`, which appends to `precmd_functions` / `preexec_functions`. That
+is much harder to clobber by accident. The analogous ways to break it are:
+
+- **Reassigning the hook arrays** in `~/.zshrc` after cmux has loaded, e.g.
+  `precmd_functions=(my_hook)` (assignment, not append). Use
+  `add-zsh-hook precmd my_hook` or `precmd_functions+=(my_hook)` instead.
+- **Overriding `ZDOTDIR`** in a way that prevents cmux's wrapper `.zshenv` from
+  running. cmux preserves a user-provided `ZDOTDIR` (`CMUX_ZSH_ZDOTDIR`) and
+  restores it, so normal `ZDOTDIR` usage is fine.
+- **Explicitly disabling it** with `CMUX_SHELL_INTEGRATION=0`.
+
+So the headline — "PROMPT_COMMAND overriding breaks it" — is bash-specific, but
+the underlying principle is shared: **add to the shell's prompt/hook mechanism;
+never replace it.**
+
+## Troubleshooting
+
+Open a **fresh** terminal in cmux (existing shells don't re-read your dotfiles),
+then check whether the integration loaded:
+
+```bash
+# bash
+type -t _cmux_restore_scrollback_once   # → "function" when loaded, empty when not
+
+# zsh
+typeset -f _cmux_restore_scrollback_once >/dev/null && echo loaded || echo missing
+```
+
+If it reports missing/empty, the integration did not load. Re-check your
+`PROMPT_COMMAND` (bash) or hook arrays (zsh) using the guidance above, then open
+another fresh terminal and re-test. With the integration loaded you should see:
+
+1. A new tab/split inherits the current shell's directory.
+2. Terminal contents come back after Cmd-Q + relaunch.
+
+[2823]: https://github.com/manaflow-ai/cmux/issues/2823


### PR DESCRIPTION
Fixes #2823 (the scrollback-restore portion).

## Summary

- **What changed?**
  - **Fix:** `SessionScrollbackReplayStore.normalizedScrollback` now guarantees a
    single trailing newline on the replayed scrollback. Captured scrollback ends
    at the prompt line where the cursor sat, which has no trailing newline, so a
    bare replay (`cat`) glued the freshly-restored live prompt onto the end of the
    old prompt line (`…$ …$`). The newline is added when the replay file is written
    at terminal spawn, so it applies to both bash and zsh and even to scrollback
    saved by older builds.
  - **Docs:** Added `docs/shell-integration.md` explaining how cmux's shell
    integration loads (bash via an exported `PROMPT_COMMAND` bootstrap; zsh via
    `ZDOTDIR`), how a dotfile that *assigns* `PROMPT_COMMAND` silently wipes it out
    (breaking new-tab cwd inheritance, scrollback restore, and shell-state
    reporting), the append / direct-source fixes, the analogous (rarer) zsh
    hook-array risk, and a troubleshooting check.

- **Why?**
  - While investigating #2823 ("sessions/terminal contents lost after restart"),
    the root cause for affected bash users turned out to be a dotfile overwriting
    `PROMPT_COMMAND`, which prevents cmux's shell integration from ever loading —
    so scrollback was never persisted and never replayed. Once the integration
    loads, restore works, which surfaced a separate, long-latent cosmetic bug: the
    restored prompt and the live prompt rendered on the same line. This PR fixes
    that cosmetic bug and documents the integration-loading pitfall so others can
    self-diagnose the underlying issue.

## Testing

- **How did you test this change?**
  - Built a tagged Debug app (`CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag cmux-2823`)
    and exercised the real save → quit → relaunch → replay path on macOS.
- **What did you verify manually?**
  - Before the fix: the restored (old) prompt and the new live prompt rendered on
    the same line (`…$ …$`).
  - After the fix: the restored prompt sits on its own line with the live prompt
    below it.
  - Verified end-to-end that the newline survives the shell side:
    `_cmux_restore_scrollback_once` uses a direct `/bin/cat -- "$path"` (not
    `$(cat)`), so the trailing newline written by `writeReplayFile` is preserved.
  - Separately confirmed the documented root cause: with the integration loaded,
    `type -t _cmux_restore_scrollback_once` returns `function` and scrollback
    restores; with `PROMPT_COMMAND` overwritten it does not.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: _N/A — before/after is a one-line terminal rendering difference; can attach a screenshot of the restored prompt on its own line if preferred._

## Review Trigger (Copy/Paste as PR comment)

​```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
​```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes — _intentionally omitted: the newline is only observable through real shell replay, which isn't exercisable in a unit test today; asserting a trailing `\n` on the private helper would be a shape test, not behavior (per the repo's test-quality policy). Happy to add a runtime seam in a follow-up if desired._
- [x] I updated docs/changelog if needed — _added `docs/shell-integration.md`._
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783726508&installation_id=133855650&pr_number=5853&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5853&signature=99551cc95f8b506362db4bd9dcb7d1e7a523ffbd021cb5158653a182719c9a9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the glued prompt after scrollback restore by guaranteeing a single trailing newline and adding it before ANSI wrapping, so the live prompt starts on its own line without extra blank lines. Adds `docs/shell-integration.md` explaining how integration loads (bash via `PROMPT_COMMAND` bootstrap; zsh via `ZDOTDIR`), common clobbers, and troubleshooting for #2823.

<sup>Written for commit 04e7377cf91bf50e5b11f52bc117a77c813c6da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrollback replay so restored output no longer concatenates the live prompt onto the final captured line.

* **Documentation**
  * Added a shell integration guide covering automatic cwd inheritance, scrollback restoration after quit/relaunch, shell activity reporting for persistence/close-confirmation UX, common failure modes, and troubleshooting steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->