### PR TITLE
iOS: park notification-tap deep links until the workspace can be navigated to

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
@@ -49,4 +49,14 @@ extension CMUXMobileShellStore {
         }
         return workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
     }
+
+    /// The workspace whose terminal list contains `terminalID`, if any.
+    func workspaceID(forTerminalID terminalID: String) -> MobileWorkspacePreview.ID? {
+        for workspace in workspaces {
+            if workspace.terminals.contains(where: { $0.id.rawValue == terminalID }) {
+                return workspace.id
+            }
+        }
+        return nil
+    }
 }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
@@ -1,0 +1,52 @@
+public import CmuxMobileShellModel
+public import Foundation
+
+/// A one-shot "actually navigate to this workspace" intent from a
+/// notification-tap deep link.
+///
+/// Setting `selectedWorkspaceID` alone is not enough on the compact (iPhone)
+/// layout: the shell's `NavigationStack` deliberately ignores selection
+/// changes while its path is empty so the attach-time auto-selection cannot
+/// yank the user off the workspace list. A deep link must push, so it carries
+/// this explicit request, which the shell consumes exactly once. The token
+/// makes repeated taps on the same workspace distinguishable.
+public struct DeeplinkWorkspaceNavigationRequest: Equatable, Sendable {
+    public let token: UUID
+    public let workspaceID: MobileWorkspacePreview.ID
+}
+
+extension CMUXMobileShellStore {
+    /// Select `id` and ask the shell to navigate to it (push the compact
+    /// stack). Called by the push coordinator when a parked notification tap
+    /// resolves; the workspace is expected to exist in ``workspaces``.
+    public func navigateToWorkspaceForDeeplink(_ id: MobileWorkspacePreview.ID) {
+        selectedWorkspaceID = id
+        deeplinkWorkspaceNavigationRequest = DeeplinkWorkspaceNavigationRequest(
+            token: UUID(),
+            workspaceID: id
+        )
+    }
+
+    /// Hand the pending deep-link navigation intent to the shell and clear it
+    /// so a later layout remount cannot replay a stale push.
+    public func consumeDeeplinkWorkspaceNavigationRequest() -> MobileWorkspacePreview.ID? {
+        defer { deeplinkWorkspaceNavigationRequest = nil }
+        return deeplinkWorkspaceNavigationRequest?.workspaceID
+    }
+
+    /// The workspace whose terminal list contains `surfaceID`, if any. Used by
+    /// the push coordinator to resolve surface-only notification deep links to
+    /// a navigable workspace, and to keep a tap parked until the terminal's
+    /// snapshot has arrived.
+    public func workspaceID(containingSurfaceID surfaceID: String) -> MobileWorkspacePreview.ID? {
+        workspaceID(forTerminalID: surfaceID)
+    }
+
+    /// Whether `surfaceID` is a terminal of the workspace `workspaceID`.
+    public func workspace(_ workspaceID: MobileWorkspacePreview.ID, containsSurfaceID surfaceID: String) -> Bool {
+        guard let workspace = workspaces.first(where: { $0.id == workspaceID }) else {
+            return false
+        }
+        return workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -177,7 +177,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return Self.attachTicketIsUnexpired(activeTicket, now: runtime?.now() ?? Date())
     }
     public var pairingCode: String
-    public var workspaces: [MobileWorkspacePreview]
+    public var workspaces: [MobileWorkspacePreview] {
+        didSet { workspaceTopologyVersion &+= 1 }
+    }
+    /// Bumped on every ``workspaces`` mutation: a cheap "workspace/terminal
+    /// lists may have changed" signal (e.g. for retrying a parked notification
+    /// deep link) that avoids allocating ID arrays per body evaluation.
+    public private(set) var workspaceTopologyVersion: UInt64 = 0
     /// Whether the connected Mac advertises the `workspace.actions.v1` capability
     /// (rename/pin over the mobile RPC). `false` until host status is read, and
     /// for older Macs that lack the handler, so the UI can hide rename/pin rather
@@ -2319,6 +2325,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         selectedTerminalID = id
     }
 
+    /// One-shot "actually navigate" deep-link intent; API in
+    /// `MobileShellComposite+DeeplinkNavigation.swift` (storage must live here).
+    public internal(set) var deeplinkWorkspaceNavigationRequest: DeeplinkWorkspaceNavigationRequest?
+
     /// Selects `id` as a chrome action (the terminal picker), so the surface
     /// that comes up does not grab the keyboard.
     ///
@@ -4199,7 +4209,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    private func workspaceID(forTerminalID terminalID: String) -> MobileWorkspacePreview.ID? {
+    func workspaceID(forTerminalID terminalID: String) -> MobileWorkspacePreview.ID? {
         for workspace in workspaces {
             if workspace.terminals.contains(where: { $0.id.rawValue == terminalID }) {
                 return workspace.id

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -180,9 +180,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public var workspaces: [MobileWorkspacePreview] {
         didSet { workspaceTopologyVersion &+= 1 }
     }
-    /// Bumped on every ``workspaces`` mutation: a cheap "workspace/terminal
-    /// lists may have changed" signal (e.g. for retrying a parked notification
-    /// deep link) that avoids allocating ID arrays per body evaluation.
+    /// Bumped on every ``workspaces`` mutation: a cheap "lists may have
+    /// changed" signal (e.g. for retrying a parked notification deep link).
     public private(set) var workspaceTopologyVersion: UInt64 = 0
     /// Whether the connected Mac advertises the `workspace.actions.v1` capability
     /// (rename/pin over the mobile RPC). `false` until host status is read, and
@@ -4207,15 +4206,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 _ = self.disconnectForAuthorizationFailureIfNeeded(error)
             }
         }
-    }
-
-    func workspaceID(forTerminalID terminalID: String) -> MobileWorkspacePreview.ID? {
-        for workspace in workspaces {
-            if workspace.terminals.contains(where: { $0.id.rawValue == terminalID }) {
-                return workspace.id
-            }
-        }
-        return nil
     }
 
     private func handleTerminalRenderGridEvent(_ event: MobileEventEnvelope) {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -88,10 +88,12 @@ struct CMUXMobileRootView: View {
             reconnectStoredMacIfNeeded()
         }
         #if os(iOS)
-        // A notification tap can arrive before the workspace it targets is
-        // loaded (cold launch, or attach still in flight); re-apply the parked
-        // deep link as the list fills in.
-        .onChange(of: store.workspaces.map(\.id)) { _, _ in
+        // A notification tap can arrive before the workspace (or terminal) it
+        // targets is loaded (cold launch, or attach still in flight); re-apply
+        // the parked deep link as the lists fill in. The version counter is a
+        // cheap change signal: it bumps on any workspace or terminal list
+        // mutation without allocating ID arrays on every body evaluation.
+        .onChange(of: store.workspaceTopologyVersion) { _, _ in
             pushCoordinator.workspacesDidChange()
         }
         #endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -87,6 +87,14 @@ struct CMUXMobileRootView: View {
             // nothing ever resolves `didFinishStoredMacReconnectAttempt`.
             reconnectStoredMacIfNeeded()
         }
+        #if os(iOS)
+        // A notification tap can arrive before the workspace it targets is
+        // loaded (cold launch, or attach still in flight); re-apply the parked
+        // deep link as the list fills in.
+        .onChange(of: store.workspaces.map(\.id)) { _, _ in
+            pushCoordinator.workspacesDidChange()
+        }
+        #endif
         .onChange(of: scenePhase) { _, phase in
             guard phase == .active else { return }
             store.resumeForegroundRefresh()

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
@@ -187,14 +187,39 @@ public final class MobilePushCoordinator {
             return
         }
         guard let store else { return }
+
+        // Resolve the workspace to navigate to: the explicit target, or for a
+        // surface-only tap the workspace that owns the terminal. Unresolvable
+        // means "not loaded yet": stay parked for the next topology change so
+        // the tap is never spent on a selection that cannot navigate.
+        let workspaceTarget: MobileWorkspacePreview.ID
         if let workspaceId = pending.workspaceId {
-            let target = MobileWorkspacePreview.ID(rawValue: workspaceId)
-            // Wait for the attach to deliver the workspace; selecting an
-            // absent ID would not navigate and a later list load could not
-            // re-trigger the push.
-            guard store.workspaces.contains(where: { $0.id == target }) else { return }
-            store.selectedWorkspaceID = target
+            workspaceTarget = MobileWorkspacePreview.ID(rawValue: workspaceId)
+            guard store.workspaces.contains(where: { $0.id == workspaceTarget }) else { return }
+        } else if let surfaceId = pending.surfaceId {
+            guard let owner = store.workspaceID(containingSurfaceID: surfaceId) else { return }
+            workspaceTarget = owner
+        } else {
+            pendingDeeplink = nil
+            return
         }
+
+        if let surfaceId = pending.surfaceId,
+           !store.workspace(workspaceTarget, containsSurfaceID: surfaceId) {
+            // The workspace is here but its terminal snapshot is not (still
+            // loading, or the terminal was closed). Land the user in the right
+            // workspace now and keep only the surface part parked so it can
+            // resolve if the terminal arrives, bounded by the same expiry.
+            store.navigateToWorkspaceForDeeplink(workspaceTarget)
+            pendingDeeplink = PendingDeeplink(
+                workspaceId: nil,
+                surfaceId: surfaceId,
+                createdAt: pending.createdAt
+            )
+            return
+        }
+
+        store.navigateToWorkspaceForDeeplink(workspaceTarget)
         if let surfaceId = pending.surfaceId {
             store.selectTerminal(MobileTerminalPreview.ID(rawValue: surfaceId))
         }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
@@ -30,6 +30,25 @@ public final class MobilePushCoordinator {
 
     @ObservationIgnored private weak var store: CMUXMobileShellStore?
 
+    /// A tap whose navigation could not complete yet. On a cold launch the
+    /// notification-center delegate delivers the tap before the root view has
+    /// mounted (no store bound yet), and even once bound the tapped workspace
+    /// is not in the store until the Mac attach finishes. The tap is parked
+    /// here and re-applied from ``bind(store:)`` and ``workspacesDidChange()``
+    /// until the target exists or the request expires.
+    private struct PendingDeeplink {
+        let workspaceId: String?
+        let surfaceId: String?
+        let createdAt: Date
+    }
+
+    @ObservationIgnored private var pendingDeeplink: PendingDeeplink?
+    /// Bounded so a tap from long ago cannot yank the user out of whatever
+    /// they navigated to in the meantime, but generous enough to cover cold
+    /// launch plus sign-in plus a slow attach.
+    private static let pendingDeeplinkLifetime: TimeInterval = 120
+    @ObservationIgnored private let now: () -> Date
+
     /// Creates a push coordinator.
     /// - Parameters:
     ///   - registration: The injected push-registration service.
@@ -37,14 +56,18 @@ public final class MobilePushCoordinator {
     ///     ``NoopAnalytics`` for previews/tests.
     ///   - defaults: The store backing the opt-in flag (must match the suite the
     ///     registration service uses). Defaults to `.standard`.
+    ///   - now: Clock seam for the pending-deeplink expiry. Defaults to
+    ///     `Date.init`.
     public init(
         registration: any PushRegistering,
         analytics: any AnalyticsEmitting = NoopAnalytics(),
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init
     ) {
         self.registration = registration
         self.analytics = analytics
         self.defaults = defaults
+        self.now = now
     }
 
     /// Whether the user has opted into phone notifications (synchronous mirror).
@@ -53,6 +76,14 @@ public final class MobilePushCoordinator {
     /// Point routing at the active store (called by the root view on appear).
     public func bind(store: CMUXMobileShellStore) {
         self.store = store
+        applyPendingDeeplinkIfReady()
+    }
+
+    /// Re-apply a parked notification tap once its target can exist. Called by
+    /// the root view whenever the store's workspace list changes (the list is
+    /// empty until the Mac attach completes).
+    public func workspacesDidChange() {
+        applyPendingDeeplinkIfReady()
     }
 
     /// Install the notification-center delegate and, if already opted in,
@@ -130,20 +161,47 @@ public final class MobilePushCoordinator {
     }
 
     /// Deep-link to the workspace/terminal a tapped notification refers to.
+    ///
+    /// The tap is parked first and applied through one path: a cold launch
+    /// delivers the tap before the root view has bound a store, and a
+    /// warm-but-detached app has not loaded the workspace yet. Navigating
+    /// immediately in those states is what stranded users on the workspaces
+    /// home screen.
     public func handleTap(workspaceId: String?, surfaceId: String?) {
-        guard let store else {
-            analytics.capture("ios_push_deeplink_failed", ["reason": .string("no_store")])
+        pendingDeeplink = PendingDeeplink(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            createdAt: now()
+        )
+        applyPendingDeeplinkIfReady()
+    }
+
+    /// Apply the parked tap if its target can be navigated to right now;
+    /// otherwise keep it parked for the next ``bind(store:)`` or
+    /// ``workspacesDidChange()``.
+    private func applyPendingDeeplinkIfReady() {
+        guard let pending = pendingDeeplink else { return }
+        guard now().timeIntervalSince(pending.createdAt) < Self.pendingDeeplinkLifetime else {
+            pendingDeeplink = nil
+            analytics.capture("ios_push_deeplink_failed", ["reason": .string("expired")])
             return
         }
-        if let workspaceId {
-            store.selectedWorkspaceID = MobileWorkspacePreview.ID(rawValue: workspaceId)
+        guard let store else { return }
+        if let workspaceId = pending.workspaceId {
+            let target = MobileWorkspacePreview.ID(rawValue: workspaceId)
+            // Wait for the attach to deliver the workspace; selecting an
+            // absent ID would not navigate and a later list load could not
+            // re-trigger the push.
+            guard store.workspaces.contains(where: { $0.id == target }) else { return }
+            store.selectedWorkspaceID = target
         }
-        if let surfaceId {
+        if let surfaceId = pending.surfaceId {
             store.selectTerminal(MobileTerminalPreview.ID(rawValue: surfaceId))
         }
+        pendingDeeplink = nil
         analytics.capture("ios_push_deeplink_resolved", [
-            "resolved_workspace": .bool(workspaceId != nil),
-            "resolved_surface": .bool(surfaceId != nil),
+            "resolved_workspace": .bool(pending.workspaceId != nil),
+            "resolved_surface": .bool(pending.surfaceId != nil),
         ])
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -47,6 +47,19 @@ struct WorkspaceShellView: View {
             }
             compactNavigationPath = [selectedWorkspaceID]
         }
+        // A notification-tap deep link must actually navigate, not just mark a
+        // selection: on the compact stack an empty path ignores selection
+        // changes by design (the attach-time auto-selection must not yank the
+        // user off the home list), so the deep link carries an explicit
+        // one-shot push intent. Consumed on change and on mount in case the
+        // request landed before this view appeared.
+        .onChange(of: store.deeplinkWorkspaceNavigationRequest) { _, request in
+            guard request != nil else { return }
+            consumeDeeplinkNavigationRequestIfNeeded()
+        }
+        .onAppear {
+            consumeDeeplinkNavigationRequestIfNeeded()
+        }
         .accessibilityIdentifier("MobileWorkspaceShell")
         .overlay(alignment: .top) {
             MobileConnectionRecoveryBanner(store: store, signOut: signOut)
@@ -137,6 +150,19 @@ struct WorkspaceShellView: View {
         .navigationSplitViewStyle(.balanced)
         .onAppear {
             hasPresentedSplitDetail = true
+        }
+    }
+
+    /// Apply (and clear) a pending deep-link navigation intent. On the compact
+    /// stack this pushes the workspace; on the split layout the store's
+    /// selection already presents the detail column, so consuming just clears
+    /// the request so a later size-class change cannot replay a stale push.
+    private func consumeDeeplinkNavigationRequestIfNeeded() {
+        guard store.deeplinkWorkspaceNavigationRequest != nil else { return }
+        guard let workspaceID = store.consumeDeeplinkWorkspaceNavigationRequest() else { return }
+        guard usesCompactStack else { return }
+        if compactNavigationPath.last != workspaceID {
+            compactNavigationPath = [workspaceID]
         }
     }
 

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -3523,3 +3523,45 @@ private func rpcErrorFrame(code: String? = nil, message: String) throws -> Data 
     let envelopeData = try JSONSerialization.data(withJSONObject: envelope)
     return try MobileSyncFrameCodec.encodeFrame(envelopeData)
 }
+
+// MARK: - Push notification deep-link
+
+/// Inert registration stub: deep-link tests exercise tap routing only.
+private struct InertPushRegistration: PushRegistering {
+    var isEnabled: Bool {
+        get async { false }
+    }
+    func setEnabled(_ enabled: Bool) async {}
+    func register(deviceToken: Data) async {}
+    func syncTokenIfPossible() async {}
+    func unregisterFromServer() async {}
+}
+
+@MainActor private func deeplinkTestStore() -> CMUXMobileShellStore {
+    CMUXMobileShellStore(
+        runtime: testRuntime(
+            transportFactory: RecordingNeverConnectTransportFactory(dials: TransportDialRecorder())
+        ),
+        reachability: OfflineReachability()
+    )
+}
+
+/// Cold launch from a notification tap: `didReceive` fires before the root
+/// view has mounted, so no store is bound yet. The tap must survive until the
+/// store binds and its workspace list loads, then navigate. Pre-fix the tap
+/// was dropped (`reason: no_store`) and the user landed on the workspaces
+/// home screen.
+@Test @MainActor func notificationTapBeforeStoreBindsNavigatesOnceWorkspacesLoad() async throws {
+    let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
+
+    // Tap arrives first: nothing is bound.
+    coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: "terminal-notes")
+
+    // Root view mounts: store binds already carrying the attached list.
+    let store = deeplinkTestStore()
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.bind(store: store)
+
+    #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
+    #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
+}

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -3603,3 +3603,69 @@ private struct InertPushRegistration: PushRegistering {
     #expect(store.selectedWorkspaceID == nil)
     #expect(store.selectedTerminalID == nil)
 }
+
+/// A surface-only tap (no workspaceId in the payload) must wait for the
+/// terminal's owning workspace to load, then navigate to that workspace and
+/// select the terminal. Pre-fix it bypassed the membership gate: the terminal
+/// was selected against an empty store and the tap was discarded with no
+/// retry, stranding the user on the home screen.
+@Test @MainActor func surfaceOnlyNotificationTapWaitsForOwningWorkspace() async throws {
+    let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
+    let store = deeplinkTestStore()
+    coordinator.bind(store: store)
+
+    coordinator.handleTap(workspaceId: nil, surfaceId: "terminal-notes")
+    // Nothing loaded yet: the tap must stay parked, not be spent.
+    #expect(store.selectedTerminalID == nil)
+
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.workspacesDidChange()
+
+    #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
+    #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
+}
+
+/// The workspace snapshot can arrive before its terminal list fills in. The
+/// tap lands the user in the right workspace immediately and keeps the
+/// terminal part parked, selecting it when its snapshot arrives instead of
+/// pointing the store at a non-existent surface.
+@Test @MainActor func notificationTapKeepsTerminalParkedUntilItsSnapshotArrives() async throws {
+    let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
+    let store = deeplinkTestStore()
+    coordinator.bind(store: store)
+
+    coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: "terminal-notes")
+    store.workspaces = [
+        MobileWorkspacePreview(id: "workspace-docs", name: "Docs", terminals: [])
+    ]
+    coordinator.workspacesDidChange()
+
+    // Workspace navigation happens now; the absent terminal is not selected.
+    #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
+    #expect(store.selectedTerminalID == nil)
+
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.workspacesDidChange()
+
+    #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
+}
+
+/// A resolved tap must emit the one-shot navigation intent the compact
+/// (iPhone) shell consumes to push its `NavigationStack`: selection alone
+/// leaves an empty path untouched by design, which is what stranded
+/// cold-launch taps on the workspaces home screen.
+@Test @MainActor func notificationTapEmitsConsumableCompactNavigationIntent() async throws {
+    let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
+    let store = deeplinkTestStore()
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.bind(store: store)
+
+    coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: nil)
+
+    let target = MobileWorkspacePreview.ID(rawValue: "workspace-docs")
+    #expect(store.deeplinkWorkspaceNavigationRequest?.workspaceID == target)
+    #expect(store.consumeDeeplinkWorkspaceNavigationRequest() == target)
+    // One-shot: a later layout remount cannot replay a stale push.
+    #expect(store.deeplinkWorkspaceNavigationRequest == nil)
+    #expect(store.consumeDeeplinkWorkspaceNavigationRequest() == nil)
+}

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -3565,3 +3565,41 @@ private struct InertPushRegistration: PushRegistering {
     #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
     #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
 }
+
+/// Tap lands while the store is bound but the Mac attach has not delivered
+/// the workspace list yet: the deep link applies when the list fills in,
+/// driven by the root view's workspace-list change hook.
+@Test @MainActor func notificationTapBeforeAttachAppliesWhenWorkspaceArrives() async throws {
+    let coordinator = MobilePushCoordinator(registration: InertPushRegistration())
+    let store = deeplinkTestStore()
+    coordinator.bind(store: store)
+
+    coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: "terminal-notes")
+    // Target not loaded yet: no navigation to an absent workspace.
+    #expect(store.selectedWorkspaceID == nil)
+
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.workspacesDidChange()
+
+    #expect(store.selectedWorkspaceID == MobileWorkspacePreview.ID(rawValue: "workspace-docs"))
+    #expect(store.selectedTerminalID == MobileTerminalPreview.ID(rawValue: "terminal-notes"))
+}
+
+/// A parked tap expires: navigating minutes later would yank the user out of
+/// whatever they moved on to.
+@Test @MainActor func notificationTapExpiresInsteadOfNavigatingLate() async throws {
+    nonisolated(unsafe) var currentTime = Date(timeIntervalSince1970: 1_000_000)
+    let coordinator = MobilePushCoordinator(
+        registration: InertPushRegistration(),
+        now: { currentTime }
+    )
+    coordinator.handleTap(workspaceId: "workspace-docs", surfaceId: "terminal-notes")
+
+    currentTime = currentTime.addingTimeInterval(121)
+    let store = deeplinkTestStore()
+    store.workspaces = PreviewMobileHost.workspaces
+    coordinator.bind(store: store)
+
+    #expect(store.selectedWorkspaceID == nil)
+    #expect(store.selectedTerminalID == nil)
+}


### PR DESCRIPTION
Fixes Lawrence's beta report: tapping a push notification opened the app at the workspaces home screen instead of the workspace the notification was about.

**Root cause.** On a cold launch `UNUserNotificationCenter`'s `didReceive` delivers the tap before the root view has mounted, so `MobilePushCoordinator.handleTap` hit its `guard let store` and silently dropped the deep link (`ios_push_deeplink_failed reason=no_store`). `bind(store:)` only happens in the root view's `.onAppear`. Warm-app taps mostly worked, which made the bug look intermittent. Secondary gap: a tap while the Mac attach is still in flight targeted a workspace not yet present in `store.workspaces`.

**Fix.** The tap is parked in the coordinator and applied through one path: `bind(store:)` and a new `workspacesDidChange()` hook the root view drives from workspace-list changes. Application is membership-gated (never select an absent workspace) and bounded by a 120s expiry (injected `now()` seam) so a stale tap cannot yank the user away from what they navigated to in the meantime.

**Red/green.** Commit https://github.com/manaflow-ai/cmux/commit/1c10afc13 adds the failing cold-start test (tap before bind must navigate once the store binds with its list); commit https://github.com/manaflow-ai/cmux/commit/68fb6e5b3 adds the fix plus coverage for tap-during-attach and expiry. Tests live in cmuxFeatureTests (Swift Testing, runs in the ios-simulator CI job — the honest one post https://github.com/manaflow-ai/cmux/pull/5906; CmuxMobileShellUI cannot `swift test` on macOS due to the pre-existing platform-floor mismatch).

iOS arm64 simulator build green (`/tmp/cmux-ios-ndl`). No user-facing strings changed, so no localization changes (audit: diff adds code and doc comments only).

Residual: navigation while attach is in flight briefly shows the default workspace before the parked tap applies on list arrival (one onChange turn); if the tapped workspace was deleted on the Mac, the tap expires quietly after 120s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783816971&installation_id=133855650&pr_number=5927&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5927&signature=f2085f76d661f8347ce197443d48c3a0a6d169106d2858a7bec17c9a2ef06cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mobile navigation and push routing across cold launch and attach timing; behavior is well-tested but wrong gating could still mis-route or drop taps.
> 
> **Overview**
> **Notification taps are parked and applied when navigation is actually possible**, instead of failing when no store is bound or the workspace list is still empty.
> 
> `MobilePushCoordinator` queues each tap and retries from `bind(store:)` and `workspacesDidChange()` (driven by a new `workspaceTopologyVersion` on workspace list mutations). Resolution is **membership-gated** (workspace must exist; surface-only taps resolve via owning workspace), can **split workspace vs terminal** when the workspace snapshot arrives before its terminals, and **expires after 120s** so stale taps do not hijack navigation later.
> 
> For **iPhone compact layout**, selection alone no longer suffices: the store emits a **one-shot** `DeeplinkWorkspaceNavigationRequest` that `WorkspaceShellView` consumes to push the `NavigationStack`, matching the existing behavior that ignores selection while the path is empty.
> 
> New Swift Testing coverage in `cmuxFeatureTests` exercises cold launch before bind, pre-attach, surface-only taps, workspace-before-terminal, compact navigation intent, and expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b493b1bb2080c56fd2dc14f5f15e880cde80c961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS push notification deep links so a tap opens the correct workspace/terminal across cold launch and iPhone’s compact layout. Taps are parked and applied when ready; deep links now push the compact stack via a one‑shot intent, and stale taps expire after 120s.

- **Bug Fixes**
  - Park taps and apply through one path on `bind(store:)` and `workspacesDidChange()`.
  - Resolve surface‑only taps to the terminal’s owning workspace; if the workspace arrives before its terminal, navigate now and keep only the terminal part parked.
  - Emit a one‑shot deep‑link navigation intent that `WorkspaceShellView` consumes to push the compact `NavigationStack`.
  - Only navigate when the target exists; never select an absent ID.
  - Drive re-apply using a lightweight `workspaceTopologyVersion` change signal.
  - Tests cover cold launch, before‑attach, surface‑only, workspace‑before‑terminal, and expiry.

- **Refactors**
  - Moved `workspaceID(forTerminalID:)` into the deep‑link extension to keep `MobileShellComposite` within its size budget.

<sup>Written for commit b493b1bb2080c56fd2dc14f5f15e880cde80c961. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App consumes one‑shot deep‑link requests and updates the compact navigation stack when appropriate.
  * Views and coordinator react to workspace/terminal list topology changes so deferred navigation can be applied.

* **Bug Fixes**
  * Notification taps are queued and reliably applied once workspace/terminal data is available.
  * Parked deep links expire after 120 seconds to avoid stale navigation; surface-only taps wait for owning workspace/terminal. 

* **Tests**
  * Added tests for deep‑link timing, surface‑only taps, delayed arrivals, and expiry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->