### PR TITLE
Fix terminal Liquid Glass rendering as opaque black on macOS 27

### DIFF
--- a/Sources/Windowing/WindowGlassEffect.swift
+++ b/Sources/Windowing/WindowGlassEffect.swift
@@ -128,13 +128,20 @@ enum WindowGlassEffect {
             currentTintColor = tintColor
             effectView.layer?.cornerRadius = cornerRadius ?? 0
             if usesNativeGlass {
+                // macOS 27 composites an NSGlassEffectView tint color far more
+                // opaquely than macOS 26: tinting the glass with the (near-opaque)
+                // terminal background color turns it into a solid dark fill — the
+                // "black layer behind the terminal" — instead of translucent glass.
+                // Suppress the cmux tint on macOS 27+ so the native glass renders
+                // its material; keep the prior tinted behavior on macOS 26.
+                let glassTint = WindowGlassEffect.suppressesNativeGlassTint ? nil : tintColor
                 updateNativeGlassConfiguration(
                     on: effectView,
-                    color: tintColor,
+                    color: glassTint,
                     style: style,
                     cornerRadius: cornerRadius
                 )
-                updateInactiveTintOverlay(tintColor: tintColor, isKeyWindow: isKeyWindow)
+                updateInactiveTintOverlay(tintColor: glassTint, isKeyWindow: isKeyWindow)
             } else if let tintColor {
                 effectView.layer?.masksToBounds = cornerRadius != nil
                 let fallbackTint = tintColor.withAlphaComponent(min(tintColor.alphaComponent, 0.45))
@@ -291,6 +298,15 @@ enum WindowGlassEffect {
     static var isAvailable: Bool {
         NSClassFromString("NSGlassEffectView") != nil
     }
+
+    /// macOS 27 changed `NSGlassEffectView` tint compositing so a near-opaque
+    /// tint renders the glass as a solid dark fill rather than a translucent
+    /// material. On macOS 27+ we skip cmux's terminal-derived tint and let the
+    /// native glass render unmodified; macOS 26 keeps the original tinted look.
+    static let suppressesNativeGlassTint: Bool =
+        ProcessInfo.processInfo.isOperatingSystemAtLeast(
+            OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0)
+        )
 
     @discardableResult
     static func apply(to window: NSWindow, tintColor: NSColor? = nil, style: Style? = nil) -> Bool {


### PR DESCRIPTION
## Summary

Fixes #5860. With the macOS Liquid Glass terminal background enabled (`background-blur = macos-glass-regular`/`-clear`), the terminal renders as an opaque dark fill — "a black layer behind the terminal" — on **macOS 27**, instead of the translucent glass seen on macOS 26.

## Root cause

`WindowGlassEffect` backs the window with a native `NSGlassEffectView` and tints it via `setTintColor:` using the terminal's background color at its background opacity (`WindowAppearanceSnapshot.tintColor` → `terminalGlassTintColor`). macOS 27 changed `NSGlassEffectView`'s tint compositing: a near-opaque dark tint (a typical dark terminal background) now renders the glass as a **solid dark fill** rather than a translucent material. macOS 26 composited the same tint subtly.

Confirmed empirically on macOS 27.0 (26A5353q): stripping the cmux tint from the native `NSGlassEffectView` makes the glass render translucent again — proving the tint compositing, not the glass view itself, is the cause. (Same "AppKit semantics change silently between macOS major versions" class flagged in `CLAUDE.md`.)

## Fix

Suppress cmux's terminal-derived tint on the native glass on **macOS 27+** (gated via `ProcessInfo.isOperatingSystemAtLeast(27)`), letting `NSGlassEffectView` render its material unmodified. macOS 26 keeps the original tinted behavior.

## Verification

Built with Xcode 27 (macOS 27 SDK) and run on macOS 27.0 (26A5353q): before the fix the glass terminal was an opaque black layer; after the fix it renders as translucent glass again. (The gate means macOS 26 rendering is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783731312&installation_id=133855650&pr_number=5861&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5861&signature=30afad38fd8b502a6ba16c9b46a0ba12bba38aaa6e39b2697c15a6dd8077200c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5860: Liquid Glass terminals appeared as a solid black layer on macOS 27; we now suppress the native `NSGlassEffectView` tint on 27+ to restore a translucent background, with macOS 26 behavior unchanged.

<sup>Written for commit b59bee2ddff368da9211a2d59fe1956260b039ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted glass effect rendering on macOS 27+ to refine tint color behavior for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->