### PR TITLE
[codex] Make dev auth and QR setup automatic

### DIFF
--- a/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthEnvironment.swift
+++ b/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthEnvironment.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Decided by the composition root (development for DEBUG builds, production
 /// otherwise) and injected; this package never reads build flags itself.
-public enum CMUXAuthEnvironment: Sendable {
+public enum CMUXAuthEnvironment: Equatable, Sendable {
     /// The development Stack project (DEBUG builds, local web stack).
     case development
     /// The production Stack project (Release/nightly builds).

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -16,6 +16,10 @@
 	<string>$(CMUX_DEV_TAG)</string>
 	<key>CMUXGitSHA</key>
 	<string>$(CMUX_GIT_SHA)</string>
+	<key>CMUXAuthEnvironment</key>
+	<string>$(CMUX_AUTH_ENVIRONMENT)</string>
+	<key>ApiBaseURL</key>
+	<string>$(CMUX_API_BASE_URL)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -23,6 +23,8 @@ CURRENT_PROJECT_VERSION = 1
 // CMUXGitSHA / CMUXDevTag Info.plist keys that AppVersionInfo reads.
 CMUX_GIT_SHA =
 CMUX_DEV_TAG =
+CMUX_AUTH_ENVIRONMENT = production
+CMUX_API_BASE_URL =
 
 // ==========================================
 // Platform Configuration

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -47,10 +47,13 @@ public struct MobileAuthComposition {
     ) {
         self.reachability = reachability
 
-        let isDevelopment = Self.isDevelopmentBuild
-        let overrides = Self.localConfigStringOverrides(in: bundle)
+        let overrides = Self.configurationStringOverrides(in: bundle)
+        let authEnvironment = Self.resolvedAuthEnvironment(
+            isDevelopmentBuild: Self.isDevelopmentBuild,
+            overrides: overrides
+        )
         let resolvedConfig = AuthConfig(
-            environment: isDevelopment ? .development : .production,
+            environment: authEnvironment,
             overrides: overrides
         )
         self.config = resolvedConfig
@@ -135,6 +138,40 @@ public struct MobileAuthComposition {
         #endif
     }
 
+    /// Resolve which Stack project this mobile build should use.
+    ///
+    /// iOS DEBUG builds default to production auth so a normal tagged iPhone
+    /// build can pair with a normal tagged Mac dev build. Local/development
+    /// auth remains available through `CMUXAuthEnvironment=development` in the
+    /// bundle Info.plist or LocalConfig.plist.
+    static func resolvedAuthEnvironment(
+        isDevelopmentBuild: Bool,
+        overrides: [String: String]
+    ) -> CMUXAuthEnvironment {
+        if let raw = overrides["CMUXAuthEnvironment"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty {
+            switch raw.lowercased() {
+            case "development", "dev", "local":
+                return .development
+            case "production", "prod":
+                return .production
+            default:
+                break
+            }
+        }
+        return .production
+    }
+
+    /// Parse optional string overrides from bundled `LocalConfig.plist` and
+    /// Info.plist build settings.
+    private static func configurationStringOverrides(in bundle: Bundle) -> [String: String] {
+        var overrides = localConfigStringOverrides(in: bundle)
+        for (key, value) in infoPlistStringOverrides(in: bundle) {
+            overrides[key] = value
+        }
+        return overrides
+    }
+
     /// Parse optional string overrides from a bundled `LocalConfig.plist`.
     /// Stored as `[String: String]` so the result is Sendable.
     private static func localConfigStringOverrides(in bundle: Bundle) -> [String: String] {
@@ -150,6 +187,30 @@ public struct MobileAuthComposition {
                     overrides[key] = trimmed
                 }
             }
+        }
+        return overrides
+    }
+
+    /// Parse auth override build settings baked into the app Info.plist.
+    ///
+    /// Empty and unexpanded values are ignored so direct Xcode builds with the
+    /// shared xcconfig defaults behave predictably.
+    private static func infoPlistStringOverrides(in bundle: Bundle) -> [String: String] {
+        guard let info = bundle.infoDictionary else { return [:] }
+        let keys = [
+            "CMUXAuthEnvironment",
+            "ApiBaseURL",
+            "STACK_PROJECT_ID_DEV",
+            "STACK_PROJECT_ID_PROD",
+            "STACK_PUBLISHABLE_CLIENT_KEY_DEV",
+            "STACK_PUBLISHABLE_CLIENT_KEY_PROD"
+        ]
+        var overrides: [String: String] = [:]
+        for key in keys {
+            guard let stringValue = info[key] as? String else { continue }
+            let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.contains("$(") else { continue }
+            overrides[key] = trimmed
         }
         return overrides
     }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthCompositionTests.swift
@@ -1,0 +1,17 @@
+import CMUXAuthCore
+import Testing
+@testable import cmuxFeature
+
+@Test func mobileAuthCompositionDefaultsDevBuildsToProductionAuth() {
+    #expect(MobileAuthComposition.resolvedAuthEnvironment(
+        isDevelopmentBuild: true,
+        overrides: [:]
+    ) == .production)
+}
+
+@Test func mobileAuthCompositionAllowsLocalDevAuthOverride() {
+    #expect(MobileAuthComposition.resolvedAuthEnvironment(
+        isDevelopmentBuild: true,
+        overrides: ["CMUXAuthEnvironment": "local"]
+    ) == .development)
+}

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -139,6 +139,20 @@ DISPLAY_NAME="cmux DEV $TAG"
 BUNDLE_ID="dev.cmux.ios.$TAG_SLUG"
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-ios-$TAG_SLUG"
 DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+CMUX_DEV_AUTH_ORIGIN_MODE="${CMUX_DEV_AUTH_ORIGIN:-auto}"
+CMUX_AUTH_ENVIRONMENT="production"
+case "$CMUX_DEV_AUTH_ORIGIN_MODE" in
+  local|development|dev)
+    CMUX_AUTH_ENVIRONMENT="development"
+    ;;
+  auto|production|prod|"")
+    CMUX_AUTH_ENVIRONMENT="production"
+    ;;
+  *)
+    echo "error: CMUX_DEV_AUTH_ORIGIN must be auto, local, or production (got '$CMUX_DEV_AUTH_ORIGIN_MODE')" >&2
+    exit 2
+    ;;
+esac
 
 # Dev-build identity baked into the app's Info.plist (CMUXGitSHA / CMUXDevTag),
 # surfaced in-app under Settings > About so a dogfood build is tellable. The
@@ -408,6 +422,7 @@ reload_simulator() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME" \
     CMUX_GIT_SHA="$GIT_SHA" \
     CMUX_DEV_TAG="$TAG" \
+    CMUX_AUTH_ENVIRONMENT="$CMUX_AUTH_ENVIRONMENT" \
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist \
     CODE_SIGNING_ALLOWED=NO \
     SWIFT_OPTIMIZATION_LEVEL=-O \
@@ -509,6 +524,7 @@ reload_device() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME"
     CMUX_GIT_SHA="$GIT_SHA"
     CMUX_DEV_TAG="$TAG"
+    CMUX_AUTH_ENVIRONMENT="$CMUX_AUTH_ENVIRONMENT"
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist
     CODE_SIGNING_ALLOWED=YES
     CODE_SIGN_STYLE=Automatic

--- a/scripts/lib/attach-url.mjs
+++ b/scripts/lib/attach-url.mjs
@@ -61,6 +61,19 @@ export function buildAttachURL(payload, filter = {}) {
   const ticket = { ...payload.ticket, routes };
   const result = { ...payload, ticket, routes };
 
+  const routeIDs = (items) => items.map((route) => route.id).join("\n");
+  const filterPreservedRoutes =
+    routes.length === payload.ticket.routes.length &&
+    routeIDs(routes) === routeIDs(payload.ticket.routes);
+  if (
+    typeof payload.attach_url === "string" &&
+    payload.attach_url &&
+    filterPreservedRoutes
+  ) {
+    result.attach_url = payload.attach_url;
+    return { attachURL: result.attach_url, routes, payload: result };
+  }
+
   const encodedPayload = Buffer.from(JSON.stringify(ticket)).toString(
     "base64url",
   );

--- a/scripts/lib/attach-url.test.mjs
+++ b/scripts/lib/attach-url.test.mjs
@@ -52,6 +52,20 @@ test("filters routes by kind and narrows the encoded ticket", () => {
   assert.equal(decoded.routes[0].kind, "tailscale");
 });
 
+test("uses host-supplied attach_url when filtering preserves the route set", () => {
+  const payload = samplePayload();
+  payload.attach_url = "cmux-ios://attach?v=1&payload=compact-host-url";
+  payload.ticket.routes = [payload.ticket.routes[0]];
+
+  const { attachURL, routes, payload: result } = buildAttachURL(payload, {
+    routeKind: "tailscale",
+  });
+
+  assert.equal(routes.length, 1);
+  assert.equal(attachURL, payload.attach_url);
+  assert.equal(result.attach_url, payload.attach_url);
+});
+
 test("filters routes by id", () => {
   const { routes } = buildAttachURL(samplePayload(), { routeID: "lo" });
   assert.equal(routes.length, 1);

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -15,6 +15,14 @@ CMUX_DEV_PORT=""
 CMUX_DEV_PORT_END=""
 CMUX_DEV_PORT_RANGE=""
 CMUX_DEV_ORIGIN=""
+CMUX_DEV_AUTH_ORIGIN_MODE="${CMUX_DEV_AUTH_ORIGIN:-auto}"
+CMUX_AUTH_WWW_ORIGIN=""
+CMUX_WWW_ORIGIN=""
+CMUX_API_BASE_URL=""
+CMUX_VM_API_BASE_URL=""
+CMUX_STACK_PROJECT_ID=""
+CMUX_STACK_PUBLISHABLE_CLIENT_KEY=""
+CMUX_DEV_AUTH_RESOLVED_MODE=""
 CLI_PATH=""
 # Matches CmuxStateDirectory (non-TCC ~/.local/state/cmux) where the app/CLI now
 # read the last-socket-path markers (https://github.com/manaflow-ai/cmux/issues/5146).
@@ -230,6 +238,9 @@ Options:
                          so macOS launches the freshly-built binary on cmd-click or --launch.
   --launch               Launch the app after building. Without this flag, the script
                          builds and prints the app path but does not open it.
+  CMUX_DEV_AUTH_ORIGIN   Auth origin mode: auto (default), production/prod, or local.
+                         auto uses local auth only when the dev web origin is reachable;
+                         otherwise it uses production auth so dev sign-in works.
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
@@ -309,6 +320,53 @@ choose_cmux_dev_port_end() {
     end="$start_num"
   fi
   echo "$end"
+}
+
+cmux_dev_origin_is_reachable() {
+  command -v curl >/dev/null 2>&1 || return 1
+  curl -fsS --max-time 1 "$CMUX_DEV_ORIGIN" >/dev/null 2>&1
+}
+
+use_local_dev_auth_origin() {
+  CMUX_AUTH_WWW_ORIGIN="$CMUX_DEV_ORIGIN"
+  CMUX_WWW_ORIGIN="$CMUX_DEV_ORIGIN"
+  CMUX_API_BASE_URL="$CMUX_DEV_ORIGIN"
+  CMUX_VM_API_BASE_URL="$CMUX_DEV_ORIGIN"
+  CMUX_STACK_PROJECT_ID=""
+  CMUX_STACK_PUBLISHABLE_CLIENT_KEY=""
+  CMUX_DEV_AUTH_RESOLVED_MODE="local"
+}
+
+use_production_dev_auth_origin() {
+  CMUX_AUTH_WWW_ORIGIN="https://cmux.com"
+  CMUX_WWW_ORIGIN="https://cmux.com"
+  CMUX_API_BASE_URL="https://api.cmux.sh"
+  CMUX_VM_API_BASE_URL="https://cmux.com"
+  CMUX_STACK_PROJECT_ID="9790718f-14cd-4f7e-824d-eaf527a82b82"
+  CMUX_STACK_PUBLISHABLE_CLIENT_KEY="pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr"
+  CMUX_DEV_AUTH_RESOLVED_MODE="production"
+}
+
+resolve_dev_auth_origin() {
+  case "$CMUX_DEV_AUTH_ORIGIN_MODE" in
+    local)
+      use_local_dev_auth_origin
+      ;;
+    production|prod)
+      use_production_dev_auth_origin
+      ;;
+    auto|"")
+      if cmux_dev_origin_is_reachable; then
+        use_local_dev_auth_origin
+      else
+        use_production_dev_auth_origin
+      fi
+      ;;
+    *)
+      echo "error: CMUX_DEV_AUTH_ORIGIN must be auto, local, or production (got '$CMUX_DEV_AUTH_ORIGIN_MODE')" >&2
+      exit 2
+      ;;
+  esac
 }
 
 set_plist_env() {
@@ -527,6 +585,14 @@ CMUX_DEV_PORT="$(choose_cmux_dev_port)"
 CMUX_DEV_PORT_RANGE="$(choose_cmux_dev_port_range)"
 CMUX_DEV_PORT_END="$(choose_cmux_dev_port_end "$CMUX_DEV_PORT" "$CMUX_DEV_PORT_RANGE")"
 CMUX_DEV_ORIGIN="http://localhost:${CMUX_DEV_PORT}"
+resolve_dev_auth_origin
+
+if [[ -n "${TAG_SLUG:-}" ]]; then
+  # The mobile pairing listener is opt-in and reads this default at app launch.
+  # Tagged dev builds are isolated, so enabling it here makes QR generation work
+  # without requiring every caller to remember a separate defaults write.
+  defaults write "$BUNDLE_ID" mobile.iOSPairingHost.enabled -bool true
+fi
 
 # Quiet logging: capture all noisy build output (xcodebuild, zig, codesign,
 # plistbuddy, etc.) to a single log file. On success we print only a one-line
@@ -589,6 +655,8 @@ reload_finalize() {
     echo
     echo "Dev web origin:"
     echo "  $CMUX_DEV_ORIGIN"
+    echo "Dev auth origin (${CMUX_DEV_AUTH_RESOLVED_MODE}):"
+    echo "  $CMUX_AUTH_WWW_ORIGIN"
     if [[ -n "${TAG_SLUG:-}" ]]; then
       echo "Dev web command:"
       echo "  cd web && CMUX_PORT=$CMUX_DEV_PORT CMUX_PORT_RANGE=$CMUX_DEV_PORT_RANGE CMUX_PORT_END=$CMUX_DEV_PORT_END CMUX_AUTH_CALLBACK_SCHEME=cmux-dev-$TAG_SLUG bun dev"
@@ -931,9 +999,16 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       set_plist_env "$INFO_PLIST" CMUX_PORT_END "$CMUX_DEV_PORT_END"
       set_plist_env "$INFO_PLIST" CMUX_PORT_RANGE "$CMUX_DEV_PORT_RANGE"
       set_plist_env "$INFO_PLIST" PORT "$CMUX_DEV_PORT"
-      set_plist_env "$INFO_PLIST" CMUX_AUTH_WWW_ORIGIN "$CMUX_DEV_ORIGIN"
-      set_plist_env "$INFO_PLIST" CMUX_API_BASE_URL "$CMUX_DEV_ORIGIN"
-      set_plist_env "$INFO_PLIST" CMUX_VM_API_BASE_URL "$CMUX_DEV_ORIGIN"
+      set_plist_env "$INFO_PLIST" CMUX_AUTH_WWW_ORIGIN "$CMUX_AUTH_WWW_ORIGIN"
+      set_plist_env "$INFO_PLIST" CMUX_WWW_ORIGIN "$CMUX_WWW_ORIGIN"
+      set_plist_env "$INFO_PLIST" CMUX_API_BASE_URL "$CMUX_API_BASE_URL"
+      set_plist_env "$INFO_PLIST" CMUX_VM_API_BASE_URL "$CMUX_VM_API_BASE_URL"
+      if [[ -n "$CMUX_STACK_PROJECT_ID" ]]; then
+        set_plist_env "$INFO_PLIST" CMUX_STACK_PROJECT_ID "$CMUX_STACK_PROJECT_ID"
+      fi
+      if [[ -n "$CMUX_STACK_PUBLISHABLE_CLIENT_KEY" ]]; then
+        set_plist_env "$INFO_PLIST" CMUX_STACK_PUBLISHABLE_CLIENT_KEY "$CMUX_STACK_PUBLISHABLE_CLIENT_KEY"
+      fi
       if [[ -S "$CMUXD_SOCKET" ]]; then
         for PID in $(lsof -t "$CMUXD_SOCKET" 2>/dev/null); do
           kill "$PID" 2>/dev/null || true
@@ -1086,27 +1161,26 @@ if [[ "$LAUNCH" -eq 1 ]]; then
     CMUX_PORT_END="$CMUX_DEV_PORT_END"
     CMUX_PORT_RANGE="$CMUX_DEV_PORT_RANGE"
     PORT="$CMUX_DEV_PORT"
-    CMUX_AUTH_WWW_ORIGIN="$CMUX_DEV_ORIGIN"
-    CMUX_API_BASE_URL="$CMUX_DEV_ORIGIN"
-    CMUX_VM_API_BASE_URL="$CMUX_DEV_ORIGIN"
+    CMUX_AUTH_WWW_ORIGIN="$CMUX_AUTH_WWW_ORIGIN"
+    CMUX_WWW_ORIGIN="$CMUX_WWW_ORIGIN"
+    CMUX_API_BASE_URL="$CMUX_API_BASE_URL"
+    CMUX_VM_API_BASE_URL="$CMUX_VM_API_BASE_URL"
   )
+  if [[ -n "$CMUX_STACK_PROJECT_ID" ]]; then
+    TAG_LAUNCH_ENV+=(CMUX_STACK_PROJECT_ID="$CMUX_STACK_PROJECT_ID")
+  fi
+  if [[ -n "$CMUX_STACK_PUBLISHABLE_CLIENT_KEY" ]]; then
+    TAG_LAUNCH_ENV+=(CMUX_STACK_PUBLISHABLE_CLIENT_KEY="$CMUX_STACK_PUBLISHABLE_CLIENT_KEY")
+  fi
 
   LAUNCH_CMD=()
   LAUNCH_RETRY_CMD=()
   if [[ -n "${TAG_SLUG:-}" ]]; then
-    # Launch tagged apps directly so LaunchServices cannot reuse a stale
-    # LSEnvironment for the tag's bundle id.
-    APP_EXECUTABLE="$APP_PATH/Contents/MacOS/${BASE_APP_NAME}"
-    if [[ ! -x "$APP_EXECUTABLE" ]]; then
-      echo "error: tagged app executable not found: $APP_EXECUTABLE" >&2
-      exit 1
-    fi
-    TAG_LAUNCH_LOG="/tmp/cmux-launch-${TAG_SLUG}.out"
-    if [[ -n "${CMUX_SOCKET_PATH_VALUE:-}" ]]; then
-      nohup "${OPEN_CLEAN_ENV[@]}" "${TAG_LAUNCH_ENV[@]}" CMUX_SOCKET_PATH="$CMUX_SOCKET_PATH_VALUE" CMUXD_UNIX_PATH="$CMUXD_SOCKET" "$APP_EXECUTABLE" >"$TAG_LAUNCH_LOG" 2>&1 &
-    else
-      nohup "${OPEN_CLEAN_ENV[@]}" "${TAG_LAUNCH_ENV[@]}" "$APP_EXECUTABLE" >"$TAG_LAUNCH_LOG" 2>&1 &
-    fi
+    # Tagged app bundles carry their tag/socket/auth settings in LSEnvironment.
+    # LaunchServices keeps the app registered as a normal GUI app; direct exec
+    # can exit after startup and leave a stale debug socket behind.
+    LAUNCH_CMD=("${OPEN_CLEAN_ENV[@]}" open -n -g "$APP_PATH")
+    LAUNCH_RETRY_CMD=("${OPEN_CLEAN_ENV[@]}" open -n -g "$APP_PATH")
   else
     echo "/tmp/cmux-debug.sock" > /tmp/cmux-last-socket-path || true
     echo "/tmp/cmux-debug.log" > /tmp/cmux-last-debug-log-path || true


### PR DESCRIPTION
## Summary

Makes tagged dev builds ready for auth and mobile pairing by default:

- resolves macOS dev auth origin automatically, using local web only when reachable and otherwise production auth/API origins
- enables the tagged iOS pairing host before launch so QR generation has routes without a separate defaults write
- preserves host-supplied compact attach URLs when QR helper filtering keeps the original route set
- aligns iOS DEBUG/dev builds with the same production Stack auth default, while preserving `CMUX_DEV_AUTH_ORIGIN=local` / `CMUXAuthEnvironment=development` for intentional local auth testing

## Why

Dev builds could route sign-in to localhost or the development Stack project while the paired Mac was using production Stack auth. That let QR transport succeed, but the Mac then rejected the iPhone token with an account verification failure. The default dogfood path now uses one auth realm on both Mac and iOS.

## Validation

- `bash -n scripts/reload.sh scripts/dev-setup.sh scripts/mobile-attach-qr.sh scripts/mobile-dev-launch.sh`
- `bash -n ios/scripts/reload.sh scripts/reload.sh scripts/dev-setup.sh scripts/mobile-attach-qr.sh scripts/mobile-dev-launch.sh`
- `node --test scripts/lib/attach-url.test.mjs`
- `./scripts/reload.sh --tag ios-close-workspace --launch`
- `ios/scripts/reload.sh --tag ios-close-workspace --device-only`
- verified tagged Mac auth status is signed in
- verified mobile host status is running with routes
- verified rebuilt iOS app Info.plist has `CMUXAuthEnvironment=production`
- generated a fresh mobile QR artifact

Note: direct relaunch after reinstall could not complete because CoreDevice reported the iPhone unavailable/locked; the device build and install succeeded.
