### PR TITLE
Revert "Revert PR 5767 remote reconnect suspension"

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7291,7 +7291,7 @@ struct CMUXCLI {
         guard let sub = commandArgs.first?.lowercased() else {
             throw CLIError(message: String(
                 localized: "cli.error.workspaceSubcommandRequired",
-                defaultValue: "workspace requires a subcommand. Try: list, create, close, rename, select, group"
+                defaultValue: "workspace requires a subcommand. Try: list, create, close, rename, select, reconnect, disconnect, group"
             ))
         }
         let rest = Array(commandArgs.dropFirst())
@@ -7352,16 +7352,74 @@ struct CMUXCLI {
                 windowOverride: windowOverride,
                 requireWorkspaceFlag: false
             )
+        case "reconnect":
+            try runWorkspaceRemoteConnectionCommand(
+                commandName: "workspace reconnect",
+                method: "workspace.remote.reconnect",
+                commandArgs: rest,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowOverride
+            )
+        case "disconnect":
+            try runWorkspaceRemoteConnectionCommand(
+                commandName: "workspace disconnect",
+                method: "workspace.remote.disconnect",
+                commandArgs: rest,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowOverride
+            )
         default:
             throw CLIError(message: String(
                 format: String(
                     localized: "cli.error.workspaceSubcommandUnknown",
-                    defaultValue: "Unknown workspace subcommand: %@. Try: list, create, close, rename, select, group"
+                    defaultValue: "Unknown workspace subcommand: %@. Try: list, create, close, rename, select, reconnect, disconnect, group"
                 ),
                 locale: .current,
                 sub
             ))
         }
+    }
+
+    /// `cmux workspace reconnect|disconnect` — manual control over a remote
+    /// (SSH) workspace's connection. Targets the positional/`--workspace`
+    /// handle, then the caller's workspace, then the selected workspace.
+    private func runWorkspaceRemoteConnectionCommand(
+        commandName: String,
+        method: String,
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let (workspaceArg, rem0) = parseOption(commandArgs, name: "--workspace")
+        let (_, rem1) = parseOption(rem0, name: "--window")
+        let positional = rem1.first(where: { !$0.hasPrefix("--") })
+        let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride)
+        // With an explicit --window and no workspace argument, target that
+        // window's selected workspace on the server instead of the caller's
+        // CMUX_WORKSPACE_ID, which may live in a different window.
+        let target = workspaceArg
+            ?? positional
+            ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+
+        var params: [String: Any] = [:]
+        let winId = try normalizeWindowHandle(windowRaw, client: client)
+        if let winId { params["window_id"] = winId }
+        if let wsId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId) {
+            params["workspace_id"] = wsId
+        }
+        let payload = try client.sendV2(method: method, params: params)
+        printV2Payload(
+            payload,
+            jsonOutput: jsonOutput,
+            idFormat: idFormat,
+            fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace", "window"])
+        )
     }
 
     /// Emit a `cmux workspace-group` mutation response: JSON when --json,
@@ -13834,12 +13892,22 @@ struct CMUXCLI {
               close <workspace>       Close a workspace
               rename <workspace> --title <new>
               select <workspace>      Make a workspace active
+              reconnect [workspace]   Reconnect a remote (SSH) workspace, including one
+                                      whose automatic reconnect paused because the host
+                                      was unreachable
+              disconnect [workspace]  Stop a remote (SSH) workspace's connection
               group <subcommand>      Workspace group operations (see cmux workspace-group --help)
+
+            reconnect/disconnect accept a positional handle or --workspace
+            <id|ref|index>, defaulting to the caller's workspace, then the
+            selected one (of --window's window when given).
 
             Examples:
               cmux workspace list --json
               cmux workspace create --name Build --cwd ~/projects/myapp
               cmux workspace close workspace:3
+              cmux workspace reconnect
+              cmux workspace disconnect --workspace workspace:3
             """)
         case "workspace-group":
             return """

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15208,6 +15208,7 @@ struct SidebarWorkspaceSnapshotBuilder {
         let remoteWorkspaceSidebarText: String?
         let remoteConnectionStatusText: String
         let remoteStateHelpText: String
+        let showsRemoteReconnectAffordance: Bool
         let copyableSidebarSSHError: String?
         let latestConversationMessage: String?
         let metadataEntries: [SidebarStatusEntry]
@@ -15486,7 +15487,12 @@ struct TabItemView: View, Equatable {
     }
 
     private var remoteWorkspaceSidebarText: String? {
-        guard tab.hasActiveRemoteTerminalSessions else { return nil }
+        // Keep the SSH row visible while auto-reconnect is suspended even if
+        // every remote terminal session already died — it hosts the manual
+        // Reconnect affordance.
+        guard tab.hasActiveRemoteTerminalSessions || tab.remoteConnectionState == .suspended else {
+            return nil
+        }
         let trimmedTarget = tab.remoteDisplayTarget?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedTarget, !trimmedTarget.isEmpty {
             return trimmedTarget
@@ -15500,7 +15506,8 @@ struct TabItemView: View, Equatable {
             defaultValue: "remote host"
         )
         let trimmedDetail = tab.remoteConnectionDetail?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if tab.remoteConnectionState == .error, let trimmedDetail, !trimmedDetail.isEmpty {
+        if tab.remoteConnectionState == .error || tab.remoteConnectionState == .suspended,
+           let trimmedDetail, !trimmedDetail.isEmpty {
             let entry = SidebarRemoteErrorCopyEntry(
                 workspaceTitle: tab.title,
                 target: fallbackTarget,
@@ -15533,6 +15540,8 @@ struct TabItemView: View, Equatable {
             return String(localized: "remote.status.error", defaultValue: "Error")
         case .disconnected:
             return String(localized: "remote.status.disconnected", defaultValue: "Disconnected")
+        case .suspended:
+            return String(localized: "remote.status.suspended", defaultValue: "Unreachable")
         }
     }
 
@@ -15566,6 +15575,29 @@ struct TabItemView: View, Equatable {
                         .font(.system(size: scaledFontSize(9), weight: .medium))
                         .foregroundColor(activeSecondaryColor(0.58))
                         .lineLimit(1)
+
+                    if workspaceSnapshot.showsRemoteReconnectAffordance {
+                        Button {
+                            tab.reconnectRemoteConnection()
+                        } label: {
+                            Label(
+                                String(localized: "sidebar.remote.reconnect.button", defaultValue: "Reconnect"),
+                                systemImage: "arrow.clockwise"
+                            )
+                            .labelStyle(.titleAndIcon)
+                            .font(.system(size: scaledFontSize(9), weight: .semibold))
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundColor(activeSecondaryColor(0.9))
+                        .safeHelp(String(
+                            format: String(
+                                localized: "sidebar.remote.reconnect.help",
+                                defaultValue: "Reconnect to %@"
+                            ),
+                            locale: .current,
+                            remoteWorkspaceSidebarText
+                        ))
+                    }
                 }
             }
             .padding(.top, latestNotificationText == nil ? 1 : 2)
@@ -16618,6 +16650,15 @@ struct TabItemView: View, Equatable {
                 locale: .current,
                 target
             )
+        case .suspended:
+            return String(
+                format: String(
+                    localized: "sidebar.remote.help.suspended",
+                    defaultValue: "SSH host %@ is unreachable. Automatic reconnect is paused — use Reconnect to retry."
+                ),
+                locale: .current,
+                target
+            )
         }
     }
 
@@ -16670,6 +16711,7 @@ struct TabItemView: View, Equatable {
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
+            showsRemoteReconnectAffordance: tab.remoteConnectionState == .suspended,
             copyableSidebarSSHError: copyableSidebarSSHError,
             latestConversationMessage: tab.latestConversationMessage,
             metadataEntries: detailVisibility.showsMetadata ? tab.sidebarStatusEntriesInDisplayOrder() : [],

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -26,6 +26,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
+            showsRemoteReconnectAffordance: showsRemoteReconnectAffordance,
             copyableSidebarSSHError: copyableSidebarSSHError,
             latestConversationMessage: latestConversationMessage,
             metadataEntries: metadataEntries,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6437,6 +6437,9 @@ final class WorkspaceRemoteSessionController {
     private var reverseRelayStderrBuffer = ""
     private var reconnectRetryCount = 0
     private var reconnectWorkItem: DispatchWorkItem?
+    private var consecutiveUnreachableProbeCount = 0
+    private var reconnectSuspended = false
+    private var reachabilityProbeGeneration: UInt64 = 0
     private var heartbeatCount: Int = 0
     private var connectionAttemptStartedAt: Date?
     private var pendingPTYBridgeStarts: [UUID: PendingPTYBridgeStart] = [:]
@@ -6824,6 +6827,9 @@ final class WorkspaceRemoteSessionController {
         reconnectWorkItem?.cancel()
         reconnectWorkItem = nil
         reconnectRetryCount = 0
+        consecutiveUnreachableProbeCount = 0
+        reconnectSuspended = false
+        reachabilityProbeGeneration &+= 1
         reverseRelayRestartWorkItem?.cancel()
         reverseRelayRestartWorkItem = nil
         remotePortScanCoalesceWorkItem?.cancel()
@@ -7206,6 +7212,11 @@ final class WorkspaceRemoteSessionController {
             reconnectWorkItem?.cancel()
             reconnectWorkItem = nil
             reconnectRetryCount = 0
+            consecutiveUnreachableProbeCount = 0
+            // A live connection ends any suspension; without this a future
+            // failure would hit the suspended guard and never reschedule.
+            reconnectSuspended = false
+            reachabilityProbeGeneration &+= 1
             guard proxyEndpoint != endpoint else {
                 recordHeartbeatActivityLocked()
                 fulfillPendingPTYBridgeStartsLocked()
@@ -7260,7 +7271,9 @@ final class WorkspaceRemoteSessionController {
     private func scheduleReconnectLocked(baseDelay: TimeInterval) -> RetrySchedule {
         let retryNumber = reconnectRetryCount + 1
         let retryDelay = Self.retryDelay(baseDelay: baseDelay, retry: retryNumber)
-        guard !isStopping else { return RetrySchedule(retry: retryNumber, delay: retryDelay) }
+        guard !isStopping, !reconnectSuspended else {
+            return RetrySchedule(retry: retryNumber, delay: retryDelay)
+        }
         reconnectWorkItem?.cancel()
         reconnectRetryCount = retryNumber
         let workItem = DispatchWorkItem { [weak self] in
@@ -7272,7 +7285,87 @@ final class WorkspaceRemoteSessionController {
         }
         reconnectWorkItem = workItem
         queue.asyncAfter(deadline: .now() + retryDelay, execute: workItem)
+        evaluateReconnectPolicyLocked()
         return RetrySchedule(retry: retryNumber, delay: retryDelay)
+    }
+
+    /// Probe whether the SSH endpoint is reachable at all after a failed
+    /// connection attempt. While the host stays unreachable the retry loop is
+    /// allowed a short streak of attempts (absorbing sleep/wake and network
+    /// handoffs) and then suspends instead of retrying indefinitely
+    /// (https://github.com/manaflow-ai/cmux/issues/5734).
+    private func evaluateReconnectPolicyLocked() {
+        guard configuration.transport == .ssh else { return }
+        reachabilityProbeGeneration &+= 1
+        let generation = reachabilityProbeGeneration
+        WorkspaceRemoteHostReachabilityProbe.probe(
+            destination: configuration.destination,
+            port: configuration.port,
+            identityFile: configuration.identityFile,
+            sshOptions: configuration.sshOptions
+        ) { [weak self] outcome in
+            guard let self else { return }
+            self.queue.async {
+                self.handleReachabilityProbeOutcomeLocked(outcome, generation: generation)
+            }
+        }
+    }
+
+    private func handleReachabilityProbeOutcomeLocked(
+        _ outcome: WorkspaceRemoteHostProbeOutcome,
+        generation: UInt64
+    ) {
+        guard generation == reachabilityProbeGeneration else { return }
+        guard !isStopping, !reconnectSuspended else { return }
+        // The probe only judges a still-pending retry; if the retry resolved
+        // while the probe ran, the connected/stopped paths own the state.
+        guard reconnectWorkItem != nil else { return }
+        let evaluation = WorkspaceRemoteReconnectPolicy.evaluate(
+            outcome: outcome,
+            previousConsecutiveUnreachableProbes: consecutiveUnreachableProbeCount
+        )
+        consecutiveUnreachableProbeCount = evaluation.consecutiveUnreachableProbes
+        debugLog(
+            "remote.session.reachability outcome=\(Self.debugDescription(for: outcome)) " +
+            "streak=\(evaluation.consecutiveUnreachableProbes) " +
+            "decision=\(evaluation.decision == .suspend ? "suspend" : "retry") \(debugConfigSummary())"
+        )
+        if evaluation.decision == .suspend {
+            suspendAutoReconnectLocked()
+        }
+    }
+
+    /// Halt the automatic reconnect loop and surface a suspended state with a
+    /// manual Reconnect affordance. `Workspace.reconnectRemoteConnection()`
+    /// (sidebar button, workspace context menu, `cmux workspace reconnect`,
+    /// and the `workspace.remote.reconnect` socket command) replaces this
+    /// controller, which resets the policy state.
+    private func suspendAutoReconnectLocked() {
+        reconnectWorkItem?.cancel()
+        reconnectWorkItem = nil
+        reconnectSuspended = true
+        debugLog(
+            "remote.session.reconnect.suspended afterUnreachableProbes=\(consecutiveUnreachableProbeCount) " +
+            debugConfigSummary()
+        )
+        let detailFormat = String(
+            localized: "remote.state.suspended.detail",
+            defaultValue: "Can't reach %@ — automatic reconnect is paused. Use Reconnect when your network is back."
+        )
+        let detail = String(format: detailFormat, configuration.displayTarget)
+        publishDaemonStatus(.unavailable, detail: detail)
+        publishState(.suspended, detail: detail)
+    }
+
+    private static func debugDescription(for outcome: WorkspaceRemoteHostProbeOutcome) -> String {
+        switch outcome {
+        case .reachable:
+            return "reachable"
+        case .unreachable(let reason):
+            return "unreachable(\(debugLogSnippet(reason, limit: 80)))"
+        case .indeterminate:
+            return "indeterminate"
+        }
     }
 
     private func publishState(_ state: WorkspaceRemoteConnectionState, detail: String?) {
@@ -9802,6 +9895,9 @@ enum WorkspaceRemoteConnectionState: String, Equatable {
     case reconnecting
     case connected
     case error
+    /// Automatic reconnect halted because the host stayed unreachable; the
+    /// user reconnects manually (sidebar Reconnect, context menu, CLI).
+    case suspended
 }
 
 enum WorkspaceRemoteDaemonState: String {
@@ -13953,7 +14049,8 @@ final class Workspace: Identifiable, ObservableObject {
             if remoteConnectionState == .error ||
                 remoteDaemonStatus.state == .error ||
                 remoteConnectionState == .connecting ||
-                remoteConnectionState == .reconnecting {
+                remoteConnectionState == .reconnecting ||
+                remoteConnectionState == .suspended {
                 return
             }
             disconnectRemoteConnection(clearConfiguration: true)
@@ -14177,6 +14274,44 @@ final class Workspace: Identifiable, ObservableObject {
         remoteConnectionState = effectiveState
         remoteConnectionDetail = detail
         applyBrowserRemoteWorkspaceStatusToPanels()
+
+        if state == .suspended {
+            let entryDetail = trimmedDetail ?? ""
+            let entryValue = String(
+                format: String(
+                    localized: "remote.statusEntry.suspended",
+                    defaultValue: "SSH reconnect paused (%@): %@"
+                ),
+                locale: .current,
+                target,
+                entryDetail
+            )
+            statusEntries[Self.remoteErrorStatusKey] = SidebarStatusEntry(
+                key: Self.remoteErrorStatusKey,
+                value: entryValue,
+                icon: "pause.circle",
+                color: nil,
+                timestamp: Date()
+            )
+            let fingerprint = "suspended:\(entryDetail)"
+            if remoteLastErrorFingerprint != fingerprint {
+                remoteLastErrorFingerprint = fingerprint
+                appendSidebarLog(message: entryValue, level: .warning, source: "remote")
+                AppDelegate.shared?.notificationStore?.addNotification(
+                    tabId: id,
+                    surfaceId: nil,
+                    title: String(
+                        localized: "remote.notification.suspendedTitle",
+                        defaultValue: "SSH Reconnect Paused"
+                    ),
+                    subtitle: target,
+                    body: entryDetail,
+                    cooldownKey: remoteNotificationCooldownKey(target: target),
+                    cooldownInterval: Self.remoteNotificationCooldown
+                )
+            }
+            return
+        }
 
         if let trimmedDetail, !trimmedDetail.isEmpty, (state == .error || proxyOnlyError) {
             let statusPrefix = proxyOnlyError ? "Remote proxy unavailable" : "SSH error"

--- a/Sources/WorkspaceRemoteHostProbeOutcome.swift
+++ b/Sources/WorkspaceRemoteHostProbeOutcome.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Outcome of a quick reachability probe against the SSH endpoint of a remote
+/// workspace, used by the auto-reconnect loop to decide whether retrying makes
+/// sense at all.
+enum WorkspaceRemoteHostProbeOutcome: Equatable, Sendable {
+    /// A TCP connection to the resolved SSH endpoint succeeded.
+    case reachable
+    /// The endpoint could not be reached (DNS failure, connection refused,
+    /// timeout, or no route). The associated reason is a short human-readable
+    /// detail for logs and connection-state messages.
+    case unreachable(reason: String)
+    /// Reachability could not be determined (for example ProxyCommand-based
+    /// transports that cannot be probed with a direct TCP connection). The
+    /// policy must never suspend the reconnect loop based on this outcome.
+    case indeterminate
+}

--- a/Sources/WorkspaceRemoteHostReachabilityProbe.swift
+++ b/Sources/WorkspaceRemoteHostReachabilityProbe.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Network
+
+/// Quick reachability probe for the SSH endpoint behind a remote workspace.
+///
+/// The auto-reconnect loop uses this to distinguish "the host is temporarily
+/// failing" (keep retrying with backoff) from "the host cannot be reached at
+/// all" (suspend the loop and wait for a manual reconnect, see
+/// https://github.com/manaflow-ai/cmux/issues/5734).
+///
+/// The probe resolves the effective endpoint with `ssh -G` so ~/.ssh/config
+/// aliases, `HostName` overrides, and `ProxyJump` hops are honored. Transports
+/// that cannot be probed with a direct TCP connection (`ProxyCommand`) report
+/// `.indeterminate`, which the policy treats like a reachable host so the
+/// loop never suspends on a guess.
+enum WorkspaceRemoteHostReachabilityProbe {
+    struct Endpoint: Equatable {
+        let host: String
+        let port: Int
+    }
+
+    static let defaultTimeout: TimeInterval = 2.5
+    private static let sshResolveTimeout: TimeInterval = 3.0
+    private static let probeQueue = DispatchQueue(
+        label: "com.cmux.remote-host-reachability",
+        qos: .utility
+    )
+
+    /// Probe the SSH endpoint for `destination`. The completion runs on an
+    /// arbitrary queue; callers hop back to their own queue.
+    static func probe(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        timeout: TimeInterval = defaultTimeout,
+        completion: @escaping (WorkspaceRemoteHostProbeOutcome) -> Void
+    ) {
+        // Endpoint resolution shells out to `ssh -G` and can block for up to
+        // its timeout; run it on the concurrent utility pool so simultaneous
+        // probes from multiple workspaces don't serialize behind it (the
+        // serial probeQueue is reserved for NWConnection callbacks).
+        DispatchQueue.global(qos: .utility).async {
+            guard let endpoint = resolveEndpoint(
+                destination: destination,
+                port: port,
+                identityFile: identityFile,
+                sshOptions: sshOptions
+            ) else {
+                completion(.indeterminate)
+                return
+            }
+            probeTCP(
+                host: endpoint.host,
+                port: endpoint.port,
+                timeout: timeout,
+                completion: completion
+            )
+        }
+    }
+
+    /// Resolve the effective `(host, port)` for an SSH destination using
+    /// `ssh -G`. Returns nil when the endpoint cannot be probed directly
+    /// (ProxyCommand transports, unparsable output, or resolution failure).
+    ///
+    /// `sshConfigFile` is a test seam: passing a path (such as `/dev/null`)
+    /// pins resolution to that config via `ssh -F`, keeping tests hermetic
+    /// against the ambient `~/.ssh/config`. Production callers leave it nil
+    /// so the user's real config (aliases, HostName, ProxyJump) is honored.
+    static func resolveEndpoint(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        sshConfigFile: String? = nil
+    ) -> Endpoint? {
+        let trimmedDestination = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDestination.isEmpty, !trimmedDestination.hasPrefix("-") else { return nil }
+
+        var arguments = ["-G"]
+        if let sshConfigFile, !sshConfigFile.isEmpty {
+            arguments += ["-F", sshConfigFile]
+        }
+        if let port, port > 0 {
+            arguments += ["-p", String(port)]
+        }
+        if let identityFile,
+           !identityFile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            arguments += ["-i", identityFile]
+        }
+        for option in sshOptions {
+            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            arguments += ["-o", trimmed]
+        }
+        arguments.append(trimmedDestination)
+
+        guard let output = runSSHConfigResolution(arguments: arguments) else { return nil }
+        let resolved = parseSSHConfigOutput(output)
+
+        if let proxyJump = resolved.proxyJump {
+            // Reachability of the first hop is the right signal for "can this
+            // network reach the SSH entry point at all".
+            guard let jump = parseJumpSpec(proxyJump) else { return nil }
+            var jumpArguments = ["-G"]
+            if let sshConfigFile, !sshConfigFile.isEmpty {
+                jumpArguments += ["-F", sshConfigFile]
+            }
+            jumpArguments.append(jump.destination)
+            guard let jumpOutput = runSSHConfigResolution(arguments: jumpArguments) else {
+                return nil
+            }
+            let jumpResolved = parseSSHConfigOutput(jumpOutput)
+            guard jumpResolved.proxyCommand == nil, jumpResolved.proxyJump == nil else { return nil }
+            guard let host = jumpResolved.hostName ?? jump.host else { return nil }
+            let jumpPort = jump.port ?? jumpResolved.port ?? 22
+            return Endpoint(host: host, port: jumpPort)
+        }
+
+        guard resolved.proxyCommand == nil else { return nil }
+        guard let host = resolved.hostName else { return nil }
+        return Endpoint(host: host, port: resolved.port ?? port ?? 22)
+    }
+
+    struct ResolvedSSHConfig: Equatable {
+        var hostName: String?
+        var port: Int?
+        var proxyJump: String?
+        var proxyCommand: String?
+    }
+
+    /// Parse the key/value lines printed by `ssh -G`.
+    static func parseSSHConfigOutput(_ output: String) -> ResolvedSSHConfig {
+        var resolved = ResolvedSSHConfig()
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard let spaceIndex = trimmed.firstIndex(of: " ") else { continue }
+            let key = trimmed[..<spaceIndex].lowercased()
+            let value = String(trimmed[trimmed.index(after: spaceIndex)...])
+                .trimmingCharacters(in: .whitespaces)
+            guard !value.isEmpty, value.lowercased() != "none" else { continue }
+            switch key {
+            case "hostname":
+                resolved.hostName = value
+            case "port":
+                resolved.port = Int(value)
+            case "proxyjump":
+                resolved.proxyJump = value
+            case "proxycommand":
+                resolved.proxyCommand = value
+            default:
+                break
+            }
+        }
+        return resolved
+    }
+
+    struct JumpSpec: Equatable {
+        /// Full `[user@]host` destination usable as an `ssh -G` argument.
+        let destination: String
+        let host: String?
+        let port: Int?
+    }
+
+    /// Parse the first hop of a ProxyJump spec: `[user@]host[:port]`, with
+    /// optional `[v6::addr]` brackets and comma-separated chains.
+    static func parseJumpSpec(_ spec: String) -> JumpSpec? {
+        guard let firstHop = spec.split(separator: ",").first else { return nil }
+        var hop = firstHop.trimmingCharacters(in: .whitespaces)
+        guard !hop.isEmpty else { return nil }
+
+        var user: String?
+        if let atIndex = hop.lastIndex(of: "@") {
+            user = String(hop[..<atIndex])
+            hop = String(hop[hop.index(after: atIndex)...])
+        }
+
+        var host = hop
+        var port: Int?
+        if hop.hasPrefix("[") {
+            guard let closeIndex = hop.firstIndex(of: "]") else { return nil }
+            host = String(hop[hop.index(after: hop.startIndex)..<closeIndex])
+            let remainder = hop[hop.index(after: closeIndex)...]
+            if remainder.hasPrefix(":") {
+                port = Int(remainder.dropFirst())
+            }
+        } else if let colonIndex = hop.lastIndex(of: ":"),
+                  hop.firstIndex(of: ":") == colonIndex {
+            // Exactly one colon: host:port. More than one without brackets is
+            // a bare IPv6 address with no port.
+            host = String(hop[..<colonIndex])
+            port = Int(hop[hop.index(after: colonIndex)...])
+        }
+
+        guard !host.isEmpty else { return nil }
+        let destination = user.map { "\($0)@\(host)" } ?? host
+        return JumpSpec(destination: destination, host: host, port: port)
+    }
+
+    private static func runSSHConfigResolution(arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        process.arguments = arguments
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let deadline = Date().addingTimeInterval(sshResolveTimeout)
+        while process.isRunning, Date() < deadline {
+            usleep(20_000)
+        }
+        if process.isRunning {
+            process.terminate()
+            return nil
+        }
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Attempt a TCP connection to `host:port`, reporting `.reachable` on a
+    /// successful handshake and `.unreachable` on refusal, timeout, DNS
+    /// failure, or no route.
+    static func probeTCP(
+        host: String,
+        port: Int,
+        timeout: TimeInterval = defaultTimeout,
+        completion: @escaping (WorkspaceRemoteHostProbeOutcome) -> Void
+    ) {
+        guard port > 0, port <= 65_535, let nwPort = NWEndpoint.Port(rawValue: UInt16(port)) else {
+            completion(.indeterminate)
+            return
+        }
+        let connection = NWConnection(host: NWEndpoint.Host(host), port: nwPort, using: .tcp)
+        // Both finish paths (state updates via `connection.start(queue:)` and
+        // the timeout below) run on the serial `probeQueue`, so the
+        // first-finisher latch needs no separate synchronization.
+        var finished = false
+        func finish(_ outcome: WorkspaceRemoteHostProbeOutcome) {
+            guard !finished else { return }
+            finished = true
+            // NWConnection retains its handler and the handler's context
+            // captures the connection; clear it before canceling so each
+            // backoff-retry probe doesn't leak a connection.
+            connection.stateUpdateHandler = nil
+            connection.cancel()
+            completion(outcome)
+        }
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                finish(.reachable)
+            case .failed(let error):
+                finish(.unreachable(reason: error.localizedDescription))
+            case .waiting(let error):
+                // NWConnection parks refused/no-route attempts in `.waiting`
+                // hoping for a better path; for a quick probe that means the
+                // endpoint is not reachable right now.
+                finish(.unreachable(reason: error.localizedDescription))
+            default:
+                break
+            }
+        }
+        connection.start(queue: probeQueue)
+        probeQueue.asyncAfter(deadline: .now() + timeout) {
+            finish(.unreachable(reason: "probe timed out after \(Int(timeout.rounded()))s"))
+        }
+    }
+}

--- a/Sources/WorkspaceRemoteReconnectPolicy.swift
+++ b/Sources/WorkspaceRemoteReconnectPolicy.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Pure decision logic for the SSH remote workspace auto-reconnect loop
+/// (https://github.com/manaflow-ai/cmux/issues/5734).
+///
+/// While the host stays reachable the loop keeps its existing exponential
+/// backoff behavior. Once consecutive reachability probes keep failing, the
+/// loop should suspend instead of retrying indefinitely, leaving the user in
+/// control of when reconnection happens.
+enum WorkspaceRemoteReconnectPolicy {
+    enum Decision: Equatable, Sendable {
+        /// Keep the scheduled backoff retry armed.
+        case scheduleRetry
+        /// Halt the automatic reconnect loop and wait for a manual reconnect.
+        case suspend
+    }
+
+    struct Evaluation: Equatable, Sendable {
+        /// Consecutive failed probes after accounting for the latest outcome.
+        let consecutiveUnreachableProbes: Int
+        let decision: Decision
+    }
+
+    /// Number of consecutive unreachable probes after which the automatic
+    /// reconnect loop suspends. Sized to absorb short network transitions
+    /// (sleep/wake, wifi handoff) without retrying indefinitely against a
+    /// host that cannot be reached.
+    static let maxConsecutiveUnreachableProbes = 3
+
+    static func evaluate(
+        outcome: WorkspaceRemoteHostProbeOutcome,
+        previousConsecutiveUnreachableProbes: Int
+    ) -> Evaluation {
+        switch outcome {
+        case .reachable, .indeterminate:
+            return Evaluation(consecutiveUnreachableProbes: 0, decision: .scheduleRetry)
+        case .unreachable:
+            let streak = previousConsecutiveUnreachableProbes + 1
+            return Evaluation(
+                consecutiveUnreachableProbes: streak,
+                decision: streak >= Self.maxConsecutiveUnreachableProbes ? .suspend : .scheduleRetry
+            )
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -719,6 +719,10 @@
 		DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */; };
 		E30780000000000000000002 /* WorkspaceRemoteConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000001 /* WorkspaceRemoteConfiguration.swift */; };
 		F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
+		E307B0000000000000000002 /* WorkspaceRemoteHostProbeOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */; };
+		E307A0000000000000000002 /* WorkspaceRemoteHostReachabilityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = E307A0000000000000000001 /* WorkspaceRemoteHostReachabilityProbe.swift */; };
+		E30790000000000000000002 /* WorkspaceRemoteReconnectPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */; };
+		F6357300A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */; };
 		E30770000000000000000002 /* WorkspaceRemoteSSHBatchCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30770000000000000000001 /* WorkspaceRemoteSSHBatchCommandBuilder.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
 		5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */; };
@@ -1465,6 +1469,10 @@
 		14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePullRequestSidebarTests.swift; sourceTree = "<group>"; };
 		E30780000000000000000001 /* WorkspaceRemoteConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConfiguration.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
+		E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteHostProbeOutcome.swift; sourceTree = "<group>"; };
+		E307A0000000000000000001 /* WorkspaceRemoteHostReachabilityProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteHostReachabilityProbe.swift; sourceTree = "<group>"; };
+		E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteReconnectPolicy.swift; sourceTree = "<group>"; };
+		F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteReconnectPolicyTests.swift; sourceTree = "<group>"; };
 		E30770000000000000000001 /* WorkspaceRemoteSSHBatchCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteSSHBatchCommandBuilder.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
 		5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservation.swift; sourceTree = "<group>"; };
@@ -1834,6 +1842,9 @@
 				C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */,
 				42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */,
 				E30780000000000000000001 /* WorkspaceRemoteConfiguration.swift */,
+				E30790000000000000000001 /* WorkspaceRemoteReconnectPolicy.swift */,
+				E307A0000000000000000001 /* WorkspaceRemoteHostReachabilityProbe.swift */,
+				E307B0000000000000000001 /* WorkspaceRemoteHostProbeOutcome.swift */,
 				D0C0D0C0D0C0D0C0D0C00002 /* RemoteLoopbackProxyAlias.swift */,
 				D0C0D0C0D0C0D0C0D0C00004 /* RemoteLoopbackRuntimeBridge.swift */,
 				E30770000000000000000001 /* WorkspaceRemoteSSHBatchCommandBuilder.swift */,
@@ -2181,6 +2192,7 @@
 				E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */,
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
+				F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */,
 				F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */,
 				F6120001A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift */,
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
@@ -3128,6 +3140,9 @@
 				D0B10004A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift in Sources */,
 				1A1B2C3D4E5F607180000001 /* WorkspacePromptSubmit.swift in Sources */,
 				E30780000000000000000002 /* WorkspaceRemoteConfiguration.swift in Sources */,
+				E307B0000000000000000002 /* WorkspaceRemoteHostProbeOutcome.swift in Sources */,
+				E307A0000000000000000002 /* WorkspaceRemoteHostReachabilityProbe.swift in Sources */,
+				E30790000000000000000002 /* WorkspaceRemoteReconnectPolicy.swift in Sources */,
 				E30770000000000000000002 /* WorkspaceRemoteSSHBatchCommandBuilder.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
 				5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */,
@@ -3407,6 +3422,7 @@
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,
 				DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
+				F6357300A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift in Sources */,
 				5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */,
 				6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */,
 				F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -106,6 +106,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             remoteWorkspaceSidebarText: nil,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: "",
+            showsRemoteReconnectAffordance: false,
             copyableSidebarSSHError: nil,
             latestConversationMessage: latestConversationMessage,
             metadataEntries: [],

--- a/cmuxTests/WorkspaceRemoteReconnectPolicyTests.swift
+++ b/cmuxTests/WorkspaceRemoteReconnectPolicyTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// Regression coverage for https://github.com/manaflow-ai/cmux/issues/5734:
+// the SSH remote auto-reconnect loop must stop retrying once the host stays
+// unreachable, instead of retrying indefinitely, so the user controls when
+// reconnection happens.
+@Suite("Workspace remote reconnect policy")
+struct WorkspaceRemoteReconnectPolicyTests {
+    private func evaluate(
+        _ outcome: WorkspaceRemoteHostProbeOutcome,
+        previous: Int
+    ) -> WorkspaceRemoteReconnectPolicy.Evaluation {
+        WorkspaceRemoteReconnectPolicy.evaluate(
+            outcome: outcome,
+            previousConsecutiveUnreachableProbes: previous
+        )
+    }
+
+    @Test("Reachable host keeps the existing backoff retry loop")
+    func reachableHostKeepsRetrying() {
+        for previous in [0, 1, WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes] {
+            let evaluation = evaluate(.reachable, previous: previous)
+            #expect(evaluation.decision == .scheduleRetry)
+            #expect(evaluation.consecutiveUnreachableProbes == 0)
+        }
+    }
+
+    @Test("Indeterminate probes keep retrying and reset the unreachable streak")
+    func indeterminateProbeKeepsRetrying() {
+        for previous in [0, 1, WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes] {
+            let evaluation = evaluate(.indeterminate, previous: previous)
+            #expect(evaluation.decision == .scheduleRetry)
+            #expect(evaluation.consecutiveUnreachableProbes == 0)
+        }
+    }
+
+    @Test("Unreachable probes below the threshold keep retrying")
+    func unreachableBelowThresholdKeepsRetrying() {
+        for previous in 0..<(WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes - 1) {
+            let evaluation = evaluate(.unreachable(reason: "connection refused"), previous: previous)
+            #expect(evaluation.decision == .scheduleRetry)
+            #expect(evaluation.consecutiveUnreachableProbes == previous + 1)
+        }
+    }
+
+    @Test("Reconnect loop suspends once the host stays unreachable")
+    func suspendsAtUnreachableThreshold() {
+        var streak = 0
+        var decisions: [WorkspaceRemoteReconnectPolicy.Decision] = []
+        for _ in 0..<WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes {
+            let evaluation = evaluate(.unreachable(reason: "host timed out"), previous: streak)
+            streak = evaluation.consecutiveUnreachableProbes
+            decisions.append(evaluation.decision)
+        }
+        #expect(
+            decisions.last == .suspend,
+            "The auto-reconnect loop must suspend after \(WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes) consecutive unreachable probes instead of retrying indefinitely."
+        )
+        #expect(streak == WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes)
+    }
+
+    @Test("Suspension persists for further unreachable probes past the threshold")
+    func staysSuspendedPastThreshold() {
+        let evaluation = evaluate(
+            .unreachable(reason: "no route to host"),
+            previous: WorkspaceRemoteReconnectPolicy.maxConsecutiveUnreachableProbes
+        )
+        #expect(evaluation.decision == .suspend)
+    }
+
+    @Test("A reachable probe in between resets the unreachable streak")
+    func reachableProbeResetsStreak() {
+        var streak = 0
+        var sawSuspend = false
+        let outcomes: [WorkspaceRemoteHostProbeOutcome] = [
+            .unreachable(reason: "timeout"),
+            .unreachable(reason: "timeout"),
+            .reachable,
+            .unreachable(reason: "timeout"),
+            .unreachable(reason: "timeout"),
+        ]
+        for outcome in outcomes {
+            let evaluation = evaluate(outcome, previous: streak)
+            streak = evaluation.consecutiveUnreachableProbes
+            if evaluation.decision == .suspend {
+                sawSuspend = true
+            }
+        }
+        #expect(!sawSuspend, "Streaks interrupted by a reachable probe must not suspend the loop.")
+        #expect(streak == 2)
+
+        let third = evaluate(.unreachable(reason: "timeout"), previous: streak)
+        #expect(
+            third.decision == .suspend,
+            "Once the streak reaches the threshold again the loop must suspend."
+        )
+    }
+}
+
+@Suite("Workspace remote host reachability probe")
+struct WorkspaceRemoteHostReachabilityProbeTests {
+    @Test("Parses hostname, port, and proxy fields from ssh -G output")
+    func parsesSSHConfigOutput() {
+        let output = """
+        user nobody
+        hostname devbox.internal
+        port 2222
+        proxyjump bastion@jump.example.com:2200
+        addressfamily any
+        """
+        let resolved = WorkspaceRemoteHostReachabilityProbe.parseSSHConfigOutput(output)
+        #expect(resolved.hostName == "devbox.internal")
+        #expect(resolved.port == 2222)
+        #expect(resolved.proxyJump == "bastion@jump.example.com:2200")
+        #expect(resolved.proxyCommand == nil)
+    }
+
+    @Test("Treats `proxycommand none` as no proxy")
+    func ignoresProxyCommandNone() {
+        let resolved = WorkspaceRemoteHostReachabilityProbe.parseSSHConfigOutput(
+            "hostname example.com\nport 22\nproxycommand none\n"
+        )
+        #expect(resolved.proxyCommand == nil)
+        #expect(resolved.hostName == "example.com")
+    }
+
+    @Test("Parses ProxyJump hop specs")
+    func parsesJumpSpecs() {
+        let plain = WorkspaceRemoteHostReachabilityProbe.parseJumpSpec("jump.example.com")
+        #expect(plain == WorkspaceRemoteHostReachabilityProbe.JumpSpec(
+            destination: "jump.example.com", host: "jump.example.com", port: nil
+        ))
+
+        let userAndPort = WorkspaceRemoteHostReachabilityProbe.parseJumpSpec("ops@jump.example.com:2200")
+        #expect(userAndPort == WorkspaceRemoteHostReachabilityProbe.JumpSpec(
+            destination: "ops@jump.example.com", host: "jump.example.com", port: 2200
+        ))
+
+        let chained = WorkspaceRemoteHostReachabilityProbe.parseJumpSpec("first.example.com:22,second.example.com")
+        #expect(chained?.host == "first.example.com")
+        #expect(chained?.port == 22)
+
+        let bracketedV6 = WorkspaceRemoteHostReachabilityProbe.parseJumpSpec("[2001:db8::1]:2200")
+        #expect(bracketedV6 == WorkspaceRemoteHostReachabilityProbe.JumpSpec(
+            destination: "2001:db8::1", host: "2001:db8::1", port: 2200
+        ))
+
+        let bareV6 = WorkspaceRemoteHostReachabilityProbe.parseJumpSpec("2001:db8::1")
+        #expect(bareV6?.host == "2001:db8::1")
+        #expect(bareV6?.port == nil)
+    }
+
+    @Test("ProxyCommand destinations cannot be probed directly")
+    func proxyCommandResolvesToNil() {
+        // sshConfigFile pins resolution to an empty config so the test stays
+        // hermetic against the developer/CI user's ~/.ssh/config.
+        let endpoint = WorkspaceRemoteHostReachabilityProbe.resolveEndpoint(
+            destination: "nobody@127.0.0.1",
+            port: 22,
+            identityFile: nil,
+            sshOptions: ["ProxyCommand=/usr/bin/nc %h %p"],
+            sshConfigFile: "/dev/null"
+        )
+        #expect(endpoint == nil)
+    }
+
+    @Test("Resolves a direct destination's endpoint via ssh -G")
+    func resolvesDirectEndpoint() throws {
+        let endpoint = WorkspaceRemoteHostReachabilityProbe.resolveEndpoint(
+            destination: "nobody@127.0.0.1",
+            port: 2222,
+            identityFile: nil,
+            sshOptions: [],
+            sshConfigFile: "/dev/null"
+        )
+        let resolved = try #require(endpoint)
+        #expect(resolved.host == "127.0.0.1")
+        #expect(resolved.port == 2222)
+    }
+
+    @Test("TCP probe reports a listening endpoint as reachable")
+    func tcpProbeReachable() async throws {
+        let listener = try BlockingTCPListener()
+        defer { listener.close() }
+        let outcome = await probeOutcome(host: "127.0.0.1", port: listener.port)
+        #expect(outcome == .reachable)
+    }
+
+    @Test("TCP probe reports a refused connection as unreachable")
+    func tcpProbeRefused() async throws {
+        // Bind then close a listener so the port is known-free; the
+        // subsequent probe gets an immediate connection refusal.
+        let listener = try BlockingTCPListener()
+        let refusedPort = listener.port
+        listener.close()
+        let outcome = await probeOutcome(host: "127.0.0.1", port: refusedPort)
+        guard case .unreachable = outcome else {
+            Issue.record("Expected .unreachable for a refused port, got \(outcome)")
+            return
+        }
+    }
+
+    private func probeOutcome(host: String, port: Int) async -> WorkspaceRemoteHostProbeOutcome {
+        await withCheckedContinuation { continuation in
+            WorkspaceRemoteHostReachabilityProbe.probeTCP(
+                host: host,
+                port: port,
+                timeout: 3.0
+            ) { outcome in
+                continuation.resume(returning: outcome)
+            }
+        }
+    }
+}
+
+/// Minimal loopback TCP listener for probe tests.
+private final class BlockingTCPListener {
+    let port: Int
+    private var fd: Int32
+
+    init() throws {
+        let socketFD = socket(AF_INET, SOCK_STREAM, 0)
+        guard socketFD >= 0 else { throw POSIXError(.EMFILE) }
+        var reuse: Int32 = 1
+        setsockopt(socketFD, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                bind(socketFD, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(socketFD, 4) == 0 else {
+            Darwin.close(socketFD)
+            throw POSIXError(.EADDRINUSE)
+        }
+        var boundAddr = sockaddr_in()
+        var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &boundAddr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+                getsockname(socketFD, sockaddrPointer, &length)
+            }
+        }
+        guard nameResult == 0 else {
+            Darwin.close(socketFD)
+            throw POSIXError(.EADDRNOTAVAIL)
+        }
+        fd = socketFD
+        port = Int(UInt16(bigEndian: boundAddr.sin_port))
+    }
+
+    func close() {
+        if fd >= 0 {
+            Darwin.close(fd)
+            fd = -1
+        }
+    }
+
+    deinit {
+        close()
+    }
+}

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -98,7 +98,7 @@ Environment:
 | `reorder-workspace` | Reorder a workspace inside a window. |
 | `reorder-workspaces` | Atomically reorder workspaces inside pinned and unpinned groups. |
 | `workspace-action` | Run workspace context-menu actions from the CLI. |
-| `workspace` | Namespace for workspace verbs: `list`, `create`, `close`, `rename`, `select`, `group`. |
+| `workspace` | Namespace for workspace verbs: `list`, `create`, `close`, `rename`, `select`, `reconnect`, `disconnect`, `group`. `workspace reconnect` manually reconnects a remote (SSH) workspace — including one whose automatic reconnect suspended because the host was unreachable — and `workspace disconnect` stops its remote connection. Both accept a positional workspace handle or `--workspace <id\|ref\|index>`, defaulting to the caller's workspace, then the selected one. |
 | `move-tab-to-new-workspace` | Move a tab or surface into a newly created workspace. |
 | `list-workspaces` | List workspaces. |
 | `new-workspace` | Create a workspace, optionally with cwd, command, description, and layout. |


### PR DESCRIPTION
Reverts manaflow-ai/cmux#5882

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783774407&installation_id=133855650&pr_number=5885&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5885&signature=02ab60888dcc5a9b480f7d3d6b8850f9455184b0b8f260601925799dc80dfa13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suspend automatic SSH reconnect when the host is unreachable and add a clear manual reconnect path in the UI and CLI. This restores the remote reconnect suspension behavior, reducing noisy retries and giving users control.

- **New Features**
  - Auto-reconnect pauses after 3 consecutive unreachable probes and shows state "Unreachable" with helpful detail and a notification.
  - Sidebar shows a Reconnect button while suspended; status/help text updated; keeps the SSH row visible to allow manual retry.
  - New CLI: `cmux workspace reconnect` and `cmux workspace disconnect` (also via `workspace.remote.reconnect` / `workspace.remote.disconnect`). Accepts positional or `--workspace <id|ref|index>`, defaults to caller or selected workspace (supports `--window`).
  - Reachability probe: resolves endpoint via `ssh -G` (honors aliases/HostName/ProxyJump), probes with a quick TCP check, and never suspends on indeterminate cases (e.g., `ProxyCommand`).
  - New state `suspended` wired through UI, state publishing, and localization; added tests for reconnect policy and reachability probing; docs/help text updated.

<sup>Written for commit 457d7965495c7c58f0d8e14b728a3fcd80e311f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `reconnect` and `disconnect` commands for manual SSH workspace control via CLI
  * New "Unreachable" status display for suspended remote connections
  * Added Reconnect button in sidebar to manually retry connection attempts
  * Auto-reconnect now intelligently suspends after repeated connection failures

* **Documentation**
  * Updated CLI help text and examples for workspace commands
  * Added multi-language localization for new status messages and commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->