### PR TITLE
browser actions: honor beforeinput on contenteditable, guard focus-mode side-effect, scope --return-to

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,8 +1,8 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-32873	CLI/cmux.swift
-22426	Sources/TerminalController.swift
+32879	CLI/cmux.swift
+22444	Sources/TerminalController.swift
 19955	Sources/Workspace.swift
 19245	Sources/ContentView.swift
 18044	Sources/AppDelegate.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11702,14 +11702,20 @@ struct CMUXCLI {
             return
         }
 
-        // Caller routing: an explicit --workspace/--window, else the invoking workspace
-        // (CMUX_WORKSPACE_ID). Resolved up front so an INDEXED --surface/--return-to is scoped to
-        // the requested workspace/window rather than the foreground selection.
-        func callerRoutingHandles() throws -> (workspace: String?, window: String?) {
+        // Routing scope for resolving an INDEXED --return-to handle. It must match the scope
+        // optionalSurfaceParams() uses for the (optional) explicit --surface: an explicit surface is
+        // scoped to explicit --workspace/--window only and does NOT inherit the env-default
+        // workspace (it may legitimately target a different workspace than the caller's terminal),
+        // while an implicit surface falls back to the caller's CMUX_WORKSPACE_ID. Scoping a return
+        // handle to the env workspace when the browser lives in another workspace would index the
+        // wrong terminal.
+        func returnToRoutingHandles() throws -> (workspace: String?, window: String?) {
             let (workspaceOpt, _) = parseOption(subArgs, name: "--workspace")
             let (windowOpt, _) = parseOption(subArgs, name: "--window")
             let windowHandle = try windowOpt.flatMap { try normalizeWindowHandle($0, client: client) }
-            let workspaceRaw = workspaceOpt ?? (windowOpt == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceRaw = surfaceRaw != nil
+                ? workspaceOpt
+                : (workspaceOpt ?? (windowOpt == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil))
             let workspaceHandle = try workspaceRaw.flatMap {
                 try normalizeWorkspaceHandle($0, client: client, windowHandle: windowHandle)
             }
@@ -11769,7 +11775,7 @@ struct CMUXCLI {
                 throw CLIError(message: "Unsupported browser react-grab subcommand: \(verb) (expected: toggle)")
             }
             var params = try optionalSurfaceParams()
-            let routing = try callerRoutingHandles()
+            let routing = try returnToRoutingHandles()
             let (returnOpt, _) = parseOption(subArgs, name: "--return-to")
             if let returnRaw = returnOpt {
                 // A supplied-but-unresolvable --return-to is an error, never a silent

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12655,6 +12655,12 @@ class TerminalController {
                 catch (e) { el.dispatchEvent(new Event('input', { bubbles: true })); }
                 el.dispatchEvent(new Event('change', { bubbles: true }));
               } else {
+                // contenteditable / non-value elements get the same cancelable beforeinput so a rich
+                // editor (ProseMirror, Slate, etc.) that manages its own model can reject the edit
+                // instead of us silently overwriting textContent and drifting from app state.
+                let proceed = true;
+                try { proceed = el.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'insertText', data: chunk })); } catch (e) {}
+                if (!proceed) return { ok: false, error: 'input_rejected' };
                 el.textContent = (el.textContent || '') + chunk;
                 try { el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: chunk })); } catch (e) {}
               }
@@ -12688,6 +12694,12 @@ class TerminalController {
                 catch (e) { el.dispatchEvent(new Event('input', { bubbles: true })); }
                 el.dispatchEvent(new Event('change', { bubbles: true }));
               } else {
+                // contenteditable / non-value elements get the same cancelable beforeinput so a rich
+                // editor that manages its own model can reject the edit instead of us silently
+                // overwriting textContent.
+                let proceed = true;
+                try { proceed = el.dispatchEvent(new InputEvent('beforeinput', { bubbles: true, cancelable: true, inputType: 'insertReplacementText', data: newValue })); } catch (e) {}
+                if (!proceed) return { ok: false, error: 'input_rejected' };
                 el.textContent = newValue;
                 try { el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertReplacementText', data: newValue })); } catch (e) {}
               }
@@ -13266,13 +13278,14 @@ class TerminalController {
         tabManager: TabManager,
         extra: [String: Any] = [:]
     ) -> [String: Any] {
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
         var payload: [String: Any] = [
             "workspace_id": workspace.id.uuidString,
             "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id),
             "surface_id": surfaceId.uuidString,
             "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
-            "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString),
-            "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId)
         ]
         for (key, value) in extra { payload[key] = value }
         return payload
@@ -13372,9 +13385,14 @@ class TerminalController {
             // Entering browser focus mode requires the target browser to be the focused, on-screen
             // panel (the GUI shortcut already runs from inside it). When the CLI targets a browser
             // that is not focused, focus it first so "enter" actually engages instead of no-opping.
+            // Focusing the panel makes the render/visibility/modal-host preconditions of
+            // canEnterBrowserFocusMode true, so those are not a reason to withhold focus. An open
+            // find bar (searchState) is the one precondition focusing does NOT satisfy: entry will
+            // fail, so don't steal foreground focus or collapse a split-zoom for an action that
+            // cannot engage.
             let willActivate = enterAliases.contains(mode)
                 || (mode == "toggle" && !target.panel.isBrowserFocusModeActive)
-            if willActivate, ws.focusedPanelId != target.surfaceId {
+            if willActivate, target.panel.searchState == nil, ws.focusedPanelId != target.surfaceId {
                 ws.clearSplitZoom()
                 ws.focusPanel(target.surfaceId)
             }


### PR DESCRIPTION
Follow-ups from the autoreview of https://github.com/manaflow-ai/cmux/pull/5766.

**contenteditable beforeinput** — `type`/`fill` honored a canceled `beforeinput` only on value-bearing inputs. The contenteditable / non-value branch now dispatches the same cancelable `beforeinput` and returns `input_rejected` when canceled, so a rich editor (ProseMirror, Slate, etc.) that manages its own model is no longer silently overwritten via `textContent`.

Verified live against a page with an accepting and a canceling contenteditable:
- accepting editor: `type "hello"` → text set, `beforeinput`=1, `input`=1
- canceling editor: `type`/`fill` → stays empty, `beforeinput` fires, `input`=0, CLI returns an error (parity with the masked text-input path)

**focus-mode side-effect** — `browser.focus_mode.set` focused the panel and cleared split-zoom *before* `setBrowserFocusModeActive`, which can return false, so a background agent could steal foreground focus and collapse a split-zoom for an enter that then no-ops. Focusing satisfies the render/visibility/modal-host preconditions of `canEnterBrowserFocusMode`; an open find bar (`searchState`) is the one it does not, so we now skip the focus/zoom mutation when entry would fail for that reason. Enter/exit happy paths verified unchanged.

**--return-to scoping** — an indexed `--return-to` for `react-grab` was always resolved against the caller's `CMUX_WORKSPACE_ID`, even when an explicit `--surface` targeted a different workspace. It now resolves in the same routing scope as the explicit surface (explicit `--workspace`/`--window`, no env-default).

**cleanup** — `v2BrowserActionPayload` resolved the window id twice; now once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783746412&installation_id=133855650&pr_number=5870&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5870&signature=add34e402c966900f913929e384f21026d8926974d633d5e7cb239af9637faa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser automation DOM injection and CLI/V2 focus-mode behavior used by agents; changes are narrow but affect cross-workspace routing and foreground focus.
> 
> **Overview**
> Browser automation and CLI routing fixes from autoreview follow-ups on PR 5766.
> 
> **`type` / `fill` on contenteditable** — The value-input path already honored a canceled `beforeinput` with `input_rejected`. The contenteditable branch now dispatches the same cancelable `beforeinput` before mutating `textContent`, so rich editors (ProseMirror, Slate, etc.) are not silently overwritten when they reject the edit.
> 
> **`browser.focus_mode.set`** — Entering focus mode used to call `focusPanel` and `clearSplitZoom` before `setBrowserFocusModeActive`, which could steal foreground focus and collapse split-zoom when entry then failed (e.g. open find bar). Focus/zoom side effects now run only when activation is intended **and** `searchState` is nil.
> 
> **`react-grab --return-to`** — Indexed `--return-to` resolution is renamed/scoped via `returnToRoutingHandles()` to match explicit `--surface` routing: with an explicit surface, workspace comes only from `--workspace`/`--window`, not `CMUX_WORKSPACE_ID`, fixing cross-workspace mis-indexing.
> 
> **Minor** — `v2BrowserActionPayload` resolves window id once instead of twice; Swift file-length budgets bumped slightly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f531580b51389b7c2e0f78c5135229c853efb56b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes input and focus-mode behavior and aligns routing for `--return-to`. Prevents overwriting rich editors, avoids unintended focus/zoom changes, and resolves return targets in the correct workspace.

- **Bug Fixes**
  - `type`/`fill` on `contenteditable`: dispatches cancelable `beforeinput`; returns `input_rejected` when canceled; no silent `textContent` overwrite; parity with value inputs.
  - `browser.focus_mode.set`: only focuses panel and clears split-zoom when entry can engage; skips when a find bar is open; normal enter/exit paths unchanged.
  - `react-grab --return-to`: resolves indexed return handle in the same routing scope as the explicit `--surface` (explicit `--workspace`/`--window`, no `CMUX_WORKSPACE_ID` fallback), fixing cross-workspace mis-indexing.

- **Refactors**
  - `v2BrowserActionPayload`: resolve window id once instead of twice.

<sup>Written for commit f531580b51389b7c2e0f78c5135229c853efb56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the find bar from losing focus or collapsing split-zoom when interacting with the terminal.
  * Terminal input now respects cancelable input events and returns a clear error when input is rejected.

* **Refactor**
  * Streamlined window identity resolution for more consistent behavior.
  * Adjusted CLI return-to routing rules to make workspace/window precedence more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->