### PR TITLE
Add vibe-coded custom sidebar examples

### DIFF
--- a/Examples/CustomSidebars/README.md
+++ b/Examples/CustomSidebars/README.md
@@ -1,0 +1,32 @@
+# Custom Sidebar Examples
+
+These are vibe-coded cmux sidebars that run as interpreted SwiftUI-style files.
+They do not need Xcode, signing, or a build step.
+
+Install one by copying it into your custom sidebar directory:
+
+```bash
+mkdir -p ~/.config/cmux/sidebars
+cp Examples/CustomSidebars/status-board.swift ~/.config/cmux/sidebars/status-board.swift
+cp Examples/CustomSidebars/finder.swift ~/.config/cmux/sidebars/finder.swift
+```
+
+Then enable **Settings -> Beta features -> Custom sidebars** and pick it from
+the sidebar toggle button's right-click menu.
+
+You can validate a copied sidebar with:
+
+```bash
+cmux sidebar validate status-board
+cmux sidebar validate finder
+```
+
+## Included Sidebars
+
+- `status-board.swift`: groups workspaces into urgent, review, progress,
+  research, and done lanes using live PR, branch, progress, unread, and prompt
+  signals.
+- `finder.swift`: a macOS Finder-style workspace browser with a source list,
+  selected workspace inspector, and tab list.
+
+See `docs/custom-sidebars.md` for the full authoring contract.

--- a/Examples/CustomSidebars/README.md
+++ b/Examples/CustomSidebars/README.md
@@ -3,6 +3,9 @@
 These are vibe-coded cmux sidebars that run as interpreted SwiftUI-style files.
 They do not need Xcode, signing, or a build step.
 
+The examples intentionally keep their labels inline because interpreted
+sidebars do not have a localization catalog yet.
+
 Install one by copying it into your custom sidebar directory:
 
 ```bash

--- a/Examples/CustomSidebars/finder.swift
+++ b/Examples/CustomSidebars/finder.swift
@@ -1,0 +1,229 @@
+func workspaceIcon(_ w) -> String {
+  if w.pinned { return "pin.fill" }
+  if w.remote != nil && w.remote.connected == true { return "network" }
+  if hasPR(w) { return "arrow.triangle.pull" }
+  return "folder.fill"
+}
+
+func workspaceTint(_ w) -> String {
+  if w.selected { return "#0A84FF" }
+  if w.unread > 0 { return "#FF9F0A" }
+  if w.dirty == true { return "#34C759" }
+  return "#8E8E93"
+}
+
+func statusText(_ w) -> String {
+  if hasPR(w) { return w.pr.label }
+  if hasBranch(w) && w.dirty == true { return "\(w.branch) modified" }
+  if hasBranch(w) { return w.branch }
+  if w.portCount > 0 { return "\(w.portCount) ports" }
+  return "\(w.tabCount) tabs"
+}
+
+func hasBranch(_ w) -> Bool {
+  return w.branch != nil && w.branch != ""
+}
+
+func hasPR(_ w) -> Bool {
+  return w.pr != nil && w.pr.label != nil && w.pr.label != ""
+}
+
+func hasProgress(_ w) -> Bool {
+  return w.progress != nil && w.progress.value != nil
+}
+
+func hasLatestMessage(_ w) -> Bool {
+  return w.latestMessage != nil && w.latestMessage != ""
+}
+
+func tabIcon(_ t) -> String {
+  if t.pinned { return "pin.fill" }
+  if t.ports.count > 0 { return "network" }
+  return t.focused ? "doc.text.fill" : "doc.text"
+}
+
+func tabSubtitle(_ t) -> String {
+  if t.branch != nil && t.branch != "" && t.dirty == true { return "\(t.branch) modified" }
+  if t.branch != nil && t.branch != "" { return t.branch }
+  if t.directory != nil && t.directory != "" { return t.directory }
+  return "Terminal tab"
+}
+
+func finderRow(_ w) -> some View {
+  Button(action: { cmux("workspace.select", workspace_id: w.id) }) {
+    HStack(spacing: 7) {
+      Image(systemName: workspaceIcon(w))
+        .font(.system(size: 12))
+        .foregroundColor(workspaceTint(w))
+        .frame(width: 15)
+      VStack(alignment: .leading, spacing: 1) {
+        Text(w.title)
+          .font(.system(size: 12))
+          .fontWeight(w.selected ? .semibold : .regular)
+          .foregroundColor(w.selected ? .primary : .secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+        Text(statusText(w))
+          .font(.system(size: 9))
+          .foregroundColor(.tertiary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+      Spacer()
+      if w.unread > 0 {
+        Text("\(w.unread)")
+          .font(.system(size: 9, design: .monospaced))
+          .fontWeight(.semibold)
+          .foregroundColor(.white)
+          .padding(4)
+          .background { Capsule().foregroundColor("#FF3B30") }
+      }
+    }
+    .padding(6)
+    .background { RoundedRectangle(cornerRadius: 7).foregroundColor(w.selected ? "#0A84FF" : "#000000").opacity(w.selected ? 0.18 : 0.0) }
+  }
+}
+
+func tabRow(_ tab) -> some View {
+  Button(action: { cmux("surface.focus", surface_id: tab.id) }) {
+    HStack(spacing: 8) {
+      Image(systemName: tabIcon(tab))
+        .foregroundColor(tab.focused ? "#0A84FF" : .secondary)
+        .frame(width: 16)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(tab.title)
+          .font(.system(size: 12))
+          .fontWeight(tab.focused ? .semibold : .regular)
+          .lineLimit(1)
+          .truncationMode(.tail)
+        Text(tabSubtitle(tab))
+          .font(.system(size: 9))
+          .foregroundColor(.tertiary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+      Spacer()
+    }
+    .padding(6)
+    .background { RoundedRectangle(cornerRadius: 7).foregroundColor(tab.focused ? "#0A84FF" : "#000000").opacity(tab.focused ? 0.12 : 0.0) }
+  }
+}
+
+func workspaceDetails(_ w) -> some View {
+  VStack(alignment: .leading, spacing: 8) {
+    HStack(alignment: .top, spacing: 9) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 8).foregroundColor(workspaceTint(w)).opacity(0.16)
+        Image(systemName: workspaceIcon(w)).foregroundColor(workspaceTint(w))
+      }
+      .frame(width: 36, height: 36)
+      VStack(alignment: .leading, spacing: 3) {
+        Text(w.title).font(.system(size: 14)).fontWeight(.semibold).lineLimit(2)
+        Text(w.directory).font(.system(size: 10)).foregroundColor(.secondary).lineLimit(1).truncationMode(.middle)
+      }
+      Spacer()
+    }
+
+    HStack(spacing: 6) {
+      Label("\(w.tabCount)", systemImage: "rectangle.on.rectangle").font(.system(size: 10)).foregroundColor(.secondary)
+      if w.portCount > 0 {
+        Label("\(w.portCount)", systemImage: "network").font(.system(size: 10)).foregroundColor("#34C759")
+      }
+      if hasPR(w) {
+        Label(w.pr.label, systemImage: "arrow.triangle.pull").font(.system(size: 10)).foregroundColor("#0A84FF")
+      }
+      if w.unread > 0 {
+        Label("\(w.unread)", systemImage: "bell.fill").font(.system(size: 10)).foregroundColor("#FF9F0A")
+      }
+      Spacer()
+    }
+
+    if hasProgress(w) {
+      VStack(alignment: .leading, spacing: 3) {
+        HStack {
+          Text(w.progress.label).font(.system(size: 10)).foregroundColor(.secondary)
+          Spacer()
+        }
+        ProgressView(value: w.progress.value, total: 1.0).tint("#0A84FF")
+      }
+    }
+
+    if hasLatestMessage(w) {
+      Text(w.latestMessage)
+        .font(.system(size: 10))
+        .foregroundColor(.secondary)
+        .lineLimit(2)
+        .padding(7)
+        .background { RoundedRectangle(cornerRadius: 7).foregroundColor("#8E8E93").opacity(0.12) }
+    }
+  }
+  .padding(8)
+  .background { RoundedRectangle(cornerRadius: 9).foregroundColor("#8E8E93").opacity(0.10) }
+}
+
+HSplitView {
+  VStack(alignment: .leading, spacing: 6) {
+    HStack {
+      Text("Cmux").font(.system(size: 13)).fontWeight(.semibold)
+      Spacer()
+      Text("\(workspaceCount)").font(.system(size: 10, design: .monospaced)).foregroundColor(.tertiary)
+    }
+    .padding(6)
+
+    Text("Favorites")
+      .font(.system(size: 10))
+      .fontWeight(.semibold)
+      .textCase(.uppercase)
+      .foregroundColor(.tertiary)
+      .padding(4)
+
+    Reorderable(workspaces.prefix(30), move: "workspace.reorder") { w in
+      finderRow(w)
+    }
+
+    Spacer()
+  }
+  .padding(4)
+
+  VStack(alignment: .leading, spacing: 7) {
+    HStack {
+      Text(selectedTitle).font(.system(size: 13)).fontWeight(.semibold).lineLimit(1)
+      Spacer()
+      Text(clock.time).font(.system(size: 10, design: .monospaced)).foregroundColor(.tertiary)
+    }
+    .padding(6)
+
+    ForEach(workspaces.filter { $0.selected }.prefix(1)) { selected in
+      workspaceDetails(selected)
+
+      HStack {
+        Text("Tabs")
+          .font(.system(size: 10))
+          .fontWeight(.semibold)
+          .textCase(.uppercase)
+          .foregroundColor(.tertiary)
+        Spacer()
+        Text("\(selected.tabCount)")
+          .font(.system(size: 10, design: .monospaced))
+          .foregroundColor(.tertiary)
+      }
+      .padding(4)
+
+      if selected.tabs.isEmpty {
+        VStack(spacing: 6) {
+          Image(systemName: "rectangle.badge.plus").font(.system(size: 20)).foregroundColor(.tertiary)
+          Text("No tabs in this workspace").font(.system(size: 11)).foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(18)
+      } else {
+        ForEach(selected.tabs.prefix(24)) { tab in
+          tabRow(tab)
+        }
+      }
+    }
+
+    Spacer()
+  }
+  .padding(4)
+}

--- a/Examples/CustomSidebars/status-board.swift
+++ b/Examples/CustomSidebars/status-board.swift
@@ -1,0 +1,171 @@
+func hasWord(_ t, _ word) -> Bool {
+  if t.hasPrefix(word) { return true }
+  if t.contains(" \(word)") { return true }
+  if t.contains("-\(word)") { return true }
+  if t.contains("/\(word)") { return true }
+  return false
+}
+
+func bugText(_ w) -> String {
+  let branch = hasBranch(w) ? w.branch : ""
+  let prompt = hasPrompt(w) ? w.latestPrompt : ""
+  let desc = w.description != nil && w.description != "" ? w.description : ""
+  return "\(w.title) \(branch) \(prompt) \(desc)".lowercased()
+}
+
+func hasBranch(_ w) -> Bool {
+  return w.branch != nil && w.branch != ""
+}
+
+func hasPrompt(_ w) -> Bool {
+  return w.latestPrompt != nil && w.latestPrompt != ""
+}
+
+func hasPR(_ w) -> Bool {
+  return w.pr != nil && w.pr.label != nil && w.pr.label != ""
+}
+
+func hasProgress(_ w) -> Bool {
+  return w.progress != nil && w.progress.value != nil
+}
+
+func hasLatestAt(_ w) -> Bool {
+  return w.latestAt != nil && w.latestAt != ""
+}
+
+func isSevere(_ w) -> Bool {
+  let t = bugText(w)
+  if hasWord(t, "crash") || hasWord(t, "hang") || hasWord(t, "freeze") || hasWord(t, "frozen") || hasWord(t, "deadlock") || hasWord(t, "panic") || hasWord(t, "beachball") || hasWord(t, "unresponsive") { return true }
+  if hasWord(t, "oom") || t.contains("out of memory") || t.contains("data loss") || hasWord(t, "corrupt") { return true }
+  if hasWord(t, "urgent") || hasWord(t, "hotfix") || hasWord(t, "p0") || hasWord(t, "sev") { return true }
+  return false
+}
+
+func isBug(_ w) -> Bool {
+  if isSevere(w) { return true }
+  let t = bugText(w)
+  return hasWord(t, "bug") || hasWord(t, "fix") || hasWord(t, "issue") || hasWord(t, "regression") || hasWord(t, "broken")
+}
+
+func urgencyRank(_ w) -> Int {
+  let base = isSevere(w) ? 100 : 0
+  return base + w.unread
+}
+
+func laneOf(_ w) -> String {
+  if hasPR(w) && w.pr.status != "open" { return "done" }
+  if isBug(w) { return "urgent" }
+  if hasPR(w) { return "review" }
+  if w.dirty == true || hasProgress(w) || hasPrompt(w) { return "wip" }
+  return "research"
+}
+
+func agoLabel(_ mins) -> String {
+  if mins < 1 { return "now" }
+  if mins < 60 { return "\(mins)m" }
+  if mins < 1440 { return "\(mins / 60)h" }
+  return "\(mins / 1440)d"
+}
+
+func laneHeader(_ icon, _ name, _ count, _ tint) -> some View {
+  HStack(spacing: 6) {
+    Image(systemName: icon).font(.system(size: 11)).foregroundColor(tint)
+    Text(name).font(.system(size: 11)).fontWeight(.semibold).textCase(.uppercase).foregroundColor(tint)
+    Text("\(count)").font(.system(size: 10, design: .monospaced)).foregroundColor(tint)
+      .padding(3)
+      .background { Capsule().foregroundColor(tint).opacity(0.18) }
+    Spacer()
+  }
+  .padding(4)
+}
+
+func row(_ w, _ tint, _ nowEpoch) -> some View {
+  Button(action: { cmux("workspace.select", workspace_id: w.id) }) {
+    HStack(alignment: .top, spacing: 7) {
+      Capsule().frame(width: 3, height: 28).foregroundColor(w.selected ? tint : Color(red: 0.5, green: 0.5, blue: 0.5)).opacity(w.selected ? 1.0 : 0.25)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(w.title)
+          .font(.system(size: 12))
+          .fontWeight(w.selected ? .semibold : .regular)
+          .lineLimit(1).truncationMode(.tail)
+        HStack(spacing: 5) {
+          if isSevere(w) {
+            Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 8)).foregroundColor("#F7768E")
+          }
+          if hasPR(w) {
+            Text(w.pr.label)
+              .font(.system(size: 9, design: .monospaced))
+              .foregroundColor(w.pr.stale == true ? .tertiary : tint)
+          }
+          if !hasPR(w) && hasBranch(w) {
+            Text(w.branch).font(.system(size: 9, design: .monospaced)).foregroundColor(.secondary).lineLimit(1)
+          }
+          if w.dirty == true {
+            Image(systemName: "pencil").font(.system(size: 8)).foregroundColor(.secondary)
+          }
+          if hasLatestAt(w) {
+            Text(agoLabel((nowEpoch - w.latestAt) / 60)).font(.system(size: 9, design: .monospaced)).foregroundColor(.tertiary)
+          }
+        }
+        if hasProgress(w) && w.progress.value < 1.0 {
+          ProgressView(value: w.progress.value, total: 1.0).tint(tint)
+        }
+      }
+      Spacer()
+      if w.unread > 0 {
+        Text("\(w.unread)")
+          .font(.system(size: 9, design: .monospaced)).bold()
+          .foregroundColor("#1A1A22")
+          .padding(4)
+          .background { Circle().foregroundColor("#E0AF68") }
+      }
+    }
+    .padding(4)
+    .background { RoundedRectangle(cornerRadius: 6).foregroundColor(w.selected ? tint : "#000000").opacity(w.selected ? 0.14 : 0.0) }
+  }
+}
+
+func lane(_ ws, _ icon, _ name, _ tint, _ nowEpoch) -> some View {
+  VStack(alignment: .leading, spacing: 2) {
+    laneHeader(icon, name, ws.count, tint)
+    if ws.count == 0 {
+      Text("none").font(.system(size: 10)).foregroundColor(.tertiary).padding(4)
+    }
+    ForEach(ws.prefix(20)) { w in
+      row(w, tint, nowEpoch)
+    }
+  }
+}
+
+VStack(alignment: .leading, spacing: 6) {
+  HStack {
+    Text("Status board").font(.system(size: 13)).bold()
+    Spacer()
+    Text(clock.time).font(.system(size: 10, design: .monospaced)).foregroundColor(.tertiary)
+  }
+  .padding(4)
+  Divider()
+
+  let urgent = workspaces.filter { laneOf($0) == "urgent" }.sorted { urgencyRank($0) > urgencyRank($1) }
+  let review = workspaces.filter { laneOf($0) == "review" }.sorted { $0.unread > $1.unread }
+  let wip = workspaces.filter { laneOf($0) == "wip" }.sorted { $0.unread > $1.unread }
+  let research = workspaces.filter { laneOf($0) == "research" }.sorted { $0.unread > $1.unread }
+  let done = workspaces.filter { laneOf($0) == "done" }
+
+  lane(urgent, "exclamationmark.triangle.fill", "Bugs urgent need help", "#F7768E", clock.epoch)
+  Divider()
+  lane(review, "eye.fill", "In review", "#7AA2F7", clock.epoch)
+  Divider()
+  lane(wip, "hammer.fill", "In progress", "#E0AF68", clock.epoch)
+  Divider()
+  lane(research, "leaf.fill", "Research", "#9ECE6A", clock.epoch)
+
+  if done.count > 0 {
+    Divider()
+    laneHeader("checkmark.circle.fill", "Done", done.count, "#565F89")
+    ForEach(done.prefix(5)) { w in
+      row(w, "#565F89", clock.epoch).opacity(0.55)
+    }
+  }
+  Spacer()
+}

--- a/Examples/CustomSidebars/status-board.swift
+++ b/Examples/CustomSidebars/status-board.swift
@@ -146,13 +146,15 @@ VStack(alignment: .leading, spacing: 6) {
   .padding(4)
   Divider()
 
-  let urgent = workspaces.filter { laneOf($0) == "urgent" }.sorted { urgencyRank($0) > urgencyRank($1) }
-  let review = workspaces.filter { laneOf($0) == "review" }.sorted { $0.unread > $1.unread }
-  let wip = workspaces.filter { laneOf($0) == "wip" }.sorted { $0.unread > $1.unread }
-  let research = workspaces.filter { laneOf($0) == "research" }.sorted { $0.unread > $1.unread }
-  let done = workspaces.filter { laneOf($0) == "done" }
+  // Bound live renders so large workspace lists do not repeatedly classify every row each tick.
+  let boardWorkspaces = workspaces.prefix(80)
+  let urgent = boardWorkspaces.filter { laneOf($0) == "urgent" }.sorted { urgencyRank($0) > urgencyRank($1) }
+  let review = boardWorkspaces.filter { laneOf($0) == "review" }.sorted { $0.unread > $1.unread }
+  let wip = boardWorkspaces.filter { laneOf($0) == "wip" }.sorted { $0.unread > $1.unread }
+  let research = boardWorkspaces.filter { laneOf($0) == "research" }.sorted { $0.unread > $1.unread }
+  let done = boardWorkspaces.filter { laneOf($0) == "done" }
 
-  lane(urgent, "exclamationmark.triangle.fill", "Bugs urgent need help", "#F7768E", clock.epoch)
+  lane(urgent, "exclamationmark.triangle.fill", "Urgent bugs", "#F7768E", clock.epoch)
   Divider()
   lane(review, "eye.fill", "In review", "#7AA2F7", clock.epoch)
   Divider()

--- a/Packages/CmuxSwiftRenderUI/Tests/CmuxSwiftRenderUITests/CustomSidebarValidationTests.swift
+++ b/Packages/CmuxSwiftRenderUI/Tests/CmuxSwiftRenderUITests/CustomSidebarValidationTests.swift
@@ -1,3 +1,4 @@
+import CmuxSwiftRender
 import Foundation
 import Testing
 @testable import CmuxSwiftRenderUI
@@ -62,6 +63,16 @@ struct CustomSidebarValidationTests {
         #expect(report.entries.first?.errorMessage == "Sidebar file is missing.")
     }
 
+    @Test("downloadable custom sidebar examples validate")
+    func downloadableCustomSidebarExamplesValidate() throws {
+        let directory = examplesDirectory()
+        let report = validator.validate(directory: directory, dataContext: Self.richSidebarContext)
+
+        #expect(report.names == ["finder", "status-board"])
+        #expect(report.validCount == 2)
+        #expect(report.errorCount == 0)
+    }
+
     @MainActor
     @Test("model re-resolves preferred file kind on reload")
     func modelReresolvesPreferredFileKind() throws {
@@ -106,4 +117,154 @@ struct CustomSidebarValidationTests {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }
+
+    private func examplesDirectory() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Examples/CustomSidebars", isDirectory: true)
+    }
+
+    private static let richSidebarContext: [String: SwiftValue] = [
+        "workspaceCount": .int(3),
+        "selectedTitle": .string("cmux"),
+        "selectedId": .string("workspace-cmux"),
+        "unreadTotal": .int(4),
+        "clock": .object([
+            "time": .string("14:32:10"),
+            "hour": .int(14),
+            "minute": .int(32),
+            "second": .int(10),
+            "weekday": .string("Thu"),
+            "epoch": .int(1_780_000_000),
+        ]),
+        "workspaces": .array([
+            .object([
+                "id": .string("workspace-cmux"),
+                "title": .string("cmux"),
+                "selected": .bool(true),
+                "pinned": .bool(true),
+                "index": .int(0),
+                "directory": .string("/Users/me/src/cmux"),
+                "ports": .array([.int(3801), .int(5173)]),
+                "portCount": .int(2),
+                "unread": .int(2),
+                "tabCount": .int(2),
+                "description": .string("Crash fix"),
+                "color": .string("#0A84FF"),
+                "branch": .string("fix-crash-on-launch"),
+                "dirty": .bool(true),
+                "pr": .object([
+                    "number": .int(5812),
+                    "label": .string("PR 5812"),
+                    "url": .string("https://github.com/manaflow-ai/cmux/pull/5812"),
+                    "status": .string("open"),
+                    "stale": .bool(false),
+                    "branch": .string("fix-crash-on-launch"),
+                ]),
+                "prs": .array([]),
+                "progress": .object([
+                    "value": .double(0.64),
+                    "label": .string("Tests running"),
+                ]),
+                "latestMessage": .string("Waiting for review"),
+                "latestPrompt": .string("Fix the crash and add coverage"),
+                "latestAt": .int(1_779_999_400),
+                "remote": .object([
+                    "target": .string("aws-m4pro-1"),
+                    "state": .string("connected"),
+                    "connected": .bool(true),
+                ]),
+                "tabs": .array([
+                    .object([
+                        "id": .string("surface-terminal"),
+                        "title": .string("Terminal"),
+                        "focused": .bool(true),
+                        "pinned": .bool(false),
+                        "directory": .string("/Users/me/src/cmux"),
+                        "branch": .string("fix-crash-on-launch"),
+                        "dirty": .bool(true),
+                        "ports": .array([.int(3801)]),
+                    ]),
+                    .object([
+                        "id": .string("surface-browser"),
+                        "title": .string("Preview"),
+                        "focused": .bool(false),
+                        "pinned": .bool(true),
+                        "directory": .string("/Users/me/src/cmux/web"),
+                        "branch": .string("fix-crash-on-launch"),
+                        "dirty": .bool(false),
+                        "ports": .array([.int(5173)]),
+                    ]),
+                ]),
+            ]),
+            .object([
+                "id": .string("workspace-review"),
+                "title": .string("review queue"),
+                "selected": .bool(false),
+                "pinned": .bool(false),
+                "index": .int(1),
+                "directory": .string("/Users/me/src/review"),
+                "ports": .array([]),
+                "portCount": .int(0),
+                "unread": .int(2),
+                "tabCount": .int(1),
+                "description": .string("Review branch"),
+                "branch": .string("main"),
+                "dirty": .bool(false),
+                "pr": .object([
+                    "number": .int(5801),
+                    "label": .string("PR 5801"),
+                    "url": .string("https://github.com/manaflow-ai/cmux/pull/5801"),
+                    "status": .string("merged"),
+                    "stale": .bool(false),
+                    "branch": .string("feat-sidebar"),
+                ]),
+                "prs": .array([]),
+                "progress": .string(""),
+                "latestMessage": .string("Merged"),
+                "latestPrompt": .string(""),
+                "latestAt": .int(1_779_996_000),
+                "remote": .string(""),
+                "tabs": .array([
+                    .object([
+                        "id": .string("surface-review"),
+                        "title": .string("Review"),
+                        "focused": .bool(false),
+                        "pinned": .bool(false),
+                        "directory": .string("/Users/me/src/review"),
+                        "branch": .string("main"),
+                        "dirty": .bool(false),
+                        "ports": .array([]),
+                    ]),
+                ]),
+            ]),
+            .object([
+                "id": .string("workspace-research"),
+                "title": .string("research spike"),
+                "selected": .bool(false),
+                "pinned": .bool(false),
+                "index": .int(2),
+                "directory": .string("/Users/me/src/research"),
+                "ports": .array([]),
+                "portCount": .int(0),
+                "unread": .int(0),
+                "tabCount": .int(0),
+                "description": .string(""),
+                "branch": .string("main"),
+                "dirty": .bool(false),
+                "pr": .string(""),
+                "prs": .array([]),
+                "progress": .string(""),
+                "latestMessage": .string(""),
+                "latestPrompt": .string(""),
+                "latestAt": .string(""),
+                "remote": .string(""),
+                "tabs": .array([]),
+            ]),
+        ]),
+    ]
 }

--- a/Packages/CmuxSwiftRenderUI/Tests/CmuxSwiftRenderUITests/CustomSidebarValidationTests.swift
+++ b/Packages/CmuxSwiftRenderUI/Tests/CmuxSwiftRenderUITests/CustomSidebarValidationTests.swift
@@ -68,7 +68,7 @@ struct CustomSidebarValidationTests {
         let directory = examplesDirectory()
         let report = validator.validate(directory: directory, dataContext: Self.richSidebarContext)
 
-        #expect(report.names == ["finder", "status-board"])
+        #expect(report.names.sorted() == ["finder", "status-board"])
         #expect(report.validCount == 2)
         #expect(report.errorCount == 0)
     }

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -49,6 +49,26 @@ hot-reloads. If both `<name>.swift` and `<name>.json` exist, `.swift` wins.
 A sidebar file is a single SwiftUI-style view expression (no `struct`, no
 `var body` wrapper, just the view).
 
+## Downloadable examples
+
+The repo includes ready-to-copy sidebars in `Examples/CustomSidebars/`:
+
+- `status-board.swift` groups workspaces by live signals like urgent bugs,
+  review, progress, research, and done.
+- `finder.swift` shows a macOS Finder-style workspace browser with a source
+  list, selected workspace details, and tabs.
+
+Install one from a cmux checkout:
+
+    mkdir -p ~/.config/cmux/sidebars
+    cp Examples/CustomSidebars/status-board.swift ~/.config/cmux/sidebars/status-board.swift
+    cp Examples/CustomSidebars/finder.swift ~/.config/cmux/sidebars/finder.swift
+
+Then validate and select it:
+
+    cmux sidebar validate status-board
+    cmux sidebar select status-board
+
 ## Quick start
 
     cat > ~/.config/cmux/sidebars/mine.swift <<'SWIFT'


### PR DESCRIPTION
## Summary
- Add downloadable custom sidebar examples under `Examples/CustomSidebars`: `status-board.swift` and a Finder-style `finder.swift`.
- Document how to copy, validate, and select the examples from `docs/custom-sidebars.md` and the examples README.
- Add validator coverage so the downloadable examples render against representative workspace, tab, PR, progress, port, and clock data.

## Testing
- `swift test --package-path Packages/CmuxSwiftRenderUI --filter CustomSidebarValidationTests`

## Issues
- None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787780&installation_id=133855650&pr_number=5895&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5895&signature=cd40806a065e6a4d1257ec81cb8cbb02b4449c0e93bcb569005cf575ec427020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two downloadable, vibe-coded custom sidebar examples for `cmux` (`status-board.swift` and `finder.swift`), with docs and tests so users can copy, enable, select, and validate them.

- **New Features**
  - Added `Examples/CustomSidebars/status-board.swift` and `Examples/CustomSidebars/finder.swift`.
  - Added examples README and expanded docs with install, validate, and select steps.
  - Added validator coverage that renders both examples against a richer, representative data set.

- **Migration**
  - Copy: `mkdir -p ~/.config/cmux/sidebars && cp Examples/CustomSidebars/{status-board.swift,finder.swift} ~/.config/cmux/sidebars/`
  - Enable + select: Settings → Beta features → Custom sidebars; or `cmux sidebar select status-board`
  - Validate: `cmux sidebar validate status-board` and `cmux sidebar validate finder`

<sup>Written for commit c324dbf193e31e771d63a744777d9ce76a66ddcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two downloadable custom sidebar examples: Status Board (organize work items by urgency) and Finder (browse workspaces and tabs).

* **Documentation**
  * Added step-by-step installation, enablement, selection, and validation instructions for custom sidebars; linked authoring guidance.

* **Tests**
  * Added an automated validation test to verify downloadable custom sidebar examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->