### PR TITLE
Fix browser keyDown stack overflow reentry

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17244,13 +17244,8 @@ private extension NSWindow {
         if ShortcutRecorderEventRouter.dispatchActiveRecordingEvent(event, preferredWindow: self) {
             return true
         }
-        if shortcutRoutingShouldBypassForPrintableOptionText(event: event) {
-            if firstResponderWebView != nil, cmuxBrowserWebKitKeyDownDispatchIsActive() {
-#if DEBUG
-                cmuxDebugLog("  → printable Option text reentry during WebKit keyDown; leaving unhandled")
-#endif
-                return false
-            }
+        if firstResponderWebView != nil, cmuxBrowserWebKitKeyDownDispatchIsActive() { return false }
+        if shortcutRoutingShouldBypassForPrintableOptionText(event: event), !cmuxBrowserWebKitKeyDownDispatchIsActive() {
             let textInputTarget: NSResponder? = firstResponderGhosttyView
                 ?? firstResponderWebView
                 ?? self.firstResponder
@@ -17448,20 +17443,13 @@ private extension NSWindow {
         // NSWindow.performKeyEquivalent consumes Enter first, submission never reaches
         // WebKit. Route Return/Enter directly to the current first responder and
         // mark handled to avoid the AppKit alert sound path.
-        if shouldDispatchBrowserReturnViaFirstResponderKeyDown(
+        if !cmuxBrowserWebKitKeyDownDispatchIsActive(), shouldDispatchBrowserReturnViaFirstResponderKeyDown(
             keyCode: event.keyCode,
             firstResponderIsBrowser: firstResponderWebView != nil,
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
-            if cmuxBrowserWebKitKeyDownDispatchIsActive() {
-#if DEBUG
-                cmuxDebugLog("  → browser Return/Enter reentry during WebKit keyDown; leaving unhandled")
-#endif
-                return false
-            }
             // Forwarding keyDown can re-enter performKeyEquivalent in WebKit/AppKit internals.
-            // On re-entry, fall back to normal dispatch to avoid an infinite loop.
             if cmuxBrowserReturnForwardingDepth > 0 {
 #if DEBUG
                 cmuxDebugLog("  → browser Return/Enter reentry; using normal dispatch")
@@ -17480,18 +17468,12 @@ private extension NSWindow {
         // Some browser content (notably Google Docs) loses plain arrows when
         // NSWindow.performKeyEquivalent claims the arrow before WebKit sees
         // keyDown. Route those arrows directly to the first responder instead.
-        if shouldDispatchBrowserArrowViaFirstResponderKeyDown(
+        if !cmuxBrowserWebKitKeyDownDispatchIsActive(), shouldDispatchBrowserArrowViaFirstResponderKeyDown(
             keyCode: event.keyCode,
             firstResponderIsBrowser: firstResponderWebView != nil,
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
-            if cmuxBrowserWebKitKeyDownDispatchIsActive() {
-#if DEBUG
-                cmuxDebugLog("  → browser arrow reentry during WebKit keyDown; leaving unhandled")
-#endif
-                return false
-            }
             if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(for: event, in: self),
                browserOmnibarPanelId(for: self.firstResponder) == nil,
                focusedOmnibarField.window === self {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17244,8 +17244,9 @@ private extension NSWindow {
         if ShortcutRecorderEventRouter.dispatchActiveRecordingEvent(event, preferredWindow: self) {
             return true
         }
-        if firstResponderWebView != nil, cmuxBrowserWebKitKeyDownDispatchIsActive() { return false }
-        if shortcutRoutingShouldBypassForPrintableOptionText(event: event), !cmuxBrowserWebKitKeyDownDispatchIsActive() {
+        let browserWebKitKeyDownReentry = firstResponderWebView != nil && cmuxBrowserWebKitKeyDownDispatchIsActive()
+        if shortcutRoutingShouldBypassForPrintableOptionText(event: event) {
+            if browserWebKitKeyDownReentry { return false }
             let textInputTarget: NSResponder? = firstResponderGhosttyView
                 ?? firstResponderWebView
                 ?? self.firstResponder
@@ -17439,16 +17440,14 @@ private extension NSWindow {
             return true
         }
 
-        // Web forms rely on Return/Enter flowing through keyDown. If the original
-        // NSWindow.performKeyEquivalent consumes Enter first, submission never reaches
-        // WebKit. Route Return/Enter directly to the current first responder and
-        // mark handled to avoid the AppKit alert sound path.
-        if !cmuxBrowserWebKitKeyDownDispatchIsActive(), shouldDispatchBrowserReturnViaFirstResponderKeyDown(
+        // Web forms rely on Return/Enter flowing through keyDown. Route it directly to the first responder.
+        if shouldDispatchBrowserReturnViaFirstResponderKeyDown(
             keyCode: event.keyCode,
             firstResponderIsBrowser: firstResponderWebView != nil,
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
+            if browserWebKitKeyDownReentry { return false }
             // Forwarding keyDown can re-enter performKeyEquivalent in WebKit/AppKit internals.
             if cmuxBrowserReturnForwardingDepth > 0 {
 #if DEBUG
@@ -17465,15 +17464,14 @@ private extension NSWindow {
             return true
         }
 
-        // Some browser content (notably Google Docs) loses plain arrows when
-        // NSWindow.performKeyEquivalent claims the arrow before WebKit sees
-        // keyDown. Route those arrows directly to the first responder instead.
-        if !cmuxBrowserWebKitKeyDownDispatchIsActive(), shouldDispatchBrowserArrowViaFirstResponderKeyDown(
+        // Browser content can lose plain arrows when performKeyEquivalent claims them before WebKit.
+        if shouldDispatchBrowserArrowViaFirstResponderKeyDown(
             keyCode: event.keyCode,
             firstResponderIsBrowser: firstResponderWebView != nil,
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
+            if browserWebKitKeyDownReentry { return false }
             if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(for: event, in: self),
                browserOmnibarPanelId(for: self.firstResponder) == nil,
                focusedOmnibarField.window === self {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17245,6 +17245,12 @@ private extension NSWindow {
             return true
         }
         if shortcutRoutingShouldBypassForPrintableOptionText(event: event) {
+            if firstResponderWebView != nil, cmuxBrowserWebKitKeyDownDispatchIsActive() {
+#if DEBUG
+                cmuxDebugLog("  → printable Option text reentry during WebKit keyDown; leaving unhandled")
+#endif
+                return false
+            }
             let textInputTarget: NSResponder? = firstResponderGhosttyView
                 ?? firstResponderWebView
                 ?? self.firstResponder
@@ -17448,6 +17454,12 @@ private extension NSWindow {
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
+            if cmuxBrowserWebKitKeyDownDispatchIsActive() {
+#if DEBUG
+                cmuxDebugLog("  → browser Return/Enter reentry during WebKit keyDown; leaving unhandled")
+#endif
+                return false
+            }
             // Forwarding keyDown can re-enter performKeyEquivalent in WebKit/AppKit internals.
             // On re-entry, fall back to normal dispatch to avoid an infinite loop.
             if cmuxBrowserReturnForwardingDepth > 0 {
@@ -17474,6 +17486,12 @@ private extension NSWindow {
             firstResponderHasMarkedText: firstResponderHasMarkedText,
             flags: event.modifierFlags
         ) {
+            if cmuxBrowserWebKitKeyDownDispatchIsActive() {
+#if DEBUG
+                cmuxDebugLog("  → browser arrow reentry during WebKit keyDown; leaving unhandled")
+#endif
+                return false
+            }
             if let focusedOmnibarField = AppDelegate.shared?.focusedBrowserOmnibarField(for: event, in: self),
                browserOmnibarPanelId(for: self.firstResponder) == nil,
                focusedOmnibarField.window === self {

--- a/Sources/Panels/BrowserWebKitKeyDownDispatch.swift
+++ b/Sources/Panels/BrowserWebKitKeyDownDispatch.swift
@@ -1,11 +1,14 @@
 import AppKit
 
+@MainActor
 private var cmuxBrowserWebKitKeyDownDispatchDepth = 0
 
+@MainActor
 func cmuxBrowserWebKitKeyDownDispatchIsActive() -> Bool {
     cmuxBrowserWebKitKeyDownDispatchDepth > 0
 }
 
+@MainActor
 func cmuxWithBrowserWebKitKeyDownDispatch<T>(_ body: () -> T) -> T {
     cmuxBrowserWebKitKeyDownDispatchDepth += 1
     defer {
@@ -14,6 +17,7 @@ func cmuxWithBrowserWebKitKeyDownDispatch<T>(_ body: () -> T) -> T {
     return body()
 }
 
+@MainActor
 extension CmuxWebView {
     func forwardKeyDownToWebKit(_ event: NSEvent) {
         cmuxWithBrowserWebKitKeyDownDispatch {

--- a/Sources/Panels/BrowserWebKitKeyDownDispatch.swift
+++ b/Sources/Panels/BrowserWebKitKeyDownDispatch.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+private var cmuxBrowserWebKitKeyDownDispatchDepth = 0
+
+func cmuxBrowserWebKitKeyDownDispatchIsActive() -> Bool {
+    cmuxBrowserWebKitKeyDownDispatchDepth > 0
+}
+
+func cmuxWithBrowserWebKitKeyDownDispatch<T>(_ body: () -> T) -> T {
+    cmuxBrowserWebKitKeyDownDispatchDepth += 1
+    defer {
+        cmuxBrowserWebKitKeyDownDispatchDepth = max(0, cmuxBrowserWebKitKeyDownDispatchDepth - 1)
+    }
+    return body()
+}
+
+extension CmuxWebView {
+    func forwardKeyDownToWebKit(_ event: NSEvent) {
+        cmuxWithBrowserWebKitKeyDownDispatch {
+            super.keyDown(with: event)
+        }
+    }
+}

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -57,6 +57,23 @@ enum BrowserFocusModeKeyDecision: Equatable {
     case consume
 }
 
+private var cmuxBrowserWebKitKeyDownDispatchDepth = 0
+
+func cmuxBrowserWebKitKeyDownDispatchIsActive() -> Bool {
+    cmuxBrowserWebKitKeyDownDispatchDepth > 0
+}
+
+func cmuxWithBrowserWebKitKeyDownDispatch<T>(_ body: () -> T) -> T {
+    cmuxBrowserWebKitKeyDownDispatchDepth += 1
+    defer {
+        cmuxBrowserWebKitKeyDownDispatchDepth = max(
+            0,
+            cmuxBrowserWebKitKeyDownDispatchDepth - 1
+        )
+    }
+    return body()
+}
+
 enum BrowserImageCopyPasteboardBuilder {
     private static let pngPasteboardType = NSPasteboard.PasteboardType(UTType.png.identifier)
     private static let tiffPasteboardType = NSPasteboard.PasteboardType(UTType.tiff.identifier)
@@ -651,7 +668,7 @@ final class CmuxWebView: WKWebView {
                 let isReturnKey = event.keyCode == 36 || event.keyCode == 76
                 if (normalizedFlags.isEmpty && event.keyCode == 53) ||
                     (isReturnKey && !normalizedFlags.contains(.command)) {
-                    super.keyDown(with: event)
+                    forwardKeyDownToWebKit(event)
                     return finish(true)
                 }
                 let result = super.performKeyEquivalent(with: event)
@@ -764,7 +781,7 @@ final class CmuxWebView: WKWebView {
 #if DEBUG
                 route = "focusModeWebView"
 #endif
-                super.keyDown(with: event)
+                forwardKeyDownToWebKit(event)
                 return
             case .consume:
 #if DEBUG
@@ -797,7 +814,7 @@ final class CmuxWebView: WKWebView {
 #if DEBUG
             route = "inlineVSCode"
 #endif
-            super.keyDown(with: event)
+            forwardKeyDownToWebKit(event)
             return
         }
 
@@ -811,7 +828,13 @@ final class CmuxWebView: WKWebView {
             return
         }
 
-        super.keyDown(with: event)
+        forwardKeyDownToWebKit(event)
+    }
+
+    private func forwardKeyDownToWebKit(_ event: NSEvent) {
+        cmuxWithBrowserWebKitKeyDownDispatch {
+            super.keyDown(with: event)
+        }
     }
 
     // MARK: - Focus on click

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -57,23 +57,6 @@ enum BrowserFocusModeKeyDecision: Equatable {
     case consume
 }
 
-private var cmuxBrowserWebKitKeyDownDispatchDepth = 0
-
-func cmuxBrowserWebKitKeyDownDispatchIsActive() -> Bool {
-    cmuxBrowserWebKitKeyDownDispatchDepth > 0
-}
-
-func cmuxWithBrowserWebKitKeyDownDispatch<T>(_ body: () -> T) -> T {
-    cmuxBrowserWebKitKeyDownDispatchDepth += 1
-    defer {
-        cmuxBrowserWebKitKeyDownDispatchDepth = max(
-            0,
-            cmuxBrowserWebKitKeyDownDispatchDepth - 1
-        )
-    }
-    return body()
-}
-
 enum BrowserImageCopyPasteboardBuilder {
     private static let pngPasteboardType = NSPasteboard.PasteboardType(UTType.png.identifier)
     private static let tiffPasteboardType = NSPasteboard.PasteboardType(UTType.tiff.identifier)
@@ -829,12 +812,6 @@ final class CmuxWebView: WKWebView {
         }
 
         forwardKeyDownToWebKit(event)
-    }
-
-    private func forwardKeyDownToWebKit(_ event: NSEvent) {
-        cmuxWithBrowserWebKitKeyDownDispatch {
-            super.keyDown(with: event)
-        }
     }
 
     // MARK: - Focus on click

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		A5008371 /* BrowserSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008370 /* BrowserSearchOverlay.swift */; };
 		A5007422 /* BrowserWebAuthnSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007423 /* BrowserWebAuthnSupport.swift */; };
 		C0DE49870000000000000001 /* BrowserWebContentProcessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */; };
+		C0DE58990000000000000003 /* BrowserWebKitKeyDownDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */; };
 		A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
 		C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35530000000000000102 /* BundledCLILinkageTests.swift */; };
 		F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
@@ -242,6 +243,7 @@
 		D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */; };
 		A5001500 /* CmuxWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001510 /* CmuxWebView.swift */; };
 		D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */; };
+		C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */; };
 		7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */; };
 		E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */; };
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
@@ -905,6 +907,7 @@
 		A5008370 /* BrowserSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserSearchOverlay.swift; sourceTree = "<group>"; };
 		A5007423 /* BrowserWebAuthnSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebAuthnSupport.swift; sourceTree = "<group>"; };
 		C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWebContentProcessTests.swift; sourceTree = "<group>"; };
+		C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserWebKitKeyDownDispatch.swift; sourceTree = "<group>"; };
 		A5001533 /* BrowserWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortal.swift; sourceTree = "<group>"; };
 		C0DE35530000000000000102 /* BundledCLILinkageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledCLILinkageTests.swift; sourceTree = "<group>"; };
 		F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
@@ -1006,6 +1009,7 @@
 		D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		A5001510 /* CmuxWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebView.swift; sourceTree = "<group>"; };
 		D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewDragRoutingTests.swift; sourceTree = "<group>"; };
+		C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewKeyDownReentryTests.swift; sourceTree = "<group>"; };
 		43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewMouseNavigationButtonTests.swift; sourceTree = "<group>"; };
 		E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkspaceDefinition.swift; sourceTree = "<group>"; };
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
@@ -2040,6 +2044,7 @@
 				A5001426 /* FilePreviewPDFSizing.swift */,
 				A5001428 /* FilePreviewPDFViewport.swift */,
 				A5001510 /* CmuxWebView.swift */,
+				C0DE58990000000000000001 /* BrowserWebKitKeyDownDispatch.swift */,
 				D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001223 /* UpdateLogStore.swift */,
@@ -2211,6 +2216,7 @@
 				A50019B3 /* SettingsSearchIndexTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
+				C0DE58990000000000000002 /* CmuxWebViewKeyDownReentryTests.swift */,
 				C0DE49870000000000000002 /* BrowserWebContentProcessTests.swift */,
 				43F90FAF3FD44F11BF547BE9 /* CmuxWebViewMouseNavigationButtonTests.swift */,
 				D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */,
@@ -2799,6 +2805,7 @@
 				4472A0034472A0034472A003 /* BrowserScreenshotSnapshotter.swift in Sources */,
 				A5008371 /* BrowserSearchOverlay.swift in Sources */,
 				A5007422 /* BrowserWebAuthnSupport.swift in Sources */,
+				C0DE58990000000000000003 /* BrowserWebKitKeyDownDispatch.swift in Sources */,
 				A5001534 /* BrowserWindowPortal.swift in Sources */,
 				A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */,
 				C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */,
@@ -3292,6 +3299,7 @@
 				C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,
 				C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */,
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,
+				C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */,
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -18,11 +18,20 @@ import Network
 var cmuxUnitTestInspectorAssociationKey: UInt8 = 0
 var cmuxUnitTestInspectorOverrideInstalled = false
 var cmuxUnitTestWKWebViewPerformKeyEquivalentOverrideInstalled = false
+var cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = false
 var cmuxUnitTestWKWebViewPerformKeyEquivalentHook: ((WKWebView, NSEvent) -> Bool?)?
+var cmuxUnitTestCmuxWebViewKeyDownHook: ((CmuxWebView, NSEvent) -> Bool)?
 
 extension CmuxWebView {
     @objc func cmuxUnitTestInspector() -> NSObject? {
         objc_getAssociatedObject(self, &cmuxUnitTestInspectorAssociationKey) as? NSObject
+    }
+
+    @objc func cmuxUnitTest_keyDown(with event: NSEvent) {
+        if cmuxUnitTestCmuxWebViewKeyDownHook?(self, event) == true {
+            return
+        }
+        cmuxUnitTest_keyDown(with: event)
     }
 }
 
@@ -98,6 +107,21 @@ func installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride() {
     }
 
     cmuxUnitTestWKWebViewPerformKeyEquivalentOverrideInstalled = true
+}
+
+func installCmuxUnitTestCmuxWebViewKeyDownOverride() {
+    guard !cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled else { return }
+
+    let originalSelector = #selector(CmuxWebView.keyDown(with:))
+    let swizzledSelector = #selector(CmuxWebView.cmuxUnitTest_keyDown(with:))
+
+    guard let originalMethod = class_getInstanceMethod(CmuxWebView.self, originalSelector),
+          let swizzledMethod = class_getInstanceMethod(CmuxWebView.self, swizzledSelector) else {
+        fatalError("Unable to locate CmuxWebView keyDown methods for swizzling")
+    }
+
+    method_exchangeImplementations(originalMethod, swizzledMethod)
+    cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = true
 }
 
 private final class BrowserMarkedTextProbeTextView: NSTextView {
@@ -606,6 +630,128 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
 
         XCTAssertFalse(webView.performKeyEquivalent(with: event!))
         XCTAssertFalse(spy.invoked)
+    }
+
+    @MainActor
+    func testPrintableOptionTextRoutesToBrowserKeyDownOnce() {
+        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "å",
+                modifiers: [.option],
+                keyCode: 0,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct printable Option event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(keyDownEvents().map(\.keyCode), [0])
+        }
+    }
+
+    @MainActor
+    func testPrintableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "å",
+                modifiers: [.option],
+                keyCode: 0,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct printable Option event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    func testBrowserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "\r",
+                modifiers: [],
+                keyCode: 36,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Return event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    func testBrowserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "\u{F701}",
+                modifiers: [],
+                keyCode: 125,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Down Arrow event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    private func withHookedBrowserKeyDownWindow(
+        _ body: (NSWindow, CmuxWebView, () -> [NSEvent]) -> Void
+    ) {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+        installCmuxUnitTestCmuxWebViewKeyDownOverride()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let webView = CmuxWebView(frame: container.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+
+        var keyDownEvents: [NSEvent] = []
+        cmuxUnitTestCmuxWebViewKeyDownHook = { currentWebView, event in
+            guard currentWebView === webView else { return false }
+            keyDownEvents.append(event)
+            return true
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cmuxUnitTestCmuxWebViewKeyDownHook = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(webView))
+        body(window, webView, { keyDownEvents })
     }
 
     @MainActor

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -18,20 +18,11 @@ import Network
 var cmuxUnitTestInspectorAssociationKey: UInt8 = 0
 var cmuxUnitTestInspectorOverrideInstalled = false
 var cmuxUnitTestWKWebViewPerformKeyEquivalentOverrideInstalled = false
-var cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = false
 var cmuxUnitTestWKWebViewPerformKeyEquivalentHook: ((WKWebView, NSEvent) -> Bool?)?
-var cmuxUnitTestCmuxWebViewKeyDownHook: ((CmuxWebView, NSEvent) -> Bool)?
 
 extension CmuxWebView {
     @objc func cmuxUnitTestInspector() -> NSObject? {
         objc_getAssociatedObject(self, &cmuxUnitTestInspectorAssociationKey) as? NSObject
-    }
-
-    @objc func cmuxUnitTest_keyDown(with event: NSEvent) {
-        if cmuxUnitTestCmuxWebViewKeyDownHook?(self, event) == true {
-            return
-        }
-        cmuxUnitTest_keyDown(with: event)
     }
 }
 
@@ -107,21 +98,6 @@ func installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride() {
     }
 
     cmuxUnitTestWKWebViewPerformKeyEquivalentOverrideInstalled = true
-}
-
-func installCmuxUnitTestCmuxWebViewKeyDownOverride() {
-    guard !cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled else { return }
-
-    let originalSelector = #selector(CmuxWebView.keyDown(with:))
-    let swizzledSelector = #selector(CmuxWebView.cmuxUnitTest_keyDown(with:))
-
-    guard let originalMethod = class_getInstanceMethod(CmuxWebView.self, originalSelector),
-          let swizzledMethod = class_getInstanceMethod(CmuxWebView.self, swizzledSelector) else {
-        fatalError("Unable to locate CmuxWebView keyDown methods for swizzling")
-    }
-
-    method_exchangeImplementations(originalMethod, swizzledMethod)
-    cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = true
 }
 
 private final class BrowserMarkedTextProbeTextView: NSTextView {
@@ -630,128 +606,6 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
 
         XCTAssertFalse(webView.performKeyEquivalent(with: event!))
         XCTAssertFalse(spy.invoked)
-    }
-
-    @MainActor
-    func testPrintableOptionTextRoutesToBrowserKeyDownOnce() {
-        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
-            guard let event = makeKeyDownEvent(
-                key: "å",
-                modifiers: [.option],
-                keyCode: 0,
-                windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct printable Option event")
-                return
-            }
-
-            XCTAssertTrue(window.performKeyEquivalent(with: event))
-            XCTAssertEqual(keyDownEvents().map(\.keyCode), [0])
-        }
-    }
-
-    @MainActor
-    func testPrintableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
-            guard let event = makeKeyDownEvent(
-                key: "å",
-                modifiers: [.option],
-                keyCode: 0,
-                windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct printable Option event")
-                return
-            }
-
-            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
-                window.performKeyEquivalent(with: event)
-            }
-
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
-        }
-    }
-
-    @MainActor
-    func testBrowserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
-            guard let event = makeKeyDownEvent(
-                key: "\r",
-                modifiers: [],
-                keyCode: 36,
-                windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Return event")
-                return
-            }
-
-            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
-                window.performKeyEquivalent(with: event)
-            }
-
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
-        }
-    }
-
-    @MainActor
-    func testBrowserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
-        withHookedBrowserKeyDownWindow { window, _, keyDownEvents in
-            guard let event = makeKeyDownEvent(
-                key: "\u{F701}",
-                modifiers: [],
-                keyCode: 125,
-                windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Down Arrow event")
-                return
-            }
-
-            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
-                window.performKeyEquivalent(with: event)
-            }
-
-            XCTAssertFalse(handled)
-            XCTAssertTrue(keyDownEvents().isEmpty)
-        }
-    }
-
-    @MainActor
-    private func withHookedBrowserKeyDownWindow(
-        _ body: (NSWindow, CmuxWebView, () -> [NSEvent]) -> Void
-    ) {
-        _ = NSApplication.shared
-        AppDelegate.installWindowResponderSwizzlesForTesting()
-        installCmuxUnitTestCmuxWebViewKeyDownOverride()
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
-        window.contentView = container
-
-        let webView = CmuxWebView(frame: container.bounds, configuration: WKWebViewConfiguration())
-        webView.autoresizingMask = [.width, .height]
-        container.addSubview(webView)
-
-        var keyDownEvents: [NSEvent] = []
-        cmuxUnitTestCmuxWebViewKeyDownHook = { currentWebView, event in
-            guard currentWebView === webView else { return false }
-            keyDownEvents.append(event)
-            return true
-        }
-
-        window.makeKeyAndOrderFront(nil)
-        defer {
-            cmuxUnitTestCmuxWebViewKeyDownHook = nil
-            window.orderOut(nil)
-        }
-
-        XCTAssertTrue(window.makeFirstResponder(webView))
-        body(window, webView, { keyDownEvents })
     }
 
     @MainActor

--- a/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
+++ b/cmuxTests/CmuxWebViewKeyDownReentryTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import AppKit
+import WebKit
+import ObjectiveC.runtime
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+private var cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = false
+private var cmuxUnitTestCmuxWebViewKeyDownHook: ((CmuxWebView, NSEvent) -> Bool)?
+
+extension CmuxWebView {
+    @objc func cmuxUnitTest_keyDown(with event: NSEvent) {
+        if cmuxUnitTestCmuxWebViewKeyDownHook?(self, event) == true {
+            return
+        }
+        cmuxUnitTest_keyDown(with: event)
+    }
+}
+
+private func installCmuxUnitTestCmuxWebViewKeyDownOverride() {
+    guard !cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled else { return }
+
+    let originalSelector = #selector(CmuxWebView.keyDown(with:))
+    let swizzledSelector = #selector(CmuxWebView.cmuxUnitTest_keyDown(with:))
+
+    guard let originalMethod = class_getInstanceMethod(CmuxWebView.self, originalSelector),
+          let swizzledMethod = class_getInstanceMethod(CmuxWebView.self, swizzledSelector) else {
+        fatalError("Unable to locate CmuxWebView keyDown methods for swizzling")
+    }
+
+    method_exchangeImplementations(originalMethod, swizzledMethod)
+    cmuxUnitTestCmuxWebViewKeyDownOverrideInstalled = true
+}
+
+final class CmuxWebViewKeyDownReentryTests: XCTestCase {
+    @MainActor
+    func testPrintableOptionTextRoutesToBrowserKeyDownOnce() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "å",
+                modifiers: [.option],
+                keyCode: 0,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct printable Option event")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(keyDownEvents().map(\.keyCode), [0])
+        }
+    }
+
+    @MainActor
+    func testPrintableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "å",
+                modifiers: [.option],
+                keyCode: 0,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct printable Option event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    func testBrowserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "\r",
+                modifiers: [],
+                keyCode: 36,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Return event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    func testBrowserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch() {
+        withHookedBrowserKeyDownWindow { window, keyDownEvents in
+            guard let event = makeKeyDownEvent(
+                key: "\u{F701}",
+                modifiers: [],
+                keyCode: 125,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct Down Arrow event")
+                return
+            }
+
+            let handled = cmuxWithBrowserWebKitKeyDownDispatch {
+                window.performKeyEquivalent(with: event)
+            }
+
+            XCTAssertFalse(handled)
+            XCTAssertTrue(keyDownEvents().isEmpty)
+        }
+    }
+
+    @MainActor
+    private func withHookedBrowserKeyDownWindow(
+        _ body: (NSWindow, () -> [NSEvent]) -> Void
+    ) {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+        installCmuxUnitTestCmuxWebViewKeyDownOverride()
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let webView = CmuxWebView(frame: container.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+
+        var keyDownEvents: [NSEvent] = []
+        cmuxUnitTestCmuxWebViewKeyDownHook = { currentWebView, event in
+            guard currentWebView === webView else { return false }
+            keyDownEvents.append(event)
+            return true
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cmuxUnitTestCmuxWebViewKeyDownHook = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(webView))
+        body(window, { keyDownEvents })
+    }
+
+    private func makeKeyDownEvent(
+        key: String,
+        modifiers: NSEvent.ModifierFlags,
+        keyCode: UInt16,
+        windowNumber: Int
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: key,
+            charactersIgnoringModifiers: key,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add regression coverage for browser key handling reentry during WebKit keyDown dispatch.
- Track when CmuxWebView is forwarding keyDown into WebKit.
- Leave nested browser keyDown replay paths unhandled for printable Option text, Return/Enter, and arrow keys while WebKit is already processing the event.

## Root Cause

WebKit can re-enter NSWindow.performKeyEquivalent while CmuxWebView.keyDown is inside super.keyDown. The window shortcut router then synthesized another browser keyDown for the same event, which could recurse through AppKit forwardMethod until the main thread stack overflowed.

## Validation

- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination platform=macOS -derivedDataPath /tmp/cmux-keyso -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testPrintableOptionTextRoutesToBrowserKeyDownOnce -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testPrintableOptionTextDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testBrowserReturnDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch -only-testing:cmuxTests/CmuxWebViewKeyEquivalentTests/testBrowserArrowDoesNotReenterBrowserKeyDownDuringWebKitKeyDownDispatch
- ./scripts/reload.sh --tag keyso

Dogfood tag: http://127.0.0.1:17320/keyso

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783791168&installation_id=133855650&pr_number=5899&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5899&signature=5670fc50316acf601a68a689ed44b28cf60d11c2ce9af29ed1e81478ee101b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stack overflow from recursive browser keyDown reentry when WebKit is handling keyDown. We now track active WebKit keyDown dispatch and block nested routing for printable Option text, Return/Enter, and arrow keys.

- **Bug Fixes**
  - Track WebKit keyDown dispatch in `BrowserWebKitKeyDownDispatch.swift` and wrap WebKit calls via `CmuxWebView.forwardKeyDownToWebKit` (`cmuxWithBrowserWebKitKeyDownDispatch`, `cmuxBrowserWebKitKeyDownDispatchIsActive`).
  - In `NSWindow.performKeyEquivalent`, if the first responder is a browser and WebKit dispatch is active, return false instead of replaying browser keyDown for printable Option text, Return/Enter, and arrow keys.
  - Add regression tests in `CmuxWebViewKeyDownReentryTests` to verify single routing and no reentry during WebKit dispatch.

<sup>Written for commit d2b24b3c85bdd60cba335a33b87dc957b6df4e91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented re-entrant Web view key-down forwarding so printable Option text, Return, and arrow keys no longer trigger duplicate or unintended browser key handling.
* **Tests**
  * Added unit tests that verify single delivery of keyDown to the browser and ensure the new dispatch guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->