### PR TITLE
Fix browser keydown recursion crash

### DIFF
--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -396,6 +396,9 @@ final class CmuxWebView: WKWebView {
     private var pointerFocusAllowanceDepth: Int = 0
     private var pasteAsPlainTextTargetAvailable = false
     private var lastPasteAsPlainTextPerformKeyEventTimestamp: TimeInterval?
+#if DEBUG
+    static var keyDownSuperDispatchForTesting: ((CmuxWebView, NSEvent) -> Void)?
+#endif
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
     }
@@ -516,6 +519,16 @@ final class CmuxWebView: WKWebView {
         typealias PasteAsPlainTextFn = @convention(c) (AnyObject, Selector, Any?) -> Void
         let implementation = method_getImplementation(method)
         unsafeBitCast(implementation, to: PasteAsPlainTextFn.self)(self, selector, sender)
+    }
+
+    private func forwardKeyDownToWebKit(_ event: NSEvent) {
+#if DEBUG
+        if let keyDownSuperDispatchForTesting = Self.keyDownSuperDispatchForTesting {
+            keyDownSuperDispatchForTesting(self, event)
+            return
+        }
+#endif
+        super.keyDown(with: event)
     }
 
     // Key-equivalent handling is synchronous, so this bounded preflight pumps the main run loop.
@@ -651,7 +664,7 @@ final class CmuxWebView: WKWebView {
                 let isReturnKey = event.keyCode == 36 || event.keyCode == 76
                 if (normalizedFlags.isEmpty && event.keyCode == 53) ||
                     (isReturnKey && !normalizedFlags.contains(.command)) {
-                    super.keyDown(with: event)
+                    forwardKeyDownToWebKit(event)
                     return finish(true)
                 }
                 let result = super.performKeyEquivalent(with: event)
@@ -764,7 +777,7 @@ final class CmuxWebView: WKWebView {
 #if DEBUG
                 route = "focusModeWebView"
 #endif
-                super.keyDown(with: event)
+                forwardKeyDownToWebKit(event)
                 return
             case .consume:
 #if DEBUG
@@ -797,7 +810,7 @@ final class CmuxWebView: WKWebView {
 #if DEBUG
             route = "inlineVSCode"
 #endif
-            super.keyDown(with: event)
+            forwardKeyDownToWebKit(event)
             return
         }
 
@@ -811,7 +824,7 @@ final class CmuxWebView: WKWebView {
             return
         }
 
-        super.keyDown(with: event)
+        forwardKeyDownToWebKit(event)
     }
 
     // MARK: - Focus on click

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -394,6 +394,7 @@ final class CmuxWebView: WKWebView {
     /// BrowserPanelView updates this as pane focus state changes.
     var allowsFirstResponderAcquisition: Bool = true
     private var pointerFocusAllowanceDepth: Int = 0
+    private var webKitKeyDownForwardingDepth = 0
     private var pasteAsPlainTextTargetAvailable = false
     private var lastPasteAsPlainTextPerformKeyEventTimestamp: TimeInterval?
 #if DEBUG
@@ -522,6 +523,8 @@ final class CmuxWebView: WKWebView {
     }
 
     private func forwardKeyDownToWebKit(_ event: NSEvent) {
+        webKitKeyDownForwardingDepth += 1
+        defer { webKitKeyDownForwardingDepth -= 1 }
 #if DEBUG
         if let keyDownSuperDispatchForTesting = Self.keyDownSuperDispatchForTesting {
             keyDownSuperDispatchForTesting(self, event)
@@ -765,6 +768,13 @@ final class CmuxWebView: WKWebView {
             )
         }
 #endif
+        if webKitKeyDownForwardingDepth > 0 {
+#if DEBUG
+            route = "webKitReentry"
+#endif
+            return
+        }
+
         if let decision = AppDelegate.shared?.handleBrowserFocusModeKeyEvent(
             event,
             webView: self,

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -398,7 +398,7 @@ final class CmuxWebView: WKWebView {
     private var pasteAsPlainTextTargetAvailable = false
     private var lastPasteAsPlainTextPerformKeyEventTimestamp: TimeInterval?
 #if DEBUG
-    static var keyDownSuperDispatchForTesting: ((CmuxWebView, NSEvent) -> Void)?
+    var keyDownSuperDispatchForTesting: ((CmuxWebView, NSEvent) -> Void)?
 #endif
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
@@ -526,7 +526,7 @@ final class CmuxWebView: WKWebView {
         webKitKeyDownForwardingDepth += 1
         defer { webKitKeyDownForwardingDepth -= 1 }
 #if DEBUG
-        if let keyDownSuperDispatchForTesting = Self.keyDownSuperDispatchForTesting {
+        if let keyDownSuperDispatchForTesting {
             keyDownSuperDispatchForTesting(self, event)
             return
         }

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -361,6 +361,40 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertTrue(spy.invoked)
     }
 
+    @MainActor
+    func testKeyDownSuppressesRecursiveWebKitSuperDispatch() {
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        guard let event = makeKeyDownEvent(key: "a", modifiers: [], keyCode: 0) else {
+            XCTFail("Failed to construct A key event")
+            return
+        }
+
+        var superDispatchCount = 0
+        var reenteredSuperDispatch = false
+        CmuxWebView.keyDownSuperDispatchForTesting = { currentWebView, event in
+            guard currentWebView === webView else { return }
+            superDispatchCount += 1
+            if superDispatchCount == 1 {
+                currentWebView.keyDown(with: event)
+            } else {
+                reenteredSuperDispatch = true
+            }
+        }
+        defer { CmuxWebView.keyDownSuperDispatchForTesting = nil }
+
+        webView.keyDown(with: event)
+
+        XCTAssertEqual(
+            superDispatchCount,
+            1,
+            "Re-entering CmuxWebView.keyDown while WebKit super dispatch is active must not dispatch back into WebKit again"
+        )
+        XCTAssertFalse(
+            reenteredSuperDispatch,
+            "A recursive WebKit keyDown bounce should stop before the second super dispatch"
+        )
+    }
+
     func testCmdCCopyPreflightsIntoWebContentBeforeMainMenu() {
         installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -371,8 +371,7 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
 
         var superDispatchCount = 0
         var reenteredSuperDispatch = false
-        CmuxWebView.keyDownSuperDispatchForTesting = { currentWebView, event in
-            guard currentWebView === webView else { return }
+        webView.keyDownSuperDispatchForTesting = { currentWebView, event in
             superDispatchCount += 1
             if superDispatchCount == 1 {
                 currentWebView.keyDown(with: event)
@@ -380,7 +379,7 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
                 reenteredSuperDispatch = true
             }
         }
-        defer { CmuxWebView.keyDownSuperDispatchForTesting = nil }
+        defer { webView.keyDownSuperDispatchForTesting = nil }
 
         webView.keyDown(with: event)
 


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5886

## Summary
- Add a regression test that re-enters `CmuxWebView.keyDown` while WebKit `super.keyDown` dispatch is active.
- Track WebKit keyDown forwarding depth and drop recursive `CmuxWebView.keyDown` bounces before they reach app shortcut/focus-mode lookup.

## Reproduction
- Crash report: `cmux NIGHTLY` `0.64.14-nightly.2734270276901`, macOS `26.4.1`, stack overflow through `CmuxWebView.keyDown`, `NSWindow.cmux_performKeyEquivalent`, AppKit `forwardMethod`, and WebKit `_web_superKeyDown:`.
- Local unfixed tag `r5886`: focused a browser webview, sent native `debug.shortcut.simulate` for `cmd+opt+b`, and the socket command timed out. Subsequent `ping` to `/tmp/cmux-debug-r5886.sock` timed out.

## Verification
- `git diff --check`
- Built fixed tag with `./scripts/reload-cloud.sh --tag r586f` (cloud slot unavailable, script fell back to tagged local `./scripts/reload.sh --tag r586f`).
- Fixed tag `r586f`: focused a browser webview, confirmed `browser.is-webview-focused=true`, sent native `debug.shortcut.simulate` for `cmd+opt+b`; command returned immediately, socket still returned `PONG`, and no new `cmux*.ips` crash report was created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783777219&installation_id=133855650&pr_number=5889&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5889&signature=0d3c00b8312e6d3e9ec22681049fc6118a60b9cfd56a95c51067c69b96a551d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a stack overflow by blocking recursive `keyDown` re-entry between `CmuxWebView.keyDown` and WebKit. Routes all `super.keyDown` through a guarded path and scopes the test hook to `DEBUG` builds (fixes #5886).

- **Bug Fixes**
  - Added `forwardKeyDownToWebKit(_:)` and `webKitKeyDownForwardingDepth`; replaced direct `super.keyDown` calls and early-return on WebKit re-entry.
  - Added `testKeyDownSuppressesRecursiveWebKitSuperDispatch`; uses `#if DEBUG`-scoped `keyDownSuperDispatchForTesting` to verify a single WebKit super dispatch with no recursion.

<sup>Written for commit d002d7fdfaf9e4e99f3024e14d44915df6424f38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard event routing into the embedded browser to prevent recursive dispatching that could break shortcuts (focus mode, command palette, surface key equivalents).

* **Tests**
  * Added test coverage confirming keyboard event recursion is suppressed during browser key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->