### PR TITLE
Drop poisoned shell-wrapper restore commands

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -694,7 +694,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         AgentResumeCommandBuilder.resumeShellCommand(
             kind: kind,
             sessionId: sessionId,
-            launchCommand: launchCommand,
+            launchCommand: trustedLaunchCommandForResume,
             workingDirectory: workingDirectory,
             registrationOverride: registration
         )
@@ -704,10 +704,19 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         AgentResumeCommandBuilder.forkShellCommand(
             kind: kind,
             sessionId: sessionId,
-            launchCommand: launchCommand,
+            launchCommand: trustedLaunchCommandForResume,
             workingDirectory: workingDirectory,
             registrationOverride: registration
         )
+    }
+
+    private var trustedLaunchCommandForResume: AgentLaunchCommandSnapshot? {
+        guard let launchCommand else { return nil }
+        guard AgentLaunchCaptureTrust.launcherDescribesKind(launchCommand.launcher, kind: kind.rawValue),
+              !AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(launchCommand.arguments) else {
+            return nil
+        }
+        return launchCommand
     }
 
     func resumeStartupInput(
@@ -741,7 +750,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
                   // the current directory (no cd), so the post-exit shell must not force the launch dir.
                   workingDirectory: registration?.cwd == .ignore
                       ? nil
-                      : (workingDirectory ?? launchCommand?.workingDirectory)
+                      : (workingDirectory ?? trustedLaunchCommandForResume?.workingDirectory)
               ) else {
             return nil
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -694,7 +694,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         AgentResumeCommandBuilder.resumeShellCommand(
             kind: kind,
             sessionId: sessionId,
-            launchCommand: trustedLaunchCommandForResume,
+            launchCommand: trustedLaunchCommandForSessionRestore,
             workingDirectory: workingDirectory,
             registrationOverride: registration
         )
@@ -704,19 +704,48 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         AgentResumeCommandBuilder.forkShellCommand(
             kind: kind,
             sessionId: sessionId,
-            launchCommand: trustedLaunchCommandForResume,
+            launchCommand: trustedLaunchCommandForSessionRestore,
             workingDirectory: workingDirectory,
             registrationOverride: registration
         )
     }
 
-    private var trustedLaunchCommandForResume: AgentLaunchCommandSnapshot? {
+    var trustedLaunchCommandForSessionRestore: AgentLaunchCommandSnapshot? {
         guard let launchCommand else { return nil }
         guard AgentLaunchCaptureTrust.launcherDescribesKind(launchCommand.launcher, kind: kind.rawValue),
               !AgentLaunchCaptureTrust.argvLooksLikeShellWrapper(launchCommand.arguments) else {
             return nil
         }
         return launchCommand
+    }
+
+    func repairedForSessionRestore(fallbackWorkingDirectory: String?) -> SessionRestorableAgentSnapshot {
+        let trustedLaunchCommand = trustedLaunchCommandForSessionRestore
+        var repaired = self
+        repaired.launchCommand = trustedLaunchCommand
+
+        let fallbackWorkingDirectory = Self.normalizedWorkingDirectory(fallbackWorkingDirectory)
+        if trustedLaunchCommand == nil {
+            if repaired.workingDirectory == nil
+                || Self.normalizedWorkingDirectory(repaired.workingDirectory)
+                    == Self.normalizedWorkingDirectory(launchCommand?.workingDirectory) {
+                repaired.workingDirectory = fallbackWorkingDirectory
+            }
+        } else if repaired.workingDirectory == nil {
+            repaired.workingDirectory = Self.normalizedWorkingDirectory(
+                trustedLaunchCommand?.workingDirectory
+            ) ?? fallbackWorkingDirectory
+        }
+
+        return repaired
+    }
+
+    private static func normalizedWorkingDirectory(_ workingDirectory: String?) -> String? {
+        guard let trimmed = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return ((trimmed as NSString).expandingTildeInPath as NSString).standardizingPath
     }
 
     func resumeStartupInput(
@@ -750,7 +779,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
                   // the current directory (no cd), so the post-exit shell must not force the launch dir.
                   workingDirectory: registration?.cwd == .ignore
                       ? nil
-                      : (workingDirectory ?? trustedLaunchCommandForResume?.workingDirectory)
+                      : (workingDirectory ?? trustedLaunchCommandForSessionRestore?.workingDirectory)
               ) else {
             return nil
         }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -356,6 +356,24 @@ nonisolated struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         autoResume == true
     }
 
+    var trustedForSessionRestore: SurfaceResumeBindingSnapshot? {
+        isPoisonedAgentHookShellWrapperResume ? nil : self
+    }
+
+    var isPoisonedAgentHookShellWrapperResume: Bool {
+        guard isAgentHookBinding,
+              let tokens = SurfaceResumeCommandCanonicalizer.tokens(from: command) else {
+            return false
+        }
+        let commandStart = SurfaceResumeCommandCanonicalizer.commandStartIndexAfterCwdGuard(tokens)
+        guard commandStart + 1 < tokens.endIndex else { return false }
+        let executable = (tokens[commandStart] as NSString).lastPathComponent.lowercased()
+        let shells: Set<String> = ["sh", "bash", "zsh", "dash", "fish", "csh", "tcsh", "ksh"]
+        guard shells.contains(executable) else { return false }
+        let resumeWord = tokens[commandStart + 1]
+        return resumeWord == "resume" || resumeWord == "--resume" || resumeWord.hasPrefix("--resume=")
+    }
+
     func shouldYieldToDetectedSurfaceResumeBinding(_ detectedBinding: SurfaceResumeBindingSnapshot) -> Bool {
         detectedBinding.isProcessDetected && (isProcessDetected || isAgentHookBinding)
     }
@@ -677,6 +695,17 @@ enum SurfaceResumeCommandCanonicalizer {
             return nil
         }
         return ((rawValue as NSString).expandingTildeInPath as NSString).standardizingPath
+    }
+
+    static func commandStartIndexAfterCwdGuard(_ tokens: [String]) -> Int {
+        guard let first = tokens.first,
+              first == "{" || first == "cd" else {
+            return tokens.startIndex
+        }
+        guard let andIndex = tokens.firstIndex(of: "&&") else {
+            return tokens.startIndex
+        }
+        return tokens.index(after: andIndex)
     }
 
     static func shellQuoted(_ value: String) -> String {
@@ -1867,6 +1896,89 @@ struct AppSessionSnapshot: Codable, Sendable {
     var windows: [SessionWindowSnapshot]
 }
 
+enum SessionSnapshotRepairer {
+    struct Result {
+        var snapshot: AppSessionSnapshot
+        var didRepair: Bool
+    }
+
+    static func repair(_ snapshot: AppSessionSnapshot) -> Result {
+        var didRepair = false
+        var repaired = snapshot
+        repaired.windows = repaired.windows.map { window in
+            repair(window, didRepair: &didRepair)
+        }
+        return Result(snapshot: repaired, didRepair: didRepair)
+    }
+
+    private static func repair(
+        _ window: SessionWindowSnapshot,
+        didRepair: inout Bool
+    ) -> SessionWindowSnapshot {
+        var repaired = window
+        repaired.tabManager.workspaces = repaired.tabManager.workspaces.map { workspace in
+            repair(workspace, didRepair: &didRepair)
+        }
+        return repaired
+    }
+
+    private static func repair(
+        _ workspace: SessionWorkspaceSnapshot,
+        didRepair: inout Bool
+    ) -> SessionWorkspaceSnapshot {
+        var repaired = workspace
+        repaired.panels = repaired.panels.map { panel in
+            repair(panel, workspaceDirectory: workspace.currentDirectory, didRepair: &didRepair)
+        }
+        return repaired
+    }
+
+    private static func repair(
+        _ panel: SessionPanelSnapshot,
+        workspaceDirectory: String,
+        didRepair: inout Bool
+    ) -> SessionPanelSnapshot {
+        guard var terminal = panel.terminal else { return panel }
+        let fallbackWorkingDirectory = firstNormalizedDirectory(
+            terminal.workingDirectory,
+            panel.directory,
+            workspaceDirectory
+        )
+
+        if let resumeBinding = terminal.resumeBinding {
+            let trustedBinding = resumeBinding.trustedForSessionRestore
+            if trustedBinding == nil {
+                didRepair = true
+            }
+            terminal.resumeBinding = trustedBinding
+        }
+
+        if let agent = terminal.agent {
+            let repairedAgent = agent.repairedForSessionRestore(
+                fallbackWorkingDirectory: fallbackWorkingDirectory
+            )
+            if agent.launchCommand != repairedAgent.launchCommand
+                || agent.workingDirectory != repairedAgent.workingDirectory {
+                didRepair = true
+            }
+            terminal.agent = repairedAgent
+        }
+
+        var repaired = panel
+        repaired.terminal = terminal
+        return repaired
+    }
+
+    private static func firstNormalizedDirectory(_ candidates: String?...) -> String? {
+        for candidate in candidates {
+            if let normalized = SurfaceResumeCommandCanonicalizer.normalizedCWD(candidate) {
+                return normalized
+            }
+        }
+        return nil
+    }
+}
+
 enum SessionPersistenceStore {
     enum SnapshotLoadOutcome {
         case loaded(AppSessionSnapshot)
@@ -1885,7 +1997,11 @@ enum SessionPersistenceStore {
         guard let snapshot = try? decoder.decode(AppSessionSnapshot.self, from: data) else { return .unusable }
         guard snapshot.version == SessionSnapshotSchema.currentVersion else { return .unusable }
         guard !snapshot.windows.isEmpty else { return .unusable }
-        return .loaded(snapshot)
+        let repairResult = SessionSnapshotRepairer.repair(snapshot)
+        if repairResult.didRepair {
+            _ = save(repairResult.snapshot, fileURL: fileURL)
+        }
+        return .loaded(repairResult.snapshot)
     }
 
     static func load(fileURL: URL? = nil) -> AppSessionSnapshot? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1055,28 +1055,6 @@ extension Workspace {
         return effectiveBinding
     }
 
-    nonisolated private static func trustedSurfaceResumeBindingForRestore(
-        _ resumeBinding: SurfaceResumeBindingSnapshot?
-    ) -> SurfaceResumeBindingSnapshot? {
-        guard let resumeBinding else { return nil }
-        guard !agentHookBindingLooksLikeShellWrapperResume(resumeBinding) else { return nil }
-        return resumeBinding
-    }
-
-    nonisolated private static func agentHookBindingLooksLikeShellWrapperResume(
-        _ binding: SurfaceResumeBindingSnapshot
-    ) -> Bool {
-        guard binding.isAgentHookBinding else { return false }
-        let words = surfaceResumeShellWords(in: binding.command)
-        let commandStart = surfaceResumeCommandStartIndexAfterCwdGuard(words)
-        guard commandStart + 1 < words.endIndex else { return false }
-        let executable = (words[commandStart].value as NSString).lastPathComponent.lowercased()
-        let shells: Set<String> = ["sh", "bash", "zsh", "dash", "fish", "csh", "tcsh", "ksh"]
-        guard shells.contains(executable) else { return false }
-        let resumeWord = words[commandStart + 1].value
-        return resumeWord == "resume" || resumeWord == "--resume" || resumeWord.hasPrefix("--resume=")
-    }
-
     nonisolated private static func hermesAgentSubrouterBindingForStartup(
         _ binding: SurfaceResumeBindingSnapshot
     ) -> SurfaceResumeBindingSnapshot {
@@ -1659,7 +1637,7 @@ extension Workspace {
     ) -> UUID? {
         switch snapshot.type {
         case .terminal:
-            let resumeBinding = Self.trustedSurfaceResumeBindingForRestore(snapshot.terminal?.resumeBinding)
+            let resumeBinding = snapshot.terminal?.resumeBinding?.trustedForSessionRestore
             let restorableAgent = snapshot.terminal?.agent
             let restoredHibernation = snapshot.terminal?.hibernation
             let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1055,6 +1055,28 @@ extension Workspace {
         return effectiveBinding
     }
 
+    nonisolated private static func trustedSurfaceResumeBindingForRestore(
+        _ resumeBinding: SurfaceResumeBindingSnapshot?
+    ) -> SurfaceResumeBindingSnapshot? {
+        guard let resumeBinding else { return nil }
+        guard !agentHookBindingLooksLikeShellWrapperResume(resumeBinding) else { return nil }
+        return resumeBinding
+    }
+
+    nonisolated private static func agentHookBindingLooksLikeShellWrapperResume(
+        _ binding: SurfaceResumeBindingSnapshot
+    ) -> Bool {
+        guard binding.isAgentHookBinding else { return false }
+        let words = surfaceResumeShellWords(in: binding.command)
+        let commandStart = surfaceResumeCommandStartIndexAfterCwdGuard(words)
+        guard commandStart + 1 < words.endIndex else { return false }
+        let executable = (words[commandStart].value as NSString).lastPathComponent.lowercased()
+        let shells: Set<String> = ["sh", "bash", "zsh", "dash", "fish", "csh", "tcsh", "ksh"]
+        guard shells.contains(executable) else { return false }
+        let resumeWord = words[commandStart + 1].value
+        return resumeWord == "resume" || resumeWord == "--resume" || resumeWord.hasPrefix("--resume=")
+    }
+
     nonisolated private static func hermesAgentSubrouterBindingForStartup(
         _ binding: SurfaceResumeBindingSnapshot
     ) -> SurfaceResumeBindingSnapshot {
@@ -1101,7 +1123,7 @@ extension Workspace {
     ) -> String {
         let bootstrapCommand = bootstrap.joined(separator: " && ") + " && "
         let words = surfaceResumeShellWords(in: command)
-        let commandStart = hermesAgentCommandStartIndexAfterCwdGuard(words)
+        let commandStart = surfaceResumeCommandStartIndexAfterCwdGuard(words)
         guard commandStart < words.endIndex else {
             return bootstrapCommand + command
         }
@@ -1137,7 +1159,7 @@ extension Workspace {
 
     nonisolated private static func hermesAgentCommandByRemovingBootstrapPrefix(_ command: String) -> String {
         let words = surfaceResumeShellWords(in: command)
-        var scanIndex = hermesAgentCommandStartIndexAfterCwdGuard(words)
+        var scanIndex = surfaceResumeCommandStartIndexAfterCwdGuard(words)
         guard scanIndex < words.endIndex else { return command }
         let removeStartIndex = scanIndex
         var removedBootstrap = false
@@ -1235,12 +1257,12 @@ extension Workspace {
     nonisolated private static func hermesAgentWordsAfterCwdGuard(
         _ words: [SurfaceResumeShellWord]
     ) -> [SurfaceResumeShellWord] {
-        let commandStart = hermesAgentCommandStartIndexAfterCwdGuard(words)
+        let commandStart = surfaceResumeCommandStartIndexAfterCwdGuard(words)
         guard commandStart < words.endIndex else { return [] }
         return Array(words[commandStart...])
     }
 
-    nonisolated private static func hermesAgentCommandStartIndexAfterCwdGuard(
+    nonisolated private static func surfaceResumeCommandStartIndexAfterCwdGuard(
         _ words: [SurfaceResumeShellWord]
     ) -> Int {
         guard let first = words.first,
@@ -1637,7 +1659,7 @@ extension Workspace {
     ) -> UUID? {
         switch snapshot.type {
         case .terminal:
-            let resumeBinding = snapshot.terminal?.resumeBinding
+            let resumeBinding = Self.trustedSurfaceResumeBindingForRestore(snapshot.terminal?.resumeBinding)
             let restorableAgent = snapshot.terminal?.agent
             let restoredHibernation = snapshot.terminal?.hibernation
             let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled()

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1889,6 +1889,32 @@ final class SessionPersistenceTests: XCTestCase {
 }
 
 final class SocketListenerAcceptPolicyTests: XCTestCase {
+    func testPersistedAgentSnapshotDropsShellWrapperLaunchCommandWhenRenderingResume() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-session-123",
+            workingDirectory: "/tmp/repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "bash",
+                arguments: [
+                    "bash",
+                    "-c",
+                    "payload=\"$1\"; shift; \"$@\" <\"$payload\" &",
+                ],
+                workingDirectory: "/tmp/dispatch-shell",
+                environment: ["CODEX_HOME": "/tmp/codex"],
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "{ cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ]; } && 'codex' 'resume' 'codex-session-123'"
+        )
+    }
+
     func testClaudeResumeCommandRoutesThroughWrapperInsteadOfCapturedRealBinary() {
         // The captured launch executable is the real claude binary
         // (CMUX_AGENT_LAUNCH_EXECUTABLE). Resuming with it directly bypasses
@@ -5794,6 +5820,88 @@ extension SessionPersistenceTests {
             restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding?.command,
             "./resume.sh"
         )
+    }
+
+    @MainActor
+    func testRestoreDropsPoisonedAgentHookShellWrapperResumeBindingAndUsesAgentSnapshot() throws {
+        try withAutoResumeAgentSessionsEnabled {
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sessionId = "019eba43-1e37-78d2-98df-d1983200273d"
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: sessionId,
+                arguments: [
+                    "/usr/local/bin/codex",
+                    "--yolo",
+                ]
+            )
+            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                    name: "Codex",
+                    kind: "codex",
+                    command: "{ cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ]; } && 'bash' 'resume' '\(sessionId)' '-c' 'payload=\"$1\"; shift; \"$@\" <\"$payload\" &'",
+                    cwd: "/Users/lawrence/fun/cmuxterm-hq",
+                    checkpointId: sessionId,
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 10
+                ),
+            ])
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: sourceIndex,
+                surfaceResumeBindingIndex: bindingIndex
+            )
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let payload = try restoredStartupPayload(for: restoredPanel)
+
+            XCTAssertTrue(payload.contains("/usr/local/bin/codex"), payload)
+            XCTAssertTrue(payload.contains("resume"), payload)
+            XCTAssertTrue(payload.contains(sessionId), payload)
+            XCTAssertTrue(payload.contains("--yolo"), payload)
+            XCTAssertFalse(payload.contains("'bash' 'resume'"), payload)
+            XCTAssertNil(restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding)
+        }
+    }
+
+    @MainActor
+    func testRestoreDropsPoisonedAgentHookShellWrapperResumeBindingWithoutAgentSnapshot() throws {
+        try withAutoResumeAgentSessionsEnabled {
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sessionId = "019eb982-d798-7123-aa2b-93326ff3bd08"
+            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                    name: "Codex",
+                    kind: "codex",
+                    command: "{ cd -- '/Users/lawrence/fun/cmuxterm-hq' 2>/dev/null || [ ! -d '/Users/lawrence/fun/cmuxterm-hq' ]; } && 'sh' 'resume' '\(sessionId)' '-c' 'payload=\"$1\"; shift; \"$@\" <\"$payload\" &'",
+                    cwd: "/Users/lawrence/fun/cmuxterm-hq",
+                    checkpointId: sessionId,
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 10
+                ),
+            ])
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                surfaceResumeBindingIndex: bindingIndex
+            )
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+            XCTAssertNil(restoredPanel.surface.debugInitialCommand())
+            XCTAssertFalse(restoredPanel.surface.debugInitialInputMetadata().hasInitialInput)
+            XCTAssertNil(restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding)
+        }
     }
 
     @MainActor

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -192,6 +192,94 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(visibleFrame.y, 25, accuracy: 0.001)
     }
 
+    @MainActor
+    func testLoadRepairsAndPersistsPoisonedAgentHookShellWrapperResumeBinding() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let sessionId = "codex-load-repair-session"
+        let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+            SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                name: "Codex",
+                kind: "codex",
+                command: "{ cd -- '/tmp/right' 2>/dev/null || [ ! -d '/tmp/right' ]; } && 'bash' 'resume' '\(sessionId)'",
+                cwd: "/tmp/right",
+                checkpointId: sessionId,
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 10
+            ),
+        ])
+        let workspaceSnapshot = source.sessionSnapshot(
+            includeScrollback: false,
+            surfaceResumeBindingIndex: bindingIndex
+        )
+        let appSnapshot = makeSnapshot(workspaceSnapshot: workspaceSnapshot)
+        XCTAssertTrue(SessionPersistenceStore.save(appSnapshot, fileURL: snapshotURL))
+
+        let loaded = try XCTUnwrap(SessionPersistenceStore.load(fileURL: snapshotURL))
+        let loadedBinding = loaded.windows.first?.tabManager.workspaces.first?.panels.first?.terminal?.resumeBinding
+        XCTAssertNil(loadedBinding)
+
+        let persistedData = try Data(contentsOf: snapshotURL)
+        let persisted = try JSONDecoder().decode(AppSessionSnapshot.self, from: persistedData)
+        let persistedBinding = persisted.windows.first?.tabManager.workspaces.first?.panels.first?.terminal?.resumeBinding
+        XCTAssertNil(persistedBinding)
+    }
+
+    @MainActor
+    func testLoadRepairsWrongForkAgentLaunchCommandAndRecoversWorkingDirectory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        source.updatePanelDirectory(panelId: sourcePanelId, directory: "/tmp/right")
+        var workspaceSnapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try XCTUnwrap(workspaceSnapshot.panels.firstIndex { $0.id == sourcePanelId })
+        var panel = workspaceSnapshot.panels[panelIndex]
+        var terminal = try XCTUnwrap(panel.terminal)
+        terminal.workingDirectory = "/tmp/right"
+        terminal.agent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-load-repair-session",
+            workingDirectory: "/tmp/wrong",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["/usr/local/bin/claude", "--resume", "claude-session"],
+                workingDirectory: "/tmp/wrong",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+        panel.directory = "/tmp/right"
+        panel.terminal = terminal
+        workspaceSnapshot.panels[panelIndex] = panel
+        let appSnapshot = makeSnapshot(workspaceSnapshot: workspaceSnapshot)
+        XCTAssertTrue(SessionPersistenceStore.save(appSnapshot, fileURL: snapshotURL))
+
+        let loaded = try XCTUnwrap(SessionPersistenceStore.load(fileURL: snapshotURL))
+        let loadedAgent = try XCTUnwrap(
+            loaded.windows.first?.tabManager.workspaces.first?.panels.first?.terminal?.agent
+        )
+        XCTAssertNil(loadedAgent.launchCommand)
+        XCTAssertEqual(loadedAgent.workingDirectory, "/tmp/right")
+        XCTAssertEqual(
+            loadedAgent.resumeCommand,
+            "{ cd -- '/tmp/right' 2>/dev/null || [ ! -d '/tmp/right' ]; } && 'codex' 'resume' 'codex-load-repair-session'"
+        )
+    }
+
     func testLoadReopenSessionSnapshotRequiresPreviousSnapshotFile() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
@@ -1877,6 +1965,23 @@ final class SessionPersistenceTests: XCTestCase {
 
         return AppSessionSnapshot(
             version: version,
+            createdAt: Date().timeIntervalSince1970,
+            windows: [window]
+        )
+    }
+
+    private func makeSnapshot(workspaceSnapshot: SessionWorkspaceSnapshot) -> AppSessionSnapshot {
+        let window = SessionWindowSnapshot(
+            frame: SessionRectSnapshot(x: 10, y: 20, width: 900, height: 700),
+            display: nil,
+            tabManager: SessionTabManagerSnapshot(
+                selectedWorkspaceIndex: 0,
+                workspaces: [workspaceSnapshot]
+            ),
+            sidebar: SessionSidebarSnapshot(isVisible: true, selection: .tabs, width: 240)
+        )
+        return AppSessionSnapshot(
+            version: SessionSnapshotSchema.currentVersion,
             createdAt: Date().timeIntervalSince1970,
             windows: [window]
         )


### PR DESCRIPTION
## Summary

Fixes a real session restoration failure seen after upgrading from 0.64.14 to 0.64.15: persisted agent-hook resume bindings shaped like `bash resume <session> -c ...` could still be trusted before the restored agent snapshot, producing `bash: resume: No such file or directory`.

This PR now repairs persisted session snapshots at load time for all users. Old snapshots are normalized before restore sees them, poisoned shell-wrapper bindings are dropped, untrusted saved agent launch captures are stripped, and recovered agent working directories fall back to the terminal/panel/workspace directory. When a repair happens, the cleaned snapshot is saved back to disk so the upgrade is durable.

## Verification

- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-rsres-green -only-testing:cmuxTests/SessionPersistenceTests/testLoadRepairsAndPersistsPoisonedAgentHookShellWrapperResumeBinding -only-testing:cmuxTests/SessionPersistenceTests/testLoadRepairsWrongForkAgentLaunchCommandAndRecoversWorkingDirectory -only-testing:cmuxTests/SessionPersistenceTests/testRestoreDropsPoisonedAgentHookShellWrapperResumeBindingAndUsesAgentSnapshot -only-testing:cmuxTests/SessionPersistenceTests/testRestoreDropsPoisonedAgentHookShellWrapperResumeBindingWithoutAgentSnapshot -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testPersistedAgentSnapshotDropsShellWrapperLaunchCommandWhenRenderingResume`
- `./scripts/reload-cloud.sh --tag rsfix`
- Launched tagged app via `http://127.0.0.1:17320/rsfix`, confirmed the `rsfix` debug socket responds with `list-workspaces`, and visually confirmed the app rendered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783893429&installation_id=133855650&pr_number=6012&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6012&signature=a080c1961400fc7a502016be6c29cb89410acdbd5dfbeb407b87afccea7759dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session loading now auto-repairs snapshots and prefers trusted resume commands, persisting repaired snapshots back to disk.

* **Bug Fixes**
  * Improved session restoration to detect and drop “poisoned” shell-wrapper resume bindings and prefer direct resume invocations, preventing problematic command reinvocation and more reliable recovery.

* **Tests**
  * Added regression tests covering poisoned shell-wrapper resume bindings, repair behavior, and resume-command rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->