### PR TITLE
Fix continuous Files sidebar flicker: keep the tree visible across same-root reloads

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1062,23 +1062,6 @@ final class FileExplorerStore: ObservableObject {
 
     // MARK: - Private
 
-    @MainActor
-    /// Drops `nodesByPath` entries no longer reachable from the fresh root
-    /// listing. Same-root reloads keep the map (for node reuse), so without
-    /// this, deleted paths would pin stale nodes — and a path deleted and
-    /// later re-created would resurface its old subtree.
-    private func pruneUnreachableNodes(from roots: [FileExplorerNode]) {
-        var reachable = Set<String>()
-        var stack = roots
-        while let node = stack.popLast() {
-            reachable.insert(node.path)
-            if let children = node.children {
-                stack.append(contentsOf: children)
-            }
-        }
-        nodesByPath = nodesByPath.filter { reachable.contains($0.key) }
-    }
-
     private func loadChildren(for parentNode: FileExplorerNode?, at path: String, silent: Bool = false) async {
         guard let provider else { return }
 
@@ -1130,7 +1113,22 @@ final class FileExplorerStore: ObservableObject {
                     selectedPath = children.first?.path
                     selectedPaths = selectedPath.map { Set([$0]) } ?? []
                 }
-                pruneUnreachableNodes(from: children)
+                // Drop nodesByPath entries no longer reachable from the fresh
+                // root listing. Same-root reloads keep the map (for node
+                // reuse), so without this, deleted paths would pin stale
+                // nodes — and a path deleted and later re-created would
+                // resurface its old subtree. Inline (not a method) so it
+                // shares this function's isolation under default-MainActor
+                // builds.
+                var reachable = Set<String>()
+                var stack = children
+                while let node = stack.popLast() {
+                    reachable.insert(node.path)
+                    if let nodeChildren = node.children {
+                        stack.append(contentsOf: nodeChildren)
+                    }
+                }
+                nodesByPath = nodesByPath.filter { reachable.contains($0.key) }
             }
             loadingPaths.remove(path)
             loadTasks.removeValue(forKey: path)

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1063,6 +1063,22 @@ final class FileExplorerStore: ObservableObject {
     // MARK: - Private
 
     @MainActor
+    /// Drops `nodesByPath` entries no longer reachable from the fresh root
+    /// listing. Same-root reloads keep the map (for node reuse), so without
+    /// this, deleted paths would pin stale nodes — and a path deleted and
+    /// later re-created would resurface its old subtree.
+    private func pruneUnreachableNodes(from roots: [FileExplorerNode]) {
+        var reachable = Set<String>()
+        var stack = roots
+        while let node = stack.popLast() {
+            reachable.insert(node.path)
+            if let children = node.children {
+                stack.append(contentsOf: children)
+            }
+        }
+        nodesByPath = nodesByPath.filter { reachable.contains($0.key) }
+    }
+
     private func loadChildren(for parentNode: FileExplorerNode?, at path: String, silent: Bool = false) async {
         guard let provider else { return }
 
@@ -1077,9 +1093,14 @@ final class FileExplorerStore: ObservableObject {
             try Task.checkCancellation()
             let children = entries.map { entry in
                 // Reuse the existing node for an unchanged path so NSOutlineView
-                // items stay valid across same-root refreshes (reused directory
-                // nodes keep their loaded subtree instead of re-listing it).
+                // items stay valid across same-root refreshes. Expanded
+                // directories keep their subtree (the re-expand pass below
+                // refreshes it); collapsed ones drop cached children so the
+                // next expand re-lists, matching pre-reuse behavior.
                 if let existing = nodesByPath[entry.path], existing.isDirectory == entry.isDirectory {
+                    if existing.isDirectory, !expandedPaths.contains(existing.path) {
+                        existing.children = nil
+                    }
                     return existing
                 }
                 let node = FileExplorerNode(name: entry.name, path: entry.path, isDirectory: entry.isDirectory)
@@ -1109,6 +1130,7 @@ final class FileExplorerStore: ObservableObject {
                     selectedPath = children.first?.path
                     selectedPaths = selectedPath.map { Set([$0]) } ?? []
                 }
+                pruneUnreachableNodes(from: children)
             }
             loadingPaths.remove(path)
             loadTasks.removeValue(forKey: path)

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -758,6 +758,11 @@ final class FileExplorerStore: ObservableObject {
     private var directoryWatchTask: Task<Void, Never>?
     private var directoryWatchPath: String?
 
+    /// The root path the currently displayed `rootNodes` were listed from.
+    /// `reload()` keeps the tree visible for same-root refreshes and only
+    /// blanks it when this differs from `rootPath`.
+    private var loadedTreeRootPath: String?
+
     /// Paths that are logically expanded (persisted across provider changes)
     private(set) var expandedPaths: Set<String> = []
 
@@ -943,10 +948,21 @@ final class FileExplorerStore: ObservableObject {
         #endif
         contentRevision &+= 1
         cancelAllLoads()
-        rootNodes = []
-        nodesByPath = [:]
+        // A same-root refresh (directory watcher, manual reload) keeps the
+        // current tree visible and swaps it atomically when the fresh listing
+        // arrives. Blanking the tree here made every watcher event flash an
+        // empty sidebar + spinner before the relisted content came back.
+        // Only a root change (or losing the provider) shows stale content from
+        // the wrong directory, so only then is the tree dropped eagerly.
+        if loadedTreeRootPath != rootPath || rootPath.isEmpty || provider == nil {
+            rootNodes = []
+            nodesByPath = [:]
+            loadedTreeRootPath = nil
+        }
         guard !rootPath.isEmpty, provider != nil else { return }
-        isRootLoading = true
+        if rootNodes.isEmpty {
+            isRootLoading = true
+        }
         let path = rootPath
         let task = Task { [weak self] in
             guard let self else { return }
@@ -1060,6 +1076,12 @@ final class FileExplorerStore: ObservableObject {
             let entries = try await provider.listDirectory(path: path, showHidden: showHiddenFiles)
             try Task.checkCancellation()
             let children = entries.map { entry in
+                // Reuse the existing node for an unchanged path so NSOutlineView
+                // items stay valid across same-root refreshes (reused directory
+                // nodes keep their loaded subtree instead of re-listing it).
+                if let existing = nodesByPath[entry.path], existing.isDirectory == entry.isDirectory {
+                    return existing
+                }
                 let node = FileExplorerNode(name: entry.name, path: entry.path, isDirectory: entry.isDirectory)
                 nodesByPath[entry.path] = node
                 return node
@@ -1080,6 +1102,7 @@ final class FileExplorerStore: ObservableObject {
                 }
             } else {
                 rootNodes = children
+                loadedTreeRootPath = path
                 isRootLoading = false
                 setRootStatusMessage(nil)
                 if selectedPath == nil {

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1062,6 +1062,7 @@ final class FileExplorerStore: ObservableObject {
 
     // MARK: - Private
 
+    @MainActor
     private func loadChildren(for parentNode: FileExplorerNode?, at path: String, silent: Bool = false) async {
         guard let provider else { return }
 
@@ -1083,6 +1084,10 @@ final class FileExplorerStore: ObservableObject {
                 if let existing = nodesByPath[entry.path], existing.isDirectory == entry.isDirectory {
                     if existing.isDirectory, !expandedPaths.contains(existing.path) {
                         existing.children = nil
+                        // A canceled in-flight load must not leave a reused
+                        // collapsed node stuck in loading/error state.
+                        existing.isLoading = false
+                        existing.error = nil
                     }
                     return existing
                 }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -153,7 +153,7 @@ struct FileExplorerPanelView: NSViewRepresentable {
         var onContainerChange: ((FileExplorerContainerView?) -> Void)?
         weak var containerView: FileExplorerContainerView?
         weak var outlineView: NSOutlineView?
-        private var lastRootNodeCount: Int = -1
+        private var lastRootContentFingerprint: Int?
         private var observationCancellable: AnyCancellable?
         private var styleObserver: Any?
         private var isUpdatingOutlineProgrammatically = false
@@ -239,10 +239,10 @@ struct FileExplorerPanelView: NSViewRepresentable {
                 statusMessage: store.rootStatusMessage
             )
 
-            let newCount = store.rootNodes.count
+            let fingerprint = Self.rootContentFingerprint(of: store.rootNodes)
             withProgrammaticOutlineUpdate {
-                if newCount != lastRootNodeCount {
-                    lastRootNodeCount = newCount
+                if fingerprint != lastRootContentFingerprint {
+                    lastRootContentFingerprint = fingerprint
                     let expandedPaths = store.expandedPaths
                     outlineView.reloadData()
                     restoreExpansionState(expandedPaths, in: outlineView)
@@ -251,6 +251,21 @@ struct FileExplorerPanelView: NSViewRepresentable {
                 }
                 applyStoredSelection(in: outlineView, fallbackToFirstVisible: false, scroll: false)
             }
+        }
+
+        /// Identity of the root listing as shown by the outline. A full
+        /// `reloadData()` runs only when this changes; a same-content refresh
+        /// (the directory watcher fires for changes deeper in the tree) goes
+        /// through row-level reconciliation instead. Comparing paths rather
+        /// than the node count also reloads when a same-sized listing has
+        /// different entries, which the old count check missed.
+        static func rootContentFingerprint(of nodes: [FileExplorerNode]) -> Int {
+            var hasher = Hasher()
+            for node in nodes {
+                hasher.combine(node.path)
+                hasher.combine(node.isDirectory)
+            }
+            return hasher.finalize()
         }
 
         private func restoreExpansionState(_ expandedPaths: Set<String>, in outlineView: NSOutlineView) {

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -177,6 +177,84 @@ struct FileExplorerStoreTests {
         #expect(!(store.rootNodes[1].isDirectory))
     }
 
+    // MARK: - Non-destructive same-root reload (sidebar flicker regression)
+
+    @Test
+    func testSameRootReloadKeepsTreeVisibleUntilFreshListingArrives() async throws {
+        let provider = DeferredListFileExplorerProvider()
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider, reloadIfAvailable: false)
+        store.setRootPath("/home/dev/project")
+
+        try await waitFor("initial listing requested") { provider.listCallPaths.count == 1 }
+        provider.resumeListing(returning: [
+            FileExplorerEntry(name: "a.txt", path: "/home/dev/project/a.txt", isDirectory: false)
+        ])
+        try await waitFor("initial root nodes loaded") { store.rootNodes.count == 1 }
+
+        // A same-root refresh (what the directory watcher triggers) must keep
+        // the current tree on screen instead of blanking it and flashing the
+        // loading spinner while the fresh listing is in flight.
+        store.reload()
+        #expect(store.rootNodes.count == 1, "tree should stay visible during same-root reload")
+        #expect(!store.isRootLoading, "spinner should not flash during same-root reload")
+
+        try await waitFor("refresh listing requested") { provider.listCallPaths.count == 2 }
+        #expect(store.rootNodes.count == 1)
+        provider.resumeListing(returning: [
+            FileExplorerEntry(name: "a.txt", path: "/home/dev/project/a.txt", isDirectory: false),
+            FileExplorerEntry(name: "b.txt", path: "/home/dev/project/b.txt", isDirectory: false),
+        ])
+        try await waitFor("refreshed root nodes swapped in") { store.rootNodes.count == 2 }
+    }
+
+    @Test
+    func testSameRootReloadReusesNodeIdentityForUnchangedPaths() async throws {
+        let provider = MockFileExplorerProvider()
+        provider.listings["/home/user/project"] = .success([
+            FileExplorerEntry(name: "src", path: "/home/user/project/src", isDirectory: true)
+        ])
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath("/home/user/project")
+        try await waitFor("root nodes loaded") { store.rootNodes.count == 1 }
+        let originalNode = try #require(store.rootNodes.first)
+
+        provider.listings["/home/user/project"] = .success([
+            FileExplorerEntry(name: "src", path: "/home/user/project/src", isDirectory: true),
+            FileExplorerEntry(name: "new.txt", path: "/home/user/project/new.txt", isDirectory: false),
+        ])
+        store.reload()
+        try await waitFor("refreshed root nodes loaded") { store.rootNodes.count == 2 }
+
+        // NSOutlineView keys row state off item identity: an unchanged path must
+        // come back as the same node object across a same-root refresh.
+        let refreshedSrc = try #require(store.rootNodes.first { $0.path == "/home/user/project/src" })
+        #expect(refreshedSrc === originalNode, "unchanged path should reuse its node instance")
+    }
+
+    @Test
+    func testRootSwitchDropsStaleTreeImmediately() async throws {
+        let provider = MockFileExplorerProvider()
+        provider.listings["/home/user/projectA"] = .success([
+            FileExplorerEntry(name: "a.txt", path: "/home/user/projectA/a.txt", isDirectory: false)
+        ])
+        provider.listings["/home/user/projectB"] = .success([
+            FileExplorerEntry(name: "b.txt", path: "/home/user/projectB/b.txt", isDirectory: false)
+        ])
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath("/home/user/projectA")
+        try await waitFor("projectA loaded") { store.rootNodes.count == 1 }
+
+        // Switching roots must not show projectA's tree under projectB's path.
+        store.setRootPath("/home/user/projectB")
+        #expect(store.rootNodes.isEmpty || store.rootNodes.first?.path.hasPrefix("/home/user/projectB") == true)
+        try await waitFor("projectB loaded") {
+            store.rootNodes.count == 1 && store.rootNodes.first?.path == "/home/user/projectB/b.txt"
+        }
+    }
+
     @Test
     func testDisplayRootPathUsesTilde() {
         let provider = MockFileExplorerProvider(homePath: "/home/user")

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -256,6 +256,33 @@ struct FileExplorerStoreTests {
     }
 
     @Test
+    func testSameRootReloadDropsCachedChildrenOfCollapsedDirectories() async throws {
+        let provider = MockFileExplorerProvider()
+        provider.listings["/home/user/project"] = .success([
+            FileExplorerEntry(name: "dir", path: "/home/user/project/dir", isDirectory: true)
+        ])
+        provider.listings["/home/user/project/dir"] = .success([
+            FileExplorerEntry(name: "old.txt", path: "/home/user/project/dir/old.txt", isDirectory: false)
+        ])
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath("/home/user/project")
+        try await waitFor("root loaded") { store.rootNodes.count == 1 }
+        let dir = try #require(store.rootNodes.first)
+
+        store.expand(node: dir)
+        try await waitFor("children loaded") { dir.children?.count == 1 }
+        store.collapse(node: dir)
+
+        // A collapsed directory must not keep a stale cached subtree across a
+        // same-root reload; the next expand should re-list from the provider.
+        store.reload()
+        try await waitFor("collapsed dir cache dropped") {
+            store.rootNodes.first === dir && dir.children == nil
+        }
+    }
+
+    @Test
     func testDisplayRootPathUsesTilde() {
         let provider = MockFileExplorerProvider(homePath: "/home/user")
         let store = FileExplorerStore()


### PR DESCRIPTION
## Problem

The Files sidebar flickers **continuously/periodically** whenever anything in the workspace writes files (coding agents streaming logs, `.git` churn, build artifacts).

Chain:
1. The recursive `FileWatcher` (FSEvents over the whole root tree, 300ms throttle) fires for any change anywhere in the workspace and calls `FileExplorerStore.reload()`.
2. `reload()` **blanks `rootNodes` and shows the loading spinner**, then relists asynchronously.
3. The coordinator's full-reload trigger compares the **root node count**, so each watcher event produces two full `outlineView.reloadData()` passes (`N → 0 → N`) plus an expansion-restore cascade.

Result: a visible repaint of the whole sidebar every throttle window. Same re-render family as #3742.

## Fix

- **`reload()` is non-destructive for same-root refreshes**: the current tree stays visible and `loadChildren` swaps `rootNodes` atomically when the fresh listing lands. Only a root change (or losing the provider) blanks the tree eagerly, tracked via `loadedTreeRootPath`. The spinner only shows when there is nothing to display yet.
- **Node identity reuse**: `loadChildren` returns the existing node object for an unchanged path, so `NSOutlineView` items stay valid across refreshes and reused directory nodes keep their loaded subtree.
- **Fingerprint-based full-reload trigger**: the coordinator compares a fingerprint of the root listing (paths + `isDirectory`) instead of the count. A same-content refresh now goes through the existing row-level reconciliation (`refreshLoadedNodes`) with **zero full repaints** — which is the common case, since most agent churn happens in subdirectories that don't change the root listing. This also fixes a latent staleness bug: a same-count-but-different-entries listing never triggered a reload under the count check.

## Commits (red/green)

1. `Add regression tests for non-destructive Files sidebar reload` — tests only, fails on current behavior (tree blanked + spinner flash during same-root reload; node identity not reused).
2. `Keep the Files sidebar tree visible across same-root reloads` — the fix.

Tests live in the existing `cmuxTests/FileExplorerStoreTests.swift` (no pbxproj changes) and use the existing `MockFileExplorerProvider` / `DeferredListFileExplorerProvider`.

## Localization audit

No user-facing strings added or changed; no localization updates required.

⚠️ Authored without a local Xcode toolchain (syntax-checked only) — relying on CI for build + red/green test verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882011&installation_id=133855650&pr_number=5986&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5986&signature=d497a6038b3bdf57375beeba315188ee24bc3b8dd224be0fb7191a31abacc159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes continuous Files sidebar flicker by keeping the tree visible during same-root reloads and avoiding unnecessary full repaints. This removes spinner flashes and stabilizes the UI in busy workspaces.

- **Bug Fixes**
  - `reload()` keeps the current tree for same-root refreshes; only clears on root changes or missing provider. Spinner shows only when the tree is empty.
  - Reuses node instances for unchanged paths; expanded directories keep their subtree, collapsed directories drop cached children and reset `isLoading`/`error`. Restored `@MainActor` on `loadChildren`.
  - Prunes unreachable nodes after each root listing to prevent stale entries from sticking around or reappearing; pruning is inlined in `loadChildren`.
  - Replaces root-node-count checks with a fingerprint of paths + `isDirectory`, so full `reloadData()` runs only when the root listing actually changes (also fixes same-count-different-entries).

<sup>Written for commit 538f3770eb4219ff1960c1ff1353ed80c3730bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the explorer tree from blanking and spinner flashes during same-root refreshes.
  * Removed stale/deleted paths so removed items no longer reappear after refreshes.
  * Ensure collapsed subtrees drop cached children on same-root reloads to avoid stale state.

* **Performance**
  * Reused existing nodes during same-root refreshes to preserve selection and instance identity.
  * Improved root-change detection to avoid unnecessary full reloads.

* **Tests**
  * Added tests for same-root reloads, node identity reuse, root switching, and collapsed-subtree cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->