### PR TITLE
Support dragging directories from the Files sidebar into terminals

### DIFF
--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -110,9 +110,11 @@ enum FileExplorerDragSource {
     ) -> (any NSPasteboardWriting)? {
         guard isLocalProvider else { return nil }
         if node.isDirectory {
-            // Plain (non-standardized) URL, matching DraggableFolderNSView:
-            // standardizing resolves symlinks (e.g. /tmp -> /private/tmp) and
-            // the inserted path should read as the path the user sees.
+            // Plain (non-standardized) URL — the same payload
+            // DraggableFolderNSView writes for the workspace folder icon drag.
+            // Read-side consumers (PasteboardFileURLReader) standardize
+            // uniformly for every drag source, so the writer stays neutral
+            // rather than baking standardization into the payload.
             return URL(fileURLWithPath: node.path) as NSURL
         }
         return FilePreviewDragPasteboardWriter(filePath: node.path, displayTitle: node.name)

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -110,7 +110,10 @@ enum FileExplorerDragSource {
     ) -> (any NSPasteboardWriting)? {
         guard isLocalProvider else { return nil }
         if node.isDirectory {
-            return URL(fileURLWithPath: node.path).standardizedFileURL as NSURL
+            // Plain (non-standardized) URL, matching DraggableFolderNSView:
+            // standardizing resolves symlinks (e.g. /tmp -> /private/tmp) and
+            // the inserted path should read as the path the user sees.
+            return URL(fileURLWithPath: node.path) as NSURL
         }
         return FilePreviewDragPasteboardWriter(filePath: node.path, displayTitle: node.name)
     }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -94,6 +94,28 @@ enum FileExplorerPanelPlacement: Equatable {
     case pane
 }
 
+enum FileExplorerDragSource {
+    /// Pasteboard writer for dragging a file-tree node.
+    ///
+    /// Files carry a `FilePreviewDragPasteboardWriter` so pane drops can open a
+    /// preview while terminal drops insert the path. Directories have no preview
+    /// surface, so they carry a plain file URL — the same payload as the
+    /// workspace folder icon drag (`DraggableFolderNSView`) — which the file-drop
+    /// text routing inserts as a shell-escaped path over terminals and editors.
+    /// Remote providers have no local URL to offer, so their nodes are not
+    /// draggable.
+    static func pasteboardWriter(
+        for node: FileExplorerNode,
+        isLocalProvider: Bool
+    ) -> (any NSPasteboardWriting)? {
+        guard isLocalProvider else { return nil }
+        if node.isDirectory {
+            return URL(fileURLWithPath: node.path).standardizedFileURL as NSURL
+        }
+        return FilePreviewDragPasteboardWriter(filePath: node.path, displayTitle: node.name)
+    }
+}
+
 /// The entire file explorer panel as one AppKit view hierarchy.
 /// Contains the header bar (path + controls) and NSOutlineView, with no SwiftUI intermediaries.
 struct FileExplorerPanelView: NSViewRepresentable {
@@ -588,9 +610,11 @@ struct FileExplorerPanelView: NSViewRepresentable {
         // MARK: - Drag-to-Preview
 
         func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> (any NSPasteboardWriting)? {
-            guard let node = item as? FileExplorerNode, !node.isDirectory else { return nil }
-            guard store.provider is LocalFileExplorerProvider else { return nil }
-            return FilePreviewDragPasteboardWriter(filePath: node.path, displayTitle: node.name)
+            guard let node = item as? FileExplorerNode else { return nil }
+            return FileExplorerDragSource.pasteboardWriter(
+                for: node,
+                isLocalProvider: store.provider is LocalFileExplorerProvider
+            )
         }
 
         func outlineView(
@@ -855,7 +879,10 @@ final class FileExplorerContainerView: NSView {
         outlineView.delegate = coordinator
         outlineView.target = coordinator
         outlineView.doubleAction = #selector(FileExplorerPanelView.Coordinator.handleDoubleClick(_:))
-        outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
+        // .copy is required for directory drags: their plain file-URL payload is
+        // accepted by terminal/editor text-drop targets with .copy, while file
+        // preview transfers keep resolving to .move.
+        outlineView.setDraggingSourceOperationMask([.move, .copy], forLocal: true)
         coordinator.outlineView = outlineView
 
         // Context menu

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2811,6 +2811,56 @@ final class FilePreviewFocusCoordinatorTests: XCTestCase {
 }
 
 
+final class FileExplorerDragSourceTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        NSPasteboard(name: .drag).clearContents()
+    }
+
+    override func tearDown() {
+        NSPasteboard(name: .drag).clearContents()
+        super.tearDown()
+    }
+
+    func testDirectoryNodeDragsAsPlainFileURL() throws {
+        let node = FileExplorerNode(name: "testdir", path: "/tmp/cmux-drag-test/testdir", isDirectory: true)
+
+        let writer = try XCTUnwrap(
+            FileExplorerDragSource.pasteboardWriter(for: node, isLocalProvider: true)
+        )
+
+        let url = try XCTUnwrap(writer as? NSURL)
+        XCTAssertTrue(url.isFileURL)
+        XCTAssertEqual(url.path, node.path)
+
+        // Directories must not advertise file-preview transfer types: a preview
+        // transfer makes terminal drops defer to bonsplit pane routing, and a
+        // directory has no preview surface to open.
+        let types = writer.writableTypes(for: NSPasteboard(name: .drag))
+        XCTAssertTrue(types.contains(.fileURL))
+        XCTAssertFalse(types.contains(DragOverlayRoutingPolicy.filePreviewTransferType))
+        XCTAssertFalse(types.contains(FilePreviewDragPasteboardWriter.bonsplitTransferType))
+    }
+
+    func testFileNodeDragsAsFilePreviewWriter() throws {
+        let node = FileExplorerNode(name: "file.txt", path: "/tmp/cmux-drag-test/file.txt", isDirectory: false)
+
+        let writer = try XCTUnwrap(
+            FileExplorerDragSource.pasteboardWriter(for: node, isLocalProvider: true)
+        )
+
+        XCTAssertTrue(writer is FilePreviewDragPasteboardWriter)
+    }
+
+    func testRemoteProviderNodesAreNotDraggable() {
+        let dir = FileExplorerNode(name: "dir", path: "/remote/dir", isDirectory: true)
+        let file = FileExplorerNode(name: "file.txt", path: "/remote/file.txt", isDirectory: false)
+
+        XCTAssertNil(FileExplorerDragSource.pasteboardWriter(for: dir, isLocalProvider: false))
+        XCTAssertNil(FileExplorerDragSource.pasteboardWriter(for: file, isLocalProvider: false))
+    }
+}
+
 final class FilePreviewDragPasteboardWriterTests: XCTestCase {
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
## Problem

Dragging a **directory** from the Files sidebar does nothing — the drag session never even starts (no drag image). Dragging a folder onto a terminal to insert its shell-escaped path (e.g. for `cd`) is a common workflow that works for files but not folders.

Root cause: `outlineView(_:pasteboardWriterForItem:)` returns `nil` for any directory node, and the outline view's local source operation mask was `.move`-only, which would have blocked the `.copy` operation that plain file-URL payloads resolve to at terminal text-drop targets.

## Fix

- Extract the drag-writer decision into `FileExplorerDragSource.pasteboardWriter(for:isLocalProvider:)` so it is unit-testable.
- **Directories drag as a plain file URL** (`NSURL`) — the same payload as the existing workspace folder icon drag (`DraggableFolderNSView`). They deliberately do **not** advertise file-preview transfer types: terminals defer those drags to bonsplit pane routing, and a directory has no preview surface to open.
- Add `.copy` to the outline view's local source operation mask. File preview transfers keep resolving to `.move` (`DragOverlayRoutingPolicy.textDropOperation`), so existing file-drag behavior is unchanged.
- Files keep the existing `FilePreviewDragPasteboardWriter` behavior; remote providers remain non-draggable.

## Behavior after this change

- Drag folder → terminal: inserts the shell-escaped path (default `fileDrop.defaultBehavior = text`), consistent with dragging a folder from Finder.
- Drag folder → editor text destinations: inserts path text via the same routing.
- Drag file: unchanged (preview transfer + text routing as before).

## Tests

Added `FileExplorerDragSourceTests` (in `cmuxTests/WindowAndDragTests.swift`, no new pbxproj wiring needed):
- directory nodes produce a file-URL-only writer (asserts preview/bonsplit transfer types are absent — the property that previously made terminal drops impossible),
- file nodes keep producing `FilePreviewDragPasteboardWriter`,
- remote-provider nodes are not draggable.

Note on the two-commit red/green convention: the regression tests target the newly extracted `FileExplorerDragSource` API, so a test-only first commit would fail to compile rather than fail as a test; they are in one commit with the fix.

## Localization audit

No user-facing strings added or changed; no localization updates required.

⚠️ Authored without a local Xcode toolchain (syntax-checked only) — relying on CI for build + test verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783880925&installation_id=133855650&pr_number=5985&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5985&signature=9b199a2dfac7e76434a74209932b487913e8a94e1d2b861ffb960117ff9ad775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dragging directories from the Files sidebar into terminals and editors. Drops insert the shell-escaped path; file drags remain unchanged.

- **New Features**
  - Directories now drag as a plain file URL (`NSURL`), matching the workspace folder icon drag (`DraggableFolderNSView`); read-side standardization is handled by `PasteboardFileURLReader`.
  - Added `.copy` to the outline view’s local drag mask; file previews still resolve to `.move`.
  - Files keep using `FilePreviewDragPasteboardWriter`; remote providers remain non-draggable.

<sup>Written for commit 6f92301f60a64d5ea9fac245fa9c55aa61f33a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop: directories now provide standard file-URL payloads and support copy and move operations for compatibility with terminals/editors; regular files continue to provide preview payloads; remote items are not draggable.

* **Tests**
  * Added tests that clear the system drag pasteboard and verify directory, file, and remote-provider drag behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->