### PR TITLE
Fix copyOnSelect default not disabling Ghostty copy-on-select

### DIFF
--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -158,15 +158,15 @@ enum TerminalCopyOnSelectSettings {
         defaults.object(forKey: copyOnSelectKey) as? Bool
     }
 
-    static func ghosttyCopyOnSelectValue(defaults: UserDefaults = .standard) -> String? {
+    static func ghosttyCopyOnSelectValue(defaults: UserDefaults = .standard) -> String {
         // cmux's default is intentionally off, but Ghostty defaults copy-on-select
         // to true on macOS. Emit the default too so fresh installs and startup
         // before settings-file hydration do not inherit Ghostty's default.
         isEnabled(defaults: defaults) ? "clipboard" : "false"
     }
 
-    static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String? {
-        guard let value = ghosttyCopyOnSelectValue(defaults: defaults) else { return nil }
+    static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String {
+        let value = ghosttyCopyOnSelectValue(defaults: defaults)
         return "copy-on-select = \(value)"
     }
 
@@ -202,11 +202,10 @@ enum TerminalCopyOnSelectSettings {
 }
 
 enum TerminalManagedGhosttySettings {
-    static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String? {
+    static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String {
         let lines = [
             TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults),
-        ].compactMap { $0 }
-        guard !lines.isEmpty else { return nil }
+        ]
         return lines.joined(separator: "\n")
     }
 }

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -159,8 +159,10 @@ enum TerminalCopyOnSelectSettings {
     }
 
     static func ghosttyCopyOnSelectValue(defaults: UserDefaults = .standard) -> String? {
-        guard let enabled = storedValue(defaults: defaults) else { return nil }
-        return enabled ? "clipboard" : "false"
+        // cmux's default is intentionally off, but Ghostty defaults copy-on-select
+        // to true on macOS. Emit the default too so fresh installs and startup
+        // before settings-file hydration do not inherit Ghostty's default.
+        isEnabled(defaults: defaults) ? "clipboard" : "false"
     }
 
     static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String? {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2422,7 +2422,7 @@ class GhosttyApp {
     }
 
     private func loadCmuxManagedTerminalSettingsConfig(_ config: ghostty_config_t) {
-        guard let contents = TerminalManagedGhosttySettings.ghosttyConfigContents() else { return }
+        let contents = TerminalManagedGhosttySettings.ghosttyConfigContents()
         loadInlineGhosttyConfig(
             contents,
             into: config,

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -788,8 +788,14 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
             "terminal.copyOnSelect"
         )
         XCTAssertFalse(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
-        XCTAssertNil(TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults))
-        XCTAssertNil(TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults))
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults),
+            "copy-on-select = false"
+        )
+        XCTAssertEqual(
+            TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
+            "copy-on-select = false"
+        )
 
         let notificationCenter = NotificationCenter()
         var notificationCount = 0
@@ -839,8 +845,14 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
             notificationCenter: notificationCenter
         )
         XCTAssertFalse(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
-        XCTAssertNil(TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults))
-        XCTAssertNil(TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults))
+        XCTAssertEqual(
+            TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults),
+            "copy-on-select = false"
+        )
+        XCTAssertEqual(
+            TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
+            "copy-on-select = false"
+        )
         XCTAssertEqual(notificationCount, 2)
     }
 }


### PR DESCRIPTION
## Summary

- Fix `terminal.copyOnSelect = false` not being applied authoritatively to the embedded Ghostty terminal on macOS.
- cmux exposes `terminal.copyOnSelect` as a cmux-managed setting and defaults it to `false`, but the default/disabled state did not emit an explicit Ghostty `copy-on-select = false` override.
- Without that explicit override, the behavior can fall through to Ghostty defaults or user Ghostty configuration, making cmux's `terminal.copyOnSelect = false` non-authoritative.
- This change makes cmux always emit the resolved setting into the managed Ghostty config:
  - `terminal.copyOnSelect = false` -> `copy-on-select = false`
  - `terminal.copyOnSelect = true` -> `copy-on-select = clipboard`

## Testing

- Built and launched a tagged debug app:

  ```bash
  ./scripts/reload.sh --tag copyfix --launch
  ```

- Manually verified in `cmux DEV copyfix` that double-clicking terminal text no longer replaces the system clipboard when `terminal.copyOnSelect` is disabled.

- Verification flow used for manual testing:

  ```bash
  printf 'copyfix-sentinel' | pbcopy
  printf 'copyfixword\n'
  # double-click copyfixword
  pbpaste
  ```

  Expected result after this fix: `pbpaste` still returns `copyfix-sentinel` when `terminal.copyOnSelect` is disabled.

- Ran the focused unit test:

  ```bash
  xcodebuild test \
    -project cmux.xcodeproj \
    -scheme cmux-unit \
    -configuration Debug \
    -destination "platform=macOS" \
    -derivedDataPath /tmp/cmux-copyfix-unit \
    -only-testing:cmuxTests/TerminalCopyOnSelectSettingsTests
  ```

  Result:

  ```text
  Test Suite 'TerminalCopyOnSelectSettingsTests' passed
  Executed 1 test, with 0 failures
  ** TEST SUCCEEDED **
  ```

- Ran:

  ```bash
  git diff --check upstream/main..HEAD
  ```

  Result: OK.

- Docs/changelog not updated: this fixes existing `terminal.copyOnSelect` behavior without adding a new setting or user-facing text.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- After: https://github.com/user-attachments/assets/0d7eb303-b881-40c2-8702-8905ffdfc25e
- Before: Not attached. My local Ghostty config now also contains `copy-on-select = false`, so the current release no longer reliably reproduces the clipboard replacement in this environment. The regression is covered by `TerminalCopyOnSelectSettingsTests`, which verifies cmux now emits `copy-on-select = false` for the default disabled state.

## Related

- Follow-up to #4011, which added `terminal.copyOnSelect`.
- Related to #2911 and the broader terminal selection/copy behavior in #2203.
- Historical context: #2282 previously emitted an explicit `copy-on-select = false` for the disabled state, #2420 removed that override when the setting was removed, and #4011 later reintroduced the cmux-managed setting.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783855554&installation_id=133855650&pr_number=5973&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5973&signature=dbd924654a929f8c63034400cc7c59bef8791aa876a269c2b1cfbbb08db75e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `terminal.copyOnSelect = false` not being enforced in the embedded Ghostty terminal on macOS. We now always emit `copy-on-select` to Ghostty, including defaults, so behavior never falls back to Ghostty or user config.

- **Bug Fixes**
  - Map `terminal.copyOnSelect`: `false` -> `copy-on-select = false`, `true` -> `copy-on-select = clipboard`.
  - Always emit the default on fresh installs and at startup before settings hydration; config helpers return non-optional strings and the Ghostty loader unconditionally applies them.
  - Updated unit tests to expect `copy-on-select = false` by default.

<sup>Written for commit f88e5746727a208352b8a788013dbcb9a28508f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The copy-on-select preference is now always written explicitly to the Ghostty configuration (e.g., "copy-on-select = true/false"), so it will no longer be omitted when unset or using defaults.

* **Tests**
  * Updated tests to expect the explicit copy-on-select configuration value even when defaults are used or reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->