### PR TITLE
Fix slow browser tab strip scrolling

### DIFF
--- a/Packages/CmuxFileWatch/Sources/CmuxFileWatch/FileSystemEventStream.swift
+++ b/Packages/CmuxFileWatch/Sources/CmuxFileWatch/FileSystemEventStream.swift
@@ -41,15 +41,28 @@ final class FileSystemEventStream: @unchecked Sendable {
     /// stream is recovered from the context's `info` pointer instead — passed
     /// *unretained* (see the type's "Context lifetime" note), so this uses
     /// `takeUnretainedValue()` and never adjusts the reference count.
-    private static let callback: FSEventStreamCallback = { _, info, _, _, _, _ in
+    private static let callback: FSEventStreamCallback = { _, info, numEvents, eventPaths, _, _ in
         guard let info else { return }
-        Unmanaged<FileSystemEventStream>.fromOpaque(info).takeUnretainedValue().onEvent()
+        let stream = Unmanaged<FileSystemEventStream>.fromOpaque(info).takeUnretainedValue()
+        let paths = FileSystemEventStream.paths(from: eventPaths, count: numEvents)
+        stream.onEvent(paths)
     }
 
     /// The non-blocking sink invoked on the shared queue for each coalesced batch
     /// of filesystem events.
-    private let onEvent: @Sendable () -> Void
+    private let onEvent: @Sendable ([String]) -> Void
     private var stream: FSEventStreamRef?
+
+    private static func paths(from eventPaths: UnsafeMutableRawPointer, count: Int) -> [String] {
+        guard count > 0 else { return [] }
+        let rawPaths = eventPaths.assumingMemoryBound(to: UnsafePointer<CChar>.self)
+        var paths: [String] = []
+        paths.reserveCapacity(count)
+        for index in 0..<count {
+            paths.append(String(cString: rawPaths[index]))
+        }
+        return paths
+    }
 
     /// Creates and starts a stream for `paths`.
     ///
@@ -60,7 +73,7 @@ final class FileSystemEventStream: @unchecked Sendable {
     ///     coalesced batch of filesystem events.
     /// - Returns: `nil` if `paths` is empty or the underlying `FSEventStream`
     ///   could not be created or started.
-    init?(paths: [String], latency: TimeInterval, onEvent: @escaping @Sendable () -> Void) {
+    init?(paths: [String], latency: TimeInterval, onEvent: @escaping @Sendable ([String]) -> Void) {
         guard !paths.isEmpty else { return nil }
         self.onEvent = onEvent
         self.stream = nil

--- a/Packages/CmuxFileWatch/Sources/CmuxFileWatch/RecursivePathWatcher.swift
+++ b/Packages/CmuxFileWatch/Sources/CmuxFileWatch/RecursivePathWatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Watches a set of filesystem paths recursively and reports changes as a
-/// coalesced `AsyncStream<Void>`.
+/// Watches a set of filesystem paths recursively and reports changes as
+/// coalesced streams.
 ///
 /// Construct one with the paths to watch (the caller resolves which paths matter
 /// for its domain) and consume ``events`` to react to changes:
@@ -9,7 +9,7 @@ import Foundation
 /// ```swift
 /// guard let watcher = RecursivePathWatcher(paths: paths) else { return }
 /// let task = Task { @MainActor in
-///     for await _ in watcher.events { reload() }
+///     for await change in watcher.pathEvents { reload(ifRelevant: change.paths) }
 /// }
 /// // later: task.cancel(); await watcher.stop()
 /// ```
@@ -31,6 +31,14 @@ import Foundation
 /// creation happen in-`init`; a single actor-isolated pump drains that raw stream
 /// and applies the throttle. The pump's lifetime is the raw stream's: ``stop()``
 /// and `deinit` finish it.
+public struct RecursivePathChange: Equatable, Sendable {
+    /// Absolute paths reported by FSEvents during one coalesced throttle window.
+    ///
+    /// Empty only for synthetic test events or if the OS reports no path detail;
+    /// callers should treat an empty list conservatively.
+    public let paths: [String]
+}
+
 public actor RecursivePathWatcher {
     /// The paths this watcher observes, as passed to ``init(paths:clock:)``.
     ///
@@ -42,14 +50,17 @@ public actor RecursivePathWatcher {
     /// in which at least one filesystem event affected a watched path. Finishes
     /// when ``stop()`` is called or the watcher is deallocated.
     public nonisolated let events: AsyncStream<Void>
+    public nonisolated let pathEvents: AsyncStream<RecursivePathChange>
 
     private let continuation: AsyncStream<Void>.Continuation
+    private let pathContinuation: AsyncStream<RecursivePathChange>.Continuation
     private let clock: any FileWatchClock
     // nil only for the test-throttle initializer, which drives the throttle
     // directly without a real FSEventStream.
     private let eventStream: FileSystemEventStream?
     // Finishing this ends the pump task (see init); raw FS events flow through it.
-    private let rawContinuation: AsyncStream<Void>.Continuation
+    private let rawContinuation: AsyncStream<[String]>.Continuation
+    private var pendingPaths: Set<String> = []
     private var throttleTask: Task<Void, Never>?
     private var isStopped = false
 
@@ -78,7 +89,10 @@ public actor RecursivePathWatcher {
         let (events, eventsContinuation) = AsyncStream<Void>.makeStream()
         self.events = events
         self.continuation = eventsContinuation
-        let (rawEvents, rawContinuation) = AsyncStream<Void>.makeStream()
+        let (pathEvents, pathEventsContinuation) = AsyncStream<RecursivePathChange>.makeStream()
+        self.pathEvents = pathEvents
+        self.pathContinuation = pathEventsContinuation
+        let (rawEvents, rawContinuation) = AsyncStream<[String]>.makeStream()
         self.rawContinuation = rawContinuation
 
         // The sink captures `rawContinuation` (a Sendable value), not `self`, so
@@ -87,9 +101,10 @@ public actor RecursivePathWatcher {
         guard let eventStream = FileSystemEventStream(
             paths: paths,
             latency: Self.streamLatency,
-            onEvent: { rawContinuation.yield(()) }
+            onEvent: { rawContinuation.yield($0) }
         ) else {
             eventsContinuation.finish()
+            pathEventsContinuation.finish()
             rawContinuation.finish()
             return nil
         }
@@ -99,8 +114,8 @@ public actor RecursivePathWatcher {
         // init touches no isolated state after `self` escapes into the task; it
         // holds `self` weakly and ends when `rawEvents` finishes (stop/deinit).
         Task { [weak self] in
-            for await _ in rawEvents {
-                await self?.handleRawEvent()
+            for await paths in rawEvents {
+                await self?.handleRawEvent(paths: paths)
             }
         }
     }
@@ -116,7 +131,10 @@ public actor RecursivePathWatcher {
         let (events, eventsContinuation) = AsyncStream<Void>.makeStream()
         self.events = events
         self.continuation = eventsContinuation
-        let (_, rawContinuation) = AsyncStream<Void>.makeStream()
+        let (pathEvents, pathEventsContinuation) = AsyncStream<RecursivePathChange>.makeStream()
+        self.pathEvents = pathEvents
+        self.pathContinuation = pathEventsContinuation
+        let (_, rawContinuation) = AsyncStream<[String]>.makeStream()
         self.rawContinuation = rawContinuation
         self.eventStream = nil
     }
@@ -130,6 +148,7 @@ public actor RecursivePathWatcher {
         eventStream?.stop()
         rawContinuation.finish()
         continuation.finish()
+        pathContinuation.finish()
     }
 
     deinit {
@@ -139,13 +158,16 @@ public actor RecursivePathWatcher {
         throttleTask?.cancel()
         rawContinuation.finish()
         continuation.finish()
+        pathContinuation.finish()
     }
 
     /// Leading-edge throttle entry point. The first event of a window arms one
     /// delay; events arriving while it is pending are no-ops (the `throttleTask
     /// == nil` guard), so a burst yields a single ``events`` element.
-    private func handleRawEvent() {
-        guard !isStopped, throttleTask == nil else { return }
+    private func handleRawEvent(paths: [String]) {
+        guard !isStopped else { return }
+        pendingPaths.formUnion(paths)
+        guard throttleTask == nil else { return }
         let clock = self.clock
         let interval = Self.throttleInterval
         throttleTask = Task { [weak self] in
@@ -157,12 +179,15 @@ public actor RecursivePathWatcher {
     private func flushThrottle() {
         throttleTask = nil
         guard !isStopped else { return }
+        let paths = pendingPaths.sorted()
+        pendingPaths.removeAll(keepingCapacity: true)
+        pathContinuation.yield(RecursivePathChange(paths: paths))
         continuation.yield(())
     }
 
     /// Feeds a synthetic filesystem event into the throttle. Test-only seam used
     /// by ``init(testThrottleClock:)``-constructed watchers.
-    func simulateFileSystemEventForTesting() {
-        handleRawEvent()
+    func simulateFileSystemEventForTesting(paths: [String] = []) {
+        handleRawEvent(paths: paths)
     }
 }

--- a/Packages/CmuxFileWatch/Tests/CmuxFileWatchTests/RecursivePathWatcherTests.swift
+++ b/Packages/CmuxFileWatch/Tests/CmuxFileWatchTests/RecursivePathWatcherTests.swift
@@ -37,6 +37,25 @@ private actor GateClock: FileWatchClock {
 }
 
 @Suite struct RecursivePathWatcherTests {
+    private func nextPathEvent(
+        _ watcher: RecursivePathWatcher,
+        within seconds: Double
+    ) async -> RecursivePathChange? {
+        await withTaskGroup(of: RecursivePathChange?.self) { group in
+            group.addTask {
+                var iterator = watcher.pathEvents.makeAsyncIterator()
+                return await iterator.next()
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return nil
+            }
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            return result
+        }
+    }
+
     @Test func emptyPathsFailsInitialization() {
         let watcher = RecursivePathWatcher(paths: [])
         #expect(watcher == nil)
@@ -52,6 +71,27 @@ private actor GateClock: FileWatchClock {
         #expect(watcher != nil)
         #expect(watcher?.watchedPaths == [directory.path])
         await watcher?.stop()
+    }
+
+    @Test func realDirectoryPathEventReportsWatchedDirectoryPath() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-file-watch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let watcher = try #require(RecursivePathWatcher(paths: [directory.path]))
+        defer { Task { await watcher.stop() } }
+
+        let file = directory.appendingPathComponent("changed.txt")
+        try "updated".write(to: file, atomically: false, encoding: .utf8)
+
+        let change = await nextPathEvent(watcher, within: 5)
+        let directoryPath = directory.standardizedFileURL.path
+        #expect(change?.paths.isEmpty == false)
+        #expect(change?.paths.allSatisfy { path in
+            let normalizedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+            return normalizedPath == directoryPath || normalizedPath.hasPrefix(directoryPath + "/")
+        } == true)
     }
 
     /// A burst of events inside one throttle window coalesces into a single
@@ -89,6 +129,23 @@ private actor GateClock: FileWatchClock {
         await watcher.stop()
         let afterStop: Void? = await iterator.next()
         #expect(afterStop == nil)
+    }
+
+    @Test func pathEventsAggregatePathsInsideThrottleWindow() async {
+        let clock = GateClock()
+        let watcher = RecursivePathWatcher(testThrottleClock: clock)
+        var iterator = watcher.pathEvents.makeAsyncIterator()
+
+        await watcher.simulateFileSystemEventForTesting(paths: ["/repo/untracked.log"])
+        await watcher.simulateFileSystemEventForTesting(paths: ["/repo/src/file.swift"])
+        await watcher.simulateFileSystemEventForTesting(paths: ["/repo/src/file.swift"])
+        await clock.waitForSleeper()
+
+        await clock.releaseOne()
+        let change = await iterator.next()
+        #expect(change?.paths == ["/repo/src/file.swift", "/repo/untracked.log"])
+
+        await watcher.stop()
     }
 
     /// Events delivered after `stop()` produce no further yields.

--- a/Packages/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -73,7 +73,14 @@ public struct GitMetadataService: Sendable {
     /// - Returns: Sorted existing paths to watch, or `nil` when `directory` is
     ///   not inside a git repository.
     public nonisolated func watchedPaths(for directory: String) async -> [String]? {
-        Self.workspaceGitMetadataWatchedPaths(for: directory)
+        Self.workspaceGitMetadataWatchDescriptor(for: directory)?.watchedPaths
+    }
+
+    /// A richer watch descriptor for `directory`, including both the paths to
+    /// observe and the path-level filter for deciding whether a filesystem event
+    /// can change the metadata returned by ``workspaceMetadata(for:)``.
+    public nonisolated func watchDescriptor(for directory: String) async -> GitWorkspaceMetadataWatchDescriptor? {
+        Self.workspaceGitMetadataWatchDescriptor(for: directory)
     }
 
     /// The GitHub repository slugs (`owner/name`) configured as remotes for the

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Index.swift
@@ -76,10 +76,9 @@ extension GitMetadataService {
         let contentEnd = bytes.count - 20
         var offset = 12
         var entries: [GitIndexEntryStat] = []
-        var contentEntries: [GitIndexEntryStat] = []
         entries.reserveCapacity(min(entryCount, 1024))
-        contentEntries.reserveCapacity(min(entryCount, 1024))
         var previousPathBytes: [UInt8] = []
+        var contentSignatureHasher = GitIndexContentSignatureHasher(entryCount: entryCount)
 
         for _ in 0..<entryCount {
             guard offset + 62 <= contentEnd else { return nil }
@@ -88,7 +87,7 @@ extension GitMetadataService {
             let mtimeNanoseconds = readBigEndianUInt32(bytes, at: offset + 12)
             let mode = readBigEndianUInt32(bytes, at: offset + 24)
             let size = readBigEndianUInt32(bytes, at: offset + 36)
-            let objectID = gitIndexHexString(bytes[(offset + 40)..<(offset + 60)])
+            let objectIDBytes = bytes[(offset + 40)..<(offset + 60)]
             let flags = readBigEndianUInt16(bytes, at: offset + 60)
             let pathLength = Int(flags & 0x0fff)
             let hasExtendedFlags = version >= 3 && (flags & 0x4000) != 0
@@ -100,7 +99,7 @@ extension GitMetadataService {
                 offset += 2
             }
 
-            let pathBytes: [UInt8]
+            let pathBytes: ArraySlice<UInt8>
             if version == 4 {
                 guard let stripLength = readGitIndexV4PathStripLength(bytes, offset: &offset),
                       stripLength <= previousPathBytes.count else {
@@ -111,7 +110,10 @@ extension GitMetadataService {
                     offset += 1
                 }
                 guard offset < contentEnd else { return nil }
-                pathBytes = Array(previousPathBytes.dropLast(stripLength)) + Array(bytes[suffixStart..<offset])
+                var reconstructedPathBytes = Array(previousPathBytes.dropLast(stripLength))
+                reconstructedPathBytes.append(contentsOf: bytes[suffixStart..<offset])
+                pathBytes = reconstructedPathBytes[...]
+                previousPathBytes = reconstructedPathBytes
             } else {
                 let pathStart = offset
                 if pathLength < 0x0fff {
@@ -123,30 +125,31 @@ extension GitMetadataService {
                     }
                     guard offset < contentEnd else { return nil }
                 }
-                pathBytes = Array(bytes[pathStart..<offset])
+                pathBytes = bytes[pathStart..<offset]
             }
 
-            let pathData = Data(pathBytes)
-            guard let path = String(data: pathData, encoding: .utf8), !path.isEmpty,
-                  isValidIndexEntryPath(path) else {
+            guard isValidIndexEntryPathBytes(pathBytes),
+                  let path = String(bytes: pathBytes, encoding: .utf8) else {
                 return nil
             }
-            previousPathBytes = pathBytes
-            let entryStat = GitIndexEntryStat(
-                path: path,
+            contentSignatureHasher.appendEntry(
+                pathBytes: pathBytes,
                 mode: mode,
-                objectID: objectID,
-                mtimeSeconds: mtimeSeconds,
-                mtimeNanoseconds: mtimeNanoseconds,
-                size: size
+                rawObjectIDBytes: objectIDBytes
             )
-            contentEntries.append(entryStat)
 
             let assumeUnchangedFlag: UInt16 = 0x8000
             let skipWorktreeExtendedFlag: UInt16 = 0x4000
             if (flags & assumeUnchangedFlag) == 0,
                (extendedFlags & skipWorktreeExtendedFlag) == 0 {
-                entries.append(entryStat)
+                entries.append(GitIndexEntryStat(
+                    path: path,
+                    mode: mode,
+                    objectID: gitIndexHexString(objectIDBytes),
+                    mtimeSeconds: mtimeSeconds,
+                    mtimeNanoseconds: mtimeNanoseconds,
+                    size: size
+                ))
             }
 
             offset += 1
@@ -161,7 +164,7 @@ extension GitMetadataService {
         return GitIndexSnapshot(
             entries: entries,
             signature: checksum,
-            contentSignature: gitIndexContentSignature(entries: contentEntries)
+            contentSignature: gitIndexFixedWidthHexString(contentSignatureHasher.hash)
         )
     }
 
@@ -169,36 +172,74 @@ extension GitMetadataService {
     /// (stat-independent), used to detect tracked-content changes across index
     /// rewrites.
     nonisolated static func gitIndexContentSignature(entries: [GitIndexEntryStat]) -> String {
-        var hash: UInt64 = 14_695_981_039_346_656_037
+        var hasher = GitIndexContentSignatureHasher(entryCount: entries.count)
+        for entry in entries {
+            hasher.appendEntry(
+                pathBytes: entry.path.utf8,
+                mode: entry.mode,
+                objectIDHexBytes: entry.objectID.utf8
+            )
+        }
+        return gitIndexFixedWidthHexString(hasher.hash)
+    }
 
-        func appendByte(_ byte: UInt8) {
+    private struct GitIndexContentSignatureHasher {
+        private(set) var hash: UInt64 = 14_695_981_039_346_656_037
+
+        init(entryCount: Int) {
+            appendUInt32(UInt32(truncatingIfNeeded: entryCount))
+        }
+
+        mutating func appendEntry<PathBytes: Sequence, ObjectIDHexBytes: Sequence>(
+            pathBytes: PathBytes,
+            mode: UInt32,
+            objectIDHexBytes: ObjectIDHexBytes
+        ) where PathBytes.Element == UInt8, ObjectIDHexBytes.Element == UInt8 {
+            appendBytes(pathBytes)
+            appendByte(0)
+            appendUInt32(mode)
+            appendByte(0)
+            appendBytes(objectIDHexBytes)
+            appendByte(0)
+        }
+
+        mutating func appendEntry<PathBytes: Sequence, RawObjectIDBytes: Sequence>(
+            pathBytes: PathBytes,
+            mode: UInt32,
+            rawObjectIDBytes: RawObjectIDBytes
+        ) where PathBytes.Element == UInt8, RawObjectIDBytes.Element == UInt8 {
+            appendBytes(pathBytes)
+            appendByte(0)
+            appendUInt32(mode)
+            appendByte(0)
+            appendHexBytes(rawObjectIDBytes)
+            appendByte(0)
+        }
+
+        private mutating func appendBytes<Bytes: Sequence>(_ bytes: Bytes) where Bytes.Element == UInt8 {
+            for byte in bytes {
+                appendByte(byte)
+            }
+        }
+
+        private mutating func appendHexBytes<Bytes: Sequence>(_ bytes: Bytes) where Bytes.Element == UInt8 {
+            for byte in bytes {
+                appendByte(gitIndexHexAlphabet[Int(byte >> 4)])
+                appendByte(gitIndexHexAlphabet[Int(byte & 0x0f)])
+            }
+        }
+
+        private mutating func appendByte(_ byte: UInt8) {
             hash ^= UInt64(byte)
             hash = hash &* 1_099_511_628_211
         }
 
-        func appendUInt32(_ value: UInt32) {
+        private mutating func appendUInt32(_ value: UInt32) {
             appendByte(UInt8((value >> 24) & 0xff))
             appendByte(UInt8((value >> 16) & 0xff))
             appendByte(UInt8((value >> 8) & 0xff))
             appendByte(UInt8(value & 0xff))
         }
-
-        func appendString(_ value: String) {
-            for byte in value.utf8 {
-                appendByte(byte)
-            }
-        }
-
-        appendUInt32(UInt32(truncatingIfNeeded: entries.count))
-        for entry in entries {
-            appendString(entry.path)
-            appendByte(0)
-            appendUInt32(entry.mode)
-            appendByte(0)
-            appendString(entry.objectID)
-            appendByte(0)
-        }
-        return gitIndexFixedWidthHexString(hash)
     }
 
     private nonisolated static func gitIndexHexString<S: Sequence>(_ bytes: S) -> String where S.Element == UInt8 {
@@ -260,8 +301,39 @@ extension GitMetadataService {
     /// (not absolute) and free of `..` traversal components. An index containing
     /// anything else is treated as malformed.
     nonisolated static func isValidIndexEntryPath(_ path: String) -> Bool {
-        guard !path.hasPrefix("/") else { return false }
-        return !path.split(separator: "/").contains("..")
+        isValidIndexEntryPathBytes(path.utf8)
+    }
+
+    private nonisolated static func isValidIndexEntryPathBytes<Bytes: Sequence>(
+        _ bytes: Bytes
+    ) -> Bool where Bytes.Element == UInt8 {
+        var sawAnyByte = false
+        var componentLength = 0
+        var componentContainsOnlyDots = true
+
+        for byte in bytes {
+            if !sawAnyByte {
+                guard byte != UInt8(ascii: "/") else { return false }
+                sawAnyByte = true
+            }
+
+            if byte == UInt8(ascii: "/") {
+                if componentLength == 2, componentContainsOnlyDots {
+                    return false
+                }
+                componentLength = 0
+                componentContainsOnlyDots = true
+                continue
+            }
+
+            componentLength += 1
+            if byte != UInt8(ascii: ".") {
+                componentContainsOnlyDots = false
+            }
+        }
+
+        guard sawAnyByte else { return false }
+        return !(componentLength == 2 && componentContainsOnlyDots)
     }
 
     /// The raw index trailing-20-byte checksum as hex, or `nil` when the index

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
@@ -1,5 +1,114 @@
 import Foundation
 
+/// The filesystem-watch plan for keeping a workspace's sidebar git metadata
+/// fresh without treating every event under a large work tree as meaningful.
+public struct GitWorkspaceMetadataWatchDescriptor: Equatable, Sendable {
+    /// Existing absolute paths that should be passed to the filesystem watcher.
+    public let watchedPaths: [String]
+
+    /// Absolute git metadata paths whose changes can affect branch, index, refs,
+    /// config, submodule gitlink state, or remote slug resolution.
+    public let gitMetadataPaths: [String]
+
+    /// Absolute tracked working-tree entry paths from the root repository index.
+    ///
+    /// Events outside these paths cannot change the dirty bit. The list is sorted
+    /// so relevance checks can binary-search instead of scanning the full index
+    /// on every filesystem event.
+    public let trackedEntryPaths: [String]
+
+    public init(watchedPaths: [String], gitMetadataPaths: [String], trackedEntryPaths: [String]) {
+        self.watchedPaths = watchedPaths
+        self.gitMetadataPaths = gitMetadataPaths
+        self.trackedEntryPaths = trackedEntryPaths
+    }
+
+    /// Whether a coalesced filesystem event can change the corresponding
+    /// ``GitWorkspaceMetadata`` snapshot.
+    ///
+    /// Empty path detail is treated as relevant so callers stay correct on OS
+    /// events that do not include file-level paths.
+    public func containsRelevantChange(paths: [String]) -> Bool {
+        guard !paths.isEmpty else { return true }
+        return paths.contains { containsRelevantChange(path: $0) }
+    }
+
+    public func containsRelevantChange(path: String) -> Bool {
+        let normalizedPath = Self.normalizedPath(path)
+        if containsRelevantChange(normalizedPath: normalizedPath) {
+            return true
+        }
+        if let alternatePath = Self.alternateVarPath(for: normalizedPath) {
+            return containsRelevantChange(normalizedPath: alternatePath)
+        }
+        return false
+    }
+
+    private func containsRelevantChange(normalizedPath: String) -> Bool {
+        if gitMetadataPaths.contains(where: { Self.path(normalizedPath, isSameOrInside: $0) }) {
+            return true
+        }
+        return containsTrackedEntryChange(path: normalizedPath)
+    }
+
+    private func containsTrackedEntryChange(path: String) -> Bool {
+        guard !trackedEntryPaths.isEmpty else { return false }
+        let index = lowerBound(for: path)
+        if index < trackedEntryPaths.endIndex, trackedEntryPaths[index] == path {
+            return true
+        }
+        let directoryPrefix = path.hasSuffix("/") ? path : path + "/"
+        let prefixIndex = lowerBound(for: directoryPrefix)
+        return prefixIndex < trackedEntryPaths.endIndex
+            && trackedEntryPaths[prefixIndex].hasPrefix(directoryPrefix)
+    }
+
+    private func lowerBound(for value: String) -> Int {
+        var low = trackedEntryPaths.startIndex
+        var high = trackedEntryPaths.endIndex
+        while low < high {
+            let mid = low + (high - low) / 2
+            if trackedEntryPaths[mid] < value {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        return low
+    }
+
+    private static func path(_ path: String, isSameOrInside root: String) -> Bool {
+        path == root || path.hasPrefix(root.hasSuffix("/") ? root : root + "/")
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        if !path.contains("//"),
+           !path.contains("/./"),
+           !path.contains("/../"),
+           !path.hasSuffix("/."),
+           !path.hasSuffix("/..") {
+            return path
+        }
+        return URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    private static func alternateVarPath(for path: String) -> String? {
+        if path == "/var" {
+            return "/private/var"
+        }
+        if path.hasPrefix("/var/") {
+            return "/private" + path
+        }
+        if path == "/private/var" {
+            return "/var"
+        }
+        if path.hasPrefix("/private/var/") {
+            return String(path.dropFirst("/private".count))
+        }
+        return nil
+    }
+}
+
 extension GitMetadataService {
     /// Computes the sorted, existing paths to watch for a directory's git
     /// metadata, including submodule gitlinks. Returns `nil` when `directory` is
@@ -7,14 +116,23 @@ extension GitMetadataService {
     nonisolated static func workspaceGitMetadataWatchedPaths(
         for directory: String
     ) -> [String]? {
+        workspaceGitMetadataWatchDescriptor(for: directory)?.watchedPaths
+    }
+
+    /// Computes the watcher descriptor for a directory's git metadata.
+    nonisolated static func workspaceGitMetadataWatchDescriptor(
+        for directory: String
+    ) -> GitWorkspaceMetadataWatchDescriptor? {
         guard let repository = resolveGitRepository(containing: directory) else {
             return nil
         }
+        let gitMetadataPaths = gitRepositoryMetadataWatchPaths(repository: repository)
+            + gitlinkMetadataWatchPaths(repository: repository)
+        let trackedEntryPaths = gitTrackedEntryWatchPaths(repository: repository)
 
         let candidatePaths = [
             repository.workTreeRoot,
-        ] + gitRepositoryMetadataWatchPaths(repository: repository)
-            + gitlinkMetadataWatchPaths(repository: repository)
+        ] + gitMetadataPaths
         var watchedPaths: [String] = []
         var seen: Set<String> = []
         for path in candidatePaths {
@@ -27,7 +145,11 @@ extension GitMetadataService {
             watchedPaths.append(normalized)
         }
 
-        return watchedPaths.sorted()
+        return GitWorkspaceMetadataWatchDescriptor(
+            watchedPaths: watchedPaths.sorted(),
+            gitMetadataPaths: sortedUniqueNormalizedPaths(gitMetadataPaths),
+            trackedEntryPaths: trackedEntryPaths
+        )
     }
 
     /// The metadata paths (`HEAD`, `index`, `refs`, `packed-refs`, every reachable
@@ -52,6 +174,32 @@ extension GitMetadataService {
     ) -> [String] {
         var visitedWorkTreeRoots: Set<String> = [repository.workTreeRoot]
         return gitlinkMetadataWatchPaths(repository: repository, visitedWorkTreeRoots: &visitedWorkTreeRoots)
+    }
+
+    private nonisolated static func gitTrackedEntryWatchPaths(
+        repository: ResolvedGitRepository
+    ) -> [String] {
+        let indexURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("index")
+        guard let indexSnapshot = gitIndexSnapshot(indexURL: indexURL) else {
+            return []
+        }
+        return sortedUniqueNormalizedPaths(indexSnapshot.entries.map { entry in
+            URL(fileURLWithPath: repository.workTreeRoot)
+                .appendingPathComponent(entry.path)
+                .standardizedFileURL
+                .path
+        })
+    }
+
+    private nonisolated static func sortedUniqueNormalizedPaths(_ paths: [String]) -> [String] {
+        var result: [String] = []
+        var seen: Set<String> = []
+        for path in paths {
+            let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+            guard seen.insert(normalized).inserted else { continue }
+            result.append(normalized)
+        }
+        return result.sorted()
     }
 
     private nonisolated static func gitlinkMetadataWatchPaths(

--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -247,6 +247,39 @@ import Testing
         #expect(paths.contains(fixture.root.standardizedFileURL.path))
     }
 
+    @Test func watchDescriptorIgnoresUntrackedWorkingTreeEvents() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try fixture.writeConfig("[core]\n\trepositoryformatversion = 0\n")
+        let entry = try fixture.writeWorkingTreeFile("src/tracked.swift", contents: "let value = 1\n")
+        try fixture.writeIndex(GitIndexFixture(version: 2, entries: [entry]))
+
+        let service = GitMetadataService()
+        let descriptor = try #require(await service.watchDescriptor(for: fixture.root.path))
+        let trackedFile = fixture.root.appendingPathComponent("src/tracked.swift").path
+        let trackedDirectory = fixture.root.appendingPathComponent("src").path
+        let untrackedFile = fixture.root.appendingPathComponent("build/output.log").path
+        let index = fixture.gitDirectory.appendingPathComponent("index").path
+
+        #expect(descriptor.containsRelevantChange(path: trackedFile))
+        #expect(descriptor.containsRelevantChange(path: trackedDirectory))
+        #expect(descriptor.containsRelevantChange(path: index))
+        #expect(descriptor.containsRelevantChange(paths: []))
+        #expect(!descriptor.containsRelevantChange(path: untrackedFile))
+    }
+
+    @Test func watchDescriptorNormalizesVarFSEventPaths() {
+        let descriptor = GitWorkspaceMetadataWatchDescriptor(
+            watchedPaths: [],
+            gitMetadataPaths: [],
+            trackedEntryPaths: ["/private/var/tmp/repo/src/tracked.swift"]
+        )
+
+        #expect(descriptor.containsRelevantChange(path: "/var/tmp/repo/src/tracked.swift"))
+        #expect(descriptor.containsRelevantChange(path: "/var/tmp/repo/src"))
+        #expect(!descriptor.containsRelevantChange(path: "/var/tmp/repo/build/output.log"))
+    }
+
     @Test func watchedPathsNilOutsideRepository() async {
         let service = GitMetadataService()
         let paths = await service.watchedPaths(for: "/nope/\(UUID().uuidString)")

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -178,16 +178,25 @@ enum MobileHostRequestActivity {
     private nonisolated(unsafe) static var activeRequestCount = 0
     private nonisolated(unsafe) static var activeConnectionCount = 0
     private nonisolated(unsafe) static var lastActivityUptime: TimeInterval = 0
+    #if DEBUG
+    private nonisolated(unsafe) static var ignoresActivityForTesting = false
+    #endif
 
     static var hasActiveRequest: Bool {
         lock.lock()
         defer { lock.unlock() }
+        #if DEBUG
+        guard !ignoresActivityForTesting else { return false }
+        #endif
         return activeRequestCount > 0
     }
 
     static func hasRecentActivity(within interval: TimeInterval) -> Bool {
         lock.lock()
         defer { lock.unlock() }
+        #if DEBUG
+        guard !ignoresActivityForTesting else { return false }
+        #endif
         guard activeRequestCount == 0 else { return true }
         guard lastActivityUptime > 0 else { return false }
         return ProcessInfo.processInfo.systemUptime - lastActivityUptime < interval
@@ -196,6 +205,9 @@ enum MobileHostRequestActivity {
     static func quietDelay(for interval: TimeInterval) -> TimeInterval {
         lock.lock()
         defer { lock.unlock() }
+        #if DEBUG
+        guard !ignoresActivityForTesting else { return 0 }
+        #endif
         guard activeRequestCount == 0 else { return interval }
         guard lastActivityUptime > 0 else { return 0 }
         let elapsed = ProcessInfo.processInfo.systemUptime - lastActivityUptime
@@ -234,6 +246,13 @@ enum MobileHostRequestActivity {
         activeRequestCount = 0
         activeConnectionCount = 0
         lastActivityUptime = 0
+        ignoresActivityForTesting = false
+        lock.unlock()
+    }
+
+    static func setIgnoresActivityForTesting(_ ignoresActivity: Bool) {
+        lock.lock()
+        ignoresActivityForTesting = ignoresActivity
         lock.unlock()
     }
     #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3110,11 +3110,8 @@ class TabManager: ObservableObject {
         defer {
             if wasInFlight, !didClearProbe {
                 let rerunPending = workspaceGitProbeRerunPending(for: probeKey)
-                if rerunPending {
+                if rerunPending, !shouldFinishProbe {
                     workspaceGitProbeStateByKey[probeKey] = .idle
-                    if shouldFinishProbe {
-                        cancelWorkspaceGitProbeTask(for: probeKey)
-                    }
                     scheduleWorkspaceGitMetadataRefreshIfPossible(
                         workspaceId: probeKey.workspaceId,
                         panelId: probeKey.panelId,
@@ -3282,7 +3279,7 @@ class TabManager: ObservableObject {
         _ snapshot: InitialWorkspaceGitMetadataSnapshot
     ) -> Bool {
         if snapshot.isRepository {
-            return false
+            return true
         }
         switch snapshot.pullRequest {
         case .deferred, .transientFailure:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1224,6 +1224,7 @@ class TabManager: ObservableObject {
     private var workspaceGitCleanIndexContentSignatureByKey: [WorkspaceGitProbeKey: String] = [:]
     private var workspaceGitHeadSignatureByKey: [WorkspaceGitProbeKey: String] = [:]
     private var workspaceGitMetadataWatchersByKey: [WorkspaceGitProbeKey: RecursivePathWatcher] = [:]
+    private var workspaceGitMetadataWatcherDescriptorsByKey: [WorkspaceGitProbeKey: GitWorkspaceMetadataWatchDescriptor] = [:]
     private var workspaceGitMetadataWatcherRefreshTasksByKey: [WorkspaceGitProbeKey: Task<Void, Never>] = [:]
     private var workspaceGitMetadataWatcherSourceDirectoryByKey: [WorkspaceGitProbeKey: String] = [:]
     private var workspaceGitMetadataWatcherDescriptorRequestsByKey: [WorkspaceGitProbeKey: WorkspaceGitMetadataWatcherDescriptorRequest] = [:]
@@ -1627,10 +1628,10 @@ class TabManager: ObservableObject {
 
         Task { [weak self] in
             guard let gitMetadataService = self?.gitMetadataService else { return }
-            let watchedPaths = await gitMetadataService.watchedPaths(for: directory)
+            let descriptor = await gitMetadataService.watchDescriptor(for: directory)
             await MainActor.run { [weak self] in
                 self?.applyWorkspaceGitMetadataWatcherDescriptor(
-                    watchedPaths,
+                    descriptor,
                     for: key,
                     request: request
                 )
@@ -1639,7 +1640,7 @@ class TabManager: ObservableObject {
     }
 
     private func applyWorkspaceGitMetadataWatcherDescriptor(
-        _ watchedPaths: [String]?,
+        _ descriptor: GitWorkspaceMetadataWatchDescriptor?,
         for key: WorkspaceGitProbeKey,
         request: WorkspaceGitMetadataWatcherDescriptorRequest
     ) {
@@ -1650,23 +1651,36 @@ class TabManager: ObservableObject {
 
         guard sidebarGitMetadataWatchEnabled,
               workspaceGitTrackedDirectoryByKey[key] == request.directory,
-              let watchedPaths else {
+              let descriptor else {
             stopWorkspaceGitMetadataWatcher(for: key)
             return
         }
 
-        if workspaceGitMetadataWatchersByKey[key]?.watchedPaths == watchedPaths {
+        if workspaceGitMetadataWatchersByKey[key]?.watchedPaths == descriptor.watchedPaths {
             workspaceGitMetadataWatcherSourceDirectoryByKey[key] = request.directory
+            workspaceGitMetadataWatcherDescriptorsByKey[key] = descriptor
             return
         }
 
         stopWorkspaceGitMetadataWatcher(for: key)
-        if let watcher = RecursivePathWatcher(paths: watchedPaths) {
+        if let watcher = RecursivePathWatcher(paths: descriptor.watchedPaths) {
             workspaceGitMetadataWatchersByKey[key] = watcher
-            let events = watcher.events
+            workspaceGitMetadataWatcherDescriptorsByKey[key] = descriptor
+            let events = watcher.pathEvents
             workspaceGitMetadataWatcherRefreshTasksByKey[key] = Task { @MainActor [weak self] in
-                for await _ in events {
+                for await change in events {
                     guard let self else { break }
+                    guard self.workspaceGitMetadataWatcherDescriptorsByKey[key]?.containsRelevantChange(
+                        paths: change.paths
+                    ) != false else {
+#if DEBUG
+                        cmuxDebugLog(
+                            "workspace.gitProbe.skipEvent workspace=\(key.workspaceId.uuidString.prefix(5)) " +
+                            "panel=\(key.panelId.uuidString.prefix(5)) paths=\(change.paths.count)"
+                        )
+#endif
+                        continue
+                    }
                     self.scheduleWorkspaceGitMetadataRefreshIfPossible(
                         workspaceId: key.workspaceId,
                         panelId: key.panelId,
@@ -1681,6 +1695,7 @@ class TabManager: ObservableObject {
     private func stopWorkspaceGitMetadataWatcher(for key: WorkspaceGitProbeKey) {
         workspaceGitMetadataWatcherDescriptorRequestsByKey.removeValue(forKey: key)
         workspaceGitMetadataWatcherSourceDirectoryByKey.removeValue(forKey: key)
+        workspaceGitMetadataWatcherDescriptorsByKey.removeValue(forKey: key)
         workspaceGitMetadataWatcherRefreshTasksByKey.removeValue(forKey: key)?.cancel()
         // Dropping the last reference runs the watcher's deinit synchronously,
         // which invalidates the FSEventStream on its shared queue before this
@@ -1705,6 +1720,7 @@ class TabManager: ObservableObject {
         // invalidating its FSEventStream.
         workspaceGitMetadataWatchersByKey.removeAll()
         workspaceGitMetadataWatcherSourceDirectoryByKey.removeAll()
+        workspaceGitMetadataWatcherDescriptorsByKey.removeAll()
         workspaceGitMetadataWatcherDescriptorRequestsByKey.removeAll()
     }
 

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -131,6 +131,45 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
     }
 }
 
+private actor CountingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
+    private let metadata: GitWorkspaceMetadata
+    private var callCount = 0
+    private var callCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    init(metadata: GitWorkspaceMetadata) {
+        self.metadata = metadata
+    }
+
+    func workspaceMetadata(for directory: String) async -> GitWorkspaceMetadata {
+        callCount += 1
+        resumeSatisfiedCallCountWaiters()
+        return metadata
+    }
+
+    func waitForCallCount(_ expected: Int) async {
+        guard callCount < expected else { return }
+        await withCheckedContinuation { continuation in
+            callCountWaiters.append((expected, continuation))
+        }
+    }
+
+    var observedCallCount: Int {
+        callCount
+    }
+
+    private func resumeSatisfiedCallCountWaiters() {
+        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
+        for waiter in callCountWaiters {
+            if callCount >= waiter.0 {
+                waiter.1.resume()
+            } else {
+                remaining.append(waiter)
+            }
+        }
+        callCountWaiters = remaining
+    }
+}
+
 private struct ProcessRunResult {
     let status: Int32
     let stdout: String
@@ -830,6 +869,78 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         )
         let finalObservedCallCount = await reader.observedCallCount
         XCTAssertEqual(finalObservedCallCount, 1)
+    }
+
+    func testInitialGitMetadataProbeStopsAfterRepositorySnapshot() async throws {
+        let defaults = UserDefaults.standard
+        let previousWatchGitStatus = defaults.object(forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
+        defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
+        defer {
+            restoreUserDefaultForTabManagerTests(
+                previousWatchGitStatus,
+                key: SidebarWorkspaceDetailDefaults.watchGitStatusKey
+            )
+        }
+
+        let directoryURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-git-stop-after-repo-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+
+        let reader = CountingWorkspaceGitMetadataReader(
+            metadata: GitWorkspaceMetadata(
+                isRepository: true,
+                branch: "main",
+                isDirty: false,
+                indexSignature: "index",
+                indexContentSignature: "content",
+                headSignature: "head"
+            )
+        )
+        let manager = TabManager(
+            autoWelcomeIfNeeded: false,
+            workspaceGitMetadataReader: reader
+        )
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        manager.updateSurfaceDirectory(
+            tabId: workspace.id,
+            surfaceId: panelId,
+            directory: directoryURL.path
+        )
+        defaults.set(true, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
+        manager.scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
+            workspaceId: workspace.id,
+            panelId: panelId,
+            reason: "test"
+        )
+
+        await reader.waitForCallCount(1)
+
+        XCTAssertTrue(
+            waitForCondition {
+                workspace.panelGitBranches[panelId]?.branch == "main"
+            },
+            "The first successful repository snapshot should update sidebar git metadata."
+        )
+
+        let secondRead = expectation(description: "retry read after repository snapshot")
+        secondRead.isInverted = true
+        Task {
+            await reader.waitForCallCount(2)
+            secondRead.fulfill()
+        }
+        await fulfillment(of: [secondRead], timeout: 0.8)
+        let observedCallCount = await reader.observedCallCount
+        XCTAssertEqual(observedCallCount, 1)
     }
 
     func testTrackedWorkspaceGitMetadataPollCandidatesExcludeDirectoriesWithoutResolvedGitMetadata() throws {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -62,6 +62,29 @@ private func waitForCondition(
     return true
 }
 
+@discardableResult
+private func waitForConditionAsync(
+    timeout: TimeInterval = 3.0,
+    pollInterval: TimeInterval = 0.05,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: @escaping () -> Bool
+) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() {
+            return true
+        }
+        let nanoseconds = UInt64(pollInterval * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: nanoseconds)
+    }
+    if condition() {
+        return true
+    }
+    XCTFail("Timed out waiting for condition", file: file, line: line)
+    return false
+}
+
 private func restoreUserDefaultForTabManagerTests(_ value: Any?, key: String) {
     let defaults = UserDefaults.standard
     if let value {
@@ -87,9 +110,9 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
         callCount += 1
         activeCallCount += 1
         maxActiveCallCount = max(maxActiveCallCount, activeCallCount)
-        resumeSatisfiedCallCountWaiters()
         await withCheckedContinuation { continuation in
             releaseContinuations.append(continuation)
+            resumeSatisfiedCallCountWaiters()
         }
         activeCallCount -= 1
         return metadata
@@ -116,45 +139,6 @@ private actor BlockingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
 
     var observedMaxActiveCallCount: Int {
         maxActiveCallCount
-    }
-
-    private func resumeSatisfiedCallCountWaiters() {
-        var remaining: [(Int, CheckedContinuation<Void, Never>)] = []
-        for waiter in callCountWaiters {
-            if callCount >= waiter.0 {
-                waiter.1.resume()
-            } else {
-                remaining.append(waiter)
-            }
-        }
-        callCountWaiters = remaining
-    }
-}
-
-private actor CountingWorkspaceGitMetadataReader: WorkspaceGitMetadataReading {
-    private let metadata: GitWorkspaceMetadata
-    private var callCount = 0
-    private var callCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
-
-    init(metadata: GitWorkspaceMetadata) {
-        self.metadata = metadata
-    }
-
-    func workspaceMetadata(for directory: String) async -> GitWorkspaceMetadata {
-        callCount += 1
-        resumeSatisfiedCallCountWaiters()
-        return metadata
-    }
-
-    func waitForCallCount(_ expected: Int) async {
-        guard callCount < expected else { return }
-        await withCheckedContinuation { continuation in
-            callCountWaiters.append((expected, continuation))
-        }
-    }
-
-    var observedCallCount: Int {
-        callCount
     }
 
     private func resumeSatisfiedCallCountWaiters() {
@@ -786,7 +770,10 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         let defaults = UserDefaults.standard
         let previousWatchGitStatus = defaults.object(forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
         defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
+        MobileHostRequestActivity.resetForTesting()
+        MobileHostRequestActivity.setIgnoresActivityForTesting(true)
         defer {
+            MobileHostRequestActivity.resetForTesting()
             restoreUserDefaultForTabManagerTests(
                 previousWatchGitStatus,
                 key: SidebarWorkspaceDetailDefaults.watchGitStatusKey
@@ -861,11 +848,15 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertEqual(observedMaxActiveCallCount, 1)
 
         await reader.releaseAll()
+        let didUpdateQueuedPanels = await waitForConditionAsync {
+            panelIds.allSatisfy { workspace.panelGitBranches[$0]?.branch == "main" }
+        }
         XCTAssertTrue(
-            waitForCondition {
-                panelIds.allSatisfy { workspace.panelGitBranches[$0]?.branch == "main" }
-            },
-            "One same-directory snapshot should update every queued panel."
+            didUpdateQueuedPanels,
+            "One same-directory snapshot should update every queued panel. " +
+            "branches=\(workspace.panelGitBranches), " +
+            "directories=\(workspace.panelDirectories), " +
+            "activeProbes=\(manager.activeWorkspaceGitProbePanelIdsForTesting(workspaceId: workspace.id))"
         )
         let finalObservedCallCount = await reader.observedCallCount
         XCTAssertEqual(finalObservedCallCount, 1)
@@ -875,7 +866,10 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         let defaults = UserDefaults.standard
         let previousWatchGitStatus = defaults.object(forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
         defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.watchGitStatusKey)
+        MobileHostRequestActivity.resetForTesting()
+        MobileHostRequestActivity.setIgnoresActivityForTesting(true)
         defer {
+            MobileHostRequestActivity.resetForTesting()
             restoreUserDefaultForTabManagerTests(
                 previousWatchGitStatus,
                 key: SidebarWorkspaceDetailDefaults.watchGitStatusKey
@@ -891,7 +885,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
             try? FileManager.default.removeItem(at: directoryURL)
         }
 
-        let reader = CountingWorkspaceGitMetadataReader(
+        let reader = BlockingWorkspaceGitMetadataReader(
             metadata: GitWorkspaceMetadata(
                 isRepository: true,
                 branch: "main",
@@ -901,6 +895,11 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
                 headSignature: "head"
             )
         )
+        defer {
+            Task {
+                await reader.releaseAll()
+            }
+        }
         let manager = TabManager(
             autoWelcomeIfNeeded: false,
             workspaceGitMetadataReader: reader
@@ -924,12 +923,18 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         )
 
         await reader.waitForCallCount(1)
+        await reader.releaseAll()
 
+        let didUpdateGitMetadata = await waitForConditionAsync {
+            workspace.panelGitBranches[panelId]?.branch == "main"
+        }
         XCTAssertTrue(
-            waitForCondition {
-                workspace.panelGitBranches[panelId]?.branch == "main"
-            },
-            "The first successful repository snapshot should update sidebar git metadata."
+            didUpdateGitMetadata,
+            "The first successful repository snapshot should update sidebar git metadata. " +
+            "branch=\(String(describing: workspace.panelGitBranches[panelId])), " +
+            "directory=\(String(describing: workspace.panelDirectories[panelId])), " +
+            "panelExists=\(workspace.panels[panelId] != nil), " +
+            "activeProbes=\(manager.activeWorkspaceGitProbePanelIdsForTesting(workspaceId: workspace.id))"
         )
 
         let secondRead = expectation(description: "retry read after repository snapshot")
@@ -939,6 +944,7 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
             secondRead.fulfill()
         }
         await fulfillment(of: [secondRead], timeout: 0.8)
+        await reader.releaseAll()
         let observedCallCount = await reader.observedCallCount
         XCTAssertEqual(observedCallCount, 1)
     }


### PR DESCRIPTION
## Summary

- Fixes slow horizontal scrolling in panes with many browser tabs by removing per-scroll SwiftUI tab-frame state churn from the Bonsplit tab strip.
- Keeps tab frames in stable scroll-content coordinates, moves the selected indicator and bottom separator into scroll content, and updates only left/right scroll affordance state when that semantic state changes.
- Translates AppKit drag, hover, hit-test, cursor-rect, and manual reorder points through the current `NSScrollView` offset so behavior stays correct after the coordinate change.
- Fixes the intermittent slowdown Lawrence reported by stopping redundant initial git metadata retries and filtering filesystem watcher churn before it can trigger full git index dirty scans.
- The remaining background-work path now uses FSEvents paths plus the parsed git index's tracked paths to ignore untracked working-tree noise, while still refreshing for tracked files, `HEAD`, `index`, refs, config, and conservative path-less events.

## Testing

- `swift test --filter 'BonsplitTests/testTabBarTrailingEmptyChromeUsesScrolledContentCoordinates|BonsplitTests/testTabBarDragZoneCursorUsesScrolledContentCoordinates'` passed.
- `swift test` in `vendor/bonsplit` passed, 138 tests.
- `swift test --package-path Packages/CmuxFileWatch` passed, 13 tests.
- `swift test --package-path Packages/CmuxGit` passed, 59 tests.
- `xcodebuild -quiet -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-tabscr-tests test -only-testing:cmuxTests/TabManagerPullRequestProbeTests/testSameDirectoryInitialGitMetadataProbesShareOneSnapshotRead -only-testing:cmuxTests/TabManagerPullRequestProbeTests/testInitialGitMetadataProbeStopsAfterRepositorySnapshot -only-testing:cmuxTests/WorkspacePullRequestSidebarTests/testDetachedHeadRepositoryKeepsGitMetadataWatcherForLaterCheckout` passed.
- `xcodebuild -quiet -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-tabscr-unit2 build` passed.
- `./scripts/reload-cloud.sh --tag tabscr` fell back to local `./scripts/reload.sh --tag tabscr` because no macbuilder fleet is configured, then passed with `BUILD_OK`.
- Tagged socket preflight on `tabscr`: `workspace:3`, `pane:5`, 12 GitHub browser tabs, with the tagged window moved to `LG HDR 4K`.

## Proof

- Before sample: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/before-proof/cmux-before-tab-scroll.sample.txt`. The old scroll path showed `TabFramePreferenceKey` 6 times and `GraphHost.updatePreferences` 14 times while horizontally scrolling the tab strip.
- After exact horizontal-scroll sample: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/after-proof/cmux-after-cg-tab-scroll-current.sample.txt`. The scan found no `TabFramePreferenceKey` or `updateTabScrollContent` frames during the gesture.
- New intermittent-load sample before the watcher filter: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/fixed-load-proof/tabscr-fixed-settled.sample.txt`. The app still spent sustained CPU in `GitMetadataService.gitTrackedChangesSnapshot` / `gitIndexSnapshot` while the repro workspace's terminal pane was at `$HOME`, which is a large git repo.
- After watcher filter, settled sample: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/path-filter-proof/tabscr-optimized-settled.sample.txt`. Process CPU was 0.2% before sampling and 1.2% after; no `gitIndexSnapshot` or `gitTrackedChangesSnapshot` frames were present.
- After watcher filter, 200 untracked writes under `$HOME/.cmux-tabscr-watch-noise`: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/path-filter-proof/tabscr-optimized-noise.sample.txt`. `git ls-files --error-unmatch` returned status 1 for that path, process CPU was 0.1% before sampling and 0.8% after, and no `gitIndexSnapshot` or `gitTrackedChangesSnapshot` frames were present.
- After screenshots for tab strip behavior: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/after-proof/tabscr-first-tab-latest.png`, `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/after-proof/tabscr-last-tab-latest.png`, `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-browser-tab-strip-scroll-perf/after-proof/tabscr-after-cg-scroll-current.png`.

## Commits

- Bonsplit red test-only commit: https://github.com/manaflow-ai/bonsplit/commit/c41a67d50f24cc6e0c70aeabfef5d5dc9f44593e
- Bonsplit runtime fix commit: https://github.com/manaflow-ai/bonsplit/commit/4584ec972dcbd921d56c295a597e61dde2cd75f2
- Bonsplit scrolled hit-region coverage: https://github.com/manaflow-ai/bonsplit/commit/674339b5d32eb8f85a76623ea8cd21b6c13366ff
- cmux git retry red test-only commit: https://github.com/manaflow-ai/cmux/commit/3e1131ff2a4e02061498aee746f0904757670da5
- cmux git retry fix commit: https://github.com/manaflow-ai/cmux/commit/0a01bb08499b4f4d49eead6ec839691312c455a9
- cmux watcher churn fix commit: https://github.com/manaflow-ai/cmux/commit/e620c43f97024d2aba7bd6ef853fa3e0058d52ee

## Related PRs

- Bonsplit PR: https://github.com/manaflow-ai/bonsplit/pull/147
- cmux PR: https://github.com/manaflow-ai/cmux/pull/6053

## Checklist

- [x] Created cmux worktree and did not edit `repo/` directly.
- [x] Read worktree-local `AGENTS.md` and `CLAUDE.md`.
- [x] Reproduced with a 12-tab GitHub browser pane in tagged `tabscr`.
- [x] Added behavior coverage for scrolled tab-strip hit regions.
- [x] Added git metadata retry and watcher-churn coverage.
- [x] Built and reloaded tagged macOS app.
- [x] Localization audit: no user-facing strings changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File system event tracking now includes affected file paths in change notifications.
  * Git sidebar monitoring now provides better filtering of relevant file system changes.

* **Bug Fixes**
  * Improved accuracy of Git metadata updates by filtering irrelevant file system events.

* **Chores**
  * Updated vendor dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->