### PR TITLE
Disable macOS 26 autofill heuristic controller to stop completion-list CPU loop

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1243,6 +1243,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        // On macOS 26, AppKit's NSAutoFillHeuristicController scans focused text
+        // input for autofillable content (one-time codes, credentials) and drives
+        // the Safari autofill completion-list XPC view service. In a terminal this
+        // burns main-thread CPU, and via its shouldReconnectOnInterruption: hook it
+        // can pin a core in a completion-list view-service terminate/respawn loop
+        // (https://github.com/manaflow-ai/cmux/issues/5946). Ghostty upstream
+        // registers the same default for the same reason. Manual autofill via
+        // Edit > AutoFill and WebKit's own browser-pane autofill still work.
+        UserDefaults.standard.register(defaults: [
+            "NSAutoFillHeuristicControllerEnabled": false,
+        ])
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1243,20 +1243,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    func applicationWillFinishLaunching(_ notification: Notification) {
-        // On macOS 26, AppKit's NSAutoFillHeuristicController scans focused text
-        // input for autofillable content (one-time codes, credentials) and drives
-        // the Safari autofill completion-list XPC view service. In a terminal this
-        // burns main-thread CPU, and via its shouldReconnectOnInterruption: hook it
-        // can pin a core in a completion-list view-service terminate/respawn loop
-        // (https://github.com/manaflow-ai/cmux/issues/5946). Ghostty upstream
-        // registers the same default for the same reason. Manual autofill via
-        // Edit > AutoFill and WebKit's own browser-pane autofill still work.
-        UserDefaults.standard.register(defaults: [
-            "NSAutoFillHeuristicControllerEnabled": false,
-        ])
-    }
-
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)

--- a/Sources/AutoFillHeuristicDefaults.swift
+++ b/Sources/AutoFillHeuristicDefaults.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+extension AppDelegate {
+    // On macOS 26, AppKit's NSAutoFillHeuristicController scans focused text
+    // input for autofillable content (one-time codes, credentials) and drives
+    // the Safari autofill completion-list XPC view service. In a terminal this
+    // burns main-thread CPU, and via its shouldReconnectOnInterruption: hook it
+    // can pin a core in a completion-list view-service terminate/respawn loop
+    // (https://github.com/manaflow-ai/cmux/issues/5946). Ghostty upstream
+    // registers the same default for the same reason. Manual autofill via
+    // Edit > AutoFill and WebKit's own browser-pane autofill still work.
+    @objc func applicationWillFinishLaunching(_ notification: Notification) {
+        UserDefaults.standard.register(defaults: [
+            "NSAutoFillHeuristicControllerEnabled": false,
+        ])
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */; };
 		A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47E00010000000000000002 /* AuthEnvironmentTests.swift */; };
+		AF5946000000000000000002 /* AutoFillHeuristicDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5946000000000000000001 /* AutoFillHeuristicDefaults.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
 		C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */; };
 		A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
@@ -905,6 +906,7 @@
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		43430FA5929121E2EAAB3091 /* AuthEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthEnvironment.swift; sourceTree = "<group>"; };
 		A47E00010000000000000002 /* AuthEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEnvironmentTests.swift; sourceTree = "<group>"; };
+		AF5946000000000000000001 /* AutoFillHeuristicDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFillHeuristicDefaults.swift; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
 		C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundWorkspacePrimeCoordinator.swift; sourceTree = "<group>"; };
 		A50012F0 /* Backport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backport.swift; sourceTree = "<group>"; };
@@ -2017,6 +2019,7 @@
 				F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */,
 				D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */,
 				A5001090 /* AppDelegate.swift */,
+				AF5946000000000000000001 /* AutoFillHeuristicDefaults.swift */,
 				3865B0063865B0063865B006 /* AppDelegate+GlobalSearch.swift */,
 				C3873002C3873002C3873002 /* GhosttyCrashBreadcrumb.swift */,
 				C3873004C3873004C3873004 /* GhosttyCrashReportMetadata.swift */,
@@ -2892,6 +2895,7 @@
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */,
+				AF5946000000000000000002 /* AutoFillHeuristicDefaults.swift in Sources */,
 				C0DE35860000000000000001 /* BackgroundWorkspacePrimeCoordinator.swift in Sources */,
 				A50012F1 /* Backport.swift in Sources */,
 				D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5946

cmux NIGHTLY 0.64.14 was pinning a full core with the main thread ~100% busy (6021 of 6039 samples) in a Safari autofill completion-list view-service terminate/respawn loop: `SPSafariPlatformSupport viewServiceDidTerminateWithError:` re-requests the view controller, which terminates again, forever. Sample and spindump evidence is in the issue.

The requester is AppKit's `NSAutoFillHeuristicController` (macOS 26), which scans focused text input for autofillable content and drives the SafariPlatformSupport completion-list XPC view service. Its method list includes `safariPlatformSupport:hasDeliveredOneTimeCodesForAutoFillDidChange:` and `shouldReconnectOnInterruption:`, the reconnect-on-termination hook behind the respawn loop. Ghostty upstream registers `NSAutoFillHeuristicControllerEnabled=false` in its own AppDelegate for exactly this macOS 26 CPU pathology ("unusable levels of slowdowns and CPU usage in the terminal window"); cmux wraps the same terminal but its own app delegate never registered it.

The fix adds `applicationWillFinishLaunching` to cmux's AppDelegate and registers `NSAutoFillHeuristicControllerEnabled=false`, mirroring ghostty. Manual autofill via Edit > AutoFill keeps working, and WebKit browser-pane autofill (the web-browser entitlement path from https://github.com/manaflow-ai/cmux/pull/1518) uses WebKit's own form detection, not the AppKit heuristic controller, so it is unaffected.

Testing: a meaningful automated test is not practical here. The loop lives entirely inside Apple frameworks and triggers under unknown conditions (ghostty hit the same wall), and a registered default is process-volatile state that source-shape tests are banned from asserting. Verified by building a tagged app and exercising launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783833537&installation_id=133855650&pr_number=5951&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5951&signature=d1305978d139cb0fdb7371fcfddf680fcc9c9d9cda3775fa76c2da4c0e761b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single launch-time UserDefaults default with no auth or data-path changes; manual and WebKit autofill stay available.
> 
> **Overview**
> Registers **`NSAutoFillHeuristicControllerEnabled: false`** in **`applicationWillFinishLaunching`** via a new `AppDelegate` extension (`AutoFillHeuristicDefaults.swift`), wired into the Xcode project.
> 
> This turns off macOS 26 AppKit’s **`NSAutoFillHeuristicController`** heuristic scanning and the Safari completion-list XPC path that was driving main-thread CPU use and a terminate/respawn loop ([#5946](https://github.com/manaflow-ai/cmux/issues/5946)), matching the approach Ghostty uses. **Edit > AutoFill** and WebKit browser-pane autofill are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0fbe05db6d7a6f786f531dd2c373c72fc8b83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable macOS 26 AppKit autofill heuristics to stop the Safari completion-list terminate/respawn loop that pins a CPU core (fixes #5946). Register `NSAutoFillHeuristicControllerEnabled=false` at launch in `AutoFillHeuristicDefaults.swift`; manual Edit > AutoFill and WebKit autofill are unchanged.

<sup>Written for commit 2c0fbe05db6d7a6f786f531dd2c373c72fc8b83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the system's autofill heuristic controller at application launch to prevent automatic text scanning and unwanted autofill completion suggestions from appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->