### PR TITLE
Fix iOS CI false-green: align manual-pairing tests with encrypted-route restriction, catch Swift Testing failures in success override

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -233,9 +233,14 @@ jobs:
           XCODEBUILD_ARGS+=(test)
           selected_tests_passed_despite_xcodebuild_status() {
             local log_path="$1"
+            # The negative grep must catch BOTH XCTest failure output and Swift
+            # Testing failure output (✘ markers): the final "Failing tests:"
+            # section is not always flushed into the tee'd log, and without the
+            # ✘ patterns a real Swift Testing failure exiting 65 was
+            # misclassified as a runner cleanup failure and turned the job green.
             grep -Eq "Test Suite 'Selected tests' passed|Test Suite 'cmuxUITests' passed" "$log_path" &&
               grep -Eq "Executed [1-9][0-9]* tests, with 0 failures \\(0 unexpected\\)" "$log_path" &&
-              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)" "$log_path"
+              ! grep -Eq "Test Suite '.*' failed|Test Case '.*' failed|Assertion Failure|Failing tests:|with [1-9][0-9]* failures|with [0-9]+ failures \\([1-9][0-9]* unexpected\\)|✘ Test|✘ Suite" "$log_path"
           }
           for attempt in 1 2; do
             LOG_PATH="/tmp/cmux-ios-${{ matrix.family }}-attempt-${attempt}.log"

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -528,11 +528,11 @@ final class TerminalOutputCollector {
 }
 
 @MainActor
-@Test func manualHostPairingUsesNetworkRouteForPrivateLANIPWithStackAuth() async throws {
-    let responses = ScriptedTransportResponses([
-        try rpcErrorFrame(code: "method_not_found", message: "unknown method"),
-        try rpcWorkspaceListFrame(workspaceID: "lan-workspace", title: "LAN Workspace"),
-    ])
+@Test func manualHostPairingRejectsPrivateLANIPWithoutSendingStackToken() async throws {
+    // Plain private-LAN routes are dialed over unencrypted TCP, so
+    // routeAllowsStackAuth excludes them: pairing must fail before any RPC
+    // (and the Stack bearer token) leaves the device.
+    let responses = ScriptedTransportResponses([])
     let runtime = testRuntime(
         supportedRouteKinds: [.tailscale],
         transportFactory: ScriptedTransportFactory(responses: responses),
@@ -543,30 +543,20 @@ final class TerminalOutputCollector {
     store.signIn()
     await store.connectManualHost(name: "Studio LAN", host: " 192.168.1.77 ", port: 15432)
 
-    let route = try #require(store.activeRoute)
-    #expect(store.phase == .workspaces)
-    #expect(store.connectionState == .connected)
-    #expect(store.connectionError == nil)
-    #expect(store.connectedHostName == "Studio LAN")
-    if case let .hostPort(host, port) = route.endpoint {
-        #expect(host == "192.168.1.77")
-        #expect(port == 15432)
-    } else {
-        Issue.record("manual LAN route should use host/port")
-    }
-    #expect(route.kind == .tailscale)
-    let requests = try await responses.sentRequests()
-    #expect(requests.map(\.method) == ["mobile.attach_ticket.create", "workspace.list"])
-    #expect(requests.allSatisfy { $0.stackAccessToken == "stack-token-for-lan" })
-    #expect(requests.allSatisfy { $0.attachToken == nil })
+    #expect(store.phase == .pairing)
+    #expect(store.connectionState == .disconnected)
+    #expect(store.activeTicket == nil)
+    #expect(store.activeRoute == nil)
+    #expect(store.connectionError == "This pairing route is not allowed. Enter a host and port, or pair with a QR/link from that computer.")
+    #expect(try await responses.sentRequests().isEmpty)
 }
 
 @MainActor
-@Test func manualHostPairingUsesNetworkRouteForLocalDNSNameWithStackAuth() async throws {
-    let responses = ScriptedTransportResponses([
-        try rpcErrorFrame(code: "method_not_found", message: "unknown method"),
-        try rpcWorkspaceListFrame(workspaceID: "local-dns-workspace", title: "Local DNS Workspace"),
-    ])
+@Test func manualHostPairingRejectsLocalDNSNameWithoutSendingStackToken() async throws {
+    // `.local`/Bonjour hosts are dialed over unencrypted TCP, so
+    // routeAllowsStackAuth excludes them: pairing must fail before any RPC
+    // (and the Stack bearer token) leaves the device.
+    let responses = ScriptedTransportResponses([])
     let runtime = testRuntime(
         supportedRouteKinds: [.tailscale],
         transportFactory: ScriptedTransportFactory(responses: responses),
@@ -577,26 +567,19 @@ final class TerminalOutputCollector {
     store.signIn()
     await store.connectManualHost(name: "", host: "devbox.local", port: 61234)
 
-    let route = try #require(store.activeRoute)
-    #expect(store.phase == .workspaces)
-    #expect(store.connectionState == .connected)
-    #expect(store.connectionError == nil)
-    #expect(store.connectedHostName == "devbox.local")
-    if case let .hostPort(host, port) = route.endpoint {
-        #expect(host == "devbox.local")
-        #expect(port == 61234)
-    } else {
-        Issue.record("manual local DNS route should use host/port")
-    }
-    #expect(route.kind == .tailscale)
-    let requests = try await responses.sentRequests()
-    #expect(requests.map(\.method) == ["mobile.attach_ticket.create", "workspace.list"])
-    #expect(requests.allSatisfy { $0.stackAccessToken == "stack-token-for-local-dns" })
-    #expect(requests.allSatisfy { $0.attachToken == nil })
+    #expect(store.phase == .pairing)
+    #expect(store.connectionState == .disconnected)
+    #expect(store.activeTicket == nil)
+    #expect(store.activeRoute == nil)
+    #expect(store.connectionError == "This pairing route is not allowed. Enter a host and port, or pair with a QR/link from that computer.")
+    #expect(try await responses.sentRequests().isEmpty)
 }
 
 @MainActor
-@Test func manualHostPairingProbesLANHostForAttachTicketBeforeStackAuthFallback() async throws {
+@Test func manualHostPairingProbesTailscaleHostForAttachTicketBeforeStackAuthFallback() async throws {
+    // A trusted (Tailscale) manual host is probed for a real attach ticket
+    // first; an older Mac that does not implement the probe method falls back
+    // to a synthetic ticket and Stack-authenticated workspace.list.
     let responses = ScriptedTransportResponses([
         try rpcErrorFrame(code: "method_not_found", message: "unknown method"),
         try rpcWorkspaceListFrame(workspaceID: "manual-workspace", title: "Manual Workspace"),
@@ -609,12 +592,12 @@ final class TerminalOutputCollector {
     let store = CMUXMobileShellStore.preview(runtime: runtime)
 
     store.signIn()
-    await store.connectManualHost(name: "Studio LAN", host: "192.168.1.77", port: 15432)
+    await store.connectManualHost(name: "Work Mac", host: "100.71.210.41", port: 15432)
 
     #expect(store.phase == .workspaces)
     #expect(store.connectionState == .connected)
     #expect(store.connectionError == nil)
-    #expect(store.connectedHostName == "Studio LAN")
+    #expect(store.connectedHostName == "Work Mac")
     let requests = try await responses.sentRequests()
     #expect(requests.map(\.method) == ["mobile.attach_ticket.create", "workspace.list"])
     #expect(requests.allSatisfy { $0.stackAccessToken == "stack-token-for-fallback" })
@@ -1375,11 +1358,11 @@ final class TerminalOutputCollector {
 }
 
 @MainActor
-@Test func manualHostPairingUsesNetworkRouteForDefaultPortLANHostWithStackAuth() async throws {
-    let responses = ScriptedTransportResponses([
-        try rpcErrorFrame(code: "method_not_found", message: "unknown method"),
-        try rpcWorkspaceListFrame(workspaceID: "default-port-lan-workspace", title: "Default Port LAN Workspace"),
-    ])
+@Test func manualHostPairingRejectsDefaultPortLANHostWithoutSendingStackToken() async throws {
+    // Same encrypted-routes-only contract as the explicit-port LAN test, on
+    // the default host port: no RPC (and no Stack bearer token) may leave the
+    // device for a plain-TCP private-LAN route.
+    let responses = ScriptedTransportResponses([])
     let runtime = testRuntime(
         supportedRouteKinds: [.tailscale],
         transportFactory: ScriptedTransportFactory(responses: responses),
@@ -1390,16 +1373,12 @@ final class TerminalOutputCollector {
     store.signIn()
     await store.connectManualHost(name: "Work Mac", host: "192.168.1.77", port: CmxMobileDefaults.defaultHostPort)
 
-    #expect(store.phase == .workspaces)
-    #expect(store.connectionState == .connected)
-    #expect(store.connectionError == nil)
-    #expect(store.connectedHostName == "Work Mac")
-    let route = try #require(store.activeRoute)
-    #expect(route.kind == .tailscale)
-    let requests = try await responses.sentRequests()
-    #expect(requests.map(\.method) == ["mobile.attach_ticket.create", "workspace.list"])
-    #expect(requests.allSatisfy { $0.stackAccessToken == "stack-token-for-default-lan" })
-    #expect(requests.allSatisfy { $0.attachToken == nil })
+    #expect(store.phase == .pairing)
+    #expect(store.connectionState == .disconnected)
+    #expect(store.activeTicket == nil)
+    #expect(store.activeRoute == nil)
+    #expect(store.connectionError == "This pairing route is not allowed. Enter a host and port, or pair with a QR/link from that computer.")
+    #expect(try await responses.sentRequests().isEmpty)
 }
 
 @MainActor


### PR DESCRIPTION
Two test/CI-only fixes extracted from https://github.com/manaflow-ai/cmux/pull/5726 so every open iOS branch can rebase onto them instead of re-fixing divergently.

**The bug:** https://github.com/manaflow-ai/cmux/commit/d7ee59384 (June 4, restrict Stack token to encrypted routes — correct security fix) updated the policy unit tests but left four cmuxFeatureTests auth-contract tests asserting the OLD contract (Stack token sent over plain-TCP LAN/.local manual routes). They have failed deterministically since, throwing insecureManualRoute before any request is sent. Nobody noticed because the ios-simulator workflow's success-override grep only recognizes XCTest failure formats, not Swift Testing's ✘ output — so the jobs false-greened (verified: the green iphone job on the merged https://github.com/manaflow-ai/cmux/pull/5876 run shows the identical 4 failures, 12 issues, exit 65, TEST FAILED in its log).

**Fixes:**
1. Rewrite the three LAN/.local tests as rejection-contract tests (pairing fails before any RPC leaves the device, actionable error surfaced, zero requests recorded) and repoint the probe-fallback test at a Tailscale host so the method_not_found → synthetic-ticket path keeps coverage.
2. Add Swift Testing's ✘ Test/✘ Suite markers to the negative grep in test-ios.yml so the success override can never mask Swift Testing failures again.

**Residual:** the loophole existed since June 4; other iOS test failures may have slipped onto main in that window. Audit queued separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783806292&installation_id=133855650&pr_number=5906&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5906&signature=7667b13fef31a54725d26fe4679ca11b7d4feb37fb216819b606d7df8ca09a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI workflow changes only; no production pairing or auth logic is modified in this PR.
> 
> **Overview**
> Fixes **iOS CI false greens** and brings **manual-host pairing feature tests** in line with the existing encrypted-route Stack-auth policy (no app behavior changes in this diff).
> 
> The `test-ios.yml` success-override helper now treats Swift Testing failures (`✘ Test` / `✘ Suite`) like XCTest failures, so exit 65 with real test failures cannot be misread as simulator cleanup and pass the job.
> 
> In `cmuxFeatureTests`, three LAN / `.local` manual-pairing cases are rewritten to assert **rejection before any RPC** (pairing phase, actionable error, zero recorded requests). The attach-ticket probe fallback test now uses a **Tailscale IP** host instead of a private LAN address so `method_not_found` → Stack-auth fallback coverage remains on a trusted route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c78606d7cd98b65993f8dbdec87dc88a0b7ddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix iOS CI false greens and align manual pairing tests with the encrypted-route-only policy. Failing simulator runs now fail, and tests no longer expect Stack auth over plain LAN/.local routes.

- **Bug Fixes**
  - CI: include Swift Testing "✘ Test"/"✘ Suite" markers in the negative grep in `test-ios.yml` so failures aren’t masked by the success override.
  - Tests: convert LAN/.local manual-pairing cases to rejection (no RPCs, no Stack token, clear error) and repoint the probe→fallback test to a Tailscale host to keep coverage.

<sup>Written for commit c5c78606d7cd98b65993f8dbdec87dc88a0b7ddf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated iOS feature tests to enforce stricter encryption requirements for untrusted targets.

* **Chores**
  * Enhanced iOS test workflow to improve failure detection in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->