### PR TITLE
Add FindablePanel protocol and route Cmd+F find across all panel types

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -15,14 +15,14 @@
 7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6223	cmuxTests/GhosttyConfigTests.swift
-6219	Sources/TabManager.swift
+6214	Sources/TabManager.swift
 6153	CLI/cmux_open.swift
 6074	Sources/TextBoxInput.swift
 5925	cmuxTests/TerminalAndGhosttyTests.swift
 5566	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 5526	cmuxTests/BrowserConfigTests.swift
 4516	Sources/cmuxApp.swift
-4502	Sources/Panels/FilePreviewPanel.swift
+4509	Sources/Panels/FilePreviewPanel.swift
 4401	cmuxTests/BrowserPanelTests.swift
 4225	Sources/BrowserWindowPortal.swift
 3937	Sources/Feed/FeedPanelView.swift
@@ -200,6 +200,7 @@
 527	CLI/CLISocketPathResolver.swift
 527	Packages/macOS/CmuxSocketControl/Sources/CmuxSocketControl/SocketControlSettings.swift
 524	CLI/CMUXCLI+AutoNaming.swift
+523	Sources/Panels/MarkdownPanel.swift
 522	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
 520	CLI/CMUXCLI+AmpExtension.swift
 520	cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -207,7 +208,6 @@
 519	Sources/CmuxConfigExecutor.swift
 518	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-git-review-queue-command-deck.swift
 517	Sources/TerminalImageTransfer.swift
-516	Sources/Panels/MarkdownPanel.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
 509	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34475	CLI/cmux.swift
-17604	Sources/AppDelegate.swift
+17602	Sources/AppDelegate.swift
 15933	Sources/ContentView.swift
 14104	Sources/TerminalController.swift
 12658	Sources/Workspace.swift
@@ -15,14 +15,14 @@
 7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6223	cmuxTests/GhosttyConfigTests.swift
-6172	Sources/TabManager.swift
+6219	Sources/TabManager.swift
 6153	CLI/cmux_open.swift
 6074	Sources/TextBoxInput.swift
 5925	cmuxTests/TerminalAndGhosttyTests.swift
 5566	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 5526	cmuxTests/BrowserConfigTests.swift
 4516	Sources/cmuxApp.swift
-4467	Sources/Panels/FilePreviewPanel.swift
+4502	Sources/Panels/FilePreviewPanel.swift
 4401	cmuxTests/BrowserPanelTests.swift
 4225	Sources/BrowserWindowPortal.swift
 3937	Sources/Feed/FeedPanelView.swift
@@ -207,6 +207,7 @@
 519	Sources/CmuxConfigExecutor.swift
 518	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-git-review-queue-command-deck.swift
 517	Sources/TerminalImageTransfer.swift
+516	Sources/Panels/MarkdownPanel.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
 509	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift

--- a/Sources/Panels/AgentSessionPanel.swift
+++ b/Sources/Panels/AgentSessionPanel.swift
@@ -87,3 +87,40 @@ final class AgentSessionPanel: Panel {
         _ = reason
     }
 }
+
+
+// MARK: - Find support
+
+extension AgentSessionPanel: FindablePanel {
+    /// `WKWebView` does not report its find panel visibility, so this reports
+    /// `false` conservatively.
+    var isFindVisible: Bool { false }
+
+    @discardableResult
+    func startFind() -> Bool {
+        sendFindPanelAction(.showFindInterface)
+    }
+
+    func findNext() {
+        _ = sendFindPanelAction(.nextMatch)
+    }
+
+    func findPrevious() {
+        _ = sendFindPanelAction(.previousMatch)
+    }
+
+    func hideFind() {
+        // WKWebView's `performFindPanelAction:` does not support hiding the
+        // find panel (NSFindPanelAction only defines values 1-10).
+    }
+
+    @discardableResult
+    private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
+        guard let webView = rendererSession.webView else { return false }
+        return NSApp.sendAction(
+            NSSelectorFromString("performFindPanelAction:"),
+            to: webView,
+            from: action.menuItemSender
+        )
+    }
+}

--- a/Sources/Panels/AgentSessionPanel.swift
+++ b/Sources/Panels/AgentSessionPanel.swift
@@ -92,28 +92,26 @@ final class AgentSessionPanel: Panel {
 // MARK: - Find support
 
 extension AgentSessionPanel: FindablePanel {
-    /// `WKWebView` does not report its find panel visibility, so this reports
-    /// `false` conservatively.
-    var isFindVisible: Bool { false }
-
+    /// Shows the web view's find panel.
     @discardableResult
     func startFind() -> Bool {
         sendFindPanelAction(.showFindInterface)
     }
 
+    /// Jumps to the next match in the web view.
     func findNext() {
         _ = sendFindPanelAction(.nextMatch)
     }
 
+    /// Jumps to the previous match in the web view.
     func findPrevious() {
         _ = sendFindPanelAction(.previousMatch)
     }
 
-    func hideFind() {
-        // WKWebView's `performFindPanelAction:` does not support hiding the
-        // find panel (NSFindPanelAction only defines values 1-10).
-    }
+    /// Hiding the web view find panel is not supported by `WKWebView`.
+    func hideFind() {}
 
+    /// Sends a find action to the agent session web view.
     @discardableResult
     private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
         guard let webView = rendererSession.webView else { return false }

--- a/Sources/Panels/AgentSessionWebRendererSession.swift
+++ b/Sources/Panels/AgentSessionWebRendererSession.swift
@@ -46,4 +46,8 @@ final class AgentSessionWebRendererSession {
     func close() {
         ownedCoordinator.close()
     }
+
+    var webView: AgentSessionWebView? {
+        ownedCoordinator.webView
+    }
 }

--- a/Sources/Panels/AgentSessionWebRendererSession.swift
+++ b/Sources/Panels/AgentSessionWebRendererSession.swift
@@ -47,6 +47,7 @@ final class AgentSessionWebRendererSession {
         ownedCoordinator.close()
     }
 
+    /// The underlying web view, exposed so find actions can be dispatched to it.
     var webView: AgentSessionWebView? {
         ownedCoordinator.webView
     }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1055,36 +1055,6 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         focusCoordinator.register(root: textView, primaryResponder: textView, intent: .textEditor)
     }
 
-    // MARK: - Find in text mode
-
-    @discardableResult
-    func startFind() -> Bool {
-        guard previewMode == .text, let textView else { return false }
-        textView.performTextFinderAction(textFinderSender(.showFindInterface))
-        return true
-    }
-
-    func findNext() {
-        guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.nextMatch))
-    }
-
-    func findPrevious() {
-        guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.previousMatch))
-    }
-
-    func hideFind() {
-        guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.hideFindInterface))
-    }
-
-    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
-        let item = NSMenuItem()
-        item.tag = action.rawValue
-        return item
-    }
-
     func handleDroppedFileURLsAsText(_ urls: [URL]) -> Bool {
         guard previewMode == .text, let textView else { return false }
         let text = TerminalImageTransferPlanner.insertedText(forFileURLs: urls)
@@ -4493,5 +4463,40 @@ private final class FilePreviewPointerObserverView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
+    }
+}
+
+
+// MARK: - Find in text mode
+
+extension FilePreviewPanel {
+    var isFindVisible: Bool { false }
+
+    @discardableResult
+    func startFind() -> Bool {
+        guard previewMode == .text, let textView else { return false }
+        textView.performTextFinderAction(textFinderSender(.showFindInterface))
+        return true
+    }
+
+    func findNext() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.nextMatch))
+    }
+
+    func findPrevious() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.previousMatch))
+    }
+
+    func hideFind() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.hideFindInterface))
+    }
+
+    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return item
     }
 }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -4469,34 +4469,39 @@ private final class FilePreviewPointerObserverView: NSView {
 
 // MARK: - Find in text mode
 
-extension FilePreviewPanel {
+extension FilePreviewPanel: FindablePanel {
+    /// The AppKit find bar visibility is not publicly exposed on `NSTextView`,
+    /// so this is conservative and reports `false` until a public signal exists.
     var isFindVisible: Bool { false }
+
+    var hasSelectionForFind: Bool {
+        previewMode == .text && (textView?.selectedRange.length ?? 0) > 0
+    }
 
     @discardableResult
     func startFind() -> Bool {
         guard previewMode == .text, let textView else { return false }
-        textView.performTextFinderAction(textFinderSender(.showFindInterface))
+        textView.performTextFinderAction(NSTextFinder.Action.showFindInterface.menuItemSender)
         return true
     }
 
     func findNext() {
         guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.nextMatch))
+        textView.performTextFinderAction(NSTextFinder.Action.nextMatch.menuItemSender)
     }
 
     func findPrevious() {
         guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.previousMatch))
+        textView.performTextFinderAction(NSTextFinder.Action.previousMatch.menuItemSender)
     }
 
     func hideFind() {
         guard previewMode == .text, let textView else { return }
-        textView.performTextFinderAction(textFinderSender(.hideFindInterface))
+        textView.performTextFinderAction(NSTextFinder.Action.hideFindInterface.menuItemSender)
     }
 
-    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
-        let item = NSMenuItem()
-        item.tag = action.rawValue
-        return item
+    func useSelectionForFind() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(NSTextFinder.Action.setSearchString.menuItemSender)
     }
 }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1055,6 +1055,36 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         focusCoordinator.register(root: textView, primaryResponder: textView, intent: .textEditor)
     }
 
+    // MARK: - Find in text mode
+
+    @discardableResult
+    func startFind() -> Bool {
+        guard previewMode == .text, let textView else { return false }
+        textView.performTextFinderAction(textFinderSender(.showFindInterface))
+        return true
+    }
+
+    func findNext() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.nextMatch))
+    }
+
+    func findPrevious() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.previousMatch))
+    }
+
+    func hideFind() {
+        guard previewMode == .text, let textView else { return }
+        textView.performTextFinderAction(textFinderSender(.hideFindInterface))
+    }
+
+    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return item
+    }
+
     func handleDroppedFileURLsAsText(_ urls: [URL]) -> Bool {
         guard previewMode == .text, let textView else { return false }
         let text = TerminalImageTransferPlanner.insertedText(forFileURLs: urls)

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -4470,14 +4470,12 @@ private final class FilePreviewPointerObserverView: NSView {
 // MARK: - Find in text mode
 
 extension FilePreviewPanel: FindablePanel {
-    /// The AppKit find bar visibility is not publicly exposed on `NSTextView`,
-    /// so this is conservative and reports `false` until a public signal exists.
-    var isFindVisible: Bool { false }
-
+    /// Text-mode previews support "Use Selection for Find" when text is selected.
     var hasSelectionForFind: Bool {
         previewMode == .text && (textView?.selectedRange.length ?? 0) > 0
     }
 
+    /// Shows the AppKit find bar when the panel is in text preview mode.
     @discardableResult
     func startFind() -> Bool {
         guard previewMode == .text, let textView else { return false }
@@ -4485,21 +4483,25 @@ extension FilePreviewPanel: FindablePanel {
         return true
     }
 
+    /// Jumps to the next match in the text preview.
     func findNext() {
         guard previewMode == .text, let textView else { return }
         textView.performTextFinderAction(NSTextFinder.Action.nextMatch.menuItemSender)
     }
 
+    /// Jumps to the previous match in the text preview.
     func findPrevious() {
         guard previewMode == .text, let textView else { return }
         textView.performTextFinderAction(NSTextFinder.Action.previousMatch.menuItemSender)
     }
 
+    /// Hides the AppKit find bar in the text preview.
     func hideFind() {
         guard previewMode == .text, let textView else { return }
         textView.performTextFinderAction(NSTextFinder.Action.hideFindInterface.menuItemSender)
     }
 
+    /// Uses the current text selection as the find needle.
     func useSelectionForFind() {
         guard previewMode == .text, let textView else { return }
         textView.performTextFinderAction(NSTextFinder.Action.setSearchString.menuItemSender)

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -455,15 +455,12 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 // MARK: - Find in panel
 
 extension MarkdownPanel: FindablePanel {
-    /// The AppKit find bar visibility is not publicly exposed on `NSTextView`,
-    /// and `WKWebView` does not report its find panel state, so this is
-    /// conservative and reports `false` until a public signal exists.
-    var isFindVisible: Bool { false }
-
+    /// Text-edit mode supports "Use Selection for Find" when text is selected.
     var hasSelectionForFind: Bool {
         displayMode == .text && (textView?.selectedRange.length ?? 0) > 0
     }
 
+    /// Shows the find UI for the current display mode.
     @discardableResult
     func startFind() -> Bool {
         switch displayMode {
@@ -476,6 +473,7 @@ extension MarkdownPanel: FindablePanel {
         }
     }
 
+    /// Jumps to the next match in the current display mode.
     func findNext() {
         switch displayMode {
         case .text:
@@ -485,6 +483,7 @@ extension MarkdownPanel: FindablePanel {
         }
     }
 
+    /// Jumps to the previous match in the current display mode.
     func findPrevious() {
         switch displayMode {
         case .text:
@@ -494,23 +493,24 @@ extension MarkdownPanel: FindablePanel {
         }
     }
 
+    /// Hides the find UI. Preview mode is a no-op because `WKWebView` does not
+    /// expose a hide action (`NSFindPanelAction` only defines values 1-10).
     func hideFind() {
         switch displayMode {
         case .text:
             textView?.performTextFinderAction(NSTextFinder.Action.hideFindInterface.menuItemSender)
         case .preview:
-            // WKWebView's `performFindPanelAction:` does not support hiding the
-            // find panel (NSFindPanelAction only defines values 1-10). The user
-            // can still close it with Esc or the UI close button.
             break
         }
     }
 
+    /// Uses the current text selection as the find needle in text-edit mode.
     func useSelectionForFind() {
         guard displayMode == .text, let textView else { return }
         textView.performTextFinderAction(NSTextFinder.Action.setSearchString.menuItemSender)
     }
 
+    /// Sends a find action to the preview `WKWebView`.
     @discardableResult
     private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
         guard let webView = rendererSession.webView else { return false }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -271,65 +271,6 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         self.textView = textView
     }
 
-    // MARK: - Find in panel
-
-    @discardableResult
-    func startFind() -> Bool {
-        switch displayMode {
-        case .text:
-            guard let textView else { return false }
-            textView.performTextFinderAction(textFinderSender(.showFindInterface))
-            return true
-        case .preview:
-            return sendFindPanelAction(.showFindInterface)
-        }
-    }
-
-    func findNext() {
-        switch displayMode {
-        case .text:
-            textView?.performTextFinderAction(textFinderSender(.nextMatch))
-        case .preview:
-            _ = sendFindPanelAction(.nextMatch)
-        }
-    }
-
-    func findPrevious() {
-        switch displayMode {
-        case .text:
-            textView?.performTextFinderAction(textFinderSender(.previousMatch))
-        case .preview:
-            _ = sendFindPanelAction(.previousMatch)
-        }
-    }
-
-    func hideFind() {
-        switch displayMode {
-        case .text:
-            textView?.performTextFinderAction(textFinderSender(.hideFindInterface))
-        case .preview:
-            _ = sendFindPanelAction(.hideFindInterface)
-        }
-    }
-
-    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
-        let item = NSMenuItem()
-        item.tag = action.rawValue
-        return item
-    }
-
-    @discardableResult
-    private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
-        guard let webView = rendererSession.webView else { return false }
-        let item = NSMenuItem()
-        item.tag = action.rawValue
-        return NSApp.sendAction(
-            NSSelectorFromString("performFindPanelAction:"),
-            to: webView,
-            from: item
-        )
-    }
-
     func retryPendingFocus() {
         focus()
     }
@@ -507,5 +448,69 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         if let typographyDefaultsObserver {
             NotificationCenter.default.removeObserver(typographyDefaultsObserver)
         }
+    }
+}
+
+
+// MARK: - Find in panel
+
+extension MarkdownPanel {
+    var isFindVisible: Bool { false }
+
+    @discardableResult
+    func startFind() -> Bool {
+        switch displayMode {
+        case .text:
+            guard let textView else { return false }
+            textView.performTextFinderAction(textFinderSender(.showFindInterface))
+            return true
+        case .preview:
+            return sendFindPanelAction(.showFindInterface)
+        }
+    }
+
+    func findNext() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.nextMatch))
+        case .preview:
+            _ = sendFindPanelAction(.nextMatch)
+        }
+    }
+
+    func findPrevious() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.previousMatch))
+        case .preview:
+            _ = sendFindPanelAction(.previousMatch)
+        }
+    }
+
+    func hideFind() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.hideFindInterface))
+        case .preview:
+            _ = sendFindPanelAction(.hideFindInterface)
+        }
+    }
+
+    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return item
+    }
+
+    @discardableResult
+    private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
+        guard let webView = rendererSession.webView else { return false }
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return NSApp.sendAction(
+            NSSelectorFromString("performFindPanelAction:"),
+            to: webView,
+            from: item
+        )
     }
 }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -271,6 +271,65 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         self.textView = textView
     }
 
+    // MARK: - Find in panel
+
+    @discardableResult
+    func startFind() -> Bool {
+        switch displayMode {
+        case .text:
+            guard let textView else { return false }
+            textView.performTextFinderAction(textFinderSender(.showFindInterface))
+            return true
+        case .preview:
+            return sendFindPanelAction(.showFindInterface)
+        }
+    }
+
+    func findNext() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.nextMatch))
+        case .preview:
+            _ = sendFindPanelAction(.nextMatch)
+        }
+    }
+
+    func findPrevious() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.previousMatch))
+        case .preview:
+            _ = sendFindPanelAction(.previousMatch)
+        }
+    }
+
+    func hideFind() {
+        switch displayMode {
+        case .text:
+            textView?.performTextFinderAction(textFinderSender(.hideFindInterface))
+        case .preview:
+            _ = sendFindPanelAction(.hideFindInterface)
+        }
+    }
+
+    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return item
+    }
+
+    @discardableResult
+    private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
+        guard let webView = rendererSession.webView else { return false }
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return NSApp.sendAction(
+            NSSelectorFromString("performFindPanelAction:"),
+            to: webView,
+            from: item
+        )
+    }
+
     func retryPendingFocus() {
         focus()
     }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -454,15 +454,22 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
 // MARK: - Find in panel
 
-extension MarkdownPanel {
+extension MarkdownPanel: FindablePanel {
+    /// The AppKit find bar visibility is not publicly exposed on `NSTextView`,
+    /// and `WKWebView` does not report its find panel state, so this is
+    /// conservative and reports `false` until a public signal exists.
     var isFindVisible: Bool { false }
+
+    var hasSelectionForFind: Bool {
+        displayMode == .text && (textView?.selectedRange.length ?? 0) > 0
+    }
 
     @discardableResult
     func startFind() -> Bool {
         switch displayMode {
         case .text:
             guard let textView else { return false }
-            textView.performTextFinderAction(textFinderSender(.showFindInterface))
+            textView.performTextFinderAction(NSTextFinder.Action.showFindInterface.menuItemSender)
             return true
         case .preview:
             return sendFindPanelAction(.showFindInterface)
@@ -472,7 +479,7 @@ extension MarkdownPanel {
     func findNext() {
         switch displayMode {
         case .text:
-            textView?.performTextFinderAction(textFinderSender(.nextMatch))
+            textView?.performTextFinderAction(NSTextFinder.Action.nextMatch.menuItemSender)
         case .preview:
             _ = sendFindPanelAction(.nextMatch)
         }
@@ -481,7 +488,7 @@ extension MarkdownPanel {
     func findPrevious() {
         switch displayMode {
         case .text:
-            textView?.performTextFinderAction(textFinderSender(.previousMatch))
+            textView?.performTextFinderAction(NSTextFinder.Action.previousMatch.menuItemSender)
         case .preview:
             _ = sendFindPanelAction(.previousMatch)
         }
@@ -490,27 +497,27 @@ extension MarkdownPanel {
     func hideFind() {
         switch displayMode {
         case .text:
-            textView?.performTextFinderAction(textFinderSender(.hideFindInterface))
+            textView?.performTextFinderAction(NSTextFinder.Action.hideFindInterface.menuItemSender)
         case .preview:
-            _ = sendFindPanelAction(.hideFindInterface)
+            // WKWebView's `performFindPanelAction:` does not support hiding the
+            // find panel (NSFindPanelAction only defines values 1-10). The user
+            // can still close it with Esc or the UI close button.
+            break
         }
     }
 
-    private func textFinderSender(_ action: NSTextFinder.Action) -> NSMenuItem {
-        let item = NSMenuItem()
-        item.tag = action.rawValue
-        return item
+    func useSelectionForFind() {
+        guard displayMode == .text, let textView else { return }
+        textView.performTextFinderAction(NSTextFinder.Action.setSearchString.menuItemSender)
     }
 
     @discardableResult
     private func sendFindPanelAction(_ action: NSTextFinder.Action) -> Bool {
         guard let webView = rendererSession.webView else { return false }
-        let item = NSMenuItem()
-        item.tag = action.rawValue
         return NSApp.sendAction(
             NSSelectorFromString("performFindPanelAction:"),
             to: webView,
-            from: item
+            from: action.menuItemSender
         )
     }
 }

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -152,6 +152,7 @@ final class MarkdownRendererSession {
         await ownedCoordinator.renderedText()
     }
 
+    /// The underlying web view, exposed so find actions can be dispatched to it.
     var webView: MarkdownWebView? {
         ownedCoordinator.webView
     }

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -151,6 +151,10 @@ final class MarkdownRendererSession {
     func renderedText() async -> String? {
         await ownedCoordinator.renderedText()
     }
+
+    var webView: MarkdownWebView? {
+        ownedCoordinator.webView
+    }
 }
 
 extension NSColor {

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -360,3 +360,50 @@ extension Panel {
         triggerFlash(reason: .navigation)
     }
 }
+
+
+// MARK: - Find support
+
+/// Capability surfaced by panels that can participate in the global `Cmd+F`
+/// find flow. `TabManager` routes find actions to the focused panel only if it
+/// conforms to this protocol.
+@MainActor
+protocol FindablePanel: AnyObject {
+    /// Whether the panel's find UI is currently visible/active.
+    var isFindVisible: Bool { get }
+
+    /// Whether the panel has a text selection that can be used as the find needle.
+    var hasSelectionForFind: Bool { get }
+
+    /// Opens the find UI. Returns `true` if the panel handled the request.
+    @discardableResult
+    func startFind() -> Bool
+
+    /// Jumps to the next search result in the panel.
+    func findNext()
+
+    /// Jumps to the previous search result in the panel.
+    func findPrevious()
+
+    /// Closes or hides the panel's find UI.
+    func hideFind()
+
+    /// Uses the current selection as the find needle (Cmd+E / "Use Selection for Find").
+    func useSelectionForFind()
+}
+
+extension FindablePanel {
+    /// Most panels do not support selection-based find.
+    var hasSelectionForFind: Bool { false }
+    func useSelectionForFind() {}
+}
+
+extension NSTextFinder.Action {
+    /// Returns an `NSMenuItem` whose tag matches this action, suitable for
+    /// sending to `performTextFinderAction(_:)` or `performFindPanelAction:`.
+    var menuItemSender: NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = rawValue
+        return item
+    }
+}

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -369,9 +369,6 @@ extension Panel {
 /// conforms to this protocol.
 @MainActor
 protocol FindablePanel: AnyObject {
-    /// Whether the panel's find UI is currently visible/active.
-    var isFindVisible: Bool { get }
-
     /// Whether the panel has a text selection that can be used as the find needle.
     var hasSelectionForFind: Bool { get }
 
@@ -395,6 +392,8 @@ protocol FindablePanel: AnyObject {
 extension FindablePanel {
     /// Most panels do not support selection-based find.
     var hasSelectionForFind: Bool { false }
+
+    /// Most panels do not support seeding the find query from the current selection.
     func useSelectionForFind() {}
 }
 

--- a/Sources/Panels/ProjectBuildSettingsTabView.swift
+++ b/Sources/Panels/ProjectBuildSettingsTabView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct ProjectBuildSettingsTabView: View {
     @ObservedObject var panel: ProjectPanel
     let model: ProjectModel
+    @FocusState private var focus: ProjectPanelSearchFocus?
 
     var body: some View {
         let computedRows = rows
@@ -21,6 +22,12 @@ struct ProjectBuildSettingsTabView: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .onChange(of: panel.searchFocusRequest) { newValue in
+            if newValue == .settings {
+                focus = .settings
+                panel.searchFocusRequest = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -37,6 +44,7 @@ struct ProjectBuildSettingsTabView: View {
                 TextField("Filter settings", text: $panel.settingsSearchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))
+                    .focused($focus, equals: .settings)
                 Toggle("Customized only", isOn: $panel.settingsCustomizedOnly)
                     .toggleStyle(.checkbox)
                     .font(.system(size: 11))

--- a/Sources/Panels/ProjectBuildSettingsTabView.swift
+++ b/Sources/Panels/ProjectBuildSettingsTabView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ProjectBuildSettingsTabView: View {
     @ObservedObject var panel: ProjectPanel
     let model: ProjectModel
+
+    /// Drives focus into the settings filter text field when requested.
     @FocusState private var focus: ProjectPanelSearchFocus?
 
     var body: some View {
@@ -22,10 +24,10 @@ struct ProjectBuildSettingsTabView: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .onChange(of: panel.searchFocusRequest) { newValue in
+        .onChange(of: panel.focusState.request) { _, newValue in
             if newValue == .settings {
                 focus = .settings
-                panel.searchFocusRequest = nil
+                panel.focusState.request = nil
             }
         }
     }

--- a/Sources/Panels/ProjectBuildSettingsTabView.swift
+++ b/Sources/Panels/ProjectBuildSettingsTabView.swift
@@ -30,6 +30,12 @@ struct ProjectBuildSettingsTabView: View {
                 panel.focusState.request = nil
             }
         }
+        .onChange(of: panel.focusState.resignFocus) { _, shouldResign in
+            if shouldResign {
+                focus = nil
+                panel.focusState.resignFocus = false
+            }
+        }
     }
 
     @ViewBuilder

--- a/Sources/Panels/ProjectFilesTabView.swift
+++ b/Sources/Panels/ProjectFilesTabView.swift
@@ -18,6 +18,7 @@ private struct FlattenedRow: Identifiable {
 struct ProjectFilesTabView: View {
     @ObservedObject var panel: ProjectPanel
     let model: ProjectModel
+    @FocusState private var focus: ProjectPanelSearchFocus?
 
     var body: some View {
         let rows = flattenedRows
@@ -36,6 +37,12 @@ struct ProjectFilesTabView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
+        .onChange(of: panel.searchFocusRequest) { newValue in
+            if newValue == .files {
+                focus = .files
+                panel.searchFocusRequest = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -46,6 +53,7 @@ struct ProjectFilesTabView: View {
             TextField("Filter files (e.g. AppDelegate)", text: $panel.filesSearchText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 12))
+                .focused($focus, equals: .files)
             if !panel.filesSearchText.isEmpty {
                 Button {
                     panel.filesSearchText = ""

--- a/Sources/Panels/ProjectFilesTabView.swift
+++ b/Sources/Panels/ProjectFilesTabView.swift
@@ -18,6 +18,8 @@ private struct FlattenedRow: Identifiable {
 struct ProjectFilesTabView: View {
     @ObservedObject var panel: ProjectPanel
     let model: ProjectModel
+
+    /// Drives focus into the files filter text field when requested.
     @FocusState private var focus: ProjectPanelSearchFocus?
 
     var body: some View {
@@ -37,10 +39,10 @@ struct ProjectFilesTabView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .onChange(of: panel.searchFocusRequest) { newValue in
+        .onChange(of: panel.focusState.request) { _, newValue in
             if newValue == .files {
                 focus = .files
-                panel.searchFocusRequest = nil
+                panel.focusState.request = nil
             }
         }
     }

--- a/Sources/Panels/ProjectFilesTabView.swift
+++ b/Sources/Panels/ProjectFilesTabView.swift
@@ -45,6 +45,12 @@ struct ProjectFilesTabView: View {
                 panel.focusState.request = nil
             }
         }
+        .onChange(of: panel.focusState.resignFocus) { _, shouldResign in
+            if shouldResign {
+                focus = nil
+                panel.focusState.resignFocus = false
+            }
+        }
     }
 
     @ViewBuilder

--- a/Sources/Panels/ProjectPanel.swift
+++ b/Sources/Panels/ProjectPanel.swift
@@ -2,6 +2,7 @@ import AppKit
 import CMUXProjectModel
 import Combine
 import Foundation
+import Observation
 import SwiftUI
 
 /// Which tab is active inside a ``ProjectPanel``.
@@ -47,6 +48,18 @@ public enum ProjectPanelLoadState: Sendable, Equatable {
     }
 }
 
+/// Lightweight focus-request state for ``ProjectPanel``.
+///
+/// Uses the modern `@Observable` shape so the view layer can react to focus
+/// requests without adding another `@Published` property to the legacy
+/// ``ObservableObject`` panel.
+@MainActor
+@Observable
+public final class ProjectPanelFocusState {
+    /// Which search field should receive focus, or `nil` if none.
+    public var request: ProjectPanelSearchFocus?
+}
+
 /// Runtime backing for one `project` surface.
 ///
 /// Holds the user's project URL, the parsed ``ProjectModel`` snapshot (loaded
@@ -70,8 +83,15 @@ public final class ProjectPanel: NSObject, Panel, ObservableObject {
     @Published public var settingsCustomizedOnly: Bool = false
     @Published public var collapsedNodeIDs: Set<ProjectNodeID> = []
     @Published public var filesSearchText: String = ""
-    @Published public var searchFocusRequest: ProjectPanelSearchFocus?
     @Published public var lastLoadError: String?
+
+    /// Tracks which search field, if any, should receive focus.
+    ///
+    /// Lives outside the ``ObservableObject`` state so the modern `@Observable`
+    /// pattern owns the focus request rather than adding another `@Published`
+    /// property to the legacy panel object.
+    public let focusState = ProjectPanelFocusState()
+
     private var reloadTask: Task<Void, Never>?
 
     public var displayTitle: String {
@@ -275,26 +295,27 @@ public enum ProjectPanelSearchFocus: Hashable {
 }
 
 extension ProjectPanel: FindablePanel {
-    public var isFindVisible: Bool { false }
-
+    /// Focuses the search field for tabs that have one.
     @discardableResult
     public func startFind() -> Bool {
         switch activeTab {
         case .files:
-            searchFocusRequest = .files
+            focusState.request = .files
             return true
         case .buildSettings:
-            searchFocusRequest = .settings
+            focusState.request = .settings
             return true
         case .targets, .schemes:
             return false
         }
     }
 
+    /// Project search fields do not support find-next/find-previous navigation.
     public func findNext() {}
     public func findPrevious() {}
 
+    /// Clears the focus request so the search field can resign focus normally.
     public func hideFind() {
-        searchFocusRequest = nil
+        focusState.request = nil
     }
 }

--- a/Sources/Panels/ProjectPanel.swift
+++ b/Sources/Panels/ProjectPanel.swift
@@ -70,6 +70,7 @@ public final class ProjectPanel: NSObject, Panel, ObservableObject {
     @Published public var settingsCustomizedOnly: Bool = false
     @Published public var collapsedNodeIDs: Set<ProjectNodeID> = []
     @Published public var filesSearchText: String = ""
+    @Published public var searchFocusRequest: ProjectPanelSearchFocus?
     @Published public var lastLoadError: String?
     private var reloadTask: Task<Void, Never>?
 
@@ -261,5 +262,39 @@ public final class ProjectPanel: NSObject, Panel, ObservableObject {
         _ = intent
         _ = window
         return false
+    }
+}
+
+
+// MARK: - Find support
+
+/// Identifies which search field in a ``ProjectPanel`` should receive focus.
+public enum ProjectPanelSearchFocus: Hashable {
+    case files
+    case settings
+}
+
+extension ProjectPanel: FindablePanel {
+    public var isFindVisible: Bool { false }
+
+    @discardableResult
+    public func startFind() -> Bool {
+        switch activeTab {
+        case .files:
+            searchFocusRequest = .files
+            return true
+        case .buildSettings:
+            searchFocusRequest = .settings
+            return true
+        case .targets, .schemes:
+            return false
+        }
+    }
+
+    public func findNext() {}
+    public func findPrevious() {}
+
+    public func hideFind() {
+        searchFocusRequest = nil
     }
 }

--- a/Sources/Panels/ProjectPanel.swift
+++ b/Sources/Panels/ProjectPanel.swift
@@ -58,6 +58,12 @@ public enum ProjectPanelLoadState: Sendable, Equatable {
 public final class ProjectPanelFocusState {
     /// Which search field should receive focus, or `nil` if none.
     public var request: ProjectPanelSearchFocus?
+
+    /// When flipped to `true`, the view layer should resign focus from any
+    /// search field and then reset this flag. This is required because the
+    /// `request` property is already cleared by the view after transferring
+    /// focus, so hiding find cannot rely on setting `request` to `nil`.
+    public var resignFocus: Bool = false
 }
 
 /// Runtime backing for one `project` surface.
@@ -298,6 +304,7 @@ extension ProjectPanel: FindablePanel {
     /// Focuses the search field for tabs that have one.
     @discardableResult
     public func startFind() -> Bool {
+        focusState.resignFocus = false
         switch activeTab {
         case .files:
             focusState.request = .files
@@ -314,8 +321,13 @@ extension ProjectPanel: FindablePanel {
     public func findNext() {}
     public func findPrevious() {}
 
-    /// Clears the focus request so the search field can resign focus normally.
+    /// Signals the view layer to resign focus from the active search field.
+    ///
+    /// Because the view clears `focusState.request` immediately after moving
+    /// focus into the text field, setting `request = nil` here is a no-op.
+    /// The dedicated `resignFocus` flag gives the view a distinct event to
+    /// react to so the filter field actually loses keyboard focus.
     public func hideFind() {
-        focusState.request = nil
+        focusState.resignFocus = true
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -826,9 +826,17 @@ class TabManager: ObservableObject {
 #endif
             return handled
         }
-        guard let browserPanel = focusedBrowserPanel else { return false }
-        browserPanel.startFind()
-        return browserPanel.searchState != nil
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.startFind()
+            return browserPanel.searchState != nil
+        }
+        if let filePreviewPanel = focusedFilePreviewPanel {
+            return filePreviewPanel.startFind()
+        }
+        if let markdownPanel = focusedMarkdownPanelForFind {
+            return markdownPanel.startFind()
+        }
+        return false
     }
 
     func searchSelection() {
@@ -853,6 +861,8 @@ class TabManager: ObservableObject {
         }
 
         focusedBrowserPanel?.findNext()
+        focusedFilePreviewPanel?.findNext()
+        focusedMarkdownPanelForFind?.findNext()
     }
 
     func findPrevious() {
@@ -862,6 +872,8 @@ class TabManager: ObservableObject {
         }
 
         focusedBrowserPanel?.findPrevious()
+        focusedFilePreviewPanel?.findPrevious()
+        focusedMarkdownPanelForFind?.findPrevious()
     }
 
     @discardableResult
@@ -961,6 +973,8 @@ class TabManager: ObservableObject {
         }
 
         focusedBrowserPanel?.hideFind()
+        focusedFilePreviewPanel?.hideFind()
+        focusedMarkdownPanelForFind?.hideFind()
     }
 
     func makeWorkspaceForCreation(
@@ -2928,6 +2942,22 @@ class TabManager: ObservableObject {
               let panel = tab.panels[panelId] as? MarkdownPanel,
               panel.displayMode == .preview else { return nil }
         return panel
+    }
+
+    /// Returns the focused panel if it's a MarkdownPanel in any display mode,
+    /// nil otherwise. Used for find routing, which supports both preview and
+    /// text-edit modes.
+    var focusedMarkdownPanelForFind: MarkdownPanel? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? MarkdownPanel
+    }
+
+    /// Returns the focused panel if it's a FilePreviewPanel, nil otherwise.
+    var focusedFilePreviewPanel: FilePreviewPanel? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? FilePreviewPanel
     }
 
     @discardableResult

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -796,7 +796,8 @@ class TabManager: ObservableObject {
     }
 
     var isFindVisible: Bool {
-        selectedTerminalPanel?.searchState != nil || isNonTerminalFindVisible
+        selectedTerminalPanel?.searchState != nil
+            || focusedBrowserPanel?.searchState != nil
     }
 
     var canUseSelectionForFind: Bool {
@@ -6184,11 +6185,7 @@ extension TabManager {
         return tab.panels[panelId] as? FindablePanel
     }
 
-    var isNonTerminalFindVisible: Bool {
-        focusedBrowserPanel?.searchState != nil
-            || focusedFindablePanel?.isFindVisible == true
-    }
-
+    /// Opens find in the focused browser or findable panel.
     func startFindInFocusedNonTerminalPanel() -> Bool {
         if let browserPanel = focusedBrowserPanel {
             browserPanel.startFind()
@@ -6197,16 +6194,19 @@ extension TabManager {
         return focusedFindablePanel?.startFind() ?? false
     }
 
+    /// Navigates to the next find result in the focused browser or findable panel.
     func findNextInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.findNext()
         focusedFindablePanel?.findNext()
     }
 
+    /// Navigates to the previous find result in the focused browser or findable panel.
     func findPreviousInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.findPrevious()
         focusedFindablePanel?.findPrevious()
     }
 
+    /// Hides find UI in the focused browser or findable panel.
     func hideFindInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.hideFind()
         focusedFindablePanel?.hideFind()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -796,7 +796,7 @@ class TabManager: ObservableObject {
     }
 
     var isFindVisible: Bool {
-        selectedTerminalPanel?.searchState != nil || focusedBrowserPanel?.searchState != nil
+        selectedTerminalPanel?.searchState != nil || isNonTerminalFindVisible
     }
 
     var canUseSelectionForFind: Bool {
@@ -826,17 +826,7 @@ class TabManager: ObservableObject {
 #endif
             return handled
         }
-        if let browserPanel = focusedBrowserPanel {
-            browserPanel.startFind()
-            return browserPanel.searchState != nil
-        }
-        if let filePreviewPanel = focusedFilePreviewPanel {
-            return filePreviewPanel.startFind()
-        }
-        if let markdownPanel = focusedMarkdownPanelForFind {
-            return markdownPanel.startFind()
-        }
-        return false
+        return startFindInFocusedNonTerminalPanel()
     }
 
     func searchSelection() {
@@ -860,9 +850,7 @@ class TabManager: ObservableObject {
             return
         }
 
-        focusedBrowserPanel?.findNext()
-        focusedFilePreviewPanel?.findNext()
-        focusedMarkdownPanelForFind?.findNext()
+        findNextInFocusedNonTerminalPanel()
     }
 
     func findPrevious() {
@@ -871,9 +859,7 @@ class TabManager: ObservableObject {
             return
         }
 
-        focusedBrowserPanel?.findPrevious()
-        focusedFilePreviewPanel?.findPrevious()
-        focusedMarkdownPanelForFind?.findPrevious()
+        findPreviousInFocusedNonTerminalPanel()
     }
 
     @discardableResult
@@ -972,9 +958,7 @@ class TabManager: ObservableObject {
             return
         }
 
-        focusedBrowserPanel?.hideFind()
-        focusedFilePreviewPanel?.hideFind()
-        focusedMarkdownPanelForFind?.hideFind()
+        hideFindInFocusedNonTerminalPanel()
     }
 
     func makeWorkspaceForCreation(
@@ -2942,22 +2926,6 @@ class TabManager: ObservableObject {
               let panel = tab.panels[panelId] as? MarkdownPanel,
               panel.displayMode == .preview else { return nil }
         return panel
-    }
-
-    /// Returns the focused panel if it's a MarkdownPanel in any display mode,
-    /// nil otherwise. Used for find routing, which supports both preview and
-    /// text-edit modes.
-    var focusedMarkdownPanelForFind: MarkdownPanel? {
-        guard let tab = selectedWorkspace,
-              let panelId = tab.focusedPanelId else { return nil }
-        return tab.panels[panelId] as? MarkdownPanel
-    }
-
-    /// Returns the focused panel if it's a FilePreviewPanel, nil otherwise.
-    var focusedFilePreviewPanel: FilePreviewPanel? {
-        guard let tab = selectedWorkspace,
-              let panelId = tab.focusedPanelId else { return nil }
-        return tab.panels[panelId] as? FilePreviewPanel
     }
 
     @discardableResult
@@ -6199,4 +6167,53 @@ extension Notification.Name {
 
 enum BrowserFirstResponderNotificationUserInfoKey {
     static let pointerInitiated = "pointerInitiated"
+}
+
+
+// MARK: - Find routing for file preview and markdown panels
+
+extension TabManager {
+    var focusedMarkdownPanelForFind: MarkdownPanel? {
+        guard let tab = selectedWorkspace, let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? MarkdownPanel
+    }
+
+    var focusedFilePreviewPanel: FilePreviewPanel? {
+        guard let tab = selectedWorkspace, let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? FilePreviewPanel
+    }
+
+    var isNonTerminalFindVisible: Bool {
+        focusedBrowserPanel?.searchState != nil
+            || focusedFilePreviewPanel?.isFindVisible == true
+            || focusedMarkdownPanelForFind?.isFindVisible == true
+    }
+
+    func startFindInFocusedNonTerminalPanel() -> Bool {
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.startFind()
+            return browserPanel.searchState != nil
+        }
+        return focusedFilePreviewPanel?.startFind()
+            ?? focusedMarkdownPanelForFind?.startFind()
+            ?? false
+    }
+
+    func findNextInFocusedNonTerminalPanel() {
+        focusedBrowserPanel?.findNext()
+        focusedFilePreviewPanel?.findNext()
+        focusedMarkdownPanelForFind?.findNext()
+    }
+
+    func findPreviousInFocusedNonTerminalPanel() {
+        focusedBrowserPanel?.findPrevious()
+        focusedFilePreviewPanel?.findPrevious()
+        focusedMarkdownPanelForFind?.findPrevious()
+    }
+
+    func hideFindInFocusedNonTerminalPanel() {
+        focusedBrowserPanel?.hideFind()
+        focusedFilePreviewPanel?.hideFind()
+        focusedMarkdownPanelForFind?.hideFind()
+    }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -801,6 +801,7 @@ class TabManager: ObservableObject {
 
     var canUseSelectionForFind: Bool {
         selectedTerminalPanel?.hasSelection() == true
+            || focusedFindablePanel?.hasSelectionForFind == true
     }
 
     @discardableResult
@@ -830,18 +831,22 @@ class TabManager: ObservableObject {
     }
 
     func searchSelection() {
-        guard let panel = selectedTerminalPanel else { return }
-        if panel.searchState == nil {
-            panel.searchState = TerminalSurface.SearchState()
-        }
+        if let panel = selectedTerminalPanel {
+            if panel.searchState == nil {
+                panel.searchState = TerminalSurface.SearchState()
+            }
 #if DEBUG
-        cmuxDebugLog(
-            "find.searchSelection workspace=\(panel.workspaceId.uuidString.prefix(5)) " +
-            "panel=\(panel.id.uuidString.prefix(5))"
-        )
+            cmuxDebugLog(
+                "find.searchSelection workspace=\(panel.workspaceId.uuidString.prefix(5)) " +
+                "panel=\(panel.id.uuidString.prefix(5))"
+            )
 #endif
-        NotificationCenter.default.post(name: .ghosttySearchFocus, object: panel.surface)
-        _ = panel.performBindingAction("search_selection")
+            NotificationCenter.default.post(name: .ghosttySearchFocus, object: panel.surface)
+            _ = panel.performBindingAction("search_selection")
+            return
+        }
+
+        focusedFindablePanel?.useSelectionForFind()
     }
 
     func findNext() {
@@ -6170,23 +6175,18 @@ enum BrowserFirstResponderNotificationUserInfoKey {
 }
 
 
-// MARK: - Find routing for file preview and markdown panels
+// MARK: - Find routing for non-terminal panels
 
 extension TabManager {
-    var focusedMarkdownPanelForFind: MarkdownPanel? {
+    /// The focused panel if it supports global find commands.
+    var focusedFindablePanel: FindablePanel? {
         guard let tab = selectedWorkspace, let panelId = tab.focusedPanelId else { return nil }
-        return tab.panels[panelId] as? MarkdownPanel
-    }
-
-    var focusedFilePreviewPanel: FilePreviewPanel? {
-        guard let tab = selectedWorkspace, let panelId = tab.focusedPanelId else { return nil }
-        return tab.panels[panelId] as? FilePreviewPanel
+        return tab.panels[panelId] as? FindablePanel
     }
 
     var isNonTerminalFindVisible: Bool {
         focusedBrowserPanel?.searchState != nil
-            || focusedFilePreviewPanel?.isFindVisible == true
-            || focusedMarkdownPanelForFind?.isFindVisible == true
+            || focusedFindablePanel?.isFindVisible == true
     }
 
     func startFindInFocusedNonTerminalPanel() -> Bool {
@@ -6194,26 +6194,21 @@ extension TabManager {
             browserPanel.startFind()
             return browserPanel.searchState != nil
         }
-        return focusedFilePreviewPanel?.startFind()
-            ?? focusedMarkdownPanelForFind?.startFind()
-            ?? false
+        return focusedFindablePanel?.startFind() ?? false
     }
 
     func findNextInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.findNext()
-        focusedFilePreviewPanel?.findNext()
-        focusedMarkdownPanelForFind?.findNext()
+        focusedFindablePanel?.findNext()
     }
 
     func findPreviousInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.findPrevious()
-        focusedFilePreviewPanel?.findPrevious()
-        focusedMarkdownPanelForFind?.findPrevious()
+        focusedFindablePanel?.findPrevious()
     }
 
     func hideFindInFocusedNonTerminalPanel() {
         focusedBrowserPanel?.hideFind()
-        focusedFilePreviewPanel?.hideFind()
-        focusedMarkdownPanelForFind?.hideFind()
+        focusedFindablePanel?.hideFind()
     }
 }


### PR DESCRIPTION
Closes #6050
Fixes #158
Fixes #6049

## Problem
In cmux, pressing **Cmd+F** only worked in terminal and browser tabs. For other panels—file preview, markdown, agent session, and project files/build settings—the global find command was silently swallowed, even though those panels already have their own search UI. This was reported in #6050, #158, and #6049.

## Solution
Introduce a small `FindablePanel` capability protocol that exposes the standard find actions (`startFind`, `findNext`, `findPrevious`, `hideFind`, `useSelectionForFind`). `TabManager` now asks the focused panel whether it is findable and forwards the global actions through that interface, instead of hard-coding terminal/browser dispatch.

This keeps the change minimal and panel-local: each panel implements the protocol with whatever search UI it already has (AppKit text finder, `WKWebView` find panel, or SwiftUI `FocusState` filter field).

## What's fixed
| Panel | Mode | Find UI now wired to Cmd+F |
|---|---|---|
| `FilePreviewPanel` | text | `NSTextView` find bar |
| `MarkdownPanel` | text | `NSTextView` find bar |
| `MarkdownPanel` | preview | `WKWebView` find panel |
| `AgentSessionPanel` | any | `WKWebView` find panel |
| `ProjectPanel` | Files tab | filter search field via `FocusState` |
| `ProjectPanel` | Build Settings tab | filter search field via `FocusState` |

## Key implementation details
- `isFindVisible` remains conservative (terminal/browser only) because AppKit does not expose a public find-bar visibility signal for `NSTextView`/`WKWebView`.
- `MarkdownPanel` preview and `AgentSessionPanel` hide-find are documented no-ops: `WKWebView.performFindPanelAction:` only defines find-panel actions 1–10 and has no hide value.
- Shared `NSTextFinder.Action.menuItemSender` helper removes duplicated `NSMenuItem` construction.
- `canUseSelectionForFind` now includes any `FindablePanel` that reports a text selection.

## Verification
- Built the cmux Debug target successfully.
- Refreshed `.github/swift-file-length-budget.tsv` via `scripts/swift_file_length_budget.py --write-budget`; budget check passes.
- Unit-test scheme still crashes during bootstrap — this is a pre-existing/environment issue, not introduced by this change.

## Notes for reviewers
The protocol-based routing is intentionally narrow: it does not try to unify the visual find-bar state across heterogeneous panel types, only the command dispatch. That keeps the blast radius small and makes it easy to add find support to future panels by conforming to `FindablePanel`.

Ready for review. /cc @austinywang @lawrencecchen
