### PR TITLE
Fix ⌘[ / ⌘] focus-history vs browser Back/Forward default collision (+ regression guard)

### DIFF
--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -230,6 +230,11 @@ extension ShortcutAction {
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
         case .sendCtrlFToTerminal:
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
+        case .focusHistoryBack, .focusHistoryForward:
+            // ⌘[ / ⌘] are the browser pane's Back/Forward. Scope workspace
+            // focus-history navigation out of browser panels so it yields the
+            // chord there instead of colliding with browserBack/browserForward.
+            return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
         case .browserBack, .browserForward, .browserReload,
              .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
              .browserZoomIn, .browserZoomOut, .browserZoomReset, .toggleBrowserFocusMode,

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/ShortcutDefaultCollisionTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/ShortcutDefaultCollisionTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+@Suite("ShortcutDefaultCollision")
+struct ShortcutDefaultCollisionTests {
+    /// Factory-default shortcut pairs that intentionally share a chord and are
+    /// resolved at runtime rather than by `when`-context, so context-aware
+    /// collision detection legitimately reports them as overlapping.
+    ///
+    /// - `groupSelectedWorkspaces` ⇄ `toggleReactGrab` (⌘⇧G): both ship
+    ///   `.application`-scoped, but the group handler propagates the event
+    ///   (returns `false`) when there are no eligible workspaces to group, so
+    ///   React Grab still fires where grouping would have been a no-op. The
+    ///   overlap is documented in the app target's default-shortcut table
+    ///   (`KeyboardShortcutSettings.swift`).
+    static let intentionalOverlaps: Set<Set<ShortcutAction>> = [
+        [.groupSelectedWorkspaces, .toggleReactGrab],
+    ]
+
+    /// Every chord that two actions share by default must be resolvable: either
+    /// their effective `when`-contexts are disjoint (so the same keystroke drives
+    /// each action in a different focus) or router priority picks a deterministic
+    /// winner. Anything else is a shipped conflict — one action shadows the other
+    /// and the duplicate is unreachable. Guards against re-introducing the class
+    /// of bug behind #3467 and #5810.
+    @Test func factoryDefaultsOnlyCollideWhereIntentional() {
+        var actionsBySharedChord: [StoredShortcut: [ShortcutAction]] = [:]
+        for action in ShortcutAction.allCases {
+            guard let shortcut = action.defaultShortcut else { continue }
+            actionsBySharedChord[shortcut, default: []].append(action)
+        }
+
+        var collisions: Set<Set<ShortcutAction>> = []
+        for actions in actionsBySharedChord.values where actions.count > 1 {
+            for i in actions.indices {
+                for j in actions.indices where j > i {
+                    let lhs = actions[i]
+                    let rhs = actions[j]
+                    if ShortcutWhenClause.bindingsCollide(
+                        lhs.defaultFocusWhenClause, lhsHasPriority: lhs.hasPriorityShortcutRouting,
+                        rhs.defaultFocusWhenClause, rhsHasPriority: rhs.hasPriorityShortcutRouting
+                    ) {
+                        collisions.insert([lhs, rhs])
+                    }
+                }
+            }
+        }
+
+        let unexpected = collisions.subtracting(Self.intentionalOverlaps)
+        #expect(
+            unexpected.isEmpty,
+            "factory default shortcuts collide outside the intentional allowlist: \(unexpected)"
+        )
+        // The allowlist must not rot: an entry that no longer collides (e.g. one
+        // side was rebound or re-scoped) should be removed so the list keeps
+        // meaning every pair it names.
+        let staleAllowlistEntries = Self.intentionalOverlaps.subtracting(collisions)
+        #expect(
+            staleAllowlistEntries.isEmpty,
+            "intentional-overlap allowlist names pairs that no longer collide: \(staleAllowlistEntries)"
+        )
+    }
+
+    /// `⌘[` / `⌘]` are the browser pane's Back / Forward. Workspace focus-history
+    /// navigation binds the same chords, so it must yield to the browser while a
+    /// browser panel is focused instead of double-firing; outside a browser it
+    /// still navigates focus history.
+    @Test func focusHistoryNavigationYieldsToBrowserBackForward() {
+        for action in [ShortcutAction.focusHistoryBack, .focusHistoryForward] {
+            let clause = action.defaultFocusWhenClause
+            #expect(!clause.evaluate(ShortcutFocusState(browser: true, markdown: false, sidebar: false)))
+            #expect(clause.evaluate(ShortcutFocusState(browser: false, markdown: false, sidebar: false)))
+        }
+    }
+}

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -127,7 +127,10 @@ extension KeyboardShortcutSettings.Action {
             return .browserPanel
         case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
             return .rightSidebarFocus
-        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal:
+        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal,
+             .focusHistoryBack, .focusHistoryForward:
+            // focusHistory ⌘[ / ⌘] must yield to the browser pane's Back/Forward
+            // (browserBack/browserForward) while a browser panel is focused.
             return .nonBrowserPanel
         case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
              .browserZoomIn, .browserZoomOut, .browserZoomReset, .toggleBrowserFocusMode:


### PR DESCRIPTION
## Summary

Adds a regression test that sweeps every factory-default shortcut for an unresolved chord collision, and fixes the one genuine collision it surfaced.

Two actions may share a default chord only when their effective `when`-contexts are disjoint (the same keystroke drives each in a different focus) or router priority picks a deterministic winner. Anything else is a shipped conflict: one action shadows the other and the duplicate chord is unreachable. This is the class behind #3467 (Rename Tab / Reload Page on ⌘R) and #5810 — but until now nothing guarded against re-introducing it.

The sweep found that **`focusHistoryBack` / `focusHistoryForward` (⌘[ / ⌘]) collide with the browser pane's Back / Forward**. Focus-history navigation ships `.application`-scoped, so while a browser panel is focused both it and `browserBack` / `browserForward` (browser-scoped) match the keystroke. The browser's own Back/Forward is the natural owner of ⌘[ / ⌘] there.

## Note on #5810

The pair the reporter screenshotted — *Zoom In/Out* vs *Markdown Viewer: Zoom In/Out* on ⌘= / ⌘- — is **not** a runtime collision: browser-zoom is scoped to `browserFocus` and markdown-zoom to `markdownFocus`, which never co-occur, so the sweep correctly treats them as non-colliding. That half of #5810 is a Settings-display matter (no context badge on context-scoped duplicates), not a binding conflict. The sweep instead caught a real one elsewhere. The non-US-layout zoom-reachability half of #5810 is a separate keystroke-resolution concern and is out of scope here.

## Changes

1. **Regression test** (`ShortcutDefaultCollisionTests`) — group actions by their `defaultShortcut`, and for every shared chord assert the pair does not `bindingsCollide` under their `defaultFocusWhenClause` + priority routing, except an explicit `intentionalOverlaps` allowlist. The allowlist is asserted to stay tight (no stale entries).
2. **Scope fix** — `focusHistoryBack` / `focusHistoryForward` move to the non-browser-panel context, mirrored in both `ShortcutAction.defaultFocusWhenClause` (CmuxSettings) and the app target's `KeyboardShortcutContext.shortcutContext` so the existing drift test stays aligned. Outside a browser panel they still navigate focus history; inside one they yield ⌘[ / ⌘] to the browser. The chord stays rebindable in Settings.

### Intentional overlap (allowlisted, not changed)

`groupSelectedWorkspaces` ⇄ `toggleReactGrab` (⌘⇧G) intentionally share a chord and are resolved at runtime — the group handler propagates the event when there are no eligible workspaces, so React Grab still fires where grouping would no-op. Documented in `KeyboardShortcutSettings.swift`; the test allowlists exactly this pair.

## Two-commit red/green

Per `AGENTS.md`:
- **Commit 1** (test): goes **red** on the focus-history ⌘[ / ⌘] collisions.
- **Commit 2** (scope fix): **green**.

## Verification

`swift test` on `Packages/CmuxSettings` (Xcode 26 toolchain): full suite green (70 tests, 9 suites); the new suite red at commit 1 as above.

I did not build the full app target locally (it needs the GhosttyKit xcframework / VM setup from `CONTRIBUTING.md`). The app-target edit is a two-line addition to the existing `.nonBrowserPanel` case of `shortcutContext`, and the package and app mappings resolve to the identical `when`-clause, so `testSettingsPackageDefaultWhenClausesMatchRuntimeShortcutContexts` stays aligned by construction — flagging it for CI to confirm.

Relates to #5810.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783767274&installation_id=133855650&pr_number=5878&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5878&signature=2967346e10f4367102a994c5b9e01d260f986a7cf3d6b2f8506c23ae618ffa16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a default shortcut collision where ⌘[ / ⌘] for focus history conflicted with the browser pane’s Back/Forward, and adds a regression test to prevent future default-chord collisions.

- **Bug Fixes**
  - Scoped `focusHistoryBack` / `focusHistoryForward` to non-browser panels in both `CmuxSettings` defaults and runtime `KeyboardShortcutContext`, so the browser owns ⌘[ / ⌘] when a browser pane is focused; behavior outside browser panels is unchanged and shortcuts remain rebindable.

- **New Features**
  - Added `ShortcutDefaultCollisionTests` to sweep factory defaults for unresolved chord collisions, with a minimal allowlist for the intentional `groupSelectedWorkspaces` ⇄ `toggleReactGrab` overlap (⌘⇧G).

<sup>Written for commit 3b2e72ee087781bd8a69c0be1c25a696148de408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus history navigation shortcuts to properly defer to browser back/forward actions when a browser panel is focused, ensuring expected behavior across different interface contexts.

* **Tests**
  * Added validation tests to detect and prevent unintended keyboard shortcut collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->