### PR TITLE
Activate cmux on Dock reopen

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1240,8 +1240,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         if mainWindowVisibilityController.showApplicationWindows(
             windows: mainWindowsForVisibilityController(),
-            reason: .applicationReopen,
-            activation: .none
+            reason: .applicationReopen
         ) == nil {
             _ = ensureInitialMainWindowIfNeeded()
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -900,6 +900,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         )
     )
+#if DEBUG
+    func replaceMainWindowVisibilityControllerForTesting(_ controller: MainWindowVisibilityController) {
+        mainWindowVisibilityController = controller
+    }
+#endif
     private static let serviceErrorNoPath = NSString(string: String(localized: "error.clipboardFolderPath", defaultValue: "Could not load any folder path from the clipboard."))
     private static let didInstallWindowKeyEquivalentSwizzle: Void = {
         let targetClass: AnyClass = NSWindow.self

--- a/cmuxTests/MainWindowVisibilityControllerTests.swift
+++ b/cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 import AppKit
 
 #if canImport(cmux_DEV)
@@ -8,8 +8,11 @@ import AppKit
 #endif
 
 @MainActor
-final class MainWindowVisibilityControllerTests: XCTestCase {
-    func testFocusDeminiaturizesAndActivatesThroughSingleOwner() {
+@Suite(.serialized)
+struct MainWindowVisibilityControllerTests {
+
+    @Test
+    func focusDeminiaturizesAndActivatesThroughSingleOwner() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -38,21 +41,23 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(
+        #expect(
             controller.focus(
                 window,
                 reason: .focusMainWindow,
                 activation: .runningApplication([.activateAllWindows])
             )
         )
-        XCTAssertTrue(activeWindows.first === window)
-        XCTAssertTrue(deminiaturizedWindows.first === window)
-        XCTAssertTrue(madeKeyWindows.first === window)
-        XCTAssertEqual(unhideCount, 1)
-        XCTAssertEqual(appActivations, [[.activateAllWindows]])
+        #expect(activeWindows.first === window)
+        #expect(deminiaturizedWindows.first === window)
+        #expect(madeKeyWindows.first === window)
+        #expect(unhideCount == 1)
+        #expect(appActivations == [[.activateAllWindows]])
     }
 
-    func testFocusSuppressionOnlyUpdatesActiveContext() {
+
+    @Test
+    func focusSuppressionOnlyUpdatesActiveContext() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -74,14 +79,16 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(controller.focus(window, reason: .focusMainWindow))
-        XCTAssertTrue(activeWindows.first === window)
-        XCTAssertEqual(deminiaturizedCount, 0)
-        XCTAssertEqual(madeKeyCount, 0)
-        XCTAssertEqual(activationCount, 0)
+        #expect(controller.focus(window, reason: .focusMainWindow))
+        #expect(activeWindows.first === window)
+        #expect(deminiaturizedCount == 0)
+        #expect(madeKeyCount == 0)
+        #expect(activationCount == 0)
     }
 
-    func testHotkeyRestoreUsesCapturedVisibleTargetsWithoutDeminiaturizingMiniaturizedWindows() {
+
+    @Test
+    func hotkeyRestoreUsesCapturedVisibleTargetsWithoutDeminiaturizingMiniaturizedWindows() {
         let visibleWindow = makeWindow()
         let miniaturizedWindow = makeWindow()
         defer {
@@ -130,20 +137,22 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             windows: [visibleWindow, miniaturizedWindow],
             reason: .globalHotkey
         )
-        XCTAssertEqual(hideCount, 1)
+        #expect(hideCount == 1)
 
         controller.toggleApplicationVisibility(
             windows: [visibleWindow, miniaturizedWindow],
             reason: .globalHotkey
         )
 
-        XCTAssertEqual(unhideCount, 1)
-        XCTAssertEqual(activationCount, 1)
-        XCTAssertTrue(madeKeyWindows.contains { $0 === visibleWindow })
-        XCTAssertFalse(deminiaturizedWindows.contains { $0 === miniaturizedWindow })
+        #expect(unhideCount == 1)
+        #expect(activationCount == 1)
+        #expect(madeKeyWindows.contains { $0 === visibleWindow })
+        #expect(!deminiaturizedWindows.contains { $0 === miniaturizedWindow })
     }
 
-    func testShowApplicationWindowsStillRestoresMiniaturizedWindowsWhenNoHiddenTargetsWereCaptured() {
+
+    @Test
+    func showApplicationWindowsStillRestoresMiniaturizedWindowsWhenNoHiddenTargetsWereCaptured() {
         let miniaturizedWindow = makeWindow()
         defer { miniaturizedWindow.orderOut(nil) }
 
@@ -171,12 +180,14 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
 
         _ = controller.showApplicationWindows(windows: [miniaturizedWindow], reason: .globalHotkey)
 
-        XCTAssertEqual(activationCount, 1)
-        XCTAssertTrue(deminiaturizedWindows.contains { $0 === miniaturizedWindow })
-        XCTAssertTrue(madeKeyWindows.contains { $0 === miniaturizedWindow })
+        #expect(activationCount == 1)
+        #expect(deminiaturizedWindows.contains { $0 === miniaturizedWindow })
+        #expect(madeKeyWindows.contains { $0 === miniaturizedWindow })
     }
 
-    func testDismissWindowsSoftHidesVisibleTargetsAndRestoresWithoutDeminiaturizing() {
+
+    @Test
+    func dismissWindowsSoftHidesVisibleTargetsAndRestoresWithoutDeminiaturizing() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -205,14 +216,16 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         controller.dismissWindows(windows: [window], reason: .titlebarDismiss)
         _ = controller.showApplicationWindows(windows: [window], reason: .applicationReopen)
 
-        XCTAssertTrue(softHiddenWindows.contains { $0 === window })
-        XCTAssertTrue(orderedRegardlessWindows.contains { $0 === window })
-        XCTAssertTrue(madeKeyWindows.contains { $0 === window })
-        XCTAssertEqual(activationCount, 1)
-        XCTAssertTrue(deminiaturizedWindows.isEmpty)
+        #expect(softHiddenWindows.contains { $0 === window })
+        #expect(orderedRegardlessWindows.contains { $0 === window })
+        #expect(madeKeyWindows.contains { $0 === window })
+        #expect(activationCount == 1)
+        #expect(deminiaturizedWindows.isEmpty)
     }
 
-    func testDismissedWindowDoesNotRestoreWhileAnotherWindowIsVisible() {
+
+    @Test
+    func dismissedWindowDoesNotRestoreWhileAnotherWindowIsVisible() {
         let dismissedWindow = makeWindow()
         let visibleWindow = makeWindow()
         defer {
@@ -252,12 +265,14 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             reason: .menuBar
         )
 
-        XCTAssertTrue(softHiddenWindows.contains { $0 === dismissedWindow })
-        XCTAssertTrue(madeKeyWindows.contains { $0 === visibleWindow })
-        XCTAssertFalse(madeKeyWindows.contains { $0 === dismissedWindow })
+        #expect(softHiddenWindows.contains { $0 === dismissedWindow })
+        #expect(madeKeyWindows.contains { $0 === visibleWindow })
+        #expect(!madeKeyWindows.contains { $0 === dismissedWindow })
     }
 
-    func testPassiveRevealWithoutKeyTransferDoesNotActivateApplication() {
+
+    @Test
+    func passiveRevealWithoutKeyTransferDoesNotActivateApplication() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -287,16 +302,17 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             makeKey: false
         )
 
-        XCTAssertEqual(
-            activationCount,
-            0,
+        #expect(
+            activationCount == 0,
             "Ordering a visible cmux window without transferring key focus must not make cmux the Launch Services frontmost app."
         )
-        XCTAssertTrue(orderedRegardlessWindows.contains { $0 === window })
-        XCTAssertTrue(madeKeyWindows.isEmpty)
+        #expect(orderedRegardlessWindows.contains { $0 === window })
+        #expect(madeKeyWindows.isEmpty)
     }
 
-    func testPassiveRevealWithoutKeyTransferDoesNotDeminiaturizeWindow() {
+
+    @Test
+    func passiveRevealWithoutKeyTransferDoesNotDeminiaturizeWindow() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -331,17 +347,19 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             makeKey: false
         )
 
-        XCTAssertNil(
-            revealedWindow,
+        #expect(
+            revealedWindow == nil,
             "A passive reveal must not unminiaturize a background cmux window because AppKit can mark the app frontmost."
         )
-        XCTAssertEqual(activationCount, 0)
-        XCTAssertTrue(deminiaturizedWindows.isEmpty)
-        XCTAssertTrue(orderedRegardlessWindows.isEmpty)
-        XCTAssertTrue(madeKeyWindows.isEmpty)
+        #expect(activationCount == 0)
+        #expect(deminiaturizedWindows.isEmpty)
+        #expect(orderedRegardlessWindows.isEmpty)
+        #expect(madeKeyWindows.isEmpty)
     }
 
-    func testHiddenAppRestoreFallsBackToSoftDismissedTargets() {
+
+    @Test
+    func hiddenAppRestoreFallsBackToSoftDismissedTargets() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -372,12 +390,66 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         isAppHidden = true
         _ = controller.showApplicationWindows(windows: [window], reason: .applicationReopen)
 
-        XCTAssertEqual(unhideCount, 1)
-        XCTAssertTrue(softShownWindows.contains { $0 === window })
-        XCTAssertTrue(madeKeyWindows.contains { $0 === window })
+        #expect(unhideCount == 1)
+        #expect(softShownWindows.contains { $0 === window })
+        #expect(madeKeyWindows.contains { $0 === window })
     }
 
-    func testApplicationActivationRestoreOrdersBeforeActivationThenMakesKeyAfterActivation() {
+#if DEBUG
+
+    @Test
+    func applicationReopenActivatesWhenRestoringBackgroundMainWindow() {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+
+        let windowId = UUID()
+        let window = makeWindow()
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+        let tabManager = TabManager()
+        app.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: tabManager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        defer {
+            app.unregisterMainWindowContextForTesting(windowId: windowId)
+            window.orderOut(nil)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        var appActivations: [NSApplication.ActivationOptions] = []
+        var madeKeyWindows: [NSWindow] = []
+        var activeWindows: [NSWindow] = []
+        let controller = MainWindowVisibilityController(
+            dependencies: .init(
+                isActivationSuppressed: { false },
+                setActiveMainWindow: { activeWindows.append($0) },
+                isApplicationHidden: { false },
+                activateRunningApplication: { appActivations.append($0) },
+                windowOperations: makeWindowOperations(
+                    isVisible: { candidate in candidate === window },
+                    isMiniaturized: { _ in false },
+                    makeKey: { madeKeyWindows.append($0) }
+                )
+            )
+        )
+        app.replaceMainWindowVisibilityControllerForTesting(controller)
+
+        #expect(app.applicationShouldHandleReopen(NSApplication.shared, hasVisibleWindows: false))
+
+        #expect(appActivations == [[.activateAllWindows]])
+        #expect(activeWindows.contains { $0 === window })
+        #expect(madeKeyWindows.contains { $0 === window })
+    }
+#endif
+
+
+    @Test
+    func applicationActivationRestoreOrdersBeforeActivationThenMakesKeyAfterActivation() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -407,30 +479,32 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         )
 
         controller.dismissWindows(windows: [window], reason: .titlebarDismiss)
-        XCTAssertTrue(visibleIds.isEmpty)
+        #expect(visibleIds.isEmpty)
 
         let preActivationWindow = controller.orderFrontApplicationWindowsBeforeActivation(
             windows: [window],
             reason: .applicationWillBecomeActive
         )
-        XCTAssertTrue(preActivationWindow === window)
-        XCTAssertEqual(activationCount, 0)
-        XCTAssertTrue(orderedRegardlessWindows.contains { $0 === window })
-        XCTAssertTrue(madeKeyWindows.isEmpty)
+        #expect(preActivationWindow === window)
+        #expect(activationCount == 0)
+        #expect(orderedRegardlessWindows.contains { $0 === window })
+        #expect(madeKeyWindows.isEmpty)
 
         let restoredWindow = controller.finishPendingApplicationActivationRestore(
             windows: [window],
             reason: .applicationDidBecomeActive
         )
-        XCTAssertTrue(restoredWindow === window)
-        XCTAssertEqual(activationCount, 0)
-        XCTAssertEqual(activeWindows.filter { $0 === window }.count, 2)
-        XCTAssertEqual(softShownWindows.filter { $0 === window }.count, 2)
-        XCTAssertEqual(orderedRegardlessWindows.filter { $0 === window }.count, 2)
-        XCTAssertEqual(madeKeyWindows.filter { $0 === window }.count, 1)
+        #expect(restoredWindow === window)
+        #expect(activationCount == 0)
+        #expect(activeWindows.filter { $0 === window }.count == 2)
+        #expect(softShownWindows.filter { $0 === window }.count == 2)
+        #expect(orderedRegardlessWindows.filter { $0 === window }.count == 2)
+        #expect(madeKeyWindows.filter { $0 === window }.count == 1)
     }
 
-    func testPassiveActivationDoesNotRestoreOnlyMiniaturizedWindows() {
+
+    @Test
+    func passiveActivationDoesNotRestoreOnlyMiniaturizedWindows() {
         let window = makeWindow()
         defer { window.orderOut(nil) }
 
@@ -458,22 +532,22 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             )
         )
 
-        XCTAssertNil(
+        #expect(
             controller.orderFrontApplicationWindowsBeforeActivation(
                 windows: [window],
                 reason: .applicationWillBecomeActive
-            )
+            ) == nil
         )
-        XCTAssertNil(
+        #expect(
             controller.restoreApplicationWindowsAfterActivation(
                 windows: [window],
                 reason: .applicationDidBecomeActive
-            )
+            ) == nil
         )
-        XCTAssertTrue(deminiaturizedWindows.isEmpty)
-        XCTAssertTrue(orderedRegardlessWindows.isEmpty)
-        XCTAssertTrue(madeKeyWindows.isEmpty)
-        XCTAssertEqual(activationCount, 0)
+        #expect(deminiaturizedWindows.isEmpty)
+        #expect(orderedRegardlessWindows.isEmpty)
+        #expect(madeKeyWindows.isEmpty)
+        #expect(activationCount == 0)
     }
 
     private func makeWindow() -> NSWindow {


### PR DESCRIPTION
## Summary
- Activate cmux when handling Dock icon reopen.
- Add regression coverage for Dock reopen activation.

## Root cause
The Dock reopen path passed `activation: .none` into the main window visibility controller. That could restore or order windows without making cmux the frontmost app, which made Dock icon clicks appear to do nothing while the app was backgrounded.

## Fix
Let the `.applicationReopen` path use the visibility controller's default activation behavior, which activates the running application with `.activateAllWindows`.

## Validation
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-fix-dock-icon-focus -only-testing:cmuxTests/MainWindowVisibilityControllerTests`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-dock-icon-focus`

Note: local validation used the verified prebuilt GhosttyKit because this machine does not have the repo-required Zig 0.15.2 installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783770693&installation_id=133855650&pr_number=5880&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5880&signature=f1c300e62a1876f32561300a2d854e3369802d095d255561b6bcd344f0c60575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the Dock icon now activates `cmux` and focuses the main window instead of restoring in the background. This fixes Dock clicks appearing to do nothing when the app was backgrounded.

- **Bug Fixes**
  - For `.applicationReopen`, use the visibility controller’s default activation (removes `activation: .none`) so the app activates with `.activateAllWindows`.

- **Refactors**
  - Added `#if DEBUG` hook `replaceMainWindowVisibilityControllerForTesting` and a regression test for Dock reopen activation; migrated visibility controller tests to `Testing`.

<sup>Written for commit 5a4b3c333e4fb80b1a70092721152b287342d0b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app reopen behavior by restoring proper window activation handling.

* **Tests**
  * Migrated test suite to Swift Testing framework with updated assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->