### PR TITLE
feat(sidebar): project identity — icons + folder-name titles for workspace recognizability

### DIFF
--- a/Packages/CmuxProjectIdentity/Package.swift
+++ b/Packages/CmuxProjectIdentity/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CmuxProjectIdentity",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "CmuxProjectIdentity", targets: ["CmuxProjectIdentity"]),
+    ],
+    targets: [
+        .target(
+            name: "CmuxProjectIdentity",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxProjectIdentityTests",
+            dependencies: ["CmuxProjectIdentity"]
+        ),
+    ]
+)

--- a/Packages/CmuxProjectIdentity/Package.swift
+++ b/Packages/CmuxProjectIdentity/Package.swift
@@ -11,7 +11,6 @@ let package = Package(
         .target(
             name: "CmuxProjectIdentity",
             swiftSettings: [
-                .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
             ]

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Locates the highest-resolution `AppIcon` image file inside a project tree.
+struct AppIconImageLocator {
+    private let fileManager: FileManager
+
+    /// Creates a locator. Inject a `FileManager` for testing.
+    init(fileManager: FileManager) { self.fileManager = fileManager }
+
+    /// Returns the URL of the largest rendered icon in the project's `AppIcon`
+    /// asset, or `nil` when no usable `*.appiconset` is found.
+    func bestIconURL(inProjectRoot root: URL) -> URL? {
+        guard let set = appIconSetURL(inRoot: root) else { return nil }
+        return largestImageURL(inAppIconSet: set)
+    }
+
+    private func appIconSetURL(inRoot root: URL) -> URL? {
+        let keys: [URLResourceKey] = [.isDirectoryKey]
+        guard let walker = fileManager.enumerator(
+            at: root, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]
+        ) else { return nil }
+        var candidates: [URL] = []
+        for case let url as URL in walker where url.pathExtension == "appiconset" {
+            candidates.append(url)
+        }
+        // Prefer the set literally named "AppIcon"; then shallowest path.
+        return candidates
+            .sorted { lhs, rhs in
+                let lhsNamed = lhs.deletingPathExtension().lastPathComponent == "AppIcon"
+                let rhsNamed = rhs.deletingPathExtension().lastPathComponent == "AppIcon"
+                if lhsNamed != rhsNamed { return lhsNamed }
+                return lhs.pathComponents.count < rhs.pathComponents.count
+            }
+            .first
+    }
+
+    private func largestImageURL(inAppIconSet set: URL) -> URL? {
+        let contentsURL = set.appendingPathComponent("Contents.json")
+        guard let data = try? Data(contentsOf: contentsURL),
+              let manifest = try? JSONDecoder().decode(AppIconManifest.self, from: data)
+        else { return nil }
+        let best = manifest.images
+            .compactMap { entry -> (URL, Double)? in
+                guard let filename = entry.filename, !filename.isEmpty else { return nil }
+                let url = set.appendingPathComponent(filename)
+                guard fileManager.fileExists(atPath: url.path) else { return nil }
+                return (url, entry.renderedPixelWidth)
+            }
+            .max { $0.1 < $1.1 }
+        return best?.0
+    }
+}
+
+/// Minimal decode of an `.appiconset` `Contents.json`.
+private struct AppIconManifest: Decodable {
+    let images: [Entry]
+    struct Entry: Decodable {
+        let size: String?
+        let scale: String?
+        let filename: String?
+        /// Rendered width in pixels = point size × scale (e.g. 1024×1 = 1024).
+        var renderedPixelWidth: Double {
+            let points = Double(size?.split(separator: "x").first.map(String.init) ?? "") ?? 0
+            let factor = Double(scale?.replacingOccurrences(of: "x", with: "") ?? "1") ?? 1
+            return points * factor
+        }
+    }
+}

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
@@ -10,29 +10,38 @@ struct AppIconImageLocator: @unchecked Sendable {
 
     /// Returns the URL of the largest rendered icon in the project's `AppIcon`
     /// asset, or `nil` when no usable `*.appiconset` is found.
+    ///
+    /// Candidates are tried in preference order and the first one that yields a
+    /// usable image wins, so an empty or image-less `*.appiconset` never shadows
+    /// a populated one elsewhere in the tree.
     func bestIconURL(inProjectRoot root: URL) -> URL? {
-        guard let set = appIconSetURL(inRoot: root) else { return nil }
-        return largestImageURL(inAppIconSet: set)
+        for set in rankedAppIconSetURLs(inRoot: root) {
+            if let url = largestImageURL(inAppIconSet: set) { return url }
+        }
+        return nil
     }
 
-    private func appIconSetURL(inRoot root: URL) -> URL? {
+    private func rankedAppIconSetURLs(inRoot root: URL) -> [URL] {
         let keys: [URLResourceKey] = [.isDirectoryKey]
         guard let walker = fileManager.enumerator(
             at: root, includingPropertiesForKeys: keys, options: [.skipsHiddenFiles]
-        ) else { return nil }
+        ) else { return [] }
         var candidates: [URL] = []
         for case let url as URL in walker where url.pathExtension == "appiconset" {
             candidates.append(url)
         }
-        // Prefer the set literally named "AppIcon"; then shallowest path.
-        return candidates
-            .sorted { lhs, rhs in
-                let lhsNamed = lhs.deletingPathExtension().lastPathComponent == "AppIcon"
-                let rhsNamed = rhs.deletingPathExtension().lastPathComponent == "AppIcon"
-                if lhsNamed != rhsNamed { return lhsNamed }
+        // Prefer the set literally named "AppIcon"; then the shallowest path; then
+        // a stable lexicographic tie-break so selection is deterministic when two
+        // sets are otherwise equal (e.g. iOS vs. Mac targets at the same depth).
+        return candidates.sorted { lhs, rhs in
+            let lhsNamed = lhs.deletingPathExtension().lastPathComponent == "AppIcon"
+            let rhsNamed = rhs.deletingPathExtension().lastPathComponent == "AppIcon"
+            if lhsNamed != rhsNamed { return lhsNamed }
+            if lhs.pathComponents.count != rhs.pathComponents.count {
                 return lhs.pathComponents.count < rhs.pathComponents.count
             }
-            .first
+            return lhs.path < rhs.path
+        }
     }
 
     private func largestImageURL(inAppIconSet set: URL) -> URL? {

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AppIconImageLocator.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// Locates the highest-resolution `AppIcon` image file inside a project tree.
-struct AppIconImageLocator {
+// FileManager is Apple-documented thread-safe; this struct holds no other state.
+struct AppIconImageLocator: @unchecked Sendable {
     private let fileManager: FileManager
 
     /// Creates a locator. Inject a `FileManager` for testing.

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AverageColor.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AverageColor.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Foundation
 
 /// Computes the average color of an image by downsampling it to a single pixel.
 struct AverageColor {
@@ -14,6 +13,7 @@ struct AverageColor {
             space: colorSpace, bitmapInfo: bitmapInfo
         ) else { return nil }
         context.interpolationQuality = .medium
+        // App icons are opaque; for non-opaque inputs, un-premultiply before reading pixel bytes to avoid darker-than-actual values.
         context.draw(image, in: CGRect(x: 0, y: 0, width: 1, height: 1))
         return String(format: "#%02X%02X%02X", pixel[0], pixel[1], pixel[2])
     }

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AverageColor.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/AverageColor.swift
@@ -1,0 +1,20 @@
+import CoreGraphics
+import Foundation
+
+/// Computes the average color of an image by downsampling it to a single pixel.
+struct AverageColor {
+    /// Returns the average color of `image` as a `#RRGGBB` hex string, or `nil`
+    /// if a drawing context could not be created.
+    func hexString(of image: CGImage) -> String? {
+        var pixel: [UInt8] = [0, 0, 0, 0]
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: &pixel, width: 1, height: 1, bitsPerComponent: 8, bytesPerRow: 4,
+            space: colorSpace, bitmapInfo: bitmapInfo
+        ) else { return nil }
+        context.interpolationQuality = .medium
+        context.draw(image, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+        return String(format: "#%02X%02X%02X", pixel[0], pixel[1], pixel[2])
+    }
+}

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentity.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentity.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+/// The resolved visual identity of a project shown in the sidebar.
+///
+/// All fields are value types so the identity can cross actor boundaries.
+/// ``iconPNGData`` is raw PNG bytes (not an `NSImage`) precisely so the value
+/// stays `Sendable`; the UI layer decodes it on the main actor.
+public struct ProjectIdentity: Sendable, Equatable {
+    /// Display name for the project (defaults to the project root folder name).
+    public let projectName: String
+    /// PNG bytes of the app icon, or `nil` when no `AppIcon` asset was found.
+    public let iconPNGData: Data?
+    /// Dominant color of the icon as a `#RRGGBB` hex string, or `nil` if unknown.
+    public let dominantColorHex: String?
+    /// 1–2 letter fallback drawn when ``iconPNGData`` is `nil`.
+    public let monogram: String
+
+    /// Creates a resolved project identity.
+    public init(projectName: String, iconPNGData: Data?, dominantColorHex: String?, monogram: String) {
+        self.projectName = projectName
+        self.iconPNGData = iconPNGData
+        self.dominantColorHex = dominantColorHex
+        self.monogram = monogram
+    }
+}

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentity.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentity.swift
@@ -3,22 +3,22 @@ public import Foundation
 /// The resolved visual identity of a project shown in the sidebar.
 ///
 /// All fields are value types so the identity can cross actor boundaries.
-/// ``iconPNGData`` is raw PNG bytes (not an `NSImage`) precisely so the value
+/// ``iconImageData`` is raw image bytes (not an `NSImage`) precisely so the value
 /// stays `Sendable`; the UI layer decodes it on the main actor.
 public struct ProjectIdentity: Sendable, Equatable {
     /// Display name for the project (defaults to the project root folder name).
     public let projectName: String
-    /// PNG bytes of the app icon, or `nil` when no `AppIcon` asset was found.
-    public let iconPNGData: Data?
+    /// Raw bytes of the app icon image, or `nil` when no `AppIcon` asset was found.
+    public let iconImageData: Data?
     /// Dominant color of the icon as a `#RRGGBB` hex string, or `nil` if unknown.
     public let dominantColorHex: String?
-    /// 1–2 letter fallback drawn when ``iconPNGData`` is `nil`.
+    /// 1–2 letter fallback drawn when ``iconImageData`` is `nil`.
     public let monogram: String
 
     /// Creates a resolved project identity.
-    public init(projectName: String, iconPNGData: Data?, dominantColorHex: String?, monogram: String) {
+    public init(projectName: String, iconImageData: Data?, dominantColorHex: String?, monogram: String) {
         self.projectName = projectName
-        self.iconPNGData = iconPNGData
+        self.iconImageData = iconImageData
         self.dominantColorHex = dominantColorHex
         self.monogram = monogram
     }

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentityResolver.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentityResolver.swift
@@ -1,0 +1,44 @@
+import AppKit
+public import Foundation
+
+/// Resolves the visual identity of a project from its files on disk.
+///
+/// This is a Service: it performs filesystem reads and image decoding off the
+/// main actor, and returns a `Sendable` ``ProjectIdentity``. Construct one at
+/// the app composition root and inject it; do not use a shared instance.
+///
+/// ```swift
+/// let resolver = ProjectIdentityResolver(fileManager: .default)
+/// let identity = await resolver.resolve(projectRootPath: "/path/to/repo")
+/// ```
+public actor ProjectIdentityResolver {
+    private let fileManager: FileManager
+    private let locator: AppIconImageLocator
+    private let averageColor = AverageColor()
+
+    /// Creates a resolver. Inject a `FileManager` for testing.
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        self.locator = AppIconImageLocator(fileManager: fileManager)
+    }
+
+    /// Resolves the identity for the project rooted at `projectRootPath`.
+    ///
+    /// Always returns a value: when no `AppIcon` asset is found, the icon and
+    /// color are `nil` and only the name + ``ProjectMonogram`` are populated.
+    public func resolve(projectRootPath: String) -> ProjectIdentity {
+        let root = URL(fileURLWithPath: projectRootPath, isDirectory: true)
+        let name = root.lastPathComponent
+        let monogram = ProjectMonogram(projectName: name).value
+
+        guard let iconURL = locator.bestIconURL(inProjectRoot: root),
+              let pngData = try? Data(contentsOf: iconURL),
+              let image = NSImage(data: pngData),
+              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        else {
+            return ProjectIdentity(projectName: name, iconPNGData: nil, dominantColorHex: nil, monogram: monogram)
+        }
+        let colorHex = averageColor.hexString(of: cgImage)
+        return ProjectIdentity(projectName: name, iconPNGData: pngData, dominantColorHex: colorHex, monogram: monogram)
+    }
+}

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentityResolver.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectIdentityResolver.swift
@@ -26,19 +26,23 @@ public actor ProjectIdentityResolver {
     ///
     /// Always returns a value: when no `AppIcon` asset is found, the icon and
     /// color are `nil` and only the name + ``ProjectMonogram`` are populated.
-    public func resolve(projectRootPath: String) -> ProjectIdentity {
-        let root = URL(fileURLWithPath: projectRootPath, isDirectory: true)
-        let name = root.lastPathComponent
-        let monogram = ProjectMonogram(projectName: name).value
+    public func resolve(projectRootPath: String) async -> ProjectIdentity {
+        let locator = self.locator
+        let averageColor = self.averageColor
+        return await Task.detached(priority: .utility) {
+            let root = URL(fileURLWithPath: projectRootPath, isDirectory: true)
+            let name = root.lastPathComponent
+            let monogram = ProjectMonogram(projectName: name).value
 
-        guard let iconURL = locator.bestIconURL(inProjectRoot: root),
-              let pngData = try? Data(contentsOf: iconURL),
-              let image = NSImage(data: pngData),
-              let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
-        else {
-            return ProjectIdentity(projectName: name, iconPNGData: nil, dominantColorHex: nil, monogram: monogram)
-        }
-        let colorHex = averageColor.hexString(of: cgImage)
-        return ProjectIdentity(projectName: name, iconPNGData: pngData, dominantColorHex: colorHex, monogram: monogram)
+            guard let iconURL = locator.bestIconURL(inProjectRoot: root),
+                  let imageData = try? Data(contentsOf: iconURL),
+                  let image = NSImage(data: imageData),
+                  let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+            else {
+                return ProjectIdentity(projectName: name, iconImageData: nil, dominantColorHex: nil, monogram: monogram)
+            }
+            let colorHex = averageColor.hexString(of: cgImage)
+            return ProjectIdentity(projectName: name, iconImageData: imageData, dominantColorHex: colorHex, monogram: monogram)
+        }.value
     }
 }

--- a/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectMonogram.swift
+++ b/Packages/CmuxProjectIdentity/Sources/CmuxProjectIdentity/ProjectMonogram.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A short, 1–2 character label derived from a project name, used as the
+/// sidebar avatar when no app icon is available.
+public struct ProjectMonogram: Sendable, Equatable {
+    /// The uppercased monogram (always 1–2 characters, or `"?"` when empty).
+    public let value: String
+
+    /// Derives a monogram from `projectName`.
+    ///
+    /// Splits on `-`, `_`, `.`, and whitespace. With two or more tokens the
+    /// monogram is the first letter of the first two tokens; with one token it
+    /// is that token's first two letters.
+    public init(projectName: String) {
+        let separators = CharacterSet(charactersIn: "-_. ").union(.whitespaces)
+        let tokens = projectName
+            .components(separatedBy: separators)
+            .filter { !$0.isEmpty }
+        if tokens.count >= 2 {
+            let first = tokens[0].prefix(1)
+            let second = tokens[1].prefix(1)
+            value = (first + second).uppercased()
+        } else if let only = tokens.first {
+            value = String(only.prefix(2)).uppercased()
+        } else {
+            value = "?"
+        }
+    }
+}

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AppIconImageLocatorTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AppIconImageLocatorTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import CmuxProjectIdentity
+
+private func makeAppIconFixture() throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("AppIconFixture-\(UUID().uuidString)", isDirectory: true)
+    let set = root.appendingPathComponent("App/Assets.xcassets/AppIcon.appiconset", isDirectory: true)
+    try FileManager.default.createDirectory(at: set, withIntermediateDirectories: true)
+    // two PNGs; the 1024 one must win
+    try Data([0x89]).write(to: set.appendingPathComponent("small.png"))   // 40x40
+    try Data([0x89]).write(to: set.appendingPathComponent("marketing.png")) // 1024x1024
+    let contents = """
+    {"images":[
+      {"size":"20x20","scale":"2x","filename":"small.png"},
+      {"size":"1024x1024","scale":"1x","filename":"marketing.png"}
+    ],"info":{"version":1,"author":"xcode"}}
+    """
+    try contents.write(to: set.appendingPathComponent("Contents.json"), atomically: true, encoding: .utf8)
+    return root
+}
+
+@Test func locatorPicksLargestImage() throws {
+    let root = try makeAppIconFixture()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let url = AppIconImageLocator(fileManager: .default).bestIconURL(inProjectRoot: root)
+    #expect(url?.lastPathComponent == "marketing.png")
+}
+
+@Test func locatorReturnsNilWhenNoAppIconSet() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    #expect(AppIconImageLocator(fileManager: .default).bestIconURL(inProjectRoot: root) == nil)
+}

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AppIconImageLocatorTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AppIconImageLocatorTests.swift
@@ -27,6 +27,32 @@ private func makeAppIconFixture() throws -> URL {
     #expect(url?.lastPathComponent == "marketing.png")
 }
 
+/// Regression: a shallower (or equal-depth) `AppIcon.appiconset` that has no
+/// usable image must NOT shadow a deeper one that does. Mirrors a real project
+/// (FilmLab) that has an empty `FilmLabMac/.../AppIcon.appiconset` alongside a
+/// populated `FilmLab/.../AppIcon.appiconset`.
+@Test func locatorSkipsUnusableAppIconSetShadowingUsableOne() throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("AppIconShadow-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    // Shallow, EMPTY AppIcon.appiconset (no Contents.json, no images).
+    let empty = root.appendingPathComponent("Assets.xcassets/AppIcon.appiconset", isDirectory: true)
+    try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+
+    // Deeper, USABLE AppIcon.appiconset.
+    let good = root.appendingPathComponent("App/Assets.xcassets/AppIcon.appiconset", isDirectory: true)
+    try FileManager.default.createDirectory(at: good, withIntermediateDirectories: true)
+    try Data([0x89]).write(to: good.appendingPathComponent("marketing.png"))
+    let contents = """
+    {"images":[{"size":"1024x1024","scale":"1x","filename":"marketing.png"}],"info":{"version":1,"author":"xcode"}}
+    """
+    try contents.write(to: good.appendingPathComponent("Contents.json"), atomically: true, encoding: .utf8)
+
+    let url = AppIconImageLocator(fileManager: .default).bestIconURL(inProjectRoot: root)
+    #expect(url?.lastPathComponent == "marketing.png")
+}
+
 @Test func locatorReturnsNilWhenNoAppIconSet() throws {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AverageColorTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/AverageColorTests.swift
@@ -1,0 +1,20 @@
+import AppKit
+import Testing
+@testable import CmuxProjectIdentity
+
+private func solidImage(_ color: NSColor, _ side: Int = 16) -> CGImage {
+    let img = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+        color.setFill(); rect.fill(); return true
+    }
+    var r = NSRect(x: 0, y: 0, width: side, height: side)
+    return img.cgImage(forProposedRect: &r, context: nil, hints: nil)!
+}
+
+@Test func averageOfSolidRedIsRed() {
+    let hex = AverageColor().hexString(of: solidImage(.red))
+    #expect(hex == "#FF0000")
+}
+@Test func averageOfSolidBlueIsBlue() {
+    let hex = AverageColor().hexString(of: solidImage(NSColor(srgbRed: 0, green: 0, blue: 1, alpha: 1)))
+    #expect(hex == "#0000FF")
+}

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityResolverTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityResolverTests.swift
@@ -1,0 +1,47 @@
+import AppKit
+import Foundation
+import Testing
+@testable import CmuxProjectIdentity
+
+private func writePNG(_ color: NSColor, to url: URL, side: Int = 32) throws {
+    let img = NSImage(size: NSSize(width: side, height: side), flipped: false) { r in
+        color.setFill(); r.fill(); return true
+    }
+    var rect = NSRect(x: 0, y: 0, width: side, height: side)
+    let cg = img.cgImage(forProposedRect: &rect, context: nil, hints: nil)!
+    let rep = NSBitmapImageRep(cgImage: cg)
+    try rep.representation(using: .png, properties: [:])!.write(to: url)
+}
+
+@Test func resolverReturnsNameMonogramIconAndColor() async throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("cmux", isDirectory: true) // name should be "cmux"
+        .appendingPathComponent("..", isDirectory: true)
+        .appendingPathComponent("RootFix-\(UUID().uuidString)/cmux", isDirectory: true)
+        .standardizedFileURL
+    let set = root.appendingPathComponent("App/Assets.xcassets/AppIcon.appiconset", isDirectory: true)
+    try FileManager.default.createDirectory(at: set, withIntermediateDirectories: true)
+    try writePNG(.red, to: set.appendingPathComponent("icon.png"))
+    try """
+    {"images":[{"size":"1024x1024","scale":"1x","filename":"icon.png"}],"info":{"version":1}}
+    """.write(to: set.appendingPathComponent("Contents.json"), atomically: true, encoding: .utf8)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let resolver = ProjectIdentityResolver(fileManager: .default)
+    let identity = await resolver.resolve(projectRootPath: root.path)
+
+    #expect(identity.projectName == "cmux")
+    #expect(identity.monogram == "CM")
+    #expect(identity.iconPNGData != nil)
+    #expect(identity.dominantColorHex == "#FF0000")
+}
+
+@Test func resolverFallsBackWhenNoIcon() async throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("webapp-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let identity = await ProjectIdentityResolver(fileManager: .default).resolve(projectRootPath: root.path)
+    #expect(identity.iconPNGData == nil)
+    #expect(identity.dominantColorHex == nil)
+    #expect(identity.monogram.count >= 1)
+}

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityResolverTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityResolverTests.swift
@@ -15,10 +15,7 @@ private func writePNG(_ color: NSColor, to url: URL, side: Int = 32) throws {
 
 @Test func resolverReturnsNameMonogramIconAndColor() async throws {
     let root = FileManager.default.temporaryDirectory
-        .appendingPathComponent("cmux", isDirectory: true) // name should be "cmux"
-        .appendingPathComponent("..", isDirectory: true)
         .appendingPathComponent("RootFix-\(UUID().uuidString)/cmux", isDirectory: true)
-        .standardizedFileURL
     let set = root.appendingPathComponent("App/Assets.xcassets/AppIcon.appiconset", isDirectory: true)
     try FileManager.default.createDirectory(at: set, withIntermediateDirectories: true)
     try writePNG(.red, to: set.appendingPathComponent("icon.png"))
@@ -32,7 +29,7 @@ private func writePNG(_ color: NSColor, to url: URL, side: Int = 32) throws {
 
     #expect(identity.projectName == "cmux")
     #expect(identity.monogram == "CM")
-    #expect(identity.iconPNGData != nil)
+    #expect(identity.iconImageData != nil)
     #expect(identity.dominantColorHex == "#FF0000")
 }
 
@@ -41,7 +38,7 @@ private func writePNG(_ color: NSColor, to url: URL, side: Int = 32) throws {
     try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: root) }
     let identity = await ProjectIdentityResolver(fileManager: .default).resolve(projectRootPath: root.path)
-    #expect(identity.iconPNGData == nil)
+    #expect(identity.iconImageData == nil)
     #expect(identity.dominantColorHex == nil)
     #expect(identity.monogram.count >= 1)
 }

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Test
 func projectIdentityIsEquatable() {
-    let a = ProjectIdentity(projectName: "cmux", iconPNGData: nil, dominantColorHex: "#FF0000", monogram: "CM")
-    let b = ProjectIdentity(projectName: "cmux", iconPNGData: nil, dominantColorHex: "#FF0000", monogram: "CM")
+    let a = ProjectIdentity(projectName: "cmux", iconImageData: nil, dominantColorHex: "#FF0000", monogram: "CM")
+    let b = ProjectIdentity(projectName: "cmux", iconImageData: nil, dominantColorHex: "#FF0000", monogram: "CM")
     #expect(a == b)
 }

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectIdentityTests.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Testing
+@testable import CmuxProjectIdentity
+
+@Test
+func projectIdentityIsEquatable() {
+    let a = ProjectIdentity(projectName: "cmux", iconPNGData: nil, dominantColorHex: "#FF0000", monogram: "CM")
+    let b = ProjectIdentity(projectName: "cmux", iconPNGData: nil, dominantColorHex: "#FF0000", monogram: "CM")
+    #expect(a == b)
+}

--- a/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectMonogramTests.swift
+++ b/Packages/CmuxProjectIdentity/Tests/CmuxProjectIdentityTests/ProjectMonogramTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import CmuxProjectIdentity
+
+@Test func monogramSingleWordTakesTwoLetters() {
+    #expect(ProjectMonogram(projectName: "cmux").value == "CM")
+    #expect(ProjectMonogram(projectName: "webapp").value == "WE")
+}
+@Test func monogramMultiWordTakesInitials() {
+    #expect(ProjectMonogram(projectName: "activelens-api").value == "AA")
+    #expect(ProjectMonogram(projectName: "my_cool.app").value == "MC")
+}
+@Test func monogramHandlesShortAndEmpty() {
+    #expect(ProjectMonogram(projectName: "x").value == "X")
+    #expect(ProjectMonogram(projectName: "").value == "?")
+    #expect(ProjectMonogram(projectName: "  - _ ").value == "?")
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9,6 +9,7 @@ import CmuxExtensionSidebarExamples
 import CmuxSettings
 import CmuxSettingsUI
 import CmuxSidebarRemoteRender
+import CmuxProjectIdentity
 import CmuxSwiftRender
 import CmuxSwiftRenderUI
 import CmuxUpdater
@@ -10636,6 +10637,12 @@ struct VerticalTabsSidebar: View {
         initialSidebarFontSize: GhosttyConfig.load().sidebarFontSize
     )
     @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
+    // Off-main-resolved per-project icon/monogram identities. Read purely in
+    // body via `cachedIdentity`; resolution is driven from each row's `.task`
+    // (never from body — snapshot-boundary / no-body-mutation rules).
+    @State private var projectIdentityCache = SidebarProjectIdentityCache(
+        resolver: ProjectIdentityResolver()
+    )
     @State var dragState = SidebarDragState()
     // Bonsplit tab drags arrive through AppKit pasteboard callbacks, not
     // `SidebarDragState`, so they need a separate transient collection flag.
@@ -12717,6 +12724,18 @@ struct VerticalTabsSidebar: View {
             )
         }
 
+        // Per-project identity (sidebar icon/monogram). Read purely here in the
+        // parent body; resolution is kicked off from the row's `.task`. Empty
+        // root → no identity (avoids resolving a bogus path).
+        let projectIdentityRoot = tab.extensionSidebarProjectRootPath ?? tab.currentDirectory
+        let projectIdentity: ProjectIdentity? = projectIdentityRoot.isEmpty
+            ? nil
+            : projectIdentityCache.cachedIdentity(forProjectRoot: projectIdentityRoot)
+        let requestProjectIdentity: () -> Void = { [projectIdentityCache, projectIdentityRoot] in
+            guard !projectIdentityRoot.isEmpty else { return }
+            projectIdentityCache.requestIdentity(forProjectRoot: projectIdentityRoot)
+        }
+
         let row = TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
@@ -12749,6 +12768,9 @@ struct VerticalTabsSidebar: View {
             contextMenuPinState: contextMenuPinState,
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             settings: renderContext.tabItemSettings,
+            projectIdentity: projectIdentity,
+            projectIdentityRoot: projectIdentityRoot,
+            requestProjectIdentity: requestProjectIdentity,
             onContextMenuAppear: onContextMenuAppear,
             onContextMenuDisappear: onContextMenuDisappear
         )
@@ -15202,6 +15224,10 @@ struct SidebarWorkspaceSnapshotBuilder {
     struct Snapshot: Equatable {
         let presentationKey: PresentationKey
         let title: String
+        /// User-assigned rename, if any (overrides the folder name).
+        let customTitle: String?
+        /// Last path component of the project root, used as the default name.
+        let folderName: String?
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
@@ -15231,6 +15257,53 @@ private final class SidebarTabItemContextMenuState: ObservableObject {
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
 
+/// Resolves the sidebar row's primary name: a user rename (custom title) wins,
+/// otherwise the project folder name, falling back to the legacy workspace
+/// title when neither is present.
+enum SidebarWorkspaceDisplayName {
+    static func resolve(customTitle: String?, folderName: String?, fallbackTitle: String) -> String {
+        if let custom = customTitle?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+            return custom
+        }
+        if let folder = folderName?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty {
+            return folder
+        }
+        return fallbackTitle
+    }
+}
+
+/// Leading sidebar glyph for a project: the resolved AppIcon when available,
+/// otherwise a neutral circular monogram fallback. Takes a value snapshot only
+/// (no store reference) so it is safe inside a `LazyVStack` row.
+private struct SidebarProjectIdentityIcon: View {
+    let identity: ProjectIdentity
+    let side: CGFloat
+
+    var body: some View {
+        Group {
+            if let data = identity.iconImageData, let nsImage = NSImage(data: data) {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: side * 0.22, style: .continuous))
+            } else {
+                ZStack {
+                    Circle().fill(Color.secondary.opacity(0.22))
+                    Text(identity.monogram)
+                        .font(.system(size: side * 0.5, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(width: side, height: side)
+        .accessibilityLabel(Text(String(
+            localized: "sidebar.project.icon.accessibilityLabel",
+            defaultValue: "Project icon"
+        )))
+    }
+}
+
 struct TabItemView: View, Equatable {
     private static let workspaceObservationCoalesceInterval: RunLoop.SchedulerTimeType.Stride = .milliseconds(40)
     private static let legacyVMWebSocketDescription = "VM WebSocket PTY"
@@ -15257,7 +15330,9 @@ struct TabItemView: View, Equatable {
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
-        lhs.settings == rhs.settings
+        lhs.settings == rhs.settings &&
+        lhs.projectIdentity == rhs.projectIdentity &&
+        lhs.projectIdentityRoot == rhs.projectIdentityRoot
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing
@@ -15301,6 +15376,15 @@ struct TabItemView: View, Equatable {
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot
     let settings: SidebarTabItemSettingsSnapshot
+    /// Resolved project icon/monogram for this row, or `nil` until it resolves.
+    /// A precomputed value snapshot (parent reads the `@Observable` cache, never
+    /// this row) — snapshot-boundary rule. `requestProjectIdentity` is excluded
+    /// from `==` like the other closures.
+    let projectIdentity: ProjectIdentity?
+    /// Project root key driving resolution; used as the `.task` id so a changed
+    /// directory re-triggers a refresh.
+    let projectIdentityRoot: String
+    let requestProjectIdentity: () -> Void
     /// Called from this row's contextMenu.onAppear so the parent can freeze
     /// `showsModifierShortcutHints` to the value it last passed in. Prevents
     /// modifier-key transitions from flipping the badges on the row sitting
@@ -15651,13 +15735,33 @@ struct TabItemView: View, Equatable {
         let effectiveSubtitle = latestNotificationSubtitle ?? conversationMessageSubtitle
         let detailVisibility = visibleAuxiliaryDetails
         let scaledUnreadBadgeSize = 16 * fontScale
+        let projectIconSide = 48 * fontScale
         let scaledCloseButtonHitSize = max(16, 16 * fontScale)
         let scaledCloseButtonWidth = max(
             SidebarTrailingAccessoryWidthPolicy.closeButtonWidth,
             scaledCloseButtonHitSize
         )
 
-        VStack(alignment: .leading, spacing: 4) {
+        HStack(alignment: .top, spacing: 10) {
+            // Drives off-main resolution from a lifecycle hook (never body).
+            // Keyed on the project root so a changed directory re-resolves.
+            Color.clear
+                .frame(width: 0, height: 0)
+                .task(id: projectIdentityRoot) { requestProjectIdentity() }
+
+            // Large leading project icon, or a neutral placeholder that
+            // reserves the same space until the identity resolves.
+            Group {
+                if let projectIdentity {
+                    SidebarProjectIdentityIcon(identity: projectIdentity, side: projectIconSide)
+                } else {
+                    RoundedRectangle(cornerRadius: projectIconSide * 0.22, style: .continuous)
+                        .fill(Color.secondary.opacity(0.12))
+                        .frame(width: projectIconSide, height: projectIconSide)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 8) {
                 if unreadCount > 0 {
                     ZStack {
@@ -15677,7 +15781,11 @@ struct TabItemView: View, Equatable {
                         .safeHelp(protectedWorkspaceTooltip)
                 }
 
-                Text(workspaceSnapshot.title)
+                Text(SidebarWorkspaceDisplayName.resolve(
+                    customTitle: workspaceSnapshot.customTitle,
+                    folderName: workspaceSnapshot.folderName,
+                    fallbackTitle: workspaceSnapshot.title
+                ))
                     .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(settings.wrapsWorkspaceTitles ? nil : 1)
@@ -15946,6 +16054,7 @@ struct TabItemView: View, Equatable {
                 .font(.system(size: scaledFontSize(10), design: .monospaced))
                 .foregroundColor(activeSecondaryColor(0.75))
                 .lineLimit(1)
+            }
             }
         }
         .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
@@ -16702,9 +16811,16 @@ struct TabItemView: View, Equatable {
             return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
         }()
 
+        let projectRootForFolderName = tab.extensionSidebarProjectRootPath ?? tab.currentDirectory
+        let folderName = projectRootForFolderName.isEmpty
+            ? nil
+            : (projectRootForFolderName as NSString).lastPathComponent.nilIfEmpty
+
         return SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: workspaceSnapshotPresentationKey,
             title: tab.title,
+            customTitle: tab.customTitle,
+            folderName: folderName,
             customDescription: settings.showsWorkspaceDescription ? sidebarVisibleCustomDescription : nil,
             isPinned: tab.isPinned,
             customColorHex: tab.customColor,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15742,15 +15742,12 @@ struct TabItemView: View, Equatable {
             scaledCloseButtonHitSize
         )
 
-        HStack(alignment: .top, spacing: 10) {
-            // Drives off-main resolution from a lifecycle hook (never body).
-            // Keyed on the project root so a changed directory re-resolves.
-            Color.clear
-                .frame(width: 0, height: 0)
-                .task(id: projectIdentityRoot) { requestProjectIdentity() }
-
-            // Large leading project icon, or a neutral placeholder that
-            // reserves the same space until the identity resolves.
+        HStack(alignment: .center, spacing: 10) {
+            // Large leading project icon, vertically centered against the row's
+            // text column, or a neutral placeholder that reserves the same space
+            // until the identity resolves. The `.task` drives
+            // off-main resolution from a lifecycle hook (never body), keyed on the
+            // project root so a changed directory re-resolves.
             Group {
                 if let projectIdentity {
                     SidebarProjectIdentityIcon(identity: projectIdentity, side: projectIconSide)
@@ -15760,6 +15757,7 @@ struct TabItemView: View, Equatable {
                         .frame(width: projectIconSide, height: projectIconSide)
                 }
             }
+            .task(id: projectIdentityRoot) { requestProjectIdentity() }
 
             VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 8) {

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -1,6 +1,8 @@
 extension SidebarWorkspaceSnapshotBuilder.Snapshot {
     struct ContextMenuImmediateFields: Equatable {
         let title: String
+        let customTitle: String?
+        let folderName: String?
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
@@ -9,6 +11,8 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
     var contextMenuImmediateFields: ContextMenuImmediateFields {
         ContextMenuImmediateFields(
             title: title,
+            customTitle: customTitle,
+            folderName: folderName,
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex
@@ -20,6 +24,8 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         return Self(
             presentationKey: snapshot.presentationKey,
             title: snapshot.title,
+            customTitle: snapshot.customTitle,
+            folderName: snapshot.folderName,
             customDescription: snapshot.customDescription,
             isPinned: snapshot.isPinned,
             customColorHex: snapshot.customColorHex,

--- a/Sources/SidebarProjectIdentityCache.swift
+++ b/Sources/SidebarProjectIdentityCache.swift
@@ -1,0 +1,84 @@
+import Foundation
+import CmuxProjectIdentity
+
+/// Main-actor cache of resolved ``ProjectIdentity`` values, keyed by project
+/// root path and invalidated when the project root directory's mtime changes.
+///
+/// The read path is split so it is safe to call from a SwiftUI `body`:
+/// ``cachedIdentity(forProjectRoot:)`` is a pure lookup (no side effects), while
+/// ``requestIdentity(forProjectRoot:)`` schedules off-main resolution and must be
+/// driven from a lifecycle hook (e.g. `.task`/`.onAppear`), never from `body`.
+/// A completed resolution publishes through `@Observable`, triggering a re-render.
+@MainActor
+@Observable
+final class SidebarProjectIdentityCache {
+    private struct Entry {
+        let identity: ProjectIdentity
+        let mtime: Date?
+    }
+
+    private let resolver: ProjectIdentityResolver
+    private let fileManager: FileManager
+    private var entries: [String: Entry] = [:]
+    private var inFlight: Set<String> = []
+
+    /// Creates a cache with the given resolver and file manager.
+    ///
+    /// - Parameters:
+    ///   - resolver: The `ProjectIdentityResolver` used for off-main resolution.
+    ///   - fileManager: Injected `FileManager`; defaults to `.default`.
+    init(resolver: ProjectIdentityResolver, fileManager: FileManager = .default) {
+        self.resolver = resolver
+        self.fileManager = fileManager
+    }
+
+    /// Pure read: returns the cached identity for `root`, or `nil` if none has
+    /// resolved yet. Does no file I/O and schedules no work, so it is safe to
+    /// call from a SwiftUI `body`. A stale value (after the project root changed)
+    /// is returned as-is so the UI degrades gracefully until a refresh lands.
+    func cachedIdentity(forProjectRoot root: String) -> ProjectIdentity? {
+        entries[root]?.identity
+    }
+
+    /// Schedules off-main resolution for `root` when no fresh entry is cached.
+    ///
+    /// Drive this from a lifecycle hook (`.task`/`.onAppear`), never from `body`.
+    /// A no-op when a fresh (matching-mtime) entry already exists or a resolution
+    /// is already in flight. The completed value publishes through `@Observable`.
+    func requestIdentity(forProjectRoot root: String) {
+        let currentMtime = appIconMTime(forProjectRoot: root)
+        if let entry = entries[root], entry.mtime == currentMtime {
+            return  // already fresh
+        }
+        scheduleResolve(root: root, mtime: currentMtime)
+    }
+
+    /// Test seam: resolves, stores, and returns the identity — awaitable by callers.
+    @discardableResult
+    func resolvedIdentity(forProjectRoot root: String) async -> ProjectIdentity {
+        let mtime = appIconMTime(forProjectRoot: root)
+        let identity = await resolver.resolve(projectRootPath: root)
+        entries[root] = Entry(identity: identity, mtime: mtime)
+        return identity
+    }
+
+    // MARK: - Private
+
+    private func scheduleResolve(root: String, mtime: Date?) {
+        guard !inFlight.contains(root) else { return }
+        inFlight.insert(root)
+        Task { @MainActor in
+            let identity = await resolver.resolve(projectRootPath: root)
+            entries[root] = Entry(identity: identity, mtime: mtime)
+            inFlight.remove(root)
+        }
+    }
+
+    private func appIconMTime(forProjectRoot root: String) -> Date? {
+        // Use the project root dir mtime as a cheap staleness key.
+        // AppIcon edits bump an ancestor directory's mtime on save, which is
+        // good enough to invalidate the cached identity.
+        let attrs = try? fileManager.attributesOfItem(atPath: root)
+        return attrs?[.modificationDate] as? Date
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		C47110020000000000000003 /* ProcessPipeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47110020000000000000002 /* ProcessPipeReader.swift */; };
 		A5C0DE0000000000000000BA /* ProjectBuildSettingsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0DE0000000000000000B9 /* ProjectBuildSettingsTabView.swift */; };
 		A5C0DE0000000000000000B6 /* ProjectFilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0DE0000000000000000B5 /* ProjectFilesTabView.swift */; };
+		5C1DCA00000000000000F012 /* ProjectIdentityFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1DCA00000000000000F011 /* ProjectIdentityFixture.swift */; };
 		A5C0DE0000000000000000B2 /* ProjectPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0DE0000000000000000B1 /* ProjectPanel.swift */; };
 		A5C0DE0000000000000000B4 /* ProjectPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0DE0000000000000000B3 /* ProjectPanelView.swift */; };
 		A5C0DE0000000000000000BC /* ProjectSchemesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C0DE0000000000000000BB /* ProjectSchemesTabView.swift */; };
@@ -568,6 +569,8 @@
 		CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
 		EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1F00000000000000000002 /* SidebarPathFormatter.swift */; };
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
+		5C1DCA00000000000000F002 /* SidebarProjectIdentityCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1DCA00000000000000F001 /* SidebarProjectIdentityCache.swift */; };
+		5C1DCA00000000000000F022 /* SidebarProjectIdentityCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1DCA00000000000000F021 /* SidebarProjectIdentityCacheTests.swift */; };
 		C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */; };
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
 		B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
@@ -1235,6 +1238,7 @@
 		C47110020000000000000002 /* ProcessPipeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessPipeReader.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000B9 /* ProjectBuildSettingsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectBuildSettingsTabView.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000B5 /* ProjectFilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectFilesTabView.swift; sourceTree = "<group>"; };
+		5C1DCA00000000000000F011 /* ProjectIdentityFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectIdentityFixture.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000B1 /* ProjectPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectPanel.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000B3 /* ProjectPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectPanelView.swift; sourceTree = "<group>"; };
 		A5C0DE0000000000000000BB /* ProjectSchemesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ProjectSchemesTabView.swift; sourceTree = "<group>"; };
@@ -1320,6 +1324,8 @@
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
 		EA1F00000000000000000002 /* SidebarPathFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarPathFormatter.swift; sourceTree = "<group>"; };
 		C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPortDisplayText.swift; sourceTree = "<group>"; };
+		5C1DCA00000000000000F001 /* SidebarProjectIdentityCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProjectIdentityCache.swift; sourceTree = "<group>"; };
+		5C1DCA00000000000000F021 /* SidebarProjectIdentityCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProjectIdentityCacheTests.swift; sourceTree = "<group>"; };
 		C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarProviderMenuRegressionTests.swift; sourceTree = "<group>"; };
 		B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPullRequestInteractivityUITests.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
@@ -1967,6 +1973,7 @@
 				A9F100000000000000000002 /* AgentExecutableResolverError.swift */,
 				A9F100000000000000000003 /* AgentSessionDebugMenuButtons.swift */,
 				A9F100000000000000000004 /* AgentSessionLaunchPlan.swift */,
+				5C1DCA00000000000000F001 /* SidebarProjectIdentityCache.swift */,
 				A9F100000000000000000005 /* CmuxRuntimeDebugCapture.swift */,
 				A9F100000000000000000006 /* CmuxRuntimeDebugCaptureConfiguration.swift */,
 				A9F10000000000000000001A /* CmuxRuntimeDebugCaptureSender.swift */,
@@ -2172,6 +2179,8 @@
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 				D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
 				A9E010000000000000000005 /* AgentExecutableResolverTests.swift */,
+				5C1DCA00000000000000F011 /* ProjectIdentityFixture.swift */,
+				5C1DCA00000000000000F021 /* SidebarProjectIdentityCacheTests.swift */,
 				A9E030000000000000000001 /* AgentSessionSocketSurfaceTests.swift */,
 				A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */,
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
@@ -3046,6 +3055,7 @@
 				D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */,
 				EA1F00000000000000000001 /* SidebarPathFormatter.swift in Sources */,
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
+				5C1DCA00000000000000F002 /* SidebarProjectIdentityCache.swift in Sources */,
 				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				C9A57511C9A57511C9A57511 /* SidebarScrollViewConfigurator.swift in Sources */,
 				E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,
@@ -3363,6 +3373,7 @@
 					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
 				C135190000000000000000A1 /* PreferredEditorSettingsTests.swift in Sources */,
 				C47110010000000000000001 /* ProcessPipeReadCrashRegressionTests.swift in Sources */,
+				5C1DCA00000000000000F012 /* ProjectIdentityFixture.swift in Sources */,
 					F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */,
 					F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,
 					F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
@@ -3386,6 +3397,7 @@
 				51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */,
 				385C6BA7E78DB87460E5D930 /* SidebarMarkdownRendererTests.swift in Sources */,
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
+				5C1DCA00000000000000F022 /* SidebarProjectIdentityCacheTests.swift in Sources */,
 				C0DE48000000000000000001 /* SidebarProviderMenuRegressionTests.swift in Sources */,
 				C9A57513C9A57513C9A57513 /* SidebarScrollViewConfiguratorTests.swift in Sources */,
 				D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -199,6 +199,8 @@
 		3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */ = {isa = PBXBuildFile; productRef = 3069F1D10000000000000006 /* CMUXPasteboardFidelity */; };
 		C8000303C8000303C8000303 /* CmuxProcess in Frameworks */ = {isa = PBXBuildFile; productRef = C8000302C8000302C8000302 /* CmuxProcess */; };
 		C8000304C8000304C8000304 /* CmuxProcess in Frameworks */ = {isa = PBXBuildFile; productRef = C8000302C8000302C8000302 /* CmuxProcess */; };
+		E1F2A3B4C5D6E7F800000003 /* CmuxProjectIdentity in Frameworks */ = {isa = PBXBuildFile; productRef = E1F2A3B4C5D6E7F800000002 /* CmuxProjectIdentity */; };
+		E1F2A3B4C5D6E7F800000004 /* CmuxProjectIdentity in Frameworks */ = {isa = PBXBuildFile; productRef = E1F2A3B4C5D6E7F800000002 /* CmuxProjectIdentity */; };
 		A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */ = {isa = PBXBuildFile; productRef = A5C0DE0000000000000000A2 /* CMUXProjectModel */; };
 		A9F200000000000000000005 /* CmuxRuntimeDebugCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000005 /* CmuxRuntimeDebugCapture.swift */; };
 		A9F200000000000000000006 /* CmuxRuntimeDebugCaptureConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000006 /* CmuxRuntimeDebugCaptureConfiguration.swift */; };
@@ -1507,6 +1509,7 @@
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
 				3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */,
 				C8000303C8000303C8000303 /* CmuxProcess in Frameworks */,
+				E1F2A3B4C5D6E7F800000003 /* CmuxProjectIdentity in Frameworks */,
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
 				CD0CFE5300000000CD0CFE53 /* CmuxSettings in Frameworks */,
 				CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */,
@@ -1567,6 +1570,7 @@
 			files = (
 				5E2701040000000000000004 /* CmuxFoundation in Frameworks */,
 				EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */,
+				E1F2A3B4C5D6E7F800000004 /* CmuxProjectIdentity in Frameworks */,
 				C52830000000000000000002 /* CmuxTerminalCopyMode in Frameworks */,
 				5E2701040000000000000003 /* Sentry in Frameworks */,
 			);
@@ -2389,6 +2393,7 @@
 				F53000A2A1B2C3D4E5F60718 /* CMUXAgentVault */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				A5354305A5354305A5354305 /* CmuxSocketControl */,
+				E1F2A3B4C5D6E7F800000002 /* CmuxProjectIdentity */,
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
 				C5A1FED000000000000000C3 /* CmuxSwiftRender */,
 				C5A1FED100000000000000D3 /* CmuxSwiftRenderUI */,
@@ -2491,6 +2496,7 @@
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C52830000000000000000004 /* CmuxTerminalCopyMode */,
+				E1F2A3B4C5D6E7F800000002 /* CmuxProjectIdentity */,
 				5E2701040000000000000001 /* Sentry */,
 				5E2701040000000000000002 /* CmuxFoundation */,
 			);
@@ -2553,6 +2559,7 @@
 				A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */,
+				E1F2A3B4C5D6E7F800000001 /* XCLocalSwiftPackageReference "CmuxProjectIdentity" */,
 				C52830000000000000000003 /* XCLocalSwiftPackageReference "CmuxTerminalCopyMode" */,
 				C5A1FED000000000000000C4 /* XCLocalSwiftPackageReference "CmuxSwiftRender" */,
 				C5A1FED100000000000000D4 /* XCLocalSwiftPackageReference "CmuxSwiftRenderUI" */,
@@ -3857,6 +3864,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSocketControl;
 		};
+		E1F2A3B4C5D6E7F800000001 /* XCLocalSwiftPackageReference "CmuxProjectIdentity" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxProjectIdentity;
+		};
 		A5B00001A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXAgentLaunch" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXAgentLaunch;
@@ -4043,6 +4054,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5354304A5354304A5354304 /* XCLocalSwiftPackageReference "CmuxSocketControl" */;
 			productName = CmuxSocketControl;
+		};
+		E1F2A3B4C5D6E7F800000002 /* CmuxProjectIdentity */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E1F2A3B4C5D6E7F800000001 /* XCLocalSwiftPackageReference "CmuxProjectIdentity" */;
+			productName = CmuxProjectIdentity;
 		};
 		C52830000000000000000004 /* CmuxTerminalCopyMode */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmuxTests/ProjectIdentityFixture.swift
+++ b/cmuxTests/ProjectIdentityFixture.swift
@@ -1,0 +1,70 @@
+import AppKit
+import Foundation
+
+/// Creates a temporary project root directory containing an `AppIcon.appiconset`
+/// with a real PNG image and a matching `Contents.json`. Used by app-target tests
+/// that need a well-formed project tree to exercise `SidebarProjectIdentityCache`
+/// and related types.
+///
+/// Each helper is a free file-private function, matching the pattern used in
+/// `AgentExecutableResolverTests.swift`.
+
+/// Returns a temporary project root whose `lastPathComponent` equals `name` and
+/// whose `App/Assets.xcassets/AppIcon.appiconset/` contains a solid-red PNG icon
+/// and a corresponding `Contents.json`.
+func makeRootWithRedIcon(named name: String) throws -> URL {
+    let tempParent = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ProjectIdentityFixture-\(UUID().uuidString)", isDirectory: true)
+    let root = tempParent.appendingPathComponent(name, isDirectory: true)
+    let set = root.appendingPathComponent(
+        "App/Assets.xcassets/AppIcon.appiconset", isDirectory: true)
+    try FileManager.default.createDirectory(at: set, withIntermediateDirectories: true)
+
+    // Write a real 32×32 red PNG so NSImage + AverageColor work end-to-end.
+    let iconURL = set.appendingPathComponent("icon.png")
+    try writeSolidColorPNG(.red, to: iconURL, side: 32)
+
+    let contents = """
+    {"images":[{"size":"1024x1024","scale":"1x","filename":"icon.png"}],"info":{"version":1,"author":"xcode"}}
+    """
+    try contents.write(
+        to: set.appendingPathComponent("Contents.json"),
+        atomically: true,
+        encoding: .utf8)
+
+    return root
+}
+
+/// Removes the temporary directory tree created by `makeRootWithRedIcon(named:)`.
+/// Silently ignores errors (the directory may already have been removed).
+func cleanupProjectIdentityFixture(_ root: URL) {
+    // Remove the parent temp directory (one level above the named root).
+    let parent = root.deletingLastPathComponent()
+    try? FileManager.default.removeItem(at: parent)
+}
+
+// MARK: - Private helpers
+
+private func writeSolidColorPNG(_ color: NSColor, to url: URL, side: Int) throws {
+    let img = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+        color.setFill()
+        rect.fill()
+        return true
+    }
+    var rect = NSRect(x: 0, y: 0, width: side, height: side)
+    guard
+        let cgImage = img.cgImage(forProposedRect: &rect, context: nil, hints: nil)
+    else {
+        throw FixtureError.cgImageUnavailable
+    }
+    let rep = NSBitmapImageRep(cgImage: cgImage)
+    guard let pngData = rep.representation(using: .png, properties: [:]) else {
+        throw FixtureError.pngRepresentationFailed
+    }
+    try pngData.write(to: url)
+}
+
+private enum FixtureError: Error {
+    case cgImageUnavailable
+    case pngRepresentationFailed
+}

--- a/cmuxTests/SidebarProjectIdentityCacheTests.swift
+++ b/cmuxTests/SidebarProjectIdentityCacheTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+import CmuxProjectIdentity
+
+// MARK: - SidebarWorkspaceDisplayName
+
+/// The sidebar row's primary name defaults to the project folder name and is
+/// overridden by a user rename (custom title), falling back to the legacy
+/// workspace title only when neither is available.
+@Test func displayNameUsesFolderNameWhenNoCustomTitle() {
+    #expect(
+        SidebarWorkspaceDisplayName.resolve(
+            customTitle: nil, folderName: "my-project", fallbackTitle: "zsh"
+        ) == "my-project")
+}
+
+@Test func displayNamePrefersCustomTitleOverFolderName() {
+    #expect(
+        SidebarWorkspaceDisplayName.resolve(
+            customTitle: "Renamed", folderName: "my-project", fallbackTitle: "zsh"
+        ) == "Renamed")
+}
+
+@Test func displayNameTreatsBlankCustomTitleAsAbsent() {
+    #expect(
+        SidebarWorkspaceDisplayName.resolve(
+            customTitle: "   ", folderName: "my-project", fallbackTitle: "zsh"
+        ) == "my-project")
+}
+
+@Test func displayNameFallsBackToTitleWhenNoFolderName() {
+    #expect(
+        SidebarWorkspaceDisplayName.resolve(
+            customTitle: nil, folderName: nil, fallbackTitle: "zsh"
+        ) == "zsh")
+}
+
+@MainActor
+@Test func resolvedIdentityResolvesAndStoresIdentity() async throws {
+    let root = try makeRootWithRedIcon(named: "cmux")
+    defer { cleanupProjectIdentityFixture(root) }
+
+    let cache = SidebarProjectIdentityCache(
+        resolver: ProjectIdentityResolver(fileManager: .default))
+
+    // Await the test-seam helper: resolves and stores synchronously.
+    let identity = await cache.resolvedIdentity(forProjectRoot: root.path)
+    #expect(identity.projectName == "cmux")
+
+    // After resolution, the pure accessor should return the cached value.
+    #expect(cache.cachedIdentity(forProjectRoot: root.path)?.projectName == "cmux")
+}
+
+/// `cachedIdentity(forProjectRoot:)` is a pure read: it returns `nil` on a miss
+/// and must NOT schedule any resolution (so it is safe to call from a SwiftUI
+/// `body`). We assert nothing ever lands after a quiet period.
+@MainActor
+@Test func cachedIdentityIsPureReadAndDoesNotResolve() async throws {
+    let root = try makeRootWithRedIcon(named: "cmux")
+    defer { cleanupProjectIdentityFixture(root) }
+
+    let cache = SidebarProjectIdentityCache(
+        resolver: ProjectIdentityResolver(fileManager: .default))
+
+    #expect(cache.cachedIdentity(forProjectRoot: root.path) == nil)
+    // Give any (erroneously) scheduled resolve time to land.
+    try await Task.sleep(nanoseconds: 50_000_000)
+    #expect(cache.cachedIdentity(forProjectRoot: root.path) == nil)
+}
+
+/// `requestIdentity(forProjectRoot:)` schedules off-main resolution; afterwards
+/// the pure accessor returns the stored value.
+@MainActor
+@Test func requestIdentityResolvesAndPopulatesCache() async throws {
+    let root = try makeRootWithRedIcon(named: "cmux")
+    defer { cleanupProjectIdentityFixture(root) }
+
+    let cache = SidebarProjectIdentityCache(
+        resolver: ProjectIdentityResolver(fileManager: .default))
+
+    cache.requestIdentity(forProjectRoot: root.path)
+
+    var identity = cache.cachedIdentity(forProjectRoot: root.path)
+    var tries = 0
+    while identity == nil && tries < 200 {
+        try await Task.sleep(nanoseconds: 5_000_000)
+        identity = cache.cachedIdentity(forProjectRoot: root.path)
+        tries += 1
+    }
+    #expect(identity?.projectName == "cmux")
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -93,6 +93,8 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         customDescription: String? = nil,
         isPinned: Bool = false,
         customColorHex: String? = nil,
+        customTitle: String? = nil,
+        folderName: String? = nil,
         remoteConnectionStatusText: String = "Disconnected",
         latestConversationMessage: String? = nil,
         listeningPorts: [Int] = []
@@ -100,6 +102,8 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: presentationKey ?? Self.presentationKey(),
             title: title,
+            customTitle: customTitle,
+            folderName: folderName,
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex,


### PR DESCRIPTION
## Why

Workspaces in the sidebar are hard to tell apart at a glance — every row looks the same, so recognising and navigating between projects relies entirely on reading the title text. This adds a per-project **visual identity** (the project's own app icon, with sensible fallbacks) plus a **folder-name title** so each workspace is instantly recognizable.

## What

- **Project icon in each sidebar row** — a large (48×48) leading icon, vertically centered against the row's text column:
  - the project's `AppIcon` asset when one is found on disk,
  - otherwise a neutral circular **monogram** derived from the project name.
- **Title defaults to the project folder name** (last path component of the project root), still overridable by the existing workspace rename (`customTitle`).
- All the previous row detail (description, metadata, logs, progress, branch/dir, PRs, ports) is unchanged — the icon is added to the left, nothing is removed.

## How

New self-contained Swift package **`CmuxProjectIdentity`** (pure value types + a Service):

- `ProjectIdentity` value (name, icon bytes, dominant color, monogram).
- `ProjectIdentityResolver` actor — off-main filesystem read + image decode, always returns a value.
- `AppIconImageLocator`, `AverageColor`, `ProjectMonogram` helpers.

App-side wiring respects the sidebar performance rules:

- `SidebarProjectIdentityCache` (`@MainActor @Observable`) lives at the sidebar composition root, **read purely** in the parent body via `cachedIdentity(forProjectRoot:)`; resolution is driven **off-body** from each row's `.task` via `requestIdentity(...)`. This keeps `TabItemView` within the snapshot-boundary / no-body-mutation rules (rows receive an immutable `ProjectIdentity?` value, added to `==`).
- `customTitle` / `folderName` added to the sidebar snapshot so rename reflects immediately; `SidebarWorkspaceDisplayName.resolve(...)` picks rename → folder name → legacy title.

## Notable fix

`AppIconImageLocator` previously committed to a single `*.appiconset` (by name, then shallowest path) and returned `nil` if it had no image — so a project with an empty/image-less `AppIcon.appiconset` at equal/shallower depth (e.g. an iOS app with both an empty Mac iconset and a populated iOS one) resolved **no icon, non-deterministically**. It now iterates ranked candidates and returns the first that yields a usable image, with a deterministic lexicographic tie-break.

## Testing

- Package tests (`CmuxProjectIdentityTests`): locator (incl. the shadowing regression), monogram, average color, resolver, identity.
- App tests (`cmuxTests`, wired into `cmux.xcodeproj`): cache pure-read / off-main resolve behavior, and `SidebarWorkspaceDisplayName` resolution (folder name default, rename override, blank handling).
- TDD red→green throughout; localized icon accessibility label (en + ja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783793296&installation_id=133855650&pr_number=5901&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5901&signature=1452c6628ec6614342984419b13ea0415fbc640630f8545fcf260ce36759e59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project icons now display in the sidebar for each project, with initials shown as fallback when no icon is available.
  * Project display names resolve from custom titles, folder names, or fallback values for improved identification.
  * Project identity information is cached to enhance performance.

* **Localization**
  * Added English and Japanese accessibility labels for project icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project identity to the sidebar: each workspace shows its app icon (or a monogram fallback) and defaults the title to the project folder name for quick recognition. Implemented via a new `CmuxProjectIdentity` package and a cache that resolves icons off the main thread without mutating view bodies.

- **New Features**
  - 48×48 leading project icon per row (uses AppIcon if available; otherwise a neutral monogram). Includes localized a11y label (en/ja).
  - Row title resolves as rename (`customTitle`) → folder name → legacy title; updates immediately via snapshot.
  - New `CmuxProjectIdentity` package (`ProjectIdentity`, `ProjectIdentityResolver`, icon lookup, average color) wired through `SidebarProjectIdentityCache` (pure read in parent body; resolution driven from each row’s `.task`).
  - Tests added for locator, monogram, average color, resolver, cache, and display-name logic.

- **Bug Fixes**
  - App icon selection no longer fails when an empty `AppIcon.appiconset` shadows a populated one; ranked candidates are tried until a usable image is found with deterministic tie-breaks.

<sup>Written for commit 68fbe666f81b8861778dbd4b95406812c46f4620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

