### PR TITLE
fix: Open replayable codex-teams receiver panes

### DIFF
--- a/CLI/CodexTeamsApprovalBridge.swift
+++ b/CLI/CodexTeamsApprovalBridge.swift
@@ -243,6 +243,21 @@ enum CodexTeamsApprovalBridge {
         return nil
     }
 
+    static func spawnReceiverThreadIds(fromAppServerMessage message: [String: Any]) -> [String] {
+        guard message["method"] as? String == "item/completed",
+              let params = message["params"] as? [String: Any],
+              let item = params["item"] as? [String: Any],
+              normalizedItemValue(item["type"]) == "collabagenttoolcall",
+              normalizedItemValue(item["tool"]) == "spawnagent" else {
+            return []
+        }
+        return stringList(
+            in: item,
+            arrayKeys: ["receiverThreadIds", "receiver_thread_ids"],
+            scalarKeys: ["receiverThreadId", "receiver_thread_id"]
+        )
+    }
+
     private static func commandApprovalDecision(params: [String: Any], mode: String) -> Any {
         if mode == "deny" { return rejectApprovalDecision(params: params) }
         if mode == "all" || mode == "bypass",
@@ -535,5 +550,40 @@ enum CodexTeamsApprovalBridge {
 
     private static func codexDecisionAvailableOrUnspecified(_ decision: String, decisions: Set<String>?) -> Bool {
         decisions?.contains(decision) ?? true
+    }
+
+    private static func normalizedItemValue(_ value: Any?) -> String? {
+        guard let text = value as? String else { return nil }
+        let normalized = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func stringList(
+        in object: [String: Any],
+        arrayKeys: [String],
+        scalarKeys: [String]
+    ) -> [String] {
+        var output: [String] = []
+        var seen = Set<String>()
+        func append(_ value: Any?) {
+            guard let text = value as? String else { return }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, seen.insert(trimmed).inserted else { return }
+            output.append(trimmed)
+        }
+        for key in arrayKeys {
+            guard let values = object[key] as? [Any] else { continue }
+            for value in values {
+                append(value)
+            }
+        }
+        for key in scalarKeys {
+            append(object[key])
+        }
+        return output
     }
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -18371,6 +18371,10 @@ struct CMUXCLI {
 
     private static let codexTeamsMaxAutoDepth = 2
     private static let codexTeamsReconcileInterval: TimeInterval = 1
+    private static let codexTeamsMetadataProbeAttempts = 24
+    private static let codexTeamsMetadataProbeInterval: TimeInterval = 0.25
+    private static let codexTeamsReplayProbeAttempts = 720
+    private static let codexTeamsReplayProbeInterval: TimeInterval = 0.5
     private static let codexTeamsMaxCachedApprovalItems = 500
     static let codexTeamsApprovalMethods: Set<String> = [
         "item/commandExecution/requestApproval",
@@ -18414,6 +18418,7 @@ struct CMUXCLI {
         let id: String
         let cwd: String?
         let statusType: String?
+        let hasReplayableTurn: Bool
         let agentNickname: String?
         let agentRole: String?
         let spawn: CodexTeamsSpawn?
@@ -18655,6 +18660,7 @@ struct CMUXCLI {
         private var threadById: [String: CodexTeamsThread] = [:]
         private var pendingThreadIds = Set<String>()
         private var openedThreadIds = Set<String>()
+        private var metadataProbeThreadIds = Set<String>()
         private var readinessProbeThreadIds = Set<String>()
         private var attachableThreadIds = Set<String>()
         private let readinessLock = NSLock()
@@ -18712,6 +18718,10 @@ struct CMUXCLI {
         }
 
         private func backfillLoadedThreads(connection: CodexTeamsAppServerConnection) throws {
+            _ = try backfillLoadedThreadsOnce(connection: connection)
+        }
+
+        private func backfillLoadedThreadsOnce(connection: CodexTeamsAppServerConnection) throws -> Int {
             let loaded = try connection.request(
                 method: "thread/loaded/list",
                 params: ["limit": 200],
@@ -18724,13 +18734,38 @@ struct CMUXCLI {
                 }
             )
             let threadIds = loaded["data"] as? [String] ?? []
+            var subscribedCount = 0
             for threadId in threadIds {
                 do {
-                    try subscribeToThreadIfNeeded(threadId, connection: connection)
+                    if try subscribeToThreadIfNeeded(threadId, connection: connection) {
+                        subscribedCount += 1
+                    }
                 } catch {
                     fputs("cmux codex-teams watcher skipped thread \(threadId): \(error)\n", stderr)
+                    if shouldReconnectAfterThreadSubscribeError(error) {
+                        throw error
+                    }
+                    if shouldProbeThreadMetadataAfterSubscribeError(error) {
+                        codexTeamsScheduleMetadataProbe(threadId: threadId)
+                    }
                 }
             }
+            return subscribedCount
+        }
+
+        private func shouldReconnectAfterThreadSubscribeError(_ error: Error) -> Bool {
+            let message = String(describing: error).lowercased()
+            return message.contains("broken pipe")
+                || message.contains("not connected")
+                || message.contains("connection reset")
+        }
+
+        private func shouldProbeThreadMetadataAfterSubscribeError(_ error: Error) -> Bool {
+            let message = String(describing: error).lowercased()
+            return message.contains("no rollout found for thread id")
+                || (message.contains("rollout at ") && message.contains(" is empty"))
+                || (message.contains("failed to read thread") && message.contains("rollout"))
+                || message.contains("thread-store internal error")
         }
 
         private func listenForNotifications(connection: CodexTeamsAppServerConnection) throws {
@@ -18752,6 +18787,20 @@ struct CMUXCLI {
                 return
             }
             if message["id"] != nil { return }
+            if allowThreadSubscribe {
+                for threadId in CMUXCLI.codexTeamsSpawnReceiverThreadIds(fromAppServerMessage: message) {
+                    do {
+                        try subscribeToThreadIfNeeded(threadId, connection: connection)
+                    } catch {
+                        fputs("cmux codex-teams watcher skipped spawned receiver thread \(threadId): \(error)\n", stderr)
+                        if shouldProbeThreadMetadataAfterSubscribeError(error) {
+                            codexTeamsScheduleMetadataProbe(threadId: threadId)
+                        } else {
+                            throw error
+                        }
+                    }
+                }
+            }
             guard method.hasPrefix("thread/"),
                   let params = message["params"] as? [String: Any],
                   let threadObject = params["thread"] as? [String: Any],
@@ -18764,18 +18813,20 @@ struct CMUXCLI {
                     try subscribeToThreadIfNeeded(thread.id, connection: connection)
                 } catch {
                     fputs("cmux codex-teams watcher skipped thread \(thread.id): \(error)\n", stderr)
+                    throw error
                 }
             }
         }
 
+        @discardableResult
         private func subscribeToThreadIfNeeded(
             _ threadId: String,
             connection: CodexTeamsAppServerConnection
-        ) throws {
+        ) throws -> Bool {
             stateLock.lock()
             let inserted = subscribedThreadIds.insert(threadId).inserted
             stateLock.unlock()
-            guard inserted else { return }
+            guard inserted else { return true }
 
             do {
                 let response = try connection.request(
@@ -18794,8 +18845,21 @@ struct CMUXCLI {
                 )
                 if let threadObject = response["thread"] as? [String: Any],
                    let thread = CMUXCLI.codexTeamsThread(from: threadObject) {
+                    if thread.spawn != nil,
+                       CMUXCLI.codexTeamsThreadMayBeAttachable(thread) {
+                        codexTeamsMarkAttachableThreadId(thread.id)
+                    }
                     try observeThreadSafely(thread)
+                    if let parentThreadId = thread.spawn?.parentThreadId,
+                       parentThreadId != thread.id {
+                        do {
+                            try subscribeToThreadIfNeeded(parentThreadId, connection: connection)
+                        } catch {
+                            fputs("cmux codex-teams watcher skipped spawned receiver parent thread \(parentThreadId): \(error)\n", stderr)
+                        }
+                    }
                 }
+                return true
             } catch {
                 stateLock.lock()
                 subscribedThreadIds.remove(threadId)
@@ -19010,7 +19074,10 @@ struct CMUXCLI {
             depthByThreadId[thread.id] = depth
             guard depth <= maxAutoDepth else { return }
             guard !openedThreadIds.contains(thread.id) else { return }
-            guard CMUXCLI.codexTeamsThreadMayBeAttachable(thread) else { return }
+            guard CMUXCLI.codexTeamsThreadMayBeAttachable(thread) else {
+                codexTeamsScheduleReadinessProbe(threadId: thread.id)
+                return
+            }
             guard codexTeamsConsumeAttachableThreadId(thread.id) else {
                 codexTeamsScheduleReadinessProbe(threadId: thread.id)
                 return
@@ -19029,6 +19096,71 @@ struct CMUXCLI {
             openedThreadIds.insert(thread.id)
         }
 
+        private func codexTeamsScheduleMetadataProbe(threadId: String) {
+            readinessLock.lock()
+            if metadataProbeThreadIds.contains(threadId)
+                || attachableThreadIds.contains(threadId)
+                || readinessProbeThreadIds.contains(threadId) {
+                readinessLock.unlock()
+                return
+            }
+            metadataProbeThreadIds.insert(threadId)
+            readinessLock.unlock()
+
+            codexTeamsRunMetadataProbe(
+                threadId: threadId,
+                attemptsRemaining: CMUXCLI.codexTeamsMetadataProbeAttempts
+            )
+        }
+
+        private func codexTeamsRunMetadataProbe(
+            threadId: String,
+            attemptsRemaining: Int
+        ) {
+            let appServerURL = appServerURL
+            DispatchQueue.global(qos: .utility).async { [weak self] in
+                guard let self else { return }
+                if let fetchedThread = try? CMUXCLI.codexTeamsFetchThread(
+                    appServerURL: appServerURL,
+                    threadId: threadId
+                ) {
+                    self.codexTeamsFinishMetadataProbe(threadId: threadId, thread: fetchedThread)
+                    return
+                }
+                guard attemptsRemaining > 1 else {
+                    self.codexTeamsFinishMetadataProbe(threadId: threadId, thread: nil)
+                    return
+                }
+                self.codexTeamsScheduleProbeRetry(after: CMUXCLI.codexTeamsMetadataProbeInterval) { [weak self] in
+                    self?.codexTeamsRunMetadataProbe(
+                        threadId: threadId,
+                        attemptsRemaining: attemptsRemaining - 1
+                    )
+                }
+            }
+        }
+
+        private func codexTeamsFinishMetadataProbe(threadId: String, thread: CodexTeamsThread?) {
+            readinessLock.lock()
+            metadataProbeThreadIds.remove(threadId)
+            if let thread,
+               thread.spawn != nil,
+               CMUXCLI.codexTeamsThreadMayBeAttachable(thread) {
+                attachableThreadIds.insert(threadId)
+            }
+            readinessLock.unlock()
+
+            guard let thread else {
+                fputs("cmux codex-teams watcher could not fetch spawned receiver metadata \(threadId) after retry\n", stderr)
+                return
+            }
+            do {
+                try observeThreadSafely(thread)
+            } catch {
+                fputs("cmux codex-teams watcher failed to open metadata-ready subagent \(threadId): \(error)\n", stderr)
+            }
+        }
+
         private func codexTeamsScheduleReadinessProbe(threadId: String) {
             readinessLock.lock()
             if attachableThreadIds.contains(threadId)
@@ -19040,26 +19172,67 @@ struct CMUXCLI {
             readinessProbeThreadIds.insert(threadId)
             readinessLock.unlock()
 
+            codexTeamsRunReadinessProbe(
+                threadId: threadId,
+                attemptsRemaining: CMUXCLI.codexTeamsReplayProbeAttempts
+            )
+        }
+
+        private func codexTeamsRunReadinessProbe(
+            threadId: String,
+            attemptsRemaining: Int
+        ) {
             let appServerURL = appServerURL
             DispatchQueue.global(qos: .utility).async { [weak self] in
-                let isAttachable = CMUXCLI.codexTeamsThreadCanResume(
+                guard let self else { return }
+                if let replayableThread = try? CMUXCLI.codexTeamsFetchThread(
                     appServerURL: appServerURL,
                     threadId: threadId
-                )
-                guard let self else { return }
-                self.readinessLock.lock()
-                self.readinessProbeThreadIds.remove(threadId)
-                if isAttachable {
-                    self.attachableThreadIds.insert(threadId)
+                ), CMUXCLI.codexTeamsThreadMayBeAttachable(replayableThread) {
+                    self.codexTeamsFinishReadinessProbe(threadId: threadId, thread: replayableThread)
+                    return
                 }
-                self.readinessLock.unlock()
-                guard isAttachable else { return }
-                do {
-                    try self.openAttachableThread(threadId: threadId)
-                } catch {
-                    fputs("cmux codex-teams watcher failed to open ready subagent \(threadId): \(error)\n", stderr)
+                guard attemptsRemaining > 1 else {
+                    self.codexTeamsFinishReadinessProbe(threadId: threadId, thread: nil)
+                    return
+                }
+                self.codexTeamsScheduleProbeRetry(after: CMUXCLI.codexTeamsReplayProbeInterval) { [weak self] in
+                    self?.codexTeamsRunReadinessProbe(
+                        threadId: threadId,
+                        attemptsRemaining: attemptsRemaining - 1
+                    )
                 }
             }
+        }
+
+        private func codexTeamsFinishReadinessProbe(threadId: String, thread: CodexTeamsThread?) {
+            readinessLock.lock()
+            readinessProbeThreadIds.remove(threadId)
+            if thread != nil {
+                attachableThreadIds.insert(threadId)
+            }
+            readinessLock.unlock()
+
+            guard let thread else {
+                fputs("cmux codex-teams watcher could not fetch replayable subagent thread \(threadId) after retry\n", stderr)
+                return
+            }
+            do {
+                try observeThreadSafely(thread)
+            } catch {
+                fputs("cmux codex-teams watcher failed to open ready subagent \(threadId): \(error)\n", stderr)
+            }
+        }
+
+        // DispatchSourceTimer schedules bounded retries without parking a GCD worker thread.
+        private func codexTeamsScheduleProbeRetry(after interval: TimeInterval, _ operation: @escaping () -> Void) {
+            let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+            timer.schedule(deadline: .now() + interval)
+            timer.setEventHandler {
+                timer.cancel()
+                operation()
+            }
+            timer.resume()
         }
 
         private func openAttachableThread(threadId: String) throws {
@@ -19071,6 +19244,12 @@ struct CMUXCLI {
                 return
             }
             try openObservedSubagent(thread, spawn: spawn)
+        }
+
+        private func codexTeamsMarkAttachableThreadId(_ threadId: String) {
+            readinessLock.lock()
+            attachableThreadIds.insert(threadId)
+            readinessLock.unlock()
         }
 
         private func codexTeamsConsumeAttachableThreadId(_ threadId: String) -> Bool {
@@ -19120,14 +19299,23 @@ struct CMUXCLI {
                 splitParams["working_directory"] = cwd
             }
 
-            let created = try socketClient.sendV2(method: "surface.split", params: splitParams)
+            let controlClient = SocketClient(path: socketClient.socketPath)
+            try controlClient.connect()
+            defer { controlClient.close() }
+            try CMUXCLI.authenticateSocketClientIfNeeded(
+                controlClient,
+                explicitPassword: socketPassword,
+                socketPath: socketClient.socketPath
+            )
+
+            let created = try controlClient.sendV2(method: "surface.split", params: splitParams)
             guard let surfaceId = created["surface_id"] as? String else {
                 throw CLIError(message: "surface.split did not return surface_id")
             }
             lastAgentSurfaceId = surfaceId
 
             do {
-                _ = try socketClient.sendV2(method: "tab.action", params: [
+                _ = try controlClient.sendV2(method: "tab.action", params: [
                     "workspace_id": workspaceId,
                     "surface_id": surfaceId,
                     "action": "rename",
@@ -19137,13 +19325,20 @@ struct CMUXCLI {
                 // The subagent pane already exists, so a rename failure should not stop watching.
             }
             do {
-                _ = try socketClient.sendV2(method: "workspace.equalize_splits", params: [
+                _ = try controlClient.sendV2(method: "workspace.equalize_splits", params: [
                     "workspace_id": workspaceId,
                     "orientation": "vertical"
                 ])
             } catch {
                 // Layout polish is best-effort after the pane is opened.
             }
+            refreshWorkspaceSurfacesAfterLayout(controlClient: controlClient)
+        }
+
+        private func refreshWorkspaceSurfacesAfterLayout(controlClient: SocketClient) {
+            _ = try? controlClient.sendV2(method: "surface.refresh", params: [
+                "workspace_id": workspaceId
+            ])
         }
     }
 
@@ -19191,23 +19386,39 @@ struct CMUXCLI {
         CodexTeamsApprovalBridge.stringValue(in: object, keys: keys)
     }
 
-    private static func codexTeamsThreadCanResume(appServerURL: String, threadId: String) -> Bool {
+    static func codexTeamsSpawnReceiverThreadIds(fromAppServerMessage message: [String: Any]) -> [String] {
+        CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: message)
+    }
+
+    private static func codexTeamsFetchThread(
+        appServerURL: String,
+        threadId: String,
+        responseTimeout: TimeInterval = 2
+    ) throws -> CodexTeamsThread? {
         guard let url = URL(string: appServerURL) else {
-            return false
+            return nil
         }
         let connection = CodexTeamsAppServerConnection(url: url)
         connection.resume()
-        do {
-            defer { connection.close() }
-            try connection.initialize(
-                clientName: codexTeamsProbeClientName,
-                version: codexTeamsClientVersion,
-                responseTimeout: 1
-            )
-            return connection.canResumeThread(threadId: threadId)
-        } catch {
-            return false
+        defer { connection.close() }
+        try connection.initialize(
+            clientName: codexTeamsProbeClientName,
+            version: codexTeamsClientVersion,
+            responseTimeout: responseTimeout
+        )
+        let response = try connection.request(
+            method: "thread/resume",
+            params: [
+                "threadId": threadId,
+                "excludeTurns": false
+            ],
+            notificationHandler: nil,
+            responseTimeout: responseTimeout
+        )
+        guard let threadObject = response["thread"] as? [String: Any] else {
+            return nil
         }
+        return codexTeamsThread(from: threadObject)
     }
 
     private static func codexTeamsThread(from object: [String: Any]) -> CodexTeamsThread? {
@@ -19216,6 +19427,7 @@ struct CMUXCLI {
             id: id,
             cwd: object["cwd"] as? String,
             statusType: codexTeamsStatusType(from: object),
+            hasReplayableTurn: codexTeamsThreadHasReplayableTurn(from: object),
             agentNickname: object["agentNickname"] as? String,
             agentRole: object["agentRole"] as? String,
             spawn: codexTeamsSpawn(from: object)
@@ -19230,14 +19442,39 @@ struct CMUXCLI {
     }
 
     private static func codexTeamsThreadMayBeAttachable(_ thread: CodexTeamsThread) -> Bool {
+        guard thread.hasReplayableTurn else {
+            return false
+        }
         guard let statusType = thread.statusType?.trimmingCharacters(in: .whitespacesAndNewlines),
               !statusType.isEmpty else {
-            return false
+            return true
         }
         let normalized = statusType
             .replacingOccurrences(of: "_", with: "")
             .lowercased()
         return normalized != "notloaded"
+    }
+
+    private static func codexTeamsThreadHasReplayableTurn(from threadObject: [String: Any]) -> Bool {
+        guard let turns = threadObject["turns"] as? [[String: Any]] else {
+            return false
+        }
+        return turns.contains { turn in
+            if let completedAt = turn["completedAt"], !(completedAt is NSNull) {
+                return true
+            }
+            guard let status = turn["status"] as? String else {
+                return false
+            }
+            let normalized = status
+                .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: "-", with: "")
+                .lowercased()
+            return normalized == "completed"
+                || normalized == "failed"
+                || normalized == "cancelled"
+                || normalized == "canceled"
+        }
     }
 
     private static func codexTeamsSpawn(from threadObject: [String: Any]) -> CodexTeamsSpawn? {
@@ -19289,6 +19526,7 @@ struct CMUXCLI {
             "\(codexTeamsDepthEnvironmentKey)=\(max(1, depth))",
             codexExecutable,
             "resume",
+            "--no-alt-screen",
             "--remote",
             appServerURL,
             threadId

--- a/cmuxTests/CodexAppServerSessionTests.swift
+++ b/cmuxTests/CodexAppServerSessionTests.swift
@@ -1035,6 +1035,141 @@ struct CodexAppServerSessionTests {
     }
 
     @Test
+    func testCodexTeamsSpawnAgentCompletionExposesReceiverThreadIds() {
+        let message: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "id": "spawn-1",
+                    "type": "collabAgentToolCall",
+                    "tool": "spawnAgent",
+                    "receiverThreadIds": [
+                        "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                        "019eb140-0e19-7bd0-b950-e2af12345678",
+                    ],
+                ],
+            ],
+        ]
+
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: message),
+            [
+                "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                "019eb140-0e19-7bd0-b950-e2af12345678",
+            ]
+        )
+    }
+
+    @Test
+    func testCodexTeamsSpawnAgentCompletionExposesSnakeCaseReceiverThreadIds() {
+        let message: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "id": "spawn-1",
+                    "type": "collab_agent_tool_call",
+                    "tool": "spawn_agent",
+                    "receiver_thread_ids": [
+                        "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                        "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                        "019eb140-0e19-7bd0-b950-e2af12345678",
+                    ],
+                ],
+            ],
+        ]
+
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: message),
+            [
+                "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                "019eb140-0e19-7bd0-b950-e2af12345678",
+            ]
+        )
+    }
+
+    @Test
+    func testCodexTeamsSpawnAgentCompletionExposesScalarReceiverThreadIds() {
+        let camelCaseMessage: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "id": "spawn-1",
+                    "type": "collabAgentToolCall",
+                    "tool": "spawnAgent",
+                    "receiverThreadId": "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                ],
+            ],
+        ]
+        let snakeCaseMessage: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "id": "spawn-2",
+                    "type": "collabAgentToolCall",
+                    "tool": "spawnAgent",
+                    "receiver_thread_id": "019eb140-0e19-7bd0-b950-e2af12345678",
+                ],
+            ],
+        ]
+
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: camelCaseMessage),
+            ["019eb13e-74c0-72f3-a78b-0535f8eabac8"]
+        )
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: snakeCaseMessage),
+            ["019eb140-0e19-7bd0-b950-e2af12345678"]
+        )
+    }
+
+    @Test
+    func testCodexTeamsSpawnAgentCompletionIgnoresNonSpawnMessages() {
+        let wrongMethod: [String: Any] = [
+            "method": "item/updated",
+            "params": [
+                "item": [
+                    "type": "collabAgentToolCall",
+                    "tool": "spawnAgent",
+                    "receiverThreadId": "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                ],
+            ],
+        ]
+        let wrongType: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "type": "commandExecution",
+                    "tool": "spawnAgent",
+                    "receiverThreadId": "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                ],
+            ],
+        ]
+        let wrongTool: [String: Any] = [
+            "method": "item/completed",
+            "params": [
+                "item": [
+                    "type": "collabAgentToolCall",
+                    "tool": "sendMessage",
+                    "receiverThreadId": "019eb13e-74c0-72f3-a78b-0535f8eabac8",
+                ],
+            ],
+        ]
+
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: wrongMethod),
+            []
+        )
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: wrongType),
+            []
+        )
+        expectEqual(
+            CodexTeamsApprovalBridge.spawnReceiverThreadIds(fromAppServerMessage: wrongTool),
+            []
+        )
+    }
+
+    @Test
     func testCodexTurnCompletionNotificationMarksAssistantTurnComplete() {
         var completions = 0
         let session = CodexAppServerSession(


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5698

## Summary

This fixes `cmux codex-teams` missing spawned subagent panes when Codex reports the spawned receiver thread through `item/completed` `receiverThreadIds` before a normal `thread/*` notification is available.

The watcher now consumes `receiverThreadIds`, subscribes those receiver threads directly, retries metadata while new rollout files are still empty, and waits until a subagent thread exposes a replayable completed turn before opening the managed pane.

## Details

- Parse `receiverThreadIds` from `collabAgentToolCall` / `spawnAgent` completion events.
- Subscribe spawned receiver threads directly instead of waiting for thread notifications.
- Retry metadata fetches for just-created receiver threads whose rollout files are not ready yet.
- Delay opening subagent panes until `thread/resume` returns replayable turn history.
- Resume managed subagent panes with `--no-alt-screen` so replayed child output stays visible in the normal terminal buffer.
- Repaint previously opened subagent panes after split equalization to keep restored history visible.
- Add a regression test for `receiverThreadIds` extraction.

## Validation

- `swiftc -parse CLI/cmux.swift`
- `swiftc -parse CLI/CodexTeamsApprovalBridge.swift`
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag devloop-fanout-repaint --launch`
- Manual tagged `codex-teams` E2E with the dev-loop roster opened five subagent panes, and surfaces 3-7 rendered `worker-ready`, `tester-ready`, `planner-ready`, `checker-ready`, and `verifier-ready`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783756155&installation_id=133855650&pr_number=5874&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5874&signature=028151eeaaf851218817ae92d1d5841d373ceeae5b04763f957fe794b6d50d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing subagent panes in `cmux codex-teams` by subscribing to spawned receiver threads immediately and only opening panes once a replayable turn exists. Panes launch with `--no-alt-screen` and a post-layout refresh keeps final child output visible.

- **Bug Fixes**
  - Parse and de-dup `receiverThreadIds` from `item/completed` `spawnAgent` events (camelCase/snake_case; arrays or scalars) and subscribe those receivers and their parent threads immediately.
  - On empty or missing rollouts, run bounded metadata probes, then poll `thread/resume` with non-blocking retries until a replayable turn exists before opening.
  - Keep history visible: launch with `--no-alt-screen` and call `surface.refresh` after `workspace.equalize_splits`.
  - Add regression tests for `receiverThreadIds` parsing, including snake_case, scalar, duplicates, and non-spawn cases.

<sup>Written for commit 6b7e7ad5bdec1d8a0d1e1fbef34ea37055911817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extract receiver thread IDs from app-server completion messages for spawned agents
  * Metadata- and replay-based readiness probing with configurable retries
  * Improved multi-agent surface layout and recovery when restoring subagents

* **Bug Fixes**
  * Better classification of subscription failures with improved recovery and retry behavior
  * More reliable detection of attachable threads and safer subscription flow

* **Tests**
  * Added tests validating receiver thread ID extraction and message matching behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->