### PR TITLE
Fix restored pane header titles showing "Terminal" until a command runs

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1930,6 +1930,17 @@ extension Workspace {
     private func applySessionPanelMetadata(_ snapshot: SessionPanelSnapshot, toPanelId panelId: UUID) {
         if let title = snapshot.title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
             panelTitles[panelId] = title
+            // The bonsplit tab was created with the default "Terminal" title in
+            // newTerminalSurface(); sync the restored title to the visible pane
+            // header so it does not stay generic until a command runs and emits
+            // an OSC title update.
+            if let tabId = surfaceIdFromPanelId(panelId), let panel = panels[panelId] {
+                bonsplitController.updateTab(
+                    tabId,
+                    title: resolvedPanelTitle(panelId: panelId, fallback: panelTitles[panelId] ?? panel.displayTitle),
+                    hasCustomTitle: panelCustomTitles[panelId] != nil
+                )
+            }
         }
 
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle)

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -59,6 +59,32 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertEqual(restored.tabs[1].customTitle, "Second")
     }
 
+    func testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        // Simulate a terminal whose title was applied at runtime (e.g. an OSC
+        // title carrying the working directory).
+        XCTAssertTrue(workspace.updatePanelTitle(panelId: panelId, title: "~/projects/cmux"))
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredWorkspace = try XCTUnwrap(restored.selectedWorkspace)
+        let restoredPanelId = try XCTUnwrap(restoredWorkspace.focusedPanelId)
+        let restoredTabId = try XCTUnwrap(restoredWorkspace.surfaceIdFromPanelId(restoredPanelId))
+
+        // The pane header (bonsplit tab) must show the restored title, not the
+        // default "Terminal", before any command runs in the restored surface.
+        XCTAssertEqual(
+            restoredWorkspace.bonsplitController.tab(restoredTabId)?.title,
+            "~/projects/cmux"
+        )
+    }
+
     func testFocusHistoryNavigatesWithinWorkspacePanels() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)


### PR DESCRIPTION
## Issue

After restarting the terminal, restored pane header tabs all show the generic title **"Terminal"** instead of their real title (e.g. the working-directory path). The real title only appears once a command runs in the pane. Workspace/sidebar titles restore correctly — only pane headers are affected.

## Root cause

Pane header tabs are rendered by the bonsplit tab layer, which is decoupled from SwiftUI and only updates when something explicitly calls `bonsplitController.updateTab(...)`.

On restore:
1. `newTerminalSurface()` creates the bonsplit tab with the **default** `"Terminal"` title.
2. `applySessionPanelMetadata()` (`Sources/Workspace.swift`) writes the restored title into the internal `panelTitles` dictionary — **but never calls `bonsplitController.updateTab`**.

So the visible header stays `"Terminal"`. When a command later runs, Ghostty emits an OSC title sequence that goes through `updatePanelTitle()` — the only other title path, which *does* call `updateTab` — and the header finally corrects itself.

**Why sidebar works but panes don't:** workspace-title restore mutates the `@Published var title` directly, which SwiftUI observes and re-renders. The bonsplit tab layer has no such observation and needs the explicit `updateTab` call that restore was missing.

## Fix

In `applySessionPanelMetadata`, after restoring the title into `panelTitles`, also push it to the bonsplit tab header — mirroring the sync that `updatePanelTitle` and `setPanelCustomTitle` already perform.

## Tests

Two-commit red/green structure per repo policy:
- **Commit 1 (red):** `testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab` — sets a pane title, snapshots, restores into a fresh `TabManager`, asserts the restored bonsplit tab title matches (not `"Terminal"`). Fails without the fix.
- **Commit 2 (green):** the fix.

> Note: could not build/run locally (no Xcode on dev machine, CommandLineTools only) — relying on CI to confirm red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783819074&installation_id=133855650&pr_number=5930&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5930&signature=819f2b21f4b9fd94558c8508ad5fcfa74c62d8e7c4387932bb60ad122b51a21f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes restored terminal pane headers showing "Terminal" after restart by syncing the restored title to the bonsplit tab during session restore. Pane headers now show the correct title (e.g., working directory) without waiting for a command to run.

- **Bug Fixes**
  - In `applySessionPanelMetadata`, after setting `panelTitles`, call `bonsplitController.updateTab(...)` with `resolvedPanelTitle` and `hasCustomTitle` to update the visible tab header.
  - Added a regression test to ensure restored panes display the correct title before any new command executes.

<sup>Written for commit 73faca8c071b0c2da5a7499106f4c083eef01dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session restoration now correctly synchronizes terminal pane header titles. When you restore a session, terminal pane headers now display the accurate, last-set title rather than reverting to default values. Custom title assignments are properly preserved during session restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->