### PR TITLE
reload.sh: block local reloads in cmuxterm-hq checkouts, steer agents to the cloud builder

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -505,6 +505,47 @@ if [[ -z "$TAG" ]]; then
   exit 1
 fi
 
+# --- cmuxterm-hq local-reload guard ------------------------------------------
+# In a cmuxterm-hq-managed checkout (one that ships a ./scripts/reload-cloud.sh
+# shim, or a Mac with a macfleet builder manifest), a LOCAL reload steals the
+# user's CPU and window focus. Agents must build on the fleet with
+# ./scripts/reload-cloud.sh instead. The cloud paths set CMUX_RELOAD_CLOUD=1 to
+# bypass this (the remote build and the no-fleet local fallback). A human who
+# really wants a local build sets CMUX_RELOAD_LOCAL_OK=1, or touches
+# ~/.cmux-reload-guard/allow-local (also honored by the background reload guard).
+if [[ -z "${CMUX_RELOAD_CLOUD:-}" && -z "${CMUX_RELOAD_LOCAL_OK:-}" ]]; then
+  _hqdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)"
+  _hq=0
+  if [[ -e "${_hqdir}/reload-cloud.sh" || -f "$HOME/.config/macfleet/hosts.json" ]]; then _hq=1; fi
+  # A cloud build runs reload.sh inside the builder's overlay work dir; never
+  # block there (belt-and-braces for the CMUX_RELOAD_CLOUD env bypass).
+  case "$PWD" in *cmux-job/reload-cloud/*) _hq=0 ;; esac
+  _allow="$HOME/.cmux-reload-guard/allow-local"
+  if [[ "$_hq" == "1" && -f "$_allow" ]]; then
+    _am="$(stat -f %m "$_allow" 2>/dev/null || echo 0)"
+    if [[ "$_am" =~ ^[0-9]+$ ]] && (( $(date +%s) - _am < 14400 )); then _hq=0; fi
+  fi
+  if [[ "$_hq" == "1" ]]; then
+    {
+      echo "=================================================================="
+      echo "  LOCAL reload is BLOCKED in this cmuxterm-hq checkout."
+      echo
+      echo "  Local builds steal the user's CPU and window focus. Build on the"
+      echo "  fleet instead (same tag, same app path, same deeplink):"
+      echo
+      echo "      ./scripts/reload-cloud.sh --tag ${TAG}"
+      echo
+      echo "  Need a live instance? add --launch (cloud build, opens locally):"
+      echo "      ./scripts/reload-cloud.sh --tag ${TAG} --launch"
+      echo
+      echo "  Force a local build anyway:"
+      echo "      CMUX_RELOAD_LOCAL_OK=1 ./scripts/reload.sh --tag ${TAG}"
+      echo "=================================================================="
+    } >&2
+    exit 3
+  fi
+fi
+
 if [[ -n "$TAG" ]]; then
   TAG_ID="$(sanitize_bundle "$TAG")"
   TAG_SLUG="$(sanitize_path "$TAG")"


### PR DESCRIPTION
## What

`./scripts/reload.sh` now hard-blocks (exit 3) when run inside a **cmuxterm-hq-managed checkout** (one that ships a `./scripts/reload-cloud.sh` shim, or a Mac with a macfleet builder manifest), pointing the agent at the cloud builder instead.

## Why

A local reload runs a full Xcode build on the user's machine, stealing CPU and stealing window focus from whatever they're doing. On our fleet we always offload builds to a leased Mac via `./scripts/reload-cloud.sh` (same tag, same local app path, same deeplink). Agents were still occasionally running local `reload.sh` (often when they wanted `--launch` for a live instance), so this makes the local path refuse and tell them what to run.

## Bypasses (so nothing legit breaks)

- `CMUX_RELOAD_CLOUD=1` — set by reload-cloud on both the remote build and its no-fleet local fallback, so cloud paths are never blocked.
- Running inside the builder's `cmux-job/reload-cloud/...` overlay dir (belt-and-braces for the env bypass).
- `CMUX_RELOAD_LOCAL_OK=1` — for a human who really wants a local build.
- A fresh `~/.cmux-reload-guard/allow-local` marker.

## External contributors are unaffected

A plain `manaflow-ai/cmux` clone has no `reload-cloud.sh` shim and no macfleet manifest, so the guard never fires and local `reload.sh` works exactly as before. The companion `--launch` support in cmuxterm-hq's `reload-cloud.sh` gives agents a cloud build + local open in one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783833656&installation_id=133855650&pr_number=5952&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5952&signature=bbc8d054708e820cabbcb7e282a57ffffaae40e0cab1a404d56ce383e4145403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only guard with explicit bypasses; external clones without reload-cloud or macfleet are unchanged.
> 
> **Overview**
> **`reload.sh` now refuses local Xcode reloads in cmuxterm-hq-style environments** so agents are pushed toward fleet builds instead of burning the user’s machine.
> 
> After `--tag` is validated, a new guard runs before any build work. It treats the checkout as “HQ-managed” when `scripts/reload-cloud.sh` exists beside `reload.sh` or `~/.config/macfleet/hosts.json` is present. In that case it **exits 3** with stderr instructions to use `./scripts/reload-cloud.sh --tag …` (and `--launch` when a live app is needed), unless bypassed.
> 
> **Bypasses:** `CMUX_RELOAD_CLOUD=1`, working directory under `cmux-job/reload-cloud/`, `CMUX_RELOAD_LOCAL_OK=1`, or a `~/.cmux-reload-guard/allow-local` file touched within the last four hours. Plain upstream clones without the shim or macfleet manifest never hit the guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fd3c1a7a5dc5d204f04b61ffa7921fa8633ca50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block local reloads in `./scripts/reload.sh` for cmuxterm-hq checkouts and direct agents to `./scripts/reload-cloud.sh`. Prevents accidental local Xcode builds that hog CPU and steal focus; external contributors are unaffected.

- **New Features**
  - Hard-blocks local reload in hq-managed checkouts; exits 3 and prints guidance to use `./scripts/reload-cloud.sh` (supports `--launch`).
  - Detection: presence of `./scripts/reload-cloud.sh` or `$HOME/.config/macfleet/hosts.json`; never blocks inside `cmux-job/reload-cloud` overlay.
  - Bypasses: `CMUX_RELOAD_CLOUD=1`, `CMUX_RELOAD_LOCAL_OK=1`, or `~/.cmux-reload-guard/allow-local` updated within the last 4h.

<sup>Written for commit 1fd3c1a7a5dc5d204f04b61ffa7921fa8633ca50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup guard for managed checkouts to prevent incompatible local reload operations in certain configurations.
  * Provides clear guidance to users when operations are blocked, including alternative command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->