### PR TITLE
Add workspace group commands to the cloud CLI relay

### DIFF
--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -163,3 +163,8 @@ Browser relay behavior:
 1. `cmux browser ...` inside an SSH session controls the local cmux browser through the authenticated relay, not a browser process inside the VM.
 2. The remote CLI supports the common automation commands: `open`, `navigate`, `back`, `forward`, `reload`, `get-url`, `snapshot`, `eval`, `wait`, `click`, `dblclick`, `hover`, `focus`, `check`, `uncheck`, `fill`, `type`, `press`, `select`, and `screenshot`.
 3. Commands that target an existing browser surface default to `CMUX_SURFACE_ID`; `open` defaults to `CMUX_WORKSPACE_ID` so agents can create a browser pane next to the active SSH terminal.
+
+Workspace group relay behavior:
+
+1. `cmux workspace group <sub>` (and the `cmux workspace-group <sub>` alias) maps to the `workspace.group.*` v2 methods, with the same subcommands and flags as the macOS CLI: `list`, `create`, `ungroup`, `delete`, `rename`, `collapse`, `expand`, `pin`, `unpin`, `add`, `remove`, `set-anchor`, `new-workspace`, `set-color`, `set-icon`, `move`, and `focus`.
+2. The group id comes from `--group <id>` or the first positional argument and accepts UUIDs or refs such as `workspace_group:1`.

--- a/daemon/remote/README.md
+++ b/daemon/remote/README.md
@@ -167,4 +167,4 @@ Browser relay behavior:
 Workspace group relay behavior:
 
 1. `cmux workspace group <sub>` (and the `cmux workspace-group <sub>` alias) maps to the `workspace.group.*` v2 methods, with the same subcommands and flags as the macOS CLI: `list`, `create`, `ungroup`, `delete`, `rename`, `collapse`, `expand`, `pin`, `unpin`, `add`, `remove`, `set-anchor`, `new-workspace`, `set-color`, `set-icon`, `move`, and `focus`.
-2. The group id comes from `--group <id>` or the first positional argument and accepts UUIDs or refs such as `workspace_group:1`.
+2. The group id comes from `--group <id>` or the first positional argument and accepts UUIDs or refs such as `workspace_group:1`. Like the macOS CLI, `add` and `set-anchor` require explicit `--group <id> --workspace <id>`.

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -190,6 +191,20 @@ doneFlags:
 		return runBrowserRelay(socketPath, cmdArgs, jsonOutput, refreshAddr)
 	}
 
+	// Workspace group subcommands: "workspace-group <sub>" and the canonical
+	// two-word "workspace group <sub>" both map to workspace.group.* methods,
+	// matching the macOS cmux CLI.
+	if cmdName == "workspace-group" {
+		return runWorkspaceGroupRelay(socketPath, cmdArgs, jsonOutput, refreshAddr)
+	}
+	if cmdName == "workspace" {
+		if len(cmdArgs) > 0 && cmdArgs[0] == "group" {
+			return runWorkspaceGroupRelay(socketPath, cmdArgs[1:], jsonOutput, refreshAddr)
+		}
+		fmt.Fprintln(os.Stderr, "cmux workspace: only the \"group\" subcommand is supported here. Use list-workspaces, new-workspace, close-workspace, or select-workspace for workspace operations.")
+		return 2
+	}
+
 	// Agent launch commands
 	if cmdName == "claude-teams" {
 		return runClaudeTeamsRelay(socketPath, cmdArgs, refreshAddr)
@@ -323,6 +338,191 @@ func runRPC(socketPath string, args []string, jsonOutput bool, refreshAddr func(
 		return 1
 	}
 	fmt.Println(resp)
+	return 0
+}
+
+// workspaceGroupFlagKeys lists the flags each "workspace group" subcommand
+// accepts. Every subcommand also takes --window to target a non-focused window.
+var workspaceGroupFlagKeys = map[string][]string{
+	"list":          {"window"},
+	"create":        {"name", "cwd", "from", "window"},
+	"ungroup":       {"group", "window"},
+	"delete":        {"group", "window"},
+	"rename":        {"group", "name", "window"},
+	"collapse":      {"group", "window"},
+	"expand":        {"group", "window"},
+	"pin":           {"group", "window"},
+	"unpin":         {"group", "window"},
+	"add":           {"group", "workspace", "window"},
+	"remove":        {"workspace", "window"},
+	"set-anchor":    {"group", "workspace", "window"},
+	"new-workspace": {"group", "placement", "window"},
+	"set-color":     {"group", "hex", "window"},
+	"set-icon":      {"group", "symbol", "window"},
+	"move":          {"group", "to-index", "before", "after", "window"},
+	"focus":         {"group", "window"},
+}
+
+// runWorkspaceGroupRelay handles "cmux workspace group <sub>" (and the
+// "workspace-group" alias) by mapping each subcommand to its
+// workspace.group.* v2 method, mirroring the macOS cmux CLI flags.
+func runWorkspaceGroupRelay(socketPath string, args []string, jsonOutput bool, refreshAddr func() string) int {
+	const subcommandHint = "list, create, ungroup, delete, rename, collapse, expand, pin, unpin, add, remove, set-anchor, new-workspace, set-color, set-icon, move, focus"
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "cmux workspace group: requires a subcommand (%s)\n", subcommandHint)
+		return 2
+	}
+	sub := args[0]
+	flagKeys, ok := workspaceGroupFlagKeys[sub]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "cmux workspace group: unknown subcommand %q (%s)\n", sub, subcommandHint)
+		return 2
+	}
+
+	fail := func(format string, a ...any) int {
+		fmt.Fprintf(os.Stderr, "cmux workspace group %s: %s\n", sub, fmt.Sprintf(format, a...))
+		return 2
+	}
+
+	parsed, err := parseFlags(args[1:], flagKeys)
+	if err != nil {
+		return fail("%v", err)
+	}
+
+	params := make(map[string]any)
+	if win, ok := parsed.flags["window"]; ok {
+		params["window_id"] = win
+	}
+
+	// The group id comes from --group or the first positional argument.
+	// takeGroupID consumes that positional so later positionals (e.g. the
+	// rename name) are still available.
+	positional := parsed.positional
+	takeGroupID := func() bool {
+		if gid, ok := parsed.flags["group"]; ok {
+			params["group_id"] = gid
+			return true
+		}
+		if len(positional) > 0 {
+			params["group_id"] = positional[0]
+			positional = positional[1:]
+			return true
+		}
+		return false
+	}
+
+	switch sub {
+	case "list":
+		// No parameters beyond the optional window.
+
+	case "create":
+		name, ok := parsed.flags["name"]
+		if !ok && len(positional) > 0 {
+			name = positional[0]
+		}
+		params["name"] = name
+		if cwd, ok := parsed.flags["cwd"]; ok {
+			params["cwd"] = cwd
+		}
+		if from, ok := parsed.flags["from"]; ok {
+			ids := []string{}
+			for _, id := range strings.Split(from, ",") {
+				if id = strings.TrimSpace(id); id != "" {
+					ids = append(ids, id)
+				}
+			}
+			params["child_workspace_ids"] = ids
+		}
+
+	case "ungroup", "delete", "collapse", "expand", "pin", "unpin", "focus":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+
+	case "rename":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+		name, ok := parsed.flags["name"]
+		if !ok && len(positional) > 0 {
+			name, ok = positional[0], true
+		}
+		if !ok {
+			return fail("requires --name <name>")
+		}
+		params["name"] = name
+
+	case "add", "set-anchor":
+		gid, hasGroup := parsed.flags["group"]
+		ws, hasWorkspace := parsed.flags["workspace"]
+		if !hasGroup || !hasWorkspace {
+			return fail("requires --group <id> --workspace <id>")
+		}
+		params["group_id"] = gid
+		params["workspace_id"] = ws
+
+	case "remove":
+		ws, ok := parsed.flags["workspace"]
+		if !ok && len(positional) > 0 {
+			ws, ok = positional[0], true
+		}
+		if !ok {
+			return fail("requires --workspace <id>")
+		}
+		params["workspace_id"] = ws
+
+	case "new-workspace":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+		if placement, ok := parsed.flags["placement"]; ok {
+			params["placement"] = placement
+		}
+
+	case "set-color":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+		// Omitting --hex clears the color, matching the macOS CLI.
+		params["hex"] = parsed.flags["hex"]
+
+	case "set-icon":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+		// Omitting --symbol clears the icon, matching the macOS CLI.
+		params["symbol"] = parsed.flags["symbol"]
+
+	case "move":
+		if !takeGroupID() {
+			return fail("requires a group id or --group <id>")
+		}
+		if v, ok := parsed.flags["to-index"]; ok {
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return fail("--to-index must be an integer")
+			}
+			params["to_index"] = n
+		} else if v, ok := parsed.flags["before"]; ok {
+			params["before_group_id"] = v
+		} else if v, ok := parsed.flags["after"]; ok {
+			params["after_group_id"] = v
+		} else {
+			return fail("requires --to-index <n>, --before <group>, or --after <group>")
+		}
+	}
+
+	method := "workspace.group." + strings.ReplaceAll(sub, "-", "_")
+	resp, err := socketRoundTripV2(socketPath, method, params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+	if jsonOutput {
+		fmt.Println(resp)
+	} else {
+		fmt.Println(defaultRelayOutput(resp))
+	}
 	return 0
 }
 
@@ -864,6 +1064,9 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  send                      Send text to a surface")
 	fmt.Fprintln(os.Stderr, "  send-key                  Send a key to a surface")
 	fmt.Fprintln(os.Stderr, "  notify                    Create a notification")
+	fmt.Fprintln(os.Stderr, "  workspace group <sub>     Manage sidebar workspace groups (list, create, ungroup,")
+	fmt.Fprintln(os.Stderr, "                            delete, rename, collapse, expand, pin, unpin, add, remove,")
+	fmt.Fprintln(os.Stderr, "                            set-anchor, new-workspace, set-color, set-icon, move, focus)")
 	fmt.Fprintln(os.Stderr, "  browser <sub>             Browser commands through the local cmux browser relay")
 	fmt.Fprintln(os.Stderr, "  claude-teams [args...]     Launch Claude Code in teammate mode")
 	fmt.Fprintln(os.Stderr, "  omo [args...]              Launch OpenCode with cmux integration")

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -512,6 +512,14 @@ func runWorkspaceGroupRelay(socketPath string, args []string, jsonOutput bool, r
 		}
 	}
 
+	// Forward the SSH caller's workspace/surface context so methods without a
+	// group id (list, create) resolve the caller's window instead of whichever
+	// local window is focused. Group-id routing still wins server-side, and
+	// subcommands that require an explicit --workspace have already validated
+	// it above, so the fallback never satisfies a missing required flag.
+	applyWorkspaceEnvFallback(params)
+	applySurfaceEnvFallback(params)
+
 	method := "workspace.group." + strings.ReplaceAll(sub, "-", "_")
 	resp, err := socketRoundTripV2(socketPath, method, params, refreshAddr)
 	if err != nil {

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -1283,3 +1283,25 @@ func TestCLIWorkspaceGroupUnknownSubcommand(t *testing.T) {
 		t.Fatalf("unsupported workspace subcommand should return 2, got %d", code)
 	}
 }
+
+func TestCLIWorkspaceGroupListForwardsCallerEnvContext(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	t.Setenv("CMUX_WORKSPACE_ID", "env-ws")
+	t.Setenv("CMUX_SURFACE_ID", "env-sf")
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "list"})
+	if code != 0 {
+		t.Fatalf("workspace group list should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.list")
+	if params["workspace_id"] != "env-ws" || params["surface_id"] != "env-sf" {
+		t.Fatalf("expected caller env context to be forwarded, got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupRemoveStillRequiresExplicitWorkspaceWithEnv(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	t.Setenv("CMUX_WORKSPACE_ID", "env-ws")
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group", "remove"}); code != 2 {
+		t.Fatalf("remove without --workspace should return 2 even with env set, got %d", code)
+	}
+}

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -1137,3 +1137,149 @@ func TestCLIEnvVarDefaults(t *testing.T) {
 		t.Fatal("timed out waiting for close-surface payload")
 	}
 }
+
+func expectGroupRequest(t *testing.T, requests <-chan map[string]any, wantMethod string) map[string]any {
+	t.Helper()
+	select {
+	case req := <-requests:
+		if got := req["method"]; got != wantMethod {
+			t.Fatalf("expected method %s, got %v", wantMethod, got)
+		}
+		params, _ := req["params"].(map[string]any)
+		return params
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s request", wantMethod)
+		return nil
+	}
+}
+
+func TestCLIWorkspaceGroupList(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "list"})
+	if code != 0 {
+		t.Fatalf("workspace group list should return 0, got %d", code)
+	}
+	expectGroupRequest(t, requests, "workspace.group.list")
+}
+
+func TestCLIWorkspaceGroupDashAlias(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace-group", "collapse", "workspace_group:1"})
+	if code != 0 {
+		t.Fatalf("workspace-group collapse should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.collapse")
+	if got := params["group_id"]; got != "workspace_group:1" {
+		t.Fatalf("expected positional group_id, got %v", got)
+	}
+}
+
+func TestCLIWorkspaceGroupCreateMapsFlags(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{
+		"--socket", sockPath, "--json",
+		"workspace", "group", "create",
+		"--name", "My Group",
+		"--cwd", "/repo/path",
+		"--from", "workspace:1, workspace:2",
+	})
+	if code != 0 {
+		t.Fatalf("workspace group create should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.create")
+	if got := params["name"]; got != "My Group" {
+		t.Fatalf("expected name, got %v", got)
+	}
+	if got := params["cwd"]; got != "/repo/path" {
+		t.Fatalf("expected cwd, got %v", got)
+	}
+	ids, _ := params["child_workspace_ids"].([]any)
+	if len(ids) != 2 || ids[0] != "workspace:1" || ids[1] != "workspace:2" {
+		t.Fatalf("expected trimmed child_workspace_ids, got %v", params["child_workspace_ids"])
+	}
+}
+
+func TestCLIWorkspaceGroupAddRequiresGroupAndWorkspace(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group", "add", "--group", "g1"}); code != 2 {
+		t.Fatalf("add without --workspace should return 2, got %d", code)
+	}
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "add", "--group", "g1", "--workspace", "ws1"})
+	if code != 0 {
+		t.Fatalf("workspace group add should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.add")
+	if params["group_id"] != "g1" || params["workspace_id"] != "ws1" {
+		t.Fatalf("expected group_id/workspace_id, got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupRenamePositionalName(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "rename", "workspace_group:2", "New Name"})
+	if code != 0 {
+		t.Fatalf("workspace group rename should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.rename")
+	if params["group_id"] != "workspace_group:2" || params["name"] != "New Name" {
+		t.Fatalf("expected positional group id and name, got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupNewWorkspaceUsesUnderscoreMethod(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "new-workspace", "workspace_group:3", "--placement", "top"})
+	if code != 0 {
+		t.Fatalf("workspace group new-workspace should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.new_workspace")
+	if params["group_id"] != "workspace_group:3" || params["placement"] != "top" {
+		t.Fatalf("expected group_id and placement, got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupSetColorOmittedHexClears(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "set-color", "workspace_group:4"})
+	if code != 0 {
+		t.Fatalf("workspace group set-color should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.set_color")
+	if got, ok := params["hex"]; !ok || got != "" {
+		t.Fatalf("expected empty hex (clear), got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupMoveValidatesPosition(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group", "move", "g1"}); code != 2 {
+		t.Fatalf("move without a position flag should return 2, got %d", code)
+	}
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group", "move", "g1", "--to-index", "abc"}); code != 2 {
+		t.Fatalf("move with non-integer --to-index should return 2, got %d", code)
+	}
+	code := runCLI([]string{"--socket", sockPath, "--json", "workspace", "group", "move", "g1", "--to-index", "2"})
+	if code != 0 {
+		t.Fatalf("workspace group move should return 0, got %d", code)
+	}
+	params := expectGroupRequest(t, requests, "workspace.group.move")
+	if got, ok := params["to_index"].(float64); !ok || got != 2 {
+		t.Fatalf("expected integer to_index 2, got %v", params)
+	}
+	if params["group_id"] != "g1" {
+		t.Fatalf("expected group_id g1, got %v", params)
+	}
+}
+
+func TestCLIWorkspaceGroupUnknownSubcommand(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group", "explode"}); code != 2 {
+		t.Fatalf("unknown group subcommand should return 2, got %d", code)
+	}
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "group"}); code != 2 {
+		t.Fatalf("bare workspace group should return 2, got %d", code)
+	}
+	if code := runCLI([]string{"--socket", sockPath, "workspace", "rename"}); code != 2 {
+		t.Fatalf("unsupported workspace subcommand should return 2, got %d", code)
+	}
+}


### PR DESCRIPTION
Agents inside Cloud VMs could not manage sidebar workspace groups: the macOS CLI has the full `cmux workspace group` family, but the cloud-side `cmuxd-remote` busybox `cmux` only exposed a curated command table, leaving groups reachable only through the raw `cmux rpc workspace.group.* '<json>'` passthrough.

This adds a workspace group relay to `cmuxd-remote` that maps the same 17 subcommands and flags as the macOS CLI (`list`, `create`, `ungroup`, `delete`, `rename`, `collapse`, `expand`, `pin`, `unpin`, `add`, `remove`, `set-anchor`, `new-workspace`, `set-color`, `set-icon`, `move`, `focus`) onto the existing `workspace.group.*` v2 socket methods. Both the canonical `cmux workspace group <sub>` form and the `cmux workspace-group <sub>` alias work, group ids accept refs like `workspace_group:1`, and `--window` is forwarded as `window_id`. Flag and positional handling mirrors the macOS CLI exactly: most subcommands take the group id via `--group` or a positional, while `add` and `set-anchor` require explicit `--group <id> --workspace <id>`, same as `CLI/cmux.swift`, so scripts behave identically on both surfaces. The relay path itself is unchanged (no new server surface; the methods were already callable over the authenticated relay via `rpc`).

Covered by new request-capture unit tests in `cli_test.go` (method mapping, flag-to-param mapping including `child_workspace_ids` and integer `to_index`, clear-on-omitted `--hex`/`--symbol`, positional group id and rename name, and usage errors). `go test ./...` in `daemon/remote` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace group CLI commands (list, create, add, rename, new-workspace, move, set-color) and a dash-alias for quick use.
  * Supports group IDs as numeric, UUID, or ref-style identifiers.

* **Documentation**
  * Documented workspace group CLI relay behavior, subcommands, flag mappings, and group/workspace sourcing for browser and SSH use.

* **Bug Fixes**
  * Improved input validation with clearer error codes for missing/invalid flags.

* **Tests**
  * Added comprehensive CLI tests covering command→RPC mapping and env/flag behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->