### PR TITLE
Dedupe TerminalNotificationStore.swift in the Swift file length budget

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -35,7 +35,6 @@
 3202	Sources/Update/UpdateTitlebarAccessory.swift
 2877	Sources/SessionIndexView.swift
 2871	cmuxTests/CMUXOpenCommandTests.swift
-2623	Sources/TerminalNotificationStore.swift
 2565	Sources/Panels/CmuxWebView.swift
 2545	cmuxTests/WorkspaceManualUnreadTests.swift
 2544	cmuxTests/CommandPaletteSearchEngineTests.swift


### PR DESCRIPTION
Two squash merges each updated the same budget entry: https://github.com/manaflow-ai/cmux/commit/ea8d79964 refreshed `Sources/TerminalNotificationStore.swift` to 2623 and https://github.com/manaflow-ai/cmux/pull/6020 replaced it with 1941 after extracting `NotificationSoundSettings`. Both applied textually in different spots, so main's `.github/swift-file-length-budget.tsv` now lists the file twice and `scripts/swift_file_length_budget.py` exits 2 on duplicates, failing `workflow-guard-tests` on every PR.

Drop the stale 2623 line; the file is 1941 lines on main. Verified locally: the budget script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783901420&installation_id=133855650&pr_number=6025&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6025&signature=4afef9663ffdf41a2f4a4457140d9f7c75b39a24e329ddd3ececad29e658fe13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line cleanup in a CI budget manifest; no runtime or product code changes.
> 
> **Overview**
> Removes a **duplicate** row for `Sources/TerminalNotificationStore.swift` from `.github/swift-file-length-budget.tsv`, leaving the current **1941**-line budget and dropping the stale **2623** entry left by overlapping squash merges.
> 
> That duplicate made `scripts/swift_file_length_budget.py` fail on load and broke **`workflow-guard-tests`** on PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c687acc7bda889e11aae8655793195c276ebd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stale 2623-line entry for `Sources/TerminalNotificationStore.swift` from `.github/swift-file-length-budget.tsv` to match the current 1941-line count. This fixes duplicate detection in `scripts/swift_file_length_budget.py` and stops `workflow-guard-tests` from failing.

<sup>Written for commit 2c687acc7bda889e11aae8655793195c276ebd1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

