### PR TITLE
Fix #5917: restore OSC 11 pane-local backgrounds

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8681,7 +8681,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let color = effectiveBackgroundColor()
         let snapshot = WindowAppearanceSnapshot
             .currentFromUserDefaults(app: GhosttyApp.shared)
-            .replacingTerminalBackgroundColor(backgroundColor ?? GhosttyApp.shared.defaultBackgroundColor)
+            .windowRootBackdropSnapshot(surfaceBackgroundColor: backgroundColor)
         let plan = snapshot.backdropPlan()
         _ = WindowBackdropController.apply(plan: plan, to: window)
         if GhosttyApp.shared.backgroundLogEnabled {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8678,11 +8678,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
         applySurfaceBackground()
-        let color = effectiveBackgroundColor()
         let snapshot = WindowAppearanceSnapshot
             .currentFromUserDefaults(app: GhosttyApp.shared)
             .windowRootBackdropSnapshot(surfaceBackgroundColor: backgroundColor)
         let plan = snapshot.backdropPlan()
+        let color = snapshot.compositedTerminalBackgroundColor
         _ = WindowBackdropController.apply(plan: plan, to: window)
         if GhosttyApp.shared.backgroundLogEnabled {
             let signature = "\(plan.hostingPhase.rawValue):\(color.hexString()):\(String(format: "%.3f", color.alphaComponent)):\(GhosttyApp.shared.defaultBackgroundBlur)"
@@ -8691,7 +8691,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 let hasOverride = backgroundColor != nil
                 let overrideHex = backgroundColor?.hexString() ?? "nil"
                 let defaultHex = GhosttyApp.shared.defaultBackgroundColor.hexString()
-                let source = hasOverride ? "surfaceOverride" : "defaultBackground"
+                let source = hasOverride ? "defaultBackground(surfaceOverrideLocal)" : "defaultBackground"
                 GhosttyApp.shared.logBackground(
                     "window background applied tab=\(tabId?.uuidString ?? "unknown") surface=\(terminalSurface?.id.uuidString ?? "unknown") source=\(source) override=\(overrideHex) default=\(defaultHex) phase=\(plan.hostingPhase.rawValue) transparent=\(plan.usesTransparentWindow) color=\(color.hexString()) opacity=\(String(format: "%.3f", color.alphaComponent)) blur=\(GhosttyApp.shared.defaultBackgroundBlur)"
                 )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8592,12 +8592,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         addSubview(keyboardCopyModeCursorOverlayView, positioned: .above, relativeTo: nil)
     }
 
-    private func effectiveBackgroundColor() -> NSColor {
-        let base = backgroundColor ?? GhosttyApp.shared.defaultBackgroundColor
-        let opacity = GhosttyApp.shared.defaultBackgroundOpacity
-        return base.withAlphaComponent(opacity)
-    }
-
     func applySurfaceBackground() {
         let renderingMode = WindowAppearanceSnapshot.terminalRenderingMode(
             usesHostLayerBackground: GhosttyApp.shared.usesHostLayerBackground

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8678,22 +8678,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
         applySurfaceBackground()
-        let snapshot = WindowAppearanceSnapshot
+        let windowRoot = WindowAppearanceSnapshot
             .currentFromUserDefaults(app: GhosttyApp.shared)
-            .windowRootBackdropSnapshot(surfaceBackgroundColor: backgroundColor)
-        let plan = snapshot.backdropPlan()
-        let color = snapshot.compositedTerminalBackgroundColor
+            .windowRootBackdropResolution(surfaceBackgroundColor: backgroundColor)
+        let plan = windowRoot.snapshot.backdropPlan()
+        let color = windowRoot.snapshot.compositedTerminalBackgroundColor
         _ = WindowBackdropController.apply(plan: plan, to: window)
         if GhosttyApp.shared.backgroundLogEnabled {
             let signature = "\(plan.hostingPhase.rawValue):\(color.hexString()):\(String(format: "%.3f", color.alphaComponent)):\(GhosttyApp.shared.defaultBackgroundBlur)"
             if signature != lastLoggedWindowBackgroundSignature {
                 lastLoggedWindowBackgroundSignature = signature
-                let hasOverride = backgroundColor != nil
-                let overrideHex = backgroundColor?.hexString() ?? "nil"
                 let defaultHex = GhosttyApp.shared.defaultBackgroundColor.hexString()
-                let source = hasOverride ? "defaultBackground(surfaceOverrideLocal)" : "defaultBackground"
                 GhosttyApp.shared.logBackground(
-                    "window background applied tab=\(tabId?.uuidString ?? "unknown") surface=\(terminalSurface?.id.uuidString ?? "unknown") source=\(source) override=\(overrideHex) default=\(defaultHex) phase=\(plan.hostingPhase.rawValue) transparent=\(plan.usesTransparentWindow) color=\(color.hexString()) opacity=\(String(format: "%.3f", color.alphaComponent)) blur=\(GhosttyApp.shared.defaultBackgroundBlur)"
+                    "window background applied tab=\(tabId?.uuidString ?? "unknown") surface=\(terminalSurface?.id.uuidString ?? "unknown") source=\(windowRoot.source) override=\(windowRoot.overrideHex) default=\(defaultHex) phase=\(plan.hostingPhase.rawValue) transparent=\(plan.usesTransparentWindow) color=\(color.hexString()) opacity=\(String(format: "%.3f", color.alphaComponent)) blur=\(GhosttyApp.shared.defaultBackgroundBlur)"
                 )
             }
         }

--- a/Sources/Windowing/WindowBackdropController.swift
+++ b/Sources/Windowing/WindowBackdropController.swift
@@ -127,9 +127,17 @@ extension WindowAppearanceSnapshot {
         )
     }
 
-    func windowRootBackdropSnapshot(surfaceBackgroundColor _: NSColor?) -> Self {
+    func windowRootBackdropResolution(surfaceBackgroundColor color: NSColor?) -> (
+        snapshot: Self,
+        source: String,
+        overrideHex: String
+    ) {
         // OSC 11 is pane-local state; the shared root remains the workspace backdrop.
-        self
+        (
+            snapshot: self,
+            source: color == nil ? "defaultBackground" : "defaultBackground(surfaceOverrideLocal)",
+            overrideHex: color?.hexString() ?? "nil"
+        )
     }
 
     var appKitWindowMutationID: String {

--- a/Sources/Windowing/WindowBackdropController.swift
+++ b/Sources/Windowing/WindowBackdropController.swift
@@ -127,28 +127,9 @@ extension WindowAppearanceSnapshot {
         )
     }
 
-    func replacingTerminalBackgroundColor(_ color: NSColor) -> Self {
-        Self(
-            terminalBackgroundColor: color,
-            terminalBackgroundOpacity: terminalBackgroundOpacity,
-            terminalBackgroundBlur: terminalBackgroundBlur,
-            terminalRenderingMode: terminalRenderingMode,
-            unifySurfaceBackdrops: unifySurfaceBackdrops,
-            sidebarSettings: sidebarSettings,
-            windowGlassSettings: WindowGlassSettingsSnapshot(
-                sidebarBlendModeRawValue: windowGlassSettings.sidebarBlendModeRawValue,
-                isEnabled: windowGlassSettings.isEnabled,
-                tintHex: windowGlassSettings.tintHex,
-                tintOpacity: windowGlassSettings.tintOpacity,
-                terminalBackgroundBlur: terminalBackgroundBlur,
-                terminalGlassTintColor: color.withAlphaComponent(terminalBackgroundOpacity)
-            )
-        )
-    }
-
-    func windowRootBackdropSnapshot(surfaceBackgroundColor color: NSColor?) -> Self {
-        guard let color else { return self }
-        return replacingTerminalBackgroundColor(color)
+    func windowRootBackdropSnapshot(surfaceBackgroundColor _: NSColor?) -> Self {
+        // OSC 11 is pane-local state; the shared root remains the workspace backdrop.
+        self
     }
 
     var appKitWindowMutationID: String {

--- a/Sources/Windowing/WindowBackdropController.swift
+++ b/Sources/Windowing/WindowBackdropController.swift
@@ -146,6 +146,11 @@ extension WindowAppearanceSnapshot {
         )
     }
 
+    func windowRootBackdropSnapshot(surfaceBackgroundColor color: NSColor?) -> Self {
+        guard let color else { return self }
+        return replacingTerminalBackgroundColor(color)
+    }
+
     var appKitWindowMutationID: String {
         backdropPlan().appKitMutationID
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -731,6 +731,7 @@
 		A500120C /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001222 /* WindowAccessor.swift */; };
 		063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 		A5001700A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */; };
+		A59170000000000000000001 /* WindowAppearanceSnapshotPaneBackgroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59170000000000000000002 /* WindowAppearanceSnapshotPaneBackgroundTests.swift */; };
 		F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */; };
 		A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */; };
 		B7F9A602B7F9A602B7F9A602 /* WindowChromeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */; };
@@ -1530,6 +1531,7 @@
 		A5001222 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowAppearanceSnapshot.swift; sourceTree = "<group>"; };
+		A59170000000000000000002 /* WindowAppearanceSnapshotPaneBackgroundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearanceSnapshotPaneBackgroundTests.swift; sourceTree = "<group>"; };
 		F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearanceSnapshotTests.swift; sourceTree = "<group>"; };
 		A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackdropController.swift; sourceTree = "<group>"; };
 		B7F9A603B7F9A603B7F9A603 /* WindowChromeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeMetrics.swift; sourceTree = "<group>"; };
@@ -2300,6 +2302,7 @@
 				C135190000000000000000B2 /* SidebarWorkspaceGroupConfigOpenerTests.swift */,
 				A11EAE000000000000000001 /* WorkspaceAppearanceConfigResolutionTests.swift */,
 				A11EAF000000000000000001 /* GhosttyNotificationDispatcherTests.swift */,
+				A59170000000000000000002 /* WindowAppearanceSnapshotPaneBackgroundTests.swift */,
 				F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */,
 				F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */,
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
@@ -3605,6 +3608,7 @@
 				F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
+				A59170000000000000000001 /* WindowAppearanceSnapshotPaneBackgroundTests.swift in Sources */,
 				F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */,
 				8770D0F2D2BB45359D6BE5E3 /* WindowKeyDownReplayGuardTests.swift in Sources */,
 				7F0A0E04A8CADC84BB4F1DF7 /* WorkspaceActionDispatcherTests.swift in Sources */,

--- a/cmuxTests/WindowAppearanceSnapshotPaneBackgroundTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotPaneBackgroundTests.swift
@@ -1,0 +1,80 @@
+import AppKit
+import SwiftUI
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+struct WindowAppearanceSnapshotPaneBackgroundTests {
+    /// Verifies pane-local OSC colors paint the surface without replacing the shared window root.
+    @Test func surfaceOSCOverrideUsesHostFillAndKeepsSharedWindowRootDefault() throws {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: true,
+            backgroundHex: "#272822",
+            backgroundOpacity: 1.0
+        )
+        let override = try #require(NSColor(hex: "#E6BE78"))
+        let fillPlan = TerminalSurfaceBackgroundFillPlan.resolve(
+            renderingMode: snapshot.terminalRenderingMode,
+            surfaceBackgroundColor: override,
+            defaultBackgroundColor: snapshot.terminalBackgroundColor,
+            backgroundOpacity: Double(snapshot.terminalBackgroundOpacity),
+            sharesWindowBackdrop: true,
+            usesBonsplitPaneBackdrop: false
+        )
+        let windowRoot = snapshot.windowRootBackdropResolution(
+            surfaceBackgroundColor: override
+        )
+
+        #expect(fillPlan.owner == .surfaceHostLayer)
+        #expect(fillPlan.hostLayerColor.hexString(includeAlpha: true) == "#E6BE78FF")
+        #expect(fillPlan.clearsSharedWindowBackdrop)
+        #expect(windowRoot.source == "defaultBackground(surfaceOverrideLocal)")
+        #expect(windowRoot.overrideHex == "#E6BE78")
+        #expect(windowRoot.snapshot.terminalBackgroundColor.hexString() == "#272822")
+        #expect(
+            windowRoot.snapshot.compositedTerminalBackgroundColor.hexString(includeAlpha: true) == "#272822FF"
+        )
+        #expect(
+            windowRoot.snapshot.windowGlassSettings.terminalGlassTintColor?.hexString(includeAlpha: true) == "#272822FF"
+        )
+    }
+
+    private func makeSnapshot(
+        unifySurfaceBackdrops: Bool,
+        backgroundHex: String,
+        backgroundOpacity: CGFloat
+    ) -> WindowAppearanceSnapshot {
+        let backgroundColor = NSColor(hex: backgroundHex) ?? .black
+        return WindowAppearanceSnapshot(
+            terminalBackgroundColor: backgroundColor,
+            terminalBackgroundOpacity: backgroundOpacity,
+            terminalBackgroundBlur: .disabled,
+            terminalRenderingMode: .windowHostBackdrop,
+            unifySurfaceBackdrops: unifySurfaceBackdrops,
+            sidebarSettings: SidebarBackdropSettingsSnapshot(
+                materialRawValue: SidebarMaterialOption.sidebar.rawValue,
+                blendModeRawValue: SidebarBlendModeOption.withinWindow.rawValue,
+                stateRawValue: SidebarStateOption.followWindow.rawValue,
+                tintHex: "#000000",
+                tintHexLight: nil,
+                tintHexDark: nil,
+                tintOpacity: 0.18,
+                cornerRadius: 0,
+                blurOpacity: 1,
+                colorScheme: .dark
+            ),
+            windowGlassSettings: WindowGlassSettingsSnapshot(
+                sidebarBlendModeRawValue: SidebarBlendModeOption.withinWindow.rawValue,
+                isEnabled: false,
+                tintHex: "#000000",
+                tintOpacity: 0.03,
+                terminalBackgroundBlur: .disabled,
+                terminalGlassTintColor: backgroundColor.withAlphaComponent(backgroundOpacity)
+            )
+        )
+    }
+}

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -326,6 +326,29 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertFalse(plan.clearsSharedWindowBackdrop)
     }
 
+    /// Verifies pane-local OSC colors do not replace the shared window root backdrop.
+    func testSurfaceOSCOverrideDoesNotReplaceSharedWindowRootBackdrop() throws {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: true,
+            backgroundHex: "#272822",
+            backgroundOpacity: 1.0
+        )
+        let override = try XCTUnwrap(NSColor(hex: "#E6BE78"))
+        let windowRootSnapshot = snapshot.windowRootBackdropSnapshot(
+            surfaceBackgroundColor: override
+        )
+
+        XCTAssertEqual(windowRootSnapshot.terminalBackgroundColor.hexString(), "#272822")
+        XCTAssertEqual(
+            windowRootSnapshot.compositedTerminalBackgroundColor.hexString(includeAlpha: true),
+            "#272822FF"
+        )
+        XCTAssertEqual(
+            windowRootSnapshot.windowGlassSettings.terminalGlassTintColor?.hexString(includeAlpha: true),
+            "#272822FF"
+        )
+    }
+
     private func makeSnapshot(
         unifySurfaceBackdrops: Bool,
         backgroundHex: String = "#272822",

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -326,29 +326,6 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertFalse(plan.clearsSharedWindowBackdrop)
     }
 
-    /// Verifies pane-local OSC colors do not replace the shared window root backdrop.
-    func testSurfaceOSCOverrideDoesNotReplaceSharedWindowRootBackdrop() throws {
-        let snapshot = makeSnapshot(
-            unifySurfaceBackdrops: true,
-            backgroundHex: "#272822",
-            backgroundOpacity: 1.0
-        )
-        let override = try XCTUnwrap(NSColor(hex: "#E6BE78"))
-        let windowRootSnapshot = snapshot.windowRootBackdropSnapshot(
-            surfaceBackgroundColor: override
-        )
-
-        XCTAssertEqual(windowRootSnapshot.terminalBackgroundColor.hexString(), "#272822")
-        XCTAssertEqual(
-            windowRootSnapshot.compositedTerminalBackgroundColor.hexString(includeAlpha: true),
-            "#272822FF"
-        )
-        XCTAssertEqual(
-            windowRootSnapshot.windowGlassSettings.terminalGlassTintColor?.hexString(includeAlpha: true),
-            "#272822FF"
-        )
-    }
-
     private func makeSnapshot(
         unifySurfaceBackdrops: Bool,
         backgroundHex: String = "#272822",


### PR DESCRIPTION
Closes #5917

## Summary
- Keep pane-local OSC 11 background overrides on the terminal surface fill path while preserving the shared window root backdrop for panes that do not set OSC 11.
- Stop replacing the active window root snapshot with the focused pane's OSC 11 color; the shared root now remains the workspace/default terminal background.
- Add a red/green regression for the shared-root snapshot so CI proves an OSC 11 surface override cannot tint the shared window root.

## Regression provenance
- PR #5106 reverted #3886 to simplify the backdrop pipeline by removing the fill-plan/cutout ownership code and making the active pane drive the root backdrop directly.
- Current main has since reintroduced the surface fill plan, but the active-pane window-root update still used the #5106 behavior (`replacingTerminalBackgroundColor`). This PR keeps the simplified shared root behavior while restoring pane-local OSC 11 isolation.

## Testing
- Not run locally per task instruction.
- `git diff --check`
- CI will validate the failing-test-first stack: commit 1 adds the red regression, commit 2 fixes it.

## Manual dogfood after CI green
Run only after explicit launch approval:
`CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag issue-5917-osc11-per-pane-background --launch`
Then in a plain shell pane run `printf '\e]11;#E6BE78\a'`; the receiving pane should turn `#E6BE78` while neighboring panes keep the shared/default backdrop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783890419&installation_id=133855650&pr_number=5997&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5997&signature=963b2d056dea7b6750ed12a772ac0619f9f2da3cf2115dd0d8a0b2bd6515559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-pane OSC 11 backgrounds without tinting the shared window root. The workspace/default background stays on the root; OSC 11 colors only affect the target pane.

- **Bug Fixes**
  - Keep OSC 11 overrides local to the pane; stop replacing the window root backdrop with the focused pane color.
  - Replace `replacingTerminalBackgroundColor(...)` with `windowRootBackdropResolution(surfaceBackgroundColor:)` that preserves the root snapshot; use `compositedTerminalBackgroundColor` when applying the plan.
  - Move the regression to Swift Testing and assert the shared root stays default while the pane uses the OSC 11 color.
  - Remove stale background color helper to avoid conflicting opacity logic.

<sup>Written for commit a122f8b9e4973fbff6aa97eb85bbce6d2dbeb5cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window backdrop resolution when pane-local background color overrides are applied, ensuring correct behavior with shared window-root backdrops while respecting local surface overrides.

* **Tests**
  * Added test coverage for pane background override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->