### PR TITLE
Email Founder's Edition customers a welcome note via Resend webhook

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -7,8 +7,8 @@ CMUX_FEEDBACK_RATE_LIMIT_ID=
 # via Resend (To customer, CC the founders). Leave the secret empty to disable the
 # route. CMUX_FOUNDERS_FROM_EMAIL overrides the sender (defaults to
 # austin@manaflow.ai) and must be on a Resend-verified domain.
-STRIPE_FOUNDERS_WEBHOOK_SECRET=
 CMUX_FOUNDERS_FROM_EMAIL=
+STRIPE_FOUNDERS_WEBHOOK_SECRET=
 
 # Stack Auth (https://stack-auth.com), required for the /handler/* routes
 # and the mac app sign-in flow.

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,6 +2,14 @@ RESEND_API_KEY=
 CMUX_FEEDBACK_FROM_EMAIL=
 CMUX_FEEDBACK_RATE_LIMIT_ID=
 
+# cmux Founder's Edition welcome email. /api/stripe/founders-welcome verifies the
+# Stripe webhook signature with this endpoint secret, then sends the welcome email
+# via Resend (To customer, CC the founders). Leave the secret empty to disable the
+# route. CMUX_FOUNDERS_FROM_EMAIL overrides the sender (defaults to
+# austin@manaflow.ai) and must be on a Resend-verified domain.
+STRIPE_FOUNDERS_WEBHOOK_SECRET=
+CMUX_FOUNDERS_FROM_EMAIL=
+
 # Stack Auth (https://stack-auth.com), required for the /handler/* routes
 # and the mac app sign-in flow.
 NEXT_PUBLIC_STACK_PROJECT_ID=

--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -175,15 +175,24 @@ export async function POST(request: Request) {
       }
 
       const name = firstName(session?.customer_details?.name);
+      // Stripe delivers webhooks at least once and retries after a transient
+      // failure (including one observed after Resend already accepted the
+      // message), so key the send by the checkout session id. Resend
+      // deduplicates identical sends for 24h, so redelivery of the same
+      // purchase will not send a second welcome email.
+      const idempotencyKey = `founders-welcome/${session?.id ?? event.id ?? customerEmail}`;
       const resend = new Resend(config.resendApiKey);
-      const { error } = await resend.emails.send({
-        from: `Austin Wang <${config.fromEmail}>`,
-        to: [customerEmail],
-        cc: FOUNDER_CC,
-        replyTo: REPLY_TO,
-        subject: EMAIL_SUBJECT,
-        text: buildBody(name),
-      });
+      const { error } = await resend.emails.send(
+        {
+          from: `Austin Wang <${config.fromEmail}>`,
+          to: [customerEmail],
+          cc: FOUNDER_CC,
+          replyTo: REPLY_TO,
+          subject: EMAIL_SUBJECT,
+          text: buildBody(name),
+        },
+        { idempotencyKey },
+      );
 
       if (error) {
         recordSpanError(span, error);
@@ -208,9 +217,11 @@ function jsonError(message: string, status: number): Response {
 }
 
 type StripeEvent = {
+  id?: string;
   type?: string;
   data?: {
     object?: {
+      id?: string;
       metadata?: Record<string, string> | null;
       customer_details?: {
         email?: string | null;

--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -170,8 +170,14 @@ export async function POST(request: Request) {
         "cmux.stripe.is_founders": isFounders,
         "cmux.stripe.has_customer_email": Boolean(customerEmail),
       });
-      if (!isFounders || !customerEmail) {
+      if (!isFounders) {
         return NextResponse.json({ ok: true, skipped: "not_founders" });
+      }
+      if (!customerEmail) {
+        // Distinct from "not_founders" so a Founder's session that arrives
+        // without a customer email is diagnosable in telemetry rather than a
+        // silent miss.
+        return NextResponse.json({ ok: true, skipped: "no_customer_email" });
       }
 
       const name = firstName(session?.customer_details?.name);
@@ -181,10 +187,17 @@ export async function POST(request: Request) {
       // deduplicates identical sends for 24h, so redelivery of the same
       // purchase will not send a second welcome email.
       const idempotencyKey = `founders-welcome/${session?.id ?? event.id ?? customerEmail}`;
+      // Only attach the personal display name to the default sender. If the
+      // address is overridden to a shared/team inbox, send from the bare
+      // address rather than a mismatched "Austin Wang" identity.
+      const fromAddress =
+        config.fromEmail === DEFAULT_FROM_EMAIL
+          ? `Austin Wang <${config.fromEmail}>`
+          : config.fromEmail;
       const resend = new Resend(config.resendApiKey);
       const { error } = await resend.emails.send(
         {
-          from: `Austin Wang <${config.fromEmail}>`,
+          from: fromAddress,
           to: [customerEmail],
           cc: FOUNDER_CC,
           replyTo: REPLY_TO,

--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -1,0 +1,221 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+
+import { env } from "@/app/env";
+import {
+  recordSpanError,
+  setSpanAttributes,
+  withApiRouteSpan,
+} from "@/services/telemetry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Stripe checkout sessions created from the cmux Founder's Edition payment link
+// carry this metadata key (copied automatically onto each session). We only send
+// the welcome email when it is present and truthy.
+const FOUNDERS_METADATA_KEY = "founders_edition";
+
+// Default sender/recipients. Sender is overridable via env so the verified Resend
+// domain can change without a code edit; the founders are always copied so both
+// see exactly what the customer received.
+const DEFAULT_FROM_EMAIL = "austin@manaflow.ai";
+const FOUNDER_CC = ["austin@manaflow.ai", "lawrence@manaflow.ai"];
+const REPLY_TO = "austin@manaflow.ai";
+const EMAIL_SUBJECT = "cmux Founder's Edition";
+
+// Stripe signs webhooks with a 5-minute default tolerance; reject older payloads
+// to blunt replay attempts.
+const SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
+
+type FoundersConfig = {
+  resendApiKey: string;
+  webhookSecret: string;
+  fromEmail: string;
+};
+
+function resolveConfig(): FoundersConfig | null {
+  const resendApiKey = env.RESEND_API_KEY;
+  const webhookSecret = env.STRIPE_FOUNDERS_WEBHOOK_SECRET;
+  if (!resendApiKey || !webhookSecret) {
+    return null;
+  }
+  return {
+    resendApiKey,
+    webhookSecret,
+    fromEmail: env.CMUX_FOUNDERS_FROM_EMAIL ?? DEFAULT_FROM_EMAIL,
+  };
+}
+
+// Verify the `Stripe-Signature` header without depending on the stripe SDK.
+// Header format: `t=<unix>,v1=<hex>,v1=<hex>...` — the signed payload is
+// `<t>.<rawBody>` and each v1 entry is its HMAC-SHA256 under the endpoint secret.
+function isValidStripeSignature(
+  rawBody: string,
+  header: string | null,
+  secret: string,
+  nowSeconds: number,
+): boolean {
+  if (!header) {
+    return false;
+  }
+  let timestamp = "";
+  const signatures: string[] = [];
+  for (const part of header.split(",")) {
+    const [key, value] = part.split("=", 2);
+    if (key === "t") {
+      timestamp = value ?? "";
+    } else if (key === "v1" && value) {
+      signatures.push(value);
+    }
+  }
+  if (!timestamp || signatures.length === 0) {
+    return false;
+  }
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(timestampSeconds)) {
+    return false;
+  }
+  if (Math.abs(nowSeconds - timestampSeconds) > SIGNATURE_TOLERANCE_SECONDS) {
+    return false;
+  }
+  const expected = createHmac("sha256", secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest("hex");
+  const expectedBuffer = Buffer.from(expected, "hex");
+  return signatures.some((candidate) => {
+    let candidateBuffer: Buffer;
+    try {
+      candidateBuffer = Buffer.from(candidate, "hex");
+    } catch {
+      return false;
+    }
+    return (
+      candidateBuffer.length === expectedBuffer.length &&
+      timingSafeEqual(candidateBuffer, expectedBuffer)
+    );
+  });
+}
+
+function firstName(fullName: string | null | undefined): string {
+  const trimmed = (fullName ?? "").trim();
+  if (!trimmed) {
+    return "there";
+  }
+  return trimmed.split(/\s+/)[0];
+}
+
+function buildBody(name: string): string {
+  return [
+    `Hi ${name}!`,
+    "",
+    "Thank you for being one of the first ever customers of cmux :)",
+    "",
+    "My number is +1(714) 699-0169 and Lawrence's number is +1(949) 302-0749. " +
+      "Our emails are austin@manaflow.ai and lawrence@manaflow.ai. Feel free to " +
+      "text me on iMessage or WhatsApp, or we can just continue talking here. " +
+      "I've CC'd my cofounder as well.",
+    "",
+    "Best,",
+    "Austin",
+  ].join("\n");
+}
+
+export async function POST(request: Request) {
+  return withApiRouteSpan(
+    request,
+    "/api/stripe/founders-welcome",
+    { "cmux.subsystem": "stripe", "cmux.stripe.operation": "founders_welcome" },
+    async (span): Promise<Response> => {
+      const config = resolveConfig();
+      if (!config) {
+        return jsonError("Founders welcome endpoint is not configured", 503);
+      }
+
+      const rawBody = await request.text();
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const valid = isValidStripeSignature(
+        rawBody,
+        request.headers.get("stripe-signature"),
+        config.webhookSecret,
+        nowSeconds,
+      );
+      setSpanAttributes(span, { "cmux.stripe.signature_valid": valid });
+      if (!valid) {
+        return jsonError("Invalid Stripe signature", 400);
+      }
+
+      let event: StripeEvent;
+      try {
+        event = JSON.parse(rawBody) as StripeEvent;
+      } catch {
+        return jsonError("Invalid JSON payload", 400);
+      }
+
+      setSpanAttributes(span, { "cmux.stripe.event_type": event.type ?? "" });
+
+      // Only react to completed checkout sessions flagged as Founder's Edition.
+      // Everything else (including renewals, which never create a checkout
+      // session) is acknowledged with 200 so Stripe stops retrying.
+      if (event.type !== "checkout.session.completed") {
+        return NextResponse.json({ ok: true, skipped: "event_type" });
+      }
+      const session = event.data?.object;
+      const isFounders =
+        session?.metadata?.[FOUNDERS_METADATA_KEY] === "true";
+      const customerEmail = session?.customer_details?.email ?? null;
+      setSpanAttributes(span, {
+        "cmux.stripe.is_founders": isFounders,
+        "cmux.stripe.has_customer_email": Boolean(customerEmail),
+      });
+      if (!isFounders || !customerEmail) {
+        return NextResponse.json({ ok: true, skipped: "not_founders" });
+      }
+
+      const name = firstName(session?.customer_details?.name);
+      const resend = new Resend(config.resendApiKey);
+      const { error } = await resend.emails.send({
+        from: `Austin Wang <${config.fromEmail}>`,
+        to: [customerEmail],
+        cc: FOUNDER_CC,
+        replyTo: REPLY_TO,
+        subject: EMAIL_SUBJECT,
+        text: buildBody(name),
+      });
+
+      if (error) {
+        recordSpanError(span, error);
+        console.error("stripe.founders_welcome.resend_failed", error);
+        // Non-2xx so Stripe retries and the email is not silently lost.
+        return jsonError("Failed to send welcome email", 502);
+      }
+
+      return NextResponse.json(
+        { ok: true, sent: true },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    },
+  );
+}
+
+function jsonError(message: string, status: number): Response {
+  return NextResponse.json(
+    { error: message },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+type StripeEvent = {
+  type?: string;
+  data?: {
+    object?: {
+      metadata?: Record<string, string> | null;
+      customer_details?: {
+        email?: string | null;
+        name?: string | null;
+      } | null;
+    };
+  };
+};

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -36,6 +36,13 @@ export const env = createEnv({
     CMUX_APNS_KEY_ID: z.string().min(1).optional(),
     CMUX_APNS_TEAM_ID: z.string().min(1).optional(),
     CMUX_PUSH_RATE_LIMIT_ID: z.string().min(1).optional(),
+    // cmux Founder's Edition welcome email (Stripe webhook -> Resend). Optional:
+    // the /api/stripe/founders-welcome route returns "not configured" until the
+    // webhook signing secret is set. CMUX_FOUNDERS_FROM_EMAIL overrides the
+    // sender (defaults to austin@manaflow.ai) so the verified Resend domain can
+    // change without a code edit.
+    STRIPE_FOUNDERS_WEBHOOK_SECRET: z.string().min(1).optional(),
+    CMUX_FOUNDERS_FROM_EMAIL: z.string().email().optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -49,6 +56,8 @@ export const env = createEnv({
     CMUX_APNS_KEY_ID: trimEnv(process.env.CMUX_APNS_KEY_ID),
     CMUX_APNS_TEAM_ID: trimEnv(process.env.CMUX_APNS_TEAM_ID),
     CMUX_PUSH_RATE_LIMIT_ID: trimEnv(process.env.CMUX_PUSH_RATE_LIMIT_ID),
+    STRIPE_FOUNDERS_WEBHOOK_SECRET: trimEnv(process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET),
+    CMUX_FOUNDERS_FROM_EMAIL: trimEnv(process.env.CMUX_FOUNDERS_FROM_EMAIL),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"


### PR DESCRIPTION
## What

Adds `web/app/api/stripe/founders-welcome/route.ts` — a Stripe webhook on **cmux.com** that automatically emails each new **cmux Founder's Edition** subscriber a personal welcome note.

On `checkout.session.completed` where the session metadata has `founders_edition=true`, it sends via the existing Resend integration:

- **To:** the customer
- **From:** `austin@manaflow.ai` (override with `CMUX_FOUNDERS_FROM_EMAIL`)
- **CC:** `austin@manaflow.ai`, `lawrence@manaflow.ai` (both founders see exactly what the customer got)
- **Reply-To:** `austin@manaflow.ai`

Renewals are invoice payments and never create a checkout session, so this fires **exactly once per new subscription**.

## Why

Stripe Workflows can only email *team members*, never the customer. The cmux.com web app already has Resend wired up (`RESEND_API_KEY`, `resend` package, `web/app/api/feedback/route.ts`), so this reuses it rather than adding a new dependency or third-party service.

## Notes

- Signature verified with `node:crypto` HMAC-SHA256 (5-min replay tolerance) — no `stripe` SDK dependency added.
- New env are **optional** (`STRIPE_FOUNDERS_WEBHOOK_SECRET`, `CMUX_FOUNDERS_FROM_EMAIL`); the route returns `503 not configured` until the secret is set, so preview/other deploys are unaffected.
- Non-Founder and non-checkout events are acknowledged with `200` so Stripe stops retrying; Resend send failures return `502` so Stripe retries (email is never silently lost).

## Go-live (after merge)

1. Create a Stripe webhook endpoint → `https://cmux.com/api/stripe/founders-welcome`, event `checkout.session.completed`.
2. Add its signing secret as `STRIPE_FOUNDERS_WEBHOOK_SECRET` in the cmux.com Vercel project.
3. Confirm `manaflow.ai` (or whatever `CMUX_FOUNDERS_FROM_EMAIL` uses) is a verified Resend sender domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783888238&installation_id=133855650&pr_number=5994&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5994&signature=3452dd68e67ff933161ebd44f2fccb7d84a80630f019720964213cf18df19d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a personal welcome email to each new cmux Founder's Edition subscriber via a Stripe webhook on `cmux.com` using `resend`. Idempotent by checkout session to avoid duplicates on Stripe retries.

- **New Features**
  - Webhook at `/api/stripe/founders-welcome`; only on `checkout.session.completed` with `founders_edition=true`; HMAC-SHA256 signature check (5m tolerance), no `stripe` SDK.
  - Sends via `resend`: To customer; CC founders; configurable From (default `austin@manaflow.ai`); Reply-To set. Uses the personal display name only for the default sender; otherwise sends from the bare address.
  - Idempotent send via Resend `idempotencyKey` (checkout session id; event id/email fallback).
  - Optional envs: `STRIPE_FOUNDERS_WEBHOOK_SECRET`, `CMUX_FOUNDERS_FROM_EMAIL`. Returns 503 until configured; 200 for non-matches, including explicit `no_customer_email`; 502 on send failure to trigger Stripe retry.

- **Migration**
  - Create a Stripe webhook: https://cmux.com/api/stripe/founders-welcome for `checkout.session.completed`.
  - Set `STRIPE_FOUNDERS_WEBHOOK_SECRET` in Vercel.
  - Use a Resend-verified domain for `CMUX_FOUNDERS_FROM_EMAIL` or rely on the default.

<sup>Written for commit 56efb6e199683c8470671f5dd51eab013fa3a85f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated "Founders Edition" welcome emails are sent after a successful Stripe checkout (reliable, retry-safe).

* **Chores**
  * Added environment settings to enable/disable the welcome webhook and optionally override the sender email for the welcome message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->