### PR TITLE
Cover current Codex hook events

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -164,7 +164,15 @@ extension CMUXCLI {
                 .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit"),
                 .init(agentEvent: "Stop", cmuxSubcommand: "stop"),
             ],
-            feedHookEvents: ["PreToolUse", "PermissionRequest"],
+            feedHookEvents: [
+                "PreToolUse",
+                "PermissionRequest",
+                "PostToolUse",
+                "PreCompact",
+                "PostCompact",
+                "SubagentStart",
+                "SubagentStop",
+            ],
             postInstallAction: .codexConfigToml
         ),
         AgentHookDef(

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -66,6 +66,12 @@ struct FeedEventClassifier {
         case response
         /// A subagent finished responding. Telemetry only.
         case subagentResponse
+        /// A subagent started. Telemetry only.
+        case subagentStart
+        /// Conversation compaction is about to run. Telemetry only.
+        case preCompact
+        /// Conversation compaction finished. Telemetry only.
+        case postCompact
         case sessionStart
         case sessionEnd
         /// A generic status/notification event. Telemetry only — real
@@ -132,6 +138,12 @@ struct FeedEventClassifier {
             return ("Stop", false)
         case .subagentResponse:
             return ("SubagentStop", false)
+        case .subagentStart:
+            return ("SubagentStart", false)
+        case .preCompact:
+            return ("PreCompact", false)
+        case .postCompact:
+            return ("PostCompact", false)
         case .sessionStart:
             return ("SessionStart", false)
         case .sessionEnd:
@@ -176,10 +188,13 @@ struct FeedEventClassifier {
             "PreToolUse": .toolStart,
             "beforeShellExecution": .toolStart,
             "PostToolUse": .toolEnd,
+            "PreCompact": .preCompact,
+            "PostCompact": .postCompact,
             "UserPromptSubmit": .promptSubmit,
             "SessionStart": .sessionStart,
             "SessionEnd": .sessionEnd,
             "Stop": .response,
+            "SubagentStart": .subagentStart,
             "SubagentStop": .subagentResponse,
             "Notification": .statusNotification,
         ],
@@ -226,10 +241,13 @@ struct FeedEventClassifier {
         "beforeShellExecution": .toolStartMaybeApproval,
         "PermissionRequest": .approvalRequest,
         "PostToolUse": .toolEnd,
+        "PreCompact": .preCompact,
+        "PostCompact": .postCompact,
         "UserPromptSubmit": .promptSubmit,
         "SessionStart": .sessionStart,
         "SessionEnd": .sessionEnd,
         "Stop": .response,
+        "SubagentStart": .subagentStart,
         "SubagentStop": .subagentResponse,
         "Notification": .statusNotification,
     ]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28113,6 +28113,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         "PostCompact",
         "SessionStart",
         "UserPromptSubmit",
+        "SubagentStart",
+        "SubagentStop",
         "Stop",
     ]
 
@@ -28125,6 +28127,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         case "PostCompact": return "post_compact"
         case "SessionStart": return "session_start"
         case "UserPromptSubmit": return "user_prompt_submit"
+        case "SubagentStart": return "subagent_start"
+        case "SubagentStop": return "subagent_stop"
         case "Stop": return "stop"
         default: return nil
         }
@@ -28132,7 +28136,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
     private static func codexHookEventUsesMatcher(_ eventName: String) -> Bool {
         switch eventName {
-        case "PreToolUse", "PermissionRequest", "PostToolUse", "PreCompact", "PostCompact", "SessionStart":
+        case "PreToolUse", "PermissionRequest", "PostToolUse", "PreCompact", "PostCompact", "SessionStart",
+             "SubagentStart", "SubagentStop":
             return true
         default:
             return false

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -3134,6 +3134,24 @@ extension CLINotifyProcessIntegrationRegressionTests {
             allCommands.contains { $0 == previousBundledHookCommand },
             "Codex setup should replace bundled-CLI hooks that did not pin CMUX_SOCKET_PATH, saw \(allCommands)"
         )
+        for feedEvent in [
+            "PreToolUse",
+            "PermissionRequest",
+            "PostToolUse",
+            "PreCompact",
+            "PostCompact",
+            "SubagentStart",
+            "SubagentStop",
+        ] {
+            XCTAssertEqual(
+                allCommands.filter {
+                    $0.contains("CMUX_BUNDLED_CLI_PATH")
+                        && $0.contains("\"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" hooks feed --source codex --event \(feedEvent)")
+                }.count,
+                1,
+                "Codex setup should install one bundled Feed hook for \(feedEvent), saw \(allCommands)"
+            )
+        }
         XCTAssertEqual(
             allCommands.filter { $0.contains("hooks codex prompt-submit") }.count,
             1,

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -115,6 +115,14 @@ struct FeedEventClassificationTests {
         #expect(classify("codex", "PermissionRequest", tool: "shell").actionable == false)
     }
 
+    @Test func codexLifecycleFeedEventsStayTelemetryAndPreserveNames() {
+        for event in ["PostToolUse", "PreCompact", "PostCompact", "SubagentStart", "SubagentStop"] {
+            let classification = classify("codex", event, tool: "shell")
+            #expect(classification.name == event)
+            #expect(classification.actionable == false)
+        }
+    }
+
     /// Unknown source + unknown event is safe by default.
     @Test func unknownSourceUnknownEventIsSafe() {
         #expect(classify("totally-new-agent", "some_future_event", tool: "Bash").actionable == false)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -27,6 +27,8 @@ CODEX_HOOK_EVENT_LABELS = {
     "PostCompact": "post_compact",
     "SessionStart": "session_start",
     "UserPromptSubmit": "user_prompt_submit",
+    "SubagentStart": "subagent_start",
+    "SubagentStop": "subagent_stop",
     "Stop": "stop",
 }
 
@@ -37,6 +39,8 @@ CODEX_HOOK_EVENTS_WITH_MATCHERS = {
     "PreCompact",
     "PostCompact",
     "SessionStart",
+    "SubagentStart",
+    "SubagentStop",
 }
 
 CMUX_CODEX_HOOK_SUBCOMMANDS = (
@@ -48,6 +52,11 @@ CMUX_CODEX_HOOK_SUBCOMMANDS = (
 CMUX_CODEX_FEED_EVENTS = (
     "PreToolUse",
     "PermissionRequest",
+    "PostToolUse",
+    "PreCompact",
+    "PostCompact",
+    "SubagentStart",
+    "SubagentStop",
 )
 
 FAKE_WORKSPACE_ID = "11111111-1111-1111-1111-111111111111"
@@ -714,7 +723,7 @@ def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -
             raise AssertionError(f"missing {event_name} hook group: {hooks!r}")
         if groups[-1]["hooks"][0].get("timeout") != 5:
             raise AssertionError(f"wrong {event_name} timeout: {groups[-1]!r}")
-    for event_name in ["PreToolUse", "PermissionRequest"]:
+    for event_name in CMUX_CODEX_FEED_EVENTS:
         groups = hook_groups.get(event_name)
         if not groups:
             raise AssertionError(f"missing {event_name} hook group: {hooks!r}")
@@ -2039,6 +2048,66 @@ def test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path: str, root: Pat
         raise AssertionError(f"wrong PreToolUse event: {frame!r}")
 
 
+def test_codex_lifecycle_feed_events_stay_telemetry_and_distinct(cli_path: str, root: Path) -> None:
+    event_payloads = {
+        "PostToolUse": {
+            "session_id": "codex-session",
+            "turn_id": "turn-post-tool",
+            "cwd": "/tmp/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "printf hi"},
+            "tool_response": {"exit_code": 0, "stdout": "hi", "stderr": ""},
+        },
+        "PreCompact": {
+            "session_id": "codex-session",
+            "turn_id": "turn-pre-compact",
+            "cwd": "/tmp/project",
+            "hook_event_name": "PreCompact",
+            "trigger": "manual",
+        },
+        "PostCompact": {
+            "session_id": "codex-session",
+            "turn_id": "turn-post-compact",
+            "cwd": "/tmp/project",
+            "hook_event_name": "PostCompact",
+            "trigger": "manual",
+        },
+        "SubagentStart": {
+            "session_id": "codex-session",
+            "turn_id": "turn-subagent-start",
+            "cwd": "/tmp/project",
+            "hook_event_name": "SubagentStart",
+            "agent_id": "agent-1",
+            "agent_type": "general",
+        },
+        "SubagentStop": {
+            "session_id": "codex-session",
+            "turn_id": "turn-subagent-stop",
+            "cwd": "/tmp/project",
+            "hook_event_name": "SubagentStop",
+            "agent_id": "agent-1",
+            "agent_type": "general",
+        },
+    }
+
+    for event_name, payload in event_payloads.items():
+        stdout, frame = run_feed_hook(
+            cli_path,
+            root / f"cmux-{event_name.lower()}.sock",
+            payload,
+            None,
+        )
+        if stdout != {}:
+            raise AssertionError(f"Codex {event_name} telemetry should not emit a decision: {stdout!r}")
+        params = frame["params"]
+        if params.get("wait_timeout_seconds") != 0:
+            raise AssertionError(f"Codex {event_name} should not wait for Feed reply: {frame!r}")
+        event = params["event"]
+        if event.get("hook_event_name") != event_name or event.get("_source") != "codex":
+            raise AssertionError(f"Codex {event_name} should stay distinct in Feed, got {event!r}")
+
+
 def test_claude_subagent_stop_stays_distinct_feed_telemetry(cli_path: str, root: Path) -> None:
     stdout, frame = run_feed_hook(
         cli_path,
@@ -2106,6 +2175,7 @@ def main() -> int:
             test_codex_permission_request_is_nonblocking_telemetry(cli_path, root)
             test_codex_permission_decisions_do_not_block_approval_reviewer(cli_path, root)
             test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)
+            test_codex_lifecycle_feed_events_stay_telemetry_and_distinct(cli_path, root)
             test_claude_subagent_stop_stays_distinct_feed_telemetry(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")


### PR DESCRIPTION
## Summary

- Fixes #5962.
- Installs Codex Feed hooks for `PostToolUse`, `PreCompact`, `PostCompact`, `SubagentStart`, and `SubagentStop` in addition to the existing `PreToolUse` and `PermissionRequest` Feed hooks.
- Keeps Codex `PermissionRequest` non-blocking Feed telemetry so Codex's approval reviewer still owns allow/deny decisions.
- Preserves distinct Codex event names in Feed and adds subagent hook trust labels.
- Expands Swift and Python coverage for install persistence and Feed classification.

## Validation

- `xcodebuild -project cmux.xcodeproj -scheme cmux-cli -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/kevinslin/Library/Developer/Xcode/DerivedData/cmux-codex-hook-coverage build`
- `CMUX_CLI_BIN=/Users/kevinslin/Library/Developer/Xcode/DerivedData/cmux-codex-hook-coverage/Build/Products/Debug/cmux python3 tests/test_codex_feed_hooks.py`
- `git diff --check`

## Caveat

- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit ...` did not reach the selected tests locally because the app target's `Build Command Palette Nucleo FFI` phase failed first: local `rustc 1.84.0` is too old for `unicode-segmentation@1.13.2`, which requires `rustc 1.85.0`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs and classifies all current Codex Feed hooks, adding PostToolUse, PreCompact, PostCompact, SubagentStart, and SubagentStop. These stay telemetry-only and PermissionRequest remains non-blocking, with new Swift/Python tests for install persistence and Feed classification.

- New Features
  - Installed Codex Feed hooks for PostToolUse, Pre/PostCompact, and SubagentStart/Stop.
  - Updated classifier and session mapping to preserve event names and keep them non-actionable.
  - Added Swift and Python tests to verify hook install, non-blocking PermissionRequest, and classification.

<sup>Written for commit 9802b89a2f850b46c0372b1feb93c69ba3887060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783845021&installation_id=133855650&pr_number=5963&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5963&signature=0adfb58b7ecb7f8f84a79e0c2f163d9a91dd1dd9abe94119fa84a67cde65606d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->