### PR TITLE
Fix 100% CPU render loop when an extension sidebar is selected (#5970)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11414,18 +11414,26 @@ struct VerticalTabsSidebar: View {
                     CmuxExtensionSidebarSelection.setProviderId(CmuxSidebarProviderDescriptor.defaultWorkspacesID)
                 }
             )
-            .onReceive(
-                extensionSidebarImmediateObservationPublisher(renderContext: renderContext)
-                    .receive(on: RunLoop.main)
-            ) { _ in
-                refreshExtensionSidebarSnapshot()
+            // Observe workspace state via `.task(id:)` so SwiftUI owns the
+            // subscription lifecycle: restarted only when the observed workspace
+            // set changes, torn down on disappear. Bridging the Combine
+            // publishers through `.values` (instead of `.onReceive` on a publisher
+            // rebuilt every body pass) avoids re-subscribing on every render,
+            // which replayed each `@Published`-backed publisher's current value,
+            // bumped `extensionSidebarUpdateToken`, re-invalidated the body, and
+            // span the main thread at 100% CPU once an extension sidebar was
+            // selected (#5970).
+            .task(id: renderContext.tabIds) {
+                for await _ in extensionSidebarImmediateObservationPublisher(renderContext: renderContext).values {
+                    refreshExtensionSidebarSnapshot()
+                }
             }
-            .onReceive(
-                extensionSidebarDebouncedObservationPublisher(renderContext: renderContext)
-                    .receive(on: RunLoop.main)
+            .task(id: renderContext.tabIds) {
+                let debounced = extensionSidebarDebouncedObservationPublisher(renderContext: renderContext)
                     .debounce(for: Self.extensionSidebarObservationCoalesceInterval, scheduler: RunLoop.main)
-            ) { _ in
-                refreshExtensionSidebarSnapshot()
+                for await _ in debounced.values {
+                    refreshExtensionSidebarSnapshot()
+                }
             }
             // Fade the extension's content out at the bottom so it dissolves behind the
             // sidebar footer instead of overlapping it sharply, matching the default
@@ -11586,18 +11594,22 @@ struct VerticalTabsSidebar: View {
             }
             .background(Color.clear)
             .modifier(ClearScrollBackground())
-            .onReceive(
-                extensionSidebarImmediateObservationPublisher(renderContext: renderContext)
-                    .receive(on: RunLoop.main)
-            ) { _ in
-                refreshExtensionSidebarSnapshot()
+            // Stable observation via `.task(id:)` (see the matching block above):
+            // SwiftUI restarts it only when the observed workspace set changes, so
+            // the publishers are not rebuilt and re-subscribed every body pass,
+            // which replayed their current value and span the main thread at 100%
+            // CPU once an extension sidebar was selected (#5970).
+            .task(id: renderContext.tabIds) {
+                for await _ in extensionSidebarImmediateObservationPublisher(renderContext: renderContext).values {
+                    refreshExtensionSidebarSnapshot()
+                }
             }
-            .onReceive(
-                    extensionSidebarDebouncedObservationPublisher(renderContext: renderContext)
-                        .receive(on: RunLoop.main)
-                        .debounce(for: Self.extensionSidebarObservationCoalesceInterval, scheduler: RunLoop.main)
-                ) { _ in
-                refreshExtensionSidebarSnapshot()
+            .task(id: renderContext.tabIds) {
+                let debounced = extensionSidebarDebouncedObservationPublisher(renderContext: renderContext)
+                    .debounce(for: Self.extensionSidebarObservationCoalesceInterval, scheduler: RunLoop.main)
+                for await _ in debounced.values {
+                    refreshExtensionSidebarSnapshot()
+                }
             }
             .onReceive(
                 NotificationCenter.default.publisher(for: BrowserStackSidebar.stateDidLoadNotification)


### PR DESCRIPTION
## Summary

Fixes #5970: selecting a bundled extension-sidebar preset (e.g. "Project Worktrees") pinned the main thread at ~100% CPU in an unbounded SwiftUI re-render loop, and because the selection persists in `cmuxExtensionSidebar.providerId`, the app re-entered the loop on every launch.

**Root cause.** `VerticalTabsSidebar` observed workspace state with `.onReceive` on a publisher built inline on every `body` pass:

```swift
.onReceive(extensionSidebarImmediateObservationPublisher(renderContext: renderContext).receive(on: RunLoop.main)) { _ in
    refreshExtensionSidebarSnapshot()
}
```

That factory returns a fresh `AnyPublisher` each render, so SwiftUI re-subscribed every render. Each publisher is a `CombineLatest` of `@Published` workspace fields, which replays its current value on every subscription. The replay called `refreshExtensionSidebarSnapshot()` -> bumped the `@State` `extensionSidebarUpdateToken` -> re-invalidated `body` -> re-subscribed -> replayed again. (The default workspaces sidebar doesn't wire a recreated-per-render publisher into a body-level `@State` bump, so it was unaffected.)

**Fix.** Observe via `.task(id: renderContext.tabIds)`, bridging the existing observation publishers through `.values`. SwiftUI owns the subscription lifecycle: the task restarts only when the observed workspace set changes and is torn down on disappear, so a subscription is established once per genuine change instead of every frame. No new Combine view state, no shadow tab-id tracker. The publishers themselves are unchanged, so their on-subscribe replay (relied on by a late-mounting sidebar row, covered by `WorkspaceSidebarObservationTests`) still fires when a subscription is genuinely established.

## Testing

- **Repro (before):** built a Debug app at the affected commit, set `cmuxExtensionSidebar.providerId = com.example.cmux.sidebar.project-worktrees` with a workspace open -> sustained ~100% CPU. `sample` shows a continuous `GraphHost.flushTransactions` -> `VerticalTabsSidebar.body` -> `CmuxExtensionSidebarSelection.descriptor(for:)`.
- **After:** rebuilt with this change, same pref + workspace -> CPU settles to idle (~0.5%); the extension sidebar renders and provider switching works.
- `WorkspaceSidebarObservationTests` (the publishers' emit-on-subscribe contract) is unaffected since the publishers are untouched.

## Notes

- Reworked from an earlier `@State`-publisher-caching approach to `.task(id:)` per reviewer feedback (`cmux-swift-concurrency-modernization` / `cmux-swift-architectural-rethink`): no new Combine `@State`, and the runtime owns the subscription lifecycle.

## Checklist

- [x] I tested the change locally
- [x] Existing publisher tests (`WorkspaceSidebarObservationTests`) remain valid; the change is in view-subscription lifecycle, not the publishers
- [ ] Demo video (can add if useful)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized extension sidebar observation to avoid repeated re-subscriptions, reducing unnecessary refreshes. This improves stability and responsiveness of the sidebar, resulting in smoother interactions when switching views or tabs. The update harmonizes observation behavior across related areas to prevent redundant updates and lessen UI jitter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->