### PR TITLE
cloud-testflight: --marketing-version override so uploads outrank installed builds

### DIFF
--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -116,6 +116,11 @@ done
 
 [[ "$LANE" == "beta" ]] || die "only the beta lane is supported"
 [[ "$TAG" =~ ^[A-Za-z0-9._-]+$ ]] || die "invalid tag: $TAG"
+# Validate the override eagerly: a malformed value (or a flag swallowed by
+# `--marketing-version --external`) must fail here, not as a silent no-op or
+# a rejected archive 25 minutes into a fleet build.
+[[ -z "$MARKETING_VERSION_OVERRIDE" || "$MARKETING_VERSION_OVERRIDE" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] \
+  || die "invalid --marketing-version (want X.Y or X.Y.Z): $MARKETING_VERSION_OVERRIDE"
 [[ -d "$IOS_DIR/cmux.xcworkspace" ]] || die "run from a cmux checkout containing ios/cmux.xcworkspace"
 
 # --- locate the hq cloud build script (mirrors ios/scripts/reload-cloud.sh) ---
@@ -149,7 +154,14 @@ build_archive_cloud() {
   log="$(mktemp "${TMPDIR:-/tmp}/cloud-testflight-cloud.XXXXXX")"
   err "building UNSIGNED Release beta archive on the fleet via $hq_cloud"
   local args=( --mode beta-archive --tag "$TAG" --keep-artifacts --beta-bundle-id "$BETA_BUNDLE_ID" )
-  [[ -n "$MARKETING_VERSION_OVERRIDE" ]] && export BETA_MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"
+  # Pin BETA_MARKETING_VERSION to exactly the requested override; explicitly
+  # unset otherwise so a stray value already in the caller's environment can
+  # not leak into the cloud build and desync it from a local cut.
+  if [[ -n "$MARKETING_VERSION_OVERRIDE" ]]; then
+    export BETA_MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"
+  else
+    unset BETA_MARKETING_VERSION
+  fi
   [[ -n "$HOST_FILTER" ]] && args+=( --host "$HOST_FILTER" )
   [[ "$WAIT_SECONDS" =~ ^[0-9]+$ && "$WAIT_SECONDS" -gt 0 ]] && args+=( --wait "$WAIT_SECONDS" )
   # Run from the repo root so the hq script's "run from a cmux checkout" check and

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -47,6 +47,10 @@ REPO_ROOT="$(cd "$IOS_DIR/.." && pwd)"
 
 LANE="beta"
 TAG="beta"
+# TestFlight orders by marketing version FIRST: uploading below the testers'
+# installed marketing version makes the build invisible as an update (hit
+# 2026-06-10: 1.0.0 uploads hidden behind an installed 1.0.1). Override per cut.
+MARKETING_VERSION_OVERRIDE="${IOS_BETA_MARKETING_VERSION:-}"
 NO_UPLOAD=0
 EXTERNAL=0
 KEEP_ARTIFACTS=0
@@ -65,7 +69,7 @@ die() { err "$*"; exit 1; }
 
 usage() {
   cat <<'EOF'
-Usage: ios/scripts/cloud-testflight.sh [--no-upload] [--external] [--tag <tag>]
+Usage: ios/scripts/cloud-testflight.sh [--no-upload] [--external] [--tag <tag>] [--marketing-version <X.Y.Z>]
                                        [--host <name>] [--wait <seconds>]
                                        [--local] [--keep-artifacts]
 
@@ -98,6 +102,7 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-upload) NO_UPLOAD=1; shift ;;
+    --marketing-version) MARKETING_VERSION_OVERRIDE="${2:-}"; shift 2 ;;
     --external) EXTERNAL=1; shift ;;
     --tag) TAG="${2:-}"; shift 2 ;;
     --host) HOST_FILTER="${2:-}"; shift 2 ;;
@@ -144,6 +149,7 @@ build_archive_cloud() {
   log="$(mktemp "${TMPDIR:-/tmp}/cloud-testflight-cloud.XXXXXX")"
   err "building UNSIGNED Release beta archive on the fleet via $hq_cloud"
   local args=( --mode beta-archive --tag "$TAG" --keep-artifacts --beta-bundle-id "$BETA_BUNDLE_ID" )
+  [[ -n "$MARKETING_VERSION_OVERRIDE" ]] && export BETA_MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"
   [[ -n "$HOST_FILTER" ]] && args+=( --host "$HOST_FILTER" )
   [[ "$WAIT_SECONDS" =~ ^[0-9]+$ && "$WAIT_SECONDS" -gt 0 ]] && args+=( --wait "$WAIT_SECONDS" )
   # Run from the repo root so the hq script's "run from a cmux checkout" check and
@@ -188,6 +194,7 @@ build_archive_local() {
       -derivedDataPath "$out/DerivedData" \
       PRODUCT_BUNDLE_IDENTIFIER="$BETA_BUNDLE_ID" \
       CURRENT_PROJECT_VERSION="$build_number" \
+      ${MARKETING_VERSION_OVERRIDE:+MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"} \
       CODE_SIGNING_ALLOWED=NO \
       CODE_SIGNING_REQUIRED=NO \
       CODE_SIGN_IDENTITY="" \

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -468,6 +468,21 @@ fi
 # and only `codesign -d --entitlements` on the EXPORTED app proves that. So we
 # re-sign here with the export baseline MERGED with the Release entitlements file.
 #
+# The merged set MUST then be reconciled against the provisioning profile, in
+# both directions (hit 2026-06-11, ASC error 90163): App Store Connect rejects
+# any signed entitlement key the profile does not authorize. The Release file
+# carries com.apple.developer.usernotifications.time-sensitive, the App ID has
+# the capability enabled, but the installed "cmux Beta Distribution" profile
+# predates it and does not list the key, so a naive baseline+Release merge is
+# rejected at upload ("bundle contains a key not in the provisioning profile").
+# The same naive merge also SHIPS WITHOUT keychain-access-groups (authorized by
+# the profile but absent from both the export baseline and the Release file).
+# So below we (1) seed from the profile's own Entitlements dict, the exact set
+# ASC validates against, and (2) drop any merged key the profile does not
+# authorize, warning per key. Restoring a dropped capability (e.g.
+# time-sensitive) requires REGENERATING the profile so it snapshots the App
+# ID's current capabilities, not editing this script or the Release file.
+#
 # This runs on the MANUAL signing path only: it re-signs with the named
 # distribution cert from the local keychain ("Apple Distribution: Manaflow,
 # Inc."), which is present for local/fleet-archive beta cuts. The cmux iOS app is
@@ -503,22 +518,56 @@ if [[ "$SIGNING" == "manual" ]]; then
   fi
 
   # Start from the exported app's current (profile-baseline) entitlements, then
-  # MERGE every key from the Release entitlements file. The merge is GENERIC:
-  # PlistBuddy Merge copies all keys from the Release file and skips any that
-  # already exist in the baseline, so future entitlements survive automatically
-  # and existing baseline values (e.g. get-task-allow=false) are preserved.
+  # MERGE the profile's authorized Entitlements dict, then every key from the
+  # Release entitlements file. The merge is GENERIC: PlistBuddy Merge copies all
+  # keys from the source and skips any that already exist, so future entitlements
+  # survive automatically and existing baseline values (e.g. get-task-allow=false)
+  # are preserved. Seeding from the profile is what carries profile-authorized
+  # keys that appear in NEITHER the baseline NOR the Release file (concretely:
+  # keychain-access-groups, which the 2026-06-10 accepted upload shipped and a
+  # baseline+Release-only merge silently lost).
   MERGED_ENTITLEMENTS="$RESIGN_DIR/entitlements.plist"
   codesign -d --entitlements :- --xml "$RESIGN_APP" > "$MERGED_ENTITLEMENTS" 2>/dev/null || {
     echo "error: could not read current entitlements from the exported app: $RESIGN_APP" >&2
     exit 1
   }
-  # `|| true`: PlistBuddy Merge prints "Duplicate Entry Was Skipped" if a future
-  # Release key ever overlaps a baseline key. That is the intended behavior
-  # (baseline wins), but its exit code on that path is not contractually 0 across
+  PROFILE_ENTITLEMENTS="$RESIGN_DIR/profile-entitlements.plist"
+  security cms -D -i "$RESIGN_APP/embedded.mobileprovision" > "$RESIGN_DIR/profile.plist" || {
+    echo "error: could not decode embedded.mobileprovision from the exported app: $RESIGN_APP" >&2
+    exit 1
+  }
+  plutil -extract Entitlements xml1 -o "$PROFILE_ENTITLEMENTS" "$RESIGN_DIR/profile.plist"
+  # `|| true`: PlistBuddy Merge prints "Duplicate Entry Was Skipped" if a
+  # source key overlaps an existing key. That is the intended behavior
+  # (existing wins), but its exit code on that path is not contractually 0 across
   # OS versions, and a stray non-zero would kill the script under `set -e`. The
   # exit code is non-load-bearing anyway: a genuinely failed merge produces no
   # aps-environment and is caught by the hard gate below with a clear error.
+  /usr/libexec/PlistBuddy -c "Merge $PROFILE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null || true
   /usr/libexec/PlistBuddy -c "Merge $RELEASE_ENTITLEMENTS" "$MERGED_ENTITLEMENTS" >/dev/null || true
+  # Intersect against the profile: ASC rejects the upload (error 90163, "bundle
+  # contains a key not in the provisioning profile") for ANY signed key the
+  # profile does not authorize. Baseline keys are authorized by construction
+  # (the export minted them FROM this profile), so a strict top-level-key
+  # intersection is safe. Each dropped key is warned so the loss is visible in
+  # the cut log (e.g. time-sensitive until the profile is regenerated).
+  python3 - "$MERGED_ENTITLEMENTS" "$PROFILE_ENTITLEMENTS" <<'PY'
+import plistlib, sys
+merged_path, profile_path = sys.argv[1], sys.argv[2]
+with open(merged_path, "rb") as f:
+    merged = plistlib.load(f)
+with open(profile_path, "rb") as f:
+    profile = plistlib.load(f)
+for key in [k for k in merged if k not in profile]:
+    del merged[key]
+    print(
+        f"warning: dropping entitlement the provisioning profile does not "
+        f"authorize (ASC error 90163 otherwise): {key}",
+        file=sys.stderr,
+    )
+with open(merged_path, "wb") as f:
+    plistlib.dump(merged, f)
+PY
   plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
 
   codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"


### PR DESCRIPTION
TestFlight orders builds by marketing version before build number. Today's beta cuts archived with the xcconfig default (1.0.0) while testers run 1.0.1 (20260609105221), so the new builds were never offered as updates. Adds an explicit --marketing-version flag (env IOS_BETA_MARKETING_VERSION), plumbed through both the cloud lane (BETA_MARKETING_VERSION to the hq reload-cloud-ios beta-archive xcodebuild, hq side already landed) and the local archive fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783728739&installation_id=133855650&pr_number=5858&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5858&signature=cd31fadc6510825c7457d34c569a3c5baa205c792806edef887ba6fa3b29429e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production beta TestFlight pipeline (version ordering and signed entitlements); mistakes could hide updates or drop capabilities until profiles are regenerated.
> 
> **Overview**
> Adds **`--marketing-version`** (and **`IOS_BETA_MARKETING_VERSION`**) to **`cloud-testflight.sh`** so beta cuts can set **`MARKETING_VERSION`** above what testers already have installed—TestFlight ranks by marketing version first, so lower versions never show as updates. The value is validated up front, passed into local **`xcodebuild`**, and exported as **`BETA_MARKETING_VERSION`** for fleet builds only when set (explicitly unset otherwise so env cannot leak).
> 
> In **`upload-testflight.sh`**, manual re-sign no longer merges only export baseline + Release entitlements. It now **merges the embedded provisioning profile’s Entitlements**, then Release, then **drops any key the profile does not authorize** (with stderr warnings). That fixes ASC **90163** rejections and restores profile-only keys like **`keychain-access-groups`** that a Release-only merge omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f93496e93d21db50e0f70be1f41f0ffe89f89f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--marketing-version` override so TestFlight uploads outrank installed builds and show as updates. Also fixes manual re-signing to align entitlements with the provisioning profile, preventing ASC 90163 and keeping required profile-only keys.

- **New Features**
  - `ios/scripts/cloud-testflight.sh`: `--marketing-version <X.Y[.Z]>` (defaults from `IOS_BETA_MARKETING_VERSION`), passed as `MARKETING_VERSION` locally and `BETA_MARKETING_VERSION` in cloud; validates format early and explicitly unsets `BETA_MARKETING_VERSION` when not provided.

- **Bug Fixes**
  - `ios/scripts/upload-testflight.sh`: during manual re-sign, seed entitlements from the embedded profile, merge Release, then drop any key not authorized by the profile with warnings; fixes ASC 90163 and preserves profile-only keys like `keychain-access-groups`.

<sup>Written for commit 7f93496e93d21db50e0f70be1f41f0ffe89f89f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * TestFlight build process now supports overriding the iOS marketing version to control update ordering via a new CLI option for cloud and local builds; the override is validated and will not leak a caller environment value into cloud builds.
* **Bug Fixes**
  * Manual re-signing for TestFlight uploads now reconciles app entitlements with the provisioning profile, removing unauthorized keys and warning for dropped keys to prevent upload rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->