### PR TITLE
[codex] Align iOS dev auth with Mac dev builds

### DIFF
--- a/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthEnvironment.swift
+++ b/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthEnvironment.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Decided by the composition root (development for DEBUG builds, production
 /// otherwise) and injected; this package never reads build flags itself.
-public enum CMUXAuthEnvironment: Sendable {
+public enum CMUXAuthEnvironment: Equatable, Sendable {
     /// The development Stack project (DEBUG builds, local web stack).
     case development
     /// The production Stack project (Release/nightly builds).

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -16,6 +16,10 @@
 	<string>$(CMUX_DEV_TAG)</string>
 	<key>CMUXGitSHA</key>
 	<string>$(CMUX_GIT_SHA)</string>
+	<key>CMUXAuthEnvironment</key>
+	<string>$(CMUX_AUTH_ENVIRONMENT)</string>
+	<key>ApiBaseURL</key>
+	<string>$(CMUX_API_BASE_URL)</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -23,6 +23,8 @@ CURRENT_PROJECT_VERSION = 1
 // CMUXGitSHA / CMUXDevTag Info.plist keys that AppVersionInfo reads.
 CMUX_GIT_SHA =
 CMUX_DEV_TAG =
+CMUX_AUTH_ENVIRONMENT = production
+CMUX_API_BASE_URL =
 
 // ==========================================
 // Platform Configuration

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -47,10 +47,13 @@ public struct MobileAuthComposition {
     ) {
         self.reachability = reachability
 
-        let isDevelopment = Self.isDevelopmentBuild
-        let overrides = Self.localConfigStringOverrides(in: bundle)
+        let overrides = Self.configurationStringOverrides(in: bundle)
+        let authEnvironment = Self.resolvedAuthEnvironment(
+            isDevelopmentBuild: Self.isDevelopmentBuild,
+            overrides: overrides
+        )
         let resolvedConfig = AuthConfig(
-            environment: isDevelopment ? .development : .production,
+            environment: authEnvironment,
             overrides: overrides
         )
         self.config = resolvedConfig
@@ -135,6 +138,40 @@ public struct MobileAuthComposition {
         #endif
     }
 
+    /// Resolve which Stack project this mobile build should use.
+    ///
+    /// iOS DEBUG builds default to production auth so a normal tagged iPhone
+    /// build can pair with a normal tagged Mac dev build. Local/development
+    /// auth remains available through `CMUXAuthEnvironment=development` in the
+    /// bundle Info.plist or LocalConfig.plist.
+    static func resolvedAuthEnvironment(
+        isDevelopmentBuild: Bool,
+        overrides: [String: String]
+    ) -> CMUXAuthEnvironment {
+        if let raw = overrides["CMUXAuthEnvironment"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty {
+            switch raw.lowercased() {
+            case "development", "dev", "local":
+                return .development
+            case "production", "prod":
+                return .production
+            default:
+                break
+            }
+        }
+        return .production
+    }
+
+    /// Parse optional string overrides from bundled `LocalConfig.plist` and
+    /// Info.plist build settings.
+    private static func configurationStringOverrides(in bundle: Bundle) -> [String: String] {
+        var overrides = localConfigStringOverrides(in: bundle)
+        for (key, value) in infoPlistStringOverrides(in: bundle) {
+            overrides[key] = value
+        }
+        return overrides
+    }
+
     /// Parse optional string overrides from a bundled `LocalConfig.plist`.
     /// Stored as `[String: String]` so the result is Sendable.
     private static func localConfigStringOverrides(in bundle: Bundle) -> [String: String] {
@@ -150,6 +187,30 @@ public struct MobileAuthComposition {
                     overrides[key] = trimmed
                 }
             }
+        }
+        return overrides
+    }
+
+    /// Parse auth override build settings baked into the app Info.plist.
+    ///
+    /// Empty and unexpanded values are ignored so direct Xcode builds with the
+    /// shared xcconfig defaults behave predictably.
+    private static func infoPlistStringOverrides(in bundle: Bundle) -> [String: String] {
+        guard let info = bundle.infoDictionary else { return [:] }
+        let keys = [
+            "CMUXAuthEnvironment",
+            "ApiBaseURL",
+            "STACK_PROJECT_ID_DEV",
+            "STACK_PROJECT_ID_PROD",
+            "STACK_PUBLISHABLE_CLIENT_KEY_DEV",
+            "STACK_PUBLISHABLE_CLIENT_KEY_PROD"
+        ]
+        var overrides: [String: String] = [:]
+        for key in keys {
+            guard let stringValue = info[key] as? String else { continue }
+            let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.contains("$(") else { continue }
+            overrides[key] = trimmed
         }
         return overrides
     }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthCompositionTests.swift
@@ -1,0 +1,17 @@
+import CMUXAuthCore
+import Testing
+@testable import cmuxFeature
+
+@Test func mobileAuthCompositionDefaultsDevBuildsToProductionAuth() {
+    #expect(MobileAuthComposition.resolvedAuthEnvironment(
+        isDevelopmentBuild: true,
+        overrides: [:]
+    ) == .production)
+}
+
+@Test func mobileAuthCompositionAllowsLocalDevAuthOverride() {
+    #expect(MobileAuthComposition.resolvedAuthEnvironment(
+        isDevelopmentBuild: true,
+        overrides: ["CMUXAuthEnvironment": "local"]
+    ) == .development)
+}

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -139,6 +139,20 @@ DISPLAY_NAME="cmux DEV $TAG"
 BUNDLE_ID="dev.cmux.ios.$TAG_SLUG"
 DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-ios-$TAG_SLUG"
 DESTINATION="platform=iOS Simulator,name=$SIMULATOR_NAME"
+CMUX_DEV_AUTH_ORIGIN_MODE="${CMUX_DEV_AUTH_ORIGIN:-auto}"
+CMUX_AUTH_ENVIRONMENT="production"
+case "$CMUX_DEV_AUTH_ORIGIN_MODE" in
+  local|development|dev)
+    CMUX_AUTH_ENVIRONMENT="development"
+    ;;
+  auto|production|prod|"")
+    CMUX_AUTH_ENVIRONMENT="production"
+    ;;
+  *)
+    echo "error: CMUX_DEV_AUTH_ORIGIN must be auto, local, or production (got '$CMUX_DEV_AUTH_ORIGIN_MODE')" >&2
+    exit 2
+    ;;
+esac
 
 # Dev-build identity baked into the app's Info.plist (CMUXGitSHA / CMUXDevTag),
 # surfaced in-app under Settings > About so a dogfood build is tellable. The
@@ -408,6 +422,7 @@ reload_simulator() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME" \
     CMUX_GIT_SHA="$GIT_SHA" \
     CMUX_DEV_TAG="$TAG" \
+    CMUX_AUTH_ENVIRONMENT="$CMUX_AUTH_ENVIRONMENT" \
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist \
     CODE_SIGNING_ALLOWED=NO \
     SWIFT_OPTIMIZATION_LEVEL=-O \
@@ -509,6 +524,7 @@ reload_device() {
     PRODUCT_DISPLAY_NAME="$DISPLAY_NAME"
     CMUX_GIT_SHA="$GIT_SHA"
     CMUX_DEV_TAG="$TAG"
+    CMUX_AUTH_ENVIRONMENT="$CMUX_AUTH_ENVIRONMENT"
     EXCLUDED_SOURCE_FILE_NAMES=Info.plist
     CODE_SIGNING_ALLOWED=YES
     CODE_SIGN_STYLE=Automatic


### PR DESCRIPTION
## Summary

Fixes iOS dev pairing account verification by aligning iOS DEBUG/dev auth with the Mac dev build auth realm:

- defaults iOS dev builds to production Stack auth
- bakes `CMUXAuthEnvironment` into the iOS app Info.plist from `ios/scripts/reload.sh`
- keeps intentional local auth testing available through `CMUX_DEV_AUTH_ORIGIN=local` / `CMUXAuthEnvironment=development`
- adds focused coverage for the default and local override

## Why

The QR transport path can succeed while account verification fails if the Mac dev build is signed into production Stack auth but the iOS DEBUG build mints a token from the development Stack project. That produces the observed state: macOS reports the iPhone connected, then iOS shows "Couldn't verify your account." Both dev builds now default to the same auth realm.

## Validation

- `bash -n ios/scripts/reload.sh`
- In the main checkout, `ios/scripts/reload.sh --tag ios-close-workspace --device-only` built and installed successfully with `CMUX_AUTH_ENVIRONMENT=production`
- Verified the built iOS app Info.plist contains `CMUXAuthEnvironment=production`
- Clean temporary worktree build was attempted but blocked by missing local `GhosttyKit.xcframework` artifact in `/tmp`, not by this patch

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783830630&installation_id=133855650&pr_number=5944&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5944&signature=f7a62ed9ca899ff99bb30246f9b9e44e8c8c45a807d0b6a568ed7809aed723ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns iOS DEBUG/dev builds with the Mac dev build by defaulting to production Stack auth, with an opt-in local override. Fixes the “Couldn't verify your account” pairing failure caused by mismatched auth realms.

- **Bug Fixes**
  - Default iOS dev builds to production auth; opt-in local dev via `CMUX_DEV_AUTH_ORIGIN=local` or `CMUXAuthEnvironment=development`.
  - Resolve auth env in `MobileAuthComposition` from Info.plist and `LocalConfig.plist`, ignoring empty/unexpanded values; added tests and made `CMUXAuthEnvironment` `Equatable`.
  - Plist/config wiring: added `CMUXAuthEnvironment` and `ApiBaseURL` to Info.plist; set `CMUX_AUTH_ENVIRONMENT=production` in `Shared.xcconfig`; `reload.sh` sets `CMUX_AUTH_ENVIRONMENT` from `CMUX_DEV_AUTH_ORIGIN` (auto/prod/local).

<sup>Written for commit 654c4bc59e71e40aa1598de140d94b183c9f21c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

