### PR TITLE
browser inputs: dispatch pointerenter non-bubbling to match mouseenter and spec

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7109,11 +7109,11 @@ class TerminalController {
     /// `__cmuxClick(el)`, `__cmuxHover(el)`, `__cmuxSetChecked(el, desired)`, and `__cmuxKey(t,type,key)`.
     private nonisolated static let browserInputHelpers = """
     function __cmuxCenter(el){const r=el.getBoundingClientRect();return {x:Math.floor(r.left+Math.min(r.width,r.width/2)),y:Math.floor(r.top+Math.min(r.height,r.height/2))};}
-    function __cmuxPointer(el,type,c,buttons){try{el.dispatchEvent(new PointerEvent(type,{bubbles:true,cancelable:true,composed:true,view:window,pointerId:1,pointerType:'mouse',isPrimary:true,button:0,buttons:buttons,clientX:c.x,clientY:c.y,screenX:c.x,screenY:c.y}));}catch(e){}}
+    function __cmuxPointer(el,type,c,buttons,bubbles){try{el.dispatchEvent(new PointerEvent(type,{bubbles:(bubbles===false?false:true),cancelable:true,composed:true,view:window,pointerId:1,pointerType:'mouse',isPrimary:true,button:0,buttons:buttons,clientX:c.x,clientY:c.y,screenX:c.x,screenY:c.y}));}catch(e){}}
     function __cmuxMouse(el,type,c,buttons,detail,bubbles){el.dispatchEvent(new MouseEvent(type,{bubbles:(bubbles===false?false:true),cancelable:true,composed:true,view:window,button:0,buttons:buttons,detail:detail||0,clientX:c.x,clientY:c.y,screenX:c.x,screenY:c.y}));}
     function __cmuxClick(el){const c=__cmuxCenter(el);
       __cmuxPointer(el,'pointerover',c,0);__cmuxMouse(el,'mouseover',c,0);
-      __cmuxPointer(el,'pointerenter',c,0);__cmuxMouse(el,'mouseenter',c,0,0,false);
+      __cmuxPointer(el,'pointerenter',c,0,false);__cmuxMouse(el,'mouseenter',c,0,0,false);
       __cmuxPointer(el,'pointermove',c,0);__cmuxMouse(el,'mousemove',c,0);
       __cmuxPointer(el,'pointerdown',c,1);__cmuxMouse(el,'mousedown',c,1,1);
       if(typeof el.focus==='function'){try{el.focus({preventScroll:true});}catch(e){try{el.focus();}catch(e2){}}}
@@ -7122,7 +7122,7 @@ class TerminalController {
     }
     function __cmuxHover(el){const c=__cmuxCenter(el);
       __cmuxPointer(el,'pointerover',c,0);__cmuxMouse(el,'mouseover',c,0);
-      __cmuxPointer(el,'pointerenter',c,0);__cmuxMouse(el,'mouseenter',c,0,0,false);
+      __cmuxPointer(el,'pointerenter',c,0,false);__cmuxMouse(el,'mouseenter',c,0,0,false);
       __cmuxPointer(el,'pointermove',c,0);__cmuxMouse(el,'mousemove',c,0);
     }
     function __cmuxSetChecked(el,desired){


### PR DESCRIPTION
The browser view CLI actions this branch was named for (`react-grab`, `devtools`, `console`, `focus-mode`, `zoom`, `history`) already landed on main via https://github.com/manaflow-ai/cmux/pull/5766, with follow-up refinements in https://github.com/manaflow-ai/cmux/pull/5870 and https://github.com/manaflow-ai/cmux/pull/5778. This PR is now reduced to the one fix from that work that was not yet on main.

`PointerEvent` `pointerenter` (like `mouseenter`) must not bubble. `__cmuxMouse` already honored a `bubbles` flag and dispatched `mouseenter` non-bubbling, but `__cmuxPointer` hardcoded `bubbles:true`, so `pointerenter` bubbled. That fires spurious enter signals on ancestor elements and can corrupt hover state (hover menus, pointer tracking) in nested components when `__cmuxClick`/`__cmuxHover` run. Fix adds a `bubbles` parameter to `__cmuxPointer` mirroring `__cmuxMouse` and passes `false` at the two `pointerenter` call sites. `pointerover`/`move`/`down`/`up` keep the default `bubbles:true`, which is correct per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to injected JS input simulation in `TerminalController`; no auth, data, or routing impact.
> 
> **Overview**
> Fixes synthetic **click** and **hover** gestures in injected `browserInputHelpers` so `pointerenter` matches real DOM behavior and existing `mouseenter` handling.
> 
> `__cmuxPointer` now accepts an optional `bubbles` flag (default on). **`pointerenter`** is dispatched with **`bubbles: false`** in `__cmuxClick` and `__cmuxHover`, aligning the pointer + mouse sequence frameworks expect for enter events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecc5a769142710d62f8251180a68795380ae337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->