### PR TITLE
Improve mobile workspace group behavior

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -6,10 +6,10 @@
 19225	Sources/ContentView.swift
 18118	Sources/AppDelegate.swift
 16674	Sources/GhosttyTerminalView.swift
-14610	Sources/TerminalController.swift
+14612	Sources/TerminalController.swift
 13606	Sources/Panels/BrowserPanel.swift
 12044	cmuxTests/AppDelegateShortcutRoutingTests.swift
-10020	Sources/TabManager.swift
+10039	Sources/TabManager.swift
 9345	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7737	Sources/Panels/BrowserPanelView.swift
 7291	cmuxTests/WorkspaceUnitTests.swift
@@ -21,7 +21,7 @@
 6071	Sources/TextBoxInput.swift
 5482	cmuxTests/BrowserConfigTests.swift
 5462	Sources/cmuxApp.swift
-4726	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+4737	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4460	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift
@@ -91,7 +91,7 @@
 939	Sources/App/TerminalDirectoryOpenSupport.swift
 937	Sources/TextBoxMentionIndexStore.swift
 924	Sources/DockPanelView.swift
-913	cmuxTests/WorkspaceGroupTests.swift
+911	cmuxTests/WorkspaceGroupTests.swift
 905	Sources/CmuxSSHURLRequest.swift
 896	Sources/CommandPalette/CommandPaletteSettingsToggle.swift
 878	Sources/WorkspaceContentView.swift

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceGroup/ControlCommandCoordinator+WorkspaceGroup.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceGroup/ControlCommandCoordinator+WorkspaceGroup.swift
@@ -326,7 +326,7 @@ extension ControlCommandCoordinator {
         let resolution = context?.controlCreateWorkspaceInGroup(
             routing: routingSelectors(params),
             groupID: gid,
-            placementRaw: string(params, "placement")
+            placementRaw: rawString(params, "placement")
         ) ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:

--- a/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorWindowTests.swift
+++ b/Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorWindowTests.swift
@@ -19,6 +19,7 @@ private final class FakeControlCommandContext: ControlCommandContext {
     var moveWindowResult: String?
     var movedWindow: (id: UUID, query: String)?
     var moveAllResult: ControlMoveAllWindowsResult?
+    var lastGroupNewWorkspacePlacementRaw: String?
 
     func controlWindowSummaries() -> [ControlWindowSummary] { windowSummaries }
 
@@ -51,6 +52,16 @@ private final class FakeControlCommandContext: ControlCommandContext {
     func controlMoveAllWindows(toDisplayMatching query: String) -> ControlMoveAllWindowsResult? {
         moveAllResult
     }
+
+    func controlCreateWorkspaceInGroup(
+        routing: ControlRoutingSelectors,
+        groupID: UUID,
+        placementRaw: String?
+    ) -> ControlWorkspaceGroupNewWorkspaceResolution {
+        lastGroupNewWorkspacePlacementRaw = placementRaw
+        if let placementRaw { return .invalidPlacement(placementRaw) }
+        return .created(workspaceID: UUID())
+    }
 }
 
 @MainActor
@@ -71,6 +82,22 @@ struct ControlCommandCoordinatorWindowTests {
         // A method no coordinator domain owns (still served by the legacy
         // app-side dispatcher), so `handle` falls through with `nil`.
         #expect(coordinator.handle(request("legacy.unowned_method")) == nil)
+    }
+
+    @Test func groupNewWorkspaceRejectsPresentEmptyPlacement() {
+        let (coordinator, context) = makeCoordinator()
+        let groupID = UUID()
+        let result = coordinator.handle(request("workspace.group.new_workspace", [
+            "group_id": .string(groupID.uuidString),
+            "placement": .string(""),
+        ]))
+
+        #expect(context.lastGroupNewWorkspacePlacementRaw == "")
+        #expect(result == .err(
+            code: "invalid_params",
+            message: "placement must be one of: afterCurrent, top, end",
+            data: .object(["placement": .string("")])
+        ))
     }
 
     @Test func windowListBuildsRowsWithMintedRefs() {

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceGroupMerging.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceGroupMerging.swift
@@ -1,0 +1,107 @@
+import CmuxMobileRPC
+import CmuxMobileShellModel
+
+extension MobileShellComposite {
+    func applyMergedRemoteWorkspaces(
+        _ remoteWorkspaces: [MobileWorkspacePreview],
+        replacingWindowSlices: Bool
+    ) -> Set<MobileWorkspacePreview.ID> {
+        guard replacingWindowSlices else {
+            workspaces = mergeRemoteWorkspacesByID(remoteWorkspaces)
+            return []
+        }
+        let windowIDs = Set(remoteWorkspaces.compactMap(\.windowID))
+        let replacedWorkspaceIDs = Set(workspaces.filter { workspace in
+            workspace.windowID.map { windowIDs.contains($0) } ?? false
+        }.map(\.id))
+        workspaces = mergeRemoteWorkspacesReplacingWindowSlices(remoteWorkspaces)
+        return replacedWorkspaceIDs
+    }
+
+    func mergeRemoteWorkspacesByID(
+        _ remoteWorkspaces: [MobileWorkspacePreview]
+    ) -> [MobileWorkspacePreview] {
+        var mergedWorkspaces = workspaces
+        for remoteWorkspace in remoteWorkspaces {
+            if let existingIndex = mergedWorkspaces.firstIndex(where: { $0.id == remoteWorkspace.id }) {
+                mergedWorkspaces[existingIndex] = remoteWorkspace
+            } else {
+                mergedWorkspaces.append(remoteWorkspace)
+            }
+        }
+        return mergedWorkspaces
+    }
+
+    func mergeRemoteWorkspacesReplacingWindowSlices(
+        _ remoteWorkspaces: [MobileWorkspacePreview]
+    ) -> [MobileWorkspacePreview] {
+        var windowOrder: [String] = []
+        var remoteByWindowID: [String: [MobileWorkspacePreview]] = [:]
+        var remoteWithoutWindowID: [MobileWorkspacePreview] = []
+        for remoteWorkspace in remoteWorkspaces {
+            guard let windowID = remoteWorkspace.windowID else {
+                remoteWithoutWindowID.append(remoteWorkspace)
+                continue
+            }
+            if remoteByWindowID[windowID] == nil {
+                windowOrder.append(windowID)
+                remoteByWindowID[windowID] = []
+            }
+            remoteByWindowID[windowID]?.append(remoteWorkspace)
+        }
+        guard !remoteByWindowID.isEmpty else {
+            return mergeRemoteWorkspacesByID(remoteWorkspaces)
+        }
+
+        var mergedWorkspaces: [MobileWorkspacePreview] = []
+        mergedWorkspaces.reserveCapacity(workspaces.count + remoteWorkspaces.count)
+        var emittedWindowIDs: Set<String> = []
+        for workspace in workspaces {
+            guard let windowID = workspace.windowID, let remoteSlice = remoteByWindowID[windowID] else {
+                mergedWorkspaces.append(workspace)
+                continue
+            }
+            if emittedWindowIDs.insert(windowID).inserted {
+                mergedWorkspaces.append(contentsOf: remoteSlice)
+            }
+        }
+        for windowID in windowOrder where !emittedWindowIDs.contains(windowID) {
+            mergedWorkspaces.append(contentsOf: remoteByWindowID[windowID] ?? [])
+        }
+        for remoteWorkspace in remoteWithoutWindowID {
+            if let existingIndex = mergedWorkspaces.firstIndex(where: { $0.id == remoteWorkspace.id }) {
+                mergedWorkspaces[existingIndex] = remoteWorkspace
+            } else {
+                mergedWorkspaces.append(remoteWorkspace)
+            }
+        }
+        return mergedWorkspaces
+    }
+
+    func mergeRemoteWorkspaceGroups(
+        _ remoteGroups: [MobileSyncWorkspaceListResponse.Group],
+        replacingGroupsAnchoredIn replacedWorkspaceIDs: Set<MobileWorkspacePreview.ID> = []
+    ) {
+        guard !remoteGroups.isEmpty || !replacedWorkspaceIDs.isEmpty else { return }
+        let remoteGroupIDs = Set(remoteGroups.map { MobileWorkspaceGroupPreview.ID(rawValue: $0.id) })
+        var mergedGroups = workspaceGroups
+        if !replacedWorkspaceIDs.isEmpty {
+            mergedGroups.removeAll { group in
+                replacedWorkspaceIDs.contains(group.anchorWorkspaceID) && !remoteGroupIDs.contains(group.id)
+            }
+        }
+        var indexByID: [MobileWorkspaceGroupPreview.ID: Int] = [:]
+        for (index, group) in mergedGroups.enumerated() where indexByID[group.id] == nil {
+            indexByID[group.id] = index
+        }
+        for remoteGroup in remoteGroups.map({ MobileWorkspaceGroupPreview(remote: $0) }) {
+            if let existingIndex = indexByID[remoteGroup.id] {
+                mergedGroups[existingIndex] = remoteGroup
+            } else {
+                indexByID[remoteGroup.id] = mergedGroups.count
+                mergedGroups.append(remoteGroup)
+            }
+        }
+        workspaceGroups = mergedGroups
+    }
+}

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -63,6 +63,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private static let workspaceCloseCapability = "workspace.close.v1"
     private static let dogfoodFeedbackCapability = "dogfood.v1"
     private static let workspaceGroupsCapability = "workspace.groups.v1"
+    private static let workspaceGroupNewWorkspaceCapability = "workspace.group.new_workspace.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
 
     /// How long the render-grid stream may stay silent (no event of any topic)
@@ -182,29 +183,25 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return Self.attachTicketIsUnexpired(activeTicket, now: runtime?.now() ?? Date())
     }
     public var pairingCode: String
-    public var workspaces: [MobileWorkspacePreview] {
-        didSet { workspaceTopologyVersion &+= 1 }
-    }
-    /// Bumped on every ``workspaces`` mutation: a cheap "lists may have
-    /// changed" signal (e.g. for retrying a parked notification deep link).
+    /// The current Mac workspace previews.
+    public var workspaces: [MobileWorkspacePreview] { didSet { workspaceTopologyVersion &+= 1 } }
+    /// Incremented whenever ``workspaces`` changes.
     public private(set) var workspaceTopologyVersion: UInt64 = 0
-    /// The Mac's workspace groups, in section order. Empty when the Mac reports no
-    /// groups (or is old enough not to emit them). Drives the collapsible group
-    /// sections in the workspace list.
+    /// The current Mac workspace groups.
     public var workspaceGroups: [MobileWorkspaceGroupPreview] = []
-    /// The connected Mac's `mobile.host.status` capabilities. Feature gates are
-    /// computed from this set so version-skew checks cannot drift from the raw
-    /// host payload.
+    /// The connected Mac's advertised capability strings.
     public private(set) var supportedHostCapabilities: Set<String> = []
-    /// Whether the Mac supports workspace group sections and collapse/expand RPCs.
+    /// Whether group list and collapse actions are available.
     public var supportsWorkspaceGroups: Bool { supportedHostCapabilities.contains(Self.workspaceGroupsCapability) }
-    /// Whether the Mac supports rename/pin workspace actions.
+    /// Whether creating a workspace inside an existing group is available.
+    public var supportsWorkspaceGroupNewWorkspace: Bool { supportedHostCapabilities.contains(Self.workspaceGroupNewWorkspaceCapability) }
+    /// Whether rename and pin workspace actions are available.
     public var supportsWorkspaceActions: Bool { supportedHostCapabilities.contains(Self.workspaceActionsCapability) }
-    /// Whether the Mac supports mark read/unread workspace actions.
+    /// Whether mark read/unread workspace actions are available.
     public var supportsWorkspaceReadStateActions: Bool { supportedHostCapabilities.contains(Self.workspaceReadStateCapability) }
-    /// Whether the Mac supports workspace close requests.
+    /// Whether workspace close actions are available.
     public var supportsWorkspaceCloseActions: Bool { supportedHostCapabilities.contains(Self.workspaceCloseCapability) }
-    /// Whether the Mac supports dogfood feedback submission.
+    /// Whether dogfood feedback submission is available.
     public var supportsDogfoodFeedback: Bool { supportedHostCapabilities.contains(Self.dogfoodFeedbackCapability) }
     /// The composer's live draft for the currently selected terminal.
     ///
@@ -215,40 +212,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public var terminalInputText: String {
         didSet {
             #if DEBUG
-            // COMPOSER: record every draft change so a captured trace shows whether
-            // the draft was cleared at the store (b == 1) during a keyboard-dismiss
-            // cycle, vs. only disappearing from the view. `didSet` does not fire on
-            // the `init` assignment, so this is safe to read `diagnosticLog`.
             diagnosticLog?.record(DiagnosticEvent(
                 .composerInputTextChanged,
                 a: terminalInputText.utf8.count,
                 b: terminalInputText.isEmpty ? 1 : 0
             ))
             #endif
-            // Persist the live edit under the CURRENT terminal so it survives a
-            // terminal switch. Skipped while a draft is being loaded (the load is
-            // the saved value, re-saving it is redundant and would race the
-            // per-terminal key swap) and when the value is unchanged.
             guard !isLoadingDraft, terminalInputText != oldValue else { return }
-            // A user edit claims field ownership for the selected terminal: the
-            // live input is now authoritative, so a still-in-flight stored-draft
-            // load must not apply over it (see ``applyLoadedDraft``).
             draftLoadPendingTerminalID = nil
             persistCurrentDraft()
         }
     }
-    /// Whether the iMessage-style composer is shown above the terminal, observed
-    /// by the terminal screen to present ``terminalInputText`` for multi-line
-    /// editing.
-    ///
-    /// OPEN BY DEFAULT per terminal: like iMessage showing its input bar in every
-    /// conversation, the composer is presented for any selected terminal the user
-    /// has not explicitly dismissed (``composerDismissedTerminalIDs`` records the
-    /// exception, not the rule). Presented does NOT mean focused — the keyboard
-    /// comes up only when the user taps the field or an explicit open/reveal
-    /// requests focus (``composerFocusRequest``). Derived from observable stored
-    /// state (`selectedTerminalID` + the dismissed set), so views tracking it
-    /// re-render on terminal switches and explicit toggles alike.
+    /// Whether the iMessage-style composer is shown above the terminal.
     public var isComposerPresented: Bool {
         guard let terminalID = selectedTerminalID?.rawValue else { return false }
         return !composerDismissedTerminalIDs.contains(terminalID)
@@ -2151,6 +2126,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     public func createWorkspace() {
+        createWorkspace(groupID: nil)
+    }
+
+    /// Creates a workspace inside the specified group.
+    public func createWorkspace(inGroup groupID: MobileWorkspaceGroupPreview.ID) {
+        createWorkspace(groupID: groupID)
+    }
+
+    private func createWorkspace(groupID: MobileWorkspaceGroupPreview.ID?) {
         guard remoteClient == nil else {
             guard createWorkspaceTask == nil else { return }
             let taskID = UUID()
@@ -2158,7 +2142,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             createWorkspaceTask = Task { @MainActor [weak self] in
                 defer { self?.clearCreateWorkspaceTask(id: taskID) }
                 guard let self else { return }
-                await self.createRemoteWorkspace()
+                await self.createRemoteWorkspace(groupID: groupID)
             }
             return
         }
@@ -2166,6 +2150,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let workspace = MobileWorkspacePreview(
             id: .init(rawValue: "workspace-\(nextIndex)"),
             name: L10n.workspaceName(index: nextIndex),
+            groupID: groupID,
             terminals: [
                 MobileTerminalPreview(
                     id: .init(rawValue: "workspace-\(nextIndex)-terminal-1"),
@@ -2173,6 +2158,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 ),
             ]
         )
+        if let groupID, let index = workspaceGroups.firstIndex(where: { $0.id == groupID }) {
+            workspaceGroups[index].isCollapsed = false
+        }
         workspaces.append(workspace)
         selectedWorkspaceID = workspace.id
         selectedTerminalID = workspace.terminals.first?.id
@@ -3260,27 +3248,31 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         MobileTerminalViewportKey(workspaceID: workspaceID, terminalID: terminalID)
     }
 
-    private func createRemoteWorkspace() async {
+    private func createRemoteWorkspace(groupID: MobileWorkspaceGroupPreview.ID? = nil) async {
         guard let client = remoteClient else { return }
         let generation = connectionGeneration
         do {
-            let resultData = try await client.sendRequest(
-                MobileCoreRPCClient.requestData(method: "workspace.create")
-            )
+            let request = try groupID.map {
+                try MobileCoreRPCClient.requestData(
+                    method: "workspace.group.new_workspace",
+                    params: [
+                        "group_id": $0.rawValue,
+                        "client_id": clientID,
+                    ]
+                )
+            } ?? MobileCoreRPCClient.requestData(method: "workspace.create")
+            let resultData = try await client.sendRequest(request)
             let response = try MobileSyncWorkspaceListResponse.decode(resultData)
             guard isCurrentRemoteOperation(client: client, generation: generation),
                   !Task.isCancelled else { return }
-            applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true)
+            applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true, mergeWorkspaceGroups: groupID != nil)
             let createdWorkspace = response.createdWorkspaceID.map(MobileWorkspacePreview.ID.init(rawValue:))
             if let createdWorkspace {
                 setSelectedWorkspaceID(createdWorkspace)
             }
             syncSelectedTerminalForWorkspace()
             if createdWorkspace != nil {
-                // A "+" actually created and selected a new workspace, so its
-                // terminal is freshly created: don't pop the keyboard on mount.
-                // When no workspace was created the selection never moved, so we
-                // must not suppress the user's current terminal.
+                // Chrome-created terminals should not pop the keyboard on mount.
                 suppressTerminalAutoFocusOnNextAttach(for: selectedTerminalID)
             }
         } catch {
@@ -4503,47 +4495,65 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         selectedWorkspaceID = id
     }
 
-    private func applyRemoteWorkspaceList(
+    func applyRemoteWorkspaceList(
         _ response: MobileSyncWorkspaceListResponse,
         preferActiveTicketTarget: Bool = false,
-        mergeExistingWorkspaces: Bool = false
+        mergeExistingWorkspaces: Bool = false, mergeWorkspaceGroups: Bool = false
     ) {
         let remoteWorkspaces = remoteWorkspacesPreservingSnapshots(from: response)
+        let replacedWorkspaceIDs: Set<MobileWorkspacePreview.ID>
         if mergeExistingWorkspaces {
-            var mergedWorkspaces = workspaces
-            for remoteWorkspace in remoteWorkspaces {
-                if let existingIndex = mergedWorkspaces.firstIndex(where: { $0.id == remoteWorkspace.id }) {
-                    mergedWorkspaces[existingIndex] = remoteWorkspace
-                } else {
-                    mergedWorkspaces.append(remoteWorkspace)
-                }
-            }
-            workspaces = mergedWorkspaces
+            replacedWorkspaceIDs = applyMergedRemoteWorkspaces(
+                remoteWorkspaces,
+                replacingWindowSlices: mergeWorkspaceGroups
+            )
         } else {
+            replacedWorkspaceIDs = []
             workspaces = remoteWorkspaces
         }
-        // Group sections always reflect the latest full response (never merged):
-        // a merge path is a single-entry create/refresh that omits groups, so
-        // applying its empty groups array would wrongly clear the sections. Only a
-        // full-list response (the non-merge path, which the event-driven refresh
-        // and initial sync use) carries authoritative group state.
-        if !mergeExistingWorkspaces {
+        if mergeWorkspaceGroups {
+            mergeRemoteWorkspaceGroups(response.groups, replacingGroupsAnchoredIn: replacedWorkspaceIDs)
+        } else if !mergeExistingWorkspaces {
             workspaceGroups = response.groups.map { MobileWorkspaceGroupPreview(remote: $0) }
         }
         if preferActiveTicketTarget, selectActiveTicketTargetIfAvailable() {
             return
         }
-        if let selectedWorkspaceID,
-           workspaces.contains(where: { $0.id == selectedWorkspaceID }) {
+        if reconcileSelectedWorkspaceWithVisibleGroupState() {
             syncSelectedTerminalForWorkspace()
             return
         }
-        setSelectedWorkspaceID(
-            response.workspaces.first(where: \.isSelected)
-                .map { MobileWorkspacePreview.ID(rawValue: $0.id) }
-                ?? workspaces.first?.id
-        )
+        let remoteSelectedWorkspaceID = response.workspaces.first(where: \.isSelected)
+            .map { MobileWorkspacePreview.ID(rawValue: $0.id) }
+        let fallbackWorkspaceID = remoteSelectedWorkspaceID ?? workspaces.first?.id
+        setSelectedWorkspaceID(visibleWorkspaceSelectionID(for: fallbackWorkspaceID) ?? workspaces.first?.id)
         syncSelectedTerminalForWorkspace()
+    }
+
+    @discardableResult
+    func reconcileSelectedWorkspaceWithVisibleGroupState() -> Bool {
+        guard let selectedWorkspaceID,
+              let visibleWorkspaceID = visibleWorkspaceSelectionID(for: selectedWorkspaceID)
+        else { return false }
+        setSelectedWorkspaceID(visibleWorkspaceID)
+        return true
+    }
+
+    private func visibleWorkspaceSelectionID(
+        for workspaceID: MobileWorkspacePreview.ID?
+    ) -> MobileWorkspacePreview.ID? {
+        guard let workspaceID,
+              let workspace = workspaces.first(where: { $0.id == workspaceID })
+        else { return nil }
+        guard let groupID = workspace.groupID,
+              let group = workspaceGroups.first(where: { $0.id == groupID }),
+              group.isCollapsed,
+              group.anchorWorkspaceID != workspaceID
+        else { return workspaceID }
+        guard workspaces.contains(where: { $0.id == group.anchorWorkspaceID }) else {
+            return workspaceID
+        }
+        return group.anchorWorkspaceID
     }
 
     private func remoteWorkspacesPreservingSnapshots(

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -64,6 +64,242 @@ import Testing
         #expect(store.workspaceGroups.isEmpty)
     }
 
+    @Test func collapsedGroupSelectionMovesHiddenMemberToAnchor() {
+        let store = MobileShellComposite(
+            workspaces: groupSelectionWorkspaces(),
+            draftStore: InMemoryTerminalDraftStore()
+        )
+        store.workspaceGroups = [
+            MobileWorkspaceGroupPreview(
+                id: "group-1",
+                name: "Feature",
+                isCollapsed: true,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-anchor"
+            )
+        ]
+        store.selectedWorkspaceID = "workspace-child"
+        store.selectedTerminalID = "terminal-child"
+
+        store.reconcileSelectedWorkspaceWithVisibleGroupState()
+
+        #expect(store.selectedWorkspaceID == "workspace-anchor")
+        #expect(store.selectedTerminalID == "terminal-anchor")
+    }
+
+    @Test func expandedGroupSelectionKeepsMemberSelected() {
+        let store = MobileShellComposite(
+            workspaces: groupSelectionWorkspaces(),
+            draftStore: InMemoryTerminalDraftStore()
+        )
+        store.workspaceGroups = [
+            MobileWorkspaceGroupPreview(
+                id: "group-1",
+                name: "Feature",
+                isCollapsed: false,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-anchor"
+            )
+        ]
+        store.selectedWorkspaceID = "workspace-child"
+        store.selectedTerminalID = "terminal-child"
+
+        store.reconcileSelectedWorkspaceWithVisibleGroupState()
+
+        #expect(store.selectedWorkspaceID == "workspace-child")
+        #expect(store.selectedTerminalID == "terminal-child")
+    }
+
+    @Test func createWorkspaceInGroupAddsGroupedWorkspaceAndExpandsGroup() {
+        let store = MobileShellComposite(
+            workspaces: groupSelectionWorkspaces(),
+            draftStore: InMemoryTerminalDraftStore()
+        )
+        store.workspaceGroups = [
+            MobileWorkspaceGroupPreview(
+                id: "group-1",
+                name: "Feature",
+                isCollapsed: true,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-anchor"
+            )
+        ]
+
+        store.createWorkspace(inGroup: "group-1")
+
+        let created = store.workspaces.last
+        #expect(created?.groupID == "group-1")
+        #expect(store.workspaceGroups.first?.isCollapsed == false)
+        #expect(store.selectedWorkspaceID == created?.id)
+        #expect(store.selectedTerminalID == created?.terminals.first?.id)
+    }
+
+    @Test func scopedGroupWorkspaceResponsePreservesOtherWindows() throws {
+        let store = MobileShellComposite(
+            workspaces: [
+                testWorkspace("workspace-anchor", windowID: "window-group", name: "Feature", groupID: "group-1", terminal: "terminal-anchor"),
+                testWorkspace("workspace-child", windowID: "window-group", name: "Implementation", groupID: "group-1", terminal: "terminal-child"),
+                testWorkspace("workspace-bottom", windowID: "window-group", name: "Bottom", terminal: "terminal-bottom"),
+                testWorkspace("workspace-stale-anchor", windowID: "window-group", name: "Stale", groupID: "group-stale", terminal: "terminal-stale"),
+                testWorkspace("workspace-other-window", windowID: "window-other", name: "Other window", groupID: "group-other", terminal: "terminal-other"),
+            ],
+            draftStore: InMemoryTerminalDraftStore()
+        )
+        store.workspaceGroups = [
+            MobileWorkspaceGroupPreview(
+                id: "group-1",
+                name: "Feature",
+                isCollapsed: true,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-anchor"
+            ),
+            MobileWorkspaceGroupPreview(
+                id: "group-stale",
+                name: "Stale",
+                isCollapsed: false,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-stale-anchor"
+            ),
+            MobileWorkspaceGroupPreview(
+                id: "group-other",
+                name: "Other window group",
+                isCollapsed: false,
+                isPinned: false,
+                anchorWorkspaceID: "workspace-other-window"
+            ),
+        ]
+
+        let response = try mobileWorkspaceListResponse(
+            """
+            {
+              "created_workspace_id": "workspace-created",
+              "workspaces": [
+                {
+                  "id": "workspace-anchor",
+                  "window_id": "window-group",
+                  "title": "Feature",
+                  "current_directory": null,
+                  "is_selected": false,
+                  "is_pinned": false,
+                  "group_id": "group-1",
+                  "terminals": [
+                    {
+                      "id": "terminal-anchor",
+                      "title": "anchor",
+                      "current_directory": null,
+                      "is_focused": true,
+                      "is_ready": true
+                    }
+                  ]
+                },
+                {
+                  "id": "workspace-created",
+                  "window_id": "window-group",
+                  "title": "New workspace",
+                  "current_directory": null,
+                  "is_selected": true,
+                  "is_pinned": false,
+                  "group_id": "group-1",
+                  "terminals": [
+                    {
+                      "id": "terminal-created",
+                      "title": "terminal",
+                      "current_directory": null,
+                      "is_focused": true,
+                      "is_ready": true
+                    }
+                  ]
+                },
+                {
+                  "id": "workspace-child",
+                  "window_id": "window-group",
+                  "title": "Implementation",
+                  "current_directory": null,
+                  "is_selected": false,
+                  "is_pinned": false,
+                  "group_id": "group-1",
+                  "terminals": [
+                    {
+                      "id": "terminal-child",
+                      "title": "child",
+                      "current_directory": null,
+                      "is_focused": true,
+                      "is_ready": true
+                    }
+                  ]
+                },
+                {
+                  "id": "workspace-bottom",
+                  "window_id": "window-group",
+                  "title": "Bottom",
+                  "current_directory": null,
+                  "is_selected": false,
+                  "is_pinned": false,
+                  "group_id": null,
+                  "terminals": [
+                    {
+                      "id": "terminal-bottom",
+                      "title": "bottom",
+                      "current_directory": null,
+                      "is_focused": true,
+                      "is_ready": true
+                    }
+                  ]
+                }
+              ],
+              "groups": [
+                {
+                  "id": "group-1",
+                  "name": "Feature",
+                  "is_collapsed": false,
+                  "is_pinned": false,
+                  "anchor_workspace_id": "workspace-anchor"
+                }
+              ]
+            }
+            """
+        )
+
+        store.applyRemoteWorkspaceList(
+            response,
+            mergeExistingWorkspaces: true,
+            mergeWorkspaceGroups: true
+        )
+
+        #expect(store.workspaces.map(\.id.rawValue).contains("workspace-other-window"))
+        #expect(store.workspaceGroups.map(\.id.rawValue).contains("group-other"))
+        #expect(!store.workspaceGroups.map(\.id.rawValue).contains("group-stale"))
+        #expect(store.workspaces.map(\.id.rawValue) == [
+            "workspace-anchor",
+            "workspace-created",
+            "workspace-child",
+            "workspace-bottom",
+            "workspace-other-window",
+        ])
+        let updatedGroup = try #require(store.workspaceGroups.first { $0.id == "group-1" })
+        #expect(updatedGroup.isCollapsed == false)
+        let created = try #require(store.workspaces.first { $0.id == "workspace-created" })
+        #expect(created.groupID == "group-1")
+        #expect(created.terminals.first?.id == "terminal-created")
+        let listItemIDs = MobileWorkspaceListItem.items(
+            workspaces: store.workspaces,
+            groups: store.workspaceGroups
+        ).map { item in
+            switch item {
+            case .groupHeader(let group, _):
+                "group.\(group.id.rawValue)"
+            case .workspace(let workspace, _):
+                "workspace.\(workspace.id.rawValue)"
+            }
+        }
+        #expect(listItemIDs.prefix(4) == [
+            "group.group-1",
+            "workspace.workspace-created",
+            "workspace.workspace-child",
+            "workspace.workspace-bottom",
+        ])
+    }
+
     @Test func createWorkspaceSelectsNewWorkspaceAndTerminal() {
         let store = MobileShellComposite.preview()
         store.signIn()
@@ -217,4 +453,47 @@ private func hostPortRoute(
         endpoint: .hostPort(host: host, port: port),
         priority: priority
     )
+}
+
+private func groupSelectionWorkspaces() -> [MobileWorkspacePreview] {
+    [
+        MobileWorkspacePreview(
+            id: "workspace-anchor",
+            name: "Feature",
+            groupID: "group-1",
+            terminals: [
+                MobileTerminalPreview(id: "terminal-anchor", name: "anchor")
+            ]
+        ),
+        MobileWorkspacePreview(
+            id: "workspace-child",
+            name: "Implementation",
+            groupID: "group-1",
+            terminals: [
+                MobileTerminalPreview(id: "terminal-child", name: "child")
+            ]
+        ),
+    ]
+}
+
+private func testWorkspace(
+    _ id: String,
+    windowID: String? = nil,
+    name: String,
+    groupID: String? = nil,
+    terminal: String
+) -> MobileWorkspacePreview {
+    MobileWorkspacePreview(
+        id: MobileWorkspacePreview.ID(rawValue: id),
+        windowID: windowID,
+        name: name,
+        groupID: groupID.map { MobileWorkspaceGroupPreview.ID(rawValue: $0) },
+        terminals: [
+            MobileTerminalPreview(id: MobileTerminalPreview.ID(rawValue: terminal), name: terminal)
+        ]
+    )
+}
+
+private func mobileWorkspaceListResponse(_ json: String) throws -> MobileSyncWorkspaceListResponse {
+    try MobileSyncWorkspaceListResponse.decode(Data(json.utf8))
 }

--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListItem.swift
@@ -115,4 +115,59 @@ public enum MobileWorkspaceListItem: Identifiable, Equatable, Sendable {
         }
         return items
     }
+
+    /// Build list items for search and narrowing filters.
+    ///
+    /// This intentionally ignores group collapse state: a search or "Unread"
+    /// filter must be able to surface matching members even when their Mac group
+    /// is folded. It still preserves the anchor model, so an anchor workspace
+    /// renders as the group header instead of falling back to a normal workspace
+    /// row and making the group look like a workspace.
+    ///
+    /// If `includeGroup` matches a group, every workspace in that group is
+    /// included. This lets a query matching the group name show the group and
+    /// its contents, not an empty header.
+    public static func filteredItems(
+        workspaces: [MobileWorkspacePreview],
+        groups: [MobileWorkspaceGroupPreview],
+        includeWorkspace: (MobileWorkspacePreview) -> Bool,
+        includeGroup: (MobileWorkspaceGroupPreview) -> Bool = { _ in false }
+    ) -> [MobileWorkspaceListItem] {
+        guard !workspaces.isEmpty else { return [] }
+        let groupsByID = Dictionary(groups.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        let matchedGroupIDs = Set(groups.filter(includeGroup).map(\.id))
+
+        var anchorUnreadByGroupID: [MobileWorkspaceGroupPreview.ID: Bool] = [:]
+        for workspace in workspaces {
+            guard let groupID = workspace.groupID,
+                  let group = groupsByID[groupID],
+                  group.anchorWorkspaceID == workspace.id else { continue }
+            anchorUnreadByGroupID[groupID] = workspace.hasUnread
+        }
+
+        var items: [MobileWorkspaceListItem] = []
+        items.reserveCapacity(workspaces.count + groups.count)
+        var emittedHeaders: Set<MobileWorkspaceGroupPreview.ID> = []
+
+        for workspace in workspaces {
+            let resolvedGroupID = workspace.groupID.flatMap { groupsByID[$0] != nil ? $0 : nil }
+            let isIncluded = includeWorkspace(workspace)
+                || resolvedGroupID.map { matchedGroupIDs.contains($0) } == true
+            guard isIncluded else { continue }
+
+            if let groupID = resolvedGroupID, let group = groupsByID[groupID] {
+                if emittedHeaders.insert(groupID).inserted {
+                    items.append(.groupHeader(group, hasUnread: anchorUnreadByGroupID[groupID, default: false]))
+                }
+                if group.anchorWorkspaceID == workspace.id {
+                    continue
+                }
+                items.append(.workspace(workspace, indented: true))
+            } else {
+                items.append(.workspace(workspace, indented: false))
+            }
+        }
+
+        return items
+    }
 }

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListItemTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListItemTests.swift
@@ -177,4 +177,77 @@ import Testing
             .workspace(workspace("mid"), indented: false),
         ])
     }
+
+    // MARK: Filtered/search projection
+
+    @Test func filteredProjectionRendersMatchedAnchorAsHeader() {
+        let anchor = workspace("anchor", group: "g", unread: true)
+        let member = workspace("member", group: "g")
+
+        let items = MobileWorkspaceListItem.filteredItems(
+            workspaces: [anchor, member],
+            groups: [group("g", anchor: "anchor")],
+            includeWorkspace: { $0.id == anchor.id }
+        )
+
+        #expect(items == [
+            .groupHeader(group("g", anchor: "anchor"), hasUnread: true),
+        ])
+    }
+
+    @Test func filteredProjectionShowsMatchedMemberWithGroupContextEvenWhenCollapsed() {
+        let items = MobileWorkspaceListItem.filteredItems(
+            workspaces: [
+                workspace("anchor", group: "g"),
+                workspace("member", group: "g", unread: true),
+            ],
+            groups: [group("g", anchor: "anchor", collapsed: true)],
+            includeWorkspace: { $0.id.rawValue == "member" }
+        )
+
+        #expect(items == [
+            .groupHeader(group("g", anchor: "anchor", collapsed: true), hasUnread: false),
+            .workspace(workspace("member", group: "g", unread: true), indented: true),
+        ])
+    }
+
+    @Test func filteredProjectionMatchingGroupNameIncludesWholeGroup() {
+        let items = MobileWorkspaceListItem.filteredItems(
+            workspaces: [
+                workspace("anchor", group: "g"),
+                workspace("member", group: "g"),
+                workspace("other"),
+            ],
+            groups: [group("g", anchor: "anchor", name: "Build Agents")],
+            includeWorkspace: { _ in false },
+            includeGroup: { $0.name == "Build Agents" }
+        )
+
+        #expect(items == [
+            .groupHeader(group("g", anchor: "anchor", name: "Build Agents"), hasUnread: false),
+            .workspace(workspace("member", group: "g"), indented: true),
+        ])
+    }
+
+    @Test func filteredProjectionCanKeepOnlyUnreadMembersFromMatchingGroup() {
+        let matchedGroupIDs: Set<MobileWorkspaceGroupPreview.ID> = [.init(rawValue: "g")]
+        let items = MobileWorkspaceListItem.filteredItems(
+            workspaces: [
+                workspace("anchor", group: "g"),
+                workspace("read", group: "g"),
+                workspace("unread", group: "g", unread: true),
+                workspace("other", unread: true),
+            ],
+            groups: [group("g", anchor: "anchor", name: "Build Agents")],
+            includeWorkspace: { workspace in
+                workspace.hasUnread
+                    && workspace.groupID.map { matchedGroupIDs.contains($0) } == true
+            }
+        )
+
+        #expect(items == [
+            .groupHeader(group("g", anchor: "anchor", name: "Build Agents"), hasUnread: false),
+            .workspace(workspace("unread", group: "g", unread: true), indented: true),
+        ])
+    }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -25,6 +25,13 @@ struct WorkspaceGroupHeaderRow: View {
     /// Mac without the groups capability), the chevron renders without a tap
     /// action.
     let toggleCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
+    /// Create a new workspace inside this group. Hidden when unavailable and in
+    /// search/filter context headers.
+    let createWorkspaceInGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)?
+    /// Whether to show the collapse disclosure. Filtered/search results can
+    /// include matching members from collapsed groups, so they render headers as
+    /// context labels without a collapse affordance.
+    var showsDisclosure: Bool = true
 
     /// The leading disclosure chevron. Its own hit target, so tapping it only
     /// collapses/expands and never opens the anchor.
@@ -78,9 +85,29 @@ struct WorkspaceGroupHeaderRow: View {
                     .foregroundStyle(.secondary)
                     .accessibilityHidden(true)
             }
-            Spacer(minLength: 0)
         }
         .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var newWorkspaceButton: some View {
+        if let createWorkspaceInGroup, showsDisclosure {
+            Button {
+                createWorkspaceInGroup(group.id)
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                L10n.string(
+                    "mobile.workspaceGroup.newWorkspaceInGroup.a11y",
+                    defaultValue: "New workspace in group"
+                )
+            )
+            .accessibilityIdentifier("MobileWorkspaceGroupNewWorkspace-\(group.id.rawValue)")
+        }
     }
 
     @ViewBuilder
@@ -108,8 +135,15 @@ struct WorkspaceGroupHeaderRow: View {
             // Same leading unread gutter as workspace rows (dot hidden when
             // read) so headers and top-level rows keep their columns aligned.
             WorkspaceUnreadDot(isUnread: hasUnread)
-            chevron
+            if showsDisclosure {
+                chevron
+            } else {
+                Color.clear
+                    .frame(width: 22, height: 22)
+                    .accessibilityHidden(true)
+            }
             anchorTarget
+                .frame(maxWidth: .infinity, alignment: .leading)
                 // The dot itself is accessibility-hidden; VoiceOver hears the
                 // unread state on the anchor target, like workspace rows.
                 .accessibilityValue(
@@ -117,6 +151,7 @@ struct WorkspaceGroupHeaderRow: View {
                         ? L10n.string("mobile.workspace.unread", defaultValue: "Unread")
                         : ""
                 )
+            newWorkspaceButton
         }
         .padding(.vertical, 2)
         .padding(.horizontal, 4)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -59,6 +59,10 @@ struct WorkspaceListView: View {
     /// disclosure indicator. Grouped rendering itself is gated on `groups`, not
     /// on this closure.
     var toggleGroupCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
+    /// Optional: create a new workspace directly inside the tapped group. Kept
+    /// separate from the global `createWorkspace` so grouped work does not fall
+    /// out into an ungrouped row.
+    var createWorkspaceInGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
@@ -91,17 +95,17 @@ struct WorkspaceListView: View {
             || workspace.terminals.contains { $0.name.localizedCaseInsensitiveContains(query) }
     }
 
-    /// Workspaces after the row filter (Unread) and search filtering, pinned
-    /// ones first (stable within each group so the Mac's order is otherwise
-    /// preserved). Used for the flat (ungrouped, filtering, or searching)
-    /// presentation.
-    private var filteredWorkspaces: [MobileWorkspacePreview] {
+    /// Drawable items after the row filter (Unread) and search filtering. Pinned
+    /// workspaces still float first, but group anchors stay group headers instead
+    /// of degrading into normal rows during search/filter mode.
+    private var filteredListItems: [MobileWorkspaceListItem] {
         let query = trimmedQuery
-        let matches = workspaces.filter { workspace in
-            filter.matches(workspace)
-                && (query.isEmpty || matchesQuery(workspace, query: query))
-        }
-        return matches.enumerated()
+        let matchedGroupIDs = Set(
+            groups
+                .filter { !query.isEmpty && $0.name.localizedCaseInsensitiveContains(query) }
+                .map(\.id)
+        )
+        let sortedWorkspaces = workspaces.enumerated()
             .sorted { lhs, rhs in
                 if lhs.element.isPinned != rhs.element.isPinned {
                     return lhs.element.isPinned
@@ -109,6 +113,21 @@ struct WorkspaceListView: View {
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
+        return MobileWorkspaceListItem.filteredItems(
+            workspaces: sortedWorkspaces,
+            groups: groups,
+            includeWorkspace: { workspace in
+                filter.matches(workspace)
+                    && (
+                        query.isEmpty
+                            || matchesQuery(workspace, query: query)
+                            || workspace.groupID.map { matchedGroupIDs.contains($0) } == true
+                    )
+            },
+            includeGroup: { group in
+                !filter.isActive && !query.isEmpty && group.name.localizedCaseInsensitiveContains(query)
+            }
+        )
     }
 
     /// Ordered drawable items for the grouped presentation. Preserves the Mac's
@@ -130,7 +149,7 @@ struct WorkspaceListView: View {
             Section {
                 if rendersGroupedSections {
                     groupedRows
-                } else if filter.isActive && trimmedQuery.isEmpty && filteredWorkspaces.isEmpty && !workspaces.isEmpty {
+                } else if filter.isActive && trimmedQuery.isEmpty && filteredListItems.isEmpty && !workspaces.isEmpty {
                     // The filter alone (not the Mac, and not a search query)
                     // emptied the list; offer the way back. While searching, the
                     // standard empty search result is shown instead, since "Show
@@ -209,8 +228,25 @@ struct WorkspaceListView: View {
     /// Mac has no groups (or lacks the capability) or while searching.
     @ViewBuilder
     private var flatRows: some View {
-        ForEach(filteredWorkspaces) { workspace in
-            workspaceRow(workspace, indented: false)
+        ForEach(filteredListItems) { item in
+            switch item {
+            case .groupHeader(let group, let hasUnread):
+                WorkspaceGroupHeaderRow(
+                    group: group,
+                    hasUnread: hasUnread,
+                    navigationStyle: navigationStyle,
+                    isAnchorSelected: navigationStyle == .sidebar
+                        && selectedWorkspaceID == group.anchorWorkspaceID,
+                    selectWorkspace: selectWorkspace,
+                    toggleCollapsed: nil,
+                    createWorkspaceInGroup: nil,
+                    showsDisclosure: false
+                )
+                .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                .listRowSeparator(.hidden)
+            case .workspace(let workspace, let indented):
+                workspaceRow(workspace, indented: indented)
+            }
         }
     }
 
@@ -228,7 +264,8 @@ struct WorkspaceListView: View {
                     isAnchorSelected: navigationStyle == .sidebar
                         && selectedWorkspaceID == group.anchorWorkspaceID,
                     selectWorkspace: selectWorkspace,
-                    toggleCollapsed: toggleGroupCollapsed
+                    toggleCollapsed: toggleGroupCollapsed,
+                    createWorkspaceInGroup: createWorkspaceInGroup
                 )
                 .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
                 .listRowSeparator(.hidden)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -87,7 +87,8 @@ struct WorkspaceShellView: View {
                 setPinned: setWorkspacePinnedClosure,
                 setUnread: setWorkspaceUnreadClosure,
                 closeWorkspace: closeWorkspaceClosure,
-                toggleGroupCollapsed: toggleGroupCollapsedClosure
+                toggleGroupCollapsed: toggleGroupCollapsedClosure,
+                createWorkspaceInGroup: createWorkspaceInGroupClosure
             )
             .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
                 workspaceDestination(for: workspaceID, createWorkspace: createWorkspaceInCompactStack)
@@ -147,7 +148,8 @@ struct WorkspaceShellView: View {
                 setPinned: setWorkspacePinnedClosure,
                 setUnread: setWorkspaceUnreadClosure,
                 closeWorkspace: closeWorkspaceClosure,
-                toggleGroupCollapsed: toggleGroupCollapsedClosure
+                toggleGroupCollapsed: toggleGroupCollapsedClosure,
+                createWorkspaceInGroup: createWorkspaceInGroupClosure
             )
             .navigationSplitViewColumnWidth(min: 320, ideal: 380, max: 440)
         } detail: {
@@ -235,6 +237,11 @@ struct WorkspaceShellView: View {
         return { id, collapsed in Task { await store.setWorkspaceGroupCollapsed(id: id, collapsed) } }
     }
 
+    private var createWorkspaceInGroupClosure: ((MobileWorkspaceGroupPreview.ID) -> Void)? {
+        guard store.supportsWorkspaceGroupNewWorkspace else { return nil }
+        return { id in createWorkspace(inGroup: id) }
+    }
+
     private func createWorkspaceInCompactStack() {
         let existingWorkspaceIDs = Set(store.workspaces.map(\.id))
         pendingCompactCreateNavigationWorkspaceIDs = existingWorkspaceIDs
@@ -246,6 +253,24 @@ struct WorkspaceShellView: View {
         ) {
             pendingCompactCreateNavigationWorkspaceIDs = nil
             compactNavigationPath = createdPath
+        }
+    }
+
+    private func createWorkspace(inGroup groupID: MobileWorkspaceGroupPreview.ID) {
+        if usesCompactStack {
+            let existingWorkspaceIDs = Set(store.workspaces.map(\.id))
+            pendingCompactCreateNavigationWorkspaceIDs = existingWorkspaceIDs
+            store.createWorkspace(inGroup: groupID)
+            if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
+                currentPath: compactNavigationPath,
+                selectedWorkspaceID: store.selectedWorkspaceID,
+                existingWorkspaceIDs: existingWorkspaceIDs
+            ) {
+                pendingCompactCreateNavigationWorkspaceIDs = nil
+                compactNavigationPath = createdPath
+            }
+        } else {
+            store.createWorkspace(inGroup: groupID)
         }
     }
 

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -28,10 +28,12 @@ extension MobileHostService {
             "workspace.close.v1",
             "dogfood.v1",
             // The workspace list carries group sections (group_id per workspace +
-            // a top-level groups array) and the host accepts
-            // workspace.group.collapse/expand from mobile. iOS feature-detects
-            // this to render collapsible groups only against a Mac that emits them.
+            // a top-level groups array) and the host accepts collapse/expand from
+            // mobile. The new-workspace action has its own capability below so
+            // iOS can avoid showing the group plus against older Macs that only
+            // support display/collapse.
             "workspace.groups.v1",
+            "workspace.group.new_workspace.v1",
         ]
     }
 }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1305,7 +1305,7 @@ final class MobileHostService {
               let object = payload as? [String: Any] else { return }
 
         switch request.method {
-        case "workspace.create":
+        case "workspace.create", "workspace.group.new_workspace":
             ticketStore.recordCreatedResources(
                 authToken: attachToken,
                 workspaceID: object["created_workspace_id"] as? String,
@@ -1360,10 +1360,10 @@ final class MobileHostService {
             return nil
         case "workspace.create":
             return nil
-        case "workspace.group.collapse", "workspace.group.expand":
-            // Display-only group state. Keyed by `group_id` (not a workspace or
-            // terminal selection), so it is Mac-scoped like the workspace list and
-            // not constrained by the ticket's workspace/terminal pin. The Stack
+        case "workspace.group.collapse", "workspace.group.expand", "workspace.group.new_workspace":
+            // Group actions are keyed by `group_id` (not a workspace or terminal
+            // selection), so they are Mac-scoped like the workspace list and not
+            // constrained by the ticket's workspace/terminal pin. The Stack
             // same-account gate in `authorizationError` remains authoritative.
             return nil
         case "mobile.terminal.create", "terminal.create":

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4478,18 +4478,28 @@ class TabManager: ObservableObject {
     func deleteWorkspaceGroup(groupId: UUID, recordHistory: Bool = true) -> Int {
         guard workspaceGroups.contains(where: { $0.id == groupId }) else { return 0 }
         let members = tabs.filter { $0.groupId == groupId }
+        if members.count == tabs.count {
+            // Deleting a group means deleting its members. If the group owns
+            // the whole window, close the window instead of preserving one
+            // member as an ungrouped workspace.
+            let app = AppDelegate.shared
+            let windowId = app?.windowId(for: self)
+            let windowToClose = windowId.flatMap { app?.mainWindow(for: $0) } ?? window
+            if let app, let windowId {
+                app.discardMainWindowWithoutClosedHistory(windowId: windowId)
+            } else if let windowToClose {
+                windowToClose.close()
+            }
+            var closed = 0
+            for tab in members where tabs.contains(where: { $0.id == tab.id }) {
+                closeWorkspaceAllowingLast(tab, recordHistory: recordHistory)
+                if !tabs.contains(where: { $0.id == tab.id }) { closed += 1 }
+            }
+            workspaceGroups.removeAll { $0.id == groupId }
+            return closed
+        }
         var closed = 0
         for tab in members {
-            // closeWorkspace short-circuits when tabs.count <= 1, so the last
-            // remaining workspace would be left alive with a stale groupId.
-            // Convert the holdout into a regular workspace (clear groupId)
-            // instead, and let the caller's surrounding flow decide whether
-            // to close the window. We still report it in the count of items
-            // "removed from the group" so the response is accurate.
-            if tabs.count <= 1 {
-                assignGroup(workspaceId: tab.id, groupId: nil)
-                continue
-            }
             let countBefore = tabs.count
             closeWorkspace(tab, recordHistory: recordHistory)
             if tabs.count < countBefore { closed += 1 }
@@ -5319,6 +5329,10 @@ class TabManager: ObservableObject {
 
     func closeWorkspace(_ workspace: Workspace, recordHistory: Bool = true) {
         guard tabs.count > 1 else { return }
+        closeWorkspaceAllowingLast(workspace, recordHistory: recordHistory)
+    }
+
+    private func closeWorkspaceAllowingLast(_ workspace: Workspace, recordHistory: Bool = true) {
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         if recordHistory,
            workspace.isRestorableInSessionSnapshot,
@@ -5363,6 +5377,11 @@ class TabManager: ObservableObject {
             dissolveGroupsAnchoredBy(closedWorkspaceId: workspace.id)
 
             if selectedTabId == workspace.id {
+                guard !tabs.isEmpty else {
+                    selectedTabId = nil
+                    publishCmuxWorkspaceClosed(workspace)
+                    return
+                }
                 // Keep the "focused index" stable when possible:
                 // - If we closed workspace i and there is still a workspace at index i, focus it (the one that moved up).
                 // - Otherwise (we closed the last workspace), focus the new last workspace (i-1).

--- a/Sources/TerminalController+ControlWorkspaceGroupContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceGroupContext.swift
@@ -248,9 +248,7 @@ extension TerminalController: ControlWorkspaceGroupContext {
         // Placement resolution: explicit `placement` param wins, then the group's
         // per-cwd `newWorkspacePlacement` from cmux.json, then the global default.
         let explicitPlacement = WorkspaceGroupNewPlacement(rawString: placementRaw)
-        if let raw = placementRaw,
-           !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           explicitPlacement == nil {
+        if let raw = placementRaw, explicitPlacement == nil {
             return .invalidPlacement(raw)
         }
         guard let group = tabManager.workspaceGroups.first(where: { $0.id == groupID }) else {

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -5,14 +5,12 @@ import Foundation
 //
 // The phone's `workspace.list` surface: enumerating workspaces across windows,
 // serializing the workspace and group-section payloads, and the mobile-gated
-// group collapse/expand handler. Lives in its own file so the mobile list
+// group handlers. Lives in its own file so the mobile list
 // payload code stays together without growing TerminalController.swift.
 extension TerminalController {
-    /// Mobile-gated collapse/expand of a workspace group. P1 group support on
-    /// iOS is display-only: the phone renders collapsible group sections and can
-    /// toggle a section open/closed, but cannot create, rename, or restructure
-    /// groups. This requires an explicit, resolvable `group_id` (it must never
-    /// fall back to the Mac's selected group) and mutates through the same
+    /// Mobile-gated collapse/expand of a workspace group. This requires an
+    /// explicit, resolvable `group_id` (it must never fall back to the Mac's
+    /// selected group) and mutates through the same
     /// `TabManager.setWorkspaceGroupCollapsed` the CLI and sidebar use, so the
     /// mutation path stays shared. `v2ResolveTabManager` routes by `group_id` to
     /// the owning window even in the multi-window case.
@@ -31,6 +29,79 @@ extension TerminalController {
         return ok
             ? .ok(["group_id": gid.uuidString, "is_collapsed": isCollapsed])
             : .err(code: "not_found", message: "Group not found", data: ["group_id": gid.uuidString])
+    }
+
+    /// Mobile-gated "new workspace in group". The Mac stays authoritative for
+    /// placement and membership: this routes by explicit `group_id`, resolves
+    /// the same placement settings as the desktop/CLI path, creates the
+    /// workspace without stealing Mac focus, then returns the normal mobile list
+    /// payload with `created_workspace_id` so iOS can select/navigate to it.
+    func v2MobileWorkspaceGroupNewWorkspace(params: [String: Any]) -> V2CallResult {
+        guard v2HasNonNullParam(params, "group_id"), let gid = v2UUID(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        let explicitPlacement: WorkspaceGroupNewPlacement?
+        if params.keys.contains("placement") {
+            guard let rawPlacement = params["placement"] as? String,
+                  !rawPlacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let placement = WorkspaceGroupNewPlacement(rawString: rawPlacement) else {
+                return .err(
+                    code: "invalid_params",
+                    message: "placement must be one of: afterCurrent, top, end",
+                    data: ["placement": params["placement"] ?? NSNull()]
+                )
+            }
+            explicitPlacement = placement
+        } else {
+            explicitPlacement = nil
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var createdWorkspaceID: UUID?
+        var groupFound = false
+        v2MainSync {
+            guard let group = tabManager.workspaceGroups.first(where: { $0.id == gid }) else { return }
+            groupFound = true
+            let anchorCwd = tabManager.tabs.first(where: { $0.id == group.anchorWorkspaceId })?.currentDirectory
+            let configStore = AppDelegate.shared?.mainWindowContexts.values.first {
+                $0.tabManager === tabManager
+            }?.cmuxConfigStore
+            let configuredPlacement = configStore?
+                .resolveWorkspaceGroupConfig(forCwd: anchorCwd)?
+                .newWorkspacePlacement
+            let placement = explicitPlacement
+                ?? configuredPlacement
+                ?? WorkspaceGroupNewWorkspacePlacementSettings.resolved()
+            createdWorkspaceID = tabManager.createWorkspaceInGroup(
+                groupId: gid,
+                placement: placement,
+                select: false
+            )?.id
+            tabManager.setWorkspaceGroupCollapsed(groupId: gid, isCollapsed: false)
+        }
+        guard groupFound else {
+            return .err(code: "not_found", message: "Group not found", data: ["group_id": gid.uuidString])
+        }
+        guard let createdWorkspaceID else {
+            return .err(
+                code: "workspace_create_failed",
+                message: "Workspace could not be created in group",
+                data: ["group_id": gid.uuidString]
+            )
+        }
+
+        var listParams = params
+        listParams["workspace_id"] = nil
+        listParams["terminal_id"] = nil
+        listParams["surface_id"] = nil
+        listParams["tab_id"] = nil
+        return v2MobileWorkspaceList(
+            params: listParams,
+            tabManager: tabManager,
+            createdWorkspaceID: createdWorkspaceID.uuidString
+        )
     }
 
     func v2MobileWorkspaceList(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13391,6 +13391,8 @@ class TerminalController {
             result = v2MobileWorkspaceGroupSetCollapsed(params: request.params, isCollapsed: true)
         case "workspace.group.expand":
             result = v2MobileWorkspaceGroupSetCollapsed(params: request.params, isCollapsed: false)
+        case "workspace.group.new_workspace":
+            result = v2MobileWorkspaceGroupNewWorkspace(params: request.params)
         case "notification.dismiss":
             result = v2MobileNotificationDismiss(params: request.params)
         case "notification.reconcile":

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		9916B44C7A9914E172D112D4 /* MobileRouteResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */; };
 		AB57F0C27BECE8EDFC6B2B97 /* MobileTerminalByteTee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */; };
 		C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F51B54FAD18160281FC1C2B6 /* MobileTerminalRenderObserver.swift */; };
+		C9A57A01C9A57A01C9A57A01 /* MobileWorkspaceGroupRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57A02C9A57A02C9A57A02 /* MobileWorkspaceGroupRPCTests.swift */; };
 		F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */; };
 		00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
@@ -1275,6 +1276,7 @@
 		7A956C76162B79EC74AF9965 /* MobileRouteResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileRouteResolver.swift; sourceTree = "<group>"; };
 		4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileTerminalByteTee.swift; sourceTree = "<group>"; };
 		F51B54FAD18160281FC1C2B6 /* MobileTerminalRenderObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileTerminalRenderObserver.swift; sourceTree = "<group>"; };
+		C9A57A02C9A57A02C9A57A02 /* MobileWorkspaceGroupRPCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceGroupRPCTests.swift; sourceTree = "<group>"; };
 		86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListFidelityTests.swift; sourceTree = "<group>"; };
 		C9F14137954A34DFFA05C88C /* MobileWorkspaceListObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileWorkspaceListObserver.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
@@ -2430,9 +2432,10 @@
 				C0DE48000000000000000002 /* SidebarProviderMenuRegressionTests.swift */,
 				C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */,
 				B37A0000000000000000000C /* FileExplorerStateModePersistenceTests.swift */,
-				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
-				86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */,
-				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
+					BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
+					C9A57A02C9A57A02C9A57A02 /* MobileWorkspaceGroupRPCTests.swift */,
+					86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */,
+					B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
@@ -3560,6 +3563,7 @@
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				4C1A7E10B2D34F56A8C90013 /* MobileHostStatusVerificationLimiterTests.swift in Sources */,
 				9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */,
+				C9A57A01C9A57A01C9A57A01 /* MobileWorkspaceGroupRPCTests.swift in Sources */,
 				F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */,
 				734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 				D7AB00000000000000B021 /* NotificationDismissSyncTests.swift in Sources */,

--- a/cmuxTests/MobileWorkspaceGroupRPCTests.swift
+++ b/cmuxTests/MobileWorkspaceGroupRPCTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct MobileWorkspaceGroupRPCTests {
+    @Test func groupNewWorkspaceReturnsGroupedCreatedWorkspace() async throws {
+        let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        let manager = TabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+        defer {
+            TerminalController.shared.setActiveTabManager(previousManager)
+        }
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Mobile Group"))
+        let selectedWorkspace = try #require(manager.selectedWorkspace)
+        manager.setWorkspaceGroupCollapsed(groupId: groupId, isCollapsed: true)
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "group-workspace-create",
+                method: "workspace.group.new_workspace",
+                params: ["group_id": groupId.uuidString],
+                auth: nil
+            )
+        )
+
+        guard case let .ok(rawPayload) = response else {
+            Issue.record("Expected mobile workspace.group.new_workspace to return a grouped workspace payload")
+            return
+        }
+        let payload = try #require(rawPayload as? [String: Any])
+        let createdWorkspaceID = try #require(payload["created_workspace_id"] as? String)
+        let createdUUID = try #require(UUID(uuidString: createdWorkspaceID))
+        let workspaces = try #require(payload["workspaces"] as? [[String: Any]])
+        let groups = try #require(payload["groups"] as? [[String: Any]])
+
+        let createdWorkspace = try #require(manager.tabs.first { $0.id == createdUUID })
+        let createdPayload = try #require(workspaces.first { ($0["id"] as? String) == createdWorkspaceID })
+        let groupPayload = try #require(groups.first { ($0["id"] as? String) == groupId.uuidString })
+        #expect(createdWorkspace.groupId == groupId)
+        #expect(createdPayload["group_id"] as? String == groupId.uuidString)
+        #expect(groupPayload["id"] as? String == groupId.uuidString)
+        #expect(manager.selectedWorkspace?.id == selectedWorkspace.id)
+        #expect(manager.workspaceGroups.first(where: { $0.id == groupId })?.isCollapsed == false)
+    }
+
+    @Test func groupNewWorkspaceRejectsInvalidPlacement() async throws {
+        let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        let manager = TabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+        defer {
+            TerminalController.shared.setActiveTabManager(previousManager)
+        }
+
+        let groupId = try #require(manager.createWorkspaceGroup(name: "Mobile Group"))
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(
+            MobileHostRPCRequest(
+                id: "group-workspace-create-invalid-placement",
+                method: "workspace.group.new_workspace",
+                params: [
+                    "group_id": groupId.uuidString,
+                    "placement": "",
+                ],
+                auth: nil
+            )
+        )
+
+        guard case let .failure(error) = response else {
+            Issue.record("Expected mobile workspace.group.new_workspace to reject an empty placement")
+            return
+        }
+        #expect(error.code == "invalid_params")
+        #expect(error.message == "placement must be one of: afterCurrent, top, end")
+    }
+}

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -748,11 +748,10 @@ struct WorkspaceGroupTests {
         })
     }
 
-    @Test func deleteKeepsLastWorkspaceUngrouped() {
-        // When the group contains every workspace in the window,
-        // closeWorkspace refuses to drop the last tab. The lingering tab must
-        // be detached from the group so the user isn't left with a stale
-        // groupId pointing at a removed group.
+    @Test func deleteAllMemberGroupClosesEveryWorkspace() {
+        // Deleting a group is destructive. If the group owns every workspace in
+        // its window, there must not be a preserved holdout that looks like the
+        // group turned into a plain workspace.
         let manager = makeTabManager()
         let children = manager.tabs.map(\.id)
         let groupId = manager.createWorkspaceGroup(name: "G", childWorkspaceIds: children)!
@@ -760,10 +759,9 @@ struct WorkspaceGroupTests {
 
         let closed = manager.deleteWorkspaceGroup(groupId: groupId)
 
-        #expect(manager.tabs.count == 1)
-        #expect(closed == groupSize - 1)
+        #expect(manager.tabs.isEmpty)
+        #expect(closed == groupSize)
         #expect(manager.workspaceGroups.first(where: { $0.id == groupId }) == nil)
-        #expect(manager.tabs.allSatisfy { $0.groupId == nil })
     }
 
     @Test func pinnedWorkspaceCannotJoinGroupViaCreate() {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -5917,6 +5917,23 @@
         }
       }
     },
+    "mobile.workspaceGroup.newWorkspaceInGroup.a11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New workspace in group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループ内に新しいワークスペース"
+          }
+        }
+      }
+    },
     "mobile.settings.previewLines": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary
- Preserve group headers in iOS search/filter results so anchor workspaces do not appear as ordinary rows.
- Keep iOS selection visible when a selected group child becomes hidden by collapse.
- Add an iOS group-header plus action backed by a mobile-gated `workspace.group.new_workspace` capability.
- Fix destructive group delete when the group owns every workspace in a window.

## Verification
- `swift test --filter MobileWorkspaceListItemTests`
- `swift test --filter MobileShellCompositePreviewTests`
- `python3 -m json.tool ios/cmux/Resources/Localizable.xcstrings >/dev/null && git diff --check`
- `reload-cloud --tag grpux2` built macOS tag locally after no cloud slot was available.
- `ios/scripts/reload.sh --tag grpux2 --simulator "iPhone 17"` succeeded.
- Debug CLI preflight: group member count 2 -> 3 after group new-workspace, created workspace appeared in `mobile.workspace.list`, group stayed expanded.
- Debug CLI preflight: deleting a group that owned a throwaway window closed that window.

## Dogfood
Tag: grpux2
Mac: http://127.0.0.1:17320/grpux2
iOS simulator tag: grpux2
Physical iPhone: unavailable by user instruction overnight.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783920873&installation_id=133855650&pr_number=6034&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6034&signature=97585d6e0cf54a844c050326f24e231c92731cbdad6b50e0f25f8fb72cb54c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves iOS workspace groups with an in-group “+” action, group-aware search/filter, and safer syncing. Merges workspace and group updates per window so other windows keep their sections, and closes a window when deleting a group that owns every workspace.

- **New Features**
  - Group header “+” creates a workspace in that group, expands it, and selects it; shown only when the Mac advertises `workspace.group.new_workspace.v1` and hidden in search/filter headers. Uses the `workspace.group.new_workspace` RPC (no Mac focus/keyboard steal), validates placement (`afterCurrent`, `top`, `end`; empty/invalid rejected), and merges returned workspaces and groups by window so other windows keep their sections.
  - Search/filter is group-aware: anchors render as headers (no disclosure), matched members show under the header even if the group is collapsed, and matching a group name includes the group with its members.

- **Bug Fixes**
  - Selection stays visible when collapsing a group: if a hidden child was selected, selection moves to the group’s anchor.
  - Deleting a group that owns every workspace in a window now closes that window instead of leaving a stray workspace.

<sup>Written for commit e3ff6f7d3582806f7b5c91ddc2549598475eeaae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create a new workspace directly inside an existing workspace group (including mobile RPC).
  * Smarter merging of remote workspace lists and groups that preserves per-window/group ordering and reconciles selection with collapsed groups.

* **UI Enhancements**
  * Group headers can show a “new workspace” button and optional disclosure chevron.
  * Added localized accessibility string for the new-workspace action.

* **Behavioral Changes**
  * Deleting a group that owns all workspaces now closes those workspaces.

* **Tests**
  * Added tests for group RPCs, merging/reconciliation, filtered list projection, and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->