### PR TITLE
Use symbol form for `depends_on macos:` in Homebrew cask templates

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -97,14 +97,14 @@ jobs:
             url "https://github.com/manaflow-ai/cmux/releases/download/v#{version}/cmux-macos.dmg"
             name "cmux"
             desc "Lightweight native macOS terminal with vertical tabs for AI coding agents"
-            homepage "https://cmux.com"
+            homepage "https://cmux.com/"
 
             livecheck do
               url :url
               strategy :github_latest
             end
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
 
             app "cmux.app"
             binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -180,14 +180,14 @@ cask "cmux" do
   url "https://github.com/manaflow-ai/cmux/releases/download/v#{version}/cmux-macos.dmg"
   name "cmux"
   desc "Lightweight native macOS terminal with vertical tabs for AI coding agents"
-  homepage "https://github.com/manaflow-ai/cmux"
+  homepage "https://cmux.com/"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :sonoma
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
## Summary

Fixes the Homebrew deprecation warning from #5877:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.

Homebrew's cask DSL now parses `depends_on macos:` via `MacOSRequirement.parse(args, comparator: ">=")`, so the bare symbol `:sonoma` means **Sonoma or newer** — identical semantics to the old `">= :sonoma"` string form, without the deprecation.

The deprecated line is regenerated on every release, so the fix lands in all three sites:

- **`homebrew-cmux` tap** (`Casks/cmux.rb`) — fixed and already pushed to the tap's `main` ([`7501cea`](https://github.com/manaflow-ai/homebrew-cmux/commit/7501cea)); this PR bumps the submodule pointer. Users' next `brew update` clears the warning.
- **`.github/workflows/update-homebrew.yml`** — the CI generator that rewrites the cask after each release.
- **`scripts/build-sign-upload.sh`** — the local-release generator. Its template had also drifted (`">= :ventura"`, GitHub homepage); synced it to the canonical template (`:sonoma` matches the app's `MACOSX_DEPLOYMENT_TARGET = 14.0`, homepage `https://cmux.com/`).

Also added the trailing slash to the homepage in all three places per brew's `Cask/HomepageUrlStyling` lint. Both templates now produce byte-identical casks (modulo version/sha) matching the live tap, so the next release won't churn the cask.

## Validation

- `brew style homebrew-cmux/Casks/cmux.rb` passes (exit 0; only a pre-existing `Cask/Desc` nit about "macOS" in the description remains — product wording, left out of scope).
- DSL evaluation via `brew ruby` + `Cask::CaskLoader::FromPathLoader` parses the new form as `comparator=">=" version=14` — empirically confirms "Sonoma or newer" is preserved.
- `bash -n scripts/build-sign-upload.sh` passes; the workflow edit is inside a literal heredoc (no YAML structure change), and its `sed` indent-strip still applies (line keeps the 10-space heredoc prefix).
- Submodule commit pushed to the tap's remote `main` before the pointer bump (`git merge-base --is-ancestor` verified).

## Localization audit

No user-facing app strings changed — only Homebrew cask metadata and release templates. No `Resources/Localizable.xcstrings` or `web/messages/*` impact.

Fixes #5877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783795409&installation_id=133855650&pr_number=5902&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5902&signature=58c0cb9dfcd900f18df234fdd5745c97943d3f3dfae6c4a1818627bab477d3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Homebrew cask templates to the symbol form for `depends_on macos:` to remove the deprecation warning while keeping “Sonoma or newer” behavior. Also align the generators with the live tap and fix the homepage URL style. Fixes #5877.

- **Bug Fixes**
  - Replace `">= :sonoma"`/`">= :ventura"` with `:sonoma` in `.github/workflows/update-homebrew.yml` and `scripts/build-sign-upload.sh` (same >= Sonoma semantics).
  - Update `homebrew-cmux` submodule to the cask with the same change.
  - Set homepage to `https://cmux.com/` to satisfy `Cask/HomepageUrlStyling` and keep generators in sync with the tap.

<sup>Written for commit 9cd472a6b20c4cd0bfd3f56e0f34dba6f9cd052c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Homebrew cask formula configuration and metadata.
  * Changed homepage URL to cmux.com.
  * Updated macOS version requirements in cask dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->