### PR TITLE
Fix iOS workspace swipe-delete confirmation crash

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -173,23 +173,6 @@ struct WorkspaceListView: View {
             #endif
         }
         .accessibilityIdentifier("MobileWorkspaceList")
-        .confirmationDialog(
-            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
-            isPresented: isConfirmingWorkspaceClose,
-            titleVisibility: .visible
-        ) {
-            if let workspacePendingCloseID, closeWorkspace != nil {
-                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
-                    confirmCloseWorkspace()
-                }
-                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspacePendingCloseID.rawValue)")
-            }
-            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
-                workspacePendingCloseID = nil
-            }
-        } message: {
-            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
-        }
         #if os(iOS)
         .sheet(isPresented: $showingShortcutsSettings) {
             TerminalShortcutsSettingsView()
@@ -272,7 +255,11 @@ struct WorkspaceListView: View {
             renameWorkspace: renameWorkspace,
             setPinned: setPinned,
             setUnread: setUnread,
-            closeWorkspace: requestWorkspaceClose
+            closeWorkspace: requestWorkspaceClose,
+            isConfirmingClose: closeConfirmationBinding(for: workspace.id),
+            confirmCloseWorkspace: closeWorkspace == nil ? nil : { _ in
+                confirmCloseWorkspace()
+            }
         )
         .listRowInsets(EdgeInsets(top: 4, leading: indented ? 32 : 12, bottom: 4, trailing: 12))
         .listRowSeparator(.hidden)
@@ -347,11 +334,13 @@ struct WorkspaceListView: View {
         }
     }
 
-    private var isConfirmingWorkspaceClose: Binding<Bool> {
+    private func closeConfirmationBinding(for workspaceID: MobileWorkspacePreview.ID) -> Binding<Bool> {
         Binding(
-            get: { workspacePendingCloseID != nil },
+            get: { workspacePendingCloseID == workspaceID },
             set: { isPresented in
-                if !isPresented {
+                if isPresented {
+                    workspacePendingCloseID = workspaceID
+                } else if workspacePendingCloseID == workspaceID {
                     workspacePendingCloseID = nil
                 }
             }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -66,6 +66,10 @@ struct WorkspaceListView: View {
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State private var filter: MobileWorkspaceListFilter = .all
+    /// The workspace whose destructive close action is awaiting confirmation.
+    /// Stored at list scope so reusable rows do not own transient presentation
+    /// state while `List` is recycling swipe-action rows.
+    @State private var workspacePendingCloseID: MobileWorkspacePreview.ID?
 
     private var trimmedQuery: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -169,6 +173,23 @@ struct WorkspaceListView: View {
             #endif
         }
         .accessibilityIdentifier("MobileWorkspaceList")
+        .confirmationDialog(
+            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
+            isPresented: isConfirmingWorkspaceClose,
+            titleVisibility: .visible
+        ) {
+            if let workspacePendingCloseID, closeWorkspace != nil {
+                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
+                    confirmCloseWorkspace()
+                }
+                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspacePendingCloseID.rawValue)")
+            }
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
+                workspacePendingCloseID = nil
+            }
+        } message: {
+            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
+        }
         #if os(iOS)
         .sheet(isPresented: $showingShortcutsSettings) {
             TerminalShortcutsSettingsView()
@@ -251,7 +272,7 @@ struct WorkspaceListView: View {
             renameWorkspace: renameWorkspace,
             setPinned: setPinned,
             setUnread: setUnread,
-            closeWorkspace: closeWorkspace
+            closeWorkspace: requestWorkspaceClose
         )
         .listRowInsets(EdgeInsets(top: 4, leading: indented ? 32 : 12, bottom: 4, trailing: 12))
         .listRowSeparator(.hidden)
@@ -315,5 +336,33 @@ struct WorkspaceListView: View {
         .accessibilityLabel(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))
         .accessibilityIdentifier("MobileWorkspaceSettingsMenu")
         #endif
+    }
+
+    private var requestWorkspaceClose: ((MobileWorkspacePreview.ID) -> Void)? {
+        guard closeWorkspace != nil else {
+            return nil
+        }
+        return { workspaceID in
+            workspacePendingCloseID = workspaceID
+        }
+    }
+
+    private var isConfirmingWorkspaceClose: Binding<Bool> {
+        Binding(
+            get: { workspacePendingCloseID != nil },
+            set: { isPresented in
+                if !isPresented {
+                    workspacePendingCloseID = nil
+                }
+            }
+        )
+    }
+
+    private func confirmCloseWorkspace() {
+        guard let workspaceID = workspacePendingCloseID else {
+            return
+        }
+        workspacePendingCloseID = nil
+        closeWorkspace?(workspaceID)
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -24,6 +24,13 @@ struct WorkspaceNavigationRow: View {
     /// Close the workspace on the Mac. When `nil` the delete affordance is
     /// hidden.
     var closeWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
+    /// Whether this row's destructive close action is awaiting confirmation.
+    /// The binding is owned by the list so recycled rows do not own presentation
+    /// state, but the presenter stays attached to the swiped row.
+    var isConfirmingClose: Binding<Bool> = .constant(false)
+    /// Performs the confirmed close. Separate from ``closeWorkspace`` so a
+    /// full-swipe can request confirmation without directly closing the row.
+    var confirmCloseWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
 
     @State private var isRenaming = false
 
@@ -51,7 +58,7 @@ struct WorkspaceNavigationRow: View {
                 .accessibilityIdentifier("MobileWorkspaceReadStateSwipeButton-\(workspace.id.rawValue)")
             }
         }
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             if let closeWorkspace {
                 Button(role: .destructive) {
                     closeWorkspace(workspace.id)
@@ -70,6 +77,23 @@ struct WorkspaceNavigationRow: View {
             WorkspaceRenameSheet(currentName: workspace.name) { newName in
                 renameWorkspace?(workspace.id, newName)
             }
+        }
+        .confirmationDialog(
+            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
+            isPresented: isConfirmingClose,
+            titleVisibility: .visible
+        ) {
+            if let confirmCloseWorkspace {
+                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
+                    confirmCloseWorkspace(workspace.id)
+                }
+                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspace.id.rawValue)")
+            }
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
+                isConfirmingClose.wrappedValue = false
+            }
+        } message: {
+            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
         }
     }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -33,35 +33,18 @@ struct WorkspaceNavigationRow: View {
     var confirmCloseWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
 
     @State private var isRenaming = false
-    @State private var deleteSwipeOffset: CGFloat = 0
 
     var body: some View {
-        ZStack(alignment: .trailing) {
-            if closeWorkspace != nil {
-                deleteActionTray
-            }
-
-            WorkspaceRow(
-                workspace: workspace,
-                connectionStatus: connectionStatus,
-                isSelected: navigationStyle == .sidebar && isSelected,
-                wrapWorkspaceTitles: wrapWorkspaceTitles,
-                previewLineLimit: previewLineLimit
-            )
-            .background(Color(.systemBackground))
-            .offset(x: rowOffset)
-        }
-        .animation(.snappy(duration: 0.22), value: isConfirmingClose.wrappedValue)
-        .animation(.snappy(duration: 0.22), value: deleteSwipeOffset)
-        .clipShape(Rectangle())
+        WorkspaceRow(
+            workspace: workspace,
+            connectionStatus: connectionStatus,
+            isSelected: navigationStyle == .sidebar && isSelected,
+            wrapWorkspaceTitles: wrapWorkspaceTitles,
+            previewLineLimit: previewLineLimit
+        )
         .onTapGesture {
-            if isConfirmingClose.wrappedValue {
-                isConfirmingClose.wrappedValue = false
-            } else {
-                selectWorkspace(workspace.id)
-            }
+            selectWorkspace(workspace.id)
         }
-        .simultaneousGesture(deleteSwipeGesture)
         .contentShape(Rectangle())
         .contextMenu { contextMenu }
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -75,6 +58,16 @@ struct WorkspaceNavigationRow: View {
                 .accessibilityIdentifier("MobileWorkspaceReadStateSwipeButton-\(workspace.id.rawValue)")
             }
         }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            if let closeWorkspace {
+                Button(role: .destructive) {
+                    closeWorkspace(workspace.id)
+                } label: {
+                    Label(L10n.string("mobile.workspace.delete", defaultValue: "Delete"), systemImage: "trash")
+                }
+                .accessibilityIdentifier("MobileWorkspaceDeleteSwipeButton-\(workspace.id.rawValue)")
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")
@@ -85,10 +78,22 @@ struct WorkspaceNavigationRow: View {
                 renameWorkspace?(workspace.id, newName)
             }
         }
-        .onChange(of: isConfirmingClose.wrappedValue) { _, isPresented in
-            if !isPresented {
-                deleteSwipeOffset = 0
+        .confirmationDialog(
+            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
+            isPresented: isConfirmingClose,
+            titleVisibility: .visible
+        ) {
+            if let confirmCloseWorkspace {
+                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
+                    confirmCloseWorkspace(workspace.id)
+                }
+                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspace.id.rawValue)")
             }
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
+                isConfirmingClose.wrappedValue = false
+            }
+        } message: {
+            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
         }
     }
 
@@ -132,97 +137,6 @@ struct WorkspaceNavigationRow: View {
         }
     }
 
-    private var rowOffset: CGFloat {
-        if isConfirmingClose.wrappedValue {
-            return -Self.deleteConfirmationWidth
-        }
-        return deleteSwipeOffset
-    }
-
-    private var deleteSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 14)
-            .onChanged { value in
-                guard closeWorkspace != nil else {
-                    return
-                }
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical), horizontal < 0 else {
-                    return
-                }
-                isConfirmingClose.wrappedValue = false
-                deleteSwipeOffset = max(-Self.deleteConfirmationWidth, horizontal)
-            }
-            .onEnded { value in
-                guard closeWorkspace != nil else {
-                    deleteSwipeOffset = 0
-                    return
-                }
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical), horizontal < 0 else {
-                    deleteSwipeOffset = 0
-                    return
-                }
-                if horizontal <= -Self.deleteConfirmationThreshold {
-                    closeWorkspace?(workspace.id)
-                    deleteSwipeOffset = -Self.deleteConfirmationWidth
-                } else if horizontal <= -Self.deleteRevealThreshold {
-                    deleteSwipeOffset = -Self.deleteRevealWidth
-                } else {
-                    deleteSwipeOffset = 0
-                }
-            }
-    }
-
-    private var deleteActionTray: some View {
-        HStack(spacing: 0) {
-            if isConfirmingClose.wrappedValue {
-                Button {
-                    isConfirmingClose.wrappedValue = false
-                } label: {
-                    VStack(spacing: 4) {
-                        Image(systemName: "xmark")
-                            .font(.headline)
-                        Text(L10n.string("mobile.common.cancel", defaultValue: "Cancel"))
-                            .font(.caption2)
-                    }
-                    .frame(width: Self.deleteCancelWidth)
-                    .frame(maxHeight: .infinity)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.white)
-                .background(Color.secondary)
-                .accessibilityIdentifier("MobileWorkspaceDeleteCancelButton-\(workspace.id.rawValue)")
-            }
-
-            Button(role: .destructive) {
-                if isConfirmingClose.wrappedValue {
-                    confirmCloseWorkspace?(workspace.id)
-                } else {
-                    closeWorkspace?(workspace.id)
-                    deleteSwipeOffset = -Self.deleteConfirmationWidth
-                }
-            } label: {
-                VStack(spacing: 4) {
-                    Image(systemName: "trash")
-                        .font(.headline)
-                    Text(L10n.string("mobile.workspace.delete", defaultValue: "Delete"))
-                        .font(.caption2)
-                }
-                .frame(width: isConfirmingClose.wrappedValue ? Self.deleteConfirmWidth : Self.deleteRevealWidth)
-                .frame(maxHeight: .infinity)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.white)
-            .background(Color.red)
-            .accessibilityIdentifier("MobileWorkspaceDeleteSwipeButton-\(workspace.id.rawValue)")
-        }
-        .frame(width: isConfirmingClose.wrappedValue ? Self.deleteConfirmationWidth : Self.deleteRevealWidth)
-        .frame(maxHeight: .infinity)
-        .accessibilityElement(children: .contain)
-    }
-
     private var readStateActionTitle: String {
         workspace.hasUnread
             ? L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")
@@ -232,11 +146,4 @@ struct WorkspaceNavigationRow: View {
     private var readStateActionSystemImage: String {
         workspace.hasUnread ? "envelope.open" : "envelope.badge"
     }
-
-    private static let deleteRevealWidth: CGFloat = 88
-    private static let deleteCancelWidth: CGFloat = 88
-    private static let deleteConfirmWidth: CGFloat = 88
-    private static let deleteConfirmationWidth = deleteCancelWidth + deleteConfirmWidth
-    private static let deleteRevealThreshold: CGFloat = 44
-    private static let deleteConfirmationThreshold: CGFloat = 132
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -26,7 +26,6 @@ struct WorkspaceNavigationRow: View {
     var closeWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
 
     @State private var isRenaming = false
-    @State private var isConfirmingClose = false
 
     var body: some View {
         WorkspaceRow(
@@ -52,10 +51,10 @@ struct WorkspaceNavigationRow: View {
                 .accessibilityIdentifier("MobileWorkspaceReadStateSwipeButton-\(workspace.id.rawValue)")
             }
         }
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if let closeWorkspace {
                 Button(role: .destructive) {
-                    requestCloseWorkspace()
+                    closeWorkspace(workspace.id)
                 } label: {
                     Label(L10n.string("mobile.workspace.delete", defaultValue: "Delete"), systemImage: "trash")
                 }
@@ -71,21 +70,6 @@ struct WorkspaceNavigationRow: View {
             WorkspaceRenameSheet(currentName: workspace.name) { newName in
                 renameWorkspace?(workspace.id, newName)
             }
-        }
-        .confirmationDialog(
-            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
-            isPresented: $isConfirmingClose,
-            titleVisibility: .visible
-        ) {
-            if let closeWorkspace {
-                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
-                    closeWorkspace(workspace.id)
-                }
-                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspace.id.rawValue)")
-            }
-            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {}
-        } message: {
-            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
         }
     }
 
@@ -121,7 +105,7 @@ struct WorkspaceNavigationRow: View {
         }
         if let closeWorkspace {
             Button(role: .destructive) {
-                requestCloseWorkspace()
+                closeWorkspace(workspace.id)
             } label: {
                 Label(L10n.string("mobile.workspace.delete", defaultValue: "Delete"), systemImage: "trash")
             }
@@ -137,9 +121,5 @@ struct WorkspaceNavigationRow: View {
 
     private var readStateActionSystemImage: String {
         workspace.hasUnread ? "envelope.open" : "envelope.badge"
-    }
-
-    private func requestCloseWorkspace() {
-        isConfirmingClose = true
     }
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -33,18 +33,35 @@ struct WorkspaceNavigationRow: View {
     var confirmCloseWorkspace: ((MobileWorkspacePreview.ID) -> Void)? = nil
 
     @State private var isRenaming = false
+    @State private var deleteSwipeOffset: CGFloat = 0
 
     var body: some View {
-        WorkspaceRow(
-            workspace: workspace,
-            connectionStatus: connectionStatus,
-            isSelected: navigationStyle == .sidebar && isSelected,
-            wrapWorkspaceTitles: wrapWorkspaceTitles,
-            previewLineLimit: previewLineLimit
-        )
-        .onTapGesture {
-            selectWorkspace(workspace.id)
+        ZStack(alignment: .trailing) {
+            if closeWorkspace != nil {
+                deleteActionTray
+            }
+
+            WorkspaceRow(
+                workspace: workspace,
+                connectionStatus: connectionStatus,
+                isSelected: navigationStyle == .sidebar && isSelected,
+                wrapWorkspaceTitles: wrapWorkspaceTitles,
+                previewLineLimit: previewLineLimit
+            )
+            .background(Color(.systemBackground))
+            .offset(x: rowOffset)
         }
+        .animation(.snappy(duration: 0.22), value: isConfirmingClose.wrappedValue)
+        .animation(.snappy(duration: 0.22), value: deleteSwipeOffset)
+        .clipShape(Rectangle())
+        .onTapGesture {
+            if isConfirmingClose.wrappedValue {
+                isConfirmingClose.wrappedValue = false
+            } else {
+                selectWorkspace(workspace.id)
+            }
+        }
+        .simultaneousGesture(deleteSwipeGesture)
         .contentShape(Rectangle())
         .contextMenu { contextMenu }
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -58,16 +75,6 @@ struct WorkspaceNavigationRow: View {
                 .accessibilityIdentifier("MobileWorkspaceReadStateSwipeButton-\(workspace.id.rawValue)")
             }
         }
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            if let closeWorkspace {
-                Button(role: .destructive) {
-                    closeWorkspace(workspace.id)
-                } label: {
-                    Label(L10n.string("mobile.workspace.delete", defaultValue: "Delete"), systemImage: "trash")
-                }
-                .accessibilityIdentifier("MobileWorkspaceDeleteSwipeButton-\(workspace.id.rawValue)")
-            }
-        }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("MobileWorkspaceRow-\(workspace.id.rawValue)")
@@ -78,22 +85,10 @@ struct WorkspaceNavigationRow: View {
                 renameWorkspace?(workspace.id, newName)
             }
         }
-        .confirmationDialog(
-            L10n.string("mobile.workspace.delete.confirmTitle", defaultValue: "Delete Workspace?"),
-            isPresented: isConfirmingClose,
-            titleVisibility: .visible
-        ) {
-            if let confirmCloseWorkspace {
-                Button(L10n.string("mobile.workspace.delete.confirmAction", defaultValue: "Delete"), role: .destructive) {
-                    confirmCloseWorkspace(workspace.id)
-                }
-                .accessibilityIdentifier("MobileWorkspaceDeleteConfirmButton-\(workspace.id.rawValue)")
+        .onChange(of: isConfirmingClose.wrappedValue) { _, isPresented in
+            if !isPresented {
+                deleteSwipeOffset = 0
             }
-            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
-                isConfirmingClose.wrappedValue = false
-            }
-        } message: {
-            Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
         }
     }
 
@@ -137,6 +132,97 @@ struct WorkspaceNavigationRow: View {
         }
     }
 
+    private var rowOffset: CGFloat {
+        if isConfirmingClose.wrappedValue {
+            return -Self.deleteConfirmationWidth
+        }
+        return deleteSwipeOffset
+    }
+
+    private var deleteSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 14)
+            .onChanged { value in
+                guard closeWorkspace != nil else {
+                    return
+                }
+                let horizontal = value.translation.width
+                let vertical = value.translation.height
+                guard abs(horizontal) > abs(vertical), horizontal < 0 else {
+                    return
+                }
+                isConfirmingClose.wrappedValue = false
+                deleteSwipeOffset = max(-Self.deleteConfirmationWidth, horizontal)
+            }
+            .onEnded { value in
+                guard closeWorkspace != nil else {
+                    deleteSwipeOffset = 0
+                    return
+                }
+                let horizontal = value.translation.width
+                let vertical = value.translation.height
+                guard abs(horizontal) > abs(vertical), horizontal < 0 else {
+                    deleteSwipeOffset = 0
+                    return
+                }
+                if horizontal <= -Self.deleteConfirmationThreshold {
+                    closeWorkspace?(workspace.id)
+                    deleteSwipeOffset = -Self.deleteConfirmationWidth
+                } else if horizontal <= -Self.deleteRevealThreshold {
+                    deleteSwipeOffset = -Self.deleteRevealWidth
+                } else {
+                    deleteSwipeOffset = 0
+                }
+            }
+    }
+
+    private var deleteActionTray: some View {
+        HStack(spacing: 0) {
+            if isConfirmingClose.wrappedValue {
+                Button {
+                    isConfirmingClose.wrappedValue = false
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: "xmark")
+                            .font(.headline)
+                        Text(L10n.string("mobile.common.cancel", defaultValue: "Cancel"))
+                            .font(.caption2)
+                    }
+                    .frame(width: Self.deleteCancelWidth)
+                    .frame(maxHeight: .infinity)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.white)
+                .background(Color.secondary)
+                .accessibilityIdentifier("MobileWorkspaceDeleteCancelButton-\(workspace.id.rawValue)")
+            }
+
+            Button(role: .destructive) {
+                if isConfirmingClose.wrappedValue {
+                    confirmCloseWorkspace?(workspace.id)
+                } else {
+                    closeWorkspace?(workspace.id)
+                    deleteSwipeOffset = -Self.deleteConfirmationWidth
+                }
+            } label: {
+                VStack(spacing: 4) {
+                    Image(systemName: "trash")
+                        .font(.headline)
+                    Text(L10n.string("mobile.workspace.delete", defaultValue: "Delete"))
+                        .font(.caption2)
+                }
+                .frame(width: isConfirmingClose.wrappedValue ? Self.deleteConfirmWidth : Self.deleteRevealWidth)
+                .frame(maxHeight: .infinity)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .background(Color.red)
+            .accessibilityIdentifier("MobileWorkspaceDeleteSwipeButton-\(workspace.id.rawValue)")
+        }
+        .frame(width: isConfirmingClose.wrappedValue ? Self.deleteConfirmationWidth : Self.deleteRevealWidth)
+        .frame(maxHeight: .infinity)
+        .accessibilityElement(children: .contain)
+    }
+
     private var readStateActionTitle: String {
         workspace.hasUnread
             ? L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")
@@ -146,4 +232,11 @@ struct WorkspaceNavigationRow: View {
     private var readStateActionSystemImage: String {
         workspace.hasUnread ? "envelope.open" : "envelope.badge"
     }
+
+    private static let deleteRevealWidth: CGFloat = 88
+    private static let deleteCancelWidth: CGFloat = 88
+    private static let deleteConfirmWidth: CGFloat = 88
+    private static let deleteConfirmationWidth = deleteCancelWidth + deleteConfirmWidth
+    private static let deleteRevealThreshold: CGFloat = 44
+    private static let deleteConfirmationThreshold: CGFloat = 132
 }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -60,11 +60,12 @@ struct WorkspaceNavigationRow: View {
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             if let closeWorkspace {
-                Button(role: .destructive) {
+                Button {
                     closeWorkspace(workspace.id)
                 } label: {
                     Label(L10n.string("mobile.workspace.delete", defaultValue: "Delete"), systemImage: "trash")
                 }
+                .tint(.red)
                 .accessibilityIdentifier("MobileWorkspaceDeleteSwipeButton-\(workspace.id.rawValue)")
             }
         }


### PR DESCRIPTION
## Summary
- move iOS workspace delete confirmation state from reusable rows to `WorkspaceListView`
- keep destructive delete as reveal-and-tap instead of full-swipe auto-presentation

## Repro fixed
Swipe-delete one workspace, then swipe-delete the row above it. The confirmation dialog is now owned by the list instead of a recycled row.

## Verification
- `git diff --check HEAD~1..HEAD`
- `./scripts/lint-ios-package-conventions.sh`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`
- `./scripts/reload-cloud.sh --tag wdel` (cloud unavailable, local fallback succeeded)
- `ios/scripts/reload.sh --tag wdel`

## Localization
No new user-facing strings. Existing localized delete confirmation strings were moved from row-level presentation to list-level presentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783962819&installation_id=133855650&pr_number=6051&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6051&signature=8ba408a9de8a13c4d2db684e00e8ed791fe2510a1778022c1466b10f2a8a475a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an iOS crash when swipe-deleting workspaces by moving delete-confirmation state to `WorkspaceListView` and presenting the native confirmation dialog from the swiped row. Full-swipe now opens the confirm dialog (no auto-delete); recycled cells no longer own presentation, and swipe and context-menu deletes share the same flow.

<sup>Written for commit c075ddf6c468018686666f83f2098648185910a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized confirmation flow for closing workspaces: rows now request and reflect a single pending close state.
  * Confirmation actions are conditionally enabled so destructive close only proceeds when confirmation is available.

* **Bug Fixes**
  * Dismissing or canceling confirmation reliably clears the pending close state.
  * Swipe/delete and context-menu actions consistently follow the confirm-or-immediate-close behavior; selection/tap no longer interferes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->