### PR TITLE
iOS: View as Text sheet for terminal copy-paste

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -179,7 +179,7 @@
 516	Sources/CmuxConfigExecutor.swift
 514	Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
-512	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+518	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 509	Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
 507	Sources/TerminalControllerTopSupport.swift
 506	Sources/App/MainWindowVisibilityController.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -29,7 +29,7 @@
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
-3694	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+3665	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift
@@ -168,10 +168,10 @@
 538	CLI/CMUXCLI+Themes.swift
 536	cmuxTests/CmuxConfigContextMenuTests.swift
 531	Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+530	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
 528	cmuxTests/CLINotifyProcessTestSupport.swift
 528	cmuxUITests/AutomationSocketUITests.swift
 527	CLI/CLISocketPathResolver.swift
-522	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
 520	CLI/CMUXCLI+AmpExtension.swift
 520	cmuxTests/MainWindowVisibilityControllerTests.swift
 519	Packages/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-two-column-cockpit-sidebar.swift
@@ -179,6 +179,7 @@
 516	Sources/CmuxConfigExecutor.swift
 514	Packages/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
+512	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 509	Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
 507	Sources/TerminalControllerTopSupport.swift
 506	Sources/App/MainWindowVisibilityController.swift

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalTextSnapshot.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalTextSnapshot.swift
@@ -1,0 +1,59 @@
+/// A plain-text capture of a terminal surface for the mobile "View as Text"
+/// sheet, capped to a line budget so a giant scrollback cannot bog down the
+/// sheet's text view.
+///
+/// The cap keeps the LAST `lineBudget` lines: the user opening the sheet is
+/// after the output that just happened, not the oldest history. `isTruncated`
+/// drives the sheet's "showing the last N lines" banner.
+public struct TerminalTextSnapshot: Equatable, Sendable {
+    /// The text the sheet shows, already capped to `lineBudget` lines.
+    public let text: String
+
+    /// Whether older lines were dropped to fit `lineBudget`.
+    public let isTruncated: Bool
+
+    /// The line budget `text` was capped to.
+    public let lineBudget: Int
+
+    /// Default budget: generous enough to carry the recent scrollback the user
+    /// wants to copy from, small enough that the sheet's `UITextView` lays out
+    /// without jank.
+    public static let defaultLineBudget = 5000
+
+    public init(text: String, isTruncated: Bool, lineBudget: Int) {
+        self.text = text
+        self.isTruncated = isTruncated
+        self.lineBudget = lineBudget
+    }
+
+    /// Cap `fullText` to the last `lineBudget` lines.
+    ///
+    /// Trailing whitespace-only lines are trimmed first: the libghostty
+    /// "screen" read includes written-but-blank rows below the last real
+    /// output, which would otherwise pad the sheet (and eat budget) with empty
+    /// tail lines.
+    ///
+    /// - Parameters:
+    ///   - fullText: The terminal's text, newline-separated.
+    ///   - lineBudget: Maximum number of lines to keep. Must be positive.
+    /// - Returns: The capped snapshot.
+    public static func capped(
+        fullText: String,
+        lineBudget: Int = defaultLineBudget
+    ) -> TerminalTextSnapshot {
+        precondition(lineBudget > 0, "lineBudget must be positive")
+        var lines = fullText.split(separator: "\n", omittingEmptySubsequences: false)[...]
+        while let last = lines.last, last.allSatisfy(\.isWhitespace) {
+            lines = lines.dropLast()
+        }
+        let isTruncated = lines.count > lineBudget
+        if isTruncated {
+            lines = lines.suffix(lineBudget)
+        }
+        return TerminalTextSnapshot(
+            text: lines.joined(separator: "\n"),
+            isTruncated: isTruncated,
+            lineBudget: lineBudget
+        )
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalTextSnapshot.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalTextSnapshot.swift
@@ -20,6 +20,16 @@ public struct TerminalTextSnapshot: Equatable, Sendable {
     /// without jank.
     public static let defaultLineBudget = 5000
 
+    /// Creates a snapshot from already-capped text.
+    ///
+    /// Prefer ``capped(fullText:lineBudget:)``, which derives all three fields
+    /// from raw terminal text; this memberwise initializer exists for tests
+    /// and callers that have applied their own bound.
+    ///
+    /// - Parameters:
+    ///   - text: The capped text the sheet shows.
+    ///   - isTruncated: Whether older lines were dropped to fit `lineBudget`.
+    ///   - lineBudget: The line budget `text` was capped to.
     public init(text: String, isTruncated: Bool, lineBudget: Int) {
         self.text = text
         self.isTruncated = isTruncated

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalTextSnapshotTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalTextSnapshotTests.swift
@@ -1,0 +1,56 @@
+import Testing
+
+@testable import CmuxMobileShell
+
+/// Verifies the line-budget capping the "View as Text" sheet applies to the
+/// terminal's screen text: under-budget passthrough, last-N-lines truncation
+/// (most recent output wins), and trailing-blank-row trimming (the libghostty
+/// "screen" read includes written-but-blank rows below the last real output).
+struct TerminalTextSnapshotTests {
+    @Test func underBudgetPassesThrough() {
+        let snapshot = TerminalTextSnapshot.capped(fullText: "a\nb\nc", lineBudget: 10)
+        #expect(snapshot.text == "a\nb\nc")
+        #expect(!snapshot.isTruncated)
+        #expect(snapshot.lineBudget == 10)
+    }
+
+    @Test func overBudgetKeepsMostRecentLines() {
+        let full = (1...10).map(String.init).joined(separator: "\n")
+        let snapshot = TerminalTextSnapshot.capped(fullText: full, lineBudget: 3)
+        #expect(snapshot.text == "8\n9\n10")
+        #expect(snapshot.isTruncated)
+        #expect(snapshot.lineBudget == 3)
+    }
+
+    @Test func exactBudgetIsNotTruncated() {
+        let snapshot = TerminalTextSnapshot.capped(fullText: "a\nb\nc", lineBudget: 3)
+        #expect(snapshot.text == "a\nb\nc")
+        #expect(!snapshot.isTruncated)
+    }
+
+    @Test func trailingBlankRowsAreTrimmedBeforeBudgeting() {
+        // Without the trim, the three blank tail rows would consume the budget
+        // and push real output lines out of the capture.
+        let snapshot = TerminalTextSnapshot.capped(fullText: "a\nb\n\n   \n\n", lineBudget: 2)
+        #expect(snapshot.text == "a\nb")
+        #expect(!snapshot.isTruncated)
+    }
+
+    @Test func interiorBlankLinesArePreserved() {
+        let snapshot = TerminalTextSnapshot.capped(fullText: "a\n\nb", lineBudget: 10)
+        #expect(snapshot.text == "a\n\nb")
+        #expect(!snapshot.isTruncated)
+    }
+
+    @Test func whitespaceOnlyTextYieldsEmptySnapshot() {
+        let snapshot = TerminalTextSnapshot.capped(fullText: "\n  \n\n", lineBudget: 5)
+        #expect(snapshot.text.isEmpty)
+        #expect(!snapshot.isTruncated)
+    }
+
+    @Test func emptyTextYieldsEmptySnapshot() {
+        let snapshot = TerminalTextSnapshot.capped(fullText: "", lineBudget: 5)
+        #expect(snapshot.text.isEmpty)
+        #expect(!snapshot.isTruncated)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -65,6 +65,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         // `nil` when no log is wired; every probe is then a no-op.
         view.diagnosticLog = store.diagnosticLog
         #endif
+        // Stamp the shell-level id so id-scoped registry lookups (the
+        // "View as Text" capture) resolve this exact terminal.
+        view.hostSurfaceID = surfaceID
         context.coordinator.attach(surfaceView: view)
         // Mount the composer band immediately if the composer was already open when
         // this surface was (re)built (e.g. a terminal switch while composing), and

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SelectableTextView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SelectableTextView.swift
@@ -1,0 +1,36 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// A read-only `UITextView` wrapper: the native iOS text view is what gives
+/// the "View as Text" sheet real long-press selection, drag handles, Select
+/// All, and Copy. SwiftUI's `Text` + `.textSelection(.enabled)` only offers
+/// whole-blob copy, not range selection, which defeats the point of the sheet.
+struct SelectableTextView: UIViewRepresentable {
+    /// The plain text to display.
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.alwaysBounceVertical = true
+        view.font = UIFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        view.textColor = .label
+        view.backgroundColor = .systemBackground
+        view.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
+        // Terminal output is data, not prose: keep iOS from restyling it.
+        view.dataDetectorTypes = []
+        view.text = text
+        view.accessibilityIdentifier = "MobileTerminalTextSheetTextView"
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        // Guarded so SwiftUI re-renders don't clobber an active selection.
+        if uiView.text != text {
+            uiView.text = text
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -103,7 +103,14 @@ struct TerminalTextSheetView: View {
 
     private func loadSnapshot() async {
         let fullText = await GhosttySurfaceView.copyableTerminalText()
-        snapshot = fullText.map { TerminalTextSnapshot.capped(fullText: $0) }
+        // Cap off the main actor: the capture is bounded by the iOS surface's
+        // scrollback-limit (~2MB, see applyiOSDefaults), but splitting and
+        // rejoining even that much text is O(content) string work that would
+        // jank the UI if run on main.
+        let capped: TerminalTextSnapshot? = await Task.detached(priority: .userInitiated) {
+            fullText.map { TerminalTextSnapshot.capped(fullText: $0) }
+        }.value
+        snapshot = capped
         isLoading = false
     }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -16,6 +16,11 @@ import UIKit
 /// capped to `TerminalTextSnapshot.defaultLineBudget` lines, with a banner
 /// when older lines were dropped.
 struct TerminalTextSheetView: View {
+    /// The shell-level surface/terminal id whose text the sheet shows — the
+    /// terminal selected in the workspace that opened it. Nil when the
+    /// workspace has no terminal; the sheet then shows its empty state.
+    let surfaceID: String?
+
     @Environment(\.dismiss) private var dismiss
 
     /// Loaded once per presentation in `.task`; nil while the off-main surface
@@ -102,7 +107,11 @@ struct TerminalTextSheetView: View {
     }
 
     private func loadSnapshot() async {
-        let fullText = await GhosttySurfaceView.copyableTerminalText()
+        guard let surfaceID else {
+            isLoading = false
+            return
+        }
+        let fullText = await GhosttySurfaceView.copyableTerminalText(surfaceID: surfaceID)
         // Cap off the main actor: the capture is bounded by the iOS surface's
         // scrollback-limit (~2MB, see applyiOSDefaults), but splitting and
         // rejoining even that much text is O(content) string work that would

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -130,35 +130,4 @@ struct TerminalTextSheetView: View {
         didCopy = true
     }
 }
-
-/// A read-only `UITextView` wrapper: the native iOS text view is what gives
-/// the sheet real long-press selection, drag handles, Select All, and Copy.
-/// SwiftUI's `Text` + `.textSelection(.enabled)` only offers whole-blob copy,
-/// not range selection, which defeats the point of the sheet.
-private struct SelectableTextView: UIViewRepresentable {
-    let text: String
-
-    func makeUIView(context: Context) -> UITextView {
-        let view = UITextView()
-        view.isEditable = false
-        view.isSelectable = true
-        view.alwaysBounceVertical = true
-        view.font = UIFont.monospacedSystemFont(ofSize: 12, weight: .regular)
-        view.textColor = .label
-        view.backgroundColor = .systemBackground
-        view.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
-        // Terminal output is data, not prose: keep iOS from restyling it.
-        view.dataDetectorTypes = []
-        view.text = text
-        view.accessibilityIdentifier = "MobileTerminalTextSheetTextView"
-        return view
-    }
-
-    func updateUIView(_ uiView: UITextView, context: Context) {
-        // Guarded so SwiftUI re-renders don't clobber an active selection.
-        if uiView.text != text {
-            uiView.text = text
-        }
-    }
-}
 #endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalTextSheetView.swift
@@ -1,0 +1,148 @@
+#if os(iOS)
+import CmuxMobileShell
+import CmuxMobileSupport
+import CmuxMobileTerminal
+import SwiftUI
+import UIKit
+
+/// "View as Text": presents the visible terminal's content (recent scrollback
+/// plus the visible screen) as plain, natively selectable text so long-press
+/// selection, Select All, and Copy just work. The Ghostty render surface has
+/// no iOS text-selection affordance, which made copy-paste from the mobile
+/// terminal effectively impossible; this sheet is the copy path.
+///
+/// Content is read locally from the phone's own libghostty surface (no Mac
+/// RPC, works offline) via `GhosttySurfaceView.copyableTerminalText()` and
+/// capped to `TerminalTextSnapshot.defaultLineBudget` lines, with a banner
+/// when older lines were dropped.
+struct TerminalTextSheetView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Loaded once per presentation in `.task`; nil while the off-main surface
+    /// read is in flight.
+    @State private var snapshot: TerminalTextSnapshot?
+    @State private var isLoading = true
+    /// Flips the Copy All label to a checkmark after a copy. Reset is the next
+    /// presentation (fresh `@State`), so no timer is needed.
+    @State private var didCopy = false
+
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle(L10n.string("mobile.textSheet.title", defaultValue: "Terminal Text"))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(L10n.string("mobile.textSheet.done", defaultValue: "Done")) {
+                            dismiss()
+                        }
+                        .accessibilityIdentifier("MobileTerminalTextSheetDone")
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        copyAllButton
+                    }
+                }
+        }
+        .task { await loadSnapshot() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let snapshot, !snapshot.text.isEmpty {
+            VStack(spacing: 0) {
+                if snapshot.isTruncated {
+                    truncationBanner(lineBudget: snapshot.lineBudget)
+                }
+                SelectableTextView(text: snapshot.text)
+            }
+        } else if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            Text(L10n.string(
+                "mobile.textSheet.empty",
+                defaultValue: "No terminal text available"
+            ))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("MobileTerminalTextSheetEmpty")
+        }
+    }
+
+    private var copyAllButton: some View {
+        Button(action: copyAll) {
+            if didCopy {
+                Label(
+                    L10n.string("mobile.textSheet.copied", defaultValue: "Copied"),
+                    systemImage: "checkmark"
+                )
+            } else {
+                Text(L10n.string("mobile.textSheet.copyAll", defaultValue: "Copy All"))
+            }
+        }
+        .disabled(snapshot?.text.isEmpty ?? true)
+        .accessibilityIdentifier("MobileTerminalTextCopyAllButton")
+    }
+
+    private func truncationBanner(lineBudget: Int) -> some View {
+        Text(String(
+            format: L10n.string(
+                "mobile.textSheet.truncated",
+                defaultValue: "Showing the last %d lines."
+            ),
+            lineBudget
+        ))
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(.bar)
+        .accessibilityIdentifier("MobileTerminalTextSheetTruncationBanner")
+    }
+
+    private func loadSnapshot() async {
+        let fullText = await GhosttySurfaceView.copyableTerminalText()
+        snapshot = fullText.map { TerminalTextSnapshot.capped(fullText: $0) }
+        isLoading = false
+    }
+
+    private func copyAll() {
+        guard let text = snapshot?.text, !text.isEmpty else { return }
+        UIPasteboard.general.string = text
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        didCopy = true
+    }
+}
+
+/// A read-only `UITextView` wrapper: the native iOS text view is what gives
+/// the sheet real long-press selection, drag handles, Select All, and Copy.
+/// SwiftUI's `Text` + `.textSelection(.enabled)` only offers whole-blob copy,
+/// not range selection, which defeats the point of the sheet.
+private struct SelectableTextView: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.alwaysBounceVertical = true
+        view.font = UIFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        view.textColor = .label
+        view.backgroundColor = .systemBackground
+        view.textContainerInset = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
+        // Terminal output is data, not prose: keep iOS from restyling it.
+        view.dataDetectorTypes = []
+        view.text = text
+        view.accessibilityIdentifier = "MobileTerminalTextSheetTextView"
+        return view
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        // Guarded so SwiftUI re-renders don't clobber an active selection.
+        if uiView.text != text {
+            uiView.text = text
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -191,7 +191,7 @@ struct WorkspaceDetailView: View {
             feedbackComposer
         }
         .sheet(isPresented: $isTextSheetPresented) {
-            TerminalTextSheetView()
+            TerminalTextSheetView(surfaceID: selectedTerminal?.id.rawValue)
         }
         #endif
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -33,6 +33,11 @@ struct WorkspaceDetailView: View {
     @State private var isSubmittingFeedback = false
     @State private var feedbackErrorMessage: String?
     @State private var isTextSheetPresented = false
+    /// Captured at the moment the "View as Text" action is tapped so the
+    /// sheet keeps showing the terminal the user asked about even if the
+    /// workspace selection changes underneath it (e.g. Mac-side sync) while
+    /// the sheet is open; the sheet loads its snapshot once per presentation.
+    @State private var textSheetSurfaceID: String?
     #endif
 
     private var selectedTerminal: MobileTerminalPreview? {
@@ -191,7 +196,7 @@ struct WorkspaceDetailView: View {
             feedbackComposer
         }
         .sheet(isPresented: $isTextSheetPresented) {
-            TerminalTextSheetView(surfaceID: selectedTerminal?.id.rawValue)
+            TerminalTextSheetView(surfaceID: textSheetSurfaceID)
         }
         #endif
     }
@@ -326,6 +331,7 @@ struct WorkspaceDetailView: View {
     /// Opens the "View as Text" sheet: the terminal's content as selectable
     /// plain text, because the render surface itself has no copy affordance.
     private func openTextSheetFromMenu() {
+        textSheetSurfaceID = selectedTerminal?.id.rawValue
         isTextSheetPresented = true
     }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -276,13 +276,19 @@ struct WorkspaceDetailView: View {
 
         #if canImport(UIKit)
         Section {
-            Button(action: openTextSheetFromMenu) {
-                Label(
-                    L10n.string("mobile.terminal.viewAsText", defaultValue: "View as Text"),
-                    systemImage: "doc.plaintext"
-                )
+            // Only while the terminal pane is showing: in browser mode the
+            // terminal surface is dismantled (nothing to capture) and the
+            // sheet modifier lives on `detailContent`, so the armed flag
+            // would pop the sheet later when the browser closes.
+            if activeBrowser == nil {
+                Button(action: openTextSheetFromMenu) {
+                    Label(
+                        L10n.string("mobile.terminal.viewAsText", defaultValue: "View as Text"),
+                        systemImage: "doc.plaintext"
+                    )
+                }
+                .accessibilityIdentifier("MobileViewAsTextMenuItem")
             }
-            .accessibilityIdentifier("MobileViewAsTextMenuItem")
 
             #if DEBUG
             Button(action: copyDebugLogsFromMenu) {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -32,6 +32,7 @@ struct WorkspaceDetailView: View {
     @State private var feedbackEmail = ""
     @State private var isSubmittingFeedback = false
     @State private var feedbackErrorMessage: String?
+    @State private var isTextSheetPresented = false
     #endif
 
     private var selectedTerminal: MobileTerminalPreview? {
@@ -189,6 +190,9 @@ struct WorkspaceDetailView: View {
         .sheet(isPresented: $isFeedbackComposerPresented) {
             feedbackComposer
         }
+        .sheet(isPresented: $isTextSheetPresented) {
+            TerminalTextSheetView()
+        }
         #endif
     }
 
@@ -272,6 +276,14 @@ struct WorkspaceDetailView: View {
 
         #if canImport(UIKit)
         Section {
+            Button(action: openTextSheetFromMenu) {
+                Label(
+                    L10n.string("mobile.terminal.viewAsText", defaultValue: "View as Text"),
+                    systemImage: "doc.plaintext"
+                )
+            }
+            .accessibilityIdentifier("MobileViewAsTextMenuItem")
+
             #if DEBUG
             Button(action: copyDebugLogsFromMenu) {
                 // DEV-only debug tooling; not shipped, so not localized.
@@ -304,6 +316,12 @@ struct WorkspaceDetailView: View {
         }
     }
     #endif
+
+    /// Opens the "View as Text" sheet: the terminal's content as selectable
+    /// plain text, because the render surface itself has no copy affordance.
+    private func openTextSheetFromMenu() {
+        isTextSheetPresented = true
+    }
 
     private func openFeedbackComposerFromMenu() {
         feedbackText = ""

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -182,7 +182,15 @@ public final class GhosttyRuntime {
     }
 
     private static func applyiOSDefaults(_ config: ghostty_config_t) {
+        // scrollback-limit: bound the mirror surface's local scrollback page
+        // memory (ghostty defaults to 10MB per surface). On iOS the user-facing
+        // scroll path forwards to the Mac's real surface, so local scrollback
+        // exists only to feed local reads (the "View as Text" copy sheet's
+        // GHOSTTY_POINT_SCREEN read). 2MB comfortably covers that sheet's
+        // 5000-line budget while keeping the worst-case read (which runs on
+        // the serial output queue) and per-surface memory phone-sized.
         let monokai = """
+        scrollback-limit = 2000000
         font-family = Menlo
         font-size = 10
         window-padding-balance = false

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceRegistry.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceRegistry.swift
@@ -1,0 +1,122 @@
+import GhosttyKit
+import UIKit
+
+/// The surface-pointer → view registry and its registry-scoped reads, split
+/// out of `GhosttySurfaceView.swift` so the lookup machinery and the "View as
+/// Text" capture live in one cohesive file. Everything here is `internal`
+/// (not `private`) only so the main class file's lifecycle/snapshot paths can
+/// keep using the registry across the file boundary; nothing is exported
+/// beyond the module except `copyableTerminalText(surfaceID:)`.
+final class WeakGhosttySurfaceViewBox {
+    weak var value: GhosttySurfaceView?
+
+    init(_ value: GhosttySurfaceView) {
+        self.value = value
+    }
+}
+
+extension GhosttySurfaceView {
+    @MainActor
+    static var registeredSurfaceViews: [UInt: WeakGhosttySurfaceViewBox] = [:]
+
+    @MainActor
+    static func register(surface: ghostty_surface_t, for view: GhosttySurfaceView) {
+        registeredSurfaceViews[surfaceIdentifier(for: surface)] = WeakGhosttySurfaceViewBox(view)
+        registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
+    }
+
+    @MainActor
+    static func unregister(surface: ghostty_surface_t) {
+        registeredSurfaceViews.removeValue(forKey: surfaceIdentifier(for: surface))
+    }
+
+    @MainActor
+    static func view(for surface: ghostty_surface_t) -> GhosttySurfaceView? {
+        let identifier = surfaceIdentifier(for: surface)
+        guard let view = registeredSurfaceViews[identifier]?.value else {
+            registeredSurfaceViews.removeValue(forKey: identifier)
+            return nil
+        }
+        return view
+    }
+
+    static func surfaceIdentifier(for surface: ghostty_surface_t) -> UInt {
+        UInt(bitPattern: UnsafeRawPointer(surface))
+    }
+
+    /// Full-content capture for the "View as Text" copy sheet: the SCREEN
+    /// range (scrollback history plus every written row) of the on-screen
+    /// terminal surface, read entirely on the phone's own libghostty surface —
+    /// no Mac round-trip, works offline.
+    ///
+    /// Same threading contract as ``visibleTerminalSnapshot()``: the read runs
+    /// on the serial `outputQueue` because `ghostty_surface_read_text` takes
+    /// the surface lock that `process_output` holds during a render storm, so
+    /// a main-thread read would stall the present and blank the terminal.
+    /// Unlike that synchronous DEV path there is no bounded semaphore wait
+    /// here — the caller awaits, so a busy queue just resumes the continuation
+    /// late while the sheet shows its loading state.
+    ///
+    /// The continuation body enqueues on `outputQueue` synchronously while
+    /// still on the main actor, so the read is FIFO-ordered before any
+    /// later-enqueued `disposeSurface` free of the same pointer — the same
+    /// lifetime argument `visibleTerminalSnapshot()` relies on.
+    ///
+    /// The read is bounded at the source: iOS surfaces are created with
+    /// `scrollback-limit = 2000000` (see `GhosttyRuntime.applyiOSDefaults`),
+    /// so the SCREEN range can never materialize more than ~2MB of text no
+    /// matter how long the session ran. The sheet's 5000-line budget is then
+    /// applied off-main on top of that hard cap.
+    ///
+    /// - Parameter surfaceID: The shell-level surface/terminal id the caller
+    ///   wants text for (the same id the mounting representable stamped on the
+    ///   view as ``hostSurfaceID``). The lookup is scoped to that id so a
+    ///   second visible surface — another iPad scene, an in-flight transition —
+    ///   can never leak a different workspace's terminal into the capture.
+    /// - Returns: The surface's screen text, or nil when that terminal has no
+    ///   mounted surface or the read fails.
+    public static func copyableTerminalText(surfaceID: String) async -> String? {
+        registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
+        // Scoped pick: only views stamped with the requested id qualify, and
+        // only while actually on screen (same visibility filter as
+        // `visibleTerminalSnapshot()`). A dismantling view can linger in the
+        // registry with a non-nil surface until its queued dispose runs, and
+        // its content stops at whenever its byte stream detached — prefer the
+        // sheet's honest empty state over silently copying that stale text.
+        // If the same terminal is mounted in several scenes the contents are
+        // identical, so the lowest-keyed visible match keeps the pick
+        // deterministic.
+        let matchingView = registeredSurfaceViews
+            .sorted { $0.key < $1.key }
+            .compactMap(\.value.value)
+            .first { candidate in
+                candidate.hostSurfaceID == surfaceID && candidate.surface != nil
+                    && candidate.window != nil && !candidate.isHidden
+                    && candidate.alpha > 0.01
+            }
+        guard let surface = matchingView?.surface else { return nil }
+        let handle = CopyableTextSurfaceHandle(surface: surface)
+        return await withCheckedContinuation { continuation in
+            outputQueue.async {
+                // SCREEN = scrollback + all written rows. Fall back to the
+                // viewport-only read if the screen read fails outright.
+                let text = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_SCREEN)
+                    ?? surfaceText(handle.surface, pointTag: GHOSTTY_POINT_VIEWPORT)
+                continuation.resume(returning: text)
+            }
+        }
+    }
+}
+
+/// Carrier for the "View as Text" sheet's surface pointer across the hop to
+/// `GhosttySurfaceView.outputQueue`. Same safety argument as
+/// `VisibleSnapshotRequest` in `GhosttySurfaceView.swift`: the pointer is only
+/// dereferenced on the queue that owns `process_output` and is FIFO-ordered
+/// before any queued free — hence `@unchecked Sendable`.
+///
+/// Deliberately `private` to this file: it holds the class's raw
+/// `ghostty_surface_t`, which must not escape `GhosttySurfaceView`'s
+/// queue/lifetime discipline into the wider module.
+private struct CopyableTextSurfaceHandle: @unchecked Sendable {
+    let surface: ghostty_surface_t
+}

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -706,7 +706,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Serial background queue for `ghostty_surface_process_output`, which
     /// blocks on libghostty's internal renderer/IO futex. Running it on the
     /// main thread hangs the app until the scene-update watchdog kills it.
-    private static let outputQueue = DispatchQueue(
+    /// Internal (not private) so the copyable-text extension in
+    /// `GhosttySurfaceCopyableText.swift` can enqueue its surface read with
+    /// the same FIFO-before-dispose ordering discipline.
+    static let outputQueue = DispatchQueue(
         label: "dev.cmux.GhosttySurfaceView.output",
         qos: .userInitiated
     )
@@ -3459,68 +3462,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return holder.sections.joined(separator: "\n\n")
     }
 
-    /// Full-content capture for the "View as Text" copy sheet: the SCREEN
-    /// range (scrollback history plus every written row) of the on-screen
-    /// terminal surface, read entirely on the phone's own libghostty surface —
-    /// no Mac round-trip, works offline.
-    ///
-    /// Same threading contract as ``visibleTerminalSnapshot()``: the read runs
-    /// on the serial `outputQueue` because `ghostty_surface_read_text` takes
-    /// the surface lock that `process_output` holds during a render storm, so
-    /// a main-thread read would stall the present and blank the terminal.
-    /// Unlike that synchronous DEV path there is no bounded semaphore wait
-    /// here — the caller awaits, so a busy queue just resumes the continuation
-    /// late while the sheet shows its loading state.
-    ///
-    /// The continuation body enqueues on `outputQueue` synchronously while
-    /// still on the main actor, so the read is FIFO-ordered before any
-    /// later-enqueued `disposeSurface` free of the same pointer — the same
-    /// lifetime argument `visibleTerminalSnapshot()` relies on.
-    ///
-    /// The read is bounded at the source: iOS surfaces are created with
-    /// `scrollback-limit = 2000000` (see `GhosttyRuntime.applyiOSDefaults`),
-    /// so the SCREEN range can never materialize more than ~2MB of text no
-    /// matter how long the session ran. The sheet's 5000-line budget is then
-    /// applied off-main on top of that hard cap.
-    ///
-    /// - Parameter surfaceID: The shell-level surface/terminal id the caller
-    ///   wants text for (the same id the mounting representable stamped on the
-    ///   view as ``hostSurfaceID``). The lookup is scoped to that id so a
-    ///   second visible surface — another iPad scene, an in-flight transition —
-    ///   can never leak a different workspace's terminal into the capture.
-    /// - Returns: The surface's screen text, or nil when that terminal has no
-    ///   mounted surface or the read fails.
-    public static func copyableTerminalText(surfaceID: String) async -> String? {
-        registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
-        // Scoped pick: only views stamped with the requested id qualify, and
-        // only while actually on screen (same visibility filter as
-        // `visibleTerminalSnapshot()`). A dismantling view can linger in the
-        // registry with a non-nil surface until its queued dispose runs, and
-        // its content stops at whenever its byte stream detached — prefer the
-        // sheet's honest empty state over silently copying that stale text.
-        // If the same terminal is mounted in several scenes the contents are
-        // identical, so the lowest-keyed visible match keeps the pick
-        // deterministic.
-        let matchingView = registeredSurfaceViews
-            .sorted { $0.key < $1.key }
-            .compactMap(\.value.value)
-            .first {
-                $0.hostSurfaceID == surfaceID && $0.surface != nil
-                    && $0.window != nil && !$0.isHidden && $0.alpha > 0.01
-            }
-        guard let surface = matchingView?.surface else { return nil }
-        let handle = CopyableTextSurfaceHandle(surface: surface)
-        return await withCheckedContinuation { continuation in
-            outputQueue.async {
-                // SCREEN = scrollback + all written rows. Fall back to the
-                // viewport-only read if the screen read fails outright.
-                let text = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_SCREEN)
-                    ?? surfaceText(handle.surface, pointTag: GHOSTTY_POINT_VIEWPORT)
-                continuation.resume(returning: text)
-            }
-        }
-    }
-
     private func handleBell() {
         UINotificationFeedbackGenerator().notificationOccurred(.warning)
         NotificationCenter.default.post(
@@ -3554,19 +3495,6 @@ extension GhosttySurfaceView: UIGestureRecognizerDelegate {
     }
 }
 
-/// Carrier for the "View as Text" sheet's surface pointer across the hop to
-/// `GhosttySurfaceView.outputQueue`. Same safety argument as
-/// ``VisibleSnapshotRequest``: the pointer is only dereferenced on the queue
-/// that owns `process_output` and is FIFO-ordered before any queued free —
-/// hence `@unchecked Sendable`.
-///
-/// Deliberately `private` to this file alongside the other snapshot carriers:
-/// it holds the class's raw `ghostty_surface_t`, which must not escape
-/// `GhosttySurfaceView`'s queue/lifetime discipline into the wider module.
-private struct CopyableTextSurfaceHandle: @unchecked Sendable {
-    let surface: ghostty_surface_t
-}
-
 /// One surface's request for the bounded visible-terminal snapshot.
 ///
 /// The `ghostty_surface_t` is a C pointer that the snapshot only dereferences on
@@ -3587,44 +3515,6 @@ private struct VisibleSnapshotRequest: @unchecked Sendable {
 /// caller never reads it, leaving the queue task the sole accessor.
 private final class VisibleSnapshotHolder: @unchecked Sendable {
     var sections: [String] = []
-}
-
-private final class WeakGhosttySurfaceViewBox {
-    weak var value: GhosttySurfaceView?
-
-    init(_ value: GhosttySurfaceView) {
-        self.value = value
-    }
-}
-
-private extension GhosttySurfaceView {
-    @MainActor
-    static var registeredSurfaceViews: [UInt: WeakGhosttySurfaceViewBox] = [:]
-
-    @MainActor
-    static func register(surface: ghostty_surface_t, for view: GhosttySurfaceView) {
-        registeredSurfaceViews[surfaceIdentifier(for: surface)] = WeakGhosttySurfaceViewBox(view)
-        registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
-    }
-
-    @MainActor
-    static func unregister(surface: ghostty_surface_t) {
-        registeredSurfaceViews.removeValue(forKey: surfaceIdentifier(for: surface))
-    }
-
-    @MainActor
-    static func view(for surface: ghostty_surface_t) -> GhosttySurfaceView? {
-        let identifier = surfaceIdentifier(for: surface)
-        guard let view = registeredSurfaceViews[identifier]?.value else {
-            registeredSurfaceViews.removeValue(forKey: identifier)
-            return nil
-        }
-        return view
-    }
-
-    static func surfaceIdentifier(for surface: ghostty_surface_t) -> UInt {
-        UInt(bitPattern: UnsafeRawPointer(surface))
-    }
 }
 
 private class DisplayLinkProxy {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3471,6 +3471,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// later-enqueued `disposeSurface` free of the same pointer — the same
     /// lifetime argument `visibleTerminalSnapshot()` relies on.
     ///
+    /// The read is bounded at the source: iOS surfaces are created with
+    /// `scrollback-limit = 2000000` (see `GhosttyRuntime.applyiOSDefaults`),
+    /// so the SCREEN range can never materialize more than ~2MB of text no
+    /// matter how long the session ran. The sheet's 5000-line budget is then
+    /// applied off-main on top of that hard cap.
+    ///
     /// - Returns: The surface's screen text, or nil when no terminal surface
     ///   is on screen or the read fails.
     public static func copyableTerminalText() async -> String? {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3492,13 +3492,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     ///   mounted surface or the read fails.
     public static func copyableTerminalText(surfaceID: String) async -> String? {
         registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
-        // Scoped pick: only views stamped with the requested id qualify. If
-        // the same terminal is mounted in several scenes the contents are
-        // identical, so the lowest-keyed match keeps the pick deterministic.
+        // Scoped pick: only views stamped with the requested id qualify, and
+        // only while actually on screen (same visibility filter as
+        // `visibleTerminalSnapshot()`). A dismantling view can linger in the
+        // registry with a non-nil surface until its queued dispose runs, and
+        // its content stops at whenever its byte stream detached — prefer the
+        // sheet's honest empty state over silently copying that stale text.
+        // If the same terminal is mounted in several scenes the contents are
+        // identical, so the lowest-keyed visible match keeps the pick
+        // deterministic.
         let matchingView = registeredSurfaceViews
             .sorted { $0.key < $1.key }
             .compactMap(\.value.value)
-            .first { $0.hostSurfaceID == surfaceID && $0.surface != nil }
+            .first {
+                $0.hostSurfaceID == surfaceID && $0.surface != nil
+                    && $0.window != nil && !$0.isHidden && $0.alpha > 0.01
+            }
         guard let surface = matchingView?.surface else { return nil }
         let handle = CopyableTextSurfaceHandle(surface: surface)
         return await withCheckedContinuation { continuation in

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1213,6 +1213,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// chrome actions (create workspace/terminal, switch terminal) so the
     /// software keyboard does not pop up unprompted.
     public var autoFocusOnWindowAttach = true
+    /// The shell-level surface/terminal id this view renders (the id the
+    /// workspace store streams bytes for), stamped by the mounting
+    /// representable. Scopes registry lookups — e.g. the "View as Text"
+    /// capture — to the terminal the caller actually asked about, instead of
+    /// whichever registered surface happens to sort first.
+    public var hostSurfaceID: String?
 
     @objc private func handleKeyboardWillShow(_ notification: Notification) {
         guard let frameEnd = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
@@ -3477,18 +3483,23 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// matter how long the session ran. The sheet's 5000-line budget is then
     /// applied off-main on top of that hard cap.
     ///
-    /// - Returns: The surface's screen text, or nil when no terminal surface
-    ///   is on screen or the read fails.
-    public static func copyableTerminalText() async -> String? {
+    /// - Parameter surfaceID: The shell-level surface/terminal id the caller
+    ///   wants text for (the same id the mounting representable stamped on the
+    ///   view as ``hostSurfaceID``). The lookup is scoped to that id so a
+    ///   second visible surface — another iPad scene, an in-flight transition —
+    ///   can never leak a different workspace's terminal into the capture.
+    /// - Returns: The surface's screen text, or nil when that terminal has no
+    ///   mounted surface or the read fails.
+    public static func copyableTerminalText(surfaceID: String) async -> String? {
         registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
-        // Deterministic pick: the lowest-keyed on-screen surface. The iOS
-        // detail layout shows one terminal at a time, so this is "the visible
-        // terminal" in practice.
-        let visibleView = registeredSurfaceViews
+        // Scoped pick: only views stamped with the requested id qualify. If
+        // the same terminal is mounted in several scenes the contents are
+        // identical, so the lowest-keyed match keeps the pick deterministic.
+        let matchingView = registeredSurfaceViews
             .sorted { $0.key < $1.key }
             .compactMap(\.value.value)
-            .first { $0.window != nil && !$0.isHidden && $0.alpha > 0.01 && $0.surface != nil }
-        guard let surface = visibleView?.surface else { return nil }
+            .first { $0.hostSurfaceID == surfaceID && $0.surface != nil }
+        guard let surface = matchingView?.surface else { return nil }
         let handle = CopyableTextSurfaceHandle(surface: surface)
         return await withCheckedContinuation { continuation in
             outputQueue.async {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3453,6 +3453,48 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return holder.sections.joined(separator: "\n\n")
     }
 
+    /// Full-content capture for the "View as Text" copy sheet: the SCREEN
+    /// range (scrollback history plus every written row) of the on-screen
+    /// terminal surface, read entirely on the phone's own libghostty surface —
+    /// no Mac round-trip, works offline.
+    ///
+    /// Same threading contract as ``visibleTerminalSnapshot()``: the read runs
+    /// on the serial `outputQueue` because `ghostty_surface_read_text` takes
+    /// the surface lock that `process_output` holds during a render storm, so
+    /// a main-thread read would stall the present and blank the terminal.
+    /// Unlike that synchronous DEV path there is no bounded semaphore wait
+    /// here — the caller awaits, so a busy queue just resumes the continuation
+    /// late while the sheet shows its loading state.
+    ///
+    /// The continuation body enqueues on `outputQueue` synchronously while
+    /// still on the main actor, so the read is FIFO-ordered before any
+    /// later-enqueued `disposeSurface` free of the same pointer — the same
+    /// lifetime argument `visibleTerminalSnapshot()` relies on.
+    ///
+    /// - Returns: The surface's screen text, or nil when no terminal surface
+    ///   is on screen or the read fails.
+    public static func copyableTerminalText() async -> String? {
+        registeredSurfaceViews = registeredSurfaceViews.filter { $0.value.value != nil }
+        // Deterministic pick: the lowest-keyed on-screen surface. The iOS
+        // detail layout shows one terminal at a time, so this is "the visible
+        // terminal" in practice.
+        let visibleView = registeredSurfaceViews
+            .sorted { $0.key < $1.key }
+            .compactMap(\.value.value)
+            .first { $0.window != nil && !$0.isHidden && $0.alpha > 0.01 && $0.surface != nil }
+        guard let surface = visibleView?.surface else { return nil }
+        let handle = CopyableTextSurfaceHandle(surface: surface)
+        return await withCheckedContinuation { continuation in
+            outputQueue.async {
+                // SCREEN = scrollback + all written rows. Fall back to the
+                // viewport-only read if the screen read fails outright.
+                let text = surfaceText(handle.surface, pointTag: GHOSTTY_POINT_SCREEN)
+                    ?? surfaceText(handle.surface, pointTag: GHOSTTY_POINT_VIEWPORT)
+                continuation.resume(returning: text)
+            }
+        }
+    }
+
     private func handleBell() {
         UINotificationFeedbackGenerator().notificationOccurred(.warning)
         NotificationCenter.default.post(
@@ -3484,6 +3526,15 @@ extension GhosttySurfaceView: UIGestureRecognizerDelegate {
         }
         return true
     }
+}
+
+/// Carrier for the "View as Text" sheet's surface pointer across the hop to
+/// `GhosttySurfaceView.outputQueue`. Same safety argument as
+/// ``VisibleSnapshotRequest``: the pointer is only dereferenced on the queue
+/// that owns `process_output` and is FIFO-ordered before any queued free —
+/// hence `@unchecked Sendable`.
+private struct CopyableTextSurfaceHandle: @unchecked Sendable {
+    let surface: ghostty_surface_t
 }
 
 /// One surface's request for the bounded visible-terminal snapshot.

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3559,6 +3559,10 @@ extension GhosttySurfaceView: UIGestureRecognizerDelegate {
 /// ``VisibleSnapshotRequest``: the pointer is only dereferenced on the queue
 /// that owns `process_output` and is FIFO-ordered before any queued free —
 /// hence `@unchecked Sendable`.
+///
+/// Deliberately `private` to this file alongside the other snapshot carriers:
+/// it holds the class's raw `ghostty_surface_t`, which must not escape
+/// `GhosttySurfaceView`'s queue/lifetime discipline into the wider module.
 private struct CopyableTextSurfaceHandle: @unchecked Sendable {
     let surface: ghostty_surface_t
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -5593,6 +5593,125 @@
           }
         }
       }
+    },
+    "mobile.terminal.viewAsText": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View as Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストとして表示"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのテキスト"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.copyAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy All"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてコピー"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.copied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピーしました"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No terminal text available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示できるターミナルテキストがありません"
+          }
+        }
+      }
+    },
+    "mobile.textSheet.truncated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Showing the last %d lines."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新の%d行を表示しています。"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Ask

Lawrence: "copy paste doesnt work -- we need a mode where we can open a sheet of just the text content so it's easy to copy paste...". The Ghostty render surface on iOS has no text-selection affordance, so there was no way to copy terminal output from the phone.

## What this adds

A "View as Text" item in the terminal screen's overflow menu (the existing terminal picker menu) opens a sheet showing the terminal's content (recent scrollback plus the visible screen) in a read-only UITextView. Native long-press selection, drag handles, Select All, and Copy all work, and the sheet has a one-tap Copy All button.

## Mechanism: local surface extraction, no RPC

The phone renders the Mac's render-grid deltas into its own libghostty surface, so the text is extracted locally from that surface. New `GhosttySurfaceView.copyableTerminalText(surfaceID:)` reads `GHOSTTY_POINT_SCREEN` (scrollback plus all written rows, viewport fallback) via the existing release-safe `surfaceText` helper. No Mac round-trip, works offline, and no new verb in the mobile RPC allowlist.

Threading follows the `visibleTerminalSnapshot()` contract: the read runs on the serial `outputQueue` (the queue that owns `process_output`), never on main, because `ghostty_surface_read_text` takes the same surface lock as `process_output` and a main-thread read can stall the present and blank the terminal. The caller awaits a continuation enqueued while still on the main actor, so the read is FIFO-ordered before any queued surface free.

Bounding is enforced at the read boundary: iOS surfaces now set `scrollback-limit = 2000000` (ghostty defaults to 10MB) since the phone mirror's local scrollback only feeds local reads (user scrolling forwards to the Mac's real surface). On top of that hard cap, the sheet keeps the last 5000 lines (`TerminalTextSnapshot.defaultLineBudget`), computed off the main actor, and shows a localized "Showing the last 5000 lines." banner when older lines were dropped.

The capture is scoped to the requesting terminal: the mounting representable stamps its surface id on the view (`hostSurfaceID`) and the lookup requires that id plus on-screen visibility, so a second iPad scene or a dismantling view can never leak another workspace's text or stale content. While the browser pane is active the menu item is hidden (the terminal surface is unmounted there).

## Tests

- `swift test --package-path Packages/CmuxMobileShell`: 62 tests pass, including 7 new `TerminalTextSnapshotTests` covering the truncation budget (under/exact/over budget, last-N-lines wins, trailing-blank-row trimming, interior blanks preserved, empty input).
- iOS app compiled for arm64 simulator with a tagged derivedDataPath: BUILD SUCCEEDED, zero errors.
- A behavior test constructing a real libghostty surface is not practical in package tests (binary GhosttyKit target, iOS-only package, no existing surface fixtures); the pure capping logic is fully covered and the surface read reuses the shipped `surfaceText` path that Copy Debug Logs already exercises.

## Localization audit

All new user-facing strings (menu item, sheet title, Done, Copy All, Copied, empty state, truncation banner) use `L10n.string` keys with en and ja entries in `ios/cmux/Resources/Localizable.xcstrings`. Audited by parsing the catalog for every key referenced from the changed files (56 keys checked, all translated in both locales, format specifiers match) and scanning changed files for bare literals (none added; the DEBUG-only Copy Debug Logs label is pre-existing and intentionally unlocalized).

## Review

Codex autoreview (branch mode vs origin/main) ran to a clean result: "patch is correct", no actionable findings. Earlier rounds raised one P1 (cap applied after an unbounded read) and three P2s (global surface pick, stale-surface pick, menu item active in browser mode); all four are fixed in dedicated commits. One Aziz one-type-per-file P2 is consciously rejected: `CopyableTextSurfaceHandle` stays private in `GhosttySurfaceView.swift` because it carries the class's raw `ghostty_surface_t`, which must not escape the file's queue/lifetime discipline, matching the file's existing private snapshot carriers; documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783758261&installation_id=133855650&pr_number=5875&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5875&signature=8873bcbffe2c1f6dac06d67bc652d9be30e168bed69d6202d3d4abde6e86abed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing iOS UX and read-path changes reuse existing output-queue and surfaceText patterns; no auth or server changes, with explicit bounds to avoid main-thread jank.
> 
> **Overview**
> Adds an iOS **View as Text** flow so users can copy terminal output from a sheet instead of the Ghostty render surface, which has no text selection.
> 
> A new overflow-menu action (terminal pane only) opens `TerminalTextSheetView` with a read-only `UITextView` (`SelectableTextView`) for native selection plus **Copy All**. Text is captured locally via new `GhosttySurfaceView.copyableTerminalText(surfaceID:)` (SCREEN read on `outputQueue`, viewport fallback), scoped with `hostSurfaceID` on mounted surfaces. Registry logic moves to `GhosttySurfaceRegistry.swift`; iOS mirror surfaces get `scrollback-limit = 2000000` and the sheet caps to the last 5000 lines via `TerminalTextSnapshot` (off-main), with a truncation banner. New en/ja strings and unit tests for capping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d06d0d7b123b539549f13419d313a35a9767cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “View as Text” sheet on iOS so users can select and copy terminal output with native controls. Text is read locally, bounded for performance, and pinned to the terminal you tapped.

- New Features
  - “View as Text” opens a read‑only `UITextView` with native selection and a Copy All button.
  - Local capture via `GhosttySurfaceView.copyableTerminalText(surfaceID:)` on `outputQueue`, reading SCREEN with viewport fallback. No Mac RPC; works offline.
  - Scoped and safe: pinned to the tapped terminal via `hostSurfaceID` (id captured at tap) and only from on‑screen surfaces; otherwise shows an empty state.
  - Bounded capture: iOS sets `scrollback-limit = 2000000`; the sheet keeps the last 5000 lines with a truncation banner, trims trailing blank rows, and caps off‑main.
  - Menu item is hidden while the browser pane is active. Localization added for new strings (en, ja). Tests cover capping and trailing‑blank trimming.

- Refactors
  - Moved the surface registry and copyable‑text read to `GhosttySurfaceRegistry.swift`; `outputQueue` and the registry are internal. `GhosttySurfaceView` gains `hostSurfaceID`.

<sup>Written for commit 9d06d0d7b123b539549f13419d313a35a9767cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS "View as Text" sheet: selectable, copyable terminal text with “Copy All”, success haptics, and a “Copied” state; accessible from the terminal picker menu; includes Done dismissal.

* **Behavior**
  * Captures are capped to recent lines (default budget) with a banner when truncated; preserves interior blank lines and trims trailing blank rows; sheet scoped to the selected terminal surface.

* **Tests**
  * Unit tests for truncation, trimming, exact-budget, and empty/edge cases.

* **Localization**
  * Added English and Japanese strings for sheet UI and messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->