### PR TITLE
zsh integration: use zsh/zselect for poll-loop sleeps (no fork)

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -14,6 +14,26 @@ if zmodload zsh/parameter 2>/dev/null && (( ${+jobstates} )); then
     _CMUX_HAS_ZSH_JOBSTATES=1
 fi
 
+# Prefer zsh/zselect for the poll-loop sleeps in the git-HEAD and PR-status
+# watchers (no fork, vs ~1 fork+exec of /bin/sleep per second per pane).
+# Falls back to /bin/sleep if the module is unavailable.
+typeset -g _CMUX_HAS_ZSELECT=0
+if zmodload zsh/zselect 2>/dev/null; then
+    _CMUX_HAS_ZSELECT=1
+fi
+
+# Fork-free sleep.  Argument is in centiseconds (zselect's -t unit), so a
+# whole-second wait is `_cmux_sleep_cs 100`.  zselect with only -t and no fds
+# returns status 1 on timeout, so call it then return 0 explicitly rather than
+# falling through to the /bin/sleep fallback (which would double the wait).
+_cmux_sleep_cs() {
+    if (( _CMUX_HAS_ZSELECT )); then
+        zselect -t "$1"
+        return 0
+    fi
+    sleep "$(( $1 / 100.0 ))"
+}
+
 _cmux_zsh_job_table_saturated() {
     (( _CMUX_HAS_ZSH_JOBSTATES )) || return 1
 
@@ -1379,14 +1399,14 @@ _cmux_run_pr_probe_with_timeout() {
     probe_pid=$!
 
     while kill -0 "$probe_pid" >/dev/null 2>&1; do
-        sleep 1
+        _cmux_sleep_cs 100
         now="${EPOCHSECONDS:-$SECONDS}"
         if (( _CMUX_ASYNC_JOB_TIMEOUT > 0 )) && (( now - started_at >= _CMUX_ASYNC_JOB_TIMEOUT )); then
             _cmux_kill_process_tree "$probe_pid" TERM
-            sleep 0.2
+            _cmux_sleep_cs 20
             if kill -0 "$probe_pid" >/dev/null 2>&1; then
                 _cmux_kill_process_tree "$probe_pid" KILL
-                sleep 0.2
+                _cmux_sleep_cs 20
             fi
             if ! kill -0 "$probe_pid" >/dev/null 2>&1; then
                 wait "$probe_pid" >/dev/null 2>&1 || true
@@ -1461,7 +1481,7 @@ _cmux_start_pr_poll_loop() {
                 if [[ -n "$signal_path" && -f "$signal_path" ]]; then
                     break
                 fi
-                sleep 1
+                _cmux_sleep_cs 100
                 slept=$(( slept + 1 ))
             done
         done
@@ -1500,7 +1520,7 @@ _cmux_start_git_head_watch() {
         local last_signature="$watch_head_signature"
         while true; do
             kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
-            sleep 1
+            _cmux_sleep_cs 100
 
             local signature
             signature="$(_cmux_git_head_signature "$watch_head_path" 2>/dev/null || true)"


### PR DESCRIPTION
# zsh integration: use `zsh/zselect` for poll-loop sleeps (no fork)

## Problem

The shell integration starts two background watcher loops **per pane**:

- `_cmux_start_git_head_watch` — polls `.git/HEAD` every second to refresh the branch/PR display
- `_cmux_start_pr_poll_loop` — counts down its poll interval in 1-second steps

Both loops fork `/bin/sleep` once per second, indefinitely, for the life of the pane. With several panes open this is a continuous, low-level source of process churn. It's especially visible on managed machines where host security/EDR agents (CrowdStrike, FortiDLP, etc.) inspect every `exec` — each `sleep` fork fans out to every Endpoint Security client.

This is the same class of overhead the file already optimizes away for socket sends (`zsh/net/unix`, "~0.2ms vs ~3ms for fork+exec") and job-table checks (`zsh/parameter`).

## Change

Add a `_cmux_sleep_cs` helper (argument in centiseconds) backed by the `zsh/zselect` builtin, whose `-t` timeout sleeps **without forking**. Falls back to `/bin/sleep` when the module is unavailable. Route the five in-shell `sleep` calls in the watcher loops through it.

Net effect: the steady-state per-pane sleep fork rate drops from ~1/sec to **0**.

### Subtlety worth a look

`zselect` with only `-t` and no fds returns status **1** on timeout. The helper therefore calls `zselect` and then `return 0` explicitly — a naive `zselect -t "$1" || sleep ...` would fall through and double every wait.

## Testing

- `zsh -n` passes on the modified file.
- `zselect -t 100` sleeps ~1.00s fork-free in a backgrounded subshell with redirected std streams + stdin from `/dev/null` (the watchers' exact context).
- Fallback path (`_CMUX_HAS_ZSELECT=0`) sleeps correctly via `/bin/sleep`.
- Process-group kill teardown (`_cmux_halt_pr_poll_loop`) is unaffected — `zselect`, like `sleep`, is interrupted by the signal.

I did not wire this into the VM-based test suite in `tests/` since those run against a built app; happy to add coverage if you'd like a specific form.

## Scope

zsh only. `bash` has no equivalent non-forking sleep builtin (macOS ships bash 3.2), so `cmux-bash-integration.bash` is intentionally left unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783916328&installation_id=133855650&pr_number=6032&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6032&signature=1470cfcfdd46b3915bae7142bff93c92d5e5304e926ff4adbcb83541985e79fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `zsh/zselect` for watcher loop sleeps to avoid forking `\bin\sleep`. This removes the steady 1/sec fork per pane and reduces process churn on EDR-heavy machines.

- **Refactors**
  - Added `_cmux_sleep_cs` (centiseconds) using `zsh/zselect -t`; returns 0 on timeout; falls back to `/bin/sleep`.
  - Routed sleeps in `_cmux_start_git_head_watch`, `_cmux_start_pr_poll_loop`, and probe timeout waits through the helper; preserves signal interruption.
  - Scope: zsh only.

<sup>Written for commit c37af7cf3a4133bde1b46b8459d3ec9aa623b6ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized zsh shell integration timing operations to improve performance and reduce system resource usage in monitoring processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->