### PR TITLE
Add a right-sidebar toggle button to the trailing edge of the title bar

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -3255,6 +3255,17 @@ private struct RightSidebarToggleTitlebarView: View {
     }
 }
 
+/// Accessory container that only claims clicks landing on actual content:
+/// the container spans the full titlebar height for layout, and an opaque
+/// container would swallow clicks meant for chrome rendered underneath
+/// (e.g. the right sidebar's X button while the toggle overlaps it).
+private final class ClickPassThroughAccessoryContainerView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let hit = super.hitTest(point)
+        return hit === self ? nil : hit
+    }
+}
+
 @MainActor
 private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewController {
     private static let styleDefaultsKey = "titlebarControlsStyle"
@@ -3269,7 +3280,7 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
     private var isBindRetryScheduled = false
 
     init() {
-        let containerView = NSView()
+        let containerView = ClickPassThroughAccessoryContainerView()
         self.containerView = containerView
         let toggle = { [weak containerView] in
             #if DEBUG

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -3256,10 +3256,11 @@ private struct RightSidebarToggleTitlebarView: View {
 }
 
 @MainActor
-final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewController {
+private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewController {
+    private static let styleDefaultsKey = "titlebarControlsStyle"
     private let hostingView: NonDraggableHostingView<RightSidebarToggleTitlebarView>
     private let containerView: NSView
-    private var userDefaultsObserver: NSObjectProtocol?
+    private var isObservingStyleDefault = false
 
     init() {
         let containerView = NSView()
@@ -3285,17 +3286,16 @@ final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewCo
         containerView.addSubview(hostingView)
         applyFittingSize()
 
-        // The button size follows the titlebar controls style; resize when the
-        // style setting changes.
-        userDefaultsObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.applyFittingSize()
-            }
-        }
+        // The button size follows the titlebar controls style; resize when
+        // that specific default changes (KVO on the key, not the broad
+        // UserDefaults.didChangeNotification).
+        UserDefaults.standard.addObserver(
+            self,
+            forKeyPath: Self.styleDefaultsKey,
+            options: [],
+            context: nil
+        )
+        isObservingStyleDefault = true
     }
 
     required init?(coder: NSCoder) {
@@ -3303,8 +3303,23 @@ final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewCo
     }
 
     deinit {
-        if let userDefaultsObserver {
-            NotificationCenter.default.removeObserver(userDefaultsObserver)
+        if isObservingStyleDefault {
+            UserDefaults.standard.removeObserver(self, forKeyPath: Self.styleDefaultsKey)
+        }
+    }
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard keyPath == Self.styleDefaultsKey else {
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+            return
+        }
+        Task { @MainActor [weak self] in
+            self?.applyFittingSize()
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -3261,6 +3261,10 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
     private let hostingView: NonDraggableHostingView<RightSidebarToggleTitlebarView>
     private let containerView: NSView
     private var isObservingStyleDefault = false
+    private var sidebarVisibilityCancellable: AnyCancellable?
+    private weak var observedFileExplorerState: FileExplorerState?
+    private var lastAppliedContentSize: NSSize = .zero
+    private var lastAppliedYOffset: CGFloat = .nan
 
     init() {
         let containerView = NSView()
@@ -3284,7 +3288,7 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
         hostingView.translatesAutoresizingMaskIntoConstraints = true
         hostingView.autoresizingMask = []
         containerView.addSubview(hostingView)
-        applyFittingSize()
+        applyLayout()
 
         // The button size follows the titlebar controls style; resize when
         // that specific default changes (KVO on the key, not the broad
@@ -3308,6 +3312,18 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
         }
     }
 
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        applyLayout()
+        bindSidebarVisibilityIfNeeded()
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        applyLayout()
+        bindSidebarVisibilityIfNeeded()
+    }
+
     override func observeValue(
         forKeyPath keyPath: String?,
         of object: Any?,
@@ -3319,14 +3335,67 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
             return
         }
         Task { @MainActor [weak self] in
-            self?.applyFittingSize()
+            self?.applyLayout()
         }
     }
 
-    private func applyFittingSize() {
-        let size = hostingView.fittingSize
-        guard size != .zero, containerView.frame.size != size else { return }
-        containerView.setFrameSize(size)
-        hostingView.frame = NSRect(origin: .zero, size: size)
+    /// Mirrors the leading cluster's vertical strategy: the container spans the
+    /// titlebar height and the button centers on the traffic lights' midY, so
+    /// the toggle sits on the same row as the other titlebar controls — which
+    /// is also where the sidebar's own X button appears once it opens.
+    private func applyLayout() {
+        let contentSize = hostingView.fittingSize
+        guard contentSize.width > 0, contentSize.height > 0 else { return }
+        let closeButton = view.window?.standardWindowButton(.closeButton)
+        let titlebarView = closeButton?.superview
+        let titlebarHeight = (titlebarView?.frame.height ?? 0) > 0
+            ? titlebarView?.frame.height ?? contentSize.height
+            : view.window.map { window in
+                window.frame.height - window.contentLayoutRect.height
+            } ?? contentSize.height
+        let containerHeight = max(contentSize.height, titlebarHeight)
+        let trafficLightFrame = closeButton.map { button in
+            view.convert(button.convert(button.bounds, to: nil), from: nil)
+        }
+        let yOffset: CGFloat
+        if let trafficLightFrame, !trafficLightFrame.isEmpty {
+            yOffset = max(0, trafficLightFrame.midY - (contentSize.height / 2.0))
+        } else {
+            yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
+        }
+        if contentSize == lastAppliedContentSize, yOffset == lastAppliedYOffset {
+            return
+        }
+        lastAppliedContentSize = contentSize
+        lastAppliedYOffset = yOffset
+        preferredContentSize = NSSize(width: contentSize.width, height: containerHeight)
+        containerView.setFrameSize(NSSize(width: contentSize.width, height: containerHeight))
+        hostingView.frame = NSRect(x: 0, y: yOffset, width: contentSize.width, height: contentSize.height)
+    }
+
+    /// The titlebar toggle only shows while the right sidebar is closed: once
+    /// it opens, the sidebar's own X button (in the chrome, at the same
+    /// trailing position — see #3757) takes over, so the control appears to
+    /// move into the sidebar the way the left sidebar toggle reads as part of
+    /// the open left sidebar.
+    private func bindSidebarVisibilityIfNeeded() {
+        guard let window = view.window,
+              let state = AppDelegate.shared?.contextForMainTerminalWindow(window, reindex: false)?.fileExplorerState
+        else { return }
+        guard state !== observedFileExplorerState else { return }
+        observedFileExplorerState = state
+        sidebarVisibilityCancellable = state.$isVisible
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] sidebarVisible in
+                self?.setToggleHidden(sidebarVisible)
+            }
+    }
+
+    private func setToggleHidden(_ hidden: Bool) {
+        guard isHidden != hidden else { return }
+        isHidden = hidden
+        view.isHidden = hidden
+        view.alphaValue = hidden ? 0 : 1
     }
 }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -3265,6 +3265,8 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
     private weak var observedFileExplorerState: FileExplorerState?
     private var lastAppliedContentSize: NSSize = .zero
     private var lastAppliedYOffset: CGFloat = .nan
+    private var bindRetriesRemaining = 40
+    private var isBindRetryScheduled = false
 
     init() {
         let containerView = NSView()
@@ -3379,10 +3381,18 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
     /// move into the sidebar the way the left sidebar toggle reads as part of
     /// the open left sidebar.
     private func bindSidebarVisibilityIfNeeded() {
+        guard observedFileExplorerState == nil else { return }
+        // The window context can register after the accessory attaches
+        // (notably during session restore with the sidebar already open), so
+        // unresolved lookups retry briefly instead of waiting for an
+        // interaction-driven layout pass.
         guard let window = view.window,
-              let state = AppDelegate.shared?.contextForMainTerminalWindow(window, reindex: false)?.fileExplorerState
-        else { return }
-        guard state !== observedFileExplorerState else { return }
+              let state = AppDelegate.shared?.contextForMainTerminalWindow(window)?.fileExplorerState
+        else {
+            scheduleBindRetryIfNeeded()
+            return
+        }
+        bindRetriesRemaining = 0
         observedFileExplorerState = state
         sidebarVisibilityCancellable = state.$isVisible
             .removeDuplicates()
@@ -3390,6 +3400,19 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
             .sink { [weak self] sidebarVisible in
                 self?.setToggleHidden(sidebarVisible)
             }
+    }
+
+    private func scheduleBindRetryIfNeeded() {
+        guard bindRetriesRemaining > 0, !isBindRetryScheduled else { return }
+        bindRetriesRemaining -= 1
+        isBindRetryScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.isBindRetryScheduled = false
+                self.bindSidebarVisibilityIfNeeded()
+            }
+        }
     }
 
     private func setToggleHidden(_ hidden: Bool) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -3392,7 +3392,6 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
     /// move into the sidebar the way the left sidebar toggle reads as part of
     /// the open left sidebar.
     private func bindSidebarVisibilityIfNeeded() {
-        guard observedFileExplorerState == nil else { return }
         // The window context can register after the accessory attaches
         // (notably during session restore with the sidebar already open), so
         // unresolved lookups retry briefly instead of waiting for an
@@ -3403,7 +3402,10 @@ private final class RightSidebarToggleAccessoryViewController: NSTitlebarAccesso
             scheduleBindRetryIfNeeded()
             return
         }
-        bindRetriesRemaining = 0
+        // Compare instances rather than binding once: session restore can
+        // replace the context's FileExplorerState after an early bind, which
+        // would leave the subscription watching a dead object.
+        guard state !== observedFileExplorerState else { return }
         observedFileExplorerState = state
         sidebarVisibilityCancellable = state.$isVisible
             .removeDuplicates()

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2822,6 +2822,7 @@ final class UpdateTitlebarAccessoryController {
     private var pendingAttachRetries: [ObjectIdentifier: Int] = [:]
     private var startupScanWorkItems: [DispatchWorkItem] = []
     private let controlsIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarControls")
+    private let rightSidebarToggleIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarRightSidebarToggle")
     private let controlsControllers = NSHashTable<TitlebarControlsAccessoryViewController>.weakObjects()
     private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
     private var detachedNotificationsPopover: NSPopover?
@@ -2981,6 +2982,13 @@ final class UpdateTitlebarAccessoryController {
             controlsControllers.add(controls)
         }
 
+        if !window.titlebarAccessoryViewControllers.contains(where: { $0.view.identifier == rightSidebarToggleIdentifier }) {
+            let rightToggle = RightSidebarToggleAccessoryViewController()
+            rightToggle.layoutAttribute = .right
+            rightToggle.view.identifier = rightSidebarToggleIdentifier
+            window.addTitlebarAccessoryViewController(rightToggle)
+        }
+
         attachedWindows.add(window)
         applyAccessoryVisibility(for: window)
 
@@ -3002,7 +3010,8 @@ final class UpdateTitlebarAccessoryController {
         let shouldHide = WorkspacePresentationModeSettings.mode() == .minimal
             || window.styleMask.contains(.fullScreen)
         for accessory in window.titlebarAccessoryViewControllers
-            where accessory.view.identifier == controlsIdentifier {
+            where accessory.view.identifier == controlsIdentifier
+                || accessory.view.identifier == rightSidebarToggleIdentifier {
             accessory.isHidden = shouldHide
             accessory.view.isHidden = shouldHide
             accessory.view.alphaValue = shouldHide ? 0 : 1
@@ -3017,7 +3026,7 @@ final class UpdateTitlebarAccessoryController {
         }
         let matchingIndices = window.titlebarAccessoryViewControllers.indices.reversed().filter { index in
             let id = window.titlebarAccessoryViewControllers[index].view.identifier
-            return id == controlsIdentifier
+            return id == controlsIdentifier || id == rightSidebarToggleIdentifier
         }
         guard !matchingIndices.isEmpty || attachedWindows.contains(window) else { return }
 
@@ -3198,5 +3207,111 @@ final class UpdateTitlebarAccessoryController {
             return
         }
         target.toggleNotificationsPopover(animated: animated)
+    }
+}
+
+// MARK: - Right Sidebar Toggle Accessory
+
+/// Single trailing-edge titlebar button that toggles the right sidebar,
+/// mirroring the left cluster's sidebar toggle. The right sidebar header has
+/// its own close button, but once the sidebar is closed nothing in the chrome
+/// reopens it without the keyboard shortcut.
+private struct RightSidebarToggleTitlebarView: View {
+    let onToggle: () -> Void
+    @AppStorage("titlebarControlsStyle") private var styleRawValue = TitlebarControlsStyle.classic.rawValue
+
+    private var config: TitlebarControlsStyleConfig {
+        (TitlebarControlsStyle(rawValue: styleRawValue) ?? .classic).config
+    }
+
+    var body: some View {
+        TitlebarControlButton(
+            config: config,
+            foregroundColor: TitlebarControlIconStyle.foregroundColor,
+            accessibilityIdentifier: "titlebarControl.toggleRightSidebar",
+            accessibilityLabel: String(
+                localized: "titlebar.rightSidebar.accessibilityLabel",
+                defaultValue: "Toggle Right Sidebar"
+            ),
+            action: onToggle
+        ) {
+            Image(systemName: "sidebar.right")
+                .symbolRenderingMode(.monochrome)
+                .font(.system(size: config.iconSize, weight: TitlebarControlIconStyle.weight))
+                .frame(
+                    width: TitlebarControlIconStyle.iconFrameSize(for: config),
+                    height: TitlebarControlIconStyle.iconFrameSize(for: config)
+                )
+        }
+        .safeHelp(
+            KeyboardShortcutSettings.Action.toggleRightSidebar.tooltip(
+                String(
+                    localized: "titlebar.rightSidebar.tooltip",
+                    defaultValue: "Show or hide the right sidebar"
+                )
+            )
+        )
+        .padding(.horizontal, 6)
+    }
+}
+
+@MainActor
+final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewController {
+    private let hostingView: NonDraggableHostingView<RightSidebarToggleTitlebarView>
+    private let containerView: NSView
+    private var userDefaultsObserver: NSObjectProtocol?
+
+    init() {
+        let containerView = NSView()
+        self.containerView = containerView
+        let toggle = { [weak containerView] in
+            #if DEBUG
+            cmuxDebugLog("titlebar.toggleRightSidebar")
+            #endif
+            _ = AppDelegate.shared?.toggleRightSidebarInActiveMainWindow(
+                preferredWindow: containerView?.window
+            )
+        }
+        hostingView = NonDraggableHostingView(
+            rootView: RightSidebarToggleTitlebarView(onToggle: toggle)
+        )
+
+        super.init(nibName: nil, bundle: nil)
+
+        view = containerView
+        containerView.translatesAutoresizingMaskIntoConstraints = true
+        hostingView.translatesAutoresizingMaskIntoConstraints = true
+        hostingView.autoresizingMask = []
+        containerView.addSubview(hostingView)
+        applyFittingSize()
+
+        // The button size follows the titlebar controls style; resize when the
+        // style setting changes.
+        userDefaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.applyFittingSize()
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let userDefaultsObserver {
+            NotificationCenter.default.removeObserver(userDefaultsObserver)
+        }
+    }
+
+    private func applyFittingSize() {
+        let size = hostingView.fittingSize
+        guard size != .zero, containerView.frame.size != size else { return }
+        containerView.setFrameSize(size)
+        hostingView.frame = NSRect(origin: .zero, size: size)
     }
 }


### PR DESCRIPTION
## Problem

The left titlebar cluster has a sidebar toggle button, but the **right sidebar** (Files / Find / Sessions / Feed / Dock) has no chrome affordance once it's closed — its header close button disappears with it, so the only way to reopen it is the keyboard shortcut. Mouse-first users lose discoverability of the whole Files panel.

## Change

A single trailing-edge titlebar accessory with a `sidebar.right` toggle button:

- `RightSidebarToggleAccessoryViewController` attached at `layoutAttribute = .right`, living in `UpdateTitlebarAccessory.swift` next to the existing controls cluster (reuses `TitlebarControlButton`, `TitlebarControlIconStyle`, `NonDraggableHostingView` — all file-internal).
- Follows the `titlebarControlsStyle` setting (classic/compact/roomy/pill/soft) via `@AppStorage` and resizes when the style changes.
- **Shared action path**: toggles through `AppDelegate.toggleRightSidebarInActiveMainWindow(preferredWindow:)`, the same path as the `toggleRightSidebar` keyboard shortcut (Cmd+Opt+B by default); the tooltip renders the currently bound shortcut via `KeyboardShortcutSettings.Action.toggleRightSidebar.tooltip`.
- Hidden in minimal mode and fullscreen together with the existing controls cluster, and removed through the same accessory lifecycle (`applyAccessoryVisibility` / `removeAccessoryIfPresent`).

## Localization audit

Two new user-facing strings (`titlebar.rightSidebar.accessibilityLabel`, `titlebar.rightSidebar.tooltip`) added to `Resources/Localizable.xcstrings` with translations for **all 19 supported locales**, phrased consistently with the existing `titlebar.sidebar.*` entries. The xcstrings edit is insertion-only (238 added lines, no reformat).

## Verification

- `accessibilityIdentifier`: `titlebarControl.toggleRightSidebar` (matches the `titlebarControl.*` convention for UI tests).
- Manual steps: launch → button appears at the right end of the title bar → click toggles the right sidebar both ways → switch titlebar controls style in the debug styles menu and confirm the button matches → minimal mode / fullscreen hides it.

⚠️ Authored without a local Xcode toolchain (syntax-checked only) — relying on CI for build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882526&installation_id=133855650&pr_number=5988&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5988&signature=97f024fdd35e8f4bbef81b0666239335fbb46a198662bb0ddd9e6a0823c2b1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right-sidebar toggle button on the title bar’s trailing edge to restore mouse discoverability for Files/Find/Sessions/Feed/Dock. It mirrors `toggleRightSidebar` (Cmd+Opt+B), aligns with the controls row, and hides in minimal, fullscreen, and while the right sidebar is open.

Shares the `toggleRightSidebar` action path; tooltip shows the bound shortcut. Follows `titlebarControlsStyle` and resizes on change via KVO. Centers on the traffic lights row. Accessory is file‑private. Container passes clicks through outside the button. Binds to sidebar visibility with retries during session restore, and rebinds when the window context replaces `FileExplorerState`, so the toggle yields to the sidebar’s X without stacking. Localized accessibility label + tooltip for 19 locales. UI test id: `titlebarControl.toggleRightSidebar`.

<sup>Written for commit 873d99234be462a3cb106b3835664959eb82e4c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a right‑sidebar toggle button in the titlebar for quick show/hide of the right sidebar; it auto-hides in fullscreen/minimal modes and respects titlebar style preferences and current sidebar visibility.

* **Localization**
  * Added accessibility label and tooltip translations for the right‑sidebar titlebar control across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->