### PR TITLE
Scope Biome checks to maintained JS sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,20 @@
 | `./scripts/reload2.sh` | Reload both Debug and Release |
 | `./scripts/rebuild.sh` | Clean rebuild |
 
+## Web and JS Tooling
+
+Run Biome from the repository root with:
+
+```bash
+bun run biome:check
+```
+
+The root `biome.json` intentionally scopes `biome check .` to maintained web and JS/TS sources.
+It excludes generated bundles, build outputs, vendored trees, and review-tool metadata such as
+`.greptile/`.
+Biome formatting and import sorting are disabled for now; do not wire this into required CI until
+the remaining source lint diagnostics are paid down.
+
 ## Rebuilding GhosttyKit
 
 If you make changes to the ghostty submodule, rebuild the xcframework:

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "root": true,
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "biome.json",
+      "package.json",
+      "scripts/**/*.{js,mjs,cjs,ts,tsx,json,jsonc}",
+      "web/**",
+      "webviews/**",
+      "Resources/feed-tui/**",
+      "!.greptile",
+      "!skills",
+      "!vendor",
+      "!ghostty",
+      "!web/db/migrations",
+      "!!GhosttyKit.xcframework",
+      "!!Native/**/target",
+      "!!Packages/**/.build",
+      "!!Resources/agent-session-react",
+      "!!Resources/agent-session-solid",
+      "!!Resources/markdown-viewer",
+      "!!skills",
+      "!!web/.next",
+      "!!web/.pagefind-site",
+      "!!web/.vercel",
+      "!!web/build",
+      "!!web/coverage",
+      "!!web/dist",
+      "!!web/out",
+      "!!web/public/pagefind",
+      "!!webviews/build",
+      "!!webviews/coverage",
+      "!!webviews/dist",
+      "!!**/node_modules"
+    ]
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -27,7 +27,6 @@
       "!!Resources/agent-session-react",
       "!!Resources/agent-session-solid",
       "!!Resources/markdown-viewer",
-      "!!skills",
       "!!web/.next",
       "!!web/.pagefind-site",
       "!!web/.vercel",

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "vercel": "^50.9.5",
       },
       "devDependencies": {
+        "@biomejs/biome": "2.5.0",
         "@tailwindcss/cli": "^4.3.0",
         "esbuild": "0.27.0",
         "tailwindcss": "^4.3.0",
@@ -22,6 +23,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
+
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "agent-session-web:build": "sh scripts/build-agent-session-web.sh",
     "agent-session-web:test": "bun test webviews/src/agent-session/shared/*.test.ts",
+    "biome:check": "biome check .",
     "feed-tui": "bun Resources/feed-tui/index.ts"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
   },
   "license": "GPL-3.0-or-later",
   "devDependencies": {
+    "@biomejs/biome": "2.5.0",
     "@tailwindcss/cli": "^4.3.0",
     "esbuild": "0.27.0",
     "tailwindcss": "^4.3.0"


### PR DESCRIPTION
## Summary

- Add a root `biome.json` pinned to the Biome 2.5.0 schema.
- Pin `@biomejs/biome@2.5.0` in the root package and add `bun run biome:check`.
- Scope `biome check .` to maintained web/JS/TS source paths and force-ignore generated bundles, build outputs, vendored trees, and review-tool metadata.
- Document the intended command in `CONTRIBUTING.md` and leave CI unwired while existing source lint diagnostics remain.

Closes #5980

## Verification

Before config, run locally before making changes:

```text
NO_COLOR=1 npx -y @biomejs/biome@2.5.0 check .
Checked 1293 files in 2s. No fixes applied.
Found 24948 errors.
Found 25038 warnings.
Found 1565 infos.
Diagnostics not shown: 51531.
```

The first diagnostics were `.greptile/config.json`, `.greptile/files.json`, asset catalog JSON, `vendor/bonsplit`, and package metadata. A verbose baseline listed 871 generated/vendor/tooling paths, including `.greptile/`, GhosttyKit cache artifacts, Rust `target`, Swift `.build`, bundled agent-session assets, and 726 markdown-viewer bundle chunks.

After config:

```text
bun run biome:check
Checked 315 files in 245ms. No fixes applied.
Found 69 errors.
Found 149 warnings.
Found 10 infos.
Diagnostics not shown: 208.
```

JSON reporter diagnostic paths after config:

```text
diagnostics_with_paths=228
scripts=13
feed_tui=2
web=91
webviews=122
generated_vendor_tool_metadata_diagnostics=0
```

No app build was run; this is a repo tooling/config change only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783891492&installation_id=133855650&pr_number=6008&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6008&signature=d3933496f3335f6aafd131ae7d8b1f91d724b6776626bc8975906db36f04fca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Biome linting to maintained JS/TS sources and ignores generated, vendor, and build outputs to cut noise and speed up checks. Adds root biome.json, pins `@biomejs/biome@2.5.0`, introduces `biome:check`, removes a redundant ignore, and updates CONTRIBUTING.md; formatting/import sorting stay disabled and CI is not wired yet — closes #5980.

<sup>Written for commit aeaa1b86ba2fa59d1eaf299ee4c6b0e7fd4874d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

