### PR TITLE
Spike: ViewBridge marshal from a CLI child (sidebar vibe-coding Spike 4)

### DIFF
--- a/tools/viewbridge-spike/.gitignore
+++ b/tools/viewbridge-spike/.gitignore
@@ -1,0 +1,2 @@
+# Throwaway compiled binaries + bundle; rebuild with ./build.sh
+build/

--- a/tools/viewbridge-spike/build.sh
+++ b/tools/viewbridge-spike/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Build the three throwaway VB spike binaries. Pure swiftc, no Xcode.
+set -euo pipefail
+cd "$(dirname "$0")"
+OUT="build"
+mkdir -p "$OUT"
+SDK="$(xcrun --show-sdk-path)"
+COMMON=(-sdk "$SDK" -O)
+
+echo "[build] broker"
+swiftc "${COMMON[@]}" src/Broker.swift -o "$OUT/broker"
+
+echo "[build] vbservice"
+swiftc "${COMMON[@]}" -framework AppKit -framework SwiftUI \
+  src/Shared.swift src/service/main.swift -o "$OUT/vbservice"
+
+echo "[build] vbhost"
+swiftc "${COMMON[@]}" -framework AppKit \
+  src/Shared.swift src/host/main.swift -o "$OUT/vbhost"
+
+echo "[build] vbprobe (rung-3 bootstrap probe)"
+swiftc "${COMMON[@]}" -framework AppKit \
+  src/probe/main.swift -o "$OUT/vbprobe"
+
+# Escalation rung 2: wrap vbservice in a minimal .app bundle that declares an
+# NSExtension view-service configuration, so Bundle.main is a real bundle with a
+# service Info dictionary that NSViewServiceApplication can validate.
+echo "[build] VBService.app shell"
+APP="$OUT/VBService.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+cp "$OUT/vbservice" "$APP/Contents/MacOS/vbservice"
+cat > "$APP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>vbservice</string>
+  <key>CFBundleIdentifier</key><string>com.cmux.vbridge.service</string>
+  <key>CFBundleName</key><string>VBService</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>LSUIElement</key><true/>
+  <key>NSExtension</key><dict>
+    <key>NSExtensionPointIdentifier</key><string>com.apple.widget-extension</string>
+    <key>NSExtensionPrincipalClass</key><string>VBServiceVC</string>
+  </dict>
+</dict></plist>
+PLIST
+# Ad-hoc sign so the bundle has a code identity (CLI child has none).
+codesign --force --sign - "$APP" 2>/dev/null || echo "[build] codesign skipped"
+
+echo "[build] done -> $OUT/"

--- a/tools/viewbridge-spike/run.sh
+++ b/tools/viewbridge-spike/run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Orchestrate one VB spike run: install the launchd broker, launch the service
+# child, launch the host, stream ViewBridge os_log, then tear everything down.
+set -uo pipefail
+cd "$(dirname "$0")"
+DIR="$(pwd)"
+OUT="$DIR/build"
+UID_NUM="$(id -u)"
+PLIST="$HOME/Library/LaunchAgents/com.cmux.vbridge.broker.plist"
+LABEL="com.cmux.vbridge.broker"
+
+cleanup() {
+  echo "[run] cleanup"
+  [ -n "${HOST_PID:-}" ] && kill "$HOST_PID" 2>/dev/null
+  [ -n "${SVC_PID:-}" ] && kill "$SVC_PID" 2>/dev/null
+  [ -n "${LOG_PID:-}" ] && kill "$LOG_PID" 2>/dev/null
+  launchctl bootout "gui/$UID_NUM" "$PLIST" 2>/dev/null
+  rm -f "$PLIST"
+  pkill -f "$OUT/vbservice" 2>/dev/null
+  pkill -f "$OUT/vbhost" 2>/dev/null
+  pkill -f "$OUT/broker" 2>/dev/null
+}
+trap cleanup EXIT
+
+# 1. install + bootstrap broker LaunchAgent (mach name routing requires launchd)
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key><array><string>$OUT/broker</string></array>
+  <key>MachServices</key><dict><key>$LABEL</key><true/></dict>
+  <key>StandardErrorPath</key><string>/tmp/vbridge-broker.err</string>
+  <key>StandardOutPath</key><string>/tmp/vbridge-broker.out</string>
+  <key>ProcessType</key><string>Interactive</string>
+</dict></plist>
+EOF
+launchctl bootout "gui/$UID_NUM" "$PLIST" 2>/dev/null
+launchctl bootstrap "gui/$UID_NUM" "$PLIST"
+echo "[run] broker bootstrapped"
+
+# 2. stream ViewBridge + our-process os_log to a file
+log stream --style compact --level debug \
+  --predicate 'subsystem == "com.apple.ViewBridge" OR processImagePath CONTAINS "vbservice" OR processImagePath CONTAINS "vbhost" OR processImagePath CONTAINS "broker"' \
+  > /tmp/vbridge-oslog.txt 2>&1 &
+LOG_PID=$!
+
+# 3. launch service child. Default = plain CLI rung. Set VBSERVICE_BIN to the
+#    bundled binary (build/VBService.app/Contents/MacOS/vbservice) for rung 2.
+SVC_BIN="${VBSERVICE_BIN:-$OUT/vbservice}"
+echo "[run] service binary: $SVC_BIN"
+"$SVC_BIN" > /tmp/vbridge-service.log 2>&1 &
+SVC_PID=$!
+echo "[run] service pid $SVC_PID"
+
+# give the service a moment to register its endpoint with the broker
+for _ in $(seq 1 20); do
+  grep -q "stored service endpoint" /tmp/vbridge-broker.err 2>/dev/null && break
+  sleep 0.25
+done
+
+# 4. launch host (auto-exits after ~7s)
+"$OUT/vbhost" > /tmp/vbridge-host.log 2>&1 &
+HOST_PID=$!
+echo "[run] host pid $HOST_PID"
+
+# wait for host to finish its bounded run
+wait "$HOST_PID" 2>/dev/null
+echo "[run] host exited"
+sleep 1
+echo "=================== SERVICE LOG ==================="; cat /tmp/vbridge-service.log
+echo "=================== HOST LOG ======================"; cat /tmp/vbridge-host.log
+echo "=================== BROKER ERR ===================="; cat /tmp/vbridge-broker.err 2>/dev/null
+echo "=================== VIEWBRIDGE OSLOG (tail) ======="; tail -n 80 /tmp/vbridge-oslog.txt 2>/dev/null

--- a/tools/viewbridge-spike/src/Broker.swift
+++ b/tools/viewbridge-spike/src/Broker.swift
@@ -1,0 +1,51 @@
+// VB spike broker. Throwaway demo binary (localization-exempt per spike rules).
+//
+// Rendezvous process. Both the ViewBridge service child and the host connect to
+// this by a hardcoded launchd mach service name. The service child hands its
+// anonymous NSXPCListenerEndpoint here (transferred as an XPC method argument so
+// NSXPCCoder can marshal the live mach send right); the host fetches it.
+//
+// We need a real mach channel because NSXPCListenerEndpoint refuses NSKeyedArchiver
+// ("This class may only be encoded by an NSXPCCoder"), so a flat file/pipe cannot
+// carry the endpoint. A launchd-registered name is the simplest channel both
+// unrelated processes can reach.
+
+import Foundation
+
+let kBrokerMachName = "com.cmux.vbridge.broker"
+
+@objc protocol VBBrokerProtocol {
+    func setServiceEndpoint(_ endpoint: NSXPCListenerEndpoint)
+    func getServiceEndpoint(reply: @escaping (NSXPCListenerEndpoint?) -> Void)
+}
+
+final class Broker: NSObject, VBBrokerProtocol, NSXPCListenerDelegate {
+    private let lock = NSLock()
+    private var stored: NSXPCListenerEndpoint?
+
+    func setServiceEndpoint(_ endpoint: NSXPCListenerEndpoint) {
+        lock.lock(); stored = endpoint; lock.unlock()
+        FileHandle.standardError.write("BROKER: stored service endpoint\n".data(using: .utf8)!)
+    }
+
+    func getServiceEndpoint(reply: @escaping (NSXPCListenerEndpoint?) -> Void) {
+        lock.lock(); let e = stored; lock.unlock()
+        FileHandle.standardError.write("BROKER: getServiceEndpoint -> \(e != nil ? "present" : "nil")\n".data(using: .utf8)!)
+        reply(e)
+    }
+
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection conn: NSXPCConnection) -> Bool {
+        conn.exportedInterface = NSXPCInterface(with: VBBrokerProtocol.self)
+        conn.exportedObject = self
+        conn.resume()
+        return true
+    }
+}
+
+let broker = Broker()
+// machServiceName listener: launchd routes the registered name to us.
+let listener = NSXPCListener(machServiceName: kBrokerMachName)
+listener.delegate = broker
+listener.resume()
+FileHandle.standardError.write("BROKER: listening on \(kBrokerMachName)\n".data(using: .utf8)!)
+RunLoop.current.run()

--- a/tools/viewbridge-spike/src/Shared.swift
+++ b/tools/viewbridge-spike/src/Shared.swift
@@ -1,0 +1,15 @@
+// Shared declarations for the VB spike host + service. Throwaway demo code.
+import Foundation
+
+let kBrokerMachName = "com.cmux.vbridge.broker"
+
+@objc protocol VBBrokerProtocol {
+    func setServiceEndpoint(_ endpoint: NSXPCListenerEndpoint)
+    func getServiceEndpoint(reply: @escaping (NSXPCListenerEndpoint?) -> Void)
+}
+
+enum SpikeLog {
+    static func err(_ tag: String, _ msg: String) {
+        FileHandle.standardError.write("\(tag): \(msg)\n".data(using: .utf8)!)
+    }
+}

--- a/tools/viewbridge-spike/src/host/main.swift
+++ b/tools/viewbridge-spike/src/host/main.swift
@@ -1,0 +1,184 @@
+// VB spike HOST. Throwaway demo binary (localization-exempt).
+//
+// Fetches the service child's anonymous endpoint from the broker, then asks
+// ViewBridge to marshal a remote view controller across it via the private
+//   +[NSRemoteViewController requestViewController:fromServiceListenerEndpoint:connectionHandler:]
+// and embeds the returned NSRemoteView in a window. Then it programmatically
+// delivers NSEvents into its own window to exercise click/typing/hover.
+
+import AppKit
+import ObjectiveC.runtime
+
+final class HostController: NSObject {
+    let window: NSWindow
+    var remoteVC: NSViewController?
+
+    override init() {
+        window = NSWindow(
+            contentRect: NSRect(x: 200, y: 200, width: 320, height: 420),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered, defer: false)
+        window.title = "VB spike host"
+        super.init()
+        window.makeKeyAndOrderFront(nil)
+        // Global watchdog: terminate after a bounded deadline no matter what, so a
+        // failure to obtain the endpoint never leaves the host hanging.
+        // Throwaway test scaffolding; deterministic shutdown.
+        let watchdog = Timer(timeInterval: 9.0, repeats: false) { _ in
+            SpikeLog.err("HOST", "watchdog auto-exit")
+            NSApp.terminate(nil)
+        }
+        RunLoop.main.add(watchdog, forMode: .common)
+    }
+
+    func fetchEndpointAndRequest() {
+        let conn = NSXPCConnection(machServiceName: kBrokerMachName, options: [])
+        conn.remoteObjectInterface = NSXPCInterface(with: VBBrokerProtocol.self)
+        conn.resume()
+        guard let proxy = conn.remoteObjectProxyWithErrorHandler({ err in
+            SpikeLog.err("HOST", "broker connect error \(err)")
+        }) as? VBBrokerProtocol else {
+            SpikeLog.err("HOST", "broker proxy nil"); return
+        }
+        proxy.getServiceEndpoint { [weak self] ep in
+            guard let self = self else { return }
+            guard let ep = ep else {
+                self.endpointRetries += 1
+                if self.endpointRetries <= 12 {
+                    SpikeLog.err("HOST", "no endpoint yet (retry \(self.endpointRetries))")
+                    // Bounded retry; throwaway scaffolding, deterministic shutdown via watchdog.
+                    DispatchQueue.main.async {
+                        let t = Timer(timeInterval: 0.4, repeats: false) { _ in self.fetchEndpointAndRequest() }
+                        RunLoop.main.add(t, forMode: .common)
+                    }
+                } else {
+                    SpikeLog.err("HOST", "no endpoint from broker after retries")
+                }
+                return
+            }
+            DispatchQueue.main.async { self.requestViewController(ep) }
+        }
+    }
+
+    private var endpointRetries = 0
+
+    private func requestViewController(_ endpoint: NSXPCListenerEndpoint) {
+        guard let cls = NSClassFromString("NSRemoteViewController") else {
+            SpikeLog.err("HOST", "NSRemoteViewController missing"); return
+        }
+        let sel = NSSelectorFromString("requestViewController:fromServiceListenerEndpoint:connectionHandler:")
+        guard let m = class_getClassMethod(cls, sel) else {
+            SpikeLog.err("HOST", "selector missing: \(sel)"); return
+        }
+        typealias Fn = @convention(c) (
+            AnyObject, Selector, NSString, NSXPCListenerEndpoint,
+            @convention(block) (AnyObject?, NSError?) -> Void) -> Void
+        let imp = method_getImplementation(m)
+        let fn = unsafeBitCast(imp, to: Fn.self)
+        let handler: @convention(block) (AnyObject?, NSError?) -> Void = { [weak self] vc, err in
+            if let err = err {
+                SpikeLog.err("HOST", "requestViewController error: \(err)")
+                return
+            }
+            guard let vc = vc as? NSViewController else {
+                SpikeLog.err("HOST", "handler vc not an NSViewController: \(String(describing: vc))")
+                return
+            }
+            SpikeLog.err("HOST", "got remote VC \(vc); view = \(String(describing: vc.view))")
+            DispatchQueue.main.async { self?.embed(vc) }
+        }
+        SpikeLog.err("HOST", "calling requestViewController:fromServiceListenerEndpoint: with VBServiceVC")
+        fn(cls, sel, "VBServiceVC" as NSString, endpoint, handler)
+    }
+
+    private func embed(_ vc: NSViewController) {
+        remoteVC = vc
+        let remoteView = vc.view
+        remoteView.frame = window.contentView!.bounds
+        remoteView.autoresizingMask = [.width, .height]
+        window.contentView?.addSubview(remoteView)
+        SpikeLog.err("HOST", "embedded remote view; valid=\(remoteView.responds(to: NSSelectorFromString("isValid")) ? String(describing: remoteView.value(forKey: "isValid")) : "n/a") frame=\(remoteView.frame)")
+        window.makeKey()
+        verify(remoteView)
+    }
+
+    private func snapshot(_ view: NSView, _ name: String) {
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            SpikeLog.err("HOST", "snapshot \(name): no rep"); return
+        }
+        view.cacheDisplay(in: view.bounds, to: rep)
+        // count non-transparent / non-uniform pixels as a crude content signal
+        var distinct = Set<UInt32>()
+        if let data = rep.bitmapData {
+            let n = rep.bytesPerRow * rep.pixelsHigh
+            var i = 0
+            while i < n - 4 {
+                let px = UInt32(data[i]) << 24 | UInt32(data[i+1]) << 16 | UInt32(data[i+2]) << 8 | UInt32(data[i+3])
+                distinct.insert(px); i += 64
+            }
+        }
+        if let png = rep.representation(using: .png, properties: [:]) {
+            try? png.write(to: URL(fileURLWithPath: "/tmp/vbridge-\(name).png"))
+        }
+        SpikeLog.err("HOST", "snapshot \(name): \(rep.pixelsWide)x\(rep.pixelsHigh), distinctColors~=\(distinct.count) (saved /tmp/vbridge-\(name).png)")
+    }
+
+    private func post(_ event: NSEvent?) {
+        guard let event = event else { return }
+        window.sendEvent(event)
+    }
+
+    private func verify(_ remoteView: NSView) {
+        // t+1s: first snapshot (should show rendered SwiftUI if marshal works)
+        runAfter(1.0) { self.snapshot(remoteView, "before") }
+        // t+2s: hover near the counter, then click the Increment button area
+        runAfter(2.0) {
+            let p = NSPoint(x: 160, y: 250)
+            self.post(NSEvent.mouseEvent(with: .mouseMoved, location: p, modifierFlags: [], timestamp: 0,
+                windowNumber: self.window.windowNumber, context: nil, eventNumber: 0, clickCount: 0, pressure: 0))
+        }
+        runAfter(3.0) {
+            let btn = NSPoint(x: 160, y: 230)
+            self.post(NSEvent.mouseEvent(with: .leftMouseDown, location: btn, modifierFlags: [], timestamp: 0,
+                windowNumber: self.window.windowNumber, context: nil, eventNumber: 1, clickCount: 1, pressure: 1))
+            self.post(NSEvent.mouseEvent(with: .leftMouseUp, location: btn, modifierFlags: [], timestamp: 0,
+                windowNumber: self.window.windowNumber, context: nil, eventNumber: 2, clickCount: 1, pressure: 0))
+        }
+        // t+4s: focus the text field and type
+        runAfter(4.0) {
+            let tf = NSPoint(x: 160, y: 150)
+            self.post(NSEvent.mouseEvent(with: .leftMouseDown, location: tf, modifierFlags: [], timestamp: 0,
+                windowNumber: self.window.windowNumber, context: nil, eventNumber: 3, clickCount: 1, pressure: 1))
+            self.post(NSEvent.mouseEvent(with: .leftMouseUp, location: tf, modifierFlags: [], timestamp: 0,
+                windowNumber: self.window.windowNumber, context: nil, eventNumber: 4, clickCount: 1, pressure: 0))
+            for ch in "hi" {
+                let s = String(ch)
+                self.post(NSEvent.keyEvent(with: .keyDown, location: tf, modifierFlags: [], timestamp: 0,
+                    windowNumber: self.window.windowNumber, context: nil, characters: s,
+                    charactersIgnoringModifiers: s, isARepeat: false, keyCode: 4))
+                self.post(NSEvent.keyEvent(with: .keyUp, location: tf, modifierFlags: [], timestamp: 0,
+                    windowNumber: self.window.windowNumber, context: nil, characters: s,
+                    charactersIgnoringModifiers: s, isARepeat: false, keyCode: 4))
+            }
+        }
+        // t+5s: second snapshot (counter/textfield should have changed if input bridged)
+        runAfter(5.0) { self.snapshot(remoteView, "after") }
+        // t+7s: bounded auto-exit (throwaway scaffolding; deterministic shutdown)
+        runAfter(7.0) {
+            SpikeLog.err("HOST", "auto-exit")
+            NSApp.terminate(nil)
+        }
+    }
+
+    private func runAfter(_ s: Double, _ block: @escaping () -> Void) {
+        let t = Timer(timeInterval: s, repeats: false) { _ in block() }
+        RunLoop.main.add(t, forMode: .common)
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let host = HostController()
+app.activate(ignoringOtherApps: true)
+DispatchQueue.main.async { host.fetchEndpointAndRequest() }
+app.run()

--- a/tools/viewbridge-spike/src/probe/main.swift
+++ b/tools/viewbridge-spike/src/probe/main.swift
@@ -1,0 +1,60 @@
+// VB spike RUNG-3 probe. Throwaway demo binary (localization-exempt).
+//
+// Rung 3 of the escalation ladder is "the real service entry point":
+// NSViewServiceApplicationMain / NSViewServiceApplication's extension bootstrap.
+// Those are what an OS-launched ViewService (appex) runs. This probe calls the
+// non-blocking bootstrap entry points and logs their result/error so we can show
+// exactly why a self-launched process cannot become a ViewBridge service: it has
+// no validated service configuration and no system-brokered host handshake.
+//
+// We deliberately do NOT call NSViewServiceApplicationMain() itself, because it
+// blocks waiting for a launchd-provided check-in endpoint that never arrives for
+// a process the OS did not launch as an extension (it would hang). The bootstrap
+// selectors it calls internally are probed here instead.
+
+import AppKit
+import ObjectiveC.runtime
+
+func log(_ m: String) { FileHandle.standardError.write("PROBE: \(m)\n".data(using: .utf8)!) }
+
+_ = NSApplication.shared
+
+guard let appCls = NSClassFromString("NSViewServiceApplication") as AnyObject? else {
+    log("NSViewServiceApplication missing"); exit(1)
+}
+
+// NOTE: +[NSViewServiceApplication bootstrapKind] asserts 'unknown bootstrap
+// kind' for any process the OS did not launch as an extension/XPC service, so we
+// do not call it here (it hard-crashes). That assertion is itself the headline
+// result: a self-launched CLI has no ViewBridge bootstrap context. We go straight
+// to the bootstrap entry points to capture their errors.
+
+// (1) commonBootstrapForExtensionWithError: the non-EXK extension bootstrap.
+let cbSel = NSSelectorFromString("commonBootstrapForExtensionWithError:")
+if let m = class_getClassMethod(appCls as? AnyClass, cbSel) {
+    typealias Fn = @convention(c) (AnyObject, Selector, UnsafeMutablePointer<NSError?>?) -> Bool
+    let fn = unsafeBitCast(method_getImplementation(m), to: Fn.self)
+    var err: NSError?
+    let ok = fn(appCls, cbSel, &err)
+    log("commonBootstrapForExtensionWithError: ok=\(ok) err=\(String(describing: err))")
+} else {
+    log("commonBootstrapForExtensionWithError: selector unavailable")
+}
+
+// (4) bootstrapForExtensionKitWithDelegate:error: the ExtensionKit/EXHost entry.
+//     This is the path EXHost drives; it needs a delegate that receives the
+//     system-brokered host connection. We pass a do-nothing delegate to capture
+//     the error a self-launched process gets (no EXHost handshake present).
+final class DummyDelegate: NSObject {}
+let ekSel = NSSelectorFromString("bootstrapForExtensionKitWithDelegate:error:")
+if let m = class_getClassMethod(appCls as? AnyClass, ekSel) {
+    typealias Fn = @convention(c) (AnyObject, Selector, AnyObject, UnsafeMutablePointer<NSError?>?) -> Bool
+    let fn = unsafeBitCast(method_getImplementation(m), to: Fn.self)
+    var err: NSError?
+    let ok = fn(appCls, ekSel, DummyDelegate(), &err)
+    log("bootstrapForExtensionKitWithDelegate:error: ok=\(ok) err=\(String(describing: err))")
+} else {
+    log("bootstrapForExtensionKitWithDelegate:error: selector unavailable")
+}
+
+log("probe done")

--- a/tools/viewbridge-spike/src/service/main.swift
+++ b/tools/viewbridge-spike/src/service/main.swift
@@ -1,0 +1,179 @@
+// VB spike SERVICE child. Throwaway demo binary (localization-exempt).
+//
+// Attempts to stand up the ViewBridge *service* side from an ordinary CLI process:
+//   1. bring up AppKit (NSViewServiceApplication as NSApp if possible),
+//   2. bootstrap the private shared service listener,
+//   3. attach our own NSXPCListener.anonymous() so the ViewBridge service protocol
+//      is vended over an endpoint we own (no launchd check-in needed for that port),
+//   4. register a runtime NSServiceViewController subclass "VBServiceVC" whose view
+//      is SwiftUI (TextField + Button(@State counter) + .onHover color),
+//   5. hand our anonymous endpoint to the broker for the host to pick up,
+//   6. run the AppKit/XPC runloop.
+//
+// Every load-bearing private call is logged so a failure pins the exact layer.
+
+import AppKit
+import SwiftUI
+import ObjectiveC.runtime
+
+// MARK: - SwiftUI content shown by the service VC
+
+struct ServiceContent: View {
+    @State private var count = 0
+    @State private var text = ""
+    @State private var hovering = false
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("ViewBridge spike service")
+                .font(.headline)
+            Text("count: \(count)")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(hovering ? Color.green : Color.primary)
+            Button("Increment") { count += 1 }
+                .buttonStyle(.borderedProminent)
+            TextField("type here", text: $text)
+                .textFieldStyle(.roundedBorder)
+            Text("echo: \(text)")
+            Spacer()
+        }
+        .padding()
+        .frame(minWidth: 240, minHeight: 320)
+        .background(hovering ? Color.yellow.opacity(0.15) : Color.clear)
+        .onHover { hovering = $0 }
+    }
+}
+
+// MARK: - Runtime NSServiceViewController subclass
+
+enum ServiceVCFactory {
+    static let className = "VBServiceVC"
+    static func register() -> Bool {
+        guard let superCls = NSClassFromString("NSServiceViewController") else {
+            SpikeLog.err("SERVICE", "NSServiceViewController class missing"); return false
+        }
+        if NSClassFromString(className) != nil { return true }
+        guard let pair = objc_allocateClassPair(superCls, className, 0) else {
+            SpikeLog.err("SERVICE", "objc_allocateClassPair failed"); return false
+        }
+        // Override -loadView to install an NSHostingView with our SwiftUI content.
+        let loadView: @convention(block) (AnyObject) -> Void = { obj in
+            SpikeLog.err("SERVICE", "VBServiceVC.loadView invoked")
+            let host = NSHostingView(rootView: ServiceContent())
+            host.frame = NSRect(x: 0, y: 0, width: 280, height: 360)
+            (obj as? NSViewController)?.view = host
+        }
+        let imp = imp_implementationWithBlock(loadView)
+        class_addMethod(pair, NSSelectorFromString("loadView"), imp, "v@:")
+        objc_registerClassPair(pair)
+        SpikeLog.err("SERVICE", "registered \(className)")
+        return true
+    }
+}
+
+// MARK: - Service-side ViewBridge bootstrap
+
+enum ServiceBootstrap {
+    // Returns the anonymous endpoint that the host should request against, or nil.
+    static func standUp() -> NSXPCListenerEndpoint? {
+        // (a) shared service listener
+        guard let sharedCls = NSClassFromString("NSXPCSharedListener") as AnyObject? else {
+            SpikeLog.err("SERVICE", "NSXPCSharedListener missing"); return nil
+        }
+        // Escalation probe: ViewBridge accepts a marshal connection only when the
+        // process has a validated service *configuration*, which it reads from the
+        // service bundle's NSExtension Info dictionary. We must adopt a service
+        // bundle (cacheMainBundleAsServiceBundle) BEFORE reading serviceConfiguration,
+        // or +serviceConfiguration asserts "unable to obtain service bundle info
+        // dictionary". On a plain CLI the main bundle has no Info dict; on the .app
+        // shell rung the main bundle carries an NSExtension dict, so this is the
+        // real test of whether a hand-built bundle satisfies the config gate.
+        if let appCls = NSClassFromString("NSViewServiceApplication") as AnyObject? {
+            let cacheSel = NSSelectorFromString("cacheMainBundleAsServiceBundle")
+            if appCls.responds(to: cacheSel) {
+                _ = appCls.perform(cacheSel)
+                SpikeLog.err("SERVICE", "called cacheMainBundleAsServiceBundle; mainBundle=\(Bundle.main.bundlePath); hasNSExtension=\(Bundle.main.object(forInfoDictionaryKey: "NSExtension") != nil)")
+            }
+            let cfgSel = NSSelectorFromString("serviceConfiguration")
+            if appCls.responds(to: cfgSel) {
+                let cfg = appCls.perform(cfgSel)?.takeUnretainedValue()
+                SpikeLog.err("SERVICE", "serviceConfiguration = \(String(describing: cfg))")
+            }
+        }
+        // bootstrap via NSViewServiceApplication if available (sets up service config)
+        if let appCls = NSClassFromString("NSViewServiceApplication") as AnyObject?,
+           appCls.responds(to: NSSelectorFromString("bootstrapSharedServiceListener")) {
+            _ = appCls.perform(NSSelectorFromString("bootstrapSharedServiceListener"))
+            SpikeLog.err("SERVICE", "called NSViewServiceApplication.bootstrapSharedServiceListener")
+        }
+        guard sharedCls.responds(to: NSSelectorFromString("sharedServiceListener")),
+              let shared = sharedCls.perform(NSSelectorFromString("sharedServiceListener"))?.takeUnretainedValue() else {
+            SpikeLog.err("SERVICE", "sharedServiceListener nil"); return nil
+        }
+        SpikeLog.err("SERVICE", "sharedServiceListener = \(shared)")
+
+        // (b) our own anonymous listener whose connections are handled by the
+        // shared ViewBridge listener (its delegate vends the service protocol).
+        // The canonical name "com.apple.view-bridge" is already owned by the
+        // shared listener (registering it throws "cannot replace existing
+        // listener named com.apple.view-bridge"), so register under a private
+        // name of our own and read the endpoint back via listenerEndpointWithName:.
+        let serviceName = "com.cmux.vbridge.service"
+        let anon = NSXPCListener.anonymous()
+        let addSel = NSSelectorFromString("addListener:withName:")
+        if shared.responds(to: addSel) {
+            _ = shared.perform(addSel, with: anon, with: serviceName)
+            SpikeLog.err("SERVICE", "added anon listener to shared under \(serviceName); anon.delegate=\(String(describing: anon.delegate))")
+        } else {
+            SpikeLog.err("SERVICE", "shared listener has no addListener:withName:")
+        }
+        // addListener:withName: takes ownership of the anonymous listener and
+        // resumes it through the shared listener's own machinery. Calling
+        // anon.resume() ourselves is a double-resume that traps with
+        // _xpc_api_misuse, so we must NOT resume or set a delegate by hand.
+        var endpoint: NSXPCListenerEndpoint?
+        let epSel = NSSelectorFromString("listenerEndpointWithName:")
+        if shared.responds(to: epSel),
+           let ep = shared.perform(epSel, with: serviceName)?.takeUnretainedValue() as? NSXPCListenerEndpoint {
+            endpoint = ep
+            SpikeLog.err("SERVICE", "shared.listenerEndpointWithName -> \(ep)")
+        }
+        if endpoint == nil { endpoint = anon.endpoint }
+        SpikeLog.err("SERVICE", "service endpoint = \(String(describing: endpoint))")
+        return endpoint
+    }
+}
+
+// MARK: - main
+
+SpikeLog.err("SERVICE", "pid \(getpid()) starting")
+
+// Try to make NSApp the ViewBridge service application subclass.
+if let vsaCls = NSClassFromString("NSViewServiceApplication") as AnyObject?,
+   vsaCls.responds(to: NSSelectorFromString("sharedApplication")) {
+    _ = vsaCls.perform(NSSelectorFromString("sharedApplication"))
+    SpikeLog.err("SERVICE", "NSApp class = \(type(of: NSApplication.shared))")
+} else {
+    _ = NSApplication.shared
+}
+NSApp.setActivationPolicy(.accessory)
+
+guard ServiceVCFactory.register() else { exit(3) }
+guard let endpoint = ServiceBootstrap.standUp() else {
+    SpikeLog.err("SERVICE", "FAILED to stand up service endpoint"); exit(4)
+}
+
+// Hand endpoint to broker.
+let conn = NSXPCConnection(machServiceName: kBrokerMachName, options: [])
+conn.remoteObjectInterface = NSXPCInterface(with: VBBrokerProtocol.self)
+conn.resume()
+if let proxy = conn.remoteObjectProxyWithErrorHandler({ err in
+    SpikeLog.err("SERVICE", "broker connect error \(err)")
+}) as? VBBrokerProtocol {
+    proxy.setServiceEndpoint(endpoint)
+    SpikeLog.err("SERVICE", "sent endpoint to broker")
+} else {
+    SpikeLog.err("SERVICE", "broker proxy nil")
+}
+
+SpikeLog.err("SERVICE", "entering runloop")
+NSApp.run()


### PR DESCRIPTION
This is a throwaway spike from the sidebar vibe-coding architecture program. It is Spike 4 (key nsremoteview) of that program. Program design doc: plans/sidebar-vibe-coding/DESIGN.md in the cmuxterm-hq control repo. Do not merge; the value is the diagnosis, not shippable code. All code lives under tools/viewbridge-spike and there is no cmux integration.

The question: can an arbitrary CLI-launched process act as the ViewBridge SERVICE side over a self-made handed-off endpoint, so a host NSRemoteView displays it with real keyboard, focus, and hover? Zero published prior art, presumed dead until proven.

Verdict: BLOCKED, with a precise failure layer. The endpoint handoff is not the blocker and window rights are never reached. The blocker is the service-side marshal/configuration gate.

What runs and what fails, proven on macOS 26.4 (build 25E246). A plain CLI service can stand up the shared ViewBridge listener, register a private-named anonymous listener, obtain a real NSXPCListenerEndpoint, hand it to a launchd mach broker, and the host can fetch it and call the private requestViewController:fromServiceListenerEndpoint:. The host connection physically reaches the service, then the service-side shared listener cancels it. The host gets NSCocoaErrorDomain Code=4099 and ViewBridge logs the NSRemoteViewController catastrophic-error client error.

Root cause: +[NSViewServiceApplication serviceConfiguration] is nil for a self-launched process, so the shared listener rejects the marshal handshake. Wrapping the same binary in a minimal .app bundle that carries an NSExtension Info.plist does not help: serviceConfiguration is still nil and the host still gets 4099. The real service bootstrap entry points confirm why: +[NSViewServiceApplication bootstrapKind] asserts unknown bootstrap kind, and commonBootstrapForExtensionWithError: asserts unable to obtain XPC bundle info dictionary, identically for the CLI and the .app shell. That XPC bundle info dictionary is injected by the OS XPC/extension launcher and cannot be faked by self-launching.

What ExtensionKit does differently is exactly the things this spike could not fake: the OS launches the extension (so it has a real bootstrap kind and the injected info dictionary), serviceConfiguration is populated from a validated extension bundle, and the host obtains the endpoint plus a fixed host identity from the OS rather than inventing an anonymous endpoint. So there is no CLI-launches-a-bundled-.app shortcut here; tier 2 stays on ExtensionKit, exactly as the program plan assumed. The SDK and CLI ergonomics envisioned for nsremoteview transfer cleanly onto the ExtensionKit transport.

Escalation ladder (each rung run, failure pinned): plain CLI child reaches the connection rejection (serviceConfiguration nil); .app bundle shell with NSExtension still yields nil config and the same 4099; the real bootstrap entry points assert on the missing bootstrap kind and XPC bundle info dictionary. Along the way two transport bugs were found and fixed to expose the real gate: the canonical name com.apple.view-bridge is already owned (register a private name and read the endpoint via listenerEndpointWithName:), and addListener:withName: already resumes the anonymous listener so an explicit resume() traps with _xpc_api_misuse.

Full design and honest results with evidence: plans/sidebar-vibe-coding/spikes/nsremoteview.md (cmuxterm-hq control repo).

Reproduce from the worktree: cd tools/viewbridge-spike && ./build.sh && ./run.sh (rung 1), VBSERVICE_BIN=build/VBService.app/Contents/MacOS/vbservice ./run.sh (rung 2), build/vbprobe (rung 3). Everything is bounded and self-terminating; run.sh tears down the broker LaunchAgent and kills all spike processes on exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783743458&installation_id=133855650&pr_number=5865&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5865&signature=1cd40c2aa5f99774e137e457835b980475f298948c6bac75665204a6eda6a66e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spike to test if a CLI-launched process can host a ViewBridge service over a self-made endpoint. Result: blocked at the service-side configuration gate; an OS-launched extension context is required (`ExtensionKit`), so tier 2 stays on `ExtensionKit`.

- **New Features**
  - Added throwaway spike under tools/viewbridge-spike with `build.sh`/`run.sh` and four binaries: `broker`, `vbservice`, `vbhost`, `vbprobe`.
  - Verified endpoint handoff via `NSXPCListenerEndpoint`: host reaches service and calls `NSRemoteViewController`.
  - Connection is rejected by the shared listener: `+[NSViewServiceApplication serviceConfiguration]` is nil; host sees `NSCocoaErrorDomain` 4099.
  - Wrapping the service in a minimal `.app` with `NSExtension` does not help; bootstrap asserts unknown kind / missing XPC bundle info.
  - Confirms the architecture: use `ExtensionKit` (OS-launched extension) for ViewBridge; no `cmux` integration in this spike.

<sup>Written for commit 2053bacd1220cff793d5dbb7624e014b0c893abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive build and run orchestration scripts for development testing infrastructure, supporting process lifecycle and coordination.
  * Introduced experimental spike components and supporting configuration files for testing and verification purposes.
  * Updated build artifact exclusion configuration to prevent compilation outputs from being committed to version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->