### PR TITLE
Pick Claude subrouter profile before fresh launches

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -250,6 +250,79 @@ pick_subrouter_claude_profile_for_fresh_launch() {
     normalize_claude_config_dir
 }
 
+subrouter_claude_routing_active() {
+    case "${ANTHROPIC_AUTH_TOKEN:-}" in
+        subrouter) return 0 ;;
+    esac
+    case "${ANTHROPIC_BASE_URL:-}" in
+        *subrouter*) return 0 ;;
+    esac
+    claude_config_dir_is_subrouter_managed
+}
+
+anthropic_custom_headers_has() {
+    local header_name="$1"
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        case "$line" in
+            "$header_name":*) return 0 ;;
+        esac
+    done <<<"${ANTHROPIC_CUSTOM_HEADERS:-}"
+    return 1
+}
+
+sanitize_subrouter_header_value() {
+    local value="$1"
+    value="${value//$'\r'/}"
+    value="${value//$'\n'/}"
+    printf '%s' "$value"
+}
+
+append_anthropic_custom_header() {
+    local header_name="$1"
+    local header_value
+    header_value="$(sanitize_subrouter_header_value "$2")"
+    [[ -n "$header_value" ]] || return 0
+    anthropic_custom_headers_has "$header_name" && return 0
+
+    if [[ -n "${ANTHROPIC_CUSTOM_HEADERS:-}" ]]; then
+        export ANTHROPIC_CUSTOM_HEADERS="${ANTHROPIC_CUSTOM_HEADERS}"$'\n'"$header_name: $header_value"
+    else
+        export ANTHROPIC_CUSTOM_HEADERS="$header_name: $header_value"
+    fi
+}
+
+extract_claude_explicit_session_key() {
+    local -a args=("$@")
+    local index arg next
+    for ((index = 0; index < ${#args[@]}; index++)); do
+        arg="${args[$index]}"
+        case "$arg" in
+            --resume=*|--session-id=*)
+                printf '%s' "${arg#*=}"
+                return 0
+                ;;
+            --resume|-r|--session-id)
+                if (( index + 1 < ${#args[@]} )); then
+                    next="${args[$((index + 1))]}"
+                    if [[ -n "$next" && "$next" != -* ]]; then
+                        printf '%s' "$next"
+                        return 0
+                    fi
+                fi
+                ;;
+        esac
+    done
+    return 1
+}
+
+configure_subrouter_claude_headers() {
+    local session_key="$1"
+    subrouter_claude_routing_active || return 0
+    append_anthropic_custom_header "X-Subrouter-Session" "$session_key"
+    append_anthropic_custom_header "X-Subrouter-Agent" "claude"
+}
+
 clear_inherited_claude_auth_selection_env() {
     if [[ "${IN_CMUX:-0}" == "1" ]]; then
         local key
@@ -538,6 +611,15 @@ done
 if [[ "$SKIP_SUBROUTER_PROFILE_PICK" == false ]]; then
     pick_subrouter_claude_profile_for_fresh_launch
 fi
+SESSION_ID=""
+SUBROUTER_CLAUDE_SESSION_KEY="$(extract_claude_explicit_session_key "$@" || true)"
+if [[ "$SKIP_SESSION_ID" == false ]]; then
+    SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    SUBROUTER_CLAUDE_SESSION_KEY="$SESSION_ID"
+elif [[ -z "$SUBROUTER_CLAUDE_SESSION_KEY" ]]; then
+    SUBROUTER_CLAUDE_SESSION_KEY="cmux-claude-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+fi
+configure_subrouter_claude_headers "$SUBROUTER_CLAUDE_SESSION_KEY"
 
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.
@@ -579,6 +661,5 @@ HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionS
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
-    SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
     exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
 fi

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -188,6 +188,68 @@ normalize_claude_config_dir() {
     esac
 }
 
+claude_config_dir_is_subrouter_managed() {
+    [[ -n "${HOME:-}" ]] || return 1
+
+    local legacy_root="$HOME/.subrouter/codex/claude"
+    local account_root="$HOME/.codex-accounts/claude"
+    if [[ -z "${CLAUDE_CONFIG_DIR:-}" ]]; then
+        [[ -d "$account_root" || -d "$legacy_root" ]] && return 0
+        return 1
+    fi
+
+    local value="$CLAUDE_CONFIG_DIR"
+    if [[ "$value" == "~/"* ]]; then
+        value="$HOME/${value#~/}"
+    fi
+
+    case "$value" in
+        "$legacy_root"|"$legacy_root"/*|"$account_root"|"$account_root"/*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+parse_subrouter_claude_env_config_dir() {
+    local line value
+    while IFS= read -r line; do
+        case "$line" in
+            "export CLAUDE_CONFIG_DIR="*)
+                value="${line#export CLAUDE_CONFIG_DIR=}"
+                value="${value%$'\r'}"
+                value="${value%\"}"
+                value="${value#\"}"
+                value="${value%\'}"
+                value="${value#\'}"
+                [[ -n "$value" ]] || return 1
+                printf '%s' "$value"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
+pick_subrouter_claude_profile_for_fresh_launch() {
+    case "${CMUX_CLAUDE_SUBROUTER_PICK_DISABLED:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+    esac
+    claude_config_dir_is_subrouter_managed || return 0
+
+    local subrouter_bin
+    subrouter_bin="$(command -v subrouter || true)"
+    [[ -n "$subrouter_bin" && -x "$subrouter_bin" ]] || return 0
+
+    "$subrouter_bin" claude pick >/dev/null 2>&1 || return 0
+
+    local picked_config_dir
+    picked_config_dir="$("$subrouter_bin" claude env 2>/dev/null | parse_subrouter_claude_env_config_dir)" || return 0
+    [[ -n "$picked_config_dir" ]] || return 0
+    export CLAUDE_CONFIG_DIR="$picked_config_dir"
+    normalize_claude_config_dir
+}
+
 clear_inherited_claude_auth_selection_env() {
     if [[ "${IN_CMUX:-0}" == "1" ]]; then
         local key
@@ -460,14 +522,22 @@ clear_inherited_claude_auth_selection_env
 # Check if the user already specified a session/resume flag.
 # If so, don't inject our own --session-id (it would conflict).
 SKIP_SESSION_ID=false
+SKIP_SUBROUTER_PROFILE_PICK=false
 for arg in "$@"; do
     case "$arg" in
         --resume|--resume=*|-r|--session-id|--session-id=*|--continue|-c)
             SKIP_SESSION_ID=true
-            break
+            case "$arg" in
+                --resume|--resume=*|-r|--continue|-c)
+                    SKIP_SUBROUTER_PROFILE_PICK=true
+                    ;;
+            esac
             ;;
     esac
 done
+if [[ "$SKIP_SUBROUTER_PROFILE_PICK" == false ]]; then
+    pick_subrouter_claude_profile_for_fresh_launch
+fi
 
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -374,6 +374,7 @@ keys=(
   ANTHROPIC_AUTH_TOKEN
   ANTHROPIC_BASE_URL
   ANTHROPIC_BEDROCK_BASE_URL
+  ANTHROPIC_CUSTOM_HEADERS
   ANTHROPIC_MODEL
   ANTHROPIC_SMALL_FAST_MODEL
   ANTHROPIC_VERTEX_BASE_URL
@@ -387,7 +388,11 @@ keys=(
 )
 for key in "${keys[@]}"; do
   if [[ ${!key+x} ]]; then
-    printf '%s=%s\\n' "$key" "${!key}" >> "$FAKE_AUTH_ENV_LOG"
+    value="${!key}"
+    if [[ "$key" == "ANTHROPIC_CUSTOM_HEADERS" ]]; then
+      value="${value//$'\\n'/\\\\n}"
+    fi
+    printf '%s=%s\\n' "$key" "$value" >> "$FAKE_AUTH_ENV_LOG"
   else
     printf '%s=__UNSET__\\n' "$key" >> "$FAKE_AUTH_ENV_LOG"
   fi
@@ -395,6 +400,7 @@ done
 for arg in "$@"; do
   printf '%s\\n' "$arg" >> "$FAKE_ARGS_LOG"
 done
+exit 0
 """,
         )
 
@@ -426,6 +432,7 @@ exit 0
                 "ANTHROPIC_AUTH_TOKEN",
                 "ANTHROPIC_BASE_URL",
                 "ANTHROPIC_BEDROCK_BASE_URL",
+                "ANTHROPIC_CUSTOM_HEADERS",
                 "ANTHROPIC_MODEL",
                 "ANTHROPIC_SMALL_FAST_MODEL",
                 "ANTHROPIC_VERTEX_BASE_URL",
@@ -772,27 +779,95 @@ def test_live_socket_normalizes_subrouter_claude_config_dir(failures: list[str])
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["path"], f"normalize config dir: expected {expected['path']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
 
 
+def test_live_socket_sets_subrouter_headers_for_fable_fresh_launch(failures: list[str]) -> None:
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--model", "claude-fable-5", "hello"],
+        inherited_env={
+            "CMUX_CLAUDE_SUBROUTER_PICK_DISABLED": "1",
+            "ANTHROPIC_AUTH_TOKEN": "subrouter",
+            "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+        },
+    )
+    expect(code == 0, f"subrouter headers fresh launch: wrapper exited {code}: {stderr}", failures)
+    expect("--session-id" in real_argv, f"subrouter headers fresh launch: expected session injection, got {real_argv}", failures)
+    session_index = real_argv.index("--session-id")
+    session_id = real_argv[session_index + 1] if session_index + 1 < len(real_argv) else ""
+    headers = auth_env.get("ANTHROPIC_CUSTOM_HEADERS", "").replace("\\n", "\n")
+    expect(
+        f"X-Subrouter-Session: {session_id}" in headers,
+        f"subrouter headers fresh launch: expected X-Subrouter-Session for {session_id!r}, got {headers!r}",
+        failures,
+    )
+    expect(
+        "X-Subrouter-Agent: claude" in headers,
+        f"subrouter headers fresh launch: expected X-Subrouter-Agent, got {headers!r}",
+        failures,
+    )
+
+
+def test_live_socket_sets_subrouter_headers_for_resume_launch(failures: list[str]) -> None:
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--resume", "claude-session-123", "--model", "claude-fable-5"],
+        inherited_env={
+            "CMUX_CLAUDE_SUBROUTER_PICK_DISABLED": "1",
+            "ANTHROPIC_AUTH_TOKEN": "subrouter",
+            "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+        },
+    )
+    expect(code == 0, f"subrouter headers resume launch: wrapper exited {code}: {stderr}", failures)
+    headers = auth_env.get("ANTHROPIC_CUSTOM_HEADERS", "").replace("\\n", "\n")
+    expect(
+        "X-Subrouter-Session: claude-session-123" in headers,
+        f"subrouter headers resume launch: expected resume X-Subrouter-Session, got {headers!r}",
+        failures,
+    )
+    expect(
+        "X-Subrouter-Agent: claude" in headers,
+        f"subrouter headers resume launch: expected X-Subrouter-Agent, got {headers!r}",
+        failures,
+    )
+    expect("--session-id" not in real_argv, f"subrouter headers resume launch: expected no injected session id, got {real_argv}", failures)
+
+
+def test_live_socket_appends_subrouter_headers_to_existing_custom_headers(failures: list[str]) -> None:
+    code, auth_env, _, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env={
+            "CMUX_CLAUDE_SUBROUTER_PICK_DISABLED": "1",
+            "ANTHROPIC_AUTH_TOKEN": "subrouter",
+            "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+            "ANTHROPIC_CUSTOM_HEADERS": "X-Existing: yes",
+        },
+    )
+    expect(code == 0, f"subrouter headers append: wrapper exited {code}: {stderr}", failures)
+    headers = auth_env.get("ANTHROPIC_CUSTOM_HEADERS", "").replace("\\n", "\n")
+    expect(headers.startswith("X-Existing: yes\n"), f"subrouter headers append: expected existing header preserved first, got {headers!r}", failures)
+    expect("X-Subrouter-Session: " in headers, f"subrouter headers append: expected X-Subrouter-Session, got {headers!r}", failures)
+    expect("X-Subrouter-Agent: claude" in headers, f"subrouter headers append: expected X-Subrouter-Agent, got {headers!r}", failures)
+
+
 def test_live_socket_picks_subrouter_claude_profile_for_fable_fresh_launch(failures: list[str]) -> None:
     expected: dict[str, str] = {}
+    with tempfile.TemporaryDirectory(prefix="cmux-subrouter-pick-log-") as log_dir:
+        pick_log = Path(log_dir) / "subrouter-pick.log"
 
-    def setup(tmp: Path) -> dict[str, str]:
-        home = tmp / "home"
-        fake_bin = tmp / "fake-bin"
-        fake_bin.mkdir(parents=True)
-        old_profile = home / ".codex-accounts" / "claude" / "_old"
-        new_profile = home / ".codex-accounts" / "claude" / "_new"
-        old_profile.mkdir(parents=True)
-        new_profile.mkdir(parents=True)
-        pick_log = tmp / "subrouter-pick.log"
-        expected["old_profile"] = str(old_profile)
-        expected["new_profile"] = str(new_profile)
-        expected["pick_log"] = str(pick_log)
-        make_executable(
-            fake_bin / "subrouter",
-            f"""#!/usr/bin/env bash
+        def setup(tmp: Path) -> dict[str, str]:
+            home = tmp / "home"
+            fake_bin = tmp / "fake-bin"
+            fake_bin.mkdir(parents=True)
+            old_profile = home / ".codex-accounts" / "claude" / "_old"
+            new_profile = home / ".codex-accounts" / "claude" / "_new"
+            old_profile.mkdir(parents=True)
+            new_profile.mkdir(parents=True)
+            expected["old_profile"] = str(old_profile)
+            expected["new_profile"] = str(new_profile)
+            expected["pick_log"] = str(pick_log)
+            make_executable(
+                fake_bin / "subrouter",
+                f"""#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\\n' "$*" >> {str(pick_log)!r}
 if [[ "${{1:-}}" == "claude" && "${{2:-}}" == "pick" ]]; then
-  printf 'pick\\n' >> {str(pick_log)!r}
   exit 0
 fi
 if [[ "${{1:-}}" == "claude" && "${{2:-}}" == "env" ]]; then
@@ -801,59 +876,61 @@ if [[ "${{1:-}}" == "claude" && "${{2:-}}" == "env" ]]; then
 fi
 exit 2
 """,
-        )
-        return {
-            "HOME": str(home),
-            "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-            "CLAUDE_CONFIG_DIR": str(old_profile),
-        }
+            )
+            return {
+                "HOME": str(home),
+                "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                "CLAUDE_CONFIG_DIR": str(old_profile),
+            }
 
-    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["--model", "claude-fable-5", "hello"],
-        inherited_env={},
-        setup_env=setup,
-    )
-    expect(code == 0, f"subrouter pick fresh launch: wrapper exited {code}: {stderr}", failures)
-    expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["new_profile"], f"subrouter pick fresh launch: expected picked CLAUDE_CONFIG_DIR {expected['new_profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
-    expect(read_lines(Path(expected["pick_log"])) == ["pick"], "subrouter pick fresh launch: expected one pick call", failures)
-    expect("--session-id" in real_argv, f"subrouter pick fresh launch: expected session injection, got {real_argv}", failures)
+        code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+            argv=["--model", "claude-fable-5", "hello"],
+            inherited_env={},
+            setup_env=setup,
+        )
+        expect(code == 0, f"subrouter pick fresh launch: wrapper exited {code}: {stderr}", failures)
+        expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["new_profile"], f"subrouter pick fresh launch: expected picked CLAUDE_CONFIG_DIR {expected['new_profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+        pick_lines = read_lines(Path(expected["pick_log"]))
+        expect(pick_lines == ["claude pick", "claude env"], f"subrouter pick fresh launch: expected pick then env, got {pick_lines}", failures)
+        expect("--session-id" in real_argv, f"subrouter pick fresh launch: expected session injection, got {real_argv}", failures)
 
 
 def test_live_socket_keeps_subrouter_claude_profile_for_resume_launch(failures: list[str]) -> None:
     expected: dict[str, str] = {}
+    with tempfile.TemporaryDirectory(prefix="cmux-subrouter-resume-log-") as log_dir:
+        pick_log = Path(log_dir) / "subrouter-pick.log"
 
-    def setup(tmp: Path) -> dict[str, str]:
-        home = tmp / "home"
-        fake_bin = tmp / "fake-bin"
-        fake_bin.mkdir(parents=True)
-        profile = home / ".codex-accounts" / "claude" / "_resume"
-        profile.mkdir(parents=True)
-        pick_log = tmp / "subrouter-pick.log"
-        expected["profile"] = str(profile)
-        expected["pick_log"] = str(pick_log)
-        make_executable(
-            fake_bin / "subrouter",
-            f"""#!/usr/bin/env bash
+        def setup(tmp: Path) -> dict[str, str]:
+            home = tmp / "home"
+            fake_bin = tmp / "fake-bin"
+            fake_bin.mkdir(parents=True)
+            profile = home / ".codex-accounts" / "claude" / "_resume"
+            profile.mkdir(parents=True)
+            expected["profile"] = str(profile)
+            expected["pick_log"] = str(pick_log)
+            make_executable(
+                fake_bin / "subrouter",
+                f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> {str(pick_log)!r}
 exit 42
 """,
-        )
-        return {
-            "HOME": str(home),
-            "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
-            "CLAUDE_CONFIG_DIR": str(profile),
-        }
+            )
+            return {
+                "HOME": str(home),
+                "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+                "CLAUDE_CONFIG_DIR": str(profile),
+            }
 
-    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["--resume", "claude-session-123", "--model", "claude-fable-5"],
-        inherited_env={},
-        setup_env=setup,
-    )
-    expect(code == 0, f"subrouter pick resume launch: wrapper exited {code}: {stderr}", failures)
-    expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["profile"], f"subrouter pick resume launch: expected resume CLAUDE_CONFIG_DIR {expected['profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
-    expect(read_lines(Path(expected["pick_log"])) == [], "subrouter pick resume launch: did not expect subrouter calls", failures)
-    expect("--session-id" not in real_argv, f"subrouter pick resume launch: expected no injected session id, got {real_argv}", failures)
+        code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+            argv=["--resume", "claude-session-123", "--model", "claude-fable-5"],
+            inherited_env={},
+            setup_env=setup,
+        )
+        expect(code == 0, f"subrouter pick resume launch: wrapper exited {code}: {stderr}", failures)
+        expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["profile"], f"subrouter pick resume launch: expected resume CLAUDE_CONFIG_DIR {expected['profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+        expect(read_lines(Path(expected["pick_log"])) == [], "subrouter pick resume launch: did not expect subrouter calls", failures)
+        expect("--session-id" not in real_argv, f"subrouter pick resume launch: expected no injected session id, got {real_argv}", failures)
 
 
 def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]) -> None:
@@ -1258,6 +1335,11 @@ def main() -> int:
     test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_hooks_disabled_clears_stale_auth_selection_before_passthrough(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
+    test_live_socket_sets_subrouter_headers_for_fable_fresh_launch(failures)
+    test_live_socket_sets_subrouter_headers_for_resume_launch(failures)
+    test_live_socket_appends_subrouter_headers_to_existing_custom_headers(failures)
+    test_live_socket_picks_subrouter_claude_profile_for_fable_fresh_launch(failures)
+    test_live_socket_keeps_subrouter_claude_profile_for_resume_launch(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -772,6 +772,90 @@ def test_live_socket_normalizes_subrouter_claude_config_dir(failures: list[str])
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["path"], f"normalize config dir: expected {expected['path']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
 
 
+def test_live_socket_picks_subrouter_claude_profile_for_fable_fresh_launch(failures: list[str]) -> None:
+    expected: dict[str, str] = {}
+
+    def setup(tmp: Path) -> dict[str, str]:
+        home = tmp / "home"
+        fake_bin = tmp / "fake-bin"
+        fake_bin.mkdir(parents=True)
+        old_profile = home / ".codex-accounts" / "claude" / "_old"
+        new_profile = home / ".codex-accounts" / "claude" / "_new"
+        old_profile.mkdir(parents=True)
+        new_profile.mkdir(parents=True)
+        pick_log = tmp / "subrouter-pick.log"
+        expected["old_profile"] = str(old_profile)
+        expected["new_profile"] = str(new_profile)
+        expected["pick_log"] = str(pick_log)
+        make_executable(
+            fake_bin / "subrouter",
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${{1:-}}" == "claude" && "${{2:-}}" == "pick" ]]; then
+  printf 'pick\\n' >> {str(pick_log)!r}
+  exit 0
+fi
+if [[ "${{1:-}}" == "claude" && "${{2:-}}" == "env" ]]; then
+  printf 'export CLAUDE_CONFIG_DIR=%s\\n' {str(new_profile)!r}
+  exit 0
+fi
+exit 2
+""",
+        )
+        return {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CLAUDE_CONFIG_DIR": str(old_profile),
+        }
+
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--model", "claude-fable-5", "hello"],
+        inherited_env={},
+        setup_env=setup,
+    )
+    expect(code == 0, f"subrouter pick fresh launch: wrapper exited {code}: {stderr}", failures)
+    expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["new_profile"], f"subrouter pick fresh launch: expected picked CLAUDE_CONFIG_DIR {expected['new_profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+    expect(read_lines(Path(expected["pick_log"])) == ["pick"], "subrouter pick fresh launch: expected one pick call", failures)
+    expect("--session-id" in real_argv, f"subrouter pick fresh launch: expected session injection, got {real_argv}", failures)
+
+
+def test_live_socket_keeps_subrouter_claude_profile_for_resume_launch(failures: list[str]) -> None:
+    expected: dict[str, str] = {}
+
+    def setup(tmp: Path) -> dict[str, str]:
+        home = tmp / "home"
+        fake_bin = tmp / "fake-bin"
+        fake_bin.mkdir(parents=True)
+        profile = home / ".codex-accounts" / "claude" / "_resume"
+        profile.mkdir(parents=True)
+        pick_log = tmp / "subrouter-pick.log"
+        expected["profile"] = str(profile)
+        expected["pick_log"] = str(pick_log)
+        make_executable(
+            fake_bin / "subrouter",
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> {str(pick_log)!r}
+exit 42
+""",
+        )
+        return {
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{tmp / 'wrapper-bin'}:{tmp / 'real-bin'}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "CLAUDE_CONFIG_DIR": str(profile),
+        }
+
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["--resume", "claude-session-123", "--model", "claude-fable-5"],
+        inherited_env={},
+        setup_env=setup,
+    )
+    expect(code == 0, f"subrouter pick resume launch: wrapper exited {code}: {stderr}", failures)
+    expect(auth_env.get("CLAUDE_CONFIG_DIR") == expected["profile"], f"subrouter pick resume launch: expected resume CLAUDE_CONFIG_DIR {expected['profile']!r}, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
+    expect(read_lines(Path(expected["pick_log"])) == [], "subrouter pick resume launch: did not expect subrouter calls", failures)
+    expect("--session-id" not in real_argv, f"subrouter pick resume launch: expected no injected session id, got {real_argv}", failures)
+
+
 def test_live_socket_preserves_claude_auth_for_resume_launch(failures: list[str]) -> None:
     expected_auth_env = {
         "CLAUDE_CONFIG_DIR": "/tmp/resume-claude-config",


### PR DESCRIPTION
## Summary
- call `subrouter claude pick` before fresh Claude launches when `CLAUDE_CONFIG_DIR` is subrouter-managed
- refresh `CLAUDE_CONFIG_DIR` from `subrouter claude env` before execing Claude
- skip profile picking for resume/continue so existing transcripts stay pinned to their original profile

## Tests
- `python3 tests/test_claude_wrapper_hooks.py`
- `./scripts/reload-cloud.sh --tag fable`
- packaged-wrapper preflight against tagged app socket with fake `subrouter` and fake `claude`

## Dogfood
Tag: http://127.0.0.1:17320/fable

Fresh `claude --model claude-fable-5 ...` launches should switch to the recommended subrouter Claude profile before Claude starts. Resume launches should keep the recorded profile.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783891066&installation_id=133855650&pr_number=6005&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6005&signature=c134ab0b4ac353663678bb0a4efe0a3a6ea56ead1ab17c1469eecb3558b310cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch-time auth/config and outbound API headers for subrouter Claude sessions; mistakes could pin wrong profiles on resume or mis-route traffic, but failures are mostly no-ops and behavior is covered by new wrapper tests.
> 
> **Overview**
> Extends the cmux Claude wrapper so **subrouter-managed** fresh launches can rotate accounts before `claude` starts, while **resume/continue** stays on the existing profile and transcript.
> 
> On non-resume launches, when `CLAUDE_CONFIG_DIR` is under subrouter paths (or those dirs exist), it runs **`subrouter claude pick`** and re-exports **`CLAUDE_CONFIG_DIR`** from **`subrouter claude env`** (with existing path normalization). **`CMUX_CLAUDE_SUBROUTER_PICK_DISABLED`** skips picking; **`--resume` / `--continue`** skip picking entirely.
> 
> When subrouter routing is active (subrouter auth/base URL or managed config dir), it **appends** `X-Subrouter-Session` and `X-Subrouter-Agent: claude` to **`ANTHROPIC_CUSTOM_HEADERS`** without clobbering existing headers. The session value follows the injected `--session-id`, explicit resume/session flags, or a generated `cmux-claude-*` id when only `--session-id` would have been skipped.
> 
> Regression tests cover fresh vs resume headers, header append behavior, profile pick vs no pick on resume, and logging **`ANTHROPIC_CUSTOM_HEADERS`** in the fake Claude harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725a15a70eb2e66ed8ff9cd31cc0a79863a07a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects the recommended `subrouter` Claude profile on fresh `claude` launches and adds subrouter session headers for per‑session routing. Resume/continue keeps the original profile; missing `subrouter` is a no‑op.

- New Features
  - Run `subrouter claude pick` on fresh runs; skip for `--resume`/`--continue`.
  - Refresh and export `CLAUDE_CONFIG_DIR` from `subrouter claude env` with path normalization.
  - Send `X-Subrouter-Session` (uses injected or explicit session id; generates a fallback when none) and `X-Subrouter-Agent: claude` when routing via subrouter; append to `ANTHROPIC_CUSTOM_HEADERS`.
  - Add opt-out via `CMUX_CLAUDE_SUBROUTER_PICK_DISABLED`.

<sup>Written for commit 725a15a70eb2e66ed8ff9cd31cc0a79863a07a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subrouter-aware Claude behavior: automatic profile selection for fresh launches, preserved profile for resumes, and injection of Subrouter session headers so sessions route consistently.

* **Bug Fixes**
  * More robust detection of resume/session flags across arguments to ensure correct resume vs. fresh-launch handling and session key assignment.

* **Tests**
  * Added regression tests covering fresh-launch/profile-pick, resume behavior, header appending, and profile-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->