### PR TITLE
Refresh Swift file length budget after #5651

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -35,10 +35,10 @@
 3202	Sources/Update/UpdateTitlebarAccessory.swift
 2877	Sources/SessionIndexView.swift
 2871	cmuxTests/CMUXOpenCommandTests.swift
+2623	Sources/TerminalNotificationStore.swift
 2565	Sources/Panels/CmuxWebView.swift
 2545	cmuxTests/WorkspaceManualUnreadTests.swift
 2544	cmuxTests/CommandPaletteSearchEngineTests.swift
-2527	Sources/TerminalNotificationStore.swift
 2516	Sources/KeyboardShortcutSettings.swift
 2340	Sources/Mobile/MobileHostService.swift
 2327	cmuxTests/CJKIMEInputTests.swift
@@ -70,7 +70,7 @@
 1362	Sources/CMUXInstalledExtensionSidebarHostView.swift
 1313	cmuxTests/MobileHostAuthorizationTests.swift
 1285	cmuxUITests/SidebarHelpMenuUITests.swift
-1239	Sources/Feed/FeedCoordinator.swift
+1255	Sources/Feed/FeedCoordinator.swift
 1205	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
 1197	cmuxTests/CodexAppServerSessionTests.swift
 1156	cmuxTests/SidebarOrderingTests.swift


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/5651 (author @austinywang per the commit; merged to main as 11f1f6c2c) grew Sources/TerminalNotificationStore.swift (+96, 2623 vs budget 2527) and Sources/Feed/FeedCoordinator.swift (+16, 1255 vs 1239) without refreshing .github/swift-file-length-budget.tsv. The "Validate Swift file length budget" step of workflow-guard-tests therefore fails on current main and on every open PR once merged with it (first seen on https://github.com/manaflow-ai/cmux/pull/6017).

This refreshes the ledger with scripts/swift_file_length_budget.py --write-budget, accepting the already-merged growth as known debt. Both files stay tracked as split candidates. Metadata-only change, no runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783898485&installation_id=133855650&pr_number=6018&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6018&signature=1e3d9f17171f933396a7a729985f15be4274285af59cd5bf42dc99b03061b2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only CI ledger update with no application code or behavior changes.
> 
> **Overview**
> Updates **`.github/swift-file-length-budget.tsv`** so CI’s “Validate Swift file length budget” step matches current line counts after growth already merged in #5651.
> 
> The ledger raises caps for **`Sources/TerminalNotificationStore.swift`** (2527 → **2623**) and **`Sources/Feed/FeedCoordinator.swift`** (1239 → **1255**). Both files stay on the tracked split list; this is bookkeeping only—**no Swift or runtime changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e311bfb476eb33fd59ad0b0ccdd1a9b0da121b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Swift file length budget to match file growth from #5651, restoring the Validate Swift file length budget CI check. Metadata-only change; accepts the increases as known debt; no runtime changes.

<sup>Written for commit 36e311bfb476eb33fd59ad0b0ccdd1a9b0da121b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

