### PR TITLE
iOS: iMessage-style terminal composer (open by default, inline send, per-terminal drafts)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 32955	CLI/cmux.swift
-22574	Sources/TerminalController.swift
+22576	Sources/TerminalController.swift
 19955	Sources/Workspace.swift
 19245	Sources/ContentView.swift
 18056	Sources/AppDelegate.swift
@@ -23,13 +23,13 @@
 5448	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
-4256	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+4264	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4227	Sources/BrowserWindowPortal.swift
 4009	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
-3654	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+3661	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -23,13 +23,13 @@
 5448	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
-4264	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+4274	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4227	Sources/BrowserWindowPortal.swift
 4009	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
-3661	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+3670	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -29,7 +29,7 @@
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
-3670	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+3694	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 32955	CLI/cmux.swift
-22444	Sources/TerminalController.swift
+22574	Sources/TerminalController.swift
 19955	Sources/Workspace.swift
 19245	Sources/ContentView.swift
 18056	Sources/AppDelegate.swift
@@ -23,16 +23,16 @@
 5448	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
+4256	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4227	Sources/BrowserWindowPortal.swift
 4009	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift
 3760	cmuxTests/TabManagerUnitTests.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
-3685	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+3654	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3396	Sources/CmuxConfig.swift
 3316	cmuxTests/TabManagerSessionSnapshotTests.swift
 3202	Sources/Update/UpdateTitlebarAccessory.swift
-2953	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 2877	Sources/SessionIndexView.swift
 2871	cmuxTests/CMUXOpenCommandTests.swift
 2654	Sources/Panels/CmuxWebView.swift
@@ -43,7 +43,7 @@
 2327	cmuxTests/CJKIMEInputTests.swift
 2290	Sources/FileExplorerView.swift
 2260	Sources/TerminalWindowPortal.swift
-2208	Sources/Mobile/MobileHostService.swift
+2209	Sources/Mobile/MobileHostService.swift
 2138	Sources/SessionPersistence.swift
 2123	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2117	cmuxTests/CmuxConfigTests.swift
@@ -71,19 +71,19 @@
 1313	cmuxTests/MobileHostAuthorizationTests.swift
 1285	cmuxUITests/SidebarHelpMenuUITests.swift
 1239	Sources/Feed/FeedCoordinator.swift
+1205	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
 1197	cmuxTests/CodexAppServerSessionTests.swift
 1156	cmuxTests/SidebarOrderingTests.swift
 1144	Sources/VaultAgentProcessScanner.swift
 1139	cmuxTests/PiVaultAgentPersistenceTests.swift
 1107	Sources/AppDelegate+CmuxSSHURL.swift
+1096	Sources/GhosttyConfig.swift
 1084	cmuxTests/AgentHibernationTests.swift
 1068	cmuxTests/FileExplorerStoreTests.swift
 1058	cmuxUITests/BonsplitTabDragUITests.swift
-1096	Sources/GhosttyConfig.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift
 1000	cmuxTests/CmuxTopSnapshotScopeTests.swift
-949	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
 947	Sources/TerminalNotificationPolicy.swift
 945	Sources/SessionIndexRegisteredAgents.swift
 944	Sources/App/ShortcutRoutingSupport.swift
@@ -167,8 +167,8 @@
 539	CLI/CodexTeamsApprovalBridge.swift
 538	CLI/CMUXCLI+Themes.swift
 536	cmuxTests/CmuxConfigContextMenuTests.swift
-530	cmuxUITests/AutomationSocketUITests.swift
 528	cmuxTests/CLINotifyProcessTestSupport.swift
+528	cmuxUITests/AutomationSocketUITests.swift
 527	CLI/CLISocketPathResolver.swift
 523	Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
 522	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -23,7 +23,7 @@
 5448	Sources/cmuxApp.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
-4274	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+4288	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4227	Sources/BrowserWindowPortal.swift
 4009	cmuxTests/WindowAndDragTests.swift
 3937	Sources/Feed/FeedPanelView.swift

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockIntent.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockIntent.swift
@@ -1,0 +1,12 @@
+/// The single coherent step the surface should take in response to a compose-button
+/// tap, computed by ``ComposerDockState/intentForComposeButtonTap()``.
+public enum ComposerDockIntent: Sendable, Equatable {
+    /// No composer is presented; present it and focus the field (the plain open).
+    case openComposer
+    /// A composer is presented but suppressed or unfocused; reveal the chrome (if
+    /// hidden), keep it presented, and focus the field. The draft is preserved.
+    case revealAndFocusComposer
+    /// A genuinely visible, focused composer; dismiss it (the only path that closes
+    /// the composer from the button).
+    case closeComposer
+}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockReducer.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockReducer.swift
@@ -1,0 +1,98 @@
+/// The four booleans that describe the iOS terminal's bottom dock at the instant
+/// the user acts on the composer, plus the pure decision that maps an action onto
+/// the one coherent next step.
+///
+/// The bottom dock is a tangle of four independent flags — chrome hidden vs shown,
+/// composer logically presented vs not, the composer field holding first responder
+/// vs not, and the software keyboard up vs down. A blind `isComposerPresented.toggle()`
+/// on the compose button ignored all of them, so the cycle compose → hide → reveal →
+/// compose closed a still-presented (but visually suppressed, or revealed-yet-unfocused)
+/// composer and the user saw their draft vanish. This type is the single source of
+/// truth for that decision so it can be unit-tested off-device and the UIKit surface
+/// only has to translate the resulting ``ComposerDockIntent`` into calls.
+public struct ComposerDockState: Sendable, Equatable {
+    /// Whether the HIDE button has visually suppressed the whole bottom chrome
+    /// (toolbar + composer band). The composer can be *presented* yet hidden:
+    /// HIDE leaves ``composerPresented`` untouched and only drops the chrome, so
+    /// the draft survives.
+    public var chromeHidden: Bool
+    /// Whether the composer is logically presented (the store's `isComposerPresented`,
+    /// mirrored onto the surface). True from the moment the composer opens until it
+    /// is genuinely dismissed; a HIDE does not flip it.
+    public var composerPresented: Bool
+    /// Whether the composer's text field currently holds first responder. After a
+    /// reveal-from-hide the chrome is back and the composer is presented, but the
+    /// terminal proxy (not the field) took first responder, so this is false — the
+    /// exact state that made the next compose tap destructive.
+    public var fieldFocused: Bool
+    /// Whether the software keyboard is currently up.
+    ///
+    /// Part of the dock's complete description, recorded so a captured trace and the
+    /// tests model the real state. It does NOT gate
+    /// ``intentForComposeButtonTap()`` today (the open/reveal/close decision turns
+    /// only on presented + suppressed/unfocused); it is retained for the dock's
+    /// faithful shape and any future keyboard-aware step.
+    public var keyboardUp: Bool
+
+    /// Creates a dock state from its four flags.
+    /// - Parameters:
+    ///   - chromeHidden: Whether the HIDE button has suppressed the chrome.
+    ///   - composerPresented: Whether the composer is logically presented.
+    ///   - fieldFocused: Whether the composer field holds first responder.
+    ///   - keyboardUp: Whether the software keyboard is up.
+    public init(
+        chromeHidden: Bool,
+        composerPresented: Bool,
+        fieldFocused: Bool,
+        keyboardUp: Bool
+    ) {
+        self.chromeHidden = chromeHidden
+        self.composerPresented = composerPresented
+        self.fieldFocused = fieldFocused
+        self.keyboardUp = keyboardUp
+    }
+
+    /// Resolve what tapping the compose accessory button should do, given this dock
+    /// state.
+    ///
+    /// The compose button has three jobs folded into one control, told apart by the
+    /// dock state:
+    ///
+    /// - **Open** when no composer is presented: present it and focus the field.
+    /// - **Reveal** when a composer is presented but suppressed (``chromeHidden``)
+    ///   or visible-yet-unfocused (presented, chrome shown, field not first
+    ///   responder — the reveal-after-hide state): bring the chrome back, keep the
+    ///   composer presented, and focus the field. The draft is never dismissed.
+    /// - **Close** only when the composer is genuinely visible and focused: a real
+    ///   "I'm done composing" tap.
+    ///
+    /// - Returns: the ``ComposerDockIntent`` the surface should carry out.
+    public func intentForComposeButtonTap() -> ComposerDockIntent {
+        guard composerPresented else {
+            // Nothing presented: a plain open.
+            return .openComposer
+        }
+        if chromeHidden || !fieldFocused {
+            // Presented but suppressed, or presented-and-visible yet the field lost
+            // first responder on a reveal. Either way the user wants the composer
+            // back and focused, NOT dismissed — reveal the chrome if needed and
+            // re-focus the field, leaving the draft intact.
+            return .revealAndFocusComposer
+        }
+        // Genuinely visible and focused: a real close.
+        return .closeComposer
+    }
+}
+
+/// The single coherent step the surface should take in response to a compose-button
+/// tap, computed by ``ComposerDockState/intentForComposeButtonTap()``.
+public enum ComposerDockIntent: Sendable, Equatable {
+    /// No composer is presented; present it and focus the field (the plain open).
+    case openComposer
+    /// A composer is presented but suppressed or unfocused; reveal the chrome (if
+    /// hidden), keep it presented, and focus the field. The draft is preserved.
+    case revealAndFocusComposer
+    /// A genuinely visible, focused composer; dismiss it (the only path that closes
+    /// the composer from the button).
+    case closeComposer
+}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockReducer.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/ComposerDockReducer.swift
@@ -83,16 +83,3 @@ public struct ComposerDockState: Sendable, Equatable {
         return .closeComposer
     }
 }
-
-/// The single coherent step the surface should take in response to a compose-button
-/// tap, computed by ``ComposerDockState/intentForComposeButtonTap()``.
-public enum ComposerDockIntent: Sendable, Equatable {
-    /// No composer is presented; present it and focus the field (the plain open).
-    case openComposer
-    /// A composer is presented but suppressed or unfocused; reveal the chrome (if
-    /// hidden), keep it presented, and focus the field. The draft is preserved.
-    case revealAndFocusComposer
-    /// A genuinely visible, focused composer; dismiss it (the only path that closes
-    /// the composer from the button).
-    case closeComposer
-}

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -39,4 +39,61 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// A pairing attempt was short-circuited because the device had no network
     /// path (the reachability preflight failed before any connect).
     case pairUnreachable = 10
+
+    // MARK: iOS composer instrumentation (draft-disappears-on-keyboard-dismiss hunt)
+    //
+    // These five codes discriminate WHY the iMessage-style composer's draft
+    // vanishes after the keyboard opens then closes. The draft text itself lives
+    // in the store (`terminalInputText`), so the symptom must be one of: the
+    // `isComposerPresented` flag toggled off, the composer view torn down + rebuilt
+    // while the flag stayed true, the draft cleared at the store, or (the residual)
+    // a `TextField`/`@FocusState` render blank. Logging the flag, the draft length,
+    // and the composer view's appear/disappear *independently* of the flag lets a
+    // single captured trace name which one happened. Raw values 11-17 are reserved
+    // for the in-flight keyboard-input instrumentation branch.
+
+    /// The store's `isComposerPresented` flag changed (store `didSet`). `a` = 1 if
+    /// the composer is now presented, else 0. An unexpected `a == 0` during a bare
+    /// keyboard dismiss is the "flag toggled off" cause.
+    case composerPresentedChanged = 18
+    /// The store's `terminalInputText` draft changed (store `didSet`). `a` = new
+    /// UTF-8 byte length; `b` = 1 if it just went to empty (a clear), else 0. A
+    /// clear (`b == 1`) with no submit/sign-out nearby is the "draft cleared at the
+    /// store" cause.
+    case composerInputTextChanged = 19
+    /// ``TerminalComposerView`` appeared (`.onAppear`). Logged independently of
+    /// ``composerPresentedChanged`` so a disappear/appear pair with no flag change
+    /// reveals a view-recreation bug (the flag stayed true but SwiftUI rebuilt the
+    /// view).
+    case composerViewAppear = 20
+    /// ``TerminalComposerView`` disappeared (`.onDisappear`). A disappear without a
+    /// matching ``composerPresentedChanged`` `a == 0` is a view-recreation bug, not
+    /// an intentional dismiss.
+    case composerViewDisappear = 21
+    /// The composer's text field focus changed (`@FocusState`). `a` = 1 focused,
+    /// else 0. A focus-lost (`a == 0`) while the flag stayed presented and the view
+    /// stayed mounted, yet the field reads empty, isolates the residual
+    /// `TextField`/`@FocusState` render-blank case.
+    case composerFieldFocusChanged = 22
+
+    // COMPOSER keyboard-toggle edge case (composer shown while the
+    // textbox/keyboard is hidden). These pin which transition desyncs the
+    // composer-presented flag from the keyboard/first-responder state, and they
+    // land in the same `store.diagnosticLog` sink the composer events above use.
+
+    /// `GhosttySurfaceView.setComposerActive` ran. `a` = 1 if the composer just
+    /// became active, else 0. `b` = the resolved first-responder owner
+    /// (``InputResponderIdentity`` raw value: which view holds first responder at
+    /// the transition). `c` = 1 if the terminal input proxy is first responder,
+    /// else 0. `ms` = the surface's `keyboardHeight` (points) at the transition. A
+    /// trace where `a == 1` but `ms == 0` and no terminal/composer responder owns
+    /// FR is the composer-up/keyboard-down desync.
+    case composerActiveTransition = 23
+
+    /// The docked bar's keyboard toggle button was tapped while the composer is
+    /// presented. `a` = 1 if the terminal input proxy was first responder when
+    /// tapped (so the tap would hide the keyboard), else 0. Purely diagnostic:
+    /// the keyboard toggle no longer dismisses the composer (the composer
+    /// survives a keyboard-down), so this records the tap for trace completeness.
+    case composerKeyboardToggleWhilePresented = 24
 }

--- a/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
+++ b/Packages/CMUXMobileCore/Sources/CMUXMobileCore/InputResponderIdentity.swift
@@ -1,0 +1,28 @@
+/// A compact integer identity for the view that owns the keyboard's first
+/// responder on the iOS terminal input path.
+///
+/// ``DiagnosticEvent`` carries only integer payloads (no allocated strings), so
+/// the first-responder *class* is encoded as one of these small raw values and
+/// decoded back to a human-readable name by `scripts/decode-ios-diagnostic.py`.
+/// The composer-dock instrumentation stamps this into the payload slots of the
+/// ``DiagnosticEventCode/composerActiveTransition`` and
+/// ``DiagnosticEventCode/composerKeyboardToggleWhilePresented`` events so a
+/// captured trace shows *which* view actually holds first responder when the
+/// composer opens, closes, or survives a keyboard toggle.
+public enum InputResponderIdentity: Int, Sendable, Codable, CaseIterable {
+    /// No first responder, or it could not be resolved.
+    case none = 0
+    /// The expected terminal keyboard proxy (`TerminalInputTextView`). The
+    /// keyboard is driving the view we instrument.
+    case terminalInputProxy = 1
+    /// The Metal/IOSurface terminal surface itself (`GhosttySurfaceView`).
+    case ghosttySurface = 2
+    /// A `UITextField` (e.g. an unexpected SwiftUI/text field stealing focus).
+    case uiTextField = 3
+    /// A `UITextView`.
+    case uiTextView = 4
+    /// Some other `UIResponder` subclass not in this list. The decoder pairs this
+    /// with the human-readable class name carried in the companion string log
+    /// (`anchormux`) for the same event.
+    case other = 9
+}

--- a/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/ComposerDockReducerTests.swift
+++ b/Packages/CMUXMobileCore/Tests/CMUXMobileCoreTests/ComposerDockReducerTests.swift
@@ -1,0 +1,93 @@
+import Testing
+@testable import CMUXMobileCore
+
+/// Verifies the pure compose-button decision that keeps the iOS terminal composer
+/// coherent across the compose → hide → reveal → compose cycle a user hit on device:
+/// the draft must never be dismissed by the compose button while the composer is
+/// still logically presented but visually suppressed or unfocused.
+@Suite struct ComposerDockReducerTests {
+    /// A fresh open: nothing presented, so the button opens the composer.
+    @Test func composeButtonOpensWhenNothingPresented() {
+        let state = ComposerDockState(
+            chromeHidden: false,
+            composerPresented: false,
+            fieldFocused: false,
+            keyboardUp: false
+        )
+        #expect(state.intentForComposeButtonTap() == .openComposer)
+    }
+
+    /// A genuinely visible, focused composer: the button closes it. This is the ONLY
+    /// path that dismisses the composer from the button.
+    @Test func composeButtonClosesWhenVisibleAndFocused() {
+        let state = ComposerDockState(
+            chromeHidden: false,
+            composerPresented: true,
+            fieldFocused: true,
+            keyboardUp: true
+        )
+        #expect(state.intentForComposeButtonTap() == .closeComposer)
+    }
+
+    /// Composer presented but the HIDE button suppressed the chrome: the button must
+    /// REVEAL + focus, not close (closing here is what lost the draft on device).
+    @Test func composeButtonRevealsWhenPresentedButChromeHidden() {
+        let state = ComposerDockState(
+            chromeHidden: true,
+            composerPresented: true,
+            fieldFocused: false,
+            keyboardUp: false
+        )
+        #expect(state.intentForComposeButtonTap() == .revealAndFocusComposer)
+    }
+
+    /// The exact device-trace state: after a reveal-from-hide the chrome is back and
+    /// the composer is presented, but the terminal proxy (not the field) holds first
+    /// responder. The button must REVEAL + focus the field, not toggle the composer
+    /// closed.
+    @Test func composeButtonRefocusesWhenPresentedAndVisibleButFieldUnfocused() {
+        let state = ComposerDockState(
+            chromeHidden: false,
+            composerPresented: true,
+            fieldFocused: false,
+            keyboardUp: false
+        )
+        #expect(state.intentForComposeButtonTap() == .revealAndFocusComposer)
+    }
+
+    /// End-to-end: replay the reported compose → hide → reveal → compose sequence as
+    /// pure state transitions and assert the final compose tap ends in a presented,
+    /// focused composer (draft preserved), never a close.
+    @Test func composeHideRevealComposeKeepsComposerPresentedAndFocused() {
+        // 1. Compose: open from nothing. Intent = open.
+        var state = ComposerDockState(
+            chromeHidden: false,
+            composerPresented: false,
+            fieldFocused: false,
+            keyboardUp: false
+        )
+        #expect(state.intentForComposeButtonTap() == .openComposer)
+
+        // After open: composer presented, field focused, keyboard up.
+        state.composerPresented = true
+        state.fieldFocused = true
+        state.keyboardUp = true
+
+        // 2. Hide: chrome suppressed, keyboard dropped, field loses first responder.
+        //    `composerPresented` stays true (HIDE never dismisses), so the draft lives.
+        state.chromeHidden = true
+        state.fieldFocused = false
+        state.keyboardUp = false
+        #expect(state.composerPresented)
+
+        // 3. Reveal (terminal tap): chrome returns but the terminal proxy takes first
+        //    responder, so the composer field is NOT focused yet.
+        state.chromeHidden = false
+        state.fieldFocused = false
+        #expect(state.composerPresented)
+
+        // 4. Compose again: presented + visible + field-unfocused → reveal/refocus,
+        //    NOT close. The composer (and its draft) stays.
+        #expect(state.intentForComposeButtonTap() == .revealAndFocusComposer)
+    }
+}

--- a/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -243,6 +243,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         case "mobile.terminal.create", "terminal.create":
             return false
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport":

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
@@ -1,0 +1,38 @@
+/// In-memory ``TerminalDraftStoring``: per-terminal composer drafts that live for
+/// the app session.
+///
+/// Drafts are tiny (a few unsent keystrokes per terminal), so the whole map is a
+/// dictionary keyed by the terminal's stable id. An `actor` serializes access, so
+/// the type is genuinely `Sendable` and the shell can fire saves without awaiting.
+///
+/// This store intentionally does NOT persist to disk: drafts survive terminal
+/// switches (the feature this PR ships) but not an app kill/relaunch. A
+/// disk-backed ``TerminalDraftStoring`` lands separately and replaces this one at
+/// the composition root without touching the shell.
+public actor InMemoryTerminalDraftStore: TerminalDraftStoring {
+    /// The in-memory draft map (terminal id raw string → draft text).
+    private var drafts: [String: String] = [:]
+
+    /// Creates an empty store.
+    public init() {}
+
+    public func draft(forTerminalID terminalID: String) async -> String? {
+        drafts[terminalID]
+    }
+
+    public func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
+        if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            drafts[terminalID] = nil
+        } else {
+            drafts[terminalID] = draft
+        }
+    }
+
+    public func clearDraft(forTerminalID terminalID: String) async {
+        drafts[terminalID] = nil
+    }
+
+    public func clearAllDrafts() async {
+        drafts.removeAll()
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
@@ -18,10 +18,13 @@ public actor InMemoryTerminalDraftStore: TerminalDraftStoring {
     /// Creates an empty store.
     public init() {}
 
+    /// Returns the saved draft for `terminalID`, or `nil` when none is stored.
     public func draft(forTerminalID terminalID: String) async -> String? {
         drafts[terminalID]
     }
 
+    /// Saves `draft` under `terminalID`. A whitespace-only draft deletes the
+    /// entry instead, so abandoned blank edits never resurface on a switch back.
     public func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
         if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             drafts[terminalID] = nil
@@ -30,10 +33,12 @@ public actor InMemoryTerminalDraftStore: TerminalDraftStoring {
         }
     }
 
+    /// Removes the draft stored under `terminalID` (after a successful send).
     public func clearDraft(forTerminalID terminalID: String) async {
         drafts[terminalID] = nil
     }
 
+    /// Removes every stored draft (the sign-out wipe).
     public func clearAllDrafts() async {
         drafts.removeAll()
     }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/InMemoryTerminalDraftStore.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// In-memory ``TerminalDraftStoring``: per-terminal composer drafts that live for
 /// the app session.
 ///

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -276,6 +276,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// would also race the key swap). Not observed: it gates a write, not view
     /// state.
     @ObservationIgnored private var isLoadingDraft = false
+    /// Tail of the FIFO draft pipeline (see ``enqueueDraftOperation(_:)``).
+    /// Every draft-store operation chains onto this so store effects apply in
+    /// exactly the order they were issued from the main actor. Not observed: it
+    /// sequences async work, not view state.
+    @ObservationIgnored private var draftOperationTail: Task<Void, Never>?
     /// The terminal id we are switching away from, captured in
     /// ``selectedTerminalID``'s `willSet` so its draft is saved under the right key.
     @ObservationIgnored private var draftedOutgoingTerminalID: MobileTerminalPreview.ID?
@@ -562,7 +567,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // store we are about to empty wholesale.
         isLoadingDraft = true
         terminalInputText = ""
-        draftStore.map { store in Task { await store.clearAllDrafts() } }
+        // Enqueued on the FIFO draft pipeline so every save issued before this
+        // point is applied first and then wiped; a pending keystroke save can
+        // never land after the wipe and leak into the next account's session.
+        if let draftStore {
+            enqueueDraftOperation { await draftStore.clearAllDrafts() }
+        }
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -2153,11 +2163,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } else if let submittedTerminalID, let draftStore {
             // Selection moved mid-flight. Clear the submitted terminal's stored
             // draft only when it is still exactly the sent text, so a newer draft
-            // (typed after Send, before the switch) is preserved.
+            // (typed after Send, before the switch) is preserved. Enqueued (and
+            // awaited) on the FIFO draft pipeline so the check runs after the
+            // terminal switch's own save of the outgoing text, and the
+            // check-then-clear pair is atomic with respect to other operations.
             let terminalID = submittedTerminalID.rawValue
-            if await draftStore.draft(forTerminalID: terminalID) == sentText {
-                await draftStore.clearDraft(forTerminalID: terminalID)
-            }
+            let sent = sentText
+            await enqueueDraftOperation {
+                if await draftStore.draft(forTerminalID: terminalID) == sent {
+                    await draftStore.clearDraft(forTerminalID: terminalID)
+                }
+            }.value
             // The user may have switched back during the awaits and had the sent
             // text restored into the field; clear that too so already-sent text
             // never resurrects.
@@ -2799,13 +2815,46 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     // MARK: - Per-terminal composer drafts
 
+    /// Enqueue one draft-store operation on a strictly ordered (FIFO) pipeline.
+    ///
+    /// All draft persistence is fire-and-forget from the caller's point of view,
+    /// but independent unstructured `Task`s are NOT ordered relative to each
+    /// other: an older keystroke save could reach the store actor after a newer
+    /// save, a post-send clear, or the sign-out wipe, resurrecting stale (or
+    /// another account's) text. Chaining every operation onto the previous one
+    /// makes store effects apply in exactly the order they were issued from the
+    /// main actor, which restores the two invariants the store exists for: sent
+    /// or superseded drafts never win over newer state, and nothing written
+    /// before sign-out survives the sign-out wipe.
+    ///
+    /// Operations are tiny (one actor dictionary access); only the tail task is
+    /// retained, so the chain does not grow under typing bursts.
+    @discardableResult
+    private func enqueueDraftOperation(
+        _ operation: @escaping @Sendable () async -> Void
+    ) -> Task<Void, Never> {
+        let previous = draftOperationTail
+        let task = Task {
+            await previous?.value
+            await operation()
+        }
+        draftOperationTail = task
+        return task
+    }
+
+    /// Wait until every draft operation enqueued so far has been applied to the
+    /// store. Test seam: lets tests assert on store contents without sleeping.
+    func drainDraftOperationsForTesting() async {
+        await draftOperationTail?.value
+    }
+
     /// Save the live ``terminalInputText`` under the currently selected
     /// terminal. Called from the field's `didSet`. A no-op when there is no
     /// selected terminal (nothing to key the draft to) or no draft store wired.
     private func persistCurrentDraft() {
         guard let draftStore, let terminalID = selectedTerminalID?.rawValue else { return }
         let text = terminalInputText
-        Task { await draftStore.saveDraft(text, forTerminalID: terminalID) }
+        enqueueDraftOperation { await draftStore.saveDraft(text, forTerminalID: terminalID) }
     }
 
     /// Swap the composer draft when the selected terminal changes: save the
@@ -2834,7 +2883,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             terminalInputText = ""
             isLoadingDraft = false
         }
-        Task { [weak self] in
+        enqueueDraftOperation { [weak self] in
             if let outgoingID {
                 await draftStore.saveDraft(outgoingText, forTerminalID: outgoingID.rawValue)
             }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -657,9 +657,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Per-terminal composer dismissals are this user's session UI state; the
         // next account starts with the default-open composer everywhere. Clear
         // the focus mirror BEFORE the selection resets below so the terminal
-        // switch they trigger cannot arm a stale focus request.
+        // switch they trigger cannot arm a stale focus request, and drop any
+        // already-armed handshake (the selection reset's didSet only clears it
+        // when the terminal id actually changes).
         composerDismissedTerminalIDs = []
         composerFieldIsFocused = false
+        composerFocusRequestPending = false
+        composerFocusRequestTerminalID = nil
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -3290,8 +3294,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     params: params
                 )
             )
-            guard isCurrentRemoteOperation(client: client, generation: generation) else { return false }
-            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+            // The Mac acked the paste: the text is applied regardless of whether a
+            // reconnect superseded this client while the request was in flight.
+            // Only the per-connection response bookkeeping is generation-guarded;
+            // returning failure here would keep the composer draft and a retry
+            // would paste the same block twice.
+            if isCurrentRemoteOperation(client: client, generation: generation) {
+                handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+            }
             return true
         } catch {
             guard generation == connectionGeneration else { return false }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -189,6 +189,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// route falls back to email rather than failing with `method_not_found`
     /// under client/server version skew.
     public private(set) var supportsDogfoodFeedback: Bool = false
+    /// The composer's live draft for the currently selected terminal.
+    ///
+    /// Edits are persisted per-terminal through the FIFO draft pipeline on every
+    /// change (see `didSet`), so the draft survives terminal switches; loads set
+    /// `isLoadingDraft` so the restore is not re-saved under the wrong terminal
+    /// key.
     public var terminalInputText: String {
         didSet {
             #if DEBUG
@@ -275,6 +281,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             syncSelectedTerminalForWorkspace()
         }
     }
+    /// The terminal whose surface (and composer draft) is currently shown.
+    ///
+    /// Changing it swaps the composer draft: `willSet` captures the outgoing
+    /// terminal's draft before the id lands, `didSet` persists it under the old
+    /// key and loads the incoming terminal's saved draft.
     public var selectedTerminalID: MobileTerminalPreview.ID? {
         willSet {
             // Capture the draft of the terminal we are leaving BEFORE the new id

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2118,11 +2118,52 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard !isSubmittingComposerInput else { return }
         isSubmittingComposerInput = true
         defer { isSubmittingComposerInput = false }
+        // Capture which terminal this text is for: if the user switches terminals
+        // while the ack is in flight, the switch persists the outgoing text as the
+        // SUBMITTED terminal's draft, and the sent text must be cleared from that
+        // key, not from whatever terminal is selected when the ack returns.
+        let submittedTerminalID = selectedTerminalID
         let sent = await sendRemoteTerminalPaste(text, submitKey: "return")
-        // Only clear if the field still holds exactly what we sent, so a value
-        // the user typed while the send was in flight is not discarded.
-        if sent, terminalInputText == text {
-            terminalInputText = ""
+        guard sent else { return }
+        await reconcileComposerDraftAfterSend(sentText: text, submittedTerminalID: submittedTerminalID)
+    }
+
+    /// Clear the sent text from wherever it now lives after a successful
+    /// composer send: the visible field when the submitted terminal is still
+    /// selected, or the submitted terminal's STORED draft when the user switched
+    /// terminals while the ack was in flight (the switch persists the outgoing
+    /// text under the submitted terminal's key, and without this it would
+    /// resurrect on switch-back and invite a duplicate submission). In both
+    /// places the clear is conditional on the value still being exactly the sent
+    /// text, so anything newer the user typed is never discarded.
+    ///
+    /// Internal (not private) so tests can drive the post-ack reconciliation
+    /// directly with a controlled draft store and selection.
+    func reconcileComposerDraftAfterSend(
+        sentText: String,
+        submittedTerminalID: MobileTerminalPreview.ID?
+    ) async {
+        if selectedTerminalID == submittedTerminalID {
+            // Only clear if the field still holds exactly what we sent, so a value
+            // the user typed while the send was in flight is not discarded. The
+            // field's `didSet` persists the clear, removing the stored draft too.
+            if terminalInputText == sentText {
+                terminalInputText = ""
+            }
+        } else if let submittedTerminalID, let draftStore {
+            // Selection moved mid-flight. Clear the submitted terminal's stored
+            // draft only when it is still exactly the sent text, so a newer draft
+            // (typed after Send, before the switch) is preserved.
+            let terminalID = submittedTerminalID.rawValue
+            if await draftStore.draft(forTerminalID: terminalID) == sentText {
+                await draftStore.clearDraft(forTerminalID: terminalID)
+            }
+            // The user may have switched back during the awaits and had the sent
+            // text restored into the field; clear that too so already-sent text
+            // never resurrects.
+            if selectedTerminalID == submittedTerminalID, terminalInputText == sentText {
+                terminalInputText = ""
+            }
         }
     }
 

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -207,6 +207,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // the saved value, re-saving it is redundant and would race the
             // per-terminal key swap) and when the value is unchanged.
             guard !isLoadingDraft, terminalInputText != oldValue else { return }
+            // A user edit claims field ownership for the selected terminal: the
+            // live input is now authoritative, so a still-in-flight stored-draft
+            // load must not apply over it (see ``applyLoadedDraft``).
+            draftLoadPendingTerminalID = nil
             persistCurrentDraft()
         }
     }
@@ -287,6 +291,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// The draft text of the terminal we are switching away from, captured with
     /// ``draftedOutgoingTerminalID``.
     @ObservationIgnored private var draftedOutgoingText: String = ""
+    /// The terminal whose stored-draft load is still in flight while the field
+    /// shows the transient cleared placeholder. While this matches a terminal,
+    /// the visible field does NOT represent that terminal's draft yet, so a
+    /// switch away from it must not persist the placeholder over its real
+    /// stored draft (the fast A -> B -> C switch erased B's untouched draft).
+    /// Consumed when the load applies; cleared by a user edit, which claims
+    /// field ownership for the selected terminal (live input wins over a late
+    /// load, so deleted text cannot resurrect). Not observed: bookkeeping, not
+    /// view state.
+    @ObservationIgnored private var draftLoadPendingTerminalID: MobileTerminalPreview.ID?
 
     /// Surface IDs whose next window attach must NOT grab the keyboard.
     ///
@@ -2875,6 +2889,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         to incomingID: MobileTerminalPreview.ID?
     ) {
         guard let draftStore else { return }
+        // The field represents the outgoing terminal's draft only when no load
+        // is still pending for it. During a fast A -> B -> C switch, B's load
+        // has not applied yet and the field is the transient cleared
+        // placeholder, not B's draft; persisting it would erase B's real stored
+        // draft. (A user edit clears the pending marker, so an edited field is
+        // always authoritative and still saved.)
+        let outgoingFieldIsAuthoritative = outgoingID != nil && draftLoadPendingTerminalID != outgoingID
+        draftLoadPendingTerminalID = incomingID
         // Clear the field synchronously so the old terminal's text is not briefly
         // shown under the new terminal while its draft loads. Guarded so this
         // clear is not itself saved.
@@ -2884,7 +2906,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             isLoadingDraft = false
         }
         enqueueDraftOperation { [weak self] in
-            if let outgoingID {
+            if let outgoingID, outgoingFieldIsAuthoritative {
                 await draftStore.saveDraft(outgoingText, forTerminalID: outgoingID.rawValue)
             }
             guard let incomingID else { return }
@@ -2895,14 +2917,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Apply a draft fetched off the main actor back into ``terminalInputText``.
     ///
-    /// Applied only if the terminal it was loaded for is still selected (a fast
-    /// re-switch could otherwise drop a stale draft into the wrong terminal) AND the
-    /// field is still empty — i.e. the user has not started typing into the
-    /// freshly-cleared field during the (tiny) async load window. A non-empty field
-    /// means the user is already composing for this terminal, and that live input
-    /// (saved on its own) must win over the stored copy. The restore write is
+    /// Applied only if this load is still the pending one — a fast re-switch
+    /// repoints ``draftLoadPendingTerminalID`` at the newer incoming terminal,
+    /// and a user edit clears it entirely (live input wins, even when the user
+    /// deleted everything: a late load must not resurrect deleted text into the
+    /// deliberately emptied field). The selected-terminal and empty-field
+    /// guards stay as defense in depth for the same races. The restore write is
     /// guarded so it is not re-saved. An empty restored draft is a no-op.
     private func applyLoadedDraft(_ draft: String, forTerminalID terminalID: MobileTerminalPreview.ID) {
+        guard draftLoadPendingTerminalID == terminalID else { return }
+        draftLoadPendingTerminalID = nil
         guard selectedTerminalID == terminalID,
               terminalInputText.isEmpty,
               !draft.isEmpty else { return }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2175,12 +2175,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// the user explicitly dismissed it on this terminal and tapped compose again
     /// — an unambiguous "I want to compose" intent, so it also requests field
     /// focus (the default-open presentation deliberately does not).
-    public func toggleComposer() {
+    /// - Parameter terminalID: The terminal whose composer the caller is acting
+    ///   on (the surface's own id). The focus handshake is keyed to it so the
+    ///   composer view serving that terminal — and only it — consumes the
+    ///   request. `nil` falls back to the selected terminal; the rendered
+    ///   terminal can diverge from the selection (the detail view falls back to
+    ///   the workspace's first terminal), so callers that know their surface
+    ///   should always pass it.
+    public func toggleComposer(forTerminalID terminalID: String? = nil) {
         if isComposerPresented {
             setComposerPresented(false)
         } else {
             setComposerPresented(true)
-            requestComposerFieldFocus()
+            requestComposerFieldFocus(forTerminalID: terminalID)
         }
     }
 
@@ -2193,9 +2200,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// ever raised here (never dismissed), so a still-presented composer and its
     /// draft are preserved; the focus token is always bumped so the field re-focuses
     /// even when the presented flag did not change.
-    public func presentAndFocusComposer() {
+    /// - Parameter terminalID: The terminal whose composer should take focus
+    ///   (the requesting surface's own id); `nil` falls back to the selected
+    ///   terminal. See ``toggleComposer(forTerminalID:)`` for why the explicit
+    ///   id matters.
+    public func presentAndFocusComposer(forTerminalID terminalID: String? = nil) {
         setComposerPresented(true)
-        requestComposerFieldFocus()
+        requestComposerFieldFocus(forTerminalID: terminalID)
     }
 
     /// Explicitly dismiss the iMessage-style composer for the selected terminal,
@@ -2239,11 +2250,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Ask the composer field to take focus: bump the token the mounted view
     /// observes and arm the pending flag a not-yet-mounted view consumes on
-    /// appear, keyed to the currently selected terminal.
-    private func requestComposerFieldFocus() {
+    /// appear, keyed to `terminalID` (`nil` = the currently selected terminal).
+    /// Callers acting on a concrete surface pass that surface's id so the
+    /// request always matches the composer view that will consume it, even
+    /// when the rendered terminal and the store selection diverge.
+    private func requestComposerFieldFocus(forTerminalID terminalID: String? = nil) {
         composerFocusRequest &+= 1
         composerFocusRequestPending = true
-        composerFocusRequestTerminalID = selectedTerminalID?.rawValue
+        composerFocusRequestTerminalID = terminalID ?? selectedTerminalID?.rawValue
     }
 
     /// Single mutation path for the per-terminal presented state (the dismissed

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -214,23 +214,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             persistCurrentDraft()
         }
     }
-    /// Whether the iMessage-style composer is shown above the terminal. Toggled
-    /// from the input accessory bar's composer button and observed by the
-    /// terminal screen to present ``terminalInputText`` for multi-line editing.
-    public var isComposerPresented: Bool = false {
-        didSet {
-            #if DEBUG
-            // COMPOSER: record every flag change (mutated by `toggleComposer`,
-            // `dismissComposer`, and `presentAndFocusComposer`). An unexpected
-            // `a == 0` during a bare keyboard dismiss is the "flag toggled off"
-            // cause of the disappearing draft.
-            diagnosticLog?.record(DiagnosticEvent(
-                .composerPresentedChanged,
-                a: isComposerPresented ? 1 : 0
-            ))
-            #endif
-        }
+    /// Whether the iMessage-style composer is shown above the terminal, observed
+    /// by the terminal screen to present ``terminalInputText`` for multi-line
+    /// editing.
+    ///
+    /// OPEN BY DEFAULT per terminal: like iMessage showing its input bar in every
+    /// conversation, the composer is presented for any selected terminal the user
+    /// has not explicitly dismissed (``composerDismissedTerminalIDs`` records the
+    /// exception, not the rule). Presented does NOT mean focused — the keyboard
+    /// comes up only when the user taps the field or an explicit open/reveal
+    /// requests focus (``composerFocusRequest``). Derived from observable stored
+    /// state (`selectedTerminalID` + the dismissed set), so views tracking it
+    /// re-render on terminal switches and explicit toggles alike.
+    public var isComposerPresented: Bool {
+        guard let terminalID = selectedTerminalID?.rawValue else { return false }
+        return !composerDismissedTerminalIDs.contains(terminalID)
     }
+    /// Terminal IDs whose composer the user explicitly dismissed (the band's
+    /// chevron, or a genuine close from the compose button). Session-only: a
+    /// relaunch returns every terminal to the default-open composer. Stored (not
+    /// `@ObservationIgnored`) so ``isComposerPresented`` is observable through it.
+    private var composerDismissedTerminalIDs: Set<String> = []
     /// Monotonic focus-request token for the iMessage-style composer field.
     ///
     /// The composer's text field owns its first responder via SwiftUI `@FocusState`,
@@ -242,6 +246,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// drives `isFieldFocused = true`, keeping `@FocusState` the single source of truth
     /// for who holds the keyboard.
     public private(set) var composerFocusRequest: Int = 0
+    /// True while a ``composerFocusRequest`` has been issued but not yet consumed
+    /// by the composer field. The field's `onChange` of the token only observes
+    /// bumps that happen while the view is mounted; an explicit open (or a
+    /// terminal switch while composing) bumps the token BEFORE the new composer
+    /// view mounts, so the view's `onAppear` consumes this flag instead
+    /// (``consumePendingComposerFocusRequest()``). Default-open presentations
+    /// never set it, which is exactly what keeps the keyboard down for them.
+    /// Not observed: a handshake with the field, not view state.
+    @ObservationIgnored private var composerFocusRequestPending = false
+    /// Whether the composer's text field currently holds first responder,
+    /// mirrored from the view's `@FocusState` via
+    /// ``composerFieldFocusChanged(_:)``. Read on terminal switches to decide
+    /// whether the incoming terminal's composer should re-take focus (keeping the
+    /// keyboard up across a switch mid-compose) — without it, every switch would
+    /// either pop the keyboard (always refocus) or drop it (never refocus).
+    /// Cleared explicitly on dismiss because the unmounting field does not
+    /// reliably deliver its final unfocus change. Not observed: bookkeeping for
+    /// the switch decision, not view state.
+    @ObservationIgnored private var composerFieldIsFocused = false
     /// Guards ``submitComposerInput()`` against re-entrancy. A quick double tap
     /// on Send would otherwise start two sends that both capture the same text
     /// (the field is cleared only on ack), pasting the message to the agent
@@ -266,6 +289,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             swapDraft(from: draftedOutgoingTerminalID, outgoingText: draftedOutgoingText, to: selectedTerminalID)
             draftedOutgoingTerminalID = nil
             draftedOutgoingText = ""
+            // Switching terminals rebuilds the surface (and the composer view with
+            // it). When the user was actively composing — the field held first
+            // responder at the moment of the switch — ask the incoming terminal's
+            // composer to re-take focus so the keyboard hands over in place
+            // instead of dropping. A default-open-but-unfocused composer issues no
+            // request, so a mere switch never pops the keyboard.
+            if composerFieldIsFocused, isComposerPresented {
+                requestComposerFieldFocus()
+            }
         }
     }
 
@@ -2093,8 +2125,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     /// Show or hide the iMessage-style composer from the input accessory bar.
+    ///
+    /// With the composer open by default, the OPEN branch is reached only after
+    /// the user explicitly dismissed it on this terminal and tapped compose again
+    /// — an unambiguous "I want to compose" intent, so it also requests field
+    /// focus (the default-open presentation deliberately does not).
     public func toggleComposer() {
-        isComposerPresented.toggle()
+        if isComposerPresented {
+            setComposerPresented(false)
+        } else {
+            setComposerPresented(true)
+            requestComposerFieldFocus()
+        }
     }
 
     /// Ensure the composer is presented and ask its field to take focus, without ever
@@ -2102,15 +2144,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ///
     /// Drives the reveal-and-focus path: the surface invokes this when the user taps
     /// the compose button (or reveals the chrome) while a composer is already
-    /// logically presented but suppressed or unfocused. `isComposerPresented` is only
-    /// set to `true` (never toggled off here), so a still-presented composer and its
+    /// logically presented but suppressed or unfocused. The presented state is only
+    /// ever raised here (never dismissed), so a still-presented composer and its
     /// draft are preserved; the focus token is always bumped so the field re-focuses
     /// even when the presented flag did not change.
     public func presentAndFocusComposer() {
-        if !isComposerPresented {
-            isComposerPresented = true
-        }
-        composerFocusRequest &+= 1
+        setComposerPresented(true)
+        requestComposerFieldFocus()
     }
 
     /// Dismiss the iMessage-style composer if it is open. Used when the user hides
@@ -2119,7 +2159,62 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// closed.
     public func dismissComposer() {
         guard isComposerPresented else { return }
-        isComposerPresented = false
+        setComposerPresented(false)
+    }
+
+    /// Mirror of the composer field's `@FocusState`, reported by
+    /// ``TerminalComposerView`` on every focus change. See
+    /// ``composerFieldIsFocused`` for what reads it.
+    public func composerFieldFocusChanged(_ focused: Bool) {
+        composerFieldIsFocused = focused
+    }
+
+    /// Consume the one-shot "focus the composer field" handshake, returning
+    /// whether a request was pending. The composer view calls this from
+    /// `onAppear` (a mount that follows an explicit open or a mid-compose
+    /// terminal switch) and from its `onChange` of ``composerFocusRequest`` (a
+    /// bump while already mounted), so a request is honored exactly once and a
+    /// later default-open remount never re-pops the keyboard.
+    public func consumePendingComposerFocusRequest() -> Bool {
+        defer { composerFocusRequestPending = false }
+        return composerFocusRequestPending
+    }
+
+    /// Ask the composer field to take focus: bump the token the mounted view
+    /// observes and arm the pending flag a not-yet-mounted view consumes on
+    /// appear.
+    private func requestComposerFieldFocus() {
+        composerFocusRequest &+= 1
+        composerFocusRequestPending = true
+    }
+
+    /// Single mutation path for the per-terminal presented state (the dismissed
+    /// set): both explicit transitions land here so the DEBUG diagnostic records
+    /// every flag change, exactly like the old stored property's `didSet`. A
+    /// no-op without a selected terminal (there is nothing to compose to) or
+    /// when the state already matches.
+    private func setComposerPresented(_ presented: Bool) {
+        guard let terminalID = selectedTerminalID?.rawValue,
+              presented != isComposerPresented else { return }
+        if presented {
+            composerDismissedTerminalIDs.remove(terminalID)
+        } else {
+            composerDismissedTerminalIDs.insert(terminalID)
+            // The band (and its field) unmounts with the dismissal; the dying
+            // field does not reliably deliver a final unfocus change, so clear
+            // the mirror here to never leave a stale "field owns the keyboard".
+            composerFieldIsFocused = false
+        }
+        #if DEBUG
+        // COMPOSER: record every flag change (mutated by `toggleComposer`,
+        // `dismissComposer`, and `presentAndFocusComposer`). An unexpected
+        // `a == 0` during a bare keyboard dismiss is the "flag toggled off"
+        // cause of the disappearing draft.
+        diagnosticLog?.record(DiagnosticEvent(
+            .composerPresentedChanged,
+            a: presented ? 1 : 0
+        ))
+        #endif
     }
 
     /// Submit the composer's text to the selected terminal as a bracketed paste

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -340,6 +340,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// exactly the order they were issued from the main actor. Not observed: it
     /// sequences async work, not view state.
     @ObservationIgnored private var draftOperationTail: Task<Void, Never>?
+    /// Latest unflushed keystroke draft per terminal (see
+    /// ``persistCurrentDraft()``). Keystroke saves coalesce here: each edit
+    /// overwrites the terminal's entry and at most ONE flush task per terminal
+    /// is queued on the pipeline, reading the entry at execution time. A typing
+    /// burst behind a slow store therefore retains one latest snapshot per
+    /// terminal instead of one snapshot per edit. Not observed: it buffers
+    /// writes, not view state.
+    @ObservationIgnored private var pendingDraftSaveTextByTerminalID: [String: String] = [:]
     /// The terminal id we are switching away from, captured in
     /// ``selectedTerminalID``'s `willSet` so its draft is saved under the right key.
     @ObservationIgnored private var draftedOutgoingTerminalID: MobileTerminalPreview.ID?
@@ -642,6 +650,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         if let draftStore {
             enqueueDraftOperation { await draftStore.clearAllDrafts() }
         }
+        // Drop unflushed keystroke snapshots too: an armed flush that runs
+        // before the wipe would only write text the wipe then deletes, but the
+        // buffer itself must not carry one account's text into the next.
+        pendingDraftSaveTextByTerminalID = [:]
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -2970,8 +2982,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// or superseded drafts never win over newer state, and nothing written
     /// before sign-out survives the sign-out wipe.
     ///
-    /// Operations are tiny (one actor dictionary access); only the tail task is
-    /// retained, so the chain does not grow under typing bursts.
+    /// Operations are tiny (one actor dictionary access) and keystroke saves
+    /// coalesce before they reach the pipeline (see ``persistCurrentDraft()``),
+    /// so the chain stays short and bounded under typing bursts; only the tail
+    /// task is retained.
     @discardableResult
     private func enqueueDraftOperation(
         _ operation: @escaping @Sendable () async -> Void
@@ -2994,10 +3008,32 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Save the live ``terminalInputText`` under the currently selected
     /// terminal. Called from the field's `didSet`. A no-op when there is no
     /// selected terminal (nothing to key the draft to) or no draft store wired.
+    ///
+    /// Saves COALESCE per terminal: the edit overwrites the terminal's entry in
+    /// ``pendingDraftSaveTextByTerminalID`` and queues a flush only when none is
+    /// already queued for that terminal. The flush reads the LATEST entry when
+    /// it executes, so a typing burst behind a slow store applies as one save of
+    /// the final text instead of queuing every intermediate snapshot (whose
+    /// retained memory would otherwise grow as edits × draft size). Barrier
+    /// operations (the switch save/load, the post-send clear, the sign-out wipe)
+    /// still order strictly after any queued flush via the shared FIFO.
     private func persistCurrentDraft() {
         guard let draftStore, let terminalID = selectedTerminalID?.rawValue else { return }
-        let text = terminalInputText
-        enqueueDraftOperation { await draftStore.saveDraft(text, forTerminalID: terminalID) }
+        let flushAlreadyQueued = pendingDraftSaveTextByTerminalID[terminalID] != nil
+        pendingDraftSaveTextByTerminalID[terminalID] = terminalInputText
+        guard !flushAlreadyQueued else { return }
+        enqueueDraftOperation { [weak self] in
+            guard let text = await self?.takePendingDraftSave(forTerminalID: terminalID) else { return }
+            await draftStore.saveDraft(text, forTerminalID: terminalID)
+        }
+    }
+
+    /// Dequeue the latest unflushed keystroke draft for `terminalID`, clearing
+    /// its entry so the next edit arms a fresh flush. Called by the queued flush
+    /// at execution time, so it always saves the newest text.
+    private func takePendingDraftSave(forTerminalID terminalID: String) -> String? {
+        defer { pendingDraftSaveTextByTerminalID[terminalID] = nil }
+        return pendingDraftSaveTextByTerminalID[terminalID]
     }
 
     /// Swap the composer draft when the selected terminal changes: save the

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -654,6 +654,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // before the wipe would only write text the wipe then deletes, but the
         // buffer itself must not carry one account's text into the next.
         pendingDraftSaveTextByTerminalID = [:]
+        // Per-terminal composer dismissals are this user's session UI state; the
+        // next account starts with the default-open composer everywhere. Clear
+        // the focus mirror BEFORE the selection resets below so the terminal
+        // switch they trigger cannot arm a stale focus request.
+        composerDismissedTerminalIDs = []
+        composerFieldIsFocused = false
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -2188,10 +2194,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         requestComposerFieldFocus()
     }
 
-    /// Dismiss the iMessage-style composer if it is open. Used when the user hides
-    /// the keyboard while composing, so the composer can never be left presented
-    /// with the keyboard down. Idempotent: a no-op when the composer is already
-    /// closed.
+    /// Explicitly dismiss the iMessage-style composer for the selected terminal,
+    /// recording the dismissal for the session. This is the explicit-close API
+    /// (hosts and tests); the user-facing closes go through ``toggleComposer()``.
+    /// The keyboard collapsing never dismisses the composer (Round 8): the band
+    /// survives a keyboard-down and only the chevron / compose toggle closes it.
+    /// Idempotent: a no-op when the composer is already closed.
     public func dismissComposer() {
         guard isComposerPresented else { return }
         setComposerPresented(false)

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -257,10 +257,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// bumps that happen while the view is mounted; an explicit open (or a
     /// terminal switch while composing) bumps the token BEFORE the new composer
     /// view mounts, so the view's `onAppear` consumes this flag instead
-    /// (``consumePendingComposerFocusRequest()``). Default-open presentations
+    /// (``consumePendingComposerFocusRequest(for:)``). Default-open presentations
     /// never set it, which is exactly what keeps the keyboard down for them.
     /// Not observed: a handshake with the field, not view state.
     @ObservationIgnored private var composerFocusRequestPending = false
+    /// The terminal the pending ``composerFocusRequest`` targets (the selected
+    /// terminal at the moment the request was issued). Consumption is keyed on
+    /// it: during a terminal switch the OUTGOING composer view is still mounted
+    /// and observes the same token, so an unkeyed pending bit could be consumed
+    /// by the dying view and the incoming terminal's field would never focus.
+    @ObservationIgnored private var composerFocusRequestTerminalID: String?
     /// Whether the composer's text field currently holds first responder,
     /// mirrored from the view's `@FocusState` via
     /// ``composerFieldFocusChanged(_:)``. Read on terminal switches to decide
@@ -308,6 +314,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // request, so a mere switch never pops the keyboard.
             if composerFieldIsFocused, isComposerPresented {
                 requestComposerFieldFocus()
+            } else {
+                // Any switch that does not arm a new handshake invalidates a
+                // stale unconsumed one, so a plain switch back to a terminal
+                // can never pop the keyboard off an old request.
+                composerFocusRequestPending = false
+                composerFocusRequestTerminalID = nil
             }
         }
     }
@@ -2180,23 +2192,34 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         composerFieldIsFocused = focused
     }
 
-    /// Consume the one-shot "focus the composer field" handshake, returning
-    /// whether a request was pending. The composer view calls this from
-    /// `onAppear` (a mount that follows an explicit open or a mid-compose
-    /// terminal switch) and from its `onChange` of ``composerFocusRequest`` (a
-    /// bump while already mounted), so a request is honored exactly once and a
-    /// later default-open remount never re-pops the keyboard.
-    public func consumePendingComposerFocusRequest() -> Bool {
-        defer { composerFocusRequestPending = false }
-        return composerFocusRequestPending
+    /// Consume the one-shot "focus the composer field" handshake for the
+    /// composer serving `terminalID`, returning whether a pending request
+    /// targeted that terminal. The composer view calls this from `onAppear` (a
+    /// mount that follows an explicit open or a mid-compose terminal switch)
+    /// and from its `onChange` of ``composerFocusRequest`` (a bump while
+    /// already mounted), so a request is honored exactly once and a later
+    /// default-open remount never re-pops the keyboard.
+    ///
+    /// Keyed on the target terminal: during a terminal switch the outgoing
+    /// composer view is still mounted and observes the same token bump, so a
+    /// mismatched consume returns `false` and leaves the request armed for the
+    /// incoming terminal's mount.
+    public func consumePendingComposerFocusRequest(for terminalID: String) -> Bool {
+        guard composerFocusRequestPending, composerFocusRequestTerminalID == terminalID else {
+            return false
+        }
+        composerFocusRequestPending = false
+        composerFocusRequestTerminalID = nil
+        return true
     }
 
     /// Ask the composer field to take focus: bump the token the mounted view
     /// observes and arm the pending flag a not-yet-mounted view consumes on
-    /// appear.
+    /// appear, keyed to the currently selected terminal.
     private func requestComposerFieldFocus() {
         composerFocusRequest &+= 1
         composerFocusRequestPending = true
+        composerFocusRequestTerminalID = selectedTerminalID?.rawValue
     }
 
     /// Single mutation path for the per-terminal presented state (the dismissed

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3219,7 +3219,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard generation == connectionGeneration else { return false }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return false }
             markMacConnectionUnavailableIfNeeded(after: error)
-            connectionError = Self.localizedConnectionError(for: error)
+            applyOperationalError(error)
             return false
         }
     }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -189,13 +189,99 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// route falls back to email rather than failing with `method_not_found`
     /// under client/server version skew.
     public private(set) var supportsDogfoodFeedback: Bool = false
-    public var terminalInputText: String
+    public var terminalInputText: String {
+        didSet {
+            #if DEBUG
+            // COMPOSER: record every draft change so a captured trace shows whether
+            // the draft was cleared at the store (b == 1) during a keyboard-dismiss
+            // cycle, vs. only disappearing from the view. `didSet` does not fire on
+            // the `init` assignment, so this is safe to read `diagnosticLog`.
+            diagnosticLog?.record(DiagnosticEvent(
+                .composerInputTextChanged,
+                a: terminalInputText.utf8.count,
+                b: terminalInputText.isEmpty ? 1 : 0
+            ))
+            #endif
+            // Persist the live edit under the CURRENT terminal so it survives a
+            // terminal switch. Skipped while a draft is being loaded (the load is
+            // the saved value, re-saving it is redundant and would race the
+            // per-terminal key swap) and when the value is unchanged.
+            guard !isLoadingDraft, terminalInputText != oldValue else { return }
+            persistCurrentDraft()
+        }
+    }
+    /// Whether the iMessage-style composer is shown above the terminal. Toggled
+    /// from the input accessory bar's composer button and observed by the
+    /// terminal screen to present ``terminalInputText`` for multi-line editing.
+    public var isComposerPresented: Bool = false {
+        didSet {
+            #if DEBUG
+            // COMPOSER: record every flag change (mutated by `toggleComposer`,
+            // `dismissComposer`, and `presentAndFocusComposer`). An unexpected
+            // `a == 0` during a bare keyboard dismiss is the "flag toggled off"
+            // cause of the disappearing draft.
+            diagnosticLog?.record(DiagnosticEvent(
+                .composerPresentedChanged,
+                a: isComposerPresented ? 1 : 0
+            ))
+            #endif
+        }
+    }
+    /// Monotonic focus-request token for the iMessage-style composer field.
+    ///
+    /// The composer's text field owns its first responder via SwiftUI `@FocusState`,
+    /// which neither the terminal surface nor the representable coordinator can set
+    /// directly. When the surface needs the field re-focused without re-presenting the
+    /// composer — the reveal-after-hide case, where the chrome and draft are already
+    /// back but the terminal proxy stole first responder — it bumps this token through
+    /// ``presentAndFocusComposer()``. ``TerminalComposerView`` observes the change and
+    /// drives `isFieldFocused = true`, keeping `@FocusState` the single source of truth
+    /// for who holds the keyboard.
+    public private(set) var composerFocusRequest: Int = 0
+    /// Guards ``submitComposerInput()`` against re-entrancy. A quick double tap
+    /// on Send would otherwise start two sends that both capture the same text
+    /// (the field is cleared only on ack), pasting the message to the agent
+    /// twice. Not observed: it gates an async flow, not view state.
+    @ObservationIgnored private var isSubmittingComposerInput = false
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             syncSelectedTerminalForWorkspace()
         }
     }
-    public var selectedTerminalID: MobileTerminalPreview.ID?
+    public var selectedTerminalID: MobileTerminalPreview.ID? {
+        willSet {
+            // Capture the draft of the terminal we are leaving BEFORE the new id
+            // lands, so `swapDraft(from:to:)` can persist it under the correct
+            // (old) key. A no-op when the id is unchanged.
+            guard newValue != selectedTerminalID else { return }
+            draftedOutgoingTerminalID = selectedTerminalID
+            draftedOutgoingText = terminalInputText
+        }
+        didSet {
+            guard selectedTerminalID != oldValue else { return }
+            swapDraft(from: draftedOutgoingTerminalID, outgoingText: draftedOutgoingText, to: selectedTerminalID)
+            draftedOutgoingTerminalID = nil
+            draftedOutgoingText = ""
+        }
+    }
+
+    /// The per-terminal composer-draft seam. `nil` in previews/tests that do not
+    /// exercise drafts; every draft hook is then a no-op and the in-memory
+    /// ``terminalInputText`` behaves exactly as before. Injected from the app
+    /// composition root.
+    private let draftStore: (any TerminalDraftStoring)?
+
+    /// True while a saved draft is being loaded INTO ``terminalInputText``, so
+    /// its `didSet` does not immediately re-save the just-loaded value (which
+    /// would also race the key swap). Not observed: it gates a write, not view
+    /// state.
+    @ObservationIgnored private var isLoadingDraft = false
+    /// The terminal id we are switching away from, captured in
+    /// ``selectedTerminalID``'s `willSet` so its draft is saved under the right key.
+    @ObservationIgnored private var draftedOutgoingTerminalID: MobileTerminalPreview.ID?
+    /// The draft text of the terminal we are switching away from, captured with
+    /// ``draftedOutgoingTerminalID``.
+    @ObservationIgnored private var draftedOutgoingText: String = ""
 
     /// Surface IDs whose next window attach must NOT grab the keyboard.
     ///
@@ -359,9 +445,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         analytics: any AnalyticsEmitting = NoopAnalytics(),
         diagnosticLog: DiagnosticLog? = nil,
         feedbackEmailSubmitter: (any MobileFeedbackEmailSubmitting)? = nil,
-        feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp }
+        feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
+        draftStore: (any TerminalDraftStoring)? = nil
     ) {
         self.runtime = runtime
+        self.draftStore = draftStore
         self.pairedMacStore = pairedMacStore
         self.deviceRegistry = deviceRegistry
         self.identityProvider = identityProvider
@@ -468,7 +556,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         macConnectionStatus = .unavailable
         connectedHostName = ""
         pairingCode = ""
+        // Wipe every saved draft so the next account never sees the previous
+        // user's unsent text. Guard the in-memory clear (and the selection resets
+        // below) so the per-terminal draft hooks do not write partial state into a
+        // store we are about to empty wholesale.
+        isLoadingDraft = true
         terminalInputText = ""
+        draftStore.map { store in Task { await store.clearAllDrafts() } }
         clearPairingError()
         activeTicket = nil
         activeRoute = nil
@@ -492,6 +586,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         workspaces = PreviewMobileHost.workspaces
         selectedWorkspaceID = workspaces.first?.id
         selectedTerminalID = workspaces.first?.terminals.first?.id
+        // Selection resets above are done; allow draft saving again so a
+        // subsequent sign-in restores drafts normally.
+        isLoadingDraft = false
     }
 
     public func resumeForegroundRefresh() {
@@ -1971,6 +2068,64 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         await sendRemoteTerminalInput(text + "\r")
     }
 
+    /// Show or hide the iMessage-style composer from the input accessory bar.
+    public func toggleComposer() {
+        isComposerPresented.toggle()
+    }
+
+    /// Ensure the composer is presented and ask its field to take focus, without ever
+    /// dismissing it.
+    ///
+    /// Drives the reveal-and-focus path: the surface invokes this when the user taps
+    /// the compose button (or reveals the chrome) while a composer is already
+    /// logically presented but suppressed or unfocused. `isComposerPresented` is only
+    /// set to `true` (never toggled off here), so a still-presented composer and its
+    /// draft are preserved; the focus token is always bumped so the field re-focuses
+    /// even when the presented flag did not change.
+    public func presentAndFocusComposer() {
+        if !isComposerPresented {
+            isComposerPresented = true
+        }
+        composerFocusRequest &+= 1
+    }
+
+    /// Dismiss the iMessage-style composer if it is open. Used when the user hides
+    /// the keyboard while composing, so the composer can never be left presented
+    /// with the keyboard down. Idempotent: a no-op when the composer is already
+    /// closed.
+    public func dismissComposer() {
+        guard isComposerPresented else { return }
+        isComposerPresented = false
+    }
+
+    /// Submit the composer's text to the selected terminal as a bracketed paste
+    /// plus a single Return, then clear the field while keeping the composer
+    /// open. Unlike ``submitTerminalInput()``, this delivers a multi-line block
+    /// as one paste + one submit (via `terminal.paste`) so interior newlines do
+    /// not fragment into multiple submissions in a TUI agent.
+    ///
+    /// The field is cleared only after the Mac acknowledges the paste. If the
+    /// send fails (no connection, or an older host that does not implement
+    /// `terminal.paste` and answers `method_not_found`), the composed text is
+    /// kept so the user can retry instead of silently losing the message.
+    public func submitComposerInput() async {
+        let text = terminalInputText
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard remoteClient != nil else { return }
+        // Reject a re-entrant send (e.g. a double tap on Send) so the same text
+        // is not pasted twice. The flag is set/cleared on the main actor around
+        // the await, so no second call can slip past it.
+        guard !isSubmittingComposerInput else { return }
+        isSubmittingComposerInput = true
+        defer { isSubmittingComposerInput = false }
+        let sent = await sendRemoteTerminalPaste(text, submitKey: "return")
+        // Only clear if the field still holds exactly what we sent, so a value
+        // the user typed while the send was in flight is not discarded.
+        if sent, terminalInputText == text {
+            terminalInputText = ""
+        }
+    }
+
     public func sendTerminalRawInput(_ text: String) {
         #if DEBUG
         mobileShellLog.debug("enqueue raw terminal input byteCount=\(text.utf8.count, privacy: .public)")
@@ -2601,6 +2756,71 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         selectedTerminalID = selectedWorkspace.preferredTerminal?.id
     }
 
+    // MARK: - Per-terminal composer drafts
+
+    /// Save the live ``terminalInputText`` under the currently selected
+    /// terminal. Called from the field's `didSet`. A no-op when there is no
+    /// selected terminal (nothing to key the draft to) or no draft store wired.
+    private func persistCurrentDraft() {
+        guard let draftStore, let terminalID = selectedTerminalID?.rawValue else { return }
+        let text = terminalInputText
+        Task { await draftStore.saveDraft(text, forTerminalID: terminalID) }
+    }
+
+    /// Swap the composer draft when the selected terminal changes: save the
+    /// outgoing terminal's text under its own key, then load the incoming
+    /// terminal's saved draft into ``terminalInputText``.
+    ///
+    /// The load is guarded by ``isLoadingDraft`` so the field's `didSet` does not
+    /// re-save the just-loaded value (and so the load can't race the key swap).
+    /// While the incoming draft is fetched asynchronously the field is cleared, so
+    /// the previous terminal's text never bleeds into a terminal that has no draft.
+    /// - Parameters:
+    ///   - outgoingID: The terminal being switched away from, or `nil`.
+    ///   - outgoingText: That terminal's draft text at the moment of the switch.
+    ///   - incomingID: The terminal being switched to, or `nil`.
+    private func swapDraft(
+        from outgoingID: MobileTerminalPreview.ID?,
+        outgoingText: String,
+        to incomingID: MobileTerminalPreview.ID?
+    ) {
+        guard let draftStore else { return }
+        // Clear the field synchronously so the old terminal's text is not briefly
+        // shown under the new terminal while its draft loads. Guarded so this
+        // clear is not itself saved.
+        if !terminalInputText.isEmpty {
+            isLoadingDraft = true
+            terminalInputText = ""
+            isLoadingDraft = false
+        }
+        Task { [weak self] in
+            if let outgoingID {
+                await draftStore.saveDraft(outgoingText, forTerminalID: outgoingID.rawValue)
+            }
+            guard let incomingID else { return }
+            let restored = await draftStore.draft(forTerminalID: incomingID.rawValue) ?? ""
+            await self?.applyLoadedDraft(restored, forTerminalID: incomingID)
+        }
+    }
+
+    /// Apply a draft fetched off the main actor back into ``terminalInputText``.
+    ///
+    /// Applied only if the terminal it was loaded for is still selected (a fast
+    /// re-switch could otherwise drop a stale draft into the wrong terminal) AND the
+    /// field is still empty — i.e. the user has not started typing into the
+    /// freshly-cleared field during the (tiny) async load window. A non-empty field
+    /// means the user is already composing for this terminal, and that live input
+    /// (saved on its own) must win over the stored copy. The restore write is
+    /// guarded so it is not re-saved. An empty restored draft is a no-op.
+    private func applyLoadedDraft(_ draft: String, forTerminalID terminalID: MobileTerminalPreview.ID) {
+        guard selectedTerminalID == terminalID,
+              terminalInputText.isEmpty,
+              !draft.isEmpty else { return }
+        isLoadingDraft = true
+        terminalInputText = draft
+        isLoadingDraft = false
+    }
+
     private func viewportKey(
         workspaceID: MobileWorkspacePreview.ID,
         terminalID: MobileTerminalPreview.ID
@@ -2720,6 +2940,78 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
             markMacConnectionUnavailableIfNeeded(after: error)
             applyOperationalError(error)
+        }
+    }
+
+    /// - Returns: `true` when the Mac acknowledged the paste, `false` when there
+    ///   is no selected workspace/terminal or the send failed.
+    @discardableResult
+    private func sendRemoteTerminalPaste(_ text: String, submitKey: String) async -> Bool {
+        guard let workspaceID = selectedWorkspace?.id,
+              let terminalID = selectedTerminalID else {
+            #if DEBUG
+            mobileShellLog.info("skip remote terminal paste selectedWorkspace=\(self.selectedWorkspace == nil ? 0 : 1, privacy: .public) selectedTerminal=\(self.selectedTerminalID == nil ? 0 : 1, privacy: .public)")
+            #endif
+            return false
+        }
+        return await sendRemoteTerminalPaste(text, submitKey: submitKey, workspaceID: workspaceID, terminalID: terminalID)
+    }
+
+    /// Deliver a composed block to the Mac surface via `terminal.paste`: a
+    /// bracketed paste (so multi-line text is inserted as one literal block)
+    /// followed by an optional submit key. Mirrors ``sendRemoteTerminalInput(_:workspaceID:terminalID:)``
+    /// but takes the dedicated paste path instead of the raw `terminal.input`
+    /// path, which rewrites newlines to carriage returns.
+    ///
+    /// - Returns: `true` when the Mac acknowledged the paste, `false` on any
+    ///   failure (no client, a stale generation, or an RPC error such as
+    ///   `method_not_found` from an older host). Callers use this to keep the
+    ///   composer text on failure instead of clearing it optimistically.
+    @discardableResult
+    private func sendRemoteTerminalPaste(
+        _ text: String,
+        submitKey: String,
+        workspaceID: MobileWorkspacePreview.ID,
+        terminalID: MobileTerminalPreview.ID
+    ) async -> Bool {
+        guard let client = remoteClient else {
+            #if DEBUG
+            mobileShellLog.info("skip remote terminal paste remoteClient=0")
+            #endif
+            return false
+        }
+        let generation = connectionGeneration
+        do {
+            #if DEBUG
+            mobileShellLog.debug("send remote terminal paste byteCount=\(text.utf8.count, privacy: .public) submit=\(submitKey, privacy: .public) workspace=\(workspaceID.rawValue, privacy: .private) terminal=\(terminalID.rawValue, privacy: .private)")
+            #endif
+            let key = viewportKey(workspaceID: workspaceID, terminalID: terminalID)
+            var params: [String: Any] = [
+                "workspace_id": workspaceID.rawValue,
+                "surface_id": terminalID.rawValue,
+                "text": text,
+                "submit_key": submitKey,
+                "client_id": clientID,
+            ]
+            if let viewportSize = reportedViewportSizesByTerminalKey[key] {
+                params["viewport_columns"] = viewportSize.columns
+                params["viewport_rows"] = viewportSize.rows
+            }
+            let responseData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "terminal.paste",
+                    params: params
+                )
+            )
+            guard isCurrentRemoteOperation(client: client, generation: generation) else { return false }
+            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+            return true
+        } catch {
+            guard generation == connectionGeneration else { return false }
+            guard !disconnectForAuthorizationFailureIfNeeded(error) else { return false }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            connectionError = Self.localizedConnectionError(for: error)
+            return false
         }
     }
 

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalDraftStoring.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/TerminalDraftStoring.swift
@@ -1,0 +1,46 @@
+/// Persistence seam for per-terminal composer drafts.
+///
+/// A draft is the unsent text the user has typed for one terminal. Drafts are
+/// keyed by the terminal's stable id (``MobileTerminalPreview/ID/rawValue``) so
+/// switching terminals shows that terminal's own draft. How long a draft
+/// survives is the conforming store's choice: the in-memory store keeps drafts
+/// for the app session; a disk-backed store (landing separately) extends them
+/// across an app kill/relaunch.
+///
+/// The shell (``MobileShellComposite``) owns one of these and calls it when the
+/// selected terminal changes, when a draft edit lands, and when a draft is sent
+/// or the user signs out. Injected as `any TerminalDraftStoring` so tests pass a
+/// fake without touching the user's container.
+///
+/// ## Concurrency
+///
+/// All methods are `async` so a conforming type can serialize its state (and any
+/// I/O) on an `actor` and stay off the main thread. The shell awaits a `load`
+/// before showing a terminal's draft and fires `save`/`clear` without awaiting
+/// (the in-memory ``MobileShellComposite/terminalInputText`` is the live value;
+/// the store is the per-terminal mirror).
+public protocol TerminalDraftStoring: Sendable {
+    /// The persisted draft for `terminalID`, or `nil` if none was saved.
+    /// - Parameter terminalID: The terminal's stable id raw string.
+    /// - Returns: The saved draft text, or `nil` when absent or unreadable.
+    func draft(forTerminalID terminalID: String) async -> String?
+
+    /// Persist (or, for an empty/whitespace draft, remove) the draft for
+    /// `terminalID`.
+    ///
+    /// An empty or whitespace-only draft is treated as "no draft" and removed, so
+    /// a cleared field never resurrects on relaunch and the store does not
+    /// accumulate empty entries.
+    /// - Parameters:
+    ///   - draft: The draft text to persist.
+    ///   - terminalID: The terminal's stable id raw string.
+    func saveDraft(_ draft: String, forTerminalID terminalID: String) async
+
+    /// Remove the persisted draft for `terminalID` (e.g. after it was sent).
+    /// - Parameter terminalID: The terminal's stable id raw string.
+    func clearDraft(forTerminalID terminalID: String) async
+
+    /// Remove every persisted draft (e.g. on sign-out, so the next account never
+    /// sees the previous user's unsent text).
+    func clearAllDrafts() async
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+import CmuxMobileShellModel
+
+/// Behavior tests for the composer's default-open presentation: like iMessage's
+/// always-present input bar, the composer is presented for every terminal the
+/// user has not explicitly dismissed, presented never implies focused (the
+/// keyboard stays down until an explicit focus request), and dismissal is
+/// remembered per terminal for the session.
+@MainActor
+@Suite struct ComposerDefaultOpenTests {
+    @Test func composerIsPresentedByDefaultForSelectedTerminal() {
+        let store = MobileShellComposite.preview()
+
+        #expect(store.selectedTerminalID != nil)
+        #expect(store.isComposerPresented)
+        // The default presentation never asks the field to take focus: the band
+        // shows with the keyboard down (iMessage's unfocused input bar).
+        #expect(store.consumePendingComposerFocusRequest() == false)
+    }
+
+    @Test func composerIsNotPresentedWithoutASelectedTerminal() {
+        let store = MobileShellComposite.preview()
+
+        store.selectedTerminalID = nil
+
+        #expect(store.isComposerPresented == false)
+    }
+
+    @Test func dismissalIsRememberedPerTerminalAcrossSwitches() {
+        let store = MobileShellComposite.preview()
+        let first = try! #require(store.selectedTerminalID)
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+
+        store.dismissComposer()
+        #expect(store.isComposerPresented == false)
+
+        // Another terminal still gets the default-open composer.
+        store.selectedTerminalID = second
+        #expect(store.isComposerPresented)
+
+        // Switching back honors the remembered dismissal for the first terminal.
+        store.selectedTerminalID = first
+        #expect(store.isComposerPresented == false)
+    }
+
+    @Test func explicitOpenAfterDismissalRequestsFieldFocus() {
+        let store = MobileShellComposite.preview()
+        store.dismissComposer()
+        let tokenBefore = store.composerFocusRequest
+
+        // The compose button's genuine OPEN (only reachable after a dismissal
+        // with open-by-default) is an unambiguous typing intent: it re-presents
+        // AND asks the field to take focus.
+        store.toggleComposer()
+
+        #expect(store.isComposerPresented)
+        #expect(store.composerFocusRequest > tokenBefore)
+        #expect(store.consumePendingComposerFocusRequest())
+        // The handshake is one-shot: a later default-open remount must not
+        // re-consume the same request and pop the keyboard again.
+        #expect(store.consumePendingComposerFocusRequest() == false)
+    }
+
+    @Test func toggleClosesAPresentedComposer() {
+        let store = MobileShellComposite.preview()
+
+        #expect(store.isComposerPresented)
+        store.toggleComposer()
+        #expect(store.isComposerPresented == false)
+    }
+
+    @Test func presentAndFocusRevivesADismissedComposer() {
+        let store = MobileShellComposite.preview()
+        store.dismissComposer()
+
+        store.presentAndFocusComposer()
+
+        #expect(store.isComposerPresented)
+        #expect(store.consumePendingComposerFocusRequest())
+    }
+
+    @Test func terminalSwitchWhileFieldFocusedRequestsRefocus() {
+        let store = MobileShellComposite.preview()
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+        // The composer view mirrors its @FocusState into the store; mid-compose
+        // the field owns the keyboard.
+        store.composerFieldFocusChanged(true)
+        let tokenBefore = store.composerFocusRequest
+
+        store.selectedTerminalID = second
+
+        // The incoming terminal's composer is asked to re-take focus so the
+        // keyboard hands over in place instead of dropping.
+        #expect(store.composerFocusRequest > tokenBefore)
+        #expect(store.consumePendingComposerFocusRequest())
+    }
+
+    @Test func terminalSwitchWhileFieldUnfocusedDoesNotRequestFocus() {
+        let store = MobileShellComposite.preview()
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+        store.composerFieldFocusChanged(false)
+        let tokenBefore = store.composerFocusRequest
+
+        store.selectedTerminalID = second
+
+        // A mere switch with the default-open (unfocused) composer must never
+        // pop the keyboard.
+        #expect(store.composerFocusRequest == tokenBefore)
+        #expect(store.consumePendingComposerFocusRequest() == false)
+    }
+
+    @Test func dismissClearsTheFieldFocusMirror() {
+        let store = MobileShellComposite.preview()
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+        store.composerFieldFocusChanged(true)
+
+        // Dismissing unmounts the field, which does not reliably deliver a final
+        // unfocus change; the store clears the mirror itself so a later terminal
+        // switch does not see a stale "field owns the keyboard" and refocus.
+        store.dismissComposer()
+        store.presentAndFocusComposer()
+        _ = store.consumePendingComposerFocusRequest()
+        let tokenBefore = store.composerFocusRequest
+
+        store.selectedTerminalID = second
+
+        #expect(store.composerFocusRequest == tokenBefore)
+        #expect(store.consumePendingComposerFocusRequest() == false)
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -64,6 +64,19 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue) == false)
     }
 
+    @Test func signOutForgetsComposerDismissals() {
+        let store = MobileShellComposite.preview()
+        store.dismissComposer()
+        #expect(store.isComposerPresented == false)
+
+        // Sign-out resets to the preview workspaces with the SAME terminal ids;
+        // the next account must get the default-open composer everywhere, not
+        // inherit the previous user's per-terminal dismissals.
+        store.signOut()
+
+        #expect(store.isComposerPresented)
+    }
+
     @Test func toggleClosesAPresentedComposer() {
         let store = MobileShellComposite.preview()
 

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -77,6 +77,22 @@ import CmuxMobileShellModel
         #expect(store.isComposerPresented)
     }
 
+    @Test func focusRequestKeyedToRequestingSurfaceNotSelection() throws {
+        let store = MobileShellComposite.preview()
+        let selected = try #require(store.selectedTerminalID)
+        // The rendered terminal can diverge from the store selection (the detail
+        // view falls back to the workspace's first terminal). A surface acting
+        // on its own terminal passes that id; the request must be consumable by
+        // the composer serving THAT terminal, not the selection.
+        let rendered = "rendered-terminal"
+        store.dismissComposer()
+
+        store.presentAndFocusComposer(forTerminalID: rendered)
+
+        #expect(store.consumePendingComposerFocusRequest(for: selected.rawValue) == false)
+        #expect(store.consumePendingComposerFocusRequest(for: rendered))
+    }
+
     @Test func toggleClosesAPresentedComposer() throws {
         let store = MobileShellComposite.preview()
 

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -13,11 +13,11 @@ import CmuxMobileShellModel
     @Test func composerIsPresentedByDefaultForSelectedTerminal() {
         let store = MobileShellComposite.preview()
 
-        #expect(store.selectedTerminalID != nil)
+        let terminal = try! #require(store.selectedTerminalID)
         #expect(store.isComposerPresented)
         // The default presentation never asks the field to take focus: the band
         // shows with the keyboard down (iMessage's unfocused input bar).
-        #expect(store.consumePendingComposerFocusRequest() == false)
+        #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue) == false)
     }
 
     @Test func composerIsNotPresentedWithoutASelectedTerminal() {
@@ -47,6 +47,7 @@ import CmuxMobileShellModel
 
     @Test func explicitOpenAfterDismissalRequestsFieldFocus() {
         let store = MobileShellComposite.preview()
+        let terminal = try! #require(store.selectedTerminalID)
         store.dismissComposer()
         let tokenBefore = store.composerFocusRequest
 
@@ -57,10 +58,10 @@ import CmuxMobileShellModel
 
         #expect(store.isComposerPresented)
         #expect(store.composerFocusRequest > tokenBefore)
-        #expect(store.consumePendingComposerFocusRequest())
+        #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue))
         // The handshake is one-shot: a later default-open remount must not
         // re-consume the same request and pop the keyboard again.
-        #expect(store.consumePendingComposerFocusRequest() == false)
+        #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue) == false)
     }
 
     @Test func toggleClosesAPresentedComposer() {
@@ -73,12 +74,13 @@ import CmuxMobileShellModel
 
     @Test func presentAndFocusRevivesADismissedComposer() {
         let store = MobileShellComposite.preview()
+        let terminal = try! #require(store.selectedTerminalID)
         store.dismissComposer()
 
         store.presentAndFocusComposer()
 
         #expect(store.isComposerPresented)
-        #expect(store.consumePendingComposerFocusRequest())
+        #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue))
     }
 
     @Test func terminalSwitchWhileFieldFocusedRequestsRefocus() {
@@ -94,7 +96,41 @@ import CmuxMobileShellModel
         // The incoming terminal's composer is asked to re-take focus so the
         // keyboard hands over in place instead of dropping.
         #expect(store.composerFocusRequest > tokenBefore)
-        #expect(store.consumePendingComposerFocusRequest())
+        #expect(store.consumePendingComposerFocusRequest(for: second.rawValue))
+    }
+
+    @Test func switchFocusRequestIsNotConsumableByTheOutgoingTerminal() {
+        let store = MobileShellComposite.preview()
+        let first = try! #require(store.selectedTerminalID)
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+        store.composerFieldFocusChanged(true)
+
+        store.selectedTerminalID = second
+
+        // During the switch the OUTGOING composer view is still mounted and
+        // observes the same token bump. Its consume attempt targets its own
+        // terminal, must fail, and must leave the request armed for the
+        // incoming terminal's mount.
+        #expect(store.consumePendingComposerFocusRequest(for: first.rawValue) == false)
+        #expect(store.consumePendingComposerFocusRequest(for: second.rawValue))
+    }
+
+    @Test func unconsumedFocusRequestDoesNotSurviveALaterSwitch() {
+        let store = MobileShellComposite.preview()
+        let first = try! #require(store.selectedTerminalID)
+        let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
+        store.composerFieldFocusChanged(true)
+        store.selectedTerminalID = second
+        // The keyboard drops (no composer consumed the request), then the user
+        // switches again without composing.
+        store.composerFieldFocusChanged(false)
+
+        store.selectedTerminalID = first
+
+        // The stale request was invalidated: a plain switch back can never pop
+        // the keyboard off an old handshake.
+        #expect(store.consumePendingComposerFocusRequest(for: first.rawValue) == false)
+        #expect(store.consumePendingComposerFocusRequest(for: second.rawValue) == false)
     }
 
     @Test func terminalSwitchWhileFieldUnfocusedDoesNotRequestFocus() {
@@ -108,7 +144,7 @@ import CmuxMobileShellModel
         // A mere switch with the default-open (unfocused) composer must never
         // pop the keyboard.
         #expect(store.composerFocusRequest == tokenBefore)
-        #expect(store.consumePendingComposerFocusRequest() == false)
+        #expect(store.consumePendingComposerFocusRequest(for: second.rawValue) == false)
     }
 
     @Test func dismissClearsTheFieldFocusMirror() {
@@ -121,12 +157,12 @@ import CmuxMobileShellModel
         // switch does not see a stale "field owns the keyboard" and refocus.
         store.dismissComposer()
         store.presentAndFocusComposer()
-        _ = store.consumePendingComposerFocusRequest()
+        _ = store.consumePendingComposerFocusRequest(for: try! #require(store.selectedTerminalID).rawValue)
         let tokenBefore = store.composerFocusRequest
 
         store.selectedTerminalID = second
 
         #expect(store.composerFocusRequest == tokenBefore)
-        #expect(store.consumePendingComposerFocusRequest() == false)
+        #expect(store.consumePendingComposerFocusRequest(for: second.rawValue) == false)
     }
 }

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -10,17 +10,17 @@ import CmuxMobileShellModel
 /// remembered per terminal for the session.
 @MainActor
 @Suite struct ComposerDefaultOpenTests {
-    @Test func composerIsPresentedByDefaultForSelectedTerminal() {
+    @Test func composerIsPresentedByDefaultForSelectedTerminal() throws {
         let store = MobileShellComposite.preview()
 
-        let terminal = try! #require(store.selectedTerminalID)
+        let terminal = try #require(store.selectedTerminalID)
         #expect(store.isComposerPresented)
         // The default presentation never asks the field to take focus: the band
         // shows with the keyboard down (iMessage's unfocused input bar).
         #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue) == false)
     }
 
-    @Test func composerIsNotPresentedWithoutASelectedTerminal() {
+    @Test func composerIsNotPresentedWithoutASelectedTerminal() throws {
         let store = MobileShellComposite.preview()
 
         store.selectedTerminalID = nil
@@ -28,9 +28,9 @@ import CmuxMobileShellModel
         #expect(store.isComposerPresented == false)
     }
 
-    @Test func dismissalIsRememberedPerTerminalAcrossSwitches() {
+    @Test func dismissalIsRememberedPerTerminalAcrossSwitches() throws {
         let store = MobileShellComposite.preview()
-        let first = try! #require(store.selectedTerminalID)
+        let first = try #require(store.selectedTerminalID)
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
 
         store.dismissComposer()
@@ -45,9 +45,9 @@ import CmuxMobileShellModel
         #expect(store.isComposerPresented == false)
     }
 
-    @Test func explicitOpenAfterDismissalRequestsFieldFocus() {
+    @Test func explicitOpenAfterDismissalRequestsFieldFocus() throws {
         let store = MobileShellComposite.preview()
-        let terminal = try! #require(store.selectedTerminalID)
+        let terminal = try #require(store.selectedTerminalID)
         store.dismissComposer()
         let tokenBefore = store.composerFocusRequest
 
@@ -64,7 +64,7 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue) == false)
     }
 
-    @Test func signOutForgetsComposerDismissals() {
+    @Test func signOutForgetsComposerDismissals() throws {
         let store = MobileShellComposite.preview()
         store.dismissComposer()
         #expect(store.isComposerPresented == false)
@@ -77,7 +77,7 @@ import CmuxMobileShellModel
         #expect(store.isComposerPresented)
     }
 
-    @Test func toggleClosesAPresentedComposer() {
+    @Test func toggleClosesAPresentedComposer() throws {
         let store = MobileShellComposite.preview()
 
         #expect(store.isComposerPresented)
@@ -85,9 +85,9 @@ import CmuxMobileShellModel
         #expect(store.isComposerPresented == false)
     }
 
-    @Test func presentAndFocusRevivesADismissedComposer() {
+    @Test func presentAndFocusRevivesADismissedComposer() throws {
         let store = MobileShellComposite.preview()
-        let terminal = try! #require(store.selectedTerminalID)
+        let terminal = try #require(store.selectedTerminalID)
         store.dismissComposer()
 
         store.presentAndFocusComposer()
@@ -96,7 +96,7 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: terminal.rawValue))
     }
 
-    @Test func terminalSwitchWhileFieldFocusedRequestsRefocus() {
+    @Test func terminalSwitchWhileFieldFocusedRequestsRefocus() throws {
         let store = MobileShellComposite.preview()
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
         // The composer view mirrors its @FocusState into the store; mid-compose
@@ -112,9 +112,9 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: second.rawValue))
     }
 
-    @Test func switchFocusRequestIsNotConsumableByTheOutgoingTerminal() {
+    @Test func switchFocusRequestIsNotConsumableByTheOutgoingTerminal() throws {
         let store = MobileShellComposite.preview()
-        let first = try! #require(store.selectedTerminalID)
+        let first = try #require(store.selectedTerminalID)
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
         store.composerFieldFocusChanged(true)
 
@@ -128,9 +128,9 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: second.rawValue))
     }
 
-    @Test func unconsumedFocusRequestDoesNotSurviveALaterSwitch() {
+    @Test func unconsumedFocusRequestDoesNotSurviveALaterSwitch() throws {
         let store = MobileShellComposite.preview()
-        let first = try! #require(store.selectedTerminalID)
+        let first = try #require(store.selectedTerminalID)
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
         store.composerFieldFocusChanged(true)
         store.selectedTerminalID = second
@@ -146,7 +146,7 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: second.rawValue) == false)
     }
 
-    @Test func terminalSwitchWhileFieldUnfocusedDoesNotRequestFocus() {
+    @Test func terminalSwitchWhileFieldUnfocusedDoesNotRequestFocus() throws {
         let store = MobileShellComposite.preview()
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
         store.composerFieldFocusChanged(false)
@@ -160,7 +160,7 @@ import CmuxMobileShellModel
         #expect(store.consumePendingComposerFocusRequest(for: second.rawValue) == false)
     }
 
-    @Test func dismissClearsTheFieldFocusMirror() {
+    @Test func dismissClearsTheFieldFocusMirror() throws {
         let store = MobileShellComposite.preview()
         let second = MobileTerminalPreview.ID(rawValue: "terminal-agent")
         store.composerFieldFocusChanged(true)
@@ -170,7 +170,7 @@ import CmuxMobileShellModel
         // switch does not see a stale "field owns the keyboard" and refocus.
         store.dismissComposer()
         store.presentAndFocusComposer()
-        _ = store.consumePendingComposerFocusRequest(for: try! #require(store.selectedTerminalID).rawValue)
+        _ = store.consumePendingComposerFocusRequest(for: try #require(store.selectedTerminalID).rawValue)
         let tokenBefore = store.composerFocusRequest
 
         store.selectedTerminalID = second

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitDraftReconcileTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitDraftReconcileTests.swift
@@ -1,0 +1,80 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``MobileShellComposite/reconcileComposerDraftAfterSend(sentText:submittedTerminalID:)``,
+/// the post-ack step of a composer send. The send itself goes over RPC (covered
+/// by the feature-level scripted-transport tests); these tests drive the
+/// reconciliation directly with a controlled draft store and selection, covering
+/// the switched-terminal-mid-flight cases that cannot be reached through the
+/// preview host.
+@MainActor
+@Suite struct ComposerSubmitDraftReconcileTests {
+    private static let terminalA = MobileTerminalPreview(id: "term-a", name: "a")
+    private static let terminalB = MobileTerminalPreview(id: "term-b", name: "b")
+
+    /// A composite whose initial selection is `term-a`, wired to `drafts`.
+    /// Selection is set by `init` (no `didSet` draft swap fires), so the store
+    /// contents stay exactly what each test seeds.
+    private static func makeComposite(drafts: InMemoryTerminalDraftStore) -> MobileShellComposite {
+        MobileShellComposite(
+            workspaces: [
+                MobileWorkspacePreview(id: "ws-1", name: "ws", terminals: [terminalA, terminalB]),
+            ],
+            draftStore: drafts
+        )
+    }
+
+    @Test func clearsStoredDraftWhenSelectionMovedMidFlight() async {
+        let drafts = InMemoryTerminalDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+        // The user sent from term-b, then switched to term-a before the ack; the
+        // switch persisted the outgoing (sent) text as term-b's draft.
+        await drafts.saveDraft("deploy it", forTerminalID: "term-b")
+
+        await composite.reconcileComposerDraftAfterSend(sentText: "deploy it", submittedTerminalID: "term-b")
+
+        // The sent text must not survive as term-b's draft (switching back would
+        // resurrect already-sent text and invite a duplicate submission).
+        let stored = await drafts.draft(forTerminalID: "term-b")
+        #expect(stored == nil)
+        // The currently selected terminal's field is untouched.
+        #expect(composite.terminalInputText.isEmpty)
+    }
+
+    @Test func preservesNewerStoredDraftWhenSelectionMovedMidFlight() async {
+        let drafts = InMemoryTerminalDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+        // The user tapped Send, typed MORE for term-b, then switched away; the
+        // stored draft is newer than the sent text and must win.
+        await drafts.saveDraft("deploy it && verify", forTerminalID: "term-b")
+
+        await composite.reconcileComposerDraftAfterSend(sentText: "deploy it", submittedTerminalID: "term-b")
+
+        let stored = await drafts.draft(forTerminalID: "term-b")
+        #expect(stored == "deploy it && verify")
+    }
+
+    @Test func clearsVisibleFieldWhenSelectionUnchanged() async {
+        let drafts = InMemoryTerminalDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+        composite.terminalInputText = "ls -la"
+
+        await composite.reconcileComposerDraftAfterSend(sentText: "ls -la", submittedTerminalID: "term-a")
+
+        #expect(composite.terminalInputText.isEmpty)
+    }
+
+    @Test func keepsVisibleFieldEditedWhileSendInFlight() async {
+        let drafts = InMemoryTerminalDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+        // The user kept typing while the ack was in flight; the newer field
+        // content must not be discarded.
+        composite.terminalInputText = "ls -la && pwd"
+
+        await composite.reconcileComposerDraftAfterSend(sentText: "ls -la", submittedTerminalID: "term-a")
+
+        #expect(composite.terminalInputText == "ls -la && pwd")
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/CountingDraftStore.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/CountingDraftStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+@testable import CmuxMobileShell
+
+/// A test ``TerminalDraftStoring`` that counts `saveDraft` calls and suspends
+/// the FIRST save for many scheduler turns. Drives the coalescing assertion:
+/// while the first save is suspended, every further keystroke must fold into
+/// one pending latest-value flush instead of queuing its own full-text
+/// snapshot, so a typing burst reaches the store as a bounded number of saves.
+actor CountingDraftStore: TerminalDraftStoring {
+    private var drafts: [String: String] = [:]
+    private var delayedFirstSave = false
+    /// Number of `saveDraft` calls received.
+    private(set) var saveCount = 0
+
+    func draft(forTerminalID terminalID: String) async -> String? {
+        drafts[terminalID]
+    }
+
+    func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
+        saveCount += 1
+        if !delayedFirstSave {
+            delayedFirstSave = true
+            for _ in 0..<50 { await Task.yield() }
+        }
+        if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            drafts[terminalID] = nil
+        } else {
+            drafts[terminalID] = draft
+        }
+    }
+
+    func clearDraft(forTerminalID terminalID: String) async {
+        drafts[terminalID] = nil
+    }
+
+    func clearAllDrafts() async {
+        drafts.removeAll()
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayingDraftStore.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DelayingDraftStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import CmuxMobileShell
+
+/// A test ``TerminalDraftStoring`` whose FIRST `saveDraft` suspends for many
+/// scheduler turns before applying. Actors are reentrant across suspension
+/// points, so without an ordering guarantee a later operation's task overtakes
+/// the suspended save and the stale save applies last. With the composite's
+/// FIFO draft pipeline, the delayed save must fully apply before any later
+/// operation starts, regardless of how long it suspends.
+actor DelayingDraftStore: TerminalDraftStoring {
+    private var drafts: [String: String] = [:]
+    private var delayedFirstSave = false
+
+    func draft(forTerminalID terminalID: String) async -> String? {
+        drafts[terminalID]
+    }
+
+    func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
+        if !delayedFirstSave {
+            delayedFirstSave = true
+            for _ in 0..<50 { await Task.yield() }
+        }
+        if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            drafts[terminalID] = nil
+        } else {
+            drafts[terminalID] = draft
+        }
+    }
+
+    func clearDraft(forTerminalID terminalID: String) async {
+        drafts[terminalID] = nil
+    }
+
+    func clearAllDrafts() async {
+        drafts.removeAll()
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
@@ -1,0 +1,89 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// A ``TerminalDraftStoring`` whose FIRST `saveDraft` suspends for many
+/// scheduler turns before applying. Actors are reentrant across suspension
+/// points, so without an ordering guarantee a later operation's task overtakes
+/// the suspended save and the stale save applies last. With the composite's
+/// FIFO draft pipeline, the delayed save must fully apply before any later
+/// operation starts, regardless of how long it suspends.
+private actor DelayingDraftStore: TerminalDraftStoring {
+    private var drafts: [String: String] = [:]
+    private var delayedFirstSave = false
+
+    func draft(forTerminalID terminalID: String) async -> String? {
+        drafts[terminalID]
+    }
+
+    func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
+        if !delayedFirstSave {
+            delayedFirstSave = true
+            for _ in 0..<50 { await Task.yield() }
+        }
+        if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            drafts[terminalID] = nil
+        } else {
+            drafts[terminalID] = draft
+        }
+    }
+
+    func clearDraft(forTerminalID terminalID: String) async {
+        drafts[terminalID] = nil
+    }
+
+    func clearAllDrafts() async {
+        drafts.removeAll()
+    }
+}
+
+/// Ordering tests for the composite's FIFO draft pipeline: store effects must
+/// apply in exactly the order they were issued, so a stale keystroke save can
+/// never overwrite a newer save, and nothing written before the sign-out wipe
+/// survives it.
+@MainActor
+@Suite struct DraftPipelineOrderingTests {
+    private static func makeComposite(drafts: DelayingDraftStore) -> MobileShellComposite {
+        MobileShellComposite(
+            workspaces: [
+                MobileWorkspacePreview(
+                    id: "ws-1",
+                    name: "ws",
+                    terminals: [MobileTerminalPreview(id: "term-a", name: "a")]
+                ),
+            ],
+            draftStore: drafts
+        )
+    }
+
+    @Test func slowEarlierSaveCannotOverwriteNewerSave() async {
+        let drafts = DelayingDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // Two keystrokes in quick succession; the first save suspends long
+        // enough that an unordered later save would overtake it and the stale
+        // "a" would apply last.
+        composite.terminalInputText = "a"
+        composite.terminalInputText = "ab"
+        await composite.drainDraftOperationsForTesting()
+
+        let stored = await drafts.draft(forTerminalID: "term-a")
+        #expect(stored == "ab")
+    }
+
+    @Test func slowEarlierSaveCannotSurviveSignOutWipe() async {
+        let drafts = DelayingDraftStore()
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // A keystroke save is still suspended when sign-out wipes the store; the
+        // wipe must apply AFTER that save, so the previous account's unsent text
+        // cannot leak into the next session.
+        composite.terminalInputText = "secret unsent text"
+        composite.signOut()
+        await composite.drainDraftOperationsForTesting()
+
+        let stored = await drafts.draft(forTerminalID: "term-a")
+        #expect(stored == nil)
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
@@ -87,3 +87,62 @@ private actor DelayingDraftStore: TerminalDraftStoring {
         #expect(stored == nil)
     }
 }
+
+/// Field-ownership tests for the terminal-switch draft swap: the visible field
+/// represents a terminal's draft only after that terminal's stored draft has
+/// actually been loaded into it (or the user has typed). Until then the field
+/// is a transient cleared placeholder, and switching away must not persist that
+/// placeholder over the terminal's real stored draft.
+@MainActor
+@Suite struct DraftSwitchOwnershipTests {
+    private static func makeComposite(drafts: InMemoryTerminalDraftStore) -> MobileShellComposite {
+        MobileShellComposite(
+            workspaces: [
+                MobileWorkspacePreview(
+                    id: "ws-1",
+                    name: "ws",
+                    terminals: [
+                        MobileTerminalPreview(id: "term-a", name: "a"),
+                        MobileTerminalPreview(id: "term-b", name: "b"),
+                        MobileTerminalPreview(id: "term-c", name: "c"),
+                    ]
+                ),
+            ],
+            draftStore: drafts
+        )
+    }
+
+    @Test func fastSwitchThroughTerminalPreservesItsUntouchedDraft() async {
+        let drafts = InMemoryTerminalDraftStore()
+        await drafts.saveDraft("b draft", forTerminalID: "term-b")
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // Type under A, then switch A -> B -> C before B's stored draft has
+        // loaded into the field. The B -> C switch sees only the transient
+        // cleared placeholder; saving it would erase B's real draft.
+        composite.terminalInputText = "a text"
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-c")
+        await composite.drainDraftOperationsForTesting()
+
+        #expect(await drafts.draft(forTerminalID: "term-a") == "a text")
+        #expect(await drafts.draft(forTerminalID: "term-b") == "b draft")
+    }
+
+    @Test func lateLoadDoesNotResurrectTextDeletedDuringLoad() async {
+        let drafts = InMemoryTerminalDraftStore()
+        await drafts.saveDraft("b draft", forTerminalID: "term-b")
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // Switch A -> B, then type and delete everything before B's stored
+        // draft load applies. The user's live (deliberately emptied) input must
+        // win: the late load cannot resurrect the deleted text into the field.
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
+        composite.terminalInputText = "x"
+        composite.terminalInputText = ""
+        await composite.drainDraftOperationsForTesting()
+
+        #expect(composite.terminalInputText.isEmpty)
+        #expect(await drafts.draft(forTerminalID: "term-b") == nil)
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
@@ -22,6 +22,37 @@ import Testing
         )
     }
 
+    @Test func typingBurstBehindSlowStoreCoalescesToBoundedSaves() async {
+        let drafts = CountingDraftStore()
+        let composite = MobileShellComposite(
+            workspaces: [
+                MobileWorkspacePreview(
+                    id: "ws-1",
+                    name: "ws",
+                    terminals: [MobileTerminalPreview(id: "term-a", name: "a")]
+                ),
+            ],
+            draftStore: drafts
+        )
+
+        // A burst of edits while the store's first save is suspended. Without
+        // coalescing each edit queues its own full-text snapshot (memory grows
+        // as edits x draft size behind a slow store); with latest-value
+        // coalescing the burst reaches the store as at most two saves (the
+        // in-flight first one plus one re-armed flush) and the final text wins.
+        composite.terminalInputText = "d"
+        composite.terminalInputText = "dr"
+        composite.terminalInputText = "dra"
+        composite.terminalInputText = "draf"
+        composite.terminalInputText = "draft"
+        await composite.drainDraftOperationsForTesting()
+
+        let stored = await drafts.draft(forTerminalID: "term-a")
+        let saves = await drafts.saveCount
+        #expect(stored == "draft")
+        #expect(saves <= 2)
+    }
+
     @Test func slowEarlierSaveCannotOverwriteNewerSave() async {
         let drafts = DelayingDraftStore()
         let composite = Self.makeComposite(drafts: drafts)

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftPipelineOrderingTests.swift
@@ -3,41 +3,6 @@ import Foundation
 import Testing
 @testable import CmuxMobileShell
 
-/// A ``TerminalDraftStoring`` whose FIRST `saveDraft` suspends for many
-/// scheduler turns before applying. Actors are reentrant across suspension
-/// points, so without an ordering guarantee a later operation's task overtakes
-/// the suspended save and the stale save applies last. With the composite's
-/// FIFO draft pipeline, the delayed save must fully apply before any later
-/// operation starts, regardless of how long it suspends.
-private actor DelayingDraftStore: TerminalDraftStoring {
-    private var drafts: [String: String] = [:]
-    private var delayedFirstSave = false
-
-    func draft(forTerminalID terminalID: String) async -> String? {
-        drafts[terminalID]
-    }
-
-    func saveDraft(_ draft: String, forTerminalID terminalID: String) async {
-        if !delayedFirstSave {
-            delayedFirstSave = true
-            for _ in 0..<50 { await Task.yield() }
-        }
-        if draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            drafts[terminalID] = nil
-        } else {
-            drafts[terminalID] = draft
-        }
-    }
-
-    func clearDraft(forTerminalID terminalID: String) async {
-        drafts[terminalID] = nil
-    }
-
-    func clearAllDrafts() async {
-        drafts.removeAll()
-    }
-}
-
 /// Ordering tests for the composite's FIFO draft pipeline: store effects must
 /// apply in exactly the order they were issued, so a stale keystroke save can
 /// never overwrite a newer save, and nothing written before the sign-out wipe
@@ -85,64 +50,5 @@ private actor DelayingDraftStore: TerminalDraftStoring {
 
         let stored = await drafts.draft(forTerminalID: "term-a")
         #expect(stored == nil)
-    }
-}
-
-/// Field-ownership tests for the terminal-switch draft swap: the visible field
-/// represents a terminal's draft only after that terminal's stored draft has
-/// actually been loaded into it (or the user has typed). Until then the field
-/// is a transient cleared placeholder, and switching away must not persist that
-/// placeholder over the terminal's real stored draft.
-@MainActor
-@Suite struct DraftSwitchOwnershipTests {
-    private static func makeComposite(drafts: InMemoryTerminalDraftStore) -> MobileShellComposite {
-        MobileShellComposite(
-            workspaces: [
-                MobileWorkspacePreview(
-                    id: "ws-1",
-                    name: "ws",
-                    terminals: [
-                        MobileTerminalPreview(id: "term-a", name: "a"),
-                        MobileTerminalPreview(id: "term-b", name: "b"),
-                        MobileTerminalPreview(id: "term-c", name: "c"),
-                    ]
-                ),
-            ],
-            draftStore: drafts
-        )
-    }
-
-    @Test func fastSwitchThroughTerminalPreservesItsUntouchedDraft() async {
-        let drafts = InMemoryTerminalDraftStore()
-        await drafts.saveDraft("b draft", forTerminalID: "term-b")
-        let composite = Self.makeComposite(drafts: drafts)
-
-        // Type under A, then switch A -> B -> C before B's stored draft has
-        // loaded into the field. The B -> C switch sees only the transient
-        // cleared placeholder; saving it would erase B's real draft.
-        composite.terminalInputText = "a text"
-        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
-        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-c")
-        await composite.drainDraftOperationsForTesting()
-
-        #expect(await drafts.draft(forTerminalID: "term-a") == "a text")
-        #expect(await drafts.draft(forTerminalID: "term-b") == "b draft")
-    }
-
-    @Test func lateLoadDoesNotResurrectTextDeletedDuringLoad() async {
-        let drafts = InMemoryTerminalDraftStore()
-        await drafts.saveDraft("b draft", forTerminalID: "term-b")
-        let composite = Self.makeComposite(drafts: drafts)
-
-        // Switch A -> B, then type and delete everything before B's stored
-        // draft load applies. The user's live (deliberately emptied) input must
-        // win: the late load cannot resurrect the deleted text into the field.
-        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
-        composite.terminalInputText = "x"
-        composite.terminalInputText = ""
-        await composite.drainDraftOperationsForTesting()
-
-        #expect(composite.terminalInputText.isEmpty)
-        #expect(await drafts.draft(forTerminalID: "term-b") == nil)
     }
 }

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftSwitchOwnershipTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DraftSwitchOwnershipTests.swift
@@ -1,0 +1,63 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Field-ownership tests for the terminal-switch draft swap: the visible field
+/// represents a terminal's draft only after that terminal's stored draft has
+/// actually been loaded into it (or the user has typed). Until then the field
+/// is a transient cleared placeholder, and switching away must not persist that
+/// placeholder over the terminal's real stored draft.
+@MainActor
+@Suite struct DraftSwitchOwnershipTests {
+    private static func makeComposite(drafts: InMemoryTerminalDraftStore) -> MobileShellComposite {
+        MobileShellComposite(
+            workspaces: [
+                MobileWorkspacePreview(
+                    id: "ws-1",
+                    name: "ws",
+                    terminals: [
+                        MobileTerminalPreview(id: "term-a", name: "a"),
+                        MobileTerminalPreview(id: "term-b", name: "b"),
+                        MobileTerminalPreview(id: "term-c", name: "c"),
+                    ]
+                ),
+            ],
+            draftStore: drafts
+        )
+    }
+
+    @Test func fastSwitchThroughTerminalPreservesItsUntouchedDraft() async {
+        let drafts = InMemoryTerminalDraftStore()
+        await drafts.saveDraft("b draft", forTerminalID: "term-b")
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // Type under A, then switch A -> B -> C before B's stored draft has
+        // loaded into the field. The B -> C switch sees only the transient
+        // cleared placeholder; saving it would erase B's real draft.
+        composite.terminalInputText = "a text"
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-c")
+        await composite.drainDraftOperationsForTesting()
+
+        #expect(await drafts.draft(forTerminalID: "term-a") == "a text")
+        #expect(await drafts.draft(forTerminalID: "term-b") == "b draft")
+    }
+
+    @Test func lateLoadDoesNotResurrectTextDeletedDuringLoad() async {
+        let drafts = InMemoryTerminalDraftStore()
+        await drafts.saveDraft("b draft", forTerminalID: "term-b")
+        let composite = Self.makeComposite(drafts: drafts)
+
+        // Switch A -> B, then type and delete everything before B's stored
+        // draft load applies. The user's live (deliberately emptied) input must
+        // win: the late load cannot resurrect the deleted text into the field.
+        composite.selectedTerminalID = MobileTerminalPreview.ID(rawValue: "term-b")
+        composite.terminalInputText = "x"
+        composite.terminalInputText = ""
+        await composite.drainDraftOperationsForTesting()
+
+        #expect(composite.terminalInputText.isEmpty)
+        #expect(await drafts.draft(forTerminalID: "term-b") == nil)
+    }
+}

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/InMemoryTerminalDraftStoreTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/InMemoryTerminalDraftStoreTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``InMemoryTerminalDraftStore``: per-terminal keying,
+/// empty-draft removal, and clear semantics.
+@Suite struct InMemoryTerminalDraftStoreTests {
+    @Test func savesAndLoadsPerTerminal() async {
+        let store = InMemoryTerminalDraftStore()
+        await store.saveDraft("git status", forTerminalID: "term-a")
+        await store.saveDraft("npm test", forTerminalID: "term-b")
+
+        let a = await store.draft(forTerminalID: "term-a")
+        let b = await store.draft(forTerminalID: "term-b")
+        #expect(a == "git status")
+        #expect(b == "npm test")
+        // A terminal with no draft reads nil, not another terminal's text.
+        let missing = await store.draft(forTerminalID: "term-c")
+        #expect(missing == nil)
+    }
+
+    @Test func emptyOrWhitespaceDraftRemovesEntry() async {
+        let store = InMemoryTerminalDraftStore()
+        await store.saveDraft("hello", forTerminalID: "term-a")
+        await store.saveDraft("   \n ", forTerminalID: "term-a")
+        let restored = await store.draft(forTerminalID: "term-a")
+        #expect(restored == nil)
+    }
+
+    @Test func clearDraftRemovesOnlyThatTerminal() async {
+        let store = InMemoryTerminalDraftStore()
+        await store.saveDraft("keep", forTerminalID: "term-a")
+        await store.saveDraft("drop", forTerminalID: "term-b")
+        await store.clearDraft(forTerminalID: "term-b")
+        let a = await store.draft(forTerminalID: "term-a")
+        let b = await store.draft(forTerminalID: "term-b")
+        #expect(a == "keep")
+        #expect(b == nil)
+    }
+
+    @Test func clearAllDraftsEmptiesEveryTerminal() async {
+        let store = InMemoryTerminalDraftStore()
+        await store.saveDraft("a", forTerminalID: "term-a")
+        await store.saveDraft("b", forTerminalID: "term-b")
+        await store.clearAllDrafts()
+        let a = await store.draft(forTerminalID: "term-a")
+        let b = await store.draft(forTerminalID: "term-b")
+        #expect(a == nil)
+        #expect(b == nil)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerStoreProbe.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerStoreProbe.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+#if os(iOS) && DEBUG
+/// Zero-impact store-side composer seam for UI tests (DEBUG only).
+///
+/// Carries the composer source-of-truth store flags as a stable, parseable
+/// `accessibilityValue` (`isComposerPresented=…;composerFocusRequest=…;draftLength=…`)
+/// on an element identified by `MobileComposerStoreProbe`, so a UI test can assert the
+/// store and the surface's mirror (`MobileComposerDockProbe`) agree across repeated
+/// open/close cycles and that the draft survives. Rendered as a 1×1 clear element so it
+/// never perturbs layout or intercepts touches. Never compiled into a shipping build.
+struct ComposerStoreProbe: View {
+    let isComposerPresented: Bool
+    let composerFocusRequest: Int
+    let draftLength: Int
+
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .allowsHitTesting(false)
+            .accessibilityElement()
+            .accessibilityIdentifier("MobileComposerStoreProbe")
+            .accessibilityValue(
+                [
+                    "isComposerPresented=\(isComposerPresented ? 1 : 0)",
+                    "composerFocusRequest=\(composerFocusRequest)",
+                    "draftLength=\(draftLength)",
+                ].joined(separator: ";")
+            )
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -105,6 +105,12 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
         private var composerController: UIHostingController<TerminalComposerView>?
         private var composerMounted = false
+        /// Bumped on every mount/unmount transition so a deferred close completion
+        /// can tell whether it is still the latest transition. Guards the
+        /// close-then-quickly-reopen race: an interrupted close animation still runs
+        /// its completion, which must not unmount a composer that was remounted in
+        /// the meantime.
+        private var composerMountGeneration = 0
 
         init(surfaceID: String, store: CMUXMobileShellStore) {
             self.surfaceID = surfaceID
@@ -140,6 +146,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         func setComposerMounted(_ mounted: Bool) {
             guard mounted != composerMounted, let store, let surfaceView else { return }
             composerMounted = mounted
+            composerMountGeneration &+= 1
             if mounted {
                 let controller = composerController ?? makeComposerController(store: store)
                 composerController = controller
@@ -153,8 +160,17 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 // mounted, on the keyboard curve, then unmount it in the completion.
                 // Unmounting first left the band collapsing over empty space (a janky
                 // close). Keep the surface reference for the deferred unmount.
-                surfaceView.setComposerBandHeight(0, animated: true) { [weak surfaceView] in
-                    surfaceView?.mountComposerView(nil)
+                //
+                // The completion is generation-guarded: UIKit runs animation
+                // completions even when the animation is interrupted, so a
+                // close-then-quick-reopen would otherwise unmount the freshly
+                // remounted field and leave `composerMounted` true with no view.
+                let generation = composerMountGeneration
+                surfaceView.setComposerBandHeight(0, animated: true) { [weak self] in
+                    guard let self,
+                          self.composerMountGeneration == generation,
+                          !self.composerMounted else { return }
+                    self.surfaceView?.mountComposerView(nil)
                 }
             }
         }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -67,7 +67,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         #endif
         context.coordinator.attach(surfaceView: view)
         // Mount the composer band immediately if the composer was already open when
-        // this surface was (re)built (e.g. a terminal switch while composing).
+        // this surface was (re)built (e.g. a terminal switch while composing), and
+        // seed the surface's composerActive flag to match. SwiftUI does call
+        // `updateUIView` right after `makeUIView`, but the compose button's intent
+        // math reads this flag, so it must never depend on that ordering contract.
+        view.setComposerActive(isComposerActive)
         context.coordinator.setComposerMounted(isComposerActive)
         return view
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -181,7 +181,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// sizes the surface band.
         @MainActor
         private func makeComposerController(store: CMUXMobileShellStore) -> UIHostingController<TerminalComposerView> {
-            let view = TerminalComposerView(store: store) { [weak self] in
+            let view = TerminalComposerView(store: store, terminalID: surfaceID) { [weak self] in
                 // Content changed (a line added/removed, or cleared after send): live
                 // grows/shrinks animate. `setComposerBandHeight` is idempotent on
                 // unchanged heights, so a no-op change is harmless.

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -319,8 +319,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // presents/dismisses the iMessage-style composer. The reveal-and-focus
             // case routes through `...DidRequestComposerFocus` instead, so this never
             // closes a still-presented-but-suppressed composer.
-            Task { @MainActor [weak store] in
-                store?.toggleComposer()
+            Task { @MainActor [weak store, surfaceID] in
+                store?.toggleComposer(forTerminalID: surfaceID)
             }
         }
 
@@ -329,8 +329,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // re-focused, without dismissing it — the reveal-after-hide and
             // present-while-suppressed paths. Ensure-present + bump the focus token the
             // composer view observes, so the draft and its focus return together.
-            Task { @MainActor [weak store] in
-                store?.presentAndFocusComposer()
+            Task { @MainActor [weak store, surfaceID] in
+                store?.presentAndFocusComposer(forTerminalID: surfaceID)
             }
         }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -12,6 +12,16 @@ import UIKit
 /// runs the same libghostty terminal core + Metal renderer as the Mac,
 /// fed by the Mac's own read thread byte-for-byte. No Swift VT parser,
 /// no snapshot rehydration, no cell-by-cell SwiftUI tree.
+///
+/// The bottom dock (terminal grid / composer band / accessory toolbar / keyboard)
+/// is owned entirely by the `GhosttySurfaceView` in one coordinate system. The
+/// iMessage-style composer is a SwiftUI view, so it is hosted in a
+/// `UIHostingController` and installed into the surface's composer band; this
+/// representable is the only layer that can see both the terminal package and the
+/// shell-UI composer, so it owns that bridge. The surface owns the band's position
+/// and the grid reservation; the host reports the field's measured height back so a
+/// field-grow pushes only the terminal up. There is no toolbar handoff and no second
+/// layout system reaching into the surface's bottom math.
 struct GhosttySurfaceRepresentable: UIViewRepresentable {
     let surfaceID: String
     let store: CMUXMobileShellStore
@@ -21,6 +31,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     /// actions (create workspace/terminal, switch terminal) do not pop the
     /// software keyboard.
     var autoFocusOnWindowAttach: Bool = true
+    /// Whether the iMessage-style composer is open. When it flips on, the
+    /// coordinator mounts the SwiftUI compose field into the surface's composer
+    /// band and pins first responder so the keyboard hands over in place; when it
+    /// flips off, the field is unmounted and the band collapses to zero height.
+    var isComposerActive: Bool = false
 
     func makeCoordinator() -> Coordinator {
         Coordinator(surfaceID: surfaceID, store: store)
@@ -44,16 +59,39 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             fontSize: fontSize
         )
         view.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        #if DEBUG
+        // Hand the surface the structured diagnostic log so the composer-dock
+        // probes land in the blob the "Send to agent" feedback pane exports.
+        // `nil` when no log is wired; every probe is then a no-op.
+        view.diagnosticLog = store.diagnosticLog
+        #endif
         context.coordinator.attach(surfaceView: view)
+        // Mount the composer band immediately if the composer was already open when
+        // this surface was (re)built (e.g. a terminal switch while composing).
+        context.coordinator.setComposerMounted(isComposerActive)
         return view
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {
-        (uiView as? GhosttySurfaceView)?.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        // Bytes flow via the byte sink; the prop-driven mutations are the autofocus
+        // suppression and the composer's open/closed state. `setComposerActive`
+        // handles the first-responder handover that keeps the keyboard up; the
+        // coordinator mounts/unmounts the hosted compose field into the surface's
+        // composer band. This is a UIKit-internal mutation, not a sibling-observed
+        // state write, so it is safe in `updateUIView`.
+        guard let surfaceView = uiView as? GhosttySurfaceView else { return }
+        surfaceView.autoFocusOnWindowAttach = autoFocusOnWindowAttach
+        surfaceView.setComposerActive(isComposerActive)
+        context.coordinator.setComposerMounted(isComposerActive)
+        // A width change (rotation) is not a text change, so the field-content trigger
+        // misses it. Re-measure the open composer here so the band height tracks the new
+        // width's wrapping. No-op when closed or when the height is unchanged.
+        context.coordinator.remeasureComposerForLayoutChange()
     }
 
     static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
         (uiView as? GhosttySurfaceView)?.prepareForDismantle()
+        coordinator.tearDownComposer()
         coordinator.detach()
     }
 
@@ -62,6 +100,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         weak var store: CMUXMobileShellStore?
         weak var surfaceView: GhosttySurfaceView?
         private var outputTask: Task<Void, Never>?
+        /// Hosts the SwiftUI ``TerminalComposerView`` so it can be installed into the
+        /// surface's composer band. Built lazily on first open and torn down on
+        /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
+        private var composerController: UIHostingController<TerminalComposerView>?
+        private var composerMounted = false
 
         init(surfaceID: String, store: CMUXMobileShellStore) {
             self.surfaceID = surfaceID
@@ -87,6 +130,88 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         func detach() {
             outputTask?.cancel()
             outputTask = nil
+        }
+
+        // MARK: - Composer band hosting
+
+        /// Mount or unmount the SwiftUI compose field into the surface's composer
+        /// band so the surface owns its position and grid reservation. Idempotent.
+        @MainActor
+        func setComposerMounted(_ mounted: Bool) {
+            guard mounted != composerMounted, let store, let surfaceView else { return }
+            composerMounted = mounted
+            if mounted {
+                let controller = composerController ?? makeComposerController(store: store)
+                composerController = controller
+                surfaceView.mountComposerView(controller.view)
+                // The field opens at one line; report its initial height without
+                // animation (the composer's open transition already animates), then
+                // live grows/shrinks animate.
+                reportComposerHeight(animated: false)
+            } else {
+                // Symmetric close: animate the band to 0 with the field STILL
+                // mounted, on the keyboard curve, then unmount it in the completion.
+                // Unmounting first left the band collapsing over empty space (a janky
+                // close). Keep the surface reference for the deferred unmount.
+                surfaceView.setComposerBandHeight(0, animated: true) { [weak surfaceView] in
+                    surfaceView?.mountComposerView(nil)
+                }
+            }
+        }
+
+        /// Build the hosting controller for the compose field. The field asks for a
+        /// re-measure (via ``reportComposerHeight(animated:)``) whenever its content
+        /// changes; the coordinator measures the ideal height with `sizeThatFits` and
+        /// sizes the surface band.
+        @MainActor
+        private func makeComposerController(store: CMUXMobileShellStore) -> UIHostingController<TerminalComposerView> {
+            let view = TerminalComposerView(store: store) { [weak self] in
+                // Content changed (a line added/removed, or cleared after send): live
+                // grows/shrinks animate. `setComposerBandHeight` is idempotent on
+                // unchanged heights, so a no-op change is harmless.
+                self?.reportComposerHeight(animated: true)
+            }
+            let controller = UIHostingController(rootView: view)
+            // The field is pinned edge-to-edge in the band, so the band frame (not an
+            // intrinsic size) drives the hosting view's height; the measured ideal
+            // height flows separately through `sizeThatFits`. Clear background so the
+            // terminal/glass shows through.
+            controller.view.backgroundColor = .clear
+            return controller
+        }
+
+        /// Measure the hosted compose field's ideal height and size the surface band.
+        /// `sizeThatFits` returns the height the content wants independent of the band's
+        /// current (pinned) frame, so it is not circular: the band height is set FROM
+        /// this measurement, and the measurement does not depend on the band height.
+        /// The proposed width is the surface width and the proposed height is unbounded
+        /// so a multi-line field measures its full desired height (capped to 14 lines by
+        /// the field's own `lineLimit`).
+        @MainActor
+        private func reportComposerHeight(animated: Bool) {
+            guard let controller = composerController, let surfaceView else { return }
+            let width = max(1, surfaceView.bounds.width)
+            let target = CGSize(width: width, height: .greatestFiniteMagnitude)
+            let fitting = controller.sizeThatFits(in: target)
+            surfaceView.setComposerBandHeight(fitting.height, animated: animated)
+        }
+
+        /// Re-measure the open composer after a non-text layout change (rotation /
+        /// width change). A no-op when the composer is closed; `setComposerBandHeight`
+        /// is idempotent on an unchanged height. Animated so a rotation reflow is smooth.
+        @MainActor
+        func remeasureComposerForLayoutChange() {
+            guard composerMounted else { return }
+            reportComposerHeight(animated: true)
+        }
+
+        /// Tear the hosting controller down on dismantle so a removed surface does not
+        /// leave a detached SwiftUI host alive.
+        @MainActor
+        func tearDownComposer() {
+            surfaceView?.mountComposerView(nil)
+            composerController = nil
+            composerMounted = false
         }
 
         // MARK: - GhosttySurfaceViewDelegate
@@ -165,6 +290,28 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             guard let presenter = presentingController(for: surfaceView) else { return }
             let editor = UIHostingController(rootView: TerminalShortcutsSettingsView())
             presenter.present(editor, animated: true)
+        }
+
+        func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {
+            // The composer button on the docked accessory bar was tapped AND the
+            // surface resolved (from the dock state) that this is a genuine open/close
+            // toggle. Flip the store flag; the terminal screen observes it and
+            // presents/dismisses the iMessage-style composer. The reveal-and-focus
+            // case routes through `...DidRequestComposerFocus` instead, so this never
+            // closes a still-presented-but-suppressed composer.
+            Task { @MainActor [weak store] in
+                store?.toggleComposer()
+            }
+        }
+
+        func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView) {
+            // The surface needs the composer presented (if not already) and its field
+            // re-focused, without dismissing it — the reveal-after-hide and
+            // present-while-suppressed paths. Ensure-present + bump the focus token the
+            // composer view observes, so the draft and its focus return together.
+            Task { @MainActor [weak store] in
+                store?.presentAndFocusComposer()
+            }
         }
 
         /// Walk up from `view` to the nearest owning `UIViewController`, then to

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -7,12 +7,18 @@ import SwiftUI
 
 /// iMessage-style composer hosted in the terminal surface's composer band.
 ///
-/// A growing multi-line text field plus a send button, rendered with Liquid
-/// Glass (iOS 26+, with a thin-material fallback). Send delivers the text as a
-/// bracketed paste followed by a single Return (via `terminal.paste`), so a
-/// multi-line message lands as one submission instead of fragmenting on every
-/// interior newline. Toggled from the input accessory bar's composer button; the
-/// chevron dismisses it.
+/// A growing multi-line text field with the send button INSIDE its rounded
+/// container (trailing edge, riding the last line as the field grows — exactly
+/// iMessage's circular up-arrow), rendered with Liquid Glass (iOS 26+, with a
+/// thin-material fallback). Send delivers the text as a bracketed paste followed
+/// by a single Return (via `terminal.paste`), so a multi-line message lands as
+/// one submission instead of fragmenting on every interior newline.
+///
+/// Open by default per terminal (like iMessage's always-present input bar), and
+/// presented does NOT mean focused: the field appears with the keyboard down and
+/// takes focus only on a user tap or an explicit focus request from the store
+/// (an explicit open/reveal, or a terminal switch mid-compose). The chevron
+/// dismisses it for that terminal.
 ///
 /// The bottom dock (terminal grid / composer band / accessory toolbar / keyboard)
 /// is owned entirely by `GhosttySurfaceView` in one coordinate system. This view is
@@ -36,9 +42,17 @@ struct TerminalComposerView: View {
         self.requestHeightRemeasure = requestHeightRemeasure
     }
 
-    /// Single-line height of the round close/send buttons. They stay pinned to the
-    /// bottom edge of the (taller) field via the `HStack`'s `.bottom` alignment.
+    /// Single-line height of the round close button beside the field. It stays
+    /// pinned to the bottom edge of the (taller) field via the outer `HStack`'s
+    /// `.bottom` alignment.
     private let controlHeight: CGFloat = 40
+
+    /// Diameter of the iMessage-style send button INSIDE the field's rounded
+    /// container. With the container's 6pt vertical padding it exactly fills the
+    /// 40pt single-line field height (6 + 28 + 6), centering the circle on a
+    /// one-line message; the inner `HStack`'s `.bottom` alignment keeps it riding
+    /// the last line as the field grows.
+    private let inlineSendDiameter: CGFloat = 28
 
     /// Line range for the growing compose field. Opens at a SINGLE line (`1...`) so it
     /// starts as a compact one-line message box and grows as the user types, up to 14
@@ -66,7 +80,14 @@ struct TerminalComposerView: View {
         }
         .onAppear {
             recordComposerEvent(.composerViewAppear)
-            focusField()
+            // Focus only when an explicit request preceded this mount (an
+            // explicit open after a dismissal, or a terminal switch while the
+            // user was mid-compose). A default-open presentation arrives with no
+            // pending request, so the field shows WITHOUT summoning the keyboard
+            // — iMessage's input bar, visible but unfocused until tapped.
+            if store.consumePendingComposerFocusRequest() {
+                focusField()
+            }
         }
         .onDisappear {
             // COMPOSER: logged independently of `isComposerPresented`. A
@@ -76,6 +97,11 @@ struct TerminalComposerView: View {
             recordComposerEvent(.composerViewDisappear)
         }
         .onChange(of: isFieldFocused) { _, focused in
+            // Mirror the field's focus into the store so a terminal switch knows
+            // whether the user was mid-compose (and should keep the keyboard up
+            // on the incoming composer) or merely looking at the default-open
+            // field (keyboard stays down).
+            store.composerFieldFocusChanged(focused)
             // COMPOSER: a focus-lost while the flag stayed presented and the
             // view stayed mounted, yet the field reads empty, isolates the
             // residual TextField/@FocusState render-blank case.
@@ -86,7 +112,9 @@ struct TerminalComposerView: View {
             // composer — the reveal-after-hide case, where the chrome and draft are
             // already back but the terminal proxy holds first responder. Driving
             // `@FocusState` here keeps it the single source of truth (the surface
-            // never touches the hosted UITextField directly).
+            // never touches the hosted UITextField directly). Consume the pending
+            // handshake too, so a later remount does not honor this request twice.
+            _ = store.consumePendingComposerFocusRequest()
             focusField()
         }
     }
@@ -130,38 +158,56 @@ struct TerminalComposerView: View {
             .accessibilityIdentifier("MobileComposerClose")
             .accessibilityLabel(L10n.string("mobile.composer.close", defaultValue: "Hide Composer"))
 
-            TextField(
-                L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
-                text: $store.terminalInputText,
-                axis: .vertical
-            )
-            // Opens at a single line and grows up to 14 lines so a long message has
-            // room. Each added line grows this view, which the host reserves above the
-            // always-visible toolbar; the toolbar and keyboard never move.
-            .lineLimit(composerLineLimit)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled(true)
-            .focused($isFieldFocused)
-            .foregroundStyle(TerminalPalette.foreground)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 9)
+            // The field and its send button share ONE rounded glass container —
+            // iMessage's layout, where the circular up-arrow lives INSIDE the
+            // field at the trailing edge. `.bottom` alignment pins the button to
+            // the field's last line as it grows, so a multi-line draft keeps the
+            // send affordance at the natural "end of message" spot.
+            HStack(alignment: .bottom, spacing: 8) {
+                TextField(
+                    L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
+                    text: $store.terminalInputText,
+                    axis: .vertical
+                )
+                // Opens at a single line and grows up to 14 lines so a long message has
+                // room. Each added line grows this view, which the host reserves above the
+                // always-visible toolbar; the toolbar and keyboard never move.
+                .lineLimit(composerLineLimit)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .focused($isFieldFocused)
+                .foregroundStyle(TerminalPalette.foreground)
+                // 6pt container padding + 3pt here keeps the text's 9pt inset
+                // from the round-7 layout, and bottom-aligns the single-line text
+                // with the inline button's circle.
+                .padding(.vertical, 3)
+                .accessibilityIdentifier("MobileComposerField")
+
+                Button {
+                    send()
+                } label: {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.35) : .white)
+                        .frame(width: inlineSendDiameter, height: inlineSendDiameter)
+                        .background(
+                            Circle().fill(
+                                trimmedIsEmpty
+                                    ? AnyShapeStyle(TerminalPalette.foreground.opacity(0.12))
+                                    : AnyShapeStyle(Color.accentColor)
+                            )
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(trimmedIsEmpty)
+                .accessibilityIdentifier("MobileComposerSend")
+                .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
+            }
+            .padding(.leading, 14)
+            .padding(.trailing, 6)
+            .padding(.vertical, 6)
             .frame(minHeight: composerFieldMinHeight, alignment: .top)
             .mobileGlassField(cornerRadius: 20)
-            .accessibilityIdentifier("MobileComposerField")
-
-            Button {
-                send()
-            } label: {
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 17, weight: .bold))
-                    .frame(width: controlHeight, height: controlHeight)
-                    .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.35) : Color.accentColor)
-            }
-            .buttonStyle(.plain)
-            .mobileGlassCircle()
-            .disabled(trimmedIsEmpty)
-            .accessibilityIdentifier("MobileComposerSend")
-            .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -1,0 +1,189 @@
+#if os(iOS)
+import CMUXMobileCore
+import CmuxMobileShell
+import CmuxMobileSupport
+import CmuxMobileTerminal
+import SwiftUI
+
+/// iMessage-style composer hosted in the terminal surface's composer band.
+///
+/// A growing multi-line text field plus a send button, rendered with Liquid
+/// Glass (iOS 26+, with a thin-material fallback). Send delivers the text as a
+/// bracketed paste followed by a single Return (via `terminal.paste`), so a
+/// multi-line message lands as one submission instead of fragmenting on every
+/// interior newline. Toggled from the input accessory bar's composer button; the
+/// chevron dismisses it.
+///
+/// The bottom dock (terminal grid / composer band / accessory toolbar / keyboard)
+/// is owned entirely by `GhosttySurfaceView` in one coordinate system. This view is
+/// hosted in a `UIHostingController` that `GhosttySurfaceRepresentable` installs into
+/// the surface's composer band, directly above the always-visible accessory toolbar.
+/// The view reports its measured height through ``onHeightChange`` so the surface can
+/// reserve exactly that much above the toolbar; a field-grow therefore pushes ONLY the
+/// terminal up while the toolbar and keyboard below stay put. There is no
+/// `safeAreaInset` and no toolbar handoff — the prior rounds' two-layout-systems fight
+/// is gone because there is only one layout system (the surface).
+struct TerminalComposerView: View {
+    @Bindable var store: CMUXMobileShellStore
+    /// Asks the host to re-measure and re-size the surface's composer band. Fired
+    /// whenever the field's content changes (the only driver of this view's height);
+    /// the host measures the ideal height via `sizeThatFits` and animates the band.
+    let requestHeightRemeasure: () -> Void
+    @FocusState private var isFieldFocused: Bool
+
+    init(store: CMUXMobileShellStore, requestHeightRemeasure: @escaping () -> Void) {
+        self.store = store
+        self.requestHeightRemeasure = requestHeightRemeasure
+    }
+
+    /// Single-line height of the round close/send buttons. They stay pinned to the
+    /// bottom edge of the (taller) field via the `HStack`'s `.bottom` alignment.
+    private let controlHeight: CGFloat = 40
+
+    /// Line range for the growing compose field. Opens at a SINGLE line (`1...`) so it
+    /// starts as a compact one-line message box and grows as the user types, up to 14
+    /// lines before scrolling. Each added line grows this view's height, which the host
+    /// reserves above the toolbar, pushing only the terminal up.
+    private let composerLineLimit = 1...14
+
+    /// Minimum height of the compose field, matching the one-line baseline.
+    private let composerFieldMinHeight: CGFloat = 40
+
+    private var trimmedIsEmpty: Bool {
+        store.terminalInputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        composerSurface
+        // The field is pinned edge-to-edge inside the surface's composer band, so its
+        // outer size is locked to the band height and cannot report its own growth.
+        // The field's height is driven solely by its content, so ask the host to
+        // re-measure (via `sizeThatFits`, which returns the ideal height independent of
+        // the current frame) whenever the text changes — the grow as the user types and
+        // the shrink when the field is cleared after a send.
+        .onChange(of: store.terminalInputText) { _, _ in
+            requestHeightRemeasure()
+        }
+        .onAppear {
+            recordComposerEvent(.composerViewAppear)
+            focusField()
+        }
+        .onDisappear {
+            // COMPOSER: logged independently of `isComposerPresented`. A
+            // disappear with no matching `composerPresentedChanged a==0` is a
+            // view-recreation bug (the flag stayed true but SwiftUI rebuilt the
+            // view), not an intentional dismiss.
+            recordComposerEvent(.composerViewDisappear)
+        }
+        .onChange(of: isFieldFocused) { _, focused in
+            // COMPOSER: a focus-lost while the flag stayed presented and the
+            // view stayed mounted, yet the field reads empty, isolates the
+            // residual TextField/@FocusState render-blank case.
+            recordComposerEvent(.composerFieldFocusChanged, a: focused ? 1 : 0)
+        }
+        .onChange(of: store.composerFocusRequest) { _, _ in
+            // The surface asked the field to take focus without re-presenting the
+            // composer — the reveal-after-hide case, where the chrome and draft are
+            // already back but the terminal proxy holds first responder. Driving
+            // `@FocusState` here keeps it the single source of truth (the surface
+            // never touches the hosted UITextField directly).
+            focusField()
+        }
+    }
+
+    /// Record a composer diagnostic event into the store's structured log (DEBUG
+    /// dogfood builds only) so the "Send to agent" feedback pane exports it. A
+    /// no-op when no log is wired (release, or a host that does not set it).
+    private func recordComposerEvent(_ code: DiagnosticEventCode, a: Int? = nil) {
+        #if DEBUG
+        store.diagnosticLog?.record(DiagnosticEvent(code, a: a))
+        #endif
+    }
+
+    /// On iOS 26 the glass controls float in a `GlassEffectContainer` over the
+    /// terminal (no opaque bar — that would be glass-on-glass). Earlier OSes get
+    /// a `.bar` material backing behind the material controls.
+    @ViewBuilder
+    private var composerSurface: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer {
+                composerBar
+            }
+        } else {
+            composerBar
+                .background(.bar)
+        }
+    }
+
+    private var composerBar: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            Button {
+                store.toggleComposer()
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 15, weight: .semibold))
+                    .frame(width: controlHeight, height: controlHeight)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(TerminalPalette.foreground.opacity(0.7))
+            .mobileGlassCircle()
+            .accessibilityIdentifier("MobileComposerClose")
+            .accessibilityLabel(L10n.string("mobile.composer.close", defaultValue: "Hide Composer"))
+
+            TextField(
+                L10n.string("mobile.composer.placeholder", defaultValue: "Message"),
+                text: $store.terminalInputText,
+                axis: .vertical
+            )
+            // Opens at a single line and grows up to 14 lines so a long message has
+            // room. Each added line grows this view, which the host reserves above the
+            // always-visible toolbar; the toolbar and keyboard never move.
+            .lineLimit(composerLineLimit)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled(true)
+            .focused($isFieldFocused)
+            .foregroundStyle(TerminalPalette.foreground)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .frame(minHeight: composerFieldMinHeight, alignment: .top)
+            .mobileGlassField(cornerRadius: 20)
+            .accessibilityIdentifier("MobileComposerField")
+
+            Button {
+                send()
+            } label: {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 17, weight: .bold))
+                    .frame(width: controlHeight, height: controlHeight)
+                    .foregroundStyle(trimmedIsEmpty ? TerminalPalette.foreground.opacity(0.35) : Color.accentColor)
+            }
+            .buttonStyle(.plain)
+            .mobileGlassCircle()
+            .disabled(trimmedIsEmpty)
+            .accessibilityIdentifier("MobileComposerSend")
+            .accessibilityLabel(L10n.string("mobile.composer.send", defaultValue: "Send"))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    /// Focus the field one runloop after appearing. Setting `@FocusState` inline
+    /// in `onAppear` is unreliable (the field may not be in the window yet);
+    /// deferring lets it take first responder from the terminal input proxy
+    /// while that keyboard is still up, so the keyboard hands over in place
+    /// instead of dropping and re-animating.
+    private func focusField() {
+        Task { @MainActor in
+            isFieldFocused = true
+        }
+    }
+
+    private func send() {
+        guard !trimmedIsEmpty else { return }
+        isFieldFocused = true
+        Task { @MainActor in
+            await store.submitComposerInput()
+        }
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -31,14 +31,20 @@ import SwiftUI
 /// is gone because there is only one layout system (the surface).
 struct TerminalComposerView: View {
     @Bindable var store: CMUXMobileShellStore
+    /// The terminal this composer serves. Focus-request consumption is keyed on
+    /// it: during a terminal switch the outgoing composer is still mounted and
+    /// observes the same token, so only the view whose terminal matches the
+    /// request's target may consume it and focus.
+    let terminalID: String
     /// Asks the host to re-measure and re-size the surface's composer band. Fired
     /// whenever the field's content changes (the only driver of this view's height);
     /// the host measures the ideal height via `sizeThatFits` and animates the band.
     let requestHeightRemeasure: () -> Void
     @FocusState private var isFieldFocused: Bool
 
-    init(store: CMUXMobileShellStore, requestHeightRemeasure: @escaping () -> Void) {
+    init(store: CMUXMobileShellStore, terminalID: String, requestHeightRemeasure: @escaping () -> Void) {
         self.store = store
+        self.terminalID = terminalID
         self.requestHeightRemeasure = requestHeightRemeasure
     }
 
@@ -85,7 +91,7 @@ struct TerminalComposerView: View {
             // user was mid-compose). A default-open presentation arrives with no
             // pending request, so the field shows WITHOUT summoning the keyboard
             // — iMessage's input bar, visible but unfocused until tapped.
-            if store.consumePendingComposerFocusRequest() {
+            if store.consumePendingComposerFocusRequest(for: terminalID) {
                 focusField()
             }
         }
@@ -112,9 +118,11 @@ struct TerminalComposerView: View {
             // composer — the reveal-after-hide case, where the chrome and draft are
             // already back but the terminal proxy holds first responder. Driving
             // `@FocusState` here keeps it the single source of truth (the surface
-            // never touches the hosted UITextField directly). Consume the pending
-            // handshake too, so a later remount does not honor this request twice.
-            _ = store.consumePendingComposerFocusRequest()
+            // never touches the hosted UITextField directly). Consuming the keyed
+            // handshake guards the focus: an outgoing composer observing the same
+            // token during a terminal switch does not match the request's target,
+            // leaves it armed for the incoming mount, and must not focus itself.
+            guard store.consumePendingComposerFocusRequest(for: terminalID) else { return }
             focusField()
         }
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -154,7 +154,7 @@ struct TerminalComposerView: View {
     private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 8) {
             Button {
-                store.toggleComposer()
+                store.toggleComposer(forTerminalID: terminalID)
             } label: {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 15, weight: .semibold))

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
@@ -60,4 +60,44 @@ extension View {
             .overlay(Capsule().stroke(.white.opacity(0.18), lineWidth: 1))
         #endif
     }
+
+    /// Glass (iOS 26+) or thin-material rounded-rect background for a multi-line
+    /// composer field. A capsule (``mobileGlassPill()``) over-rounds once the
+    /// field grows to several lines, so the composer uses a fixed corner radius.
+    @ViewBuilder
+    func mobileGlassField(cornerRadius: CGFloat = 20) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: shape)
+        } else {
+            self
+                .background(.thinMaterial, in: shape)
+                .overlay(shape.stroke(.white.opacity(0.18), lineWidth: 1))
+        }
+        #else
+        self
+            .background(.thinMaterial, in: shape)
+            .overlay(shape.stroke(.white.opacity(0.18), lineWidth: 1))
+        #endif
+    }
+
+    /// Glass (iOS 26+) or thin-material circular background for a composer icon
+    /// button (send / dismiss). Pair with a fixed-size icon label.
+    @ViewBuilder
+    func mobileGlassCircle() -> some View {
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            self
+                .background(.thinMaterial, in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.18), lineWidth: 1))
+        }
+        #else
+        self
+            .background(.thinMaterial, in: Circle())
+            .overlay(Circle().stroke(.white.opacity(0.18), lineWidth: 1))
+        #endif
+    }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -486,34 +486,3 @@ struct WorkspaceDetailView: View {
         UIApplication.shared.dismissMobileKeyboard()
     }
 }
-
-#if os(iOS) && DEBUG
-/// Zero-impact store-side composer seam for UI tests (DEBUG only).
-///
-/// Carries the composer source-of-truth store flags as a stable, parseable
-/// `accessibilityValue` (`isComposerPresented=…;composerFocusRequest=…;draftLength=…`)
-/// on an element identified by `MobileComposerStoreProbe`, so a UI test can assert the
-/// store and the surface's mirror (`MobileComposerDockProbe`) agree across repeated
-/// open/close cycles and that the draft survives. Rendered as a 1×1 clear element so it
-/// never perturbs layout or intercepts touches. Never compiled into a shipping build.
-private struct ComposerStoreProbe: View {
-    let isComposerPresented: Bool
-    let composerFocusRequest: Int
-    let draftLength: Int
-
-    var body: some View {
-        Color.clear
-            .frame(width: 1, height: 1)
-            .allowsHitTesting(false)
-            .accessibilityElement()
-            .accessibilityIdentifier("MobileComposerStoreProbe")
-            .accessibilityValue(
-                [
-                    "isComposerPresented=\(isComposerPresented ? 1 : 0)",
-                    "composerFocusRequest=\(composerFocusRequest)",
-                    "draftLength=\(draftLength)",
-                ].joined(separator: ";")
-            )
-    }
-}
-#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -93,7 +93,12 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
+                    // While the composer is open it owns the keyboard, so a
+                    // surface re-create from switching terminals must not let the
+                    // hidden terminal input proxy grab first responder back.
                     autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
+                        && !store.isComposerPresented,
+                    isComposerActive: store.isComposerPresented
                 )
                 // Identity must track the selected terminal. The representable's
                 // coordinator binds its byte sink to the surfaceID at make time and
@@ -127,7 +132,29 @@ struct WorkspaceDetailView: View {
                 .padding(.top, 10)
                 .padding(.leading, 10)
         }
+        #if os(iOS) && DEBUG
+        // Store-side composer seam (DEBUG/UI-test only): exposes the source-of-truth
+        // store flags that drive the surface's composer mirror, so a UI test can assert
+        // the store and surface agree across repeated open/close cycles and that the
+        // draft (`terminalInputText`) survives. Zero-size + read live on every query;
+        // never compiled into a shipping build. Pairs with `MobileComposerDockProbe`
+        // on the surface side.
+        .overlay {
+            ComposerStoreProbe(
+                isComposerPresented: store.isComposerPresented,
+                composerFocusRequest: store.composerFocusRequest,
+                draftLength: store.terminalInputText.count
+            )
+        }
+        #endif
         #if os(iOS)
+        // The whole bottom dock (terminal grid / composer band / accessory toolbar /
+        // keyboard) is owned by `GhosttySurfaceView` in one coordinate system. The
+        // iMessage composer is mounted INTO the surface's composer band by
+        // `GhosttySurfaceRepresentable` (a `UIHostingController`), not added here as a
+        // `safeAreaInset`. There is no second layout system reaching into the
+        // surface's bottom, so the accessory toolbar can never be reparented out (its
+        // buttons can never disappear) and a composer-grow pushes only the terminal up.
         .mobileTerminalSafeAreaExpansion(
             context: safeAreaContext,
             includesBottom: true
@@ -454,3 +481,34 @@ struct WorkspaceDetailView: View {
         UIApplication.shared.dismissMobileKeyboard()
     }
 }
+
+#if os(iOS) && DEBUG
+/// Zero-impact store-side composer seam for UI tests (DEBUG only).
+///
+/// Carries the composer source-of-truth store flags as a stable, parseable
+/// `accessibilityValue` (`isComposerPresented=…;composerFocusRequest=…;draftLength=…`)
+/// on an element identified by `MobileComposerStoreProbe`, so a UI test can assert the
+/// store and the surface's mirror (`MobileComposerDockProbe`) agree across repeated
+/// open/close cycles and that the draft survives. Rendered as a 1×1 clear element so it
+/// never perturbs layout or intercepts touches. Never compiled into a shipping build.
+private struct ComposerStoreProbe: View {
+    let isComposerPresented: Bool
+    let composerFocusRequest: Int
+    let draftLength: Int
+
+    var body: some View {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .allowsHitTesting(false)
+            .accessibilityElement()
+            .accessibilityIdentifier("MobileComposerStoreProbe")
+            .accessibilityValue(
+                [
+                    "isComposerPresented=\(isComposerPresented ? 1 : 0)",
+                    "composerFocusRequest=\(composerFocusRequest)",
+                    "draftLength=\(draftLength)",
+                ].joined(separator: ";")
+            )
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -93,9 +93,14 @@ struct WorkspaceDetailView: View {
                     surfaceID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
-                    // While the composer is open it owns the keyboard, so a
-                    // surface re-create from switching terminals must not let the
-                    // hidden terminal input proxy grab first responder back.
+                    // While the composer is presented the terminal input proxy
+                    // must not grab first responder on attach. This covers both
+                    // composer states: mid-compose (the field owns the keyboard
+                    // and a surface re-create from switching terminals must not
+                    // steal it back) and the default-open presentation (the field
+                    // is visible but unfocused — iMessage semantics — so the
+                    // keyboard stays DOWN until the user taps the terminal or the
+                    // field).
                     autoFocusOnWindowAttach: store.shouldAutoFocusTerminalSurface(terminalID)
                         && !store.isComposerPresented,
                     isComposerActive: store.isComposerPresented

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryActionButton.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryActionButton.swift
@@ -13,6 +13,28 @@ final class AccessoryActionButton: UIButton {
     /// The configurable item this button triggers.
     let item: ResolvedToolbarItem
 
+    /// Whether this modifier is double-tap *sticky-locked* (vs. single-tap armed).
+    ///
+    /// A sticky-locked modifier stays applied to every keystroke until the user
+    /// taps it off, whereas an armed modifier is consumed by the next key. On
+    /// iOS 26 both states share the same prominent-glass blue fill, so the lock
+    /// needs its own visual cue: a white capsule border drawn on the button's
+    /// layer, *over* the glass, mirroring the 2pt white stroke the pre-26 flat
+    /// style already used for the locked state. The border is drawn at the layer
+    /// level (not via `UIButton.Configuration.background.strokeColor`) so it
+    /// composites on top of Liquid Glass regardless of how the glass material
+    /// renders its own background, and adds zero intrinsic width so it does not
+    /// fight the bar's min-width sizing.
+    var isStickyLocked = false {
+        didSet {
+            guard oldValue != isStickyLocked else { return }
+            updateStickyLockBorder()
+        }
+    }
+
+    /// Width of the sticky-lock capsule border, matching the pre-26 flat stroke.
+    private static let stickyLockBorderWidth: CGFloat = 2
+
     /// Creates a button bound to a resolved toolbar item.
     /// - Parameter item: The built-in or custom action the button represents.
     init(item: ResolvedToolbarItem) {
@@ -23,5 +45,29 @@ final class AccessoryActionButton: UIButton {
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Keep the lock border a true capsule that hugs the glass pill as the
+        // button's bounds settle (height is fixed, but the corner radius is
+        // derived here so the border tracks any future sizing change).
+        updateStickyLockBorder()
+    }
+
+    /// Sync the layer-level white capsule border to ``isStickyLocked``.
+    ///
+    /// Always clears the border when not locked, so a button that transitions
+    /// locked → armed → resting never keeps a stale border.
+    private func updateStickyLockBorder() {
+        if isStickyLocked {
+            layer.cornerRadius = bounds.height / 2
+            layer.cornerCurve = .continuous
+            layer.borderColor = UIColor.white.cgColor
+            layer.borderWidth = Self.stickyLockBorderWidth
+        } else {
+            layer.borderWidth = 0
+            layer.borderColor = nil
+        }
     }
 }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/ComposerDockProbeView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/ComposerDockProbeView.swift
@@ -1,0 +1,21 @@
+#if canImport(UIKit)
+import UIKit
+
+#if DEBUG
+/// Off-screen accessibility carrier that reports ``GhosttySurfaceView``'s live
+/// bottom-dock state to UI tests. Computes ``accessibilityValue`` on every read
+/// (delegating to ``GhosttySurfaceView/composerDockProbeValue``) so an XCUITest
+/// predicate-wait converges on the SETTLED post-transition state even though
+/// `fieldFocused`/`proxyFirstResponder` flip a runloop after the synchronous
+/// transition. DEBUG-only; never compiled into a shipping build.
+final class ComposerDockProbeView: UIView {
+    /// The surface whose dock state this probe re-reads on every query.
+    weak var surface: GhosttySurfaceView?
+
+    override var accessibilityValue: String? {
+        get { surface?.composerDockProbeValue }
+        set { /* read-only live probe; ignore writes */ }
+    }
+}
+#endif
+#endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
@@ -1,0 +1,55 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Resolves the current `UIResponder` first responder for DEBUG input
+/// instrumentation.
+///
+/// UIKit exposes no public "who is first responder" API. The standard technique
+/// is to send an action to the `nil` target: UIKit walks the responder chain
+/// from the current first responder and invokes the first responder that
+/// implements the selector. By defining the capture selector as a
+/// ``UIResponder`` extension, *every* responder implements it, so the action
+/// lands on the actual first responder, which records `self`.
+///
+/// This is a DEBUG-only diagnostic aid for the composer-dock instrumentation;
+/// it never drives behavior. `@MainActor` because it touches
+/// `UIApplication.shared.sendAction` on the main thread.
+@MainActor
+enum CurrentResponderProbe {
+    /// Returns the current first responder, or `nil` if there is none.
+    static func current() -> UIResponder? {
+        CurrentResponderCapture.captured = nil
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+        let captured = CurrentResponderCapture.captured
+        CurrentResponderCapture.captured = nil
+        return captured
+    }
+}
+
+/// Holds the responder captured during a ``CurrentResponderProbe/current()``
+/// probe.
+///
+/// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and the
+/// captured pointer is read immediately after on the same call, so the single
+/// stored slot never races. `nonisolated(unsafe)` is acceptable here: writes and
+/// reads are confined to the main actor's synchronous `sendAction` round-trip in
+/// ``CurrentResponderProbe/current()``, and this is DEBUG-only diagnostic
+/// scaffolding.
+private enum CurrentResponderCapture {
+    nonisolated(unsafe) static weak var captured: UIResponder?
+}
+
+private extension UIResponder {
+    /// Records `self` as the captured first responder. Invoked by UIKit's
+    /// responder-chain walk during ``CurrentResponderProbe/current()``; only the
+    /// actual first responder receives it.
+    @objc func cmuxDiagnosticCaptureFirstResponder(_ sender: Any?) {
+        CurrentResponderCapture.captured = self
+    }
+}
+#endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
@@ -1,17 +1,6 @@
 #if canImport(UIKit)
 import UIKit
 
-/// Holds the responder captured during a ``currentFirstResponderForDiagnostics()``
-/// probe.
-///
-/// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and the
-/// captured pointer is read immediately after on the same call, so the single
-/// stored slot never races. `nonisolated(unsafe)` is acceptable here: writes and
-/// reads are confined to the main actor's synchronous `sendAction` round-trip in
-/// ``currentFirstResponderForDiagnostics()``, and this is DEBUG-only diagnostic
-/// scaffolding.
-private nonisolated(unsafe) weak var diagnosticCapturedFirstResponder: UIResponder?
-
 /// Resolves the current `UIResponder` first responder for DEBUG input
 /// instrumentation.
 ///
@@ -24,28 +13,44 @@ private nonisolated(unsafe) weak var diagnosticCapturedFirstResponder: UIRespond
 ///
 /// This is a DEBUG-only diagnostic aid for the composer-dock instrumentation;
 /// it never drives behavior. `@MainActor` because it touches
-/// `UIApplication.shared.sendAction` on the main thread. Returns the current
-/// first responder, or `nil` if there is none.
+/// `UIApplication.shared.sendAction` on the main thread. An injectable value
+/// type so call sites construct it where they probe.
 @MainActor
-func currentFirstResponderForDiagnostics() -> UIResponder? {
-    diagnosticCapturedFirstResponder = nil
-    UIApplication.shared.sendAction(
-        #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
-        to: nil,
-        from: nil,
-        for: nil
-    )
-    let captured = diagnosticCapturedFirstResponder
-    diagnosticCapturedFirstResponder = nil
-    return captured
+struct CurrentResponderProbe {
+    /// Holds the responder captured during a ``current()`` probe.
+    ///
+    /// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and
+    /// the captured pointer is read immediately after on the same call, so the
+    /// single stored slot never races. `nonisolated(unsafe)` is acceptable
+    /// here: writes and reads are confined to the main actor's synchronous
+    /// `sendAction` round-trip in ``current()``, and this is DEBUG-only
+    /// diagnostic scaffolding.
+    fileprivate nonisolated(unsafe) static weak var captured: UIResponder?
+
+    /// Creates a probe.
+    init() {}
+
+    /// Returns the current first responder, or `nil` if there is none.
+    func current() -> UIResponder? {
+        Self.captured = nil
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+        let captured = Self.captured
+        Self.captured = nil
+        return captured
+    }
 }
 
 private extension UIResponder {
     /// Records `self` as the captured first responder. Invoked by UIKit's
-    /// responder-chain walk during ``currentFirstResponderForDiagnostics()``;
-    /// only the actual first responder receives it.
+    /// responder-chain walk during ``CurrentResponderProbe/current()``; only
+    /// the actual first responder receives it.
     @objc func cmuxDiagnosticCaptureFirstResponder(_ sender: Any?) {
-        diagnosticCapturedFirstResponder = self
+        CurrentResponderProbe.captured = self
     }
 }
 #endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/CurrentResponderProbe.swift
@@ -1,6 +1,17 @@
 #if canImport(UIKit)
 import UIKit
 
+/// Holds the responder captured during a ``currentFirstResponderForDiagnostics()``
+/// probe.
+///
+/// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and the
+/// captured pointer is read immediately after on the same call, so the single
+/// stored slot never races. `nonisolated(unsafe)` is acceptable here: writes and
+/// reads are confined to the main actor's synchronous `sendAction` round-trip in
+/// ``currentFirstResponderForDiagnostics()``, and this is DEBUG-only diagnostic
+/// scaffolding.
+private nonisolated(unsafe) weak var diagnosticCapturedFirstResponder: UIResponder?
+
 /// Resolves the current `UIResponder` first responder for DEBUG input
 /// instrumentation.
 ///
@@ -13,43 +24,28 @@ import UIKit
 ///
 /// This is a DEBUG-only diagnostic aid for the composer-dock instrumentation;
 /// it never drives behavior. `@MainActor` because it touches
-/// `UIApplication.shared.sendAction` on the main thread.
+/// `UIApplication.shared.sendAction` on the main thread. Returns the current
+/// first responder, or `nil` if there is none.
 @MainActor
-enum CurrentResponderProbe {
-    /// Returns the current first responder, or `nil` if there is none.
-    static func current() -> UIResponder? {
-        CurrentResponderCapture.captured = nil
-        UIApplication.shared.sendAction(
-            #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
-            to: nil,
-            from: nil,
-            for: nil
-        )
-        let captured = CurrentResponderCapture.captured
-        CurrentResponderCapture.captured = nil
-        return captured
-    }
-}
-
-/// Holds the responder captured during a ``CurrentResponderProbe/current()``
-/// probe.
-///
-/// The `sendAction(to: nil)` walk is synchronous and main-thread-only, and the
-/// captured pointer is read immediately after on the same call, so the single
-/// stored slot never races. `nonisolated(unsafe)` is acceptable here: writes and
-/// reads are confined to the main actor's synchronous `sendAction` round-trip in
-/// ``CurrentResponderProbe/current()``, and this is DEBUG-only diagnostic
-/// scaffolding.
-private enum CurrentResponderCapture {
-    nonisolated(unsafe) static weak var captured: UIResponder?
+func currentFirstResponderForDiagnostics() -> UIResponder? {
+    diagnosticCapturedFirstResponder = nil
+    UIApplication.shared.sendAction(
+        #selector(UIResponder.cmuxDiagnosticCaptureFirstResponder(_:)),
+        to: nil,
+        from: nil,
+        for: nil
+    )
+    let captured = diagnosticCapturedFirstResponder
+    diagnosticCapturedFirstResponder = nil
+    return captured
 }
 
 private extension UIResponder {
     /// Records `self` as the captured first responder. Invoked by UIKit's
-    /// responder-chain walk during ``CurrentResponderProbe/current()``; only the
-    /// actual first responder receives it.
+    /// responder-chain walk during ``currentFirstResponderForDiagnostics()``;
+    /// only the actual first responder receives it.
     @objc func cmuxDiagnosticCaptureFirstResponder(_ sender: Any?) {
-        CurrentResponderCapture.captured = self
+        diagnosticCapturedFirstResponder = self
     }
 }
 #endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1176,28 +1176,32 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// edge (up) or above the home indicator (down).
     private weak var dockedToolbar: UIView?
     /// Whether the iMessage-style composer is currently open. The surface owns the
-    /// whole bottom dock (terminal grid / composer band / toolbar / keyboard) in ONE
+    /// whole bottom dock (terminal grid / toolbar / composer band / keyboard) in ONE
     /// coordinate system, so `composerActive` only drives the first-responder
     /// handover that keeps the keyboard up across the toggle. It deliberately does
     /// NOT gate the toolbar's visibility (the bar stays visible while composing) and
     /// does NOT alter the keyboard occupancy math: the composer band is reserved
-    /// SEPARATELY (``composerBandHeight``) above the toolbar, never by reparenting the
-    /// toolbar into a second layout system.
+    /// SEPARATELY (``composerBandHeight``) above the keyboard edge, never by
+    /// reparenting the toolbar into a second layout system.
     private var composerActive = false
     /// The composer band: a surface-owned container the host installs the SwiftUI
     /// compose field into (via a `UIHostingController` in
     /// `GhosttySurfaceRepresentable`, which can see both layers; the terminal package
-    /// cannot import the UI package). The surface positions it itself — directly above
-    /// the docked toolbar, below the terminal grid — and reserves its height in the
-    /// grid, so the compose field, the toolbar, and the keyboard all live in the
-    /// surface's single coordinate system. Replaces the round-5/6
-    /// `safeAreaInset`-plus-toolbar-handoff that fought the surface's frame math.
+    /// cannot import the UI package). The surface positions it itself — pinned
+    /// directly above the keyboard (iMessage's field-nearest-keyboard layout), with
+    /// the docked toolbar riding its top edge and the terminal grid above that — and
+    /// reserves its height in the grid, so the compose field, the toolbar, and the
+    /// keyboard all live in the surface's single coordinate system (see
+    /// ``bottomDockFrames()`` for the `terminal / toolbar / composer / keyboard`
+    /// stack). Replaces the round-5/6 `safeAreaInset`-plus-toolbar-handoff that
+    /// fought the surface's frame math.
     private let composerContainer = UIView()
-    /// Height (points) the open composer band reserves above the docked toolbar. Fed
+    /// Height (points) the open composer band reserves above the keyboard edge. Fed
     /// by the host from the hosted compose field's intrinsic content size
     /// (``setComposerBandHeight(_:animated:)``); 0 while the composer is closed. The
-    /// grid reservation adds this so a field-grow pushes ONLY the terminal up — the
-    /// toolbar and keyboard below it never move.
+    /// grid reservation adds this so a field-grow pushes the toolbar and terminal
+    /// above it upward while the band stays pinned to the keyboard — the keyboard
+    /// itself never moves.
     private var composerBandHeight: CGFloat = 0
     /// True once SwiftUI has dismantled the hosting representable for this
     /// surface. A dismantled surface performs no render, output, or

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -905,12 +905,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastReportedSize ?? TerminalGridSize(columns: 100, rows: 32, pixelWidth: 900, pixelHeight: 650)
     }
 
+    #if DEBUG
     /// Structured diagnostic log (DEBUG dogfood builds only), property-injected
     /// from the shell store by ``GhosttySurfaceRepresentable`` so the
     /// composer-dock probes land in the blob the diagnostic export captures.
-    /// `nil` in release and in hosts that do not wire it; every probe is then a
-    /// no-op.
+    /// `nil` in hosts that do not wire it; every probe is then a no-op. The
+    /// property does not exist in release builds — every reader is inside a
+    /// `#if DEBUG` block.
     public var diagnosticLog: DiagnosticLog?
+    #endif
 
     private lazy var inputProxy: TerminalInputTextView = {
         let inputProxy = TerminalInputTextView()

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2877,10 +2877,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // ``bottomDockFrames()`` encode the `terminal / toolbar / composer / keyboard`
         // stack. While the HIDE button has suppressed the chrome (``chromeHidden``) the
         // toolbar is off screen and reserves nothing, and the composer band is hidden,
-        // so the grid reclaims the whole height; reserve only the keyboard if it is
-        // somehow still up.
+        // so the grid reclaims the whole height — including the bottom safe area
+        // (the home-indicator strip), matching ``bottomDockFrames()`` pinning the
+        // dock to `bounds.height`. Reserve only an actual keyboard if it is
+        // somehow still up; `keyboardOccupancyInBounds` must not be used here
+        // because its keyboard-down fallback is the safe-area inset, which would
+        // leave an empty strip under the full-screen grid.
         let reservedBottom = chromeHidden
-            ? keyboardOccupancyInBounds
+            ? max(0, keyboardHeight)
             : composerBandHeight + reservedToolbarHeight + keyboardOccupancyInBounds
         let bottomInset = min(reservedBottom, max(0, bounds.height - 1))
         let containerW = max(1, bounds.width)

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -55,18 +55,71 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// The user tapped the "customize" button at the end of the input-accessory
     /// bar; the host should present the toolbar shortcuts editor. Optional.
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView)
+    /// The user tapped the attachments button on the input-accessory bar; the host
+    /// should present the iOS photo/file picker and route any picked image through
+    /// the existing image-attach path (``ghosttySurfaceView(_:didPasteImage:format:)``).
+    /// Optional.
+    func ghosttySurfaceViewDidRequestAttachment(_ surfaceView: GhosttySurfaceView)
     /// Forward an image the user pasted from the system clipboard. The host
     /// uploads `data` to the Mac, which materializes a temp file and injects its
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
+    /// The user pasted an image that is too large to send even after trying a
+    /// compressed JPEG, so nothing was uploaded. The host should surface a
+    /// user-visible "too large" notice. Optional.
+    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView)
+    /// The composer accessory button was tapped; the host should toggle the
+    /// iMessage-style composer above the terminal. Optional.
+    ///
+    /// Round 8: the composer is dismissed ONLY by its own chevron or this toggle. The
+    /// keyboard collapsing no longer dismisses the composer (it survives a keyboard-down
+    /// and the toolbar stays visible), so there is no separate collapse/dismiss
+    /// delegate hook anymore.
+    func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView)
+    /// The surface needs the iMessage-style composer presented (if it is not already)
+    /// and its field re-focused, without dismissing it. The host ensures the composer
+    /// is presented and bumps the focus token the composer view observes. Used on the
+    /// reveal-after-hide and the present-while-suppressed paths so the draft and its
+    /// focus return together. Optional.
+    func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView)
+    /// Forward a committed block of text (system dictation, an autocorrect
+    /// replacement, or keyboard-inserted clipboard text) that should reach the
+    /// remote terminal as a bracketed paste rather than per-character input. The
+    /// host sends it via the `terminal.paste` RPC so embedded newlines do not
+    /// fragment into separate Returns. Defaults to the raw-input path so existing
+    /// conformers keep working. Optional.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String)
+    /// The user tapped the floating jump-to-bottom button; the host should ask
+    /// the Mac's real surface to scroll all the way to the live bottom (out of
+    /// scrollback). The mirror has no local scrollback, so this cannot be done
+    /// on-device. Optional.
+    func ghosttySurfaceViewDidRequestScrollToBottom(_ surfaceView: GhosttySurfaceView)
 }
 
 public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didScrollLines lines: Double, atCol col: Int, row: Int) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
+    func ghosttySurfaceViewDidRequestAttachment(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView) {}
+    func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {}
+    func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView) {}
+    func ghosttySurfaceViewDidRequestScrollToBottom(_ surfaceView: GhosttySurfaceView) {}
+    /// Default bracketed-paste handler that falls back to per-character input.
+    ///
+    /// A conformer that does not implement the bracketed-paste path still
+    /// delivers the text: newlines are normalized to CR (matching the
+    /// per-keystroke input path) and the bytes are forwarded through
+    /// ``ghosttySurfaceView(_:didProduceInput:)``.
+    /// - Parameters:
+    ///   - surfaceView: The surface view that produced the committed block.
+    ///   - text: The committed block of pasted/dictated text.
+    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
+        let normalized = text.replacingOccurrences(of: "\n", with: "\r")
+        ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))
+    }
 }
 
 @MainActor
@@ -268,6 +321,9 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     /// path. Unlike the other actions it carries no fixed byte ``output``; the
     /// host reads the pasteboard when it is tapped.
     case paste
+    // Appended at the end so existing persisted raw values (user accessory bar
+    // order/enabled set) are preserved.
+    case composer
     var title: String {
         title(isMacRemote: false)
     }
@@ -285,6 +341,8 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .zoomOut:
             return ""
         case .zoomIn:
+            return ""
+        case .composer:
             return ""
         case .escape:
             return String(localized: "terminal.input_accessory.title.escape", defaultValue: "Esc")
@@ -341,6 +399,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .shift: return "terminal.inputAccessory.shift"
         case .zoomOut: return "terminal.inputAccessory.zoomOut"
         case .zoomIn: return "terminal.inputAccessory.zoomIn"
+        case .composer: return "terminal.inputAccessory.composer"
         case .escape: return "terminal.inputAccessory.escape"
         case .tab: return "terminal.inputAccessory.tab"
         case .upArrow: return "terminal.inputAccessory.up"
@@ -374,6 +433,16 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return String(localized: "terminal.input_accessory.zoom_in", defaultValue: "Zoom In")
         case .paste:
             return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
+        case .composer:
+            return String(localized: "terminal.input_accessory.composer", defaultValue: "Composer")
+        case .upArrow:
+            return String(localized: "terminal.input_accessory.up_arrow", defaultValue: "Up Arrow")
+        case .downArrow:
+            return String(localized: "terminal.input_accessory.down_arrow", defaultValue: "Down Arrow")
+        case .leftArrow:
+            return String(localized: "terminal.input_accessory.left_arrow", defaultValue: "Left Arrow")
+        case .rightArrow:
+            return String(localized: "terminal.input_accessory.right_arrow", defaultValue: "Right Arrow")
         default:
             return nil
         }
@@ -387,6 +456,16 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return "plus.magnifyingglass"
         case .paste:
             return "doc.on.clipboard"
+        case .composer:
+            return "square.and.pencil"
+        case .upArrow:
+            return "arrow.up"
+        case .downArrow:
+            return "arrow.down"
+        case .leftArrow:
+            return "arrow.left"
+        case .rightArrow:
+            return "arrow.right"
         default:
             return nil
         }
@@ -413,7 +492,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
 
     var output: Data? {
         switch self {
-        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn, .paste:
+        case .control, .alternate, .command, .shift, .zoomOut, .zoomIn, .paste, .composer:
             return nil
         case .escape:
             return Data([0x1B])
@@ -462,14 +541,16 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
 
     /// Whether the user can show/hide/reorder this action.
     ///
-    /// Every button on the bar is configurable except ``shift``, which has armed
-    /// machinery but is intentionally not surfaced as a bar button. The leading
-    /// modifier keys (⌃ ⌥ ⌘), zoom controls, and paste used to be structurally
-    /// pinned; they are now part of the user-configurable region too, so their
-    /// position can be moved alongside the insertable shortcuts.
+    /// Every button on the bar is configurable except ``shift`` and ``composer``,
+    /// which have armed machinery but are intentionally not surfaced as bar
+    /// buttons (``composer`` is the iMessage-style composer toggle, not a normal
+    /// shortcut). The leading modifier keys (⌃ ⌥ ⌘), zoom controls, and paste used
+    /// to be structurally pinned; they are now part of the user-configurable
+    /// region too, so their position can be moved alongside the insertable
+    /// shortcuts.
     public var isUserConfigurable: Bool {
         switch self {
-        case .shift:
+        case .shift, .composer:
             return false
         default:
             return true
@@ -556,7 +637,7 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
         case .command: return String(localized: "terminal.shortcut.name.command", defaultValue: "Command")
         case .zoomIn: return String(localized: "terminal.input_accessory.zoom_in", defaultValue: "Zoom In")
         case .zoomOut: return String(localized: "terminal.input_accessory.zoom_out", defaultValue: "Zoom Out")
-        case .shift:
+        case .shift, .composer:
             return title
         }
     }
@@ -649,6 +730,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// GPU is available so any in-flight render drains — and gate dispatch so
     /// no `render_now` is sent into the background.
     private var renderingSuspended: Bool = false
+    /// Set when a foreground transition (`didBecomeActive` / `willEnterForeground`)
+    /// reached this view but could not finish resuming the render loop because the
+    /// view was momentarily off-window or surfaceless. The next ``didMoveToWindow``
+    /// (window non-nil) completes the resume so the terminal repaints. Without
+    /// this, a foreground that races the SwiftUI representable re-attach would
+    /// clear suspension but never restart the display link, leaving the terminal
+    /// frozen on stale content while input (a separate RPC) still worked — the
+    /// home-button background→foreground render-freeze.
+    private var pendingForegroundResume: Bool = false
     #if DEBUG
     /// Last time the display-link heartbeat logged (DEBUG diagnostic). The
     /// per-frame callback runs on the main thread, so a steady heartbeat proves
@@ -659,6 +749,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Time of the most recent applied render-grid output, for the heartbeat's
     /// `sinceOutput` field (ties an idle blank to a stream gap).
     private var lastOutputAppliedTime: CFTimeInterval = 0
+    /// Time-gate stamp for the ``DiagnosticEventCode/renderFrameApplied`` heartbeat so
+    /// it records ≈1/s instead of per output chunk (RENDER: frame-apply).
+    private var lastRenderFrameDiagTime: CFTimeInterval = 0
+    /// Time-gate stamp for the ``DiagnosticEventCode/renderBusySkipped`` event so a
+    /// continuous render-coalesce burst records ≈1/s, not per skipped frame.
+    private var lastRenderBusyDiagTime: CFTimeInterval = 0
+    /// Media time the in-flight `render_now` was enqueued, for the busy/duration
+    /// RENDER: events. 0 when no render is in flight.
+    private var renderInFlightStart: CFTimeInterval = 0
+    /// Only a `render_now` slower than this (ms) records a
+    /// ``DiagnosticEventCode/renderCompleted`` event, so the bounded diagnostic ring is
+    /// not flooded by normal fast renders at 120fps.
+    private static let renderCompletedSlowThresholdMs: Double = 50
     #endif
     /// Set by any geometry trigger (resize/zoom/keyboard/effective-grid pin);
     /// the display link applies geometry at most once per frame. Coalescing
@@ -698,6 +801,72 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         proxy.accessibilityIdentifier = "MobileTerminalSurface"
         return proxy
     }()
+
+    /// DEBUG/UI-test accessibility carrier for the surface's live bottom-dock state.
+    ///
+    /// Exposes the four dock bits the round-9 reducer turns on
+    /// (``ComposerDockState``) plus the last resolved ``ComposerDockIntent`` and the
+    /// terminal proxy's first-responder status as a stable, parseable
+    /// `accessibilityValue` string so an XCUITest can assert the surface's internal
+    /// composer state precisely across repeated open/close cycles — the discriminating
+    /// seam for the "composer jank" repro. Non-interactive, off-screen (1×1 at the
+    /// origin) so it never intercepts taps or perturbs layout; it carries no rendered
+    /// text (that stays on ``debugAccessibilityProxy``).
+    ///
+    /// The value is computed live on every accessibility READ (not cached on a
+    /// transition), because `fieldFocused`/`proxyFirstResponder` flip a runloop after
+    /// the synchronous transition (the focus token / `@FocusState` are deferred). An
+    /// XCUITest predicate-wait re-reads the element until it converges, so a live getter
+    /// is the only thing that lets the test see the SETTLED post-transition state.
+    private lazy var composerDockProbe: ComposerDockProbeView = {
+        let probe = ComposerDockProbeView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        probe.backgroundColor = .clear
+        probe.isUserInteractionEnabled = false
+        probe.isAccessibilityElement = true
+        probe.accessibilityIdentifier = "MobileComposerDockProbe"
+        probe.surface = self
+        return probe
+    }()
+
+    /// The last ``ComposerDockIntent`` ``handleComposerButtonTap()`` resolved, recorded
+    /// purely so the dock probe can report it to the UI test. `nil` until the first
+    /// compose-button tap.
+    fileprivate var lastComposerDockIntent: ComposerDockIntent?
+
+    /// The live `key=value;…` description of the bottom dock, read by
+    /// ``ComposerDockProbeView`` on every accessibility query. `fieldFocused` is the
+    /// SAME ``composerFieldIsFirstResponder`` walk the reducer reads, so the probe and
+    /// the real decision can never disagree.
+    fileprivate var composerDockProbeValue: String {
+        let intent: String
+        switch lastComposerDockIntent {
+        case .openComposer: intent = "open"
+        case .revealAndFocusComposer: intent = "reveal"
+        case .closeComposer: intent = "close"
+        case nil: intent = "none"
+        }
+        // Toolbar horizontal geometry, to localize the hide→reveal "compose button
+        // off-screen" jank. `surfaceMinXInWindow` is exactly what
+        // `accessoryLayoutInsetsProvider` feeds into the toolbar's leading inset; if it
+        // is wrong during a reveal reflow the button row shifts. `toolbarOriginX` is the
+        // docked container's own X (set to 0 by `layoutBottomDock`), so a nonzero value
+        // here, or a large `surfaceMinXInWindow`, points at the displacement source.
+        let surfaceMinXInWindow = window.map { Int(convert(bounds, to: $0).minX) } ?? -1
+        let toolbarOriginX = dockedToolbar.map { Int($0.frame.minX) } ?? -1
+        return [
+            "chromeHidden=\(chromeHidden ? 1 : 0)",
+            "composerActive=\(composerActive ? 1 : 0)",
+            "fieldFocused=\(composerFieldIsFirstResponder ? 1 : 0)",
+            "keyboardUp=\(keyboardHeight > 0 ? 1 : 0)",
+            "proxyFirstResponder=\(inputProxy.isFirstResponder ? 1 : 0)",
+            "bandMounted=\(composerContainer.subviews.isEmpty ? 0 : 1)",
+            "toolbarVisible=\(dockedToolbar?.isHidden == false ? 1 : 0)",
+            "surfaceMinXInWindow=\(surfaceMinXInWindow)",
+            "toolbarOriginX=\(toolbarOriginX)",
+            "lastIntent=\(intent)",
+            inputProxy.accessoryLayoutDiagnostics,
+        ].joined(separator: ";")
+    }
     #endif
     private let snapshotFallbackView: UITextView = {
         let view = UITextView()
@@ -807,8 +976,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastReportedSize ?? TerminalGridSize(columns: 100, rows: 32, pixelWidth: 900, pixelHeight: 650)
     }
 
+    /// Structured diagnostic log (DEBUG dogfood builds only), property-injected
+    /// from the shell store by ``GhosttySurfaceRepresentable`` so the
+    /// hold-backspace + dictation input probes land in the blob the "Send to
+    /// agent" feedback pane exports. Forwarded to ``inputProxy`` on set. `nil` in
+    /// release and in hosts that do not wire it; every probe is then a no-op.
+    public var diagnosticLog: DiagnosticLog? {
+        didSet { inputProxy.diagnosticLog = diagnosticLog }
+    }
+
     private lazy var inputProxy: TerminalInputTextView = {
         let inputProxy = TerminalInputTextView()
+        inputProxy.diagnosticLog = diagnosticLog
         inputProxy.onText = { [weak self] text in
             guard let self else { return }
             self.resetCursorBlink()
@@ -828,6 +1007,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             // Send DEL (0x7F) directly to transport as raw byte.
             let data = Data([0x7F])
+            #if DEBUG
+            // Pairs with `inputDeleteBackward`: if N delete calls produce N
+            // emitted DEL bytes, the iOS input view is correct and the
+            // hold-backspace failure is downstream (transport/Mac/render), not in
+            // this view — redirecting the hunt instead of a 4th input-view guess.
+            self.diagnosticLog?.record(DiagnosticEvent(.inputBackspaceEmitted, ms: UInt32(data.count)))
+            #endif
             TerminalInputDebugLog.log("surface.onBackspace data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
         }
@@ -837,26 +1023,74 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             TerminalInputDebugLog.log("surface.onEscape data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
         }
+        inputProxy.onPasteText = { [weak self] text in
+            guard let self else { return }
+            self.resetCursorBlink()
+            // Multi-character commits (dictation, autocorrect, keyboard clipboard
+            // insert) go through the bracketed-paste RPC so embedded newlines are
+            // not split into separate Returns by the remote terminal.
+            TerminalInputDebugLog.log("surface.onPasteText text=\(TerminalInputDebugLog.textSummary(text))")
+            self.delegate?.ghosttySurfaceView(self, didPasteText: text)
+        }
         inputProxy.onPasteImage = { [weak self] data, format in
             guard let self else { return }
             TerminalInputDebugLog.log("surface.onPasteImage bytes=\(data.count) format=\(format)")
             self.delegate?.ghosttySurfaceView(self, didPasteImage: data, format: format)
         }
+        inputProxy.onPasteImageTooLarge = { [weak self] in
+            guard let self else { return }
+            TerminalInputDebugLog.log("surface.onPasteImageTooLarge")
+            self.delegate?.ghosttySurfaceViewDidFailToPasteImageTooLarge(self)
+        }
         inputProxy.onZoom = { [weak self] direction in
             self?.performFontZoom(direction)
         }
+        inputProxy.onToggleComposer = { [weak self] in
+            guard let self else { return }
+            self.handleComposerButtonTap()
+        }
         inputProxy.onHideKeyboard = { [weak self] in
             guard let self else { return }
-            // Toggle: dismiss when the keyboard is up, bring it back when down.
-            if self.inputProxy.isFirstResponder {
-                self.resignInput()
+            #if DEBUG
+            // The keyboard-toggle was tapped while composing. Round 8 no longer
+            // dismisses the composer here (the composer survives a keyboard-down), so
+            // this is now purely diagnostic.
+            if self.composerActive {
+                let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+                self.diagnosticLog?.record(DiagnosticEvent(
+                    .composerKeyboardToggleWhilePresented,
+                    ms: UInt32(max(0, self.keyboardHeight)),
+                    a: self.inputProxy.isFirstResponder ? 1 : 0,
+                    b: frOwner.rawValue
+                ))
+            }
+            #endif
+            // Round 8: the keyboard-toggle button only raises/lowers the keyboard. The
+            // toolbar stays visible either way, and an open composer survives a
+            // keyboard-down (its draft lives in the store; the field just loses focus).
+            // While composing, the composer's hosted field — not `inputProxy` — holds
+            // first responder, so resign through the container to drop the keyboard;
+            // otherwise toggle the terminal input proxy.
+            if self.keyboardHeight > 0 {
+                if self.composerActive {
+                    self.composerContainer.endEditing(true)
+                } else {
+                    self.resignInput()
+                }
             } else {
                 self.focusInput()
             }
         }
+        inputProxy.onHideChrome = { [weak self] in
+            self?.setChromeHidden(true)
+        }
         inputProxy.onOpenToolbarSettings = { [weak self] in
             guard let self else { return }
             self.delegate?.ghosttySurfaceViewDidRequestToolbarSettings(self)
+        }
+        inputProxy.onOpenAttachments = { [weak self] in
+            guard let self else { return }
+            self.delegate?.ghosttySurfaceViewDidRequestAttachment(self)
         }
         inputProxy.accessoryLayoutInsetsProvider = { [weak self] in
             guard let self,
@@ -894,8 +1128,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         addSubview(inputProxy)
         #if DEBUG
         addSubview(debugAccessibilityProxy)
+        addSubview(composerDockProbe)
         #endif
         installPersistentToolbar()
+        installComposerContainer()
         initializeSurface()
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
@@ -967,6 +1203,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     @objc private func handleAppWillEnterForeground() {
+        // `willEnterForeground` fires before `didBecomeActive` on every foreground
+        // (including the home-button case), so resume the render loop here too,
+        // not only from `didBecomeActive`. `resumeRendering` is idempotent and, if
+        // the view is momentarily off-window, arms `pendingForegroundResume` so
+        // `didMoveToWindow` completes the resume — the terminal repaints regardless
+        // of how the foreground notifications and the SwiftUI re-attach interleave.
+        resumeRendering()
         guard surface != nil, window != nil else { return }
         // The Mac drops this device's sticky viewport pin a few seconds after the
         // connection backgrounds, so on reconnect it reverts to its own (often
@@ -994,19 +1237,53 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Resume the render loop once the app is active again.
     ///
-    /// A `render_now` in flight at suspend either drained (the GPU was still
-    /// available before background) or never dispatched, and its main-thread
-    /// completion may have been deferred while the queue was suspended — so clear
-    /// the in-flight flag to guarantee the first foreground frame can dispatch,
-    /// re-mark the surface visible, and restart the frame pump. Idempotent.
+    /// Called from both `willEnterForeground` and `didBecomeActive` (and indirectly
+    /// from `didMoveToWindow` via the pending-resume completion), so it must be
+    /// idempotent: the in-flight render gate is reset only on the suspended→active
+    /// transition, never on a second call while already running. Resetting it
+    /// unconditionally would race a `render_now` that a display-link tick enqueued
+    /// between the two foreground notifications — marking it not-in-flight defeats
+    /// the coalescing guard and lets extra renders pile on `outputQueue`.
     private func resumeRendering() {
+        let wasSuspended = renderingSuspended
         renderingSuspended = false
-        renderInFlight = false
-        needsAnotherRender = false
-        guard let surface, window != nil else { return }
-        ghostty_surface_set_occlusion(surface, true)  // true = visible
+        if wasSuspended {
+            // A `render_now` in flight at suspend either drained (the GPU was
+            // still available before background) or never dispatched, and its
+            // main-thread completion may have been deferred while the queue was
+            // suspended — clear the in-flight flag so the first foreground frame
+            // can dispatch. Safe here because no live render can be enqueued while
+            // suspended (`requestRender` early-returns on `renderingSuspended`).
+            renderInFlight = false
+            needsAnotherRender = false
+        }
+        guard let surface, window != nil else {
+            // The foreground notification reached this view before it was back
+            // on-window (a SwiftUI representable re-attach can race the scene
+            // becoming active). Suspension is already cleared, but the display
+            // link can't restart while detached — arm a pending resume so the
+            // next `didMoveToWindow` (window non-nil) finishes the job and the
+            // terminal repaints instead of staying frozen on stale content.
+            pendingForegroundResume = true
+            MobileDebugLog.anchormux("resume.skip hasSurface=\(surface != nil) win=\(window != nil) armedPending")
+            return
+        }
+        pendingForegroundResume = false
+        MobileDebugLog.anchormux("resume.enter restartingDisplayLink")
+        // Re-assert occlusion against the current view state (not unconditionally
+        // visible): a still-hidden/zero-size surface stays occluded so a stale
+        // present can't flash. `syncSurfaceVisibility` updates the cursor overlay.
+        syncSurfaceVisibility()
         setFocus(true)
+        // Force a fresh repaint at the correct size: the IOSurface may have lost
+        // its backing while backgrounded, so a single stale-size draw can land
+        // blank. Clearing `lastReportedSize` forces the natural grid to re-report
+        // even if it is unchanged (the Mac drops the sticky viewport pin while
+        // backgrounded), and the geometry resync guarantees the first foreground
+        // frame is sized and drawn from current content.
+        lastReportedSize = nil
         needsDraw = true
+        setNeedsGeometrySync(reassertNaturalSize: true)
         startDisplayLink()
     }
 
@@ -1018,14 +1295,53 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// installed (`installPersistentToolbar`), so the home-indicator reservation
     /// still lands even if the toolbar UI is absent.
     private var reservedToolbarHeight: CGFloat = 0
-    /// Height of the docked accessory bar (the button row). Reserved in the grid
-    /// geometry so the bottom TUI rows stay visible above it.
-    private static let persistentToolbarHeight: CGFloat = 44
-    /// The docked accessory bar. Positioned by `dockedToolbarFrame()` with the
+    /// Height of the docked accessory bar reserved in the grid geometry so the
+    /// bottom TUI rows stay visible above it. Locked to the bar's actual button-row
+    /// height (`TerminalInputTextView.dockedButtonRowHeight`) so the grid reserves
+    /// EXACTLY the strip the buttons occupy — no taller. Round 3 reserved 44 while
+    /// the strip was only 34, so the extra 10pt rendered as bar background below
+    /// the buttons (the "gap below" Lawrence kept seeing). Matching them removes it,
+    /// leaving only the sub-cell render remainder, which the bar absorbs below the
+    /// top-pinned button row.
+    private static let persistentToolbarHeight: CGFloat = TerminalInputTextView.dockedButtonRowHeight
+    /// The docked accessory bar. Positioned by ``bottomDockFrames()`` with the
     /// SAME bottom-occupancy math as the grid reservation, so its top is always
     /// flush with the grid bottom (no gap) and its bottom rests on the keyboard
     /// edge (up) or above the home indicator (down).
     private weak var dockedToolbar: UIView?
+    /// The floating jump-to-bottom button. Installed lazily alongside the docked
+    /// toolbar, positioned bottom-right just above the toolbar/composer/keyboard
+    /// reserve in ``layoutBottomDock()``, and shown only while ``scrolledUp`` is
+    /// true (the Mac reported the viewport is scrolled up into scrollback).
+    private weak var scrollToBottomButton: ScrollToBottomButton?
+    /// Whether the terminal is scrolled up (has room to jump to the live bottom),
+    /// pushed down from the render-grid producer's authoritative position via
+    /// ``setScrolledUp(_:)``. Drives ``scrollToBottomButton`` visibility.
+    private var scrolledUp = false
+    /// Whether the iMessage-style composer is currently open. The surface owns the
+    /// whole bottom dock (terminal grid / composer band / toolbar / keyboard) in ONE
+    /// coordinate system, so `composerActive` only drives the first-responder
+    /// handover that keeps the keyboard up across the toggle. It deliberately does
+    /// NOT gate the toolbar's visibility (the bar stays visible while composing) and
+    /// does NOT alter the keyboard occupancy math: the composer band is reserved
+    /// SEPARATELY (``composerBandHeight``) above the toolbar, never by reparenting the
+    /// toolbar into a second layout system.
+    private var composerActive = false
+    /// The composer band: a surface-owned container the host installs the SwiftUI
+    /// compose field into (via a `UIHostingController` in
+    /// `GhosttySurfaceRepresentable`, which can see both layers; the terminal package
+    /// cannot import the UI package). The surface positions it itself — directly above
+    /// the docked toolbar, below the terminal grid — and reserves its height in the
+    /// grid, so the compose field, the toolbar, and the keyboard all live in the
+    /// surface's single coordinate system. Replaces the round-5/6
+    /// `safeAreaInset`-plus-toolbar-handoff that fought the surface's frame math.
+    private let composerContainer = UIView()
+    /// Height (points) the open composer band reserves above the docked toolbar. Fed
+    /// by the host from the hosted compose field's intrinsic content size
+    /// (``setComposerBandHeight(_:animated:)``); 0 while the composer is closed. The
+    /// grid reservation adds this so a field-grow pushes ONLY the terminal up — the
+    /// toolbar and keyboard below it never move.
+    private var composerBandHeight: CGFloat = 0
     /// True once SwiftUI has dismantled the hosting representable for this
     /// surface. A dismantled surface performs no render, output, or
     /// accessibility work so a view SwiftUI has removed cannot keep driving the
@@ -1038,21 +1354,70 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public var autoFocusOnWindowAttach = true
 
     @objc private func handleKeyboardWillShow(_ notification: Notification) {
+        #if DEBUG
+        // Capture WHICH view owns first responder the instant the keyboard comes
+        // up — the load-bearing question for the hold-backspace + dictation hunt.
+        // Recorded before any geometry guard so it fires on every keyboard-up,
+        // even when the height is unchanged. This is the iOS analog of checking
+        // for a Mac-style `keyRepair` focus-steal: if this is not
+        // `terminalInputProxy`, the keyboard never drives the view we instrument.
+        let kbResponder = CurrentResponderProbe.current()
+        let kbIdentity = TerminalInputTextView.responderIdentity(of: kbResponder)
+        diagnosticLog?.record(DiagnosticEvent(.inputKeyboardUp, a: kbIdentity.rawValue))
+        MobileDebugLog.anchormux(
+            "input.keyboardUp identity=\(kbIdentity) class=\(TerminalInputTextView.responderClassName(kbResponder)) proxyIsFR=\(inputProxy.isFirstResponder)"
+        )
+        #endif
         guard let frameEnd = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
               let window else { return }
         let keyboardFrameInView = convert(frameEnd, from: window)
         let overlap = max(0, bounds.maxY - keyboardFrameInView.minY)
         guard overlap != keyboardHeight else { return }
+        let wasDown = keyboardHeight == 0
         keyboardHeight = overlap
         inputProxy.setKeyboardShown(true)
+        // The bar is keyboard-tied: reveal it (and reserve its grid height) as the
+        // keyboard comes up. Done before the frame animation so it animates in
+        // with the keyboard instead of popping after.
+        if wasDown { updateDockedToolbarVisibility() }
         animateDockedToolbar(with: notification)
         setNeedsGeometrySync()
     }
 
     @objc private func handleKeyboardWillHide(_ notification: Notification) {
         guard keyboardHeight != 0 else { return }
+        #if DEBUG
+        // The composer-up/keyboard-down desync can be reached WITHOUT the dismiss
+        // button (code 24): a swipe-to-dismiss, an attached hardware keyboard, or
+        // backgrounding all collapse the keyboard straight through this overlap→0
+        // transition. Codes 23/24 are silent on those paths, so the onset of the
+        // desync — `keyboardHeight→0 while the composer is still active` — is recorded
+        // here too, with the resolved first-responder owner, so a Capture&Send trace
+        // is complete no matter how the keyboard went down. Pure diagnostics; the hide
+        // behavior below is unchanged.
+        if composerActive {
+            let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+            MobileDebugLog.anchormux(
+                "composer.keyboardHideWhilePresented prevKeyboardHeight=\(Int(keyboardHeight)) frOwner=\(frOwner.rawValue) proxyIsFR=\(inputProxy.isFirstResponder ? 1 : 0)"
+            )
+        }
+        #endif
         keyboardHeight = 0
         inputProxy.setKeyboardShown(false)
+        // Round 8 removes the `composerPresented ⇒ keyboardUp` enforcement: the
+        // toolbar is ALWAYS visible and the composer band survives a keyboard-down, so
+        // the keyboard collapsing no longer dismisses the composer. The composer's
+        // draft lives in the store (`terminalInputText`), so the field just loses focus
+        // and its text stays; tapping it refocuses and re-raises the keyboard. The
+        // composer is dismissed only by its chevron or the toolbar composer button.
+        //
+        // The toolbar stays visible while the keyboard is down (it now rides the bottom
+        // safe area), so visibility does not change here. Re-seat the dock and re-sync
+        // the grid: `keyboardOccupancyInBounds` flips from the keyboard height to the
+        // safe-area inset, so the dock drops to ride the home indicator and the grid
+        // reclaims the keyboard's space (minus the now-reserved safe area + toolbar +
+        // composer band).
+        updateDockedToolbarVisibility()
         animateDockedToolbar(with: notification)
         setNeedsGeometrySync()
         // No explicit scrollback request here: the grid grew, so the viewport
@@ -1069,7 +1434,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func debugSetKeyboardHeightForLayoutPreview(_ height: CGFloat) {
         keyboardHeight = max(0, height)
         inputProxy.setKeyboardShown(height > 0)
-        layoutDockedToolbar()
+        // Mirror the live keyboard-tied visibility so the preview shows the bar
+        // only when the synthetic keyboard is "up".
+        updateDockedToolbarVisibility()
+        layoutBottomDock()
         setNeedsGeometrySync()
         setNeedsLayout()
     }
@@ -1092,42 +1460,554 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let toolbar = inputProxy.toolbarView
         addSubview(toolbar)
         dockedToolbar = toolbar
-        reservedToolbarHeight = Self.persistentToolbarHeight
-        layoutDockedToolbar()
+        // Raise the toolbar above the Ghostty renderer's own sublayer (which it
+        // inserts directly into `self.layer`), so a dragged/lifted Liquid-Glass button
+        // floating UP over the terminal is not occluded or clipped by the render layer
+        // (item 6). Subview order alone does not guarantee this because the renderer
+        // sublayer is composited at the layer level; the zoom overlay uses the same
+        // `zPosition` lever. The toolbar must also not clip its own bounds so the lift
+        // is visible above the strip.
+        toolbar.layer.zPosition = Self.bottomChromeZPosition
+        toolbar.clipsToBounds = false
+        installScrollToBottomButton()
+        updateDockedToolbarVisibility()
+        layoutBottomDock()
     }
 
-    /// Full-width bar whose bottom sits on the keyboard (when up) or the very
-    /// bottom edge (when down). It intentionally does NOT reserve the bottom
-    /// safe area: the toolbar IS the bottom chrome, so the home indicator simply
-    /// overlays its lower edge (like a system tab bar) instead of leaving an
-    /// empty strip below it. Mirrors the `bottomInset` math in
-    /// `syncSurfaceGeometry` so the toolbar top equals the grid bottom exactly.
-    private func dockedToolbarFrame() -> CGRect {
-        let occupied = max(0, keyboardHeight)
-        let height = Self.persistentToolbarHeight
-        return CGRect(x: 0, y: bounds.height - height - occupied, width: bounds.width, height: height)
+    /// Install the floating jump-to-bottom button as a sibling of the docked
+    /// toolbar. It shares the bottom-chrome `zPosition` so the lifted glass is
+    /// not clipped by the Ghostty render sublayer (item 6), and starts hidden
+    /// until ``setScrolledUp(_:)`` reports the viewport is scrolled up. Tapping
+    /// it routes to the surface delegate, which asks the Mac to scroll to bottom.
+    private func installScrollToBottomButton() {
+        guard scrollToBottomButton == nil else { return }
+        let button = ScrollToBottomButton()
+        button.layer.zPosition = Self.bottomChromeZPosition
+        button.alpha = 0
+        button.isHidden = true
+        button.onTap = { [weak self] in
+            guard let self else { return }
+            self.delegate?.ghosttySurfaceViewDidRequestScrollToBottom(self)
+        }
+        addSubview(button)
+        scrollToBottomButton = button
     }
 
-    private func layoutDockedToolbar() {
-        dockedToolbar?.frame = dockedToolbarFrame()
+    /// Update whether the terminal is scrolled up and animate the floating
+    /// jump-to-bottom button in or out to match.
+    ///
+    /// Driven by the render-grid producer's authoritative viewport position
+    /// (pushed down from the shell store through the representable). Idempotent:
+    /// an unchanged value is a no-op so the steady stream of at-bottom frames
+    /// does not thrash the button. Hiding the bottom chrome (HIDE button) also
+    /// suppresses the floating button via ``layoutBottomDock``.
+    public func setScrolledUp(_ value: Bool) {
+        guard scrolledUp != value else { return }
+        scrolledUp = value
+        layoutBottomDock()
+        updateScrollToBottomButtonVisibility(animated: true)
     }
 
-    /// Animate the docked toolbar in lockstep with a keyboard show/hide so it
-    /// rides the keyboard edge instead of jumping. There is no interactive
-    /// (swipe-down) dismissal in this terminal, so a notification-driven animate
-    /// is sufficient and avoids the `keyboardLayoutGuide` safe-area mismatch.
+    /// Whether the floating jump-to-bottom button should currently be on screen:
+    /// the terminal is scrolled up AND the bottom chrome is not suppressed.
+    private var scrollToBottomButtonShouldBeVisible: Bool {
+        scrolledUp && !chromeHidden
+    }
+
+    /// Reconcile the floating button's visibility with the scrolled-up + chrome
+    /// state, optionally on the keyboard animation curve.
+    private func updateScrollToBottomButtonVisibility(animated: Bool) {
+        guard let button = scrollToBottomButton else { return }
+        let shouldShow = scrollToBottomButtonShouldBeVisible
+        let targetAlpha: CGFloat = shouldShow ? 1 : 0
+        guard button.alpha != targetAlpha || button.isHidden == shouldShow else { return }
+        if shouldShow { button.isHidden = false }
+        let apply = {
+            button.alpha = targetAlpha
+        }
+        let finish: (Bool) -> Void = { _ in
+            if !shouldShow { button.isHidden = true }
+        }
+        if animated {
+            UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseInOut], animations: apply, completion: finish)
+        } else {
+            apply()
+            finish(true)
+        }
+    }
+
+    /// Layer `zPosition` for the bottom chrome (toolbar + composer band), placing it
+    /// above the Ghostty renderer's sublayer so a lifted Liquid-Glass button is not
+    /// clipped by the terminal render bounds (item 6). Below the zoom HUD (1100).
+    private static let bottomChromeZPosition: CGFloat = 1000
+
+    /// Whether the always-visible bottom chrome (the docked accessory toolbar and,
+    /// when open, the composer band) is currently on screen.
+    ///
+    /// Round 8 makes the toolbar ALWAYS visible — terminal mode, composer mode,
+    /// keyboard up AND down — so the only thing that hides it is the explicit HIDE
+    /// button (``chromeHidden``). The toolbar is no longer keyboard-tied. When the
+    /// keyboard is down the toolbar (and any open composer) ride above the bottom
+    /// safe area instead of disappearing; see ``bottomChromeInset``.
+    private var dockedToolbarShouldBeVisible: Bool {
+        !chromeHidden
+    }
+
+    /// True while the HIDE button has temporarily suppressed the bottom chrome
+    /// (toolbar + composer band). The chrome reappears on the next tap of the
+    /// terminal (``handleTap``). `isComposerPresented` is unchanged while hidden, so
+    /// the composer (and its draft) reappear intact. Item 2 of the Round 8 spec.
+    private var chromeHidden = false
+
+    /// Bottom space (points) reserved below the toolbar for the keyboard OR the home
+    /// indicator, whichever applies.
+    ///
+    /// When the software keyboard is up the toolbar rides its top, so this is the
+    /// live keyboard height. When the keyboard is down the toolbar is still visible
+    /// (Round 8), so it must clear the bottom safe area (home indicator) rather than
+    /// sit flush on the screen edge — this returns ``safeAreaInsetsBottom`` then. The
+    /// composer band and toolbar stack ABOVE this inset; the grid reserves it too.
+    /// Used by ``bottomDockFrames()`` and the grid reservation.
+    private var keyboardOccupancyInBounds: CGFloat {
+        keyboardHeight > 0 ? keyboardHeight : safeAreaInsetsBottom
+    }
+
+    /// The bottom safe-area inset (home-indicator height) in this surface's bounds.
+    ///
+    /// The surface extends under the bottom safe area (the host applies
+    /// `ignoresSafeArea(.container, .bottom)`), so when the keyboard is down the
+    /// always-visible toolbar must clear this much to avoid the home indicator. Reads
+    /// the view's own inset, falling back to the window's, because `safeAreaInsets`
+    /// can be zero before the view is on a window.
+    private var safeAreaInsetsBottom: CGFloat {
+        let own = safeAreaInsets.bottom
+        if own > 0 { return own }
+        return window?.safeAreaInsets.bottom ?? 0
+    }
+
+    /// Reconcile the docked bar's visibility (and its reserved grid height) with
+    /// the current keyboard + composer state. Hiding the bar releases its reserved
+    /// height so the terminal grid reclaims that space; showing it reserves the
+    /// height again. Idempotent: a no-op when already in the target state.
+    private func updateDockedToolbarVisibility() {
+        let shouldShow = dockedToolbarShouldBeVisible
+        let reserved: CGFloat = shouldShow ? Self.persistentToolbarHeight : 0
+        guard dockedToolbar?.isHidden != !shouldShow || reservedToolbarHeight != reserved else { return }
+        dockedToolbar?.isHidden = !shouldShow
+        // The composer band rides with the toolbar: hide it when the chrome is
+        // suppressed, show it again when the chrome returns and a field is mounted.
+        // Its frame already collapses to `.zero` while hidden (see
+        // ``bottomDockFrames()``); toggling `isHidden` also stops it intercepting taps.
+        composerContainer.isHidden = !shouldShow || composerContainer.subviews.isEmpty
+        reservedToolbarHeight = reserved
+        setNeedsGeometrySync()
+        setNeedsLayout()
+    }
+
+    /// Temporarily hide (or re-show) the bottom chrome — the always-visible toolbar
+    /// and any open composer band — via the HIDE button (item 2).
+    ///
+    /// Hiding also drops the software keyboard: with the toolbar always visible, HIDE
+    /// only makes sense as "clear all chrome to see the full terminal", which requires
+    /// resigning the keyboard too. `isComposerPresented` is left untouched, so the
+    /// composer (and its draft) reappear intact on the next terminal tap
+    /// (``handleTap``). Animated on the keyboard curve via ``animateBottomDock``.
+    private func setChromeHidden(_ hidden: Bool) {
+        guard chromeHidden != hidden else { return }
+        chromeHidden = hidden
+        if hidden, keyboardHeight > 0 {
+            // Drop the keyboard first; its hide notification re-seats the dock, then
+            // the visibility update below removes the toolbar/composer.
+            if composerActive {
+                composerContainer.endEditing(true)
+            } else {
+                resignInput()
+            }
+        }
+        updateDockedToolbarVisibility()
+        if hidden {
+            // Hide: animate the dock collapsing down into the bottom edge. (The toolbar
+            // is set `isHidden` only after this animation by `updateDockedToolbarVisibility`
+            // — actually `isHidden` is set synchronously, so this animate-out is largely
+            // invisible, but it keeps the frame coherent for the next show.)
+            animateBottomDock()
+        } else {
+            // Show: snap real frames into place with the bar visible, then let the
+            // ``handleTap``-driven `focusInput()` → keyboard-show animation carry the
+            // motion. Animating here from the collapsed bottom-edge strip would
+            // double-animate against the keyboard rise.
+            layoutBottomDock()
+        }
+        // The floating jump-to-bottom button rides with the chrome: HIDE suppresses
+        // it, and a re-show restores it if the terminal is still scrolled up.
+        updateScrollToBottomButtonVisibility(animated: true)
+        setNeedsGeometrySync()
+    }
+
+    /// Track whether the composer is open and keep the keyboard up across the
+    /// draft↔normal toggle in BOTH directions.
+    ///
+    /// The surface owns the whole bottom dock (terminal grid / composer band /
+    /// toolbar / keyboard) in one coordinate system; the toolbar is never reparented
+    /// out, so it stays visible while composing and its buttons cannot disappear. The
+    /// only job here is the first-responder handover that keeps the keyboard from
+    /// dropping across the toggle:
+    ///
+    /// - Opening (`active == true`): deliberately do NOT resign the terminal input
+    ///   proxy. The composer's hosted text field becomes first responder while this
+    ///   keyboard is still up, so iOS hands the keyboard over in place. Resigning
+    ///   first tore the keyboard down and the composer re-summoned it (a flicker).
+    /// - Closing (`active == false`): two distinct intents share this path, told
+    ///   apart by ``keyboardHeight``:
+    ///   - Chevron-close while typing: `keyboardHeight > 0`. The user wants to keep the
+    ///     keyboard (a genuine return to the terminal). The composer's field resigns
+    ///     first responder as it is torn out, with nothing to take it back, so re-take it
+    ///     on the terminal input proxy in the same update — some responder is always
+    ///     first responder at runloop end and the keyboard hands back in place instead of
+    ///     dropping.
+    ///   - Chevron-close while the keyboard is already down: `keyboardHeight == 0` (a
+    ///     legal Round 8 state — the composer survives a keyboard-down). Do NOT re-focus
+    ///     the proxy; that would re-summon the keyboard the user already dismissed. The
+    ///     toolbar stays visible regardless, so closing the composer just collapses its
+    ///     band. Gating the re-focus on `keyboardHeight > 0` makes both directions
+    ///     correct.
+    ///   No sleep / `asyncAfter`: the `become` is issued synchronously here.
+    public func setComposerActive(_ active: Bool) {
+        guard composerActive != active else { return }
+        composerActive = active
+        if active {
+            // Opening: deliberately do NOT resign the terminal input proxy. The
+            // composer's hosted text field becomes first responder while this
+            // keyboard is still up, so iOS hands the keyboard over in place. The
+            // toolbar stays a child of this surface throughout — it is never
+            // reparented — so its buttons remain on screen. The composer band's
+            // height arrives separately via `setComposerBandHeight(_:animated:)` once
+            // the host mounts and measures the field.
+        } else {
+            // Closing: re-take first responder on the terminal input proxy ONLY when the
+            // keyboard is still up (`keyboardHeight > 0`, a chevron-close while typing) so
+            // the keyboard hands back in place instead of dropping. When the keyboard is
+            // already down (a legal Round 8 state — the composer survived a keyboard-down)
+            // re-focusing would re-summon the keyboard the user dismissed, so skip it. The
+            // host animates the band height back to 0 (with the field still mounted, item
+            // 3), so the band shrink reads as one motion; do NOT snap it to 0 here or that
+            // pre-empts the animation.
+            if keyboardHeight > 0, window != nil, !isDismantled, !inputProxy.isFirstResponder {
+                Self.activeInputSurface = self
+                inputProxy.updateAccessoryLayoutInsets()
+                inputProxy.becomeFirstResponder()
+            }
+        }
+        // The toolbar's visibility and reserved height do not change with the composer
+        // (it stays shown while the keyboard is up either way), so re-seat the whole
+        // bottom dock and re-sync the grid unconditionally: the composer band opening
+        // or closing changes where the terminal grid bottom and the dock sit.
+        updateDockedToolbarVisibility()
+        layoutBottomDock()
+        setNeedsGeometrySync()
+        #if DEBUG
+        // PILL/COMPOSER instrumentation (#5574 sink): one toggle line makes a single
+        // device dogfood pass conclusive about whether the bar stays visible and
+        // docks correctly while composing, since the simulator cannot show the
+        // keyboard. Records the state that decides the bar's frame.
+        let barFrame = dockedToolbar?.frame ?? .zero
+        MobileDebugLog.anchormux(
+            "composer.toggle active=\(active) keyboardHeight=\(Int(keyboardHeight)) occInBounds=\(Int(keyboardOccupancyInBounds)) barHidden=\(dockedToolbar?.isHidden ?? true) barY=\(Int(barFrame.minY)) barH=\(Int(barFrame.height)) boundsH=\(Int(bounds.height))"
+        )
+        // COMPOSER: structured event for the item-4 edge case (composer shown while
+        // textbox/keyboard hidden). Captures the composer-active transition plus the
+        // resolved first-responder owner and keyboardHeight at that instant, into the
+        // same sink the round-4 composer flag/appear/focus events use. With these,
+        // a captured trace shows whether the composer ever ends up active with the
+        // FR owned by no terminal/composer responder and keyboardHeight 0.
+        let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+        diagnosticLog?.record(DiagnosticEvent(
+            .composerActiveTransition,
+            ms: UInt32(max(0, keyboardHeight)),
+            a: active ? 1 : 0,
+            b: frOwner.rawValue,
+            c: inputProxy.isFirstResponder ? 1 : 0
+        ))
+        #endif
+    }
+
+    /// Whether the composer's hosted field currently holds first responder.
+    ///
+    /// The composer field is a SwiftUI `TextField` deep inside a `UIHostingController`
+    /// mounted under ``composerContainer``, so `composerContainer.isFirstResponder` is
+    /// always false (the container is not the responder, the nested field is). A
+    /// recursive subtree walk (``UIView/firstResponderInSubtree()``) finds the actual
+    /// first responder; it is the composer field iff that responder lives under the
+    /// container. Drives the compose-button open/close-vs-refocus decision; false when
+    /// the band is empty (no field mounted).
+    private var composerFieldIsFirstResponder: Bool {
+        guard !composerContainer.subviews.isEmpty else { return false }
+        return composerContainer.firstResponderInSubtree() != nil
+    }
+
+    /// Resolve the current bottom-dock state and act on a compose-button tap so the
+    /// draft is never lost across the compose → hide → reveal → compose cycle.
+    ///
+    /// The decision is the pure ``ComposerDockState/intentForComposeButtonTap()``
+    /// reducer (unit-tested off-device); this method only reads the four live dock
+    /// bits and maps the resulting ``ComposerDockIntent`` onto UIKit/delegate calls:
+    ///
+    /// - ``ComposerDockIntent/openComposer`` / ``ComposerDockIntent/closeComposer``:
+    ///   forward the genuine toggle (open from nothing, or close a visible+focused
+    ///   composer) to the host's `toggleComposer`.
+    /// - ``ComposerDockIntent/revealAndFocusComposer``: the composer is presented but
+    ///   suppressed by HIDE, or visible-yet-unfocused after a reveal. Bring the chrome
+    ///   back if hidden, then ask the host to ensure-present + re-focus the field. The
+    ///   presented flag is never toggled off, so the draft and band return intact —
+    ///   this is the fix for the blind toggle that dismissed a still-presented composer.
+    private func handleComposerButtonTap() {
+        let dockState = ComposerDockState(
+            chromeHidden: chromeHidden,
+            composerPresented: composerActive,
+            fieldFocused: composerFieldIsFirstResponder,
+            keyboardUp: keyboardHeight > 0
+        )
+        let intent = dockState.intentForComposeButtonTap()
+        #if DEBUG
+        lastComposerDockIntent = intent
+        #endif
+        switch intent {
+        case .openComposer, .closeComposer:
+            delegate?.ghosttySurfaceViewDidRequestComposerToggle(self)
+        case .revealAndFocusComposer:
+            if chromeHidden {
+                setChromeHidden(false)
+            }
+            delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+        }
+    }
+
+    /// Install the composer band container into the surface's view hierarchy, above
+    /// the docked toolbar. Hidden and zero-height until the host mounts a compose
+    /// field into it (``mountComposerView(_:)``); the surface positions it in
+    /// ``layoutBottomDock()`` and reserves its height in the grid. Frame-positioned
+    /// (`translatesAutoresizingMaskIntoConstraints = true`) like the docked toolbar so
+    /// the whole bottom dock shares one coordinate system.
+    private func installComposerContainer() {
+        composerContainer.backgroundColor = .clear
+        composerContainer.isHidden = true
+        // Do NOT clip: the composer's Liquid-Glass controls lift/shadow past the band
+        // edge, and the band must sit above the Ghostty render layer (item 6) so the
+        // glass is not clipped by the terminal bounds. Raised to the same chrome
+        // z-position as the toolbar.
+        composerContainer.clipsToBounds = false
+        composerContainer.layer.zPosition = Self.bottomChromeZPosition
+        addSubview(composerContainer)
+        layoutBottomDock()
+    }
+
+    /// Mount (or unmount, with `nil`) the host-built compose field into the surface's
+    /// composer band. The terminal package cannot import the SwiftUI composer (that
+    /// would invert the package DAG), so `GhosttySurfaceRepresentable` builds it in a
+    /// `UIHostingController` and hands the controller's view here. The surface owns the
+    /// band's position and the grid reservation; the host owns the field's content and
+    /// reports its measured height via ``setComposerBandHeight(_:animated:)``.
+    ///
+    /// The mounted view is pinned edge-to-edge inside the band with Auto Layout, so it
+    /// fills whatever height the surface frames the band to — there is no second layout
+    /// system fighting the surface for the band's frame (the band's own frame is set by
+    /// `layoutBottomDock()`).
+    public func mountComposerView(_ view: UIView?) {
+        composerContainer.subviews.forEach { $0.removeFromSuperview() }
+        guard let view else {
+            composerContainer.isHidden = true
+            return
+        }
+        view.translatesAutoresizingMaskIntoConstraints = false
+        composerContainer.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: composerContainer.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: composerContainer.trailingAnchor),
+            view.topAnchor.constraint(equalTo: composerContainer.topAnchor),
+            view.bottomAnchor.constraint(equalTo: composerContainer.bottomAnchor),
+        ])
+        composerContainer.isHidden = false
+    }
+
+    /// Set the height (points) the open composer band reserves below the docked
+    /// toolbar, from the hosted compose field's intrinsic content size. Drives the
+    /// grid reservation (so a field-grow pushes only the terminal up) and the dock
+    /// layout. When `animated`, the reservation + reflow run inside a `UIView.animate`
+    /// using the keyboard curve so the height change reads as one smooth motion with
+    /// the rest of the dock (item 3/4). Idempotent: a no-op when the height is
+    /// unchanged (then `completion` runs immediately so an unmount-on-close never
+    /// strands the mounted field).
+    ///
+    /// - Parameters:
+    ///   - height: The compose field's measured height, clamped to non-negative.
+    ///   - animated: Whether to animate the reflow (true for a live grow/shrink as the
+    ///     user types and for the symmetric close; false for the initial mount, where
+    ///     the open transition already animates).
+    ///   - completion: Run after the reflow lands. The close path passes the field
+    ///     unmount here so the band animates to 0 with the field STILL mounted (item 3:
+    ///     a symmetric, coordinated close), and the field is removed only once the band
+    ///     has collapsed — reversing the round-7 order that unmounted first and left the
+    ///     band collapsing over empty space (the janky close).
+    public func setComposerBandHeight(_ height: CGFloat, animated: Bool, completion: (() -> Void)? = nil) {
+        let clamped = max(0, height)
+        guard abs(clamped - composerBandHeight) > 0.5 else {
+            completion?()
+            return
+        }
+        composerBandHeight = clamped
+        let apply = { [weak self] in
+            guard let self else { return }
+            self.layoutBottomDock()
+            self.layoutIfNeeded()
+        }
+        if animated {
+            UIView.animate(
+                withDuration: Self.composerReflowDuration,
+                delay: 0,
+                options: [.curveEaseInOut, .beginFromCurrentState],
+                animations: apply,
+                completion: { _ in completion?() }
+            )
+        } else {
+            apply()
+            completion?()
+        }
+        setNeedsGeometrySync()
+    }
+
+    /// Duration (seconds) of the composer band grow/shrink reflow. Matches the system
+    /// keyboard's default animation duration so a field-grow reads as one smooth
+    /// motion with the dock; the keyboard show/hide reflow uses the notification's own
+    /// curve/duration (``animateDockedToolbar(with:)``).
+    private static let composerReflowDuration: TimeInterval = 0.25
+
+    /// Frames for the whole bottom dock, computed together so the composer band, the
+    /// docked toolbar, and the keyboard top stack consistently in the surface's single
+    /// coordinate system.
+    ///
+    /// Round 8 stack, from the BOTTOM up: the keyboard (or, keyboard-down, the bottom
+    /// safe area) occupies `keyboardOccupancyInBounds` at the surface bottom; the
+    /// composer band (when open) sits directly above that; the toolbar button band
+    /// sits directly above the composer; the terminal grid fills the rest. So the
+    /// visual order top→bottom is `terminal / toolbar / composer / keyboard` (item 1).
+    /// This is the inverse of Round 7 (toolbar-on-keyboard, composer-above-toolbar):
+    /// the composer is now the chrome closest to the keyboard, with the always-visible
+    /// toolbar above it.
+    ///
+    /// The toolbar's button row is bottom-pinned inside its container (see
+    /// `TerminalInputTextView.dockedButtonRowHeight`), so the controls always hug the
+    /// band's bottom no matter how tall the container is — the round-6 fix for "toolbar
+    /// rides up off the keyboard on a letterbox/resize", kept for free because the
+    /// toolbar never leaves the surface. When there is no composer band, the toolbar's
+    /// TOP floats up to the rendered terminal's bottom (`lastRenderRect.maxY`) to
+    /// absorb the sub-cell remainder (no terminal-background gap above the bar). When
+    /// the composer band is open, the toolbar is exactly its button band and the
+    /// composer below absorbs the layout.
+    ///
+    /// While the HIDE button has suppressed the chrome (``chromeHidden``) the dock is
+    /// off screen (both frames `.zero`); the grid reservation matches (it reserves 0),
+    /// so the terminal reclaims the whole height.
+    private func bottomDockFrames() -> (composer: CGRect, toolbar: CGRect) {
+        let occupied = keyboardOccupancyInBounds
+        // While the HIDE button has suppressed the chrome, collapse the dock to a
+        // zero-height strip pinned at the bottom edge (NOT `CGRect.zero` at the origin,
+        // which would make the next show animate the bar growing out of the top-left
+        // corner). The toolbar is also `isHidden`, so this is purely about leaving a
+        // sane frame to animate from/to.
+        let bottomEdge = chromeHidden ? bounds.height : bounds.height - occupied
+        let width = bounds.width
+        let effectiveComposerHeight = chromeHidden ? 0 : composerBandHeight
+        // Composer band sits directly above the keyboard (or the safe-area inset),
+        // pinned to the bottom edge; the toolbar's button band reserves
+        // `persistentToolbarHeight` directly above the composer. At height 0 the band
+        // frame is a zero-height strip AT `bottomEdge` (composerTop == bottomEdge), so a
+        // close animates a smooth downward height-collapse into the toolbar/keyboard
+        // edge rather than flying to the origin (item 3).
+        let composerTop = bottomEdge - effectiveComposerHeight
+        let composerFrame = CGRect(x: 0, y: max(0, composerTop), width: width, height: effectiveComposerHeight)
+        // Toolbar's reserved bottom is the composer's top (or the bottom edge with no
+        // composer), and its reserved top is one button-row band above that.
+        let toolbarBottom = effectiveComposerHeight > 0 ? composerTop : bottomEdge
+        let toolbarReservedTop = toolbarBottom - Self.persistentToolbarHeight
+        // Toolbar top: with a composer band below, the toolbar container is exactly its
+        // button band (no slack to absorb — the composer owns the space below). Without
+        // a composer, let the top float up to the rendered terminal's bottom so the
+        // container's background fills the sub-cell remainder (libghostty floors the
+        // grid to whole cells and top-anchors the render, so `lastRenderRect.maxY` is at
+        // or above `toolbarReservedTop`). Never drop below `toolbarReservedTop` (that
+        // would re-open the gap) and never go negative.
+        let toolbarTop: CGFloat
+        if effectiveComposerHeight > 0 {
+            toolbarTop = max(0, toolbarReservedTop)
+        } else {
+            let renderBottom = lastRenderRect.isEmpty ? toolbarReservedTop : lastRenderRect.maxY
+            toolbarTop = max(0, min(renderBottom, toolbarReservedTop))
+        }
+        let toolbarFrame = CGRect(x: 0, y: toolbarTop, width: width, height: toolbarBottom - toolbarTop)
+        return (composerFrame, toolbarFrame)
+    }
+
+    /// Position the composer band and the docked toolbar from ``bottomDockFrames()``.
+    /// The single layout entry point for the bottom dock; called on every geometry,
+    /// keyboard, and composer-height change so the whole dock moves as one.
+    private func layoutBottomDock() {
+        let frames = bottomDockFrames()
+        composerContainer.frame = frames.composer
+        dockedToolbar?.frame = frames.toolbar
+        layoutScrollToBottomButton(aboveDockTop: frames.toolbar.minY)
+    }
+
+    /// Spacing (points) between the floating jump-to-bottom button and the dock
+    /// above which it floats, and the trailing edge.
+    private static let scrollToBottomButtonMargin: CGFloat = 12
+
+    /// Pin the floating jump-to-bottom button to the bottom-right, floating just
+    /// above the bottom dock (the toolbar top, which already rides above the
+    /// composer band, keyboard, and home-indicator reserve). Reuses the dock's
+    /// own computed top edge so the button tracks the toolbar/composer/keyboard
+    /// as they show and hide instead of a hardcoded offset.
+    private func layoutScrollToBottomButton(aboveDockTop dockTop: CGFloat) {
+        guard let button = scrollToBottomButton else { return }
+        let size = ScrollToBottomButton.diameter
+        let margin = Self.scrollToBottomButtonMargin
+        // When the chrome is suppressed the dock collapses to the bottom edge;
+        // float the button above the bottom safe area instead so HIDE does not
+        // shove it under the home indicator (it is hidden in that state anyway).
+        let referenceTop = chromeHidden ? bounds.height - safeAreaInsetsBottom : dockTop
+        let x = bounds.width - size - margin
+        let y = referenceTop - size - margin
+        button.frame = CGRect(x: x, y: max(0, y), width: size, height: size)
+    }
+
+    /// Animate the whole bottom dock (composer band + toolbar) in lockstep with a
+    /// keyboard show/hide so it rides the keyboard edge instead of jumping. There is no
+    /// interactive (swipe-down) dismissal in this terminal, so a notification-driven
+    /// animate is sufficient and avoids the `keyboardLayoutGuide` safe-area mismatch.
     private func animateDockedToolbar(with notification: Notification) {
-        guard let dockedToolbar else { return }
-        let target = dockedToolbarFrame()
         let duration = (notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
         let curveRaw = (notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int)
             ?? Int(UIView.AnimationCurve.easeInOut.rawValue)
+        animateBottomDock(duration: duration, curveOption: UIView.AnimationOptions(rawValue: UInt(curveRaw) << 16))
+    }
+
+    /// Animate the whole bottom dock (composer band + toolbar) to its current target
+    /// frames over the given duration/curve. Used by ``animateDockedToolbar(with:)``
+    /// (keyboard show/hide, with the notification's own curve) and by the HIDE/show and
+    /// composer close paths (item 3), which have no keyboard notification and so default
+    /// to the system keyboard duration + easeInOut so the motion still reads as one
+    /// smooth coordinated reflow.
+    private func animateBottomDock(
+        duration: TimeInterval = 0.25,
+        curveOption: UIView.AnimationOptions = .curveEaseInOut
+    ) {
+        let frames = bottomDockFrames()
         UIView.animate(
             withDuration: duration,
             delay: 0,
-            options: UIView.AnimationOptions(rawValue: UInt(curveRaw) << 16)
-        ) {
-            dockedToolbar.frame = target
+            options: [curveOption, .beginFromCurrentState]
+        ) { [weak self] in
+            self?.composerContainer.frame = frames.composer
+            self?.dockedToolbar?.frame = frames.toolbar
         }
     }
 
@@ -1194,9 +2074,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// treats it as a harmless empty selection, so tapping a shell still just
     /// focuses input.
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        // A tap re-reveals chrome the HIDE button suppressed (item 2). Done before
+        // forwarding the tap/focus so the toolbar (and any open composer) animate back
+        // in as the keyboard comes up. Capture the pre-reveal state: a reveal that
+        // brings back a still-presented composer must restore focus to the COMPOSER
+        // field, not the terminal proxy — otherwise the next compose-button tap reads
+        // "presented but unfocused" and the prior round dismissed it, losing the draft.
+        let wasHidden = chromeHidden
+        if chromeHidden {
+            setChromeHidden(false)
+        }
         let cell = scrollCell(at: gesture.location(in: self))
         delegate?.ghosttySurfaceView(self, didTapAtCol: cell.col, row: cell.row)
-        focusInput()
+        // A tap inside the composer band is excluded by the gesture recognizer
+        // (`gestureRecognizer(_:shouldReceive:)`), so any tap reaching here is a
+        // deliberate terminal tap. Only a reveal-from-hide with the composer still
+        // presented re-focuses the composer; every other terminal tap focuses the
+        // terminal proxy as before.
+        if wasHidden, composerActive {
+            delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+        } else {
+            focusInput()
+        }
     }
 
     @objc private func handlePinch(_ gesture: UIPinchGestureRecognizer) {
@@ -1376,7 +2275,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard let zoomOverlay else { return }
         let fitting = zoomOverlay.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         let size = CGSize(width: max(fitting.width, 220), height: max(fitting.height, 1))
-        let bottomReserve = reservedToolbarHeight + max(0, keyboardHeight)
+        let bottomReserve = composerBandHeight + reservedToolbarHeight + keyboardOccupancyInBounds
         let availableH = max(1, bounds.height - bottomReserve)
         zoomOverlay.bounds = CGRect(origin: .zero, size: size)
         zoomOverlay.center = CGPoint(x: bounds.midX, y: availableH * 0.45)
@@ -1408,14 +2307,29 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         snapshotFallbackView.frame = bounds
         #if DEBUG
         debugAccessibilityProxy.frame = bounds
+        // The dock probe stays a 1×1 off-screen carrier; its accessibility value is
+        // computed live on every read (see ``composerDockProbeValue``), so it never
+        // needs a frame-driven refresh.
+        composerDockProbe.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
         #endif
         inputProxy.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 1)
         inputProxy.updateAccessoryLayoutInsets()
-        layoutDockedToolbar()
+        layoutBottomDock()
         layoutZoomOverlay()
         MobileDebugLog.anchormux("surface.layout bounds=\(Int(bounds.width))x\(Int(bounds.height)) window=\(window != nil)")
         setNeedsGeometrySync()
         syncSurfaceVisibility()
+    }
+
+    public override func safeAreaInsetsDidChange() {
+        super.safeAreaInsetsDidChange()
+        // The always-visible toolbar rides the bottom safe area while the keyboard
+        // is down (Round 8). The inset can arrive after the first layout (it is 0
+        // before window attach), so re-seat the dock and re-reserve the grid when it
+        // changes; otherwise the toolbar would sit on the home indicator until the
+        // next unrelated relayout.
+        layoutBottomDock()
+        setNeedsGeometrySync()
     }
 
     public override func didMoveToWindow() {
@@ -1427,12 +2341,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             #if DEBUG
             debugAccessibilityProxy.isAccessibilityElement = true
             #endif
-            setNeedsGeometrySync()
             setFocus(true)
             if autoFocusOnWindowAttach {
                 focusInput()
             }
-            startDisplayLink()
+            // Complete a foreground resume that arrived while the view was still
+            // off-window. `resumeRendering` (now back on-window) clears suspension
+            // — otherwise `requestRender` early-returns on every tick and the loop
+            // never paints again — and forces the full repaint (occlusion,
+            // viewport reassert, geometry resync, display link). For a normal
+            // attach (no pending resume) keep the lighter geometry sync + link
+            // restart so an unrelated reattach does not force a viewport re-report.
+            if pendingForegroundResume {
+                MobileDebugLog.anchormux("resume.completeOnAttach")
+                resumeRendering()
+            } else {
+                setNeedsGeometrySync()
+                startDisplayLink()
+            }
         } else {
             prepareForReuseAfterDetach()
         }
@@ -1500,7 +2426,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     self.updateCursorOverlay()
                 }
                 #if DEBUG
-                self.lastOutputAppliedTime = CACurrentMediaTime()
+                // RENDER: frame-apply heartbeat. Time-gated to ≈1/s so it is a
+                // heartbeat, not a per-chunk flood, on the lock-free diagnostic sink.
+                // `ms` = gap since the previous applied chunk; `a` = this chunk's byte
+                // length. A growing gap or this event ceasing while input still works
+                // localizes a stalled render-grid consumer.
+                let applyNow = CACurrentMediaTime()
+                if applyNow - self.lastRenderFrameDiagTime >= 1.0 {
+                    let gapMs = self.lastOutputAppliedTime > 0
+                        ? UInt32(min(Double(UInt32.max), max(0, (applyNow - self.lastOutputAppliedTime) * 1000)))
+                        : 0
+                    self.diagnosticLog?.record(DiagnosticEvent(
+                        .renderFrameApplied,
+                        ms: gapMs,
+                        a: forwarded.count
+                    ))
+                    self.lastRenderFrameDiagTime = applyNow
+                }
+                self.lastOutputAppliedTime = applyNow
                 #endif
                 if !self.surfaceHasReceivedOutput {
                     self.surfaceHasReceivedOutput = true
@@ -1842,7 +2785,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 ? Int((nowHeartbeat - lastOutputAppliedTime) * 1000)
                 : -1
             MobileDebugLog.anchormux(
-                "tick.alive win=\(window != nil) renderInFlight=\(renderInFlight) "
+                "tick.alive win=\(window != nil) suspended=\(renderingSuspended) "
+                + "renderInFlight=\(renderInFlight) "
                 + "needsDraw=\(needsDraw) contents=\(renderLayer?.contents != nil) "
                 + "surf=\(Int(renderSize.width))x\(Int(renderSize.height)) "
                 + "sinceOutput=\(sinceOutputMs)ms"
@@ -1961,19 +2905,64 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // (Called on main from the display link.)
         if renderInFlight {
             needsAnotherRender = true
+            #if DEBUG
+            // RENDER: render busy / snapshot skipped. A render is already in flight, so
+            // this frame's render is coalesced away. Time-gated to ≈1/s; `a` = how long
+            // the in-flight render has been running so far (ms). A long, climbing value
+            // with a frozen screen is the wedged-render-queue signal while input still
+            // works.
+            let busyNow = CACurrentMediaTime()
+            if busyNow - lastRenderBusyDiagTime >= 1.0 {
+                lastRenderBusyDiagTime = busyNow
+                let inFlightMs = renderInFlightStart > 0
+                    ? UInt32(min(Double(UInt32.max), max(0, (busyNow - renderInFlightStart) * 1000)))
+                    : 0
+                diagnosticLog?.record(DiagnosticEvent(.renderBusySkipped, a: Int(inFlightMs)))
+            }
+            #endif
             return
         }
         renderInFlight = true
         let enqueuedAt = CACurrentMediaTime()
+        #if DEBUG
+        renderInFlightStart = enqueuedAt
+        #endif
         Self.outputQueue.async { [weak self] in
             // Queue LAG = how long this render waited behind other ops. If this
             // climbs into hundreds of ms the queue is backlogged (the freeze).
             let lagMs = (CACurrentMediaTime() - enqueuedAt) * 1000
-            if lagMs > 150 { MobileDebugLog.anchormux("oq.render.LAG \(Int(lagMs))ms") }
+            if lagMs > 150 {
+                MobileDebugLog.anchormux("oq.render.LAG \(Int(lagMs))ms")
+                #if DEBUG
+                // RENDER: the render queue lagged — this render waited a long time
+                // behind other ops before running. `ms` = the measured wait.
+                self?.diagnosticLog?.record(DiagnosticEvent(
+                    .renderGridLag,
+                    ms: UInt32(min(Double(UInt32.max), lagMs))
+                ))
+                #endif
+            }
             ghostty_surface_render_now(surface)
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.renderInFlight = false
+                #if DEBUG
+                // RENDER: render-busy duration — enqueue → completion, in ms. Recorded
+                // ONLY for a slow render (> `renderCompletedSlowThresholdMs`); a normal
+                // few-ms render at 120fps would flood the bounded ring and evict every
+                // other event. A spike here with a frozen screen confirms `render_now`
+                // itself (GPU/swap-chain) stalled rather than the stream drying up.
+                let completedMs = self.renderInFlightStart > 0
+                    ? max(0, (CACurrentMediaTime() - self.renderInFlightStart) * 1000)
+                    : 0
+                if completedMs > Self.renderCompletedSlowThresholdMs {
+                    self.diagnosticLog?.record(DiagnosticEvent(
+                        .renderCompleted,
+                        ms: UInt32(min(Double(UInt32.max), completedMs))
+                    ))
+                }
+                self.renderInFlightStart = 0
+                #endif
                 guard !self.isDismantled else {
                     self.needsAnotherRender = false
                     return
@@ -2209,13 +3198,20 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // The main thread only applies the UIKit result. This is the single
         // off-main surface owner: main never calls a blocking libghostty API.
         let scale = preferredScreenScale
-        // Reserve the persistent toolbar plus the keyboard when it is up. The
-        // toolbar sits flush at the bottom edge and is what keeps the bottom TUI
-        // rows off the home indicator, so the grid does NOT also reserve the
-        // bottom safe area (that left an empty strip below the toolbar). The
-        // toolbar and keyboard never stack (the toolbar rides above the
-        // keyboard), so the bottom occupancy is the toolbar plus the keyboard.
-        let reservedBottom = reservedToolbarHeight + max(0, keyboardHeight)
+        // Reserve, from the bottom up, the keyboard/safe-area inset
+        // (`keyboardOccupancyInBounds`: keyboard height when up, else the bottom safe
+        // area so the always-visible toolbar clears the home indicator), the open
+        // composer band, and the persistent toolbar — the surface owns the whole bottom
+        // dock in one coordinate system, so the grid shrinks by all three. The order is
+        // immaterial to the reserved total; only the frame positions in
+        // ``bottomDockFrames()`` encode the `terminal / toolbar / composer / keyboard`
+        // stack. While the HIDE button has suppressed the chrome (``chromeHidden``) the
+        // toolbar is off screen and reserves nothing, and the composer band is hidden,
+        // so the grid reclaims the whole height; reserve only the keyboard if it is
+        // somehow still up.
+        let reservedBottom = chromeHidden
+            ? keyboardOccupancyInBounds
+            : composerBandHeight + reservedToolbarHeight + keyboardOccupancyInBounds
         let bottomInset = min(reservedBottom, max(0, bounds.height - 1))
         let containerW = max(1, bounds.width)
         let containerH = max(1, bounds.height - bottomInset)
@@ -2305,6 +3301,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let renderRect = result.pinnedSize.map { CGRect(origin: .zero, size: $0) }
             ?? CGRect(origin: .zero, size: naturalRenderSize)
         lastRenderRect = renderRect
+        // The docked toolbar's top hugs `lastRenderRect.maxY` (see
+        // ``bottomDockFrames()``), so re-seat the whole bottom dock now that the
+        // rendered terminal bottom has moved; otherwise the bar keeps the pre-geometry
+        // position and the sub-cell gap above it reappears.
+        layoutBottomDock()
         MobileDebugLog.anchormux(
             "geom container=\(Int(containerW))x\(Int(containerH)) scale=\(scale) "
             + "cellPx=\(Int(result.cellPixelSize.width))x\(Int(result.cellPixelSize.height)) "
@@ -2744,6 +3745,14 @@ extension GhosttySurfaceView: UIGestureRecognizerDelegate {
            let touched = touch.view, touched.isDescendant(of: zoomOverlay) {
             return false
         }
+        // A tap inside the hosted composer band belongs to the compose field /
+        // buttons, not the terminal's focus tap (which would steal first responder
+        // from the field and fight the keyboard). The band is a surface subview, so
+        // the surface-level tap recognizer would otherwise also fire; exclude it.
+        if !composerContainer.isHidden,
+           let touched = touch.view, touched.isDescendant(of: composerContainer) {
+            return false
+        }
         return true
     }
 }
@@ -2825,7 +3834,9 @@ private class DisplayLinkProxy {
 final class TerminalArrowNubView: UIView {
     var onArrowKey: ((Data) -> Void)?
 
-    private let nubSize: CGFloat = 34
+    // Locked to the size the docked bar actually pins the nub to, so the circular
+    // background (cornerRadius = nubSize/2) and the drag clamp track the real frame.
+    private let nubSize: CGFloat = TerminalInputTextView.dockedNubSize
     private let deadZone: CGFloat = 8
     private let repeatInterval: Duration = .milliseconds(80)
     private let innerDot = UIView()
@@ -2949,5 +3960,22 @@ final class TerminalArrowNubView: UIView {
         repeatTask = nil
     }
 }
+
+#if DEBUG
+/// Off-screen accessibility carrier that reports ``GhosttySurfaceView``'s live
+/// bottom-dock state to UI tests. Computes ``accessibilityValue`` on every read
+/// (delegating to ``GhosttySurfaceView/composerDockProbeValue``) so an XCUITest
+/// predicate-wait converges on the SETTLED post-transition state even though
+/// `fieldFocused`/`proxyFirstResponder` flip a runloop after the synchronous
+/// transition. DEBUG-only; never compiled into a shipping build.
+final class ComposerDockProbeView: UIView {
+    weak var surface: GhosttySurfaceView?
+
+    override var accessibilityValue: String? {
+        get { surface?.composerDockProbeValue }
+        set { /* read-only live probe; ignore writes */ }
+    }
+}
+#endif
 
 #endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1559,6 +1559,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         #endif
         switch intent {
         case .openComposer, .closeComposer:
+            // Optimistically flip the local mirror to the intent's outcome BEFORE
+            // the store round-trip. `composerActive` is otherwise synced back via
+            // SwiftUI's `updateUIView`, which runs a render pass after the store
+            // mutation — a second tap landing inside that window would read the
+            // stale flag, resolve `.openComposer` again, and the toggle would
+            // dismiss the composer the first tap just presented. The authoritative
+            // sync still arrives via `setComposerActive` (idempotent when the
+            // optimistic value already matches).
+            setComposerActive(intent == .openComposer)
             delegate?.ghosttySurfaceViewDidRequestComposerToggle(self)
         case .revealAndFocusComposer:
             if chromeHidden {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1574,6 +1574,29 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 setChromeHidden(false)
             }
             delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+            focusMountedComposerField()
+        }
+    }
+
+    /// Deterministic UIKit focus for an already-mounted composer band.
+    ///
+    /// The store handshake (`composerFocusRequest`) drives the SwiftUI field's
+    /// `@FocusState`, but a programmatic `@FocusState` set inside a hosting
+    /// controller whose view is frame-mounted into the band can be dropped
+    /// (observed as a device-dependent flake: the request is consumed yet the
+    /// field never becomes first responder). After asking the host to focus,
+    /// drive the band's backing text input to first responder directly on the
+    /// next runloop hop; SwiftUI mirrors UIKit first responder back into
+    /// `@FocusState`, so the store's focus mirror stays consistent. A no-op
+    /// when the band is unmounted (the fresh-mount path focuses via the
+    /// consumed request in `onAppear`) or the field already holds focus.
+    private func focusMountedComposerField() {
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.composerActive,
+                  !self.composerFieldIsFirstResponder,
+                  let input = self.composerContainer.firstFocusableTextInputInSubtree() else { return }
+            input.becomeFirstResponder()
         }
     }
 
@@ -1865,6 +1888,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // terminal proxy as before.
         if wasHidden, composerActive {
             delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+            focusMountedComposerField()
         } else {
             focusInput()
         }

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -969,14 +969,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // Round 8: the keyboard-toggle button only raises/lowers the keyboard. The
             // toolbar stays visible either way, and an open composer survives a
             // keyboard-down (its draft lives in the store; the field just loses focus).
-            // While composing, the composer's hosted field — not `inputProxy` — holds
-            // first responder, so resign through the container to drop the keyboard;
-            // otherwise toggle the terminal input proxy.
+            // Resign whichever responder actually owns the keyboard: with the composer
+            // open by default the band can be presented (`composerActive == true`)
+            // while the terminal's hidden input proxy holds first responder (a
+            // terminal tap focuses the proxy without closing the band), and the proxy
+            // is a sibling of `composerContainer`, so `endEditing` on the container
+            // alone would resign nothing and the keyboard would stay up.
             if self.keyboardHeight > 0 {
-                if self.composerActive {
-                    self.composerContainer.endEditing(true)
-                } else {
+                if self.inputProxy.isFirstResponder {
                     self.resignInput()
+                } else {
+                    self.composerContainer.endEditing(true)
                 }
             } else {
                 self.focusInput()
@@ -1387,11 +1390,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         chromeHidden = hidden
         if hidden, keyboardHeight > 0 {
             // Drop the keyboard first; its hide notification re-seats the dock, then
-            // the visibility update below removes the toolbar/composer.
-            if composerActive {
-                composerContainer.endEditing(true)
-            } else {
+            // the visibility update below removes the toolbar/composer. Resign
+            // whichever responder actually owns the keyboard — the band can be
+            // presented while the terminal's hidden input proxy (a sibling of
+            // `composerContainer`) holds first responder, so gating on
+            // `composerActive` alone would leave the keyboard up while the chrome
+            // hides.
+            if inputProxy.isFirstResponder {
                 resignInput()
+            } else {
+                composerContainer.endEditing(true)
             }
         }
         updateDockedToolbarVisibility()

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -55,27 +55,18 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// The user tapped the "customize" button at the end of the input-accessory
     /// bar; the host should present the toolbar shortcuts editor. Optional.
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView)
-    /// The user tapped the attachments button on the input-accessory bar; the host
-    /// should present the iOS photo/file picker and route any picked image through
-    /// the existing image-attach path (``ghosttySurfaceView(_:didPasteImage:format:)``).
-    /// Optional.
-    func ghosttySurfaceViewDidRequestAttachment(_ surfaceView: GhosttySurfaceView)
     /// Forward an image the user pasted from the system clipboard. The host
     /// uploads `data` to the Mac, which materializes a temp file and injects its
     /// path into the terminal so a running TUI (e.g. Claude Code) attaches it.
     /// `format` is a lowercase file-extension hint (e.g. `"png"`). Optional.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String)
-    /// The user pasted an image that is too large to send even after trying a
-    /// compressed JPEG, so nothing was uploaded. The host should surface a
-    /// user-visible "too large" notice. Optional.
-    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView)
     /// The composer accessory button was tapped; the host should toggle the
     /// iMessage-style composer above the terminal. Optional.
     ///
-    /// Round 8: the composer is dismissed ONLY by its own chevron or this toggle. The
-    /// keyboard collapsing no longer dismisses the composer (it survives a keyboard-down
+    /// The composer is dismissed ONLY by its own chevron or this toggle. The
+    /// keyboard collapsing does not dismiss the composer (it survives a keyboard-down
     /// and the toolbar stays visible), so there is no separate collapse/dismiss
-    /// delegate hook anymore.
+    /// delegate hook.
     func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView)
     /// The surface needs the iMessage-style composer presented (if it is not already)
     /// and its field re-focused, without dismissing it. The host ensures the composer
@@ -83,43 +74,15 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// reveal-after-hide and the present-while-suppressed paths so the draft and its
     /// focus return together. Optional.
     func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView)
-    /// Forward a committed block of text (system dictation, an autocorrect
-    /// replacement, or keyboard-inserted clipboard text) that should reach the
-    /// remote terminal as a bracketed paste rather than per-character input. The
-    /// host sends it via the `terminal.paste` RPC so embedded newlines do not
-    /// fragment into separate Returns. Defaults to the raw-input path so existing
-    /// conformers keep working. Optional.
-    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String)
-    /// The user tapped the floating jump-to-bottom button; the host should ask
-    /// the Mac's real surface to scroll all the way to the live bottom (out of
-    /// scrollback). The mirror has no local scrollback, so this cannot be done
-    /// on-device. Optional.
-    func ghosttySurfaceViewDidRequestScrollToBottom(_ surfaceView: GhosttySurfaceView)
 }
 
 public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didScrollLines lines: Double, atCol col: Int, row: Int) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
-    func ghosttySurfaceViewDidRequestAttachment(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
-    func ghosttySurfaceViewDidFailToPasteImageTooLarge(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView) {}
-    func ghosttySurfaceViewDidRequestScrollToBottom(_ surfaceView: GhosttySurfaceView) {}
-    /// Default bracketed-paste handler that falls back to per-character input.
-    ///
-    /// A conformer that does not implement the bracketed-paste path still
-    /// delivers the text: newlines are normalized to CR (matching the
-    /// per-keystroke input path) and the bytes are forwarded through
-    /// ``ghosttySurfaceView(_:didProduceInput:)``.
-    /// - Parameters:
-    ///   - surfaceView: The surface view that produced the committed block.
-    ///   - text: The committed block of pasted/dictated text.
-    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteText text: String) {
-        let normalized = text.replacingOccurrences(of: "\n", with: "\r")
-        ghosttySurfaceView(surfaceView, didProduceInput: Data(normalized.utf8))
-    }
 }
 
 @MainActor
@@ -435,14 +398,6 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return String(localized: "terminal.input_accessory.paste", defaultValue: "Paste")
         case .composer:
             return String(localized: "terminal.input_accessory.composer", defaultValue: "Composer")
-        case .upArrow:
-            return String(localized: "terminal.input_accessory.up_arrow", defaultValue: "Up Arrow")
-        case .downArrow:
-            return String(localized: "terminal.input_accessory.down_arrow", defaultValue: "Down Arrow")
-        case .leftArrow:
-            return String(localized: "terminal.input_accessory.left_arrow", defaultValue: "Left Arrow")
-        case .rightArrow:
-            return String(localized: "terminal.input_accessory.right_arrow", defaultValue: "Right Arrow")
         default:
             return nil
         }
@@ -458,14 +413,6 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
             return "doc.on.clipboard"
         case .composer:
             return "square.and.pencil"
-        case .upArrow:
-            return "arrow.up"
-        case .downArrow:
-            return "arrow.down"
-        case .leftArrow:
-            return "arrow.left"
-        case .rightArrow:
-            return "arrow.right"
         default:
             return nil
         }
@@ -730,15 +677,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// GPU is available so any in-flight render drains — and gate dispatch so
     /// no `render_now` is sent into the background.
     private var renderingSuspended: Bool = false
-    /// Set when a foreground transition (`didBecomeActive` / `willEnterForeground`)
-    /// reached this view but could not finish resuming the render loop because the
-    /// view was momentarily off-window or surfaceless. The next ``didMoveToWindow``
-    /// (window non-nil) completes the resume so the terminal repaints. Without
-    /// this, a foreground that races the SwiftUI representable re-attach would
-    /// clear suspension but never restart the display link, leaving the terminal
-    /// frozen on stale content while input (a separate RPC) still worked — the
-    /// home-button background→foreground render-freeze.
-    private var pendingForegroundResume: Bool = false
     #if DEBUG
     /// Last time the display-link heartbeat logged (DEBUG diagnostic). The
     /// per-frame callback runs on the main thread, so a steady heartbeat proves
@@ -749,19 +687,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Time of the most recent applied render-grid output, for the heartbeat's
     /// `sinceOutput` field (ties an idle blank to a stream gap).
     private var lastOutputAppliedTime: CFTimeInterval = 0
-    /// Time-gate stamp for the ``DiagnosticEventCode/renderFrameApplied`` heartbeat so
-    /// it records ≈1/s instead of per output chunk (RENDER: frame-apply).
-    private var lastRenderFrameDiagTime: CFTimeInterval = 0
-    /// Time-gate stamp for the ``DiagnosticEventCode/renderBusySkipped`` event so a
-    /// continuous render-coalesce burst records ≈1/s, not per skipped frame.
-    private var lastRenderBusyDiagTime: CFTimeInterval = 0
-    /// Media time the in-flight `render_now` was enqueued, for the busy/duration
-    /// RENDER: events. 0 when no render is in flight.
-    private var renderInFlightStart: CFTimeInterval = 0
-    /// Only a `render_now` slower than this (ms) records a
-    /// ``DiagnosticEventCode/renderCompleted`` event, so the bounded diagnostic ring is
-    /// not flooded by normal fast renders at 120fps.
-    private static let renderCompletedSlowThresholdMs: Double = 50
     #endif
     /// Set by any geometry trigger (resize/zoom/keyboard/effective-grid pin);
     /// the display link applies geometry at most once per frame. Coalescing
@@ -978,16 +903,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Structured diagnostic log (DEBUG dogfood builds only), property-injected
     /// from the shell store by ``GhosttySurfaceRepresentable`` so the
-    /// hold-backspace + dictation input probes land in the blob the "Send to
-    /// agent" feedback pane exports. Forwarded to ``inputProxy`` on set. `nil` in
-    /// release and in hosts that do not wire it; every probe is then a no-op.
-    public var diagnosticLog: DiagnosticLog? {
-        didSet { inputProxy.diagnosticLog = diagnosticLog }
-    }
+    /// composer-dock probes land in the blob the diagnostic export captures.
+    /// `nil` in release and in hosts that do not wire it; every probe is then a
+    /// no-op.
+    public var diagnosticLog: DiagnosticLog?
 
     private lazy var inputProxy: TerminalInputTextView = {
         let inputProxy = TerminalInputTextView()
-        inputProxy.diagnosticLog = diagnosticLog
         inputProxy.onText = { [weak self] text in
             guard let self else { return }
             self.resetCursorBlink()
@@ -1007,13 +929,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.resetCursorBlink()
             // Send DEL (0x7F) directly to transport as raw byte.
             let data = Data([0x7F])
-            #if DEBUG
-            // Pairs with `inputDeleteBackward`: if N delete calls produce N
-            // emitted DEL bytes, the iOS input view is correct and the
-            // hold-backspace failure is downstream (transport/Mac/render), not in
-            // this view — redirecting the hunt instead of a 4th input-view guess.
-            self.diagnosticLog?.record(DiagnosticEvent(.inputBackspaceEmitted, ms: UInt32(data.count)))
-            #endif
             TerminalInputDebugLog.log("surface.onBackspace data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
         }
@@ -1023,24 +938,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             TerminalInputDebugLog.log("surface.onEscape data=\(TerminalInputDebugLog.dataSummary(data))")
             self.delegate?.ghosttySurfaceView(self, didProduceInput: data)
         }
-        inputProxy.onPasteText = { [weak self] text in
-            guard let self else { return }
-            self.resetCursorBlink()
-            // Multi-character commits (dictation, autocorrect, keyboard clipboard
-            // insert) go through the bracketed-paste RPC so embedded newlines are
-            // not split into separate Returns by the remote terminal.
-            TerminalInputDebugLog.log("surface.onPasteText text=\(TerminalInputDebugLog.textSummary(text))")
-            self.delegate?.ghosttySurfaceView(self, didPasteText: text)
-        }
         inputProxy.onPasteImage = { [weak self] data, format in
             guard let self else { return }
             TerminalInputDebugLog.log("surface.onPasteImage bytes=\(data.count) format=\(format)")
             self.delegate?.ghosttySurfaceView(self, didPasteImage: data, format: format)
-        }
-        inputProxy.onPasteImageTooLarge = { [weak self] in
-            guard let self else { return }
-            TerminalInputDebugLog.log("surface.onPasteImageTooLarge")
-            self.delegate?.ghosttySurfaceViewDidFailToPasteImageTooLarge(self)
         }
         inputProxy.onZoom = { [weak self] direction in
             self?.performFontZoom(direction)
@@ -1087,10 +988,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         inputProxy.onOpenToolbarSettings = { [weak self] in
             guard let self else { return }
             self.delegate?.ghosttySurfaceViewDidRequestToolbarSettings(self)
-        }
-        inputProxy.onOpenAttachments = { [weak self] in
-            guard let self else { return }
-            self.delegate?.ghosttySurfaceViewDidRequestAttachment(self)
         }
         inputProxy.accessoryLayoutInsetsProvider = { [weak self] in
             guard let self,
@@ -1203,13 +1100,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     @objc private func handleAppWillEnterForeground() {
-        // `willEnterForeground` fires before `didBecomeActive` on every foreground
-        // (including the home-button case), so resume the render loop here too,
-        // not only from `didBecomeActive`. `resumeRendering` is idempotent and, if
-        // the view is momentarily off-window, arms `pendingForegroundResume` so
-        // `didMoveToWindow` completes the resume — the terminal repaints regardless
-        // of how the foreground notifications and the SwiftUI re-attach interleave.
-        resumeRendering()
         guard surface != nil, window != nil else { return }
         // The Mac drops this device's sticky viewport pin a few seconds after the
         // connection backgrounds, so on reconnect it reverts to its own (often
@@ -1237,53 +1127,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Resume the render loop once the app is active again.
     ///
-    /// Called from both `willEnterForeground` and `didBecomeActive` (and indirectly
-    /// from `didMoveToWindow` via the pending-resume completion), so it must be
-    /// idempotent: the in-flight render gate is reset only on the suspended→active
-    /// transition, never on a second call while already running. Resetting it
-    /// unconditionally would race a `render_now` that a display-link tick enqueued
-    /// between the two foreground notifications — marking it not-in-flight defeats
-    /// the coalescing guard and lets extra renders pile on `outputQueue`.
+    /// A `render_now` in flight at suspend either drained (the GPU was still
+    /// available before background) or never dispatched, and its main-thread
+    /// completion may have been deferred while the queue was suspended — so clear
+    /// the in-flight flag to guarantee the first foreground frame can dispatch,
+    /// re-mark the surface visible, and restart the frame pump. Idempotent.
     private func resumeRendering() {
-        let wasSuspended = renderingSuspended
         renderingSuspended = false
-        if wasSuspended {
-            // A `render_now` in flight at suspend either drained (the GPU was
-            // still available before background) or never dispatched, and its
-            // main-thread completion may have been deferred while the queue was
-            // suspended — clear the in-flight flag so the first foreground frame
-            // can dispatch. Safe here because no live render can be enqueued while
-            // suspended (`requestRender` early-returns on `renderingSuspended`).
-            renderInFlight = false
-            needsAnotherRender = false
-        }
-        guard let surface, window != nil else {
-            // The foreground notification reached this view before it was back
-            // on-window (a SwiftUI representable re-attach can race the scene
-            // becoming active). Suspension is already cleared, but the display
-            // link can't restart while detached — arm a pending resume so the
-            // next `didMoveToWindow` (window non-nil) finishes the job and the
-            // terminal repaints instead of staying frozen on stale content.
-            pendingForegroundResume = true
-            MobileDebugLog.anchormux("resume.skip hasSurface=\(surface != nil) win=\(window != nil) armedPending")
-            return
-        }
-        pendingForegroundResume = false
-        MobileDebugLog.anchormux("resume.enter restartingDisplayLink")
-        // Re-assert occlusion against the current view state (not unconditionally
-        // visible): a still-hidden/zero-size surface stays occluded so a stale
-        // present can't flash. `syncSurfaceVisibility` updates the cursor overlay.
-        syncSurfaceVisibility()
+        renderInFlight = false
+        needsAnotherRender = false
+        guard let surface, window != nil else { return }
+        ghostty_surface_set_occlusion(surface, true)  // true = visible
         setFocus(true)
-        // Force a fresh repaint at the correct size: the IOSurface may have lost
-        // its backing while backgrounded, so a single stale-size draw can land
-        // blank. Clearing `lastReportedSize` forces the natural grid to re-report
-        // even if it is unchanged (the Mac drops the sticky viewport pin while
-        // backgrounded), and the geometry resync guarantees the first foreground
-        // frame is sized and drawn from current content.
-        lastReportedSize = nil
         needsDraw = true
-        setNeedsGeometrySync(reassertNaturalSize: true)
         startDisplayLink()
     }
 
@@ -1309,15 +1165,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// flush with the grid bottom (no gap) and its bottom rests on the keyboard
     /// edge (up) or above the home indicator (down).
     private weak var dockedToolbar: UIView?
-    /// The floating jump-to-bottom button. Installed lazily alongside the docked
-    /// toolbar, positioned bottom-right just above the toolbar/composer/keyboard
-    /// reserve in ``layoutBottomDock()``, and shown only while ``scrolledUp`` is
-    /// true (the Mac reported the viewport is scrolled up into scrollback).
-    private weak var scrollToBottomButton: ScrollToBottomButton?
-    /// Whether the terminal is scrolled up (has room to jump to the live bottom),
-    /// pushed down from the render-grid producer's authoritative position via
-    /// ``setScrolledUp(_:)``. Drives ``scrollToBottomButton`` visibility.
-    private var scrolledUp = false
     /// Whether the iMessage-style composer is currently open. The surface owns the
     /// whole bottom dock (terminal grid / composer band / toolbar / keyboard) in ONE
     /// coordinate system, so `composerActive` only drives the first-responder
@@ -1354,20 +1201,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public var autoFocusOnWindowAttach = true
 
     @objc private func handleKeyboardWillShow(_ notification: Notification) {
-        #if DEBUG
-        // Capture WHICH view owns first responder the instant the keyboard comes
-        // up — the load-bearing question for the hold-backspace + dictation hunt.
-        // Recorded before any geometry guard so it fires on every keyboard-up,
-        // even when the height is unchanged. This is the iOS analog of checking
-        // for a Mac-style `keyRepair` focus-steal: if this is not
-        // `terminalInputProxy`, the keyboard never drives the view we instrument.
-        let kbResponder = CurrentResponderProbe.current()
-        let kbIdentity = TerminalInputTextView.responderIdentity(of: kbResponder)
-        diagnosticLog?.record(DiagnosticEvent(.inputKeyboardUp, a: kbIdentity.rawValue))
-        MobileDebugLog.anchormux(
-            "input.keyboardUp identity=\(kbIdentity) class=\(TerminalInputTextView.responderClassName(kbResponder)) proxyIsFR=\(inputProxy.isFirstResponder)"
-        )
-        #endif
         guard let frameEnd = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
               let window else { return }
         let keyboardFrameInView = convert(frameEnd, from: window)
@@ -1469,71 +1302,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // is visible above the strip.
         toolbar.layer.zPosition = Self.bottomChromeZPosition
         toolbar.clipsToBounds = false
-        installScrollToBottomButton()
         updateDockedToolbarVisibility()
         layoutBottomDock()
-    }
-
-    /// Install the floating jump-to-bottom button as a sibling of the docked
-    /// toolbar. It shares the bottom-chrome `zPosition` so the lifted glass is
-    /// not clipped by the Ghostty render sublayer (item 6), and starts hidden
-    /// until ``setScrolledUp(_:)`` reports the viewport is scrolled up. Tapping
-    /// it routes to the surface delegate, which asks the Mac to scroll to bottom.
-    private func installScrollToBottomButton() {
-        guard scrollToBottomButton == nil else { return }
-        let button = ScrollToBottomButton()
-        button.layer.zPosition = Self.bottomChromeZPosition
-        button.alpha = 0
-        button.isHidden = true
-        button.onTap = { [weak self] in
-            guard let self else { return }
-            self.delegate?.ghosttySurfaceViewDidRequestScrollToBottom(self)
-        }
-        addSubview(button)
-        scrollToBottomButton = button
-    }
-
-    /// Update whether the terminal is scrolled up and animate the floating
-    /// jump-to-bottom button in or out to match.
-    ///
-    /// Driven by the render-grid producer's authoritative viewport position
-    /// (pushed down from the shell store through the representable). Idempotent:
-    /// an unchanged value is a no-op so the steady stream of at-bottom frames
-    /// does not thrash the button. Hiding the bottom chrome (HIDE button) also
-    /// suppresses the floating button via ``layoutBottomDock``.
-    public func setScrolledUp(_ value: Bool) {
-        guard scrolledUp != value else { return }
-        scrolledUp = value
-        layoutBottomDock()
-        updateScrollToBottomButtonVisibility(animated: true)
-    }
-
-    /// Whether the floating jump-to-bottom button should currently be on screen:
-    /// the terminal is scrolled up AND the bottom chrome is not suppressed.
-    private var scrollToBottomButtonShouldBeVisible: Bool {
-        scrolledUp && !chromeHidden
-    }
-
-    /// Reconcile the floating button's visibility with the scrolled-up + chrome
-    /// state, optionally on the keyboard animation curve.
-    private func updateScrollToBottomButtonVisibility(animated: Bool) {
-        guard let button = scrollToBottomButton else { return }
-        let shouldShow = scrollToBottomButtonShouldBeVisible
-        let targetAlpha: CGFloat = shouldShow ? 1 : 0
-        guard button.alpha != targetAlpha || button.isHidden == shouldShow else { return }
-        if shouldShow { button.isHidden = false }
-        let apply = {
-            button.alpha = targetAlpha
-        }
-        let finish: (Bool) -> Void = { _ in
-            if !shouldShow { button.isHidden = true }
-        }
-        if animated {
-            UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseInOut], animations: apply, completion: finish)
-        } else {
-            apply()
-            finish(true)
-        }
     }
 
     /// Layer `zPosition` for the bottom chrome (toolbar + composer band), placing it
@@ -1638,9 +1408,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // double-animate against the keyboard rise.
             layoutBottomDock()
         }
-        // The floating jump-to-bottom button rides with the chrome: HIDE suppresses
-        // it, and a re-show restores it if the terminal is still scrolled up.
-        updateScrollToBottomButtonVisibility(animated: true)
         setNeedsGeometrySync()
     }
 
@@ -1954,29 +1721,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let frames = bottomDockFrames()
         composerContainer.frame = frames.composer
         dockedToolbar?.frame = frames.toolbar
-        layoutScrollToBottomButton(aboveDockTop: frames.toolbar.minY)
-    }
-
-    /// Spacing (points) between the floating jump-to-bottom button and the dock
-    /// above which it floats, and the trailing edge.
-    private static let scrollToBottomButtonMargin: CGFloat = 12
-
-    /// Pin the floating jump-to-bottom button to the bottom-right, floating just
-    /// above the bottom dock (the toolbar top, which already rides above the
-    /// composer band, keyboard, and home-indicator reserve). Reuses the dock's
-    /// own computed top edge so the button tracks the toolbar/composer/keyboard
-    /// as they show and hide instead of a hardcoded offset.
-    private func layoutScrollToBottomButton(aboveDockTop dockTop: CGFloat) {
-        guard let button = scrollToBottomButton else { return }
-        let size = ScrollToBottomButton.diameter
-        let margin = Self.scrollToBottomButtonMargin
-        // When the chrome is suppressed the dock collapses to the bottom edge;
-        // float the button above the bottom safe area instead so HIDE does not
-        // shove it under the home indicator (it is hidden in that state anyway).
-        let referenceTop = chromeHidden ? bounds.height - safeAreaInsetsBottom : dockTop
-        let x = bounds.width - size - margin
-        let y = referenceTop - size - margin
-        button.frame = CGRect(x: x, y: max(0, y), width: size, height: size)
     }
 
     /// Animate the whole bottom dock (composer band + toolbar) in lockstep with a
@@ -2341,24 +2085,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             #if DEBUG
             debugAccessibilityProxy.isAccessibilityElement = true
             #endif
+            setNeedsGeometrySync()
             setFocus(true)
             if autoFocusOnWindowAttach {
                 focusInput()
             }
-            // Complete a foreground resume that arrived while the view was still
-            // off-window. `resumeRendering` (now back on-window) clears suspension
-            // — otherwise `requestRender` early-returns on every tick and the loop
-            // never paints again — and forces the full repaint (occlusion,
-            // viewport reassert, geometry resync, display link). For a normal
-            // attach (no pending resume) keep the lighter geometry sync + link
-            // restart so an unrelated reattach does not force a viewport re-report.
-            if pendingForegroundResume {
-                MobileDebugLog.anchormux("resume.completeOnAttach")
-                resumeRendering()
-            } else {
-                setNeedsGeometrySync()
-                startDisplayLink()
-            }
+            startDisplayLink()
         } else {
             prepareForReuseAfterDetach()
         }
@@ -2426,24 +2158,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     self.updateCursorOverlay()
                 }
                 #if DEBUG
-                // RENDER: frame-apply heartbeat. Time-gated to ≈1/s so it is a
-                // heartbeat, not a per-chunk flood, on the lock-free diagnostic sink.
-                // `ms` = gap since the previous applied chunk; `a` = this chunk's byte
-                // length. A growing gap or this event ceasing while input still works
-                // localizes a stalled render-grid consumer.
-                let applyNow = CACurrentMediaTime()
-                if applyNow - self.lastRenderFrameDiagTime >= 1.0 {
-                    let gapMs = self.lastOutputAppliedTime > 0
-                        ? UInt32(min(Double(UInt32.max), max(0, (applyNow - self.lastOutputAppliedTime) * 1000)))
-                        : 0
-                    self.diagnosticLog?.record(DiagnosticEvent(
-                        .renderFrameApplied,
-                        ms: gapMs,
-                        a: forwarded.count
-                    ))
-                    self.lastRenderFrameDiagTime = applyNow
-                }
-                self.lastOutputAppliedTime = applyNow
+                self.lastOutputAppliedTime = CACurrentMediaTime()
                 #endif
                 if !self.surfaceHasReceivedOutput {
                     self.surfaceHasReceivedOutput = true
@@ -2905,64 +2620,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // (Called on main from the display link.)
         if renderInFlight {
             needsAnotherRender = true
-            #if DEBUG
-            // RENDER: render busy / snapshot skipped. A render is already in flight, so
-            // this frame's render is coalesced away. Time-gated to ≈1/s; `a` = how long
-            // the in-flight render has been running so far (ms). A long, climbing value
-            // with a frozen screen is the wedged-render-queue signal while input still
-            // works.
-            let busyNow = CACurrentMediaTime()
-            if busyNow - lastRenderBusyDiagTime >= 1.0 {
-                lastRenderBusyDiagTime = busyNow
-                let inFlightMs = renderInFlightStart > 0
-                    ? UInt32(min(Double(UInt32.max), max(0, (busyNow - renderInFlightStart) * 1000)))
-                    : 0
-                diagnosticLog?.record(DiagnosticEvent(.renderBusySkipped, a: Int(inFlightMs)))
-            }
-            #endif
             return
         }
         renderInFlight = true
         let enqueuedAt = CACurrentMediaTime()
-        #if DEBUG
-        renderInFlightStart = enqueuedAt
-        #endif
         Self.outputQueue.async { [weak self] in
             // Queue LAG = how long this render waited behind other ops. If this
             // climbs into hundreds of ms the queue is backlogged (the freeze).
             let lagMs = (CACurrentMediaTime() - enqueuedAt) * 1000
-            if lagMs > 150 {
-                MobileDebugLog.anchormux("oq.render.LAG \(Int(lagMs))ms")
-                #if DEBUG
-                // RENDER: the render queue lagged — this render waited a long time
-                // behind other ops before running. `ms` = the measured wait.
-                self?.diagnosticLog?.record(DiagnosticEvent(
-                    .renderGridLag,
-                    ms: UInt32(min(Double(UInt32.max), lagMs))
-                ))
-                #endif
-            }
+            if lagMs > 150 { MobileDebugLog.anchormux("oq.render.LAG \(Int(lagMs))ms") }
             ghostty_surface_render_now(surface)
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.renderInFlight = false
-                #if DEBUG
-                // RENDER: render-busy duration — enqueue → completion, in ms. Recorded
-                // ONLY for a slow render (> `renderCompletedSlowThresholdMs`); a normal
-                // few-ms render at 120fps would flood the bounded ring and evict every
-                // other event. A spike here with a frozen screen confirms `render_now`
-                // itself (GPU/swap-chain) stalled rather than the stream drying up.
-                let completedMs = self.renderInFlightStart > 0
-                    ? max(0, (CACurrentMediaTime() - self.renderInFlightStart) * 1000)
-                    : 0
-                if completedMs > Self.renderCompletedSlowThresholdMs {
-                    self.diagnosticLog?.record(DiagnosticEvent(
-                        .renderCompleted,
-                        ms: UInt32(min(Double(UInt32.max), completedMs))
-                    ))
-                }
-                self.renderInFlightStart = 0
-                #endif
                 guard !self.isDismantled else {
                     self.needsAnotherRender = false
                     return

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -81,7 +81,9 @@ public extension GhosttySurfaceViewDelegate {
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {}
+    /// Default no-op so hosts without a composer can ignore the toggle request.
     func ghosttySurfaceViewDidRequestComposerToggle(_ surfaceView: GhosttySurfaceView) {}
+    /// Default no-op so hosts without a composer can ignore the focus request.
     func ghosttySurfaceViewDidRequestComposerFocus(_ surfaceView: GhosttySurfaceView) {}
 }
 
@@ -284,8 +286,10 @@ public enum TerminalInputAccessoryAction: Int, CaseIterable, Sendable {
     /// path. Unlike the other actions it carries no fixed byte ``output``; the
     /// host reads the pasteboard when it is tapped.
     case paste
-    // Appended at the end so existing persisted raw values (user accessory bar
-    // order/enabled set) are preserved.
+    /// Toggle the iMessage-style composer band above the terminal.
+    ///
+    /// Appended at the end so existing persisted raw values (user accessory bar
+    /// order/enabled set) are preserved.
     case composer
     var title: String {
         title(isMacRemote: false)
@@ -762,7 +766,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// ``ComposerDockProbeView`` on every accessibility query. `fieldFocused` is the
     /// SAME ``composerFieldIsFirstResponder`` walk the reducer reads, so the probe and
     /// the real decision can never disagree.
-    fileprivate var composerDockProbeValue: String {
+    var composerDockProbeValue: String {
         let intent: String
         switch lastComposerDockIntent {
         case .openComposer: intent = "open"
@@ -957,7 +961,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // dismisses the composer here (the composer survives a keyboard-down), so
             // this is now purely diagnostic.
             if self.composerActive {
-                let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+                let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
                 self.diagnosticLog?.record(DiagnosticEvent(
                     .composerKeyboardToggleWhilePresented,
                     ms: UInt32(max(0, self.keyboardHeight)),
@@ -1232,7 +1236,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // is complete no matter how the keyboard went down. Pure diagnostics; the hide
         // behavior below is unchanged.
         if composerActive {
-            let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+            let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
             MobileDebugLog.anchormux(
                 "composer.keyboardHideWhilePresented prevKeyboardHeight=\(Int(keyboardHeight)) frOwner=\(frOwner.rawValue) proxyIsFR=\(inputProxy.isFirstResponder ? 1 : 0)"
             )
@@ -1495,7 +1499,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // same sink the round-4 composer flag/appear/focus events use. With these,
         // a captured trace shows whether the composer ever ends up active with the
         // FR owned by no terminal/composer responder and keyboardHeight 0.
-        let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe.current())
+        let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
         diagnosticLog?.record(DiagnosticEvent(
             .composerActiveTransition,
             ms: UInt32(max(0, keyboardHeight)),
@@ -2073,13 +2077,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         syncSurfaceVisibility()
     }
 
+    /// Re-seats the bottom dock and grid reservation when the safe-area inset
+    /// changes.
+    ///
+    /// The always-visible toolbar rides the bottom safe area while the keyboard
+    /// is down (Round 8). The inset can arrive after the first layout (it is 0
+    /// before window attach), so re-seat the dock and re-reserve the grid when it
+    /// changes; otherwise the toolbar would sit on the home indicator until the
+    /// next unrelated relayout.
     public override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
-        // The always-visible toolbar rides the bottom safe area while the keyboard
-        // is down (Round 8). The inset can arrive after the first layout (it is 0
-        // before window attach), so re-seat the dock and re-reserve the grid when it
-        // changes; otherwise the toolbar would sit on the home indicator until the
-        // next unrelated relayout.
         layoutBottomDock()
         setNeedsGeometrySync()
     }
@@ -3643,21 +3650,5 @@ final class TerminalArrowNubView: UIView {
     }
 }
 
-#if DEBUG
-/// Off-screen accessibility carrier that reports ``GhosttySurfaceView``'s live
-/// bottom-dock state to UI tests. Computes ``accessibilityValue`` on every read
-/// (delegating to ``GhosttySurfaceView/composerDockProbeValue``) so an XCUITest
-/// predicate-wait converges on the SETTLED post-transition state even though
-/// `fieldFocused`/`proxyFirstResponder` flip a runloop after the synchronous
-/// transition. DEBUG-only; never compiled into a shipping build.
-final class ComposerDockProbeView: UIView {
-    weak var surface: GhosttySurfaceView?
-
-    override var accessibilityValue: String? {
-        get { surface?.composerDockProbeValue }
-        set { /* read-only live probe; ignore writes */ }
-    }
-}
-#endif
 
 #endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -961,7 +961,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // dismisses the composer here (the composer survives a keyboard-down), so
             // this is now purely diagnostic.
             if self.composerActive {
-                let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
+                let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe().current())
                 self.diagnosticLog?.record(DiagnosticEvent(
                     .composerKeyboardToggleWhilePresented,
                     ms: UInt32(max(0, self.keyboardHeight)),
@@ -1236,7 +1236,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // is complete no matter how the keyboard went down. Pure diagnostics; the hide
         // behavior below is unchanged.
         if composerActive {
-            let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
+            let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe().current())
             MobileDebugLog.anchormux(
                 "composer.keyboardHideWhilePresented prevKeyboardHeight=\(Int(keyboardHeight)) frOwner=\(frOwner.rawValue) proxyIsFR=\(inputProxy.isFirstResponder ? 1 : 0)"
             )
@@ -1499,7 +1499,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // same sink the round-4 composer flag/appear/focus events use. With these,
         // a captured trace shows whether the composer ever ends up active with the
         // FR owned by no terminal/composer responder and keyboardHeight 0.
-        let frOwner = TerminalInputTextView.responderIdentity(of: currentFirstResponderForDiagnostics())
+        let frOwner = TerminalInputTextView.responderIdentity(of: CurrentResponderProbe().current())
         diagnosticLog?.record(DiagnosticEvent(
             .composerActiveTransition,
             ms: UInt32(max(0, keyboardHeight)),

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileTerminalKit
 import Foundation
 import UIKit
@@ -16,11 +17,20 @@ final class TerminalInputTextView: UITextView {
     /// Fired by the trailing "customize" button so the SwiftUI host can present
     /// the toolbar shortcuts editor.
     var onOpenToolbarSettings: (() -> Void)?
+    /// Invoked when the composer accessory button is tapped. The host toggles
+    /// the iMessage-style composer above the terminal.
+    var onToggleComposer: (() -> Void)?
+    /// Fired by the pinned HIDE button: temporarily hides the toolbar + composer
+    /// until the next terminal tap.
+    var onHideChrome: (() -> Void)?
     var accessoryLayoutInsetsProvider: (() -> UIEdgeInsets)?
     /// The leftmost toolbar button. Toggles its glyph between dismiss-keyboard
     /// (when the keyboard is up) and show-keyboard (when down) via
     /// ``setKeyboardShown(_:)``.
     private weak var dismissButton: UIButton?
+    /// The composer toggle, pinned in the container (not the scrollable stack) so
+    /// it is always reachable regardless of the button row's scroll position.
+    private weak var composerButton: UIButton?
     /// The armed/sticky modifier state machine, extracted into the testable
     /// ``TerminalInputModifierState`` reducer. This view is now a dumb
     /// first-responder that forwards taps into the reducer and reads its state
@@ -55,11 +65,63 @@ final class TerminalInputTextView: UITextView {
     private static let monokaiBarColor = UIColor(red: 0x27/255.0, green: 0x28/255.0, blue: 0x22/255.0, alpha: 1)
     private static let accessoryHorizontalInset: CGFloat = 16
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
-    private static let accessoryButtonSymbolConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-    private static let accessoryButtonContentInsets = NSDirectionalEdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10)
+    /// One shared SF Symbol config for every icon on the bar (paste, zoom,
+    /// arrows, settings, keyboard toggle) so all glyphs render at one size.
+    /// The point size sits just under the 14pt text font because an SF Symbol's
+    /// bounding box reads larger than text at the same size; 13pt keeps the
+    /// icons visually in line with the text keys instead of looming over them.
+    private static let accessoryButtonSymbolConfig = UIImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+    /// Dedicated, slightly smaller config for the leading composer toggle.
+    /// `square.and.pencil` has a denser, taller bounding box than the
+    /// magnifying-glass/clipboard glyphs, so at the shared 13pt it still loomed
+    /// larger than its neighbors; 11pt brings it visually in line with them.
+    private static let composerButtonSymbolConfig = UIImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+    /// One comfortable inset applied to every button so the bar reads tappable and
+    /// uniform. Each button hugs its label/icon plus this inset. The bar's vertical
+    /// breathing room lives BELOW the strip (``dockedBottomPadding``), not as a
+    /// scroll-view margin that would shrink the capsule inside the strip, so the
+    /// glass capsule grows to fill the full strip height. The horizontal inset is
+    /// trimmed so the capsule hugs its glyph.
+    private static let accessoryButtonContentInsets = NSDirectionalEdgeInsets(top: 6, leading: 6, bottom: 6, trailing: 6)
     private static let accessoryButtonCornerRadius: CGFloat = 6
-    private static let accessoryButtonHeight: CGFloat = 28
-    private static let accessoryButtonMinWidth: CGFloat = 44
+    /// Button height. Equal to ``dockedNubSize`` so the capsule fills the strip
+    /// vertically: the buttons are as tall as the section, with the breathing
+    /// room living BELOW the strip (``dockedBottomPadding``) instead of inside it.
+    private static let accessoryButtonHeight: CGFloat = dockedNubSize
+    /// Size of the directional arrow nub (the tallest control in the bar). The
+    /// button-row strip is sized to exactly this so the nub fills the strip with no
+    /// slack above it, and the host reserves exactly this much grid height. Flush
+    /// with ``accessoryButtonHeight`` (the floor below which the buttons would clip
+    /// the strip) so the bar — and the reserved grid band above the keyboard — is as
+    /// short as it can be while every control stays a comfortable tap target.
+    static let dockedNubSize: CGFloat = 28
+    /// Breathing room below the control row, between the buttons and the keyboard
+    /// top (or the home indicator when the keyboard is down), so the bar is not
+    /// flush-tight at its bottom while the TOP stays snug to the terminal's last
+    /// row. It is part of ``dockedButtonRowHeight`` so the grid reservation, the
+    /// surface frame, and the composer host all reserve the same total band; the
+    /// button row itself is pinned to the BOTTOM of that band minus this padding
+    /// (see the docked bar's constraints), so the extra space lands below the
+    /// controls.
+    static let dockedBottomPadding: CGFloat = 8
+    /// Fixed height of the docked bar's button row band, reserved by the grid and
+    /// the composer host. It is the tallest control (the arrow nub,
+    /// ``dockedNubSize``) plus ``dockedBottomPadding`` below it. The controls are
+    /// pinned to the BOTTOM of this band (minus the padding) instead of the top:
+    /// when the surface-hosted container grows taller than this band (a
+    /// letterbox/resize pushes the rendered terminal's bottom up), the buttons stay
+    /// glued to the keyboard top and only the slack ABOVE them grows, so the
+    /// control row never rides up off the keyboard. In the composer host the frame
+    /// is exactly this height (no slack), so bottom-pinning is identical to
+    /// top-pinning there.
+    static let dockedButtonRowHeight: CGFloat = dockedNubSize + dockedBottomPadding
+    /// Minimum (not fixed) button width. Text buttons (Tab, Esc, ^C, ^D) size to
+    /// their intrinsic content width and only floor here so they hug their label
+    /// plus the comfortable inset; single-glyph modifiers/icons (⌃ ⌥ ⌘, the arrow
+    /// keys, paste) take this as a FIXED width so they stay uniform. The glyph keys
+    /// hug their icon tightly; the taller capsule supplies the tap area that a
+    /// wider button used to.
+    private static let accessoryButtonMinWidth: CGFloat = 32
     private static let accessoryButtonNormalBackground = UIColor(white: 0.35, alpha: 1)
     private var accessoryBackgroundLeadingConstraint: NSLayoutConstraint?
     private var accessoryBackgroundTrailingConstraint: NSLayoutConstraint?
@@ -69,7 +131,10 @@ final class TerminalInputTextView: UITextView {
     private lazy var terminalAccessoryToolbar: UIView = {
         let container = UIView()
         container.backgroundColor = .clear
-        container.frame = CGRect(x: 0, y: 0, width: 0, height: 44)
+        // Placeholder height until the host positions the bar via
+        // `GhosttySurfaceView.bottomDockFrames()`; sized to the button-row strip so
+        // the pre-layout frame matches the reserved grid height.
+        container.frame = CGRect(x: 0, y: 0, width: 0, height: Self.dockedButtonRowHeight)
 
         let backgroundView = UIView()
         backgroundView.backgroundColor = Self.monokaiBarColor
@@ -77,8 +142,7 @@ final class TerminalInputTextView: UITextView {
 
         // Pinned keyboard dismiss button on the left
         let dismissButton = UIButton(type: .system)
-        let dismissConfig = UIImage.SymbolConfiguration(pointSize: 16, weight: .medium)
-        dismissButton.setImage(UIImage(systemName: "keyboard.chevron.compact.down", withConfiguration: dismissConfig), for: .normal)
+        dismissButton.setImage(UIImage(systemName: "keyboard.chevron.compact.down", withConfiguration: Self.accessoryButtonSymbolConfig), for: .normal)
         dismissButton.tintColor = UIColor(white: 0.7, alpha: 1)
         dismissButton.addTarget(self, action: #selector(handleHideKeyboard), for: .touchUpInside)
         dismissButton.accessibilityIdentifier = "terminal.inputAccessory.hideKeyboard"
@@ -95,7 +159,8 @@ final class TerminalInputTextView: UITextView {
 
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 6
+        // Tighter inter-button spacing so the keys read as a compact row.
+        stack.spacing = 4
         stack.alignment = .center
 
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -110,9 +175,24 @@ final class TerminalInputTextView: UITextView {
         }
         nub.translatesAutoresizingMaskIntoConstraints = false
 
+        // The composer toggle is pinned directly in the container (like the
+        // keyboard-dismiss button and the arrow nub), OUTSIDE the horizontally
+        // scrollable button row. It used to be the leading item of the scrollable
+        // stack, but any scroll (e.g. reaching the HIDE/customize controls at the
+        // right edge of the strip) carried it off-screen left, and that offset
+        // survived a hide→reveal reflow, stranding the compose button at a large
+        // negative window X (~-840 in a 402pt window) where it was unhittable.
+        // Pinning it makes "the composer is always one tap away" a structural
+        // invariant immune to `contentOffset`, which is what the populate comment
+        // below already claimed. It is not config/remote dependent, so it is built
+        // once here (not rebuilt by `populateAccessoryActions`).
+        let composerButton = makeAccessoryButton(for: .composer)
+        self.composerButton = composerButton
+
         container.addSubview(backgroundView)
         container.addSubview(dismissButton)
         container.addSubview(nub)
+        container.addSubview(composerButton)
         container.addSubview(scrollView)
 
         let backgroundLeadingConstraint = backgroundView.leadingAnchor.constraint(equalTo: container.leadingAnchor)
@@ -121,10 +201,27 @@ final class TerminalInputTextView: UITextView {
             equalTo: container.safeAreaLayoutGuide.leadingAnchor,
             constant: Self.accessoryHorizontalInset
         )
+        // The bar scrolls horizontally, so the right edge runs flush to the
+        // screen (zero trailing inset). `updateAccessoryLayoutInsets` only adds a
+        // safe-area inset when the surface itself does not reach the window edge.
         let scrollTrailingConstraint = scrollView.trailingAnchor.constraint(
             equalTo: container.safeAreaLayoutGuide.trailingAnchor,
-            constant: -Self.accessoryHorizontalInset
+            constant: 0
         )
+
+        // A short fixed-height strip pinned to the container's BOTTOM (minus
+        // ``dockedBottomPadding``) that holds the button row. The docked container
+        // can be TALLER than this strip, because the host
+        // (`GhosttySurfaceView.bottomDockFrames`) anchors the bar's TOP to the
+        // rendered terminal's bottom and its BOTTOM to the keyboard top, so a
+        // letterbox/resize that pushes the rendered terminal up grows the container
+        // upward. Bottom-pinning the controls keeps them glued to the keyboard top
+        // (the container's bottom edge) with the slack absorbed ABOVE them; a
+        // top-pin would let the controls ride UP off the keyboard whenever the
+        // terminal was letterboxed. `dockedBottomPadding` lifts the strip off the
+        // very bottom edge so the controls have breathing room.
+        let buttonRow = UILayoutGuide()
+        container.addLayoutGuide(buttonRow)
 
         NSLayoutConstraint.activate([
             backgroundLeadingConstraint,
@@ -132,25 +229,54 @@ final class TerminalInputTextView: UITextView {
             backgroundView.topAnchor.constraint(equalTo: container.topAnchor),
             backgroundView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
 
+            // Bottom-pinned (minus the bottom padding) so the controls hug the
+            // keyboard top no matter how tall the container grows; the strip itself
+            // stays exactly the nub height.
+            buttonRow.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -Self.dockedBottomPadding),
+            buttonRow.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            buttonRow.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            buttonRow.heightAnchor.constraint(equalToConstant: Self.dockedNubSize),
+
+            // Every control shares the strip's single centerline. The strip is sized
+            // to the tallest control (the ``dockedNubSize`` nub), so centering keeps
+            // all three groups — keyboard button, nub, and the scrollable Ctrl/Esc/Tab
+            // row — on ONE horizontal line, hugging the keyboard top (the strip is
+            // bottom-pinned). (Top-pinning the directly-anchored controls instead
+            // would float them above the scroll row, which is centered inside its own
+            // scroll view.)
             dismissLeadingConstraint,
-            dismissButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            dismissButton.centerYAnchor.constraint(equalTo: buttonRow.centerYAnchor),
             dismissButton.widthAnchor.constraint(equalToConstant: 32),
 
             nub.leadingAnchor.constraint(equalTo: dismissButton.trailingAnchor, constant: 6),
-            nub.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            nub.widthAnchor.constraint(equalToConstant: 34),
-            nub.heightAnchor.constraint(equalToConstant: 34),
+            nub.centerYAnchor.constraint(equalTo: buttonRow.centerYAnchor),
+            nub.widthAnchor.constraint(equalToConstant: Self.dockedNubSize),
+            nub.heightAnchor.constraint(equalToConstant: Self.dockedNubSize),
 
-            scrollView.leadingAnchor.constraint(equalTo: nub.trailingAnchor, constant: 6),
+            // Pinned composer toggle: directly after the nub (same 6pt gap the
+            // scroll view used to take), centered on the shared strip line. The
+            // scroll view starts after it with the 4pt inter-button spacing the
+            // stack uses, so the bar reads identically to before — only now the
+            // composer can never scroll away.
+            composerButton.leadingAnchor.constraint(equalTo: nub.trailingAnchor, constant: 6),
+            composerButton.centerYAnchor.constraint(equalTo: buttonRow.centerYAnchor),
+
+            scrollView.leadingAnchor.constraint(equalTo: composerButton.trailingAnchor, constant: 4),
             scrollTrailingConstraint,
-            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: buttonRow.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: buttonRow.bottomAnchor),
 
-            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 4),
-            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -4),
+            // No vertical margin inside the scroll view: the stack fills the strip
+            // height so the glass capsules grow to the full section height. The
+            // bar's breathing room lives BELOW the strip (`dockedBottomPadding`),
+            // not as a margin that shrinks the buttons.
+            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
             stack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -8),
-            stack.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor, constant: -8),
+            // Zero trailing content padding so the last button runs to the screen
+            // edge when scrolled to the end (the bar scrolls horizontally).
+            stack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            stack.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
         ])
 
         accessoryBackgroundLeadingConstraint = backgroundLeadingConstraint
@@ -177,6 +303,34 @@ final class TerminalInputTextView: UITextView {
     private weak var accessoryStackView: UIStackView?
     private var isMacRemote = false
 
+    #if DEBUG
+    /// Regression sentinel for the hide→reveal "compose button off-screen left" jank.
+    /// The composer toggle is pinned in the container (not the scrollable stack),
+    /// so its window X (``composeWinX``) must stay on-screen REGARDLESS of how far the
+    /// button row is scrolled (``scrollOffsetX`` can be anything up to
+    /// `scrollContentW - scrollFrameW`). Before the fix the composer rode inside the
+    /// scroll view and a persisted right-scroll carried it to ~-840. Appended to
+    /// ``GhosttySurfaceView.composerDockProbeValue`` so it lands in the XCUITest
+    /// failure message with no log plumbing.
+    var accessoryLayoutDiagnostics: String {
+        let scroll = accessoryStackView?.superview as? UIScrollView
+        let win = window
+        let scrollOffsetX = scroll.map { Int($0.contentOffset.x) } ?? -1
+        let scrollContentW = scroll.map { Int($0.contentSize.width) } ?? -1
+        let scrollFrameW = scroll.map { Int($0.frame.width) } ?? -1
+        let composeWinX: Int = {
+            guard let compose = composerButton, let win else { return -9999 }
+            return Int(compose.convert(compose.bounds, to: win).minX)
+        }()
+        return [
+            "scrollOffsetX=\(scrollOffsetX)",
+            "scrollContentW=\(scrollContentW)",
+            "scrollFrameW=\(scrollFrameW)",
+            "composeWinX=\(composeWinX)",
+        ].joined(separator: ";")
+    }
+    #endif
+
     func updateAccessoryLayoutInsets() {
         let insets = accessoryLayoutInsetsProvider?() ?? .zero
         let leftInset = max(0, insets.left)
@@ -185,7 +339,10 @@ final class TerminalInputTextView: UITextView {
         accessoryBackgroundLeadingConstraint?.constant = leftInset
         accessoryBackgroundTrailingConstraint?.constant = -rightInset
         accessoryDismissLeadingConstraint?.constant = Self.accessoryHorizontalInset + leftInset
-        accessoryScrollTrailingConstraint?.constant = -(Self.accessoryHorizontalInset + rightInset)
+        // Right edge runs flush to the surface edge: only honor the surface's own
+        // right offset from the window (when it does not span full width), not the
+        // bar's leading inset, so the rightmost button hugs the screen edge.
+        accessoryScrollTrailingConstraint?.constant = -rightInset
 
         if accessoryStackView != nil {
             terminalAccessoryToolbar.setNeedsLayout()
@@ -193,11 +350,13 @@ final class TerminalInputTextView: UITextView {
         }
     }
 
-    /// Build (or rebuild) the bar's buttons in the user's configured order
+    /// Build (or rebuild) the SCROLLABLE button row: the user's configured order
     /// (modifiers, zoom, paste, shortcuts, and custom actions all reorderable
-    /// together), followed by the fixed trailing "customize" control. The ⌘ item
-    /// is rendered only when driving a Mac remote. Safe to call repeatedly; it
-    /// clears the stack first.
+    /// together), followed by the fixed trailing HIDE and "customize" controls.
+    /// The composer toggle is NOT here — it is pinned in the container outside
+    /// the scroll view (see ``terminalAccessoryToolbar``). The ⌘ item is rendered
+    /// only when driving a Mac remote. Safe to call repeatedly; it clears the
+    /// stack first.
     private func populateAccessoryActions() {
         guard let stack = accessoryStackView else { return }
         for view in stack.arrangedSubviews {
@@ -205,6 +364,12 @@ final class TerminalInputTextView: UITextView {
             view.removeFromSuperview()
         }
 
+        // The composer toggle is NOT added here: it is pinned directly in the
+        // container (see ``terminalAccessoryToolbar``), OUTSIDE this scrollable
+        // stack, so it can never be carried off-screen by the button row's scroll
+        // position. It is built once at toolbar construction (not config/remote
+        // dependent), so a repopulate must not re-add or rebuild it.
+        //
         // The user-configurable region: built-in shortcuts/modifiers/zoom/paste
         // and custom actions, all in the user's saved order.
         for item in TerminalAccessoryConfiguration.shared.enabledItems {
@@ -219,6 +384,9 @@ final class TerminalInputTextView: UITextView {
                 stack.addArrangedSubview(makeCustomAccessoryButton(for: custom))
             }
         }
+        // The HIDE button, pinned just before "customize": temporarily hides the
+        // whole bottom chrome (toolbar + composer) until the next terminal tap.
+        stack.addArrangedSubview(makeHideChromeButton())
         // The "customize" button pinned at the very end of the bar.
         stack.addArrangedSubview(makeToolbarSettingsButton())
 
@@ -422,9 +590,8 @@ final class TerminalInputTextView: UITextView {
     /// glyphs, cross-dissolved, so it reads as a single keyboard toggle.
     func setKeyboardShown(_ shown: Bool) {
         guard let dismissButton else { return }
-        let config = UIImage.SymbolConfiguration(pointSize: 16, weight: .medium)
         let symbol = shown ? "keyboard.chevron.compact.down" : "keyboard"
-        let image = UIImage(systemName: symbol, withConfiguration: config)
+        let image = UIImage(systemName: symbol, withConfiguration: Self.accessoryButtonSymbolConfig)
         UIView.transition(with: dismissButton, duration: 0.2, options: .transitionCrossDissolve) {
             dismissButton.setImage(image, for: .normal)
         }
@@ -447,6 +614,11 @@ final class TerminalInputTextView: UITextView {
     @objc
     private func handleOpenToolbarSettings() {
         onOpenToolbarSettings?()
+    }
+
+    @objc
+    private func handleHideChrome() {
+        onHideChrome?()
     }
 
     /// Fire a custom action's bytes. Custom actions are macros, so any armed
@@ -508,6 +680,32 @@ final class TerminalInputTextView: UITextView {
         return button
     }
 
+    /// The HIDE button. A plain `UIButton` (not an ``AccessoryActionButton``) so the
+    /// armed-modifier styling/relabel loops skip it. Styled as a de-emphasized control
+    /// like "customize"; tapping it temporarily hides the whole bottom chrome (toolbar
+    /// + composer) until the next terminal tap. Min-width matches the glyph keys so it
+    /// stays uniform.
+    private func makeHideChromeButton() -> UIButton {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(handleHideChrome), for: .touchUpInside)
+        button.accessibilityIdentifier = "terminal.inputAccessory.hideChrome"
+        button.accessibilityLabel = String(
+            localized: "terminal.input_accessory.hideChrome",
+            defaultValue: "Hide Toolbar"
+        )
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "chevron.down.square")
+        config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+        config.baseForegroundColor = UIColor(white: 0.7, alpha: 1)
+        config.contentInsets = Self.accessoryButtonContentInsets
+        button.configuration = config
+        button.tintColor = UIColor(white: 0.7, alpha: 1)
+        button.heightAnchor.constraint(equalToConstant: Self.accessoryButtonHeight).isActive = true
+        button.widthAnchor.constraint(equalToConstant: Self.accessoryButtonMinWidth).isActive = true
+        return button
+    }
+
     /// The trailing button that opens the toolbar shortcuts editor. A plain
     /// `UIButton` (not an ``AccessoryActionButton``) so the armed-modifier
     /// styling/relabel loops skip it, and styled to read as a de-emphasized
@@ -565,7 +763,13 @@ final class TerminalInputTextView: UITextView {
         }
         if let symbolName {
             config.image = UIImage(systemName: symbolName)
-            config.preferredSymbolConfigurationForImage = Self.accessoryButtonSymbolConfig
+            // The composer's `square.and.pencil` glyph reads heavier than the
+            // other icons, so it takes a slightly smaller config to sit in line.
+            let isComposer: Bool
+            if case .builtin(.composer) = item { isComposer = true } else { isComposer = false }
+            config.preferredSymbolConfigurationForImage = isComposer
+                ? Self.composerButtonSymbolConfig
+                : Self.accessoryButtonSymbolConfig
             config.attributedTitle = nil
         } else {
             var attributed = AttributedString(title)
@@ -575,6 +779,20 @@ final class TerminalInputTextView: UITextView {
         }
         config.contentInsets = Self.accessoryButtonContentInsets
         button.configuration = config
+        if let actionButton = button as? AccessoryActionButton {
+            // On iOS 26 the armed and sticky states share the same
+            // prominent-glass blue fill, so the double-tap *lock* is
+            // distinguished by a white capsule border drawn over the glass (see
+            // ``AccessoryActionButton/isStickyLocked``). On earlier OSes the
+            // flat style already renders the locked white stroke through the
+            // background configuration, so the layer border stays off to avoid
+            // a doubled stroke.
+            if #available(iOS 26.0, *) {
+                actionButton.isStickyLocked = sticky
+            } else {
+                actionButton.isStickyLocked = false
+            }
+        }
     }
 
     private static func accessoryButtonConfiguration(armed: Bool, sticky: Bool) -> UIButton.Configuration {
@@ -604,6 +822,17 @@ final class TerminalInputTextView: UITextView {
     }
 
     private func handleAccessoryAction(_ action: TerminalInputAccessoryAction) {
+        if action == .composer {
+            // Opening the composer moves first responder off this proxy, so clear
+            // any armed modifier first (like Paste/Zoom do); otherwise a
+            // Ctrl/Alt/Cmd/Shift armed before opening would linger invisibly and
+            // modify the next key after the composer is dismissed.
+            disarmAllModifiers()
+            refreshAccessoryButtonStyles()
+            onToggleComposer?()
+            return
+        }
+
         if action == .paste {
             // Paste is a clipboard read, not a key sequence: ignore any armed
             // modifier and route clipboard content to the host directly.
@@ -932,6 +1161,33 @@ final class TerminalInputTextView: UITextView {
     private func setShiftAccessoryArmed(_ armed: Bool) {
         if !armed { consumeModifier(.shift) }
     }
+
+    #if DEBUG
+    /// Maps a `UIResponder` to its compact ``InputResponderIdentity`` for the
+    /// composer-dock diagnostics. Used to encode *which* view owns first
+    /// responder into the integer ``DiagnosticEvent`` payload. The `.other` case
+    /// is paired with the responder's class name in the companion `anchormux`
+    /// string log for a human-readable readback.
+    static func responderIdentity(of responder: UIResponder?) -> InputResponderIdentity {
+        switch responder {
+        case nil: return .none
+        case is TerminalInputTextView: return .terminalInputProxy
+        case is GhosttySurfaceView: return .ghosttySurface
+        case is UITextField: return .uiTextField
+        case is UITextView: return .uiTextView
+        default: return .other
+        }
+    }
+
+    /// The responder's concrete class name for the human-readable `anchormux`
+    /// readback (the integer ``InputResponderIdentity`` collapses every
+    /// unexpected class to `.other`; this preserves the exact type for the copied
+    /// debug log).
+    static func responderClassName(_ responder: UIResponder?) -> String {
+        guard let responder else { return "nil" }
+        return String(describing: type(of: responder))
+    }
+    #endif
 }
 
 extension TerminalInputTextView: UITextViewDelegate {

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
@@ -1,0 +1,31 @@
+#if canImport(UIKit)
+import UIKit
+
+extension UIView {
+    /// Returns the first responder within this view's subtree (including `self`), or
+    /// `nil` if no view in the subtree holds first responder.
+    ///
+    /// UIKit exposes no public "which view is first responder" API, but the question
+    /// can be answered locally for a known subtree by a synchronous recursive walk:
+    /// each view reports `isFirstResponder` for itself only, so the subtree must be
+    /// searched to find a nested first responder (e.g. a `UITextField` deep inside a
+    /// hosting controller's view). This drives the composer's open/close-vs-refocus
+    /// decision on the terminal surface, so unlike the DEBUG-only
+    /// ``CurrentResponderProbe`` it must be available in release and must not depend on
+    /// a `sendAction(to: nil)` round-trip.
+    ///
+    /// The walk is depth-first and short-circuits on the first match. It runs on the
+    /// main actor (UIKit), at the instant of a user tap, so it sees the live responder
+    /// state with no SwiftUI-cycle lag.
+    @MainActor
+    func firstResponderInSubtree() -> UIView? {
+        if isFirstResponder { return self }
+        for subview in subviews {
+            if let found = subview.firstResponderInSubtree() {
+                return found
+            }
+        }
+        return nil
+    }
+}
+#endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
@@ -27,5 +27,27 @@ extension UIView {
         }
         return nil
     }
+
+    /// Returns the first focusable text input (`UITextField` / `UITextView`)
+    /// within this view's subtree (including `self`), or `nil` when none exists.
+    ///
+    /// Used as the deterministic UIKit focus path for the composer band: SwiftUI's
+    /// programmatic `@FocusState` set can be dropped for a field hosted inside a
+    /// `UIHostingController`'s view that is frame-mounted into a UIKit container,
+    /// so the surface drives the backing text input to first responder directly
+    /// (which SwiftUI then mirrors back into `@FocusState`). Depth-first,
+    /// short-circuits on the first match, main-actor (UIKit).
+    @MainActor
+    func firstFocusableTextInputInSubtree() -> UIView? {
+        if (self is UITextField || self is UITextView), canBecomeFirstResponder {
+            return self
+        }
+        for subview in subviews {
+            if let found = subview.firstFocusableTextInputInSubtree() {
+                return found
+            }
+        }
+        return nil
+    }
 }
 #endif

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
@@ -11,7 +11,7 @@ extension UIView {
     /// searched to find a nested first responder (e.g. a `UITextField` deep inside a
     /// hosting controller's view). This drives the composer's open/close-vs-refocus
     /// decision on the terminal surface, so unlike the DEBUG-only
-    /// ``CurrentResponderProbe`` it must be available in release and must not depend on
+    /// ``currentFirstResponderForDiagnostics()`` it must be available in release and must not depend on
     /// a `sendAction(to: nil)` round-trip.
     ///
     /// The walk is depth-first and short-circuits on the first match. It runs on the

--- a/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
+++ b/Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
@@ -11,7 +11,7 @@ extension UIView {
     /// searched to find a nested first responder (e.g. a `UITextField` deep inside a
     /// hosting controller's view). This drives the composer's open/close-vs-refocus
     /// decision on the terminal surface, so unlike the DEBUG-only
-    /// ``currentFirstResponderForDiagnostics()`` it must be available in release and must not depend on
+    /// ``CurrentResponderProbe`` it must be available in release and must not depend on
     /// a `sendAction(to: nil)` round-trip.
     ///
     /// The walk is depth-first and short-circuits on the first match. It runs on the

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1289,6 +1289,7 @@ final class MobileHostService {
         case "mobile.terminal.create", "terminal.create":
             return nil
         case "mobile.terminal.input", "terminal.input",
+             "mobile.terminal.paste", "terminal.paste",
              "mobile.terminal.paste_image", "terminal.paste_image",
              "mobile.terminal.replay", "terminal.replay",
              "mobile.terminal.viewport", "terminal.viewport",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -22312,8 +22312,11 @@ class TerminalController {
 
         applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
 
-        let surface = terminalPanel.surface
-        guard surface.sendText(text) else {
+        // Send through the TerminalPanel explicit-input wrappers (not the raw
+        // surface): they run `resumeForExplicitInputIfNeeded()` first, waking a
+        // hibernated agent terminal the same way local typing does, so a mobile
+        // composer submit cannot write into a cold surface.
+        guard terminalPanel.sendText(text) else {
             return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
         }
 
@@ -22327,7 +22330,7 @@ class TerminalController {
         var submitted = false
         var submitError: String?
         if let submitKeyName {
-            let keyResult = surface.sendNamedKey(submitKeyName)
+            let keyResult = terminalPanel.sendNamedKeyResult(submitKeyName)
             if keyResult.accepted {
                 submitted = true
             } else {
@@ -22344,7 +22347,7 @@ class TerminalController {
             }
         }
 
-        surface.forceRefresh(reason: "mobileHost.terminalPaste")
+        terminalPanel.surface.forceRefresh(reason: "mobileHost.terminalPaste")
 
         #if DEBUG
         cmuxDebugLog(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -22342,6 +22342,8 @@ class TerminalController {
                 case .processExited:
                     submitError = "process_exited"
                 case .unknownKey, .sent, .queued:
+                    // .sent / .queued are accepted results and unreachable in this
+                    // else-branch; grouped here only to keep the switch exhaustive.
                     submitError = "unknown_key"
                 }
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -22317,22 +22317,31 @@ class TerminalController {
             return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
         }
 
+        // The paste text is already accepted by the surface above. From here on a
+        // submit-key failure must NOT surface as an RPC error: the client treats
+        // any error as "nothing was sent" and keeps the composer draft, so a
+        // retry would paste the whole block a second time. Report partial
+        // success instead — `submitted: false` plus `submit_error` — so the
+        // client clears the draft (the text is sitting at the prompt) and can
+        // tell the user the submit keypress is still needed.
         var submitted = false
+        var submitError: String?
         if let submitKeyName {
             let keyResult = surface.sendNamedKey(submitKeyName)
-            guard keyResult.accepted else {
+            if keyResult.accepted {
+                submitted = true
+            } else {
                 switch keyResult {
                 case .inputQueueFull:
-                    return .err(code: "input_queue_full", message: Self.terminalInputQueueFullMessage, data: ["surface_id": surfaceId.uuidString])
+                    submitError = "input_queue_full"
                 case .surfaceUnavailable:
-                    return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+                    submitError = "surface_unavailable"
                 case .processExited:
-                    return .err(code: "process_exited", message: Self.terminalProcessExitedMessage, data: ["surface_id": surfaceId.uuidString])
+                    submitError = "process_exited"
                 case .unknownKey, .sent, .queued:
-                    return .err(code: "invalid_params", message: "Unsupported submit_key", data: ["submit_key": submitKeyRaw])
+                    submitError = "unknown_key"
                 }
             }
-            submitted = true
         }
 
         surface.forceRefresh(reason: "mobileHost.terminalPaste")
@@ -22348,6 +22357,9 @@ class TerminalController {
             "surface_id": terminalPanel.id.uuidString,
             "submitted": submitted,
         ]
+        if let submitError {
+            payload["submit_error"] = submitError
+        }
         if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
             payload["terminal_seq"] = seq
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1899,6 +1899,8 @@ class TerminalController {
             return v2Result(id: id, self.v2MobileTerminalCreate(params: params))
         case "mobile.terminal.input", "terminal.input":
             return v2Result(id: id, self.v2MobileTerminalInput(params: params))
+        case "mobile.terminal.paste", "terminal.paste":
+            return v2Result(id: id, self.v2MobileTerminalPaste(params: params))
         case "mobile.terminal.replay", "terminal.replay":
             return v2Result(id: id, self.v2MobileTerminalReplay(params: params))
         case "mobile.terminal.viewport", "terminal.viewport":
@@ -2454,10 +2456,12 @@ class TerminalController {
             "mobile.workspace.list",
             "mobile.terminal.create",
             "mobile.terminal.input",
+            "mobile.terminal.paste",
             "mobile.terminal.replay",
             "mobile.terminal.viewport",
             "terminal.create",
             "terminal.input",
+            "terminal.paste",
             "terminal.replay",
             "terminal.viewport",
             "auth.login",
@@ -21245,6 +21249,8 @@ class TerminalController {
             result = v2MobileTerminalCreate(params: request.params)
         case "mobile.terminal.input", "terminal.input":
             result = v2MobileTerminalInput(params: request.params)
+        case "mobile.terminal.paste", "terminal.paste":
+            result = v2MobileTerminalPaste(params: request.params)
         case "mobile.terminal.paste_image", "terminal.paste_image":
             result = v2MobileTerminalPasteImage(params: request.params)
         case "mobile.terminal.replay", "terminal.replay":
@@ -22237,6 +22243,115 @@ class TerminalController {
             "surface_id": terminalPanel.id.uuidString,
             "queued": sendResult == .queued,
         ])
+    }
+
+    /// Deliver a composed block from the mobile composer as a bracketed paste
+    /// followed by an optional single submit key.
+    ///
+    /// This mirrors the macOS TextBox composer dispatch
+    /// (`[.pasteText(payload), .namedKey(submitKey)]`): the text goes through
+    /// `sendText` (libghostty `ghostty_surface_text`), which bracketed-pastes it
+    /// (`ESC[200~ … ESC[201~` when DECSET 2004 is active) so the agent's line
+    /// editor inserts the whole, possibly multi-line, block as literal text
+    /// instead of treating every interior newline as a submit. A single named
+    /// submit key then commits it once. The `terminal.input` path is wrong for a
+    /// composed block: `parsedSocketInputEvents` rewrites every `\n`/`\r` to a
+    /// raw CR, so an N-line message fragments into N submissions.
+    ///
+    /// `submit_key` is optional: `return`/`enter` (default) or `ctrl+enter`
+    /// submit; `none` pastes without submitting so the composer can keep editing.
+    private func v2MobileTerminalPaste(params: [String: Any]) -> V2CallResult {
+        guard let text = v2RawString(params, "text"), !text.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing text", data: nil)
+        }
+        // Resolve the optional submit key up front so an unsupported value fails
+        // before any text is pasted (no partial application). The phone sends
+        // `return` as the default submit *intent*; the agent-aware upgrade to
+        // `ctrl+enter` happens below once the surface (and its agent context) is
+        // resolved, because only the Mac knows which agent is running.
+        let submitKeyRaw = (v2String(params, "submit_key") ?? "return").lowercased()
+        var submitKeyName: String?
+        var submitKeyWasReturnIntent = false
+        switch submitKeyRaw {
+        case "", "return", "enter":
+            submitKeyName = "return"
+            submitKeyWasReturnIntent = true
+        case "ctrl+enter":
+            submitKeyName = "ctrl+enter"
+        case "none":
+            submitKeyName = nil
+        default:
+            return .err(code: "invalid_params", message: "Unsupported submit_key", data: ["submit_key": submitKeyRaw])
+        }
+        if let error = mobileWorkspaceIDValidationError(params: params) {
+            return error
+        }
+        if let error = mobileTerminalAliasValidationError(params: params) {
+            return error
+        }
+        guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
+              let surfaceId = resolved.surfaceId,
+              let terminalPanel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return .err(code: "not_found", message: "Terminal surface not found", data: nil)
+        }
+
+        // Mirror the macOS TextBox composer's submit-key selection
+        // (`TextBoxInput.dispatchEvents`): Claude Code needs `ctrl+enter` to
+        // submit a multi-line block, while plain `return` submits a newline mid
+        // prompt. The phone cannot know the running agent, so it always asks for
+        // `return`; upgrade that intent here when the surface is Claude and the
+        // composed text spans multiple lines. Explicit `ctrl+enter`/`none` from
+        // the client are honored as-is.
+        if submitKeyWasReturnIntent,
+           text.contains("\n") || text.contains("\r"),
+           TextBoxAgentDetection.isClaudeCode(
+               context: WorkspaceContentView.terminalAgentContext(panel: terminalPanel, workspace: resolved.workspace)
+           ) {
+            submitKeyName = "ctrl+enter"
+        }
+
+        applyMobileViewportReport(params: params, terminalPanel: terminalPanel)
+
+        let surface = terminalPanel.surface
+        guard surface.sendText(text) else {
+            return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+        }
+
+        var submitted = false
+        if let submitKeyName {
+            let keyResult = surface.sendNamedKey(submitKeyName)
+            guard keyResult.accepted else {
+                switch keyResult {
+                case .inputQueueFull:
+                    return .err(code: "input_queue_full", message: Self.terminalInputQueueFullMessage, data: ["surface_id": surfaceId.uuidString])
+                case .surfaceUnavailable:
+                    return .err(code: "surface_unavailable", message: Self.terminalSurfaceUnavailableMessage, data: ["surface_id": surfaceId.uuidString])
+                case .processExited:
+                    return .err(code: "process_exited", message: Self.terminalProcessExitedMessage, data: ["surface_id": surfaceId.uuidString])
+                case .unknownKey, .sent, .queued:
+                    return .err(code: "invalid_params", message: "Unsupported submit_key", data: ["submit_key": submitKeyRaw])
+                }
+            }
+            submitted = true
+        }
+
+        surface.forceRefresh(reason: "mobileHost.terminalPaste")
+
+        #if DEBUG
+        cmuxDebugLog(
+            "mobile.terminal.paste workspace=\(resolved.workspace.id.uuidString.prefix(8)) surface=\(surfaceId.uuidString.prefix(8)) chars=\(text.count) submitted=\(submitted ? 1 : 0)"
+        )
+        #endif
+
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspace.id.uuidString,
+            "surface_id": terminalPanel.id.uuidString,
+            "submitted": submitted,
+        ]
+        if let seq = MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) {
+            payload["terminal_seq"] = seq
+        }
+        return .ok(payload)
     }
 
     private func applyMobileViewportReport(

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1259,7 +1259,7 @@ func textBoxCommandShortcutKey(
     return normalizedCharacters(event).lowercased()
 }
 
-private enum TextBoxAgentDetection: CaseIterable {
+enum TextBoxAgentDetection: CaseIterable {
     case claudeCode
     case codex
     case opencode

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -715,6 +715,57 @@
         }
       }
     },
+    "mobile.composer.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Composer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ作成を閉じる"
+          }
+        }
+      }
+    },
+    "mobile.composer.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ"
+          }
+        }
+      }
+    },
+    "mobile.composer.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信"
+          }
+        }
+      }
+    },
     "mobile.connection.connected": {
       "extractionState": "manual",
       "localizations": {
@@ -3605,6 +3656,23 @@
         }
       }
     },
+    "terminal.input_accessory.composer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Composer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ作成"
+          }
+        }
+      }
+    },
     "terminal.input_accessory.customize": {
       "extractionState": "manual",
       "localizations": {
@@ -3618,6 +3686,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "ツールバーをカスタマイズ"
+          }
+        }
+      }
+    },
+    "terminal.input_accessory.hideChrome": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Toolbar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ツールバーを隠す"
           }
         }
       }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -46,6 +46,12 @@ public struct CMUXMobileRootScene: View {
     /// non-iOS roots, which simply shows no Tailscale guidance.
     private let tailscaleStatusMonitor: (any TailscaleStatusObserving)?
     private let pairedMacStore: (any MobilePairedMacStoring)?
+    /// Per-terminal composer drafts for the app session, so an unsent message
+    /// survives keyboard dismiss and terminal switches. In-memory only for now;
+    /// a disk-backed ``TerminalDraftStoring`` (drafts surviving relaunch) lands
+    /// separately and replaces this at the composition root without touching the
+    /// shell.
+    private let draftStore: any TerminalDraftStoring
     #if DEBUG
     /// The structured diagnostic log injected into the shell store so the DEV
     /// dogfood feedback round-trip can export it. DEBUG-only; `nil` when the app
@@ -91,6 +97,7 @@ public struct CMUXMobileRootScene: View {
         self.onboardingStore = onboardingStore
         self.tailscaleStatusMonitor = tailscaleStatusMonitor
         self.pairedMacStore = Self.openPairedMacStore()
+        self.draftStore = InMemoryTerminalDraftStore()
         #if DEBUG
         self.diagnosticLog = diagnosticLog
         #endif
@@ -109,6 +116,7 @@ public struct CMUXMobileRootScene: View {
         self.analytics = analytics
         self.tailscaleStatusMonitor = nil
         self.pairedMacStore = Self.openPairedMacStore()
+        self.draftStore = InMemoryTerminalDraftStore()
         #if DEBUG
         self.diagnosticLog = nil
         #endif
@@ -194,7 +202,8 @@ public struct CMUXMobileRootScene: View {
             analytics: analytics,
             diagnosticLog: diagnosticLog,
             feedbackEmailSubmitter: feedbackEmailSubmitter,
-            feedbackStampProvider: feedbackStampProvider
+            feedbackStampProvider: feedbackStampProvider,
+            draftStore: draftStore
         )
         #else
         return CMUXMobileShellStore(
@@ -205,7 +214,8 @@ public struct CMUXMobileRootScene: View {
             reachability: reachability,
             analytics: analytics,
             feedbackEmailSubmitter: feedbackEmailSubmitter,
-            feedbackStampProvider: feedbackStampProvider
+            feedbackStampProvider: feedbackStampProvider,
+            draftStore: draftStore
         )
         #endif
     }

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1135,9 +1135,20 @@ final class cmuxUITests: XCTestCase {
         let app = try launchConnectedApp(port: port)
         XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
 
-        // Baseline: nothing presented, toolbar visible.
-        let baseline = surfaceDock(in: app)
-        XCTAssertEqual(baseline["composerActive"], "0", "should start with no composer. \(baseline)")
+        // Baseline: the composer is OPEN BY DEFAULT for the selected terminal
+        // (iMessage-style input bar), but UNFOCUSED — the keyboard stays down.
+        let baseline = waitForDock(in: app, describe: "baseline: default-open composer band") {
+            $0["composerActive"] == "1" && $0["bandMounted"] == "1"
+        }
+        XCTAssertEqual(baseline["fieldFocused"], "0", "default-open must not focus the field. \(baseline)")
+        assertDockCoherent(in: app, cycle: 0)
+
+        // Dismiss the default-open composer via the band's chevron so the loop
+        // below exercises the explicit open→close cycle from a closed dock.
+        app.buttons[Composer.bandClose].tap()
+        waitForDock(in: app, describe: "baseline: chevron dismissed the default-open composer") {
+            $0["composerActive"] == "0"
+        }
         assertDockCoherent(in: app, cycle: 0)
 
         let composeButton = app.buttons[Composer.composeButton]

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -293,9 +293,14 @@ final class cmuxUITests: XCTestCase {
             // AND either several distinct bands (lower zoom) or one band that
             // solidly fills the keyboard-clear strip (higher zoom, where a
             // single thick band can span the whole window). Blank => no strong
-            // pixels; garbled => not uniform.
+            // pixels; garbled => not uniform. The single-band threshold leaves
+            // room for the always-visible bottom dock (toolbar + default-open
+            // composer band) that shortens the terminal grid: on the iPhone
+            // height a clean max-zoom band fills ~14 of the 24 strip samples
+            // with row gaps in between, which is a clean render, not a blank
+            // or torn one.
             let enoughBands = (distinct >= 2 && strong.count >= 6)
-                || (distinct == 1 && strong.count >= 16)
+                || (distinct == 1 && strong.count >= 12)
             if uniform, enoughBands {
                 return
             }
@@ -604,9 +609,14 @@ final class cmuxUITests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
+        // 20s: a saturated CI runner can take well past the old 8s default for
+        // the create round-trip + the new surface (and its composer band) to
+        // mount and report the selection. This is a wait-until, so a fast run
+        // still returns immediately.
         let didSelect = await server.waitForSelection(
             workspaceID: workspaceID,
-            terminalID: terminalID
+            terminalID: terminalID,
+            timeout: 20
         )
         if !didSelect {
             let selection = await server.selectionDescription()

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -966,6 +966,357 @@ final class cmuxUITests: XCTestCase {
         }
     }
 
+    // MARK: - Composer open/close repro
+
+    /// Identifiers for the composer dock controls and the DEBUG state probes.
+    private enum Composer {
+        /// Toolbar compose button (`square.and.pencil`) — opens / closes / reveals.
+        static let composeButton = "terminal.inputAccessory.composer"
+        /// Toolbar HIDE button (`chevron.down.square`) — suppresses all bottom chrome.
+        static let hideButton = "terminal.inputAccessory.hideChrome"
+        /// The growing message field inside the composer band.
+        static let field = "MobileComposerField"
+        /// The chevron-down inside the composer band that dismisses the composer.
+        static let bandClose = "MobileComposerClose"
+        /// Surface-side live dock-state probe (`key=value;…`).
+        static let surfaceProbe = "MobileComposerDockProbe"
+        /// Store-side source-of-truth probe (`key=value;…`).
+        static let storeProbe = "MobileComposerStoreProbe"
+    }
+
+    /// Parse a `key=value;key=value;…` probe value into a dictionary.
+    private func parseProbe(_ value: String) -> [String: String] {
+        var out: [String: String] = [:]
+        for pair in value.split(separator: ";") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            guard kv.count == 2 else { continue }
+            out[String(kv[0])] = String(kv[1])
+        }
+        return out
+    }
+
+    /// Read the surface-side dock probe (live on every query) as a parsed dictionary.
+    @MainActor
+    private func surfaceDock(in app: XCUIApplication) -> [String: String] {
+        let probe = app.descendants(matching: .any)[Composer.surfaceProbe]
+        guard probe.waitForExistence(timeout: 4) else { return [:] }
+        return parseProbe(probe.value as? String ?? "")
+    }
+
+    /// Read the store-side composer probe as a parsed dictionary.
+    @MainActor
+    private func storeComposer(in app: XCUIApplication) -> [String: String] {
+        let probe = app.descendants(matching: .any)[Composer.storeProbe]
+        guard probe.waitForExistence(timeout: 4) else { return [:] }
+        return parseProbe(probe.value as? String ?? "")
+    }
+
+    /// Wait until the surface dock probe satisfies `predicate`, then return the parsed
+    /// dock. The probe is computed live on every accessibility read, so this converges
+    /// on the SETTLED post-transition state even though field focus flips a runloop
+    /// after the synchronous toggle.
+    @MainActor
+    @discardableResult
+    private func waitForDock(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 5,
+        describe: String,
+        _ predicate: @escaping ([String: String]) -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> [String: String] {
+        let probe = app.descendants(matching: .any)[Composer.surfaceProbe]
+        XCTAssertTrue(probe.waitForExistence(timeout: timeout), "dock probe missing", file: file, line: line)
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { [weak self] object, _ in
+                guard let self, let element = object as? XCUIElement else { return false }
+                return predicate(self.parseProbe(element.value as? String ?? ""))
+            },
+            object: probe
+        )
+        let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        let dock = parseProbe(probe.value as? String ?? "")
+        XCTAssertEqual(
+            result,
+            .completed,
+            "Timed out waiting for dock: \(describe). Last surface=\(dock) store=\(storeComposer(in: app))",
+            file: file,
+            line: line
+        )
+        return dock
+    }
+
+    /// Assert the structural invariants that hold on the SIMULATOR (which has no
+    /// software keyboard, so `keyboardUp`/`proxyFirstResponder` are not reliable
+    /// pass/fail signals — see the keyboard-state segregation note). These are the
+    /// sim-faithful "is the dock coherent?" checks:
+    ///   1. surface `composerActive` mirrors store `isComposerPresented`,
+    ///   2. the always-visible toolbar is visible (never stuck hidden), and
+    ///   3. there is never a "band/composer up while the whole chrome is hidden" state.
+    @MainActor
+    private func assertDockCoherent(
+        in app: XCUIApplication,
+        cycle: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let surface = surfaceDock(in: app)
+        let store = storeComposer(in: app)
+        let composerActive = surface["composerActive"] == "1"
+        let presented = store["isComposerPresented"] == "1"
+        XCTAssertEqual(
+            composerActive, presented,
+            "cycle \(cycle): surface composerActive(\(composerActive)) must mirror store isComposerPresented(\(presented)). surface=\(surface) store=\(store)",
+            file: file, line: line
+        )
+        XCTAssertEqual(
+            surface["toolbarVisible"], "1",
+            "cycle \(cycle): the always-visible toolbar must stay visible. surface=\(surface)",
+            file: file, line: line
+        )
+        // Capture the geometry that decides hittability BEFORE asserting it (the assert
+        // aborts the test under `continueAfterFailure=false`). This disambiguates the
+        // two failure modes the advisor flagged:
+        //   - compose-button hit-point UNDER the software keyboard frame → a SIM
+        //     ARTIFACT: the surface positions the toolbar at keyboardHeight=0 (it never
+        //     sees the keyboard height on the sim) while a real keyboard is drawn over
+        //     it. On device the toolbar rides above the keyboard and is hittable.
+        //   - compose-button clear of the keyboard but under the composer field/band →
+        //     a REAL reveal-path z-order/geometry bug.
+        let composeFrame = app.buttons[Composer.composeButton].frame
+        let kb = app.keyboards.firstMatch
+        let kbInfo = kb.exists ? "\(kb.frame)" : "absent"
+        let fieldEl = app.descendants(matching: .any)[Composer.field]
+        let fieldInfo = fieldEl.exists ? "\(fieldEl.frame)" : "absent"
+        let windowFrame = app.windows.firstMatch.frame
+        // ROOT-CAUSE ASSERTION: the compose button must be horizontally ON-SCREEN.
+        // The hide→reveal reflow corrupts the accessory toolbar's leading inset
+        // (`accessoryLayoutInsetsProvider` reads the surface's window-relative `minX`
+        // at a moment it is wrong), shifting the whole button row ~840pt OFF-SCREEN
+        // LEFT (observed composeFrame.minX ≈ -840) even though the surface still reports
+        // `chromeHidden=0`/`toolbarVisible=1`. This is the real jank — NOT the keyboard
+        // covering the bar (compose y is well above the keyboard) and NOT the reducer.
+        XCTAssertGreaterThanOrEqual(
+            composeFrame.minX, windowFrame.minX - 1,
+            "cycle \(cycle): compose button shifted OFF-SCREEN LEFT (reveal-path toolbar inset corruption). composeFrame=\(composeFrame) window=\(windowFrame) keyboard=\(kbInfo) field=\(fieldInfo) surface=\(surface)",
+            file: file, line: line
+        )
+        XCTAssertLessThanOrEqual(
+            composeFrame.maxX, windowFrame.maxX + 1,
+            "cycle \(cycle): compose button shifted OFF-SCREEN RIGHT. composeFrame=\(composeFrame) window=\(windowFrame) surface=\(surface)",
+            file: file, line: line
+        )
+        XCTAssertTrue(
+            app.buttons[Composer.composeButton].isHittable,
+            "cycle \(cycle): compose button must stay tappable. composeFrame=\(composeFrame) keyboard=\(kbInfo) field=\(fieldInfo) surface=\(surface)",
+            file: file, line: line
+        )
+        // Item-4 edge case: a presented composer must not be left with the chrome
+        // suppressed (band up but textbox hidden), which strands the draft visually.
+        XCTAssertFalse(
+            composerActive && surface["chromeHidden"] == "1" && surface["toolbarVisible"] == "0",
+            "cycle \(cycle): composer presented while ALL chrome is hidden (band-up/textbox-hidden stuck state). surface=\(surface)",
+            file: file, line: line
+        )
+    }
+
+    /// Repeatedly open and close the composer via the toolbar compose button and assert
+    /// the dock stays coherent each cycle. This is the primary "composer jank" repro:
+    /// the round-9 reducer reads `fieldFocused` synchronously, but the field's focus is
+    /// set a runloop later (deferred `@FocusState`), so a fast re-tap can resolve
+    /// `revealAndFocus` instead of `close` and the composer fails to close — a stuck
+    /// state this asserts against.
+    @MainActor
+    func testComposerSurvivesRepeatedOpenCloseCycles() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
+
+        // Baseline: nothing presented, toolbar visible.
+        let baseline = surfaceDock(in: app)
+        XCTAssertEqual(baseline["composerActive"], "0", "should start with no composer. \(baseline)")
+        assertDockCoherent(in: app, cycle: 0)
+
+        let composeButton = app.buttons[Composer.composeButton]
+        XCTAssertTrue(composeButton.waitForExistence(timeout: 6))
+
+        for cycle in 1...10 {
+            // OPEN: tap compose → reducer should resolve `open`, store presents,
+            // surface mirrors, band mounts, and the field SETTLES to first responder.
+            // Waiting for `fieldFocused=1` here isolates the steady-state close path
+            // from the deferred-focus race (which the rapid-double-toggle test probes):
+            // once the field is genuinely focused, a close tap MUST resolve `close`.
+            //
+            // NOTE: use the RAW `.tap()`, not the `tap(_:in:)` helper — that helper
+            // force-dismisses the keyboard via the keyboard 'Return' key, which the
+            // multi-line composer field treats as a newline (and the AX scroll-to
+            // -visible on 'Return' fails fatally with `continueAfterFailure=false`).
+            composeButton.tap()
+            waitForDock(in: app, describe: "cycle \(cycle) OPEN: composerActive=1 && bandMounted=1 && fieldFocused=1") {
+                $0["composerActive"] == "1" && $0["bandMounted"] == "1" && $0["fieldFocused"] == "1"
+            }
+            assertDockCoherent(in: app, cycle: cycle)
+            XCTAssertTrue(
+                app.descendants(matching: .any)[Composer.field].waitForExistence(timeout: 4),
+                "cycle \(cycle): composer field must be present after open"
+            )
+
+            // CLOSE: tap compose again. On a genuinely visible+focused composer the
+            // reducer must resolve `close` and the composer must dismiss. If the field
+            // has not yet taken first responder (deferred focus), the reducer reads
+            // `fieldFocused=0` and resolves `reveal` instead, leaving it stuck open —
+            // that is the jank this assertion pins.
+            composeButton.tap()
+            let closed = waitForDock(in: app, describe: "cycle \(cycle) CLOSE: composerActive=0") {
+                $0["composerActive"] == "0"
+            }
+            XCTAssertEqual(
+                closed["lastIntent"], "close",
+                "cycle \(cycle): a second compose tap on a visible composer must resolve `close`, not `\(closed["lastIntent"] ?? "?")` (deferred-focus jank). surface=\(closed) store=\(storeComposer(in: app))"
+            )
+            assertDockCoherent(in: app, cycle: cycle)
+        }
+    }
+
+    /// The specific bug Lawrence reported: compose → hide → tap terminal (reveal) →
+    /// compose must NOT lose the draft. Asserts the draft text survives the full cycle
+    /// and the composer stays presented (never toggled off). Draft survival is the
+    /// sim-faithful signal here (the text lives in `store.terminalInputText`).
+    @MainActor
+    func testComposerDraftSurvivesHideRevealCompose() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        let surface = app.otherElements["MobileTerminalSurface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 8))
+
+        // OPEN + type a draft. Use the RAW `.tap()` (the `tap(_:in:)` helper would
+        // force-dismiss the keyboard via 'Return', which a multi-line composer field
+        // treats as a newline and which fails fatally under `continueAfterFailure`).
+        let composeButton = app.buttons[Composer.composeButton]
+        composeButton.tap()
+        let field = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(field.waitForExistence(timeout: 4))
+        // The field auto-focuses on appear (deferred a runloop); wait for the dock to
+        // report it as first responder before typing so the keystrokes land in it.
+        waitForDock(in: app, describe: "OPEN: fieldFocused=1 before typing") {
+            $0["composerActive"] == "1" && $0["fieldFocused"] == "1"
+        }
+        let draft = "hello agent draft"
+        field.typeText(draft)
+        let typed = waitForDock(in: app, describe: "draft typed: store draftLength>0") { _ in
+            (self.storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? 0) >= draft.count
+        }
+        XCTAssertEqual(typed["composerActive"], "1")
+
+        // HIDE: suppress the chrome via the HIDE button (raw tap). The composer stays
+        // presented; only the chrome is suppressed; the draft must be untouched.
+        app.buttons[Composer.hideButton].tap()
+        let hidden = waitForDock(in: app, describe: "HIDE: chromeHidden=1, still presented") {
+            $0["chromeHidden"] == "1" && $0["composerActive"] == "1"
+        }
+        XCTAssertEqual(hidden["composerActive"], "1", "HIDE must not dismiss the composer: \(hidden)")
+        let draftAfterHide = storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? -1
+        XCTAssertGreaterThanOrEqual(draftAfterHide, draft.count, "draft must survive HIDE. store=\(storeComposer(in: app))")
+
+        // REVEAL: tap the terminal surface. handleTap should reveal the chrome and
+        // re-focus the composer field (presented stays true).
+        surface.tap()
+        waitForDock(in: app, describe: "REVEAL: chromeHidden=0, still presented") {
+            $0["chromeHidden"] == "0" && $0["composerActive"] == "1"
+        }
+        // Assert draft survival FIRST (the survival data must be captured even if the
+        // dock-coherence hittability check below aborts the test).
+        XCTAssertGreaterThanOrEqual(
+            storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? -1, draft.count,
+            "draft must survive REVEAL. store=\(storeComposer(in: app))"
+        )
+        assertDockCoherent(in: app, cycle: 99)
+
+        // COMPOSE again: the historically-destructive tap. With round-9 it must resolve
+        // `reveal` (presented+visible-but-unfocused) or `close`, NEVER silently dropping
+        // the draft. Assert the draft text still exists no matter the intent.
+        composeButton.tap()
+        let afterRecompose = waitForDock(in: app, describe: "RECOMPOSE settled") { _ in true }
+        let finalDraft = storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? -1
+        XCTAssertGreaterThanOrEqual(
+            finalDraft, draft.count,
+            "DRAFT LOST after compose→hide→reveal→compose. surface=\(afterRecompose) store=\(storeComposer(in: app))"
+        )
+    }
+
+    /// CONTROL test for the draft test's hittability failure: open the composer, type
+    /// (which draws a real software keyboard on the sim), but do NOT hide/reveal. Then
+    /// assert the compose button is still hittable.
+    ///
+    /// This isolates the variable. If the compose button is NOT hittable here either,
+    /// the cause is the drawn software keyboard covering the toolbar (the surface
+    /// positions it at keyboardHeight=0 because it never sees the keyboard height on the
+    /// sim) — a SIM ARTIFACT, not the reveal path. If it IS hittable here but not after
+    /// hide→reveal, the reveal path is the real culprit.
+    @MainActor
+    func testComposerButtonHittabilityAfterTypingNoHideReveal() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
+
+        let composeButton = app.buttons[Composer.composeButton]
+        composeButton.tap()
+        let field = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(field.waitForExistence(timeout: 4))
+        waitForDock(in: app, describe: "OPEN: fieldFocused=1 before typing") {
+            $0["composerActive"] == "1" && $0["fieldFocused"] == "1"
+        }
+        field.typeText("control")
+        _ = waitForDock(in: app, describe: "typed, settled") { _ in true }
+
+        // Same coherence check as the draft test, but with NO hide/reveal in between.
+        // A failure here means the keyboard/typing — not the reveal path — drives the
+        // hittability loss (sim artifact). A pass here while the draft test fails means
+        // the reveal path is the real bug.
+        assertDockCoherent(in: app, cycle: 1)
+    }
+
+    /// Rapid double-toggle: two compose taps with no settle in between. This is the
+    /// most direct provocation of the deferred-focus race — the second tap can land
+    /// before the field has taken first responder, so the reducer mis-resolves and the
+    /// composer ends in an inconsistent state. Asserts surface and store agree once it
+    /// settles (the dock must not be left desynced).
+    @MainActor
+    func testComposerRapidDoubleToggleSettlesConsistently() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
+        let composeButton = app.buttons[Composer.composeButton]
+        XCTAssertTrue(composeButton.waitForExistence(timeout: 6))
+
+        for cycle in 1...5 {
+            // Two taps back-to-back with no wait between them.
+            composeButton.tap()
+            composeButton.tap()
+            // Let everything settle, then surface and store MUST agree.
+            _ = waitForDock(in: app, describe: "cycle \(cycle): dock settled") { _ in true }
+            let surface = surfaceDock(in: app)
+            let store = storeComposer(in: app)
+            XCTAssertEqual(
+                surface["composerActive"], store["isComposerPresented"],
+                "cycle \(cycle): rapid double-toggle left surface(\(surface["composerActive"] ?? "?")) and store(\(store["isComposerPresented"] ?? "?")) desynced. surface=\(surface) store=\(store)"
+            )
+            assertDockCoherent(in: app, cycle: cycle)
+        }
+    }
+
     @MainActor
     private func waitForKeyboardDismissal(in app: XCUIApplication) -> Bool {
         let expectation = XCTNSPredicateExpectation(


### PR DESCRIPTION
Lands the iMessage-style terminal composer for iOS. Supersedes https://github.com/manaflow-ai/cmux/pull/5511.

## What ships

- **Composer open by default per terminal.** The composer band presents by default for every terminal, like iMessage shows its input bar in every conversation. `isComposerPresented` is derived per-terminal state over a session-only dismissed set: the chevron hides it (remembered per terminal), and dismissing one terminal leaves every other terminal open. Presented does not imply focused; the band appears with the keyboard down, and focus is a one-shot store handshake (`composerFocusRequest` + a pending flag) armed only by an explicit open, the reveal-and-focus path, or a mid-compose terminal switch.
- **Inline send button.** The send button sits inside the textbox container (iMessage's circular up-arrow riding the last line), replacing a detached accessory-bar send.
- **One-surface bottom dock.** Terminal grid, composer band, always-visible toolbar, and keyboard live in one surface-owned coordinate system; a field grow pushes only the terminal up.
- **Per-terminal drafts with a FIFO pipeline.** Draft saves, loads, swaps, and wipes apply in exactly the order they were issued, so a stale keystroke save can never overwrite a newer save and nothing written before the sign-out wipe survives it. Keystroke saves coalesce to one latest-value flush per terminal, so a typing burst behind a slow store stays bounded in memory.
- **Field-ownership marker.** Fixes the draft-erasure bug class on fast terminal switches (A→B→C): the field is persisted on switch only when it actually represents the outgoing terminal's draft, so a transient cleared placeholder can never erase a real stored draft. Red/green pair: failing tests in https://github.com/manaflow-ai/cmux/commit/6c5e5c13d94cf3e0500c5dfc3803ccba482aaa73, fix in https://github.com/manaflow-ai/cmux/commit/8a9ebb32ac56119b496a420824dcf375ab5fc104.
- **Post-send hardening.** The draft clears on send ack with a re-entrancy-guarded submit (a double tap cannot paste twice), and the deferred-close unmount path cannot unmount a freshly reopened field.
- **Mac host: `terminal.paste` RPC.** Multi-line composer text lands as one bracketed paste plus a single submit keypress (upgraded to ctrl+enter for Claude Code multi-line), instead of `terminal.input` CR-fragmenting each line into separate commands.

## Review hardening (autoreview loop, 8 rounds to clean)

- `terminal.paste` reports partial success (`submitted: false` + `submit_error`) when the submit key fails after the text was already delivered, so the client clears the draft and a retry cannot paste a duplicate block.
- `terminal.paste` routes through the `TerminalPanel` explicit-input wrappers, waking a hibernated agent terminal the way local typing does.
- Keyboard toggle and HIDE resign whichever responder actually owns the keyboard; with the composer open by default the terminal input proxy can hold first responder while the band is presented, and `endEditing` on the composer container alone resigned nothing.
- The focus handshake is keyed to its target terminal so the outgoing composer (still mounted during a switch) cannot consume the request meant for the incoming one.
- Hidden chrome (HIDE) reclaims the full grid height including the home-indicator strip, matching the dock frame math.

## Tests

- `swift test`: CmuxMobileShell 79 / CMUXMobileCore 74 / CmuxMobileRPC 23, all green, including suites for the dock reducer, default-open, submit/draft reconcile, FIFO ordering + coalescing, draft-swap field ownership, and focus-request keying.
- XCUITests added for dock coherence (open/close cycles, draft survival across terminal switches).
- Compile-verified: iOS arm64 simulator (`cmux-ios`) and macOS app, tagged derivedDataPaths.

## Localization

Composer strings (`mobile.composer.placeholder`, `mobile.composer.send`, `mobile.composer.close`, `terminal.input_accessory.composer`) are localized in en + ja in `ios/cmux/Resources/Localizable.xcstrings`; the branch diff was audited for bare English UI strings (none found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783760887&installation_id=133855650&pr_number=5876&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5876&signature=96bf43615e27d15d43aaee01971febb96b6ce098e7f7aa888eca811f20599f07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large mobile UI/state-machine change across shell, surface layout, and remote terminal input (`terminal.paste`); mitigated by extensive tests but still affects core typing/submit flows on iOS.
> 
> **Overview**
> Adds an **iMessage-style iOS terminal composer** that is **open by default per terminal** (session-only dismiss per terminal), with an **inline send** control and **per-terminal drafts** wired through a new `TerminalDraftStoring` seam and in-memory store plus a **FIFO draft pipeline** (coalesced saves, sign-out wipe, post-send reconcile).
> 
> **Bottom dock** moves into **`GhosttySurfaceView`**: composer band + always-visible toolbar + keyboard in one layout stack (replacing `safeAreaInset`/toolbar handoff). `GhosttySurfaceRepresentable` hosts `TerminalComposerView` in the surface composer band; compose-button behavior uses **`ComposerDockState`** (open / reveal-and-focus / close) so hide/reveal cycles do not clear drafts.
> 
> **Send path** uses new **`terminal.paste`** RPC from the shell (ack-gated draft clear, re-entrancy guard); mobile RPC client treats paste like terminal input for ticket coverage. **Focus** uses a terminal-keyed `composerFocusRequest` handshake plus UIKit assist on reveal.
> 
> Adds **DEBUG diagnostics** (composer events, dock probes) and **broad unit tests** for dock reducer, default-open, draft ordering/switch ownership, and submit reconcile; minor toolbar UX (sticky-lock border, composer accessory action).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d7d0e7eb380eb75a8306fae647c007d91a1911. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships an iMessage-style terminal composer on iOS with a default-open band, inline send, and per-terminal drafts in a surface-owned bottom dock. Adds `terminal.paste` for bracketed multi-line sends and hardens focus/draft handling to prevent draft loss, double submits, and flaky reveal focus.

- **New Features**
  - Default-open composer per terminal; unfocused by default; chevron hides it per session.
  - Inline send; multi-line input submits as one bracketed paste + single submit via `terminal.paste`.
  - One bottom dock (grid, composer, toolbar, keyboard) owned by the terminal surface; field growth only moves the grid; pinned compose toggle.
  - Per-terminal drafts behind `TerminalDraftStoring` with FIFO ordering and coalesced keystroke saves; in-memory store for this PR; composer strings localized (en, ja).

- **Bug Fixes**
  - Compose button resolves to open → reveal-and-focus → close so hidden or unfocused composers aren’t dismissed.
  - Field-ownership marker stops draft erasure on fast terminal switches; late loads no longer overwrite edits.
  - Post-send clears the submitted terminal’s stored draft on ack (guarded against double taps and mid-flight switches); `terminal.paste` accepts late acks after reconnect; partial submit failures return `submitted: false` with `submit_error`.
  - Keyboard toggle and HIDE resign the actual first responder; hidden chrome fully reclaims grid height.
  - Focus is keyed to the requesting surface’s terminal ID, plus a deterministic UIKit assist on reveal/HIDE.
  - UI tests updated for the always-visible dock (ColorBands threshold) and longer selection waits on slow CI.

<sup>Written for commit 2b2c4d9aca7ba59c2923eef90ba8375141a6321f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iMessage‑style bottom composer: multi-line input, toggle/hide controls, focus-handshake, measured band height, and preserved drafts across hide/reveal and terminal switches.
  * Per‑terminal session draft persistence with async FIFO/coalescing pipeline and ack‑gated clearing on send.
  * Remote terminal paste RPC support for multi-line submissions.
  * New composer state/intents, diagnostic probes, responder identity tokens, and localized composer labels.

* **Tests**
  * Extensive unit and UI tests covering open/close, focus/refocus handshake, draft persistence, terminal switching, pipeline ordering/races, and UI regressions.

* **UI**
  * Accessibility probes for surface/store composer state and a sticky‑locked visual state for accessory buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->