### PR TITLE
Agent chat entrypoints: CLI verb, configurable shortcut, terminal context menu

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,12 +1,12 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-33266	CLI/cmux.swift
+33335	CLI/cmux.swift
 20085	Sources/Workspace.swift
 19298	Sources/ContentView.swift
-18116	Sources/AppDelegate.swift
-16539	Sources/GhosttyTerminalView.swift
-14776	Sources/TerminalController.swift
+18124	Sources/AppDelegate.swift
+16568	Sources/GhosttyTerminalView.swift
+14777	Sources/TerminalController.swift
 13606	Sources/Panels/BrowserPanel.swift
 12044	cmuxTests/AppDelegateShortcutRoutingTests.swift
 10023	Sources/TabManager.swift
@@ -20,7 +20,7 @@
 6153	CLI/cmux_open.swift
 6071	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
-5465	Sources/cmuxApp.swift
+5468	Sources/cmuxApp.swift
 4827	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
@@ -39,7 +39,7 @@
 2545	cmuxTests/WorkspaceManualUnreadTests.swift
 2544	cmuxTests/CommandPaletteSearchEngineTests.swift
 2527	Sources/TerminalNotificationStore.swift
-2516	Sources/KeyboardShortcutSettings.swift
+2524	Sources/KeyboardShortcutSettings.swift
 2340	Sources/Mobile/MobileHostService.swift
 2327	cmuxTests/CJKIMEInputTests.swift
 2290	Sources/FileExplorerView.swift
@@ -177,9 +177,9 @@
 528	cmuxUITests/AutomationSocketUITests.swift
 527	CLI/CLISocketPathResolver.swift
 520	CLI/CMUXCLI+AmpExtension.swift
+520	Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
 520	cmuxTests/MainWindowVisibilityControllerTests.swift
 519	Packages/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-two-column-cockpit-sidebar.swift
-518	Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
 518	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 518	Packages/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-git-review-queue-command-deck.swift
 516	Sources/CmuxConfigExecutor.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -6,7 +6,7 @@
 19298	Sources/ContentView.swift
 18124	Sources/AppDelegate.swift
 16568	Sources/GhosttyTerminalView.swift
-14777	Sources/TerminalController.swift
+14778	Sources/TerminalController.swift
 13606	Sources/Panels/BrowserPanel.swift
 12044	cmuxTests/AppDelegateShortcutRoutingTests.swift
 10023	Sources/TabManager.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4280,6 +4280,54 @@ struct CMUXCLI {
             let payload = try client.sendV2(method: "surface.trigger_flash", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
+        case "agent-chat":
+            // Open (or focus) the agent chat pane for a terminal surface through
+            // the shared in-app presenter path (same as Window → View Chat).
+            // Target resolution mirrors trigger-flash: explicit flags win, then
+            // the caller's own workspace/surface env, then the focused surface.
+            let acWsFlag = optionValue(commandArgs, name: "--workspace")
+            let acExplicitWorkspaceArg = acWsFlag
+            let acWindowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowId)
+            let acPreferTTYFallback = acWindowRaw == nil && ProcessInfo.processInfo.environment["TMUX"] != nil
+            let acCallerWorkspaceArg = acPreferTTYFallback
+                ? nil
+                : (acWindowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let acWorkspaceArg = acExplicitWorkspaceArg ?? acCallerWorkspaceArg
+            let acExplicitSurfaceArg = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel")
+            let acCallerSurfaceArg = acExplicitSurfaceArg == nil && acPreferTTYFallback == false && acWindowRaw == nil
+                ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+                : nil
+            let acSurfaceArg = acExplicitSurfaceArg ?? acCallerSurfaceArg
+            var params: [String: Any] = [:]
+            let acWinId = try normalizeWindowHandle(acWindowRaw, client: client)
+            if let acWinId { params["window_id"] = acWinId }
+            let acWsId = try {
+                if acExplicitWorkspaceArg != nil || acWinId != nil {
+                    return try normalizeWorkspaceHandle(
+                        acWorkspaceArg,
+                        client: client,
+                        windowHandle: acWinId,
+                        allowCurrent: acWinId != nil
+                    )
+                }
+                return try resolveWorkspaceIdAllowingFallback(acWorkspaceArg, client: client)
+            }()
+            if let acWsId { params["workspace_id"] = acWsId }
+            let acSfId = try {
+                if acExplicitSurfaceArg != nil {
+                    return try normalizeSurfaceHandle(acSurfaceArg, client: client, workspaceHandle: acWsId, windowHandle: acWinId)
+                }
+                guard let acWsId else { return nil }
+                return try resolveSurfaceIdAllowingFallback(
+                    acSurfaceArg,
+                    workspaceId: acWsId,
+                    client: client
+                )
+            }()
+            if let acSfId { params["surface_id"] = acSfId }
+            let payload = try client.sendV2(method: "surface.agent_chat.open", params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+
         case "list-panels":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
             var params: [String: Any] = [:]
@@ -5128,6 +5176,7 @@ struct CMUXCLI {
     private static let topLevelCommandNames: Set<String> = [
         "__codex-teams-watch",
         "__tmux-compat",
+        "agent-chat",
         "agent-hibernation",
         "auth",
         "bind-key",
@@ -14467,6 +14516,25 @@ struct CMUXCLI {
             Example:
               cmux trigger-flash
               cmux trigger-flash --workspace workspace:2 --surface surface:3
+            """
+        case "agent-chat":
+            return """
+            Usage: cmux agent-chat [--workspace <id|ref|index>] [--surface <id|ref|index>] [--panel <id|ref|index>] [--window <id|ref|index>]
+
+            Open (or focus) the agent chat pane for a terminal surface running
+            Claude Code or Codex. Defaults to the caller's surface, then the
+            focused surface. Same action as Window → View Chat and the
+            "Open Agent Chat" command palette entry.
+
+            Flags:
+              --workspace <id|ref|index>   Workspace context (default: $CMUX_WORKSPACE_ID)
+              --surface <id|ref|index>     Target surface (default: $CMUX_SURFACE_ID)
+              --panel <id|ref|index>       Alias for --surface
+              --window <id|ref|index>      Window context for workspace/surface refs and indexes
+
+            Example:
+              cmux agent-chat
+              cmux agent-chat --workspace workspace:2 --surface surface:3
             """
         case "list-panels":
             return """
@@ -33097,6 +33165,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           surface-health [--workspace <id|ref|index>] [--window <id|ref|index>]
           debug-terminals
           trigger-flash [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>]
+          agent-chat [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>]
           list-panels [--workspace <id|ref|index>] [--window <id|ref|index>]
           focus-panel --panel <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
           close-workspace --workspace <id|ref|index> [--window <id|ref|index>]

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -62,6 +62,8 @@ extension ControlCommandCoordinator {
             return surfaceReadText(request.params)
         case "surface.trigger_flash":
             return surfaceTriggerFlash(request.params)
+        case "surface.agent_chat.open":
+            return surfaceAgentChatOpen(request.params)
         case "debug.terminals":
             return debugTerminals(request.params)
         default:

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
@@ -11,9 +11,16 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
+        let surfaceID = uuid(params, "surface_id")
+        if params["surface_id"] != nil && surfaceID == nil {
+            // A present-but-malformed explicit target must not silently fall
+            // back to the focused surface (the caller would open a chat pane
+            // for the wrong surface and see success).
+            return .err(code: "invalid_params", message: "surface_id is not a valid UUID", data: nil)
+        }
         let resolution = context?.controlSurfaceAgentChatOpen(
             routing: routing,
-            surfaceID: uuid(params, "surface_id")
+            surfaceID: surfaceID
         ) ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
@@ -15,14 +15,19 @@ extension ControlCommandCoordinator {
         // back to the current window/workspace/focused surface: this verb is
         // focus-intent and opens UI, so a typo'd target would mutate the
         // wrong place and report success (same rule as the resume verbs).
-        for key in ["window_id", "workspace_id", "surface_id", "tab_id"] where hasNonNull(params, key) {
+        for key in ["window_id", "workspace_id", "surface_id", "terminal_id", "tab_id"]
+        where hasNonNull(params, key) {
             if uuid(params, key) == nil {
                 return .err(code: "invalid_params", message: "Missing or invalid \(key)", data: nil)
             }
         }
         let resolution = context?.controlSurfaceAgentChatOpen(
             routing: routing,
-            surfaceID: uuid(params, "surface_id")
+            // The alias-resolved surface selector (surface_id / terminal_id /
+            // tab_id), exactly what routingSelectors computed — forwarding
+            // only surface_id would drop the aliases and fall back to the
+            // focused surface for a caller who targeted explicitly.
+            surfaceID: routing.surfaceID
         ) ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
@@ -1,0 +1,43 @@
+internal import Foundation
+
+/// `surface.agent_chat.open` — open (or focus) the agent chat pane for a
+/// surface through the shared `AgentChatPresenter` path. Split from
+/// `+Surface2.swift` to stay inside the per-file line budget.
+extension ControlCommandCoordinator {
+    /// `surface.agent_chat.open` — resolve the target surface and ask the app
+    /// to run the shared agent-chat resolve-then-present flow for it.
+    func surfaceAgentChatOpen(_ params: [String: JSONValue]) -> ControlCallResult {
+        let routing = routingSelectors(params)
+        guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        let resolution = context?.controlSurfaceAgentChatOpen(
+            routing: routing,
+            surfaceID: uuid(params, "surface_id")
+        ) ?? .tabManagerUnavailable
+        switch resolution {
+        case .tabManagerUnavailable:
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        case .workspaceNotFound:
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        case .noFocusedSurface:
+            return .err(code: "not_found", message: "No focused surface", data: nil)
+        case .surfaceNotFound(let id):
+            return .err(
+                code: "not_found",
+                message: "Surface not found",
+                data: .object(["surface_id": .string(id.uuidString)])
+            )
+        case .requested(let windowID, let workspaceID, let surfaceID):
+            return .ok(.object([
+                "requested": .bool(true),
+                "workspace_id": .string(workspaceID.uuidString),
+                "workspace_ref": ref(.workspace, workspaceID),
+                "surface_id": .string(surfaceID.uuidString),
+                "surface_ref": ref(.surface, surfaceID),
+                "window_id": orNull(windowID?.uuidString),
+                "window_ref": ref(.window, windowID),
+            ]))
+        }
+    }
+}

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
@@ -7,19 +7,22 @@ extension ControlCommandCoordinator {
     /// `surface.agent_chat.open` — resolve the target surface and ask the app
     /// to run the shared agent-chat resolve-then-present flow for it.
     func surfaceAgentChatOpen(_ params: [String: JSONValue]) -> ControlCallResult {
-        let routing = routingSelectors(params)
-        guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
-            return .err(code: "unavailable", message: "TabManager not available", data: nil)
-        }
         // A present-but-malformed explicit selector must not silently fall
         // back to the current window/workspace/focused surface: this verb is
         // focus-intent and opens UI, so a typo'd target would mutate the
         // wrong place and report success (same rule as the resume verbs).
+        // Validated BEFORE the availability guard: a malformed window_id
+        // also fails TabManager resolution, which would misreport caller
+        // error as `unavailable`.
         for key in ["window_id", "workspace_id", "surface_id", "terminal_id", "tab_id"]
         where hasNonNull(params, key) {
             if uuid(params, key) == nil {
                 return .err(code: "invalid_params", message: "Missing or invalid \(key)", data: nil)
             }
+        }
+        let routing = routingSelectors(params)
+        guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
         let resolution = context?.controlSurfaceAgentChatOpen(
             routing: routing,

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+SurfaceAgentChat.swift
@@ -11,16 +11,18 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
-        let surfaceID = uuid(params, "surface_id")
-        if params["surface_id"] != nil && surfaceID == nil {
-            // A present-but-malformed explicit target must not silently fall
-            // back to the focused surface (the caller would open a chat pane
-            // for the wrong surface and see success).
-            return .err(code: "invalid_params", message: "surface_id is not a valid UUID", data: nil)
+        // A present-but-malformed explicit selector must not silently fall
+        // back to the current window/workspace/focused surface: this verb is
+        // focus-intent and opens UI, so a typo'd target would mutate the
+        // wrong place and report success (same rule as the resume verbs).
+        for key in ["window_id", "workspace_id", "surface_id", "tab_id"] where hasNonNull(params, key) {
+            if uuid(params, key) == nil {
+                return .err(code: "invalid_params", message: "Missing or invalid \(key)", data: nil)
+            }
         }
         let resolution = context?.controlSurfaceAgentChatOpen(
             routing: routing,
-            surfaceID: surfaceID
+            surfaceID: uuid(params, "surface_id")
         ) ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceAgentChatOpenResolution.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceAgentChatOpenResolution.swift
@@ -1,0 +1,25 @@
+public import Foundation
+
+/// The outcome of `surface.agent_chat.open`, mirroring the
+/// `surface.trigger_flash` resolution shape.
+///
+/// The coordinator signals `unavailable`; the app resolves the workspace and
+/// surface, hands the panel to the shared `AgentChatPresenter` path (the same
+/// resolve-then-present flow the menu, command palette, keyboard shortcut, and
+/// terminal context menu drive), and returns this resolution. Presentation is
+/// asynchronous (transcript resolution globs the filesystem off-main), so the
+/// success case acknowledges the request rather than the opened pane.
+public enum ControlSurfaceAgentChatOpenResolution: Sendable, Equatable {
+    /// No TabManager resolved (`unavailable` / "TabManager not available").
+    case tabManagerUnavailable
+    /// No workspace resolved (`not_found` / "Workspace not found").
+    case workspaceNotFound
+    /// No surface resolved and none focused (`not_found` / "No focused
+    /// surface").
+    case noFocusedSurface
+    /// The surface id did not exist (`not_found` / "Surface not found",
+    /// `data: {"surface_id": …}`). Carries the surface id.
+    case surfaceNotFound(UUID)
+    /// The shared presenter accepted the request. Carries the echoed identity.
+    case requested(windowID: UUID?, workspaceID: UUID, surfaceID: UUID)
+}

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -178,6 +178,21 @@ public protocol ControlSurfaceContext: AnyObject {
         surfaceID: UUID?
     ) -> ControlSurfaceTriggerFlashResolution
 
+    /// Opens (or focuses) the agent chat pane for a surface for
+    /// `surface.agent_chat.open`. The app resolves the target and hands it to
+    /// the shared `AgentChatPresenter` resolve-then-present path (the same one
+    /// the Window menu, command palette, keyboard shortcut, and terminal
+    /// context menu drive).
+    ///
+    /// - Parameters:
+    ///   - routing: The routing selectors.
+    ///   - surfaceID: The explicit `surface_id`, or `nil` for the focused surface.
+    /// - Returns: The agent-chat-open resolution.
+    func controlSurfaceAgentChatOpen(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?
+    ) -> ControlSurfaceAgentChatOpenResolution
+
     /// The app-bundle-resolved localized terminal-input error strings, shared by
     /// `surface.send_text` and `surface.send_key`. The app resolves each
     /// `String(localized:)` so the package never binds them to the wrong bundle.

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -361,6 +361,11 @@ extension ControlSurfaceContext {
         surfaceID: UUID?
     ) -> ControlSurfaceTriggerFlashResolution { .tabManagerUnavailable }
 
+    func controlSurfaceAgentChatOpen(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?
+    ) -> ControlSurfaceAgentChatOpenResolution { .tabManagerUnavailable }
+
     func controlSurfaceInputStrings() -> ControlSurfaceInputStrings {
         ControlSurfaceInputStrings(inputQueueFull: "", surfaceUnavailable: "", processExited: "")
     }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
@@ -139,7 +139,10 @@ extension ControlCommandCoordinatorSurfaceAgentChatTests {
     @Test(arguments: ["window_id", "workspace_id", "surface_id", "terminal_id", "tab_id"])
     func malformedExplicitSelectorIsInvalidParams(key: String) {
         let (coordinator, context) = makeCoordinator()
-        context.routingResolvesTabManager = true
+        // false: a malformed window_id also fails TabManager resolution, so
+        // validation must win over the availability guard (caller error, not
+        // `unavailable`).
+        context.routingResolvesTabManager = false
         guard case .err(let code, let message, _)? = coordinator.handle(
             request([key: .string("not-a-uuid")])
         ) else {

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+/// A scriptable ``ControlCommandContext`` for driving `surface.agent_chat.open`
+/// without the app target. Every other domain seam comes from the benign stub
+/// defaults in `ControlCommandContextTestStubs.swift`.
+@MainActor
+private final class FakeAgentChatContext: ControlCommandContext {
+    var routingResolvesTabManager = false
+    var agentChatResolution: ControlSurfaceAgentChatOpenResolution = .tabManagerUnavailable
+    var lastRouting: ControlRoutingSelectors?
+    var lastSurfaceID: UUID?
+    var openCallCount = 0
+
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routingResolvesTabManager
+    }
+
+    func controlSurfaceAgentChatOpen(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?
+    ) -> ControlSurfaceAgentChatOpenResolution {
+        openCallCount += 1
+        lastRouting = routing
+        lastSurfaceID = surfaceID
+        return agentChatResolution
+    }
+
+    // Inert window-domain members: the stubs file deliberately carries no
+    // defaults for the window domain, and this fake never exercises it.
+    func controlWindowSummaries() -> [ControlWindowSummary] { [] }
+    func controlResolveCurrentWindow(routing: ControlRoutingSelectors) -> ControlCurrentWindowResolution {
+        .tabManagerUnavailable
+    }
+    func controlFocusWindow(id: UUID) -> Bool { false }
+    func controlCreateWindowAndActivate() -> UUID? { nil }
+    func controlCloseWindow(id: UUID) -> Bool { false }
+    func controlAvailableDisplays() -> [ControlDisplayInfo] { [] }
+    func controlWindowExists(id: UUID) -> Bool { false }
+    func controlMoveWindow(id: UUID, toDisplayMatching query: String) -> String? { nil }
+    func controlMoveAllWindows(toDisplayMatching query: String) -> ControlMoveAllWindowsResult? { nil }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator surface.agent_chat.open")
+struct ControlCommandCoordinatorSurfaceAgentChatTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeAgentChatContext) {
+        let context = FakeAgentChatContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        return (coordinator, context)
+    }
+
+    private func request(_ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: "surface.agent_chat.open", params: params)
+    }
+
+    /// The verb is registered in the surface domain (the coordinator must not
+    /// fall through to the legacy app-side dispatcher).
+    @Test func verbIsDispatchedBySurfaceDomain() {
+        let (coordinator, _) = makeCoordinator()
+        let result = coordinator.handle(request())
+        #expect(result != nil)
+    }
+
+    /// The verb runs on the main actor lane like every other surface verb.
+    @Test func verbRunsOnMainActor() {
+        #expect(ControlCommandExecutionPolicy(forMethod: "surface.agent_chat.open") == .mainActor)
+    }
+
+    @Test func unresolvedTabManagerIsUnavailable() {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = false
+        guard case .err(let code, _, _)? = coordinator.handle(request()) else {
+            Issue.record("Expected an error result")
+            return
+        }
+        #expect(code == "unavailable")
+        #expect(context.openCallCount == 0)
+    }
+
+    @Test func explicitSurfaceIDReachesTheContextSeam() {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = true
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        context.agentChatResolution = .requested(
+            windowID: nil,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID
+        )
+        let result = coordinator.handle(request([
+            "workspace_id": .string(workspaceID.uuidString),
+            "surface_id": .string(surfaceID.uuidString),
+        ]))
+        guard case .ok(.object(let payload))? = result else {
+            Issue.record("Expected ok result, got \(String(describing: result))")
+            return
+        }
+        #expect(context.openCallCount == 1)
+        #expect(context.lastSurfaceID == surfaceID)
+        #expect(context.lastRouting?.workspaceID == workspaceID)
+        #expect(payload["requested"] == .bool(true))
+        #expect(payload["workspace_id"] == .string(workspaceID.uuidString))
+        #expect(payload["surface_id"] == .string(surfaceID.uuidString))
+    }
+
+    @Test func missingSurfaceMapsToNotFound() {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = true
+        let missing = UUID()
+        context.agentChatResolution = .surfaceNotFound(missing)
+        guard case .err(let code, let message, let data)? = coordinator.handle(request()) else {
+            Issue.record("Expected an error result")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(message == "Surface not found")
+        #expect(data == .object(["surface_id": .string(missing.uuidString)]))
+    }
+
+    @Test func noFocusedSurfaceMapsToNotFound() {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = true
+        context.agentChatResolution = .noFocusedSurface
+        guard case .err(let code, let message, _)? = coordinator.handle(request()) else {
+            Issue.record("Expected an error result")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(message == "No focused surface")
+    }
+}

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
@@ -136,7 +136,7 @@ extension ControlCommandCoordinatorSurfaceAgentChatTests {
     /// A present-but-malformed explicit selector must fail instead of silently
     /// falling back to the current window/workspace/focused surface
     /// (wrong-target open with success). Same rule as the resume verbs.
-    @Test(arguments: ["window_id", "workspace_id", "surface_id", "tab_id"])
+    @Test(arguments: ["window_id", "workspace_id", "surface_id", "terminal_id", "tab_id"])
     func malformedExplicitSelectorIsInvalidParams(key: String) {
         let (coordinator, context) = makeCoordinator()
         context.routingResolvesTabManager = true
@@ -149,5 +149,25 @@ extension ControlCommandCoordinatorSurfaceAgentChatTests {
         #expect(code == "invalid_params")
         #expect(message == "Missing or invalid \(key)")
         #expect(context.openCallCount == 0)
+    }
+
+    /// The surface aliases other verbs accept (terminal_id, tab_id) must reach
+    /// the seam as the explicit selector, not silently fall back to the
+    /// focused surface.
+    @Test(arguments: ["surface_id", "terminal_id", "tab_id"])
+    func surfaceAliasReachesTheContextSeam(key: String) {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = true
+        let target = UUID()
+        context.agentChatResolution = .requested(
+            windowID: nil,
+            workspaceID: UUID(),
+            surfaceID: target
+        )
+        guard case .ok? = coordinator.handle(request([key: .string(target.uuidString)])) else {
+            Issue.record("Expected ok result for \(key)")
+            return
+        }
+        #expect(context.lastSurfaceID == target)
     }
 }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
@@ -133,18 +133,21 @@ struct ControlCommandCoordinatorSurfaceAgentChatTests {
 }
 
 extension ControlCommandCoordinatorSurfaceAgentChatTests {
-    /// A present-but-malformed explicit target must fail instead of silently
-    /// falling back to the focused surface (wrong-target open with success).
-    @Test func malformedSurfaceIDIsInvalidParams() {
+    /// A present-but-malformed explicit selector must fail instead of silently
+    /// falling back to the current window/workspace/focused surface
+    /// (wrong-target open with success). Same rule as the resume verbs.
+    @Test(arguments: ["window_id", "workspace_id", "surface_id", "tab_id"])
+    func malformedExplicitSelectorIsInvalidParams(key: String) {
         let (coordinator, context) = makeCoordinator()
         context.routingResolvesTabManager = true
-        guard case .err(let code, _, _)? = coordinator.handle(
-            request(["surface_id": .string("not-a-uuid")])
+        guard case .err(let code, let message, _)? = coordinator.handle(
+            request([key: .string("not-a-uuid")])
         ) else {
-            Issue.record("Expected an error result")
+            Issue.record("Expected an error result for \(key)")
             return
         }
         #expect(code == "invalid_params")
+        #expect(message == "Missing or invalid \(key)")
         #expect(context.openCallCount == 0)
     }
 }

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceAgentChatTests.swift
@@ -131,3 +131,20 @@ struct ControlCommandCoordinatorSurfaceAgentChatTests {
         #expect(message == "No focused surface")
     }
 }
+
+extension ControlCommandCoordinatorSurfaceAgentChatTests {
+    /// A present-but-malformed explicit target must fail instead of silently
+    /// falling back to the focused surface (wrong-target open with success).
+    @Test func malformedSurfaceIDIsInvalidParams() {
+        let (coordinator, context) = makeCoordinator()
+        context.routingResolvesTabManager = true
+        guard case .err(let code, _, _)? = coordinator.handle(
+            request(["surface_id": .string("not-a-uuid")])
+        ) else {
+            Issue.record("Expected an error result")
+            return
+        }
+        #expect(code == "invalid_params")
+        #expect(context.openCallCount == 0)
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -85,6 +85,10 @@ extension ShortcutAction {
         case .focusTextBoxInput: return ShortcutStroke(key: "a", command: true, shift: true)
         case .attachTextBoxFile: return ShortcutStroke(key: "a", command: true, shift: true, option: true)
         case .sendCtrlFToTerminal: return nil
+        // Cmd+Shift+A (the "A for Agent" mnemonic) is taken by focusTextBoxInput;
+        // Cmd+Shift+C ("C for Chat") is unclaimed by cmux defaults, Ghostty's
+        // macOS defaults (copy is plain Cmd+C), and AppKit-reserved chords.
+        case .openAgentChat: return ShortcutStroke(key: "c", command: true, shift: true)
         case .toggleRightSidebar: return ShortcutStroke(key: "b", command: true, option: true)
         case .openDiffViewer: return ShortcutStroke(key: "d", command: true, shift: true, control: true)
         case .saveFilePreview: return ShortcutStroke(key: "s", command: true)

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -232,7 +232,7 @@ extension ShortcutAction {
             return .atom(.sidebarFocus)
         case .renameTab, .renameWorkspace:
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
-        case .sendCtrlFToTerminal:
+        case .sendCtrlFToTerminal, .openAgentChat:
             return .and(.not(.atom(.browserFocus)), .not(.atom(.sidebarFocus)))
         case .browserBack, .browserForward, .browserReload,
              .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -70,6 +70,8 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case attachTextBoxFile
     /// Sends a Ctrl-F keystroke through to the focused terminal.
     case sendCtrlFToTerminal
+    /// Opens (or focuses) the agent chat pane for the focused terminal.
+    case openAgentChat
 
     // MARK: Panes
     case focusLeft
@@ -159,7 +161,8 @@ extension ShortcutAction {
              .editWorkspaceDescription, .closeTab, .closeOtherTabsInPane, .closeWorkspace,
              .groupSelectedWorkspaces, .toggleFocusedWorkspaceGroupCollapsed,
              .reopenClosedBrowserPanel, .newSurface, .toggleTerminalCopyMode,
-             .focusTextBoxInput, .attachTextBoxFile, .sendCtrlFToTerminal:
+             .focusTextBoxInput, .attachTextBoxFile, .sendCtrlFToTerminal,
+             .openAgentChat:
             return .navigation
         case .focusLeft, .focusRight, .focusUp, .focusDown, .splitRight, .splitDown,
              .toggleSplitZoom, .equalizeSplits, .splitBrowserRight, .splitBrowserDown,
@@ -323,6 +326,8 @@ extension ShortcutAction {
         case .attachTextBoxFile: return "Attach File to TextBox Input"
         case .sendCtrlFToTerminal:
             return String(localized: "shortcut.sendCtrlFToTerminal.label", defaultValue: "Send Ctrl-F to Terminal")
+        case .openAgentChat:
+            return String(localized: "shortcut.openAgentChat.label", defaultValue: "Open Agent Chat")
         case .focusLeft: return "Focus Pane Left"
         case .focusRight: return "Focus Pane Right"
         case .focusUp: return "Focus Pane Up"

--- a/Sources/AgentChat/AgentChatPresenter.swift
+++ b/Sources/AgentChat/AgentChatPresenter.swift
@@ -3,11 +3,15 @@ import Foundation
 
 /// The shared action path for opening the agent chat pane for a panel.
 ///
-/// All entry points (command palette, Window menu) call
-/// ``AgentChatPresenter/presentForFocusedPanel()`` so the resolve-and-open flow
-/// lives in one place. Resolution reads the restorable-session index and globs
-/// the filesystem, so it runs off-main; the pane is opened back on the main
-/// actor as a split next to the panel it mirrors.
+/// All entry points route through one resolve-and-open flow: the Window menu,
+/// command palette, and keyboard shortcut call
+/// ``AgentChatPresenter/presentForFocusedPanel()``, while the terminal context
+/// menu and the `surface.agent_chat.open` socket verb (the `cmux agent-chat`
+/// CLI command) target an explicit panel via
+/// ``AgentChatPresenter/present(panelId:in:manager:)``. Resolution reads the
+/// restorable-session index and globs the filesystem, so it runs off-main; the
+/// pane is opened back on the main actor as a split next to the panel it
+/// mirrors.
 @MainActor
 struct AgentChatPresenter {
     /// The resolver used to map a panel to its transcript file.
@@ -48,10 +52,25 @@ struct AgentChatPresenter {
             presentNoSessionAlert()
             return
         }
+        present(panelId: panelId, in: workspace, manager: manager)
+    }
+
+    /// Resolves a specific panel's agent and opens (or focuses) its chat pane,
+    /// or shows an alert when the panel has no recognizable agent session.
+    ///
+    /// This is the shared resolve-then-present body behind every entry point;
+    /// callers that target a non-focused panel (terminal context menu, the
+    /// `surface.agent_chat.open` socket verb) call it directly.
+    ///
+    /// - Parameters:
+    ///   - panelId: The panel whose agent conversation should be shown.
+    ///   - workspace: The workspace owning `panelId`.
+    ///   - manager: The TabManager owning `workspace`.
+    func present(panelId: UUID, in workspace: Workspace, manager: TabManager) {
         if let chatPanel = workspace.panels[panelId] as? AgentChatPanel {
-            // The chat pane itself is focused; it is already open.
+            // The target panel is itself a chat pane; it is already open.
 #if DEBUG
-            cmuxDebugLog("agentChat.present.skip reason=chatPanelFocused panel=\(panelId.uuidString.prefix(5))")
+            cmuxDebugLog("agentChat.present.skip reason=chatPanelTargeted panel=\(panelId.uuidString.prefix(5))")
 #endif
             workspace.focusPanel(chatPanel.id)
             return

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13284,6 +13284,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Open (or focus) the agent chat pane for the focused terminal through
+        // the shared presenter path (same as Window → View Chat, the command
+        // palette, the terminal context menu, and `cmux agent-chat`).
+        if matchConfiguredShortcut(event: event, action: .openAgentChat) {
+            AgentChatPresenter().presentForFocusedPanel()
+            return true
+        }
+
         // Surface navigation: Cmd+Shift+] / Cmd+Shift+[
         if matchConfiguredShortcut(event: event, action: .nextSurface) {
             tabManager?.selectNextSurface()

--- a/Sources/ContentView+RightSidebarCommandPalette.swift
+++ b/Sources/ContentView+RightSidebarCommandPalette.swift
@@ -87,6 +87,8 @@ extension ContentView {
             return .equalizeSplits
         case "palette.triggerFlash":
             return .triggerFlash
+        case "palette.openAgentChat":
+            return .openAgentChat
         default:
             return nil
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11655,6 +11655,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             accessibilityDescription: nil
         )
         appendMoveCurrentSurfaceMoveMenuItems(to: menu); menu.addItem(.separator())
+        if terminalSurface != nil {
+            let agentChatItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.viewAgentChat", defaultValue: "View Agent Chat"),
+                action: #selector(viewAgentChat(_:)),
+                keyEquivalent: ""
+            )
+            agentChatItem.target = self
+            applyConfiguredMenuShortcut(KeyboardShortcutSettings.menuShortcut(for: .openAgentChat), to: agentChatItem)
+            agentChatItem.image = NSImage(
+                systemSymbolName: "bubble.left.and.bubble.right",
+                accessibilityDescription: nil
+            )
+        }
         let resetTerminalItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.resetTerminal", defaultValue: "Reset Terminal"),
             action: #selector(resetTerminal(_:)),
@@ -11715,6 +11728,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @objc private func triggerFlash(_ sender: Any?) {
         onTriggerFlash?()
+    }
+
+    /// Opens the agent chat pane for this terminal panel through the shared
+    /// presenter path (same as Window → View Chat, the command palette, the
+    /// keyboard shortcut, and `cmux agent-chat`), targeting the right-clicked
+    /// panel explicitly rather than the focused one.
+    @objc private func viewAgentChat(_ sender: Any?) {
+        guard let tabId,
+              let surfaceId = terminalSurface?.id,
+              let app = AppDelegate.shared,
+              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+              let workspace = manager.tabs.first(where: { $0.id == tabId }) else {
+            NSSound.beep()
+            return
+        }
+        AgentChatPresenter().present(panelId: surfaceId, in: workspace, manager: manager)
     }
 
     @objc private func resetTerminal(_ sender: Any?) {

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -127,7 +127,7 @@ extension KeyboardShortcutSettings.Action {
             return .browserPanel
         case .switchRightSidebarToFiles, .switchRightSidebarToFind, .switchRightSidebarToSessions, .switchRightSidebarToFeed, .switchRightSidebarToDock:
             return .rightSidebarFocus
-        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal:
+        case .renameTab, .renameWorkspace, .sendCtrlFToTerminal, .openAgentChat:
             return .nonBrowserPanel
         case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
              .browserZoomIn, .browserZoomOut, .browserZoomReset, .toggleBrowserFocusMode:

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -116,6 +116,7 @@ enum KeyboardShortcutSettings {
         case focusTextBoxInput
         case attachTextBoxFile
         case sendCtrlFToTerminal
+        case openAgentChat
 
         // Panes / splits
         case focusLeft
@@ -217,6 +218,7 @@ enum KeyboardShortcutSettings {
             case .focusTextBoxInput: return String(localized: "shortcut.focusTextBoxInput.label", defaultValue: "Focus TextBox Input")
             case .attachTextBoxFile: return String(localized: "shortcut.attachTextBoxFile.label", defaultValue: "Attach File to TextBox Input")
             case .sendCtrlFToTerminal: return String(localized: "shortcut.sendCtrlFToTerminal.label", defaultValue: "Send Ctrl-F to Terminal")
+            case .openAgentChat: return String(localized: "shortcut.openAgentChat.label", defaultValue: "Open Agent Chat")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -415,6 +417,12 @@ enum KeyboardShortcutSettings {
                 // opt in via Settings; it stays reachable through the command palette and
                 // the `send_key ctrl-f` socket command.
                 return .unbound
+            case .openAgentChat:
+                // Cmd+Shift+A ("A for Agent") is taken by focusTextBoxInput;
+                // Cmd+Shift+C ("C for Chat") is unclaimed by cmux defaults,
+                // Ghostty's macOS defaults (copy is plain Cmd+C), and
+                // AppKit-reserved chords. Rebindable in Settings or cmux.json.
+                return StoredShortcut(key: "c", command: true, shift: true, option: false, control: false)
             case .selectWorkspaceByNumber:
                 return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
             case .toggleRightSidebar:

--- a/Sources/KeyboardShortcutSettingsLookup.swift
+++ b/Sources/KeyboardShortcutSettingsLookup.swift
@@ -48,6 +48,12 @@ extension KeyboardShortcutSettings {
         case .browserForward
             where !shortcut.isUnbound && shortcut == KeyboardShortcutSettings.shortcut(for: .focusHistoryForward):
             return .unbound
+        case .openAgentChat:
+            // nonBrowserPanel-scoped by default: a static menu key equivalent
+            // would fire while a browser/sidebar has focus and steal that
+            // surface's chord. The context-gated keyDown route is the sole
+            // dispatcher; the menu item stays clickable, just badge-less.
+            return .unbound
         default:
             return shortcut
         }

--- a/Sources/TerminalController+ControlSurfaceContext3.swift
+++ b/Sources/TerminalController+ControlSurfaceContext3.swift
@@ -158,6 +158,37 @@ extension TerminalController {
         )
     }
 
+    // MARK: - agent_chat.open
+
+    func controlSurfaceAgentChatOpen(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?
+    ) -> ControlSurfaceAgentChatOpenResolution {
+        guard let tabManager = resolveTabManager(routing: routing) else {
+            return .tabManagerUnavailable
+        }
+        guard let ws = resolveSurfaceWorkspace(routing: routing, tabManager: tabManager) else {
+            return .workspaceNotFound
+        }
+        guard let surfaceId = surfaceID ?? ws.focusedPanelId else {
+            return .noFocusedSurface
+        }
+        guard ws.panels[surfaceId] != nil else {
+            return .surfaceNotFound(surfaceId)
+        }
+        v2MaybeFocusWindow(for: tabManager)
+        v2MaybeSelectWorkspace(tabManager, workspace: ws)
+        // The ONE shared resolve-then-present path (also driven by the Window
+        // menu, command palette, keyboard shortcut, and terminal context menu).
+        // Resolution is async, so this acknowledges the accepted request.
+        AgentChatPresenter().present(panelId: surfaceId, in: ws, manager: tabManager)
+        return .requested(
+            windowID: v2ResolveWindowId(tabManager: tabManager),
+            workspaceID: ws.id,
+            surfaceID: surfaceId
+        )
+    }
+
     // MARK: - send_text / send_key
 
     func controlSurfaceInputStrings() -> ControlSurfaceInputStrings {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1826,8 +1826,8 @@ class TerminalController {
         // still-shared v2SurfaceSplitOff) handled by ControlCommandCoordinator too.
         // surface.refresh/health/resume.set/get/clear, debug.terminals (forwards to the
         // still-shared v2DebugTerminals), surface.send_text/send_key/report_tty/
-        // report_shell_state/ports_kick/clear_history/trigger_flash, and surface.read_text
-        // handled by ControlCommandCoordinator.
+        // report_shell_state/ports_kick/clear_history/trigger_flash/agent_chat.open, and
+        // surface.read_text handled by ControlCommandCoordinator.
 
         // Panes
         // pane.* handled by ControlCommandCoordinator.
@@ -2083,6 +2083,7 @@ class TerminalController {
             "surface.read_text",
             "surface.clear_history",
             "surface.trigger_flash",
+            "surface.agent_chat.open",
             "pane.list",
             "pane.focus",
             "pane.surfaces",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -191,6 +191,7 @@ class TerminalController {
         "workspace.last",
         "workspace.group.focus",
         "surface.focus",
+        "surface.agent_chat.open",
         "pane.focus",
         "pane.last",
         "file.open",

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -878,7 +878,10 @@ struct cmuxApp: App {
             Button(String(localized: "menu.window.taskManager", defaultValue: "Task Manager...")) {
                 TaskManagerWindowController.shared.show()
             }
-            Button(String(localized: "menu.window.viewChat", defaultValue: "View Chat...")) {
+            splitCommandButton(
+                title: String(localized: "menu.window.viewChat", defaultValue: "View Chat..."),
+                shortcut: menuShortcut(for: .openAgentChat)
+            ) {
                 AgentChatPresenter().presentForFocusedPanel()
             }
         }

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -145,6 +145,11 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "focusTextBoxInput", combos: [["⌘", "⇧", "A"]], description: { en: "Switch focus between terminal and TextBox input", ja: "ターミナルとTextBox入力のフォーカスを切り替え" } },
       { id: "attachTextBoxFile", combos: [["⌥", "⌘", "⇧", "A"]], description: { en: "Attach file to TextBox input", ja: "TextBox入力にファイルを添付" } },
       {
+        id: "openAgentChat",
+        combos: [["⌘", "⇧", "C"]],
+        description: { en: "Open agent chat for the focused terminal", ja: "フォーカス中のターミナルのエージェントチャットを開く" },
+      },
+      {
         id: "sendCtrlFToTerminal",
         combos: [],
         description: { en: "Send Ctrl-F to terminal", ja: "ターミナルにCtrl-Fを送信" },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1139,6 +1139,7 @@
               "focusTextBoxInput",
               "attachTextBoxFile",
               "sendCtrlFToTerminal",
+              "openAgentChat",
               "focusLeft",
               "focusRight",
               "focusUp",


### PR DESCRIPTION
Entrypoint parity for the agent chat pane, in the https://github.com/manaflow-ai/cmux/pull/5736 lane. All three new surfaces route through the ONE shared resolve-then-present path (AgentChatPresenter), per the shared-entrypoint rule:

- **Socket/CLI verb:** `surface.agent_chat.open` in the CmuxControlSocket surface domain (main-actor lane, registered in the TerminalController verb allowlists), exposed as `cmux agent-chat [--workspace ...] [--surface ...]`; resolves the focused terminal when no target is given. Coordinator coverage in the package tests (verb dispatch, main-actor policy, unavailable/not-found mappings, explicit surface id threading).
- **Keyboard shortcut:** `openAgentChat`, registered in KeyboardShortcutSettings (visible/editable in Settings), supported in ~/.config/cmux/cmux.json (schema updated), documented via web/data/cmux-shortcuts.ts which feeds the keyboard-shortcut docs page.
- **Terminal context menu:** "View Agent Chat" on the terminal pane right-click menu.

Localization: new Settings/menu strings have en + ja entries in Resources/Localizable.xcstrings.

Verification: CmuxControlSocket package tests green (swift test), app build-only green with tagged DerivedData, lint-pbxproj-test-wiring ok, Swift file-length budget refreshed for the registration-point growth (+117 lines across five files of CLI verb/help, context-menu and shortcut wiring that must live in those files).

Worker note: built by a worker session that died on a rate limit after the two feature commits; the manager finished the package-test fake (inert window-domain members), gates, budget refresh, and this closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783892067&installation_id=133855650&pr_number=6009&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6009&signature=753b2b1c6955ec601d3ef439bee478157dceb01653889285a0cf11d77bbf1222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing navigation and automation entrypoints only; no auth, persistence, or terminal I/O changes beyond existing presenter behavior.
> 
> **Overview**
> Adds **three new ways to open or focus Agent Chat**, all routed through the shared `AgentChatPresenter` resolve-then-present flow (same as Window → View Chat).
> 
> **CLI & control socket:** New `cmux agent-chat` command and `surface.agent_chat.open` verb, with workspace/surface/window resolution aligned to `trigger-flash`. Malformed explicit selectors return `invalid_params` instead of silently targeting the focused surface; `terminal_id` / `tab_id` aliases are honored. Package tests cover dispatch, main-actor policy, and error mapping.
> 
> **Keyboard:** New `openAgentChat` action (default **⌘⇧C**, rebindable in Settings and `cmux.json`), wired in `AppDelegate`, command palette (`palette.openAgentChat`), and docs/schema. Menu shortcuts stay **unbound** so the chord only fires in terminal-scoped context.
> 
> **Terminal UI:** **View Agent Chat** on the terminal right-click menu targets the clicked panel via `present(panelId:in:manager:)`. `AgentChatPresenter` refactors focused vs explicit-panel entry onto that shared body.
> 
> Localization (en/ja) and Swift file-length budget updates included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47d4cf68fa70128f85cc2613bca5f2ff924365e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three ways to open Agent Chat—CLI, keyboard shortcut, and terminal context menu—through one shared presenter for consistent behavior. Adds a control-socket verb with strict selector validation (including `terminal_id`/`tab_id`), updates docs, and adds tests; the Window menu stays badge-less so Cmd+Shift+C remains terminal-scoped.

- New Features
  - CLI: `cmux agent-chat [--workspace ...] [--surface ...] [--panel ...] [--window ...]` opens or focuses Agent Chat, matching trigger-flash resolution and focusing the target window/workspace.
  - Socket: `surface.agent_chat.open` in `CmuxControlSocket` (main-actor), accepts `surface_id` plus `terminal_id`/`tab_id` aliases; coordinator tests added.
  - Shortcut: new `openAgentChat` action (default Cmd+Shift+C), rebindable in Settings and `cmux.json`; command palette entry wired; docs/schema updated.
  - Terminal context menu: “View Agent Chat” for terminal panes; uses the same `AgentChatPresenter` path.
  - Localization: new en/ja strings for the shortcut and context menu labels.

- Bug Fixes
  - Validation now runs before availability checks: explicit `window_id`, `workspace_id`, `surface_id`, `terminal_id`, and `tab_id` return `invalid_params` when malformed; parameterized tests cover each.
  - Routing: alias-targeted opens (`terminal_id`/`tab_id`) now reach the app seam and no longer fall back to the focused surface.

<sup>Written for commit c47d4cf68fa70128f85cc2613bca5f2ff924365e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

