### PR TITLE
Fix macOS 27 SF Symbol rasterization crash

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14587,18 +14587,9 @@ private struct SidebarHelpMenuButton: View {
             isPopoverPresented.toggle()
         } label: {
             Image(systemName: "questionmark.circle")
-                .resizable()
-                .scaledToFit()
-                .fontWeight(.medium)
                 .symbolRenderingMode(.monochrome)
+                .cmuxSymbolRasterSize(iconSize, weight: .medium)
                 .foregroundStyle(Color(nsColor: .secondaryLabelColor))
-                // Drive the symbol's raster size from an explicit frame rather
-                // than font metrics. During the window's pre-visible layout pass
-                // the font metrics aren't resolved yet, so a `.font`-sized symbol
-                // rasterizes at 0×0 — which macOS 26+ rejects with an uncaught
-                // `NSInvalidArgumentException` (targetSizeInPoints.width/height>0),
-                // crashing on launch. A fixed frame keeps the raster size positive.
-                .frame(width: iconSize, height: iconSize, alignment: .center)
                 .frame(width: buttonSize, height: buttonSize, alignment: .center)
         }
         .buttonStyle(SidebarFooterIconButtonStyle())
@@ -17389,7 +17380,7 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(Image(systemName: symbolName).font(.system(size: 8 * fontScale, weight: .medium)))
+        return AnyView(Image(systemName: symbolName).cmuxSymbolRasterSize(8 * fontScale, weight: .medium))
     }
 
     @ViewBuilder

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -325,8 +325,8 @@ private struct OmnibarAddressButtonStyleBody: View {
     }
 }
 
-private extension View {
-    func cmuxFlatSymbolColorRendering() -> some View {
+private extension Image {
+    func cmuxFlatSymbolColorRendering() -> Image {
         // `symbolColorRenderingMode(.flat)` is not available in the current SDK
         // used by CI/local builds. Keep this modifier as a compatibility no-op.
         self
@@ -1265,7 +1265,7 @@ struct BrowserPanelView: View {
                 panel.goBack()
             }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1281,7 +1281,7 @@ struct BrowserPanelView: View {
                 panel.goForward()
             }) {
                 Image(systemName: "chevron.right")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1292,7 +1292,7 @@ struct BrowserPanelView: View {
 
             Button(action: handleReloadOrStopButtonAction) {
                 Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .font(.system(size: chromeMetrics.navigationIconFontSize, weight: .medium))
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1318,7 +1318,7 @@ struct BrowserPanelView: View {
             Image(systemName: screenshotPageCopied ? "checkmark" : "camera")
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(screenshotPageButtonColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1372,7 +1372,7 @@ struct BrowserPanelView: View {
         Button(action: handleBrowserFocusModeButtonAction) {
             HStack(spacing: 5) {
                 Image(systemName: "keyboard")
-                    .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                    .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                     .scaleEffect(panel.isBrowserFocusModeActive ? 1.08 : 1.0)
                     .animation(.spring(response: 0.18, dampingFraction: 0.82), value: panel.isBrowserFocusModeActive)
                 if panel.isBrowserFocusModeActive {
@@ -1420,7 +1420,7 @@ struct BrowserPanelView: View {
             Image(systemName: "cursorarrow.click.2")
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(panel.isReactGrabActive ? Color.accentColor : Color.secondary)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1437,7 +1437,7 @@ struct BrowserPanelView: View {
             Image(systemName: devToolsIconOption.rawValue)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1454,7 +1454,7 @@ struct BrowserPanelView: View {
             Image(systemName: "person.crop.circle")
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(devToolsColorOption.color)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1482,7 +1482,7 @@ struct BrowserPanelView: View {
             Image(systemName: browserThemeMode.iconName)
                 .symbolRenderingMode(.monochrome)
                 .cmuxFlatSymbolColorRendering()
-                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .cmuxSymbolRasterSize(devToolsButtonIconSize, weight: .medium)
                 .foregroundStyle(browserThemeModeIconColor)
                 .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
         }
@@ -1509,7 +1509,7 @@ struct BrowserPanelView: View {
         }) {
             HStack(spacing: 4) {
                 Image(systemName: "square.and.arrow.down.on.square")
-                    .font(.system(size: 10, weight: .medium))
+                    .cmuxSymbolRasterSize(10, weight: .medium)
                 Text(String(localized: "browser.import.hint.toolbar", defaultValue: "Import"))
                     .font(.system(size: 11, weight: .medium))
                     .lineLimit(1)
@@ -1539,7 +1539,7 @@ struct BrowserPanelView: View {
                     } label: {
                         HStack(spacing: 8) {
                             Image(systemName: profile.id == panel.profileID ? "checkmark" : "circle")
-                                .font(.system(size: 10, weight: .semibold))
+                                .cmuxSymbolRasterSize(10, weight: .semibold)
                                 .opacity(profile.id == panel.profileID ? 1.0 : 0.0)
                                 .frame(width: 12, alignment: .center)
                             Text(profile.displayName)
@@ -1602,7 +1602,7 @@ struct BrowserPanelView: View {
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: mode == browserThemeMode ? "checkmark" : "circle")
-                            .font(.system(size: 10, weight: .semibold))
+                            .cmuxSymbolRasterSize(10, weight: .semibold)
                             .opacity(mode == browserThemeMode ? 1.0 : 0.0)
                             .frame(width: 12, alignment: .center)
                         Text(mode.displayName)
@@ -1635,7 +1635,7 @@ struct BrowserPanelView: View {
         return HStack(spacing: 4) {
             if showSecureBadge {
                 Image(systemName: "lock.fill")
-                    .font(.system(size: chromeMetrics.secureBadgeFontSize))
+                    .cmuxSymbolRasterSize(chromeMetrics.secureBadgeFontSize)
                     .foregroundColor(.secondary)
             }
 

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -1,8 +1,10 @@
 import AppKit
+import SwiftUI
 
 enum RenderableSystemSymbol {
     static let defaultWorkspaceGroupIcon = "folder.fill"
     static let defaultSurfaceTabIcon = "doc.text"
+    private static let minimumRasterPointSize: CGFloat = 1
     @MainActor
     private static var renderabilityCache: [String: Bool] = [:]
 
@@ -49,10 +51,32 @@ enum RenderableSystemSymbol {
         return resolved
     }
 
+    static func clampedRasterPointSize(_ pointSize: CGFloat) -> CGFloat {
+        guard pointSize.isFinite else {
+            return minimumRasterPointSize
+        }
+        return max(minimumRasterPointSize, pointSize)
+    }
+
     #if DEBUG
     @MainActor
     static func resetRenderabilityCacheForTesting() {
         renderabilityCache.removeAll()
     }
     #endif
+}
+
+extension Image {
+    /// Sizes SF Symbols from an explicit positive frame instead of transient font metrics.
+    func cmuxSymbolRasterSize(
+        _ pointSize: CGFloat,
+        weight: Font.Weight? = nil,
+        alignment: Alignment = .center
+    ) -> some View {
+        let rasterSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
+        return resizable()
+            .scaledToFit()
+            .fontWeight(weight)
+            .frame(width: rasterSize, height: rasterSize, alignment: alignment)
+    }
 }

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -13,6 +13,11 @@ enum HeaderChromeIconStyle {
         HeaderChromeControlMetrics.iconFrameSize(forIconSize: iconSize)
     }
 
+    static func symbol(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .cmuxSymbolRasterSize(RightSidebarChromeMetrics.headerIconSize, weight: weight)
+    }
+
     static func foregroundOpacity(isHovering: Bool, isPressed: Bool, isEnabled: Bool = true) -> Double {
         guard isEnabled else { return disabledOpacity }
         if isPressed {

--- a/Sources/RightSidebarChromeStyle.swift
+++ b/Sources/RightSidebarChromeStyle.swift
@@ -164,7 +164,6 @@ private struct RightSidebarHeaderIconButtonStyleBody: View {
     var body: some View {
         configuration.label
             .symbolRenderingMode(.monochrome)
-            .font(.system(size: RightSidebarChromeMetrics.headerIconSize, weight: HeaderChromeIconStyle.weight))
             .frame(
                 width: RightSidebarChromeMetrics.headerIconFrameSize,
                 height: RightSidebarChromeMetrics.headerIconFrameSize

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -322,11 +322,7 @@ struct RightSidebarPanelView: View {
         Button {
             onOpenAsPane(mode)
         } label: {
-            Image(systemName: "rectangle.split.2x1")
-                .cmuxSymbolRasterSize(
-                    RightSidebarChromeMetrics.headerIconSize,
-                    weight: HeaderChromeIconStyle.weight
-                )
+            HeaderChromeIconStyle.symbol("rectangle.split.2x1")
         }
         .buttonStyle(RightSidebarHeaderIconButtonStyle(iconGeometryKeyPrefix: "rightSidebarHeaderOpenAsPaneIcon"))
         .frame(
@@ -359,11 +355,7 @@ struct RightSidebarPanelView: View {
         )
         return ZStack {
             Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .cmuxSymbolRasterSize(
-                        RightSidebarChromeMetrics.headerIconSize,
-                        weight: HeaderChromeIconStyle.weight
-                    )
+                HeaderChromeIconStyle.symbol("xmark")
             }
             .buttonStyle(RightSidebarHeaderIconButtonStyle(iconGeometryKeyPrefix: "rightSidebarHeaderCloseIcon"))
             .frame(

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -323,6 +323,10 @@ struct RightSidebarPanelView: View {
             onOpenAsPane(mode)
         } label: {
             Image(systemName: "rectangle.split.2x1")
+                .cmuxSymbolRasterSize(
+                    RightSidebarChromeMetrics.headerIconSize,
+                    weight: HeaderChromeIconStyle.weight
+                )
         }
         .buttonStyle(RightSidebarHeaderIconButtonStyle(iconGeometryKeyPrefix: "rightSidebarHeaderOpenAsPaneIcon"))
         .frame(
@@ -356,6 +360,10 @@ struct RightSidebarPanelView: View {
         return ZStack {
             Button(action: onClose) {
                 Image(systemName: "xmark")
+                    .cmuxSymbolRasterSize(
+                        RightSidebarChromeMetrics.headerIconSize,
+                        weight: HeaderChromeIconStyle.weight
+                    )
             }
             .buttonStyle(RightSidebarHeaderIconButtonStyle(iconGeometryKeyPrefix: "rightSidebarHeaderCloseIcon"))
             .frame(

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1161,7 +1161,7 @@ struct TitlebarControlsView: View {
         titlebarIconChrome(config: config, iconGeometryKeyPrefix: iconGeometryKeyPrefix) {
             Image(systemName: systemName)
                 .symbolRenderingMode(.monochrome)
-                .font(.system(size: config.iconSize, weight: TitlebarControlIconStyle.weight))
+                .cmuxSymbolRasterSize(config.iconSize, weight: TitlebarControlIconStyle.weight)
         }
     }
 
@@ -2347,7 +2347,7 @@ private struct NotificationsPopoverView: View {
             Button(action: jumpToLatestUnread) {
                 HStack(spacing: 5) {
                     Image(systemName: "arrow.down.to.line")
-                        .font(.system(size: 10, weight: .semibold))
+                        .cmuxSymbolRasterSize(10, weight: .semibold)
                     Text(String(localized: "notifications.jumpToLatest", defaultValue: "Jump to Latest"))
                         .font(.system(size: 11))
                     if !jumpToUnreadShortcut.displayString.isEmpty {
@@ -2471,7 +2471,7 @@ private struct NotificationsPopoverView: View {
     private func emptyState(systemImage: String, title: String, subtitle: String?) -> some View {
         VStack(spacing: 10) {
             Image(systemName: systemImage)
-                .font(.system(size: 30, weight: .light))
+                .cmuxSymbolRasterSize(30, weight: .light)
                 .foregroundColor(.secondary.opacity(0.7))
             Text(title)
                 .font(.system(size: 14, weight: .medium))
@@ -2655,7 +2655,7 @@ private struct NotificationPopoverRow: View {
                 Circle()
                     .fill(Color.primary.opacity(0.1))
                 Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
+                    .cmuxSymbolRasterSize(9, weight: .bold)
                     .foregroundColor(.primary.opacity(0.7))
             }
             .frame(width: 20, height: 20)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 		B9000027A1B2C3D4E5F60719 /* RemoteRelayZshBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001641 /* RemoteRelayZshBootstrap.swift */; };
 		E4321000E4321000E4321001 /* RemoteShellSessionParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */; };
 		D5037010000000000000003 /* RenderableSystemSymbol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5037010000000000000002 /* RenderableSystemSymbol.swift */; };
+		C58410010000000000000001 /* RenderableSystemSymbolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58410010000000000000002 /* RenderableSystemSymbolTests.swift */; };
 		D36A00040000000000000001 /* RendererRealizationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00040000000000000002 /* RendererRealizationController.swift */; };
 		D36A00060000000000000001 /* RendererRealizationPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00060000000000000002 /* RendererRealizationPlanner.swift */; };
 		D36A00050000000000000001 /* RendererRealizationPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */; };
@@ -1314,6 +1315,7 @@
 		A5001641 /* RemoteRelayZshBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteRelayZshBootstrap.swift; sourceTree = "<group>"; };
 		E4321000E4321000E4321002 /* RemoteShellSessionParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShellSessionParsing.swift; sourceTree = "<group>"; };
 		D5037010000000000000002 /* RenderableSystemSymbol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableSystemSymbol.swift; sourceTree = "<group>"; };
+		C58410010000000000000002 /* RenderableSystemSymbolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderableSystemSymbolTests.swift; sourceTree = "<group>"; };
 		D36A00040000000000000002 /* RendererRealizationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationController.swift; sourceTree = "<group>"; };
 		D36A00060000000000000002 /* RendererRealizationPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/RendererRealizationPlanner.swift; sourceTree = "<group>"; };
 		D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererRealizationPlannerTests.swift; sourceTree = "<group>"; };
@@ -2311,6 +2313,7 @@
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
+				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
 				F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */,
 				F5410005A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift */,
 				F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */,
@@ -3550,6 +3553,7 @@
 					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
 				C135190000000000000000A1 /* PreferredEditorSettingsTests.swift in Sources */,
 				C47110010000000000000001 /* ProcessPipeReadCrashRegressionTests.swift in Sources */,
+				C58410010000000000000001 /* RenderableSystemSymbolTests.swift in Sources */,
 				D36A00050000000000000001 /* RendererRealizationPlannerTests.swift in Sources */,
 					F5410004A1B2C3D4E5F60718 /* RestorableAgentHookProviderHermesTests.swift in Sources */,
 					F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Renderable system symbols")
+struct RenderableSystemSymbolTests {
+    @Test func rasterPointSizeClampsInvalidInputs() {
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(0) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(-8) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(11) == 11)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(.nan) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(.infinity) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(-.infinity) == 1)
+    }
+}

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -871,6 +871,12 @@ struct WorkspaceGroupTests {
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("   ") == "doc.text")
     }
 
+    @Test func symbolRasterPointSizeClampsZeroAndNegativeInputs() {
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(0) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(-8) == 1)
+        #expect(RenderableSystemSymbol.clampedRasterPointSize(11) == 11)
+    }
+
     // Regression for #5404: renaming a group must update the name shown in
     // window chrome (the custom title bar / NSWindow title / toolbar label),
     // not just the sidebar header. The chrome derives a grouped anchor's

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -877,12 +877,6 @@ struct WorkspaceGroupTests {
         #expect(RenderableSystemSymbol.clampedRasterPointSize(11) == 11)
     }
 
-    // Regression for #5404: renaming a group must update the name shown in
-    // window chrome (the custom title bar / NSWindow title / toolbar label),
-    // not just the sidebar header. The chrome derives a grouped anchor's
-    // displayed name from `resolvedWorkspaceDisplayTitle(for:)`, which must
-    // track the group's `name` — the single source of truth — rather than the
-    // anchor's own (stale) title that was merely seeded at creation.
     @Test func renamingGroupUpdatesAnchorDisplayTitle() throws {
         let manager = makeTabManager()
         let groupId = try #require(

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -871,12 +871,12 @@ struct WorkspaceGroupTests {
         #expect(RenderableSystemSymbol.resolvedSurfaceTabIcon("   ") == "doc.text")
     }
 
-    @Test func symbolRasterPointSizeClampsZeroAndNegativeInputs() {
-        #expect(RenderableSystemSymbol.clampedRasterPointSize(0) == 1)
-        #expect(RenderableSystemSymbol.clampedRasterPointSize(-8) == 1)
-        #expect(RenderableSystemSymbol.clampedRasterPointSize(11) == 11)
-    }
-
+    // Regression for #5404: renaming a group must update the name shown in
+    // window chrome (the custom title bar / NSWindow title / toolbar label),
+    // not just the sidebar header. The chrome derives a grouped anchor's
+    // displayed name from `resolvedWorkspaceDisplayTitle(for:)`, which must
+    // track the group's `name` — the single source of truth — rather than the
+    // anchor's own (stale) title that was merely seeded at creation.
     @Test func renamingGroupUpdatesAnchorDisplayTitle() throws {
         let manager = makeTabManager()
         let groupId = try #require(


### PR DESCRIPTION
## Summary
- add a shared `Image.cmuxSymbolRasterSize` guard that clamps SF Symbol raster frames to at least 1pt and sizes symbols with `resizable().scaledToFit().frame(...)` instead of transient font metrics
- apply the guard to the browser toolbar dev-tools surface that crashes on `wrench.and.screwdriver`, plus related browser toolbar/profile/theme icons, sidebar Help/metadata icons, right-sidebar header icons, and titlebar/update accessory icons
- keep the #5670 sidebar Help fix on the same guarded path so future small-symbol sites can opt into the same raster sizing behavior

## Root cause
macOS 27 / CoreUI can reject SwiftUI SF Symbol rasterization when a font-sized symbol is laid out during a transient pre-visible/window layout pass and the target size collapses to 0x0. #5841 captured this for `wrench.and.screwdriver` in the browser toolbar after cmd-clicking a terminal link. #5890 reports the same CoreUI/SwiftUI vector glyph throw during initial main-window bootstrap.

This follows the #5670 precedent: use explicit positive symbol frames rather than relying on font metrics during those layout passes.

## Reproduction
I did not fake a local repro: this machine is not on macOS 27, and the available evidence is the lldb/crash-report data in #5841 and #5890.

## Tests
- Added `symbolRasterPointSizeClampsZeroAndNegativeInputs` in the existing wired `WorkspaceGroupTests.swift` suite.
- Not run locally per instruction; CI is the validation gate.

Fixes #5841
Fixes #5890
Refs #5670

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/5999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783890456&installation_id=133855650&pr_number=5999&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F5999&signature=947201584494e7be0f5ab55f3aaf96285ab3983aeb6c1a21fd9006d769d9b85a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SF Symbol rasterization crashes on macOS 27 by clamping symbol sizes to at least 1 pt and sizing with explicit frames. Uses `Image.cmuxSymbolRasterSize(...)` across the app to avoid 0×0 pre-layout sizes.

- **Bug Fixes**
  - Added `RenderableSystemSymbol.clampedRasterPointSize` and `Image.cmuxSymbolRasterSize(pointSize, weight)` using `resizable().scaledToFit().frame(...)`.
  - Replaced font-based sizing in browser navigation/dev-tools, profile/theme menus, sidebar Help/metadata, right-sidebar header (via `HeaderChromeIconStyle.symbol`), titlebar controls, and notifications popover.
  - Moved `cmuxFlatSymbolColorRendering` to an `Image` extension for consistent symbol pipelines.
  - Added tests covering zero, negative, and non-finite size inputs.
  - Fixes #5841 and #5890; refs #5670.

<sup>Written for commit 046ceccaabdac8756ee7cd1d3e04fc566ab484c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/5999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized symbol icon rendering across browser panels, sidebars, and titlebar accessories using a unified sizing and weight approach.

* **Tests**
  * Added test coverage for symbol size point clamping edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->