### PR TITLE
iOS Devices sheet: always-available Add device entry that re-enters the pairing flow

### DIFF
--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
@@ -35,18 +35,28 @@ public struct DeviceTreeAddDevicePolicy: Sendable {
     /// Whether a completed add-device attempt should reconnect the Mac that
     /// was live when the attempt started.
     ///
-    /// The underlying pairing path is destructive: a failed (or cancelled)
-    /// attempt leaves the shell `.disconnected` even when a healthy connection
-    /// existed before it began. When the attempt started over a live
-    /// connection (`previousMacDeviceID` non-nil) and ended disconnected,
-    /// restore that Mac via `switchToMac` instead of stranding the user —
-    /// the same "never strand the user" contract `switchToMac` documents for
-    /// its own failure path. A successful attempt is connected (to the new
-    /// device), so no restore happens.
+    /// The underlying pairing path is destructive: a cancelled attempt leaves
+    /// the shell `.disconnected` even when a healthy connection existed before
+    /// it began. When the attempt started over a live connection
+    /// (`previousMacDeviceID` non-nil), ended disconnected, and reported no
+    /// connection error (the store's cancellation path sets none, while every
+    /// real failure does), restore that Mac via `switchToMac` instead of
+    /// stranding the user — the same "never strand the user" contract
+    /// `switchToMac` documents for its own failure path.
+    ///
+    /// A failed attempt (`hasConnectionError`) deliberately does NOT restore:
+    /// the reconnect path begins a fresh pairing attempt, which clears
+    /// `connectionError` and would erase the actionable failure reason while
+    /// the user is reading it. The disconnected shell auto-presents the
+    /// pairing sheet with that error for an in-place retry; reconnecting the
+    /// previous Mac without losing the error needs a store-owned error
+    /// channel that survives reconnects (follow-up). A successful attempt is
+    /// connected (to the new device), so no restore happens either.
     public func restoresPreviousConnection(
         connectionState: MobileConnectionState,
-        previousMacDeviceID: String?
+        previousMacDeviceID: String?,
+        hasConnectionError: Bool
     ) -> Bool {
-        connectionState != .connected && previousMacDeviceID != nil
+        connectionState != .connected && previousMacDeviceID != nil && !hasConnectionError
     }
 }

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
@@ -6,8 +6,11 @@ import Foundation
 ///
 /// Lives in the model package (with ``MobileConnectionState``) so it stays
 /// platform-neutral and `swift test` exercises it on any host, following the
-/// `MobileShellRouteAuthPolicy` pattern.
-public enum DeviceTreeAddDevicePolicy {
+/// `MobileShellRouteAuthPolicy` pattern. A value type (not a static-helper
+/// namespace) per the package API design policy.
+public struct DeviceTreeAddDevicePolicy: Sendable {
+    public init() {}
+
     /// Whether tapping Cancel in the add-device sheet may reset the store's
     /// pairing state via `cancelPairing()`.
     ///
@@ -17,7 +20,7 @@ public enum DeviceTreeAddDevicePolicy {
     /// already replaced the live client), but cancelling a freshly opened
     /// sheet while the shell is still connected must NOT tear down the live
     /// connection the user is actively using.
-    public static func cancelResetsPairingState(connectionState: MobileConnectionState) -> Bool {
+    public func cancelResetsPairingState(connectionState: MobileConnectionState) -> Bool {
         connectionState != .connected
     }
 
@@ -25,7 +28,25 @@ public enum DeviceTreeAddDevicePolicy {
     /// completes. Success leaves the shell connected (to the newly added
     /// device); failure leaves it disconnected with `connectionError` set, and
     /// the sheet stays up so the user can read the error and retry.
-    public static func dismissesAfterPairingAttempt(connectionState: MobileConnectionState) -> Bool {
+    public func dismissesAfterPairingAttempt(connectionState: MobileConnectionState) -> Bool {
         connectionState == .connected
+    }
+
+    /// Whether a completed add-device attempt should reconnect the Mac that
+    /// was live when the attempt started.
+    ///
+    /// The underlying pairing path is destructive: a failed (or cancelled)
+    /// attempt leaves the shell `.disconnected` even when a healthy connection
+    /// existed before it began. When the attempt started over a live
+    /// connection (`previousMacDeviceID` non-nil) and ended disconnected,
+    /// restore that Mac via `switchToMac` instead of stranding the user —
+    /// the same "never strand the user" contract `switchToMac` documents for
+    /// its own failure path. A successful attempt is connected (to the new
+    /// device), so no restore happens.
+    public func restoresPreviousConnection(
+        connectionState: MobileConnectionState,
+        previousMacDeviceID: String?
+    ) -> Bool {
+        connectionState != .connected && previousMacDeviceID != nil
     }
 }

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
@@ -9,6 +9,9 @@ import Foundation
 /// `MobileShellRouteAuthPolicy` pattern. A value type (not a static-helper
 /// namespace) per the package API design policy.
 public struct DeviceTreeAddDevicePolicy: Sendable {
+    /// Creates the policy. Stateless today; an initializer (rather than a
+    /// static-helper namespace) keeps the public API injectable and free to
+    /// grow configuration without breaking call sites.
     public init() {}
 
     /// Whether tapping Cancel in the add-device sheet may reset the store's

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/DeviceTreeAddDevicePolicy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure policy for the device tree's "Add device" entry point, which re-enters
+/// the pairing flow while a live connection may already exist (unlike the
+/// first-run flow, which only ever runs disconnected).
+///
+/// Lives in the model package (with ``MobileConnectionState``) so it stays
+/// platform-neutral and `swift test` exercises it on any host, following the
+/// `MobileShellRouteAuthPolicy` pattern.
+public enum DeviceTreeAddDevicePolicy {
+    /// Whether tapping Cancel in the add-device sheet may reset the store's
+    /// pairing state via `cancelPairing()`.
+    ///
+    /// `cancelPairing()` sets `connectionState = .disconnected` and clears the
+    /// remote connection context. That is correct when the sheet was the only
+    /// path to a connection (first-run, or an attempt that is mid-flight and
+    /// already replaced the live client), but cancelling a freshly opened
+    /// sheet while the shell is still connected must NOT tear down the live
+    /// connection the user is actively using.
+    public static func cancelResetsPairingState(connectionState: MobileConnectionState) -> Bool {
+        connectionState != .connected
+    }
+
+    /// Whether the add-device sheet should dismiss after a pairing attempt
+    /// completes. Success leaves the shell connected (to the newly added
+    /// device); failure leaves it disconnected with `connectionError` set, and
+    /// the sheet stays up so the user can read the error and retry.
+    public static func dismissesAfterPairingAttempt(connectionState: MobileConnectionState) -> Bool {
+        connectionState == .connected
+    }
+}

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
@@ -32,13 +32,27 @@ import Testing
         #expect(!policy.dismissesAfterPairingAttempt(connectionState: .disconnected))
     }
 
-    /// A failed or cancelled attempt that started over a live connection
+    /// A cancelled attempt (disconnected, no connection error — the store's
+    /// cancellation path sets none) that started over a live connection
     /// reconnects that Mac: the pairing path is destructive, and the user must
-    /// not lose a working session to a bad QR code or a cancelled attempt.
-    @Test func failedAttemptOverLiveConnectionRestoresIt() {
+    /// not lose a working session just by backing out of the sheet.
+    @Test func cancelledAttemptOverLiveConnectionRestoresIt() {
         #expect(policy.restoresPreviousConnection(
             connectionState: .disconnected,
-            previousMacDeviceID: "mac-1"
+            previousMacDeviceID: "mac-1",
+            hasConnectionError: false
+        ))
+    }
+
+    /// A failed attempt (connection error set) must NOT auto-restore: the
+    /// reconnect path begins a fresh pairing attempt, which clears
+    /// `connectionError` and would erase the failure reason while the user is
+    /// reading it on the auto-presented pairing sheet.
+    @Test func failedAttemptKeepsErrorInsteadOfRestoring() {
+        #expect(!policy.restoresPreviousConnection(
+            connectionState: .disconnected,
+            previousMacDeviceID: "mac-1",
+            hasConnectionError: true
         ))
     }
 
@@ -47,16 +61,18 @@ import Testing
     @Test func successfulAttemptDoesNotRestorePreviousMac() {
         #expect(!policy.restoresPreviousConnection(
             connectionState: .connected,
-            previousMacDeviceID: "mac-1"
+            previousMacDeviceID: "mac-1",
+            hasConnectionError: false
         ))
     }
 
     /// An attempt that started without a live connection (first pair from the
     /// tree's empty state) has nothing to restore.
-    @Test func failedAttemptWithNoPreviousMacDoesNotRestore() {
+    @Test func cancelledAttemptWithNoPreviousMacDoesNotRestore() {
         #expect(!policy.restoresPreviousConnection(
             connectionState: .disconnected,
-            previousMacDeviceID: nil
+            previousMacDeviceID: nil,
+            hasConnectionError: false
         ))
     }
 }

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
@@ -4,29 +4,59 @@ import Testing
 /// Behavior of the device tree's "Add device" entry point, which re-enters the
 /// pairing flow while a live connection may already exist.
 @Suite struct DeviceTreeAddDevicePolicyTests {
+    private let policy = DeviceTreeAddDevicePolicy()
+
     /// Cancelling a sheet opened over a live connection must NOT call
     /// `cancelPairing()` — that would flip the store to `.disconnected` and
     /// tear down the connection the user is actively using.
     @Test func cancelOverLiveConnectionPreservesIt() {
-        #expect(!DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: .connected))
+        #expect(!policy.cancelResetsPairingState(connectionState: .connected))
     }
 
     /// Cancelling while disconnected (the attempt failed, or it already
     /// replaced the live client mid-flight) resets pairing state, matching the
     /// first-run flow's cancel semantics.
     @Test func cancelWhileDisconnectedResetsPairingState() {
-        #expect(DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: .disconnected))
+        #expect(policy.cancelResetsPairingState(connectionState: .disconnected))
     }
 
     /// A successful attempt leaves the shell connected to the added device, so
     /// the sheet dismisses (and the tree refreshes to show it).
     @Test func successfulAttemptDismissesSheet() {
-        #expect(DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: .connected))
+        #expect(policy.dismissesAfterPairingAttempt(connectionState: .connected))
     }
 
     /// A failed attempt leaves the shell disconnected with `connectionError`
     /// set; the sheet stays up so the user can read the error and retry.
     @Test func failedAttemptKeepsSheetForRetry() {
-        #expect(!DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: .disconnected))
+        #expect(!policy.dismissesAfterPairingAttempt(connectionState: .disconnected))
+    }
+
+    /// A failed or cancelled attempt that started over a live connection
+    /// reconnects that Mac: the pairing path is destructive, and the user must
+    /// not lose a working session to a bad QR code or a cancelled attempt.
+    @Test func failedAttemptOverLiveConnectionRestoresIt() {
+        #expect(policy.restoresPreviousConnection(
+            connectionState: .disconnected,
+            previousMacDeviceID: "mac-1"
+        ))
+    }
+
+    /// A successful attempt is connected to the newly added device; the
+    /// previous Mac must not be reconnected over it.
+    @Test func successfulAttemptDoesNotRestorePreviousMac() {
+        #expect(!policy.restoresPreviousConnection(
+            connectionState: .connected,
+            previousMacDeviceID: "mac-1"
+        ))
+    }
+
+    /// An attempt that started without a live connection (first pair from the
+    /// tree's empty state) has nothing to restore.
+    @Test func failedAttemptWithNoPreviousMacDoesNotRestore() {
+        #expect(!policy.restoresPreviousConnection(
+            connectionState: .disconnected,
+            previousMacDeviceID: nil
+        ))
     }
 }

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/DeviceTreeAddDevicePolicyTests.swift
@@ -1,0 +1,32 @@
+import CmuxMobileShellModel
+import Testing
+
+/// Behavior of the device tree's "Add device" entry point, which re-enters the
+/// pairing flow while a live connection may already exist.
+@Suite struct DeviceTreeAddDevicePolicyTests {
+    /// Cancelling a sheet opened over a live connection must NOT call
+    /// `cancelPairing()` — that would flip the store to `.disconnected` and
+    /// tear down the connection the user is actively using.
+    @Test func cancelOverLiveConnectionPreservesIt() {
+        #expect(!DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: .connected))
+    }
+
+    /// Cancelling while disconnected (the attempt failed, or it already
+    /// replaced the live client mid-flight) resets pairing state, matching the
+    /// first-run flow's cancel semantics.
+    @Test func cancelWhileDisconnectedResetsPairingState() {
+        #expect(DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: .disconnected))
+    }
+
+    /// A successful attempt leaves the shell connected to the added device, so
+    /// the sheet dismisses (and the tree refreshes to show it).
+    @Test func successfulAttemptDismissesSheet() {
+        #expect(DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: .connected))
+    }
+
+    /// A failed attempt leaves the shell disconnected with `connectionError`
+    /// set; the sheet stays up so the user can read the error and retry.
+    @Test func failedAttemptKeepsSheetForRetry() {
+        #expect(!DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: .disconnected))
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -166,12 +166,16 @@ struct DeviceTreeView: View {
     ///
     /// Success (the shell is connected, to the added device): dismiss the
     /// sheet and refresh both device sources so the new device appears in the
-    /// tree. Failure or cancellation over what was a live connection: the
-    /// pairing path has already torn that connection down, so reconnect the
-    /// previous Mac via ``CMUXMobileShellStore/switchToMac(macDeviceID:)``
-    /// instead of stranding the user disconnected. The restore runs in a
-    /// fresh unstructured `Task` because a cancelled attempt's continuation
-    /// executes in an already-cancelled task.
+    /// tree. Cancellation over what was a live connection (disconnected, no
+    /// connection error): the pairing path has already torn that connection
+    /// down, so reconnect the previous Mac via
+    /// ``CMUXMobileShellStore/switchToMac(macDeviceID:)`` instead of
+    /// stranding the user. The restore runs in a fresh unstructured `Task`
+    /// because a cancelled attempt's continuation executes in an
+    /// already-cancelled task. A real failure (connection error set) does not
+    /// restore — the reconnect would clear the error the user needs to read;
+    /// the disconnected shell auto-presents the pairing sheet with that error
+    /// for an in-place retry (see the policy's rationale).
     private func finishAddDevice(previousMacDeviceID: String?) {
         let state = store.connectionState
         if addDevicePolicy.dismissesAfterPairingAttempt(connectionState: state) {
@@ -184,7 +188,8 @@ struct DeviceTreeView: View {
         }
         if addDevicePolicy.restoresPreviousConnection(
             connectionState: state,
-            previousMacDeviceID: previousMacDeviceID
+            previousMacDeviceID: previousMacDeviceID,
+            hasConnectionError: store.connectionError != nil
         ), let previousMacDeviceID {
             let store = store
             Task {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -30,6 +30,10 @@ struct DeviceTreeView: View {
     /// Persisted expansion shape, encoded as a newline-separated id string.
     @AppStorage("cmux.mobile.deviceTree.expanded") private var expandedStorage = ""
     @State private var isRefreshing = false
+    /// Presents the add-device pairing flow (the same ``PairingView`` the
+    /// first-run path uses), so another device can be paired from here at any
+    /// time — not only while disconnected.
+    @State private var isShowingAddDevice = false
 
     private var expansion: DeviceTreeExpansionStore {
         DeviceTreeExpansionStore(storage: expandedStorage)
@@ -53,11 +57,20 @@ struct DeviceTreeView: View {
                         deviceSection(device)
                     }
                 }
+
+                addDeviceSection
             }
             .listStyle(.insetGrouped)
             .navigationTitle(L10n.string("mobile.deviceTree.title", defaultValue: "Devices"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: beginAddDevice) {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel(L10n.string("mobile.addDevice.title", defaultValue: "Add device"))
+                    .accessibilityIdentifier("MobileDeviceTreeAddDeviceToolbar")
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(L10n.string("mobile.common.done", defaultValue: "Done")) {
                         dismiss()
@@ -75,8 +88,76 @@ struct DeviceTreeView: View {
                 await store.loadPairedMacs()
                 await store.loadRegistryDevices()
             }
+            .sheet(isPresented: $isShowingAddDevice) {
+                addDeviceSheet
+            }
         }
         .accessibilityIdentifier("MobileDeviceTree")
+    }
+
+    /// One always-available entry into the pairing flow (the list row); the
+    /// toolbar `plus` invokes the same ``beginAddDevice()`` action, per the
+    /// shared-behavior policy (one action path for every entrypoint).
+    @ViewBuilder
+    private var addDeviceSection: some View {
+        Section {
+            Button(action: beginAddDevice) {
+                Label(
+                    L10n.string("mobile.addDevice.title", defaultValue: "Add device"),
+                    systemImage: "plus"
+                )
+            }
+            .accessibilityIdentifier("MobileDeviceTreeAddDevice")
+        }
+    }
+
+    /// The first-run pairing flow, re-entered in place: QR scan or manual
+    /// host, driven by the same store mutations as the root pairing path. On
+    /// success the attempt leaves the shell connected to the new device, so
+    /// the sheet dismisses and the tree refreshes to show it; on failure the
+    /// sheet stays up with the store's error so the user can retry.
+    private var addDeviceSheet: some View {
+        PairingView(
+            pairingCode: $store.pairingCode,
+            connectionError: store.connectionError,
+            connectionErrorGuidance: store.connectionErrorGuidance,
+            connectPairingCode: {
+                await store.connectPairingInput()
+                finishAddDeviceIfConnected()
+            },
+            connectManualHost: { name, host, port in
+                await store.connectManualHost(name: name, host: host, port: port)
+                finishAddDeviceIfConnected()
+            },
+            cancelPairing: {
+                // Cancelling a sheet opened over a live connection must not
+                // tear that connection down; `cancelPairing()` flips the store
+                // to `.disconnected`. Pure decision, unit tested.
+                if DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: store.connectionState) {
+                    store.cancelPairing()
+                }
+            },
+            cancel: { isShowingAddDevice = false }
+        )
+        .presentationDragIndicator(.visible)
+    }
+
+    private func beginAddDevice() {
+        isShowingAddDevice = true
+    }
+
+    /// Called after a pairing attempt from the add-device sheet completes.
+    /// Dismisses only on success (the shell is connected to the added device)
+    /// and refreshes both device sources so the new device appears in the tree.
+    private func finishAddDeviceIfConnected() {
+        guard DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: store.connectionState) else {
+            return
+        }
+        isShowingAddDevice = false
+        Task {
+            await store.loadPairedMacs()
+            await store.loadRegistryDevices()
+        }
     }
 
     @ViewBuilder

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -114,26 +114,33 @@ struct DeviceTreeView: View {
     /// The first-run pairing flow, re-entered in place: QR scan or manual
     /// host, driven by the same store mutations as the root pairing path. On
     /// success the attempt leaves the shell connected to the new device, so
-    /// the sheet dismisses and the tree refreshes to show it; on failure the
-    /// sheet stays up with the store's error so the user can retry.
+    /// the sheet dismisses and the tree refreshes to show it. The underlying
+    /// pairing path is destructive on failure, so each attempt captures the
+    /// Mac that was live when it started and ``finishAddDevice(previousMacDeviceID:)``
+    /// reconnects it when the attempt ends disconnected.
     private var addDeviceSheet: some View {
         PairingView(
             pairingCode: $store.pairingCode,
             connectionError: store.connectionError,
             connectionErrorGuidance: store.connectionErrorGuidance,
             connectPairingCode: {
+                let previousMacDeviceID = liveMacDeviceID
                 await store.connectPairingInput()
-                finishAddDeviceIfConnected()
+                finishAddDevice(previousMacDeviceID: previousMacDeviceID)
             },
             connectManualHost: { name, host, port in
+                let previousMacDeviceID = liveMacDeviceID
                 await store.connectManualHost(name: name, host: host, port: port)
-                finishAddDeviceIfConnected()
+                finishAddDevice(previousMacDeviceID: previousMacDeviceID)
             },
             cancelPairing: {
                 // Cancelling a sheet opened over a live connection must not
                 // tear that connection down; `cancelPairing()` flips the store
-                // to `.disconnected`. Pure decision, unit tested.
-                if DeviceTreeAddDevicePolicy.cancelResetsPairingState(connectionState: store.connectionState) {
+                // to `.disconnected`. Pure decision, unit tested. A cancel
+                // mid-attempt is handled by the attempt's own continuation:
+                // the store ends the cancelled attempt `.disconnected`, and
+                // `finishAddDevice` restores the previous Mac.
+                if addDevicePolicy.cancelResetsPairingState(connectionState: store.connectionState) {
                     store.cancelPairing()
                 }
             },
@@ -142,21 +149,47 @@ struct DeviceTreeView: View {
         .presentationDragIndicator(.visible)
     }
 
+    private var addDevicePolicy: DeviceTreeAddDevicePolicy { DeviceTreeAddDevicePolicy() }
+
+    /// The device id of the currently live Mac, captured before a pairing
+    /// attempt so a destructive failure can restore it. `nil` when not
+    /// connected (nothing to restore).
+    private var liveMacDeviceID: String? {
+        store.connectionState == .connected ? store.connectedMacDeviceID : nil
+    }
+
     private func beginAddDevice() {
         isShowingAddDevice = true
     }
 
     /// Called after a pairing attempt from the add-device sheet completes.
-    /// Dismisses only on success (the shell is connected to the added device)
-    /// and refreshes both device sources so the new device appears in the tree.
-    private func finishAddDeviceIfConnected() {
-        guard DeviceTreeAddDevicePolicy.dismissesAfterPairingAttempt(connectionState: store.connectionState) else {
+    ///
+    /// Success (the shell is connected, to the added device): dismiss the
+    /// sheet and refresh both device sources so the new device appears in the
+    /// tree. Failure or cancellation over what was a live connection: the
+    /// pairing path has already torn that connection down, so reconnect the
+    /// previous Mac via ``CMUXMobileShellStore/switchToMac(macDeviceID:)``
+    /// instead of stranding the user disconnected. The restore runs in a
+    /// fresh unstructured `Task` because a cancelled attempt's continuation
+    /// executes in an already-cancelled task.
+    private func finishAddDevice(previousMacDeviceID: String?) {
+        let state = store.connectionState
+        if addDevicePolicy.dismissesAfterPairingAttempt(connectionState: state) {
+            isShowingAddDevice = false
+            Task {
+                await store.loadPairedMacs()
+                await store.loadRegistryDevices()
+            }
             return
         }
-        isShowingAddDevice = false
-        Task {
-            await store.loadPairedMacs()
-            await store.loadRegistryDevices()
+        if addDevicePolicy.restoresPreviousConnection(
+            connectionState: state,
+            previousMacDeviceID: previousMacDeviceID
+        ), let previousMacDeviceID {
+            let store = store
+            Task {
+                await store.switchToMac(macDeviceID: previousMacDeviceID)
+            }
         }
     }
 


### PR DESCRIPTION
Lawrence: "in the devices menu we should also be able to add a new device and go through the flow again."

## Which side

The "devices menu" is the iOS Devices sheet (`DeviceTreeView`, titled "Devices", opened from the workspace list toolbar). Once a phone was paired, the add-device pairing flow became unreachable from there: the root `PairingView` sheet only mounts on the disconnected branch, and the only connected-state path was Settings -> Switch Mac, which offers a bare QR scanner, not the full flow.

The Mac side already has two re-entry points into its pairing window (Settings -> Mobile -> "Pair…" and the command palette "Connect iPhone/iPad") and has no Devices menu to extend, so no Mac changes here. A dedicated Mac menu item is a possible follow-up; left out to avoid colliding with the in-flight pairing-window changes.

## Shared action and entry points

One shared `beginAddDevice()` action in `DeviceTreeView`, invoked from two entry points per the shared-behavior policy:

- an always-visible "Add device" list row (also present in the empty state), `MobileDeviceTreeAddDevice`
- a toolbar plus button, `MobileDeviceTreeAddDeviceToolbar`

Both present the existing first-run `PairingView` (QR scan or manual host) as a sheet over the tree, driven by the same store mutations as the root pairing path (`connectPairingInput` / `connectManualHost`). No keyboard shortcut added. Pairing window internals (`MobilePairingView`/`Model`/`WindowController`, iOS URL scheme) are untouched.

Re-entering the flow over a live connection needed explicit policy, extracted into `DeviceTreeAddDevicePolicy` (a documented public value type in `CmuxMobileShellModel`, next to `MobileConnectionState`):

- Cancelling a freshly opened sheet must not call `cancelPairing()` while still connected; that call sets `connectionState = .disconnected` and would tear down the live connection.
- The sheet dismisses only when the attempt left the shell connected (success), then refreshes `loadPairedMacs` + `loadRegistryDevices` so the new device appears in the tree.
- A cancelled attempt (disconnected, no `connectionError` — the store's cancellation path sets none) restores the previously live Mac via the existing `switchToMac(macDeviceID:)`, so backing out of the sheet never strands the user.
- A failed attempt (error set) deliberately does not auto-restore: the reconnect path begins a fresh pairing attempt, which clears `connectionError` and would erase the failure reason while the user reads it on the auto-presented pairing sheet.

## Review notes (autoreview, 3 rounds)

Fixed from review: the policy is a value type with an initializer (was a namespace enum), all public API has DocC, and the cancel-restore behavior above came out of round 1. `cmux-policy-check` is clean.

Consciously deferred (one root cause, store-owned): `MobileShellComposite`'s pairing attempt is destructive — it can replace the live client before success, any new attempt clears the store-owned `connectionError`, and there is no way to invalidate an in-flight attempt without clearing the live context. Consequences the reviewer flagged: a genuinely failed add attempt still drops the live session (error stays readable, recovery is Settings -> Switch Mac), and a cancel during a mid-flight attempt cannot guarantee the attempt stops. Both are pre-existing in the shipped Settings -> Switch Mac -> "Pair Another Mac" path, which calls the same destructive `connectPairingURL` while connected with no restore and no cancellation at all; this PR's entry point is strictly safer than that path. The real fix is an attempt-scoped pairing API in the store (do not tear down the live client until the new connection succeeds; non-destructive cancel; failure reporting that survives a reconnect) — follow-up, and it intersects the concurrent pairing-flow work. Malformed input never reaches the destructive path: `PairingView` validates manual hosts locally and the QR scanner accepts only `cmux-ios://` pairing links.

## Tests

`DeviceTreeAddDevicePolicyTests` (8 tests) in `CmuxMobileShellModelTests`; `swift test --package-path Packages/CmuxMobileShellModel` green (38 tests, 7 suites). The policy lives in the model package because `CmuxMobileShellUI` declares iOS-only platforms and cannot host-run `swift test`.

Builds verified: iOS simulator arm64 (`ios/cmux.xcworkspace`, scheme `cmux-ios`) and macOS (`cmux.xcodeproj`, scheme `cmux`, build-only; the Mac app is behaviorally unchanged).

## Localization audit

No new user-facing strings. The row and the toolbar button's accessibility label reuse `mobile.addDevice.title` ("Add device"); `mobile.addDevice.title`, `mobile.common.done`, `mobile.deviceTree.title` verified present with en + ja in `ios/cmux/Resources/Localizable.xcstrings`. Accessibility identifiers are not user-facing.

## Dogfood

1. Pair the iPhone/simulator (`ios/scripts/reload.sh --tag adddev`), open the workspace list, tap the Devices toolbar icon.
2. Previously bad: the Devices sheet had no way to add a device. Now: an "Add device" row sits below the tree and a plus button sits in the toolbar; either opens the full Add device flow (QR scan or manual host).
3. Cancel the sheet without starting an attempt: the live connection must survive.
4. Pair a second Mac through it: on success the sheet closes and the new Mac appears in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mobile connection lifecycle around destructive pairing while connected; mitigated by explicit policy, restore via existing `switchToMac`, and unit tests, with known pre-existing limits on mid-flight cancel documented in the PR.
> 
> **Overview**
> The iOS **Devices** sheet (`DeviceTreeView`) now exposes **Add device** at all times—a list row (including empty state) and a toolbar **+**—both driving one `beginAddDevice()` path that presents the existing **`PairingView`** sheet over the tree.
> 
> A new **`DeviceTreeAddDevicePolicy`** in the model package encodes behavior when pairing re-enters over a live Mac session: **Cancel** must not call `cancelPairing()` while still connected; the sheet **dismisses and refreshes** the device list only on success; a **cancelled** attempt (disconnected, no `connectionError`) **restores** the prior Mac via `switchToMac`; **failed** attempts keep the sheet and error visible and do **not** auto-restore (reconnect would clear the error).
> 
> **`DeviceTreeAddDevicePolicyTests`** (8 cases) lock in those rules for `swift test` on the model package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ec65652f29c9b8751c0444830cefa2c93e4058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Add-device entry in the device tree (toolbar button and list row) opens a pairing sheet.
  * Pairing flow: safer cancel behavior that preserves live connections, restores previous Mac when appropriate, and refreshes paired/registry devices after successful pairing.
  * Accessibility identifier added to the device tree view.

* **Tests**
  * Tests covering cancel/dismiss/restore behavior across connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->