### PR TITLE
CI: refresh Swift file-length budget for files grown by merged PR 5726

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -38,7 +38,7 @@
 2565	Sources/Panels/CmuxWebView.swift
 2545	cmuxTests/WorkspaceManualUnreadTests.swift
 2544	cmuxTests/CommandPaletteSearchEngineTests.swift
-2527	Sources/TerminalNotificationStore.swift
+2623	Sources/TerminalNotificationStore.swift
 2516	Sources/KeyboardShortcutSettings.swift
 2327	cmuxTests/CJKIMEInputTests.swift
 2322	Sources/Mobile/MobileHostService.swift
@@ -70,7 +70,7 @@
 1362	Sources/CMUXInstalledExtensionSidebarHostView.swift
 1313	cmuxTests/MobileHostAuthorizationTests.swift
 1285	cmuxUITests/SidebarHelpMenuUITests.swift
-1239	Sources/Feed/FeedCoordinator.swift
+1255	Sources/Feed/FeedCoordinator.swift
 1205	Packages/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
 1197	cmuxTests/CodexAppServerSessionTests.swift
 1156	cmuxTests/SidebarOrderingTests.swift


### PR DESCRIPTION
workflow-guard-tests is failing on main and on every PR branched from it: https://github.com/manaflow-ai/cmux/pull/5726 grew `Sources/TerminalNotificationStore.swift` to 2623 lines (budget 2527) and `Sources/Feed/FeedCoordinator.swift` to 1255 (budget 1239) without refreshing `.github/swift-file-length-budget.tsv`.

This refreshes exactly those two entries to the already-merged line counts (accepting the landed growth as known debt, per the guard's own guidance). Metadata-only, no source changes, no runtime behavior change. Verified locally: `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv` passes.

Unblocks current PRs hitting this on unrelated diffs, e.g. https://github.com/manaflow-ai/cmux/pull/6019 and https://github.com/manaflow-ai/cmux/pull/6021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783900129&installation_id=133855650&pr_number=6023&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6023&signature=76fab8ae19a349e62438671f72c8fc307d19fa2c2e92c2ed5009acffb8f02375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the Swift file-length budget to match merged changes, restoring workflow-guard-tests on main and PRs. Updated `.github/swift-file-length-budget.tsv` for `Sources/TerminalNotificationStore.swift` to 2623 lines and `Sources/Feed/FeedCoordinator.swift` to 1255; no source or runtime changes.

<sup>Written for commit 72bf9226ec1b6b4be3e6812f08b7b441624ff2d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

