### PR TITLE
iOS: show compact workspace disclosure affordance

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -29,13 +29,7 @@ struct WorkspaceNavigationRow: View {
     @State private var isConfirmingClose = false
 
     var body: some View {
-        WorkspaceRow(
-            workspace: workspace,
-            connectionStatus: connectionStatus,
-            isSelected: navigationStyle == .sidebar && isSelected,
-            wrapWorkspaceTitles: wrapWorkspaceTitles,
-            previewLineLimit: previewLineLimit
-        )
+        rowContent
         .onTapGesture {
             selectWorkspace(workspace.id)
         }
@@ -86,6 +80,30 @@ struct WorkspaceNavigationRow: View {
             Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {}
         } message: {
             Text(L10n.string("mobile.workspace.delete.confirmMessage", defaultValue: "This will close the workspace on your Mac."))
+        }
+    }
+
+    private var rowContent: some View {
+        HStack(alignment: .center, spacing: 8) {
+            WorkspaceRow(
+                workspace: workspace,
+                connectionStatus: connectionStatus,
+                isSelected: navigationStyle == .sidebar && isSelected,
+                wrapWorkspaceTitles: wrapWorkspaceTitles,
+                previewLineLimit: previewLineLimit
+            )
+            .layoutPriority(1)
+
+            // NavigationLink(value:) restores the system disclosure row, but in
+            // this List it prevents swipe/context delete confirmation from
+            // presenting reliably. Keep the manual tap path and draw the
+            // compact-stack affordance explicitly.
+            if navigationStyle == .push {
+                Image(systemName: "chevron.forward")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the manual compact workspace-row tap path after simulator testing showed `NavigationLink(value:)` still interferes with row swipe/context delete confirmation in `List`
- add an explicit trailing compact-stack disclosure chevron while preserving PR 6022 row actions
- document the SwiftUI `List` interaction constraint next to the row content

## Testing
- `git diff --check`
- `xcodebuild build -workspace ios/cmux.xcworkspace -scheme cmux-ios -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /tmp/cmux-ios-wlnk-build PRODUCT_BUNDLE_IDENTIFIER=dev.cmux.ios.wlnkbuild PRODUCT_DISPLAY_NAME='cmux DEV wlnk' CMUX_DEV_TAG=wlnk CMUX_GIT_SHA=$(git rev-parse --short HEAD)+ EXCLUDED_SOURCE_FILE_NAMES=Info.plist CODE_SIGNING_ALLOWED=NO`\n- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`\n\n## Issues\n- Related: https://github.com/manaflow-ai/cmux/pull/6022

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783967370&installation_id=133855650&pr_number=6060&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6060&signature=c441ff4fe7d1b89dc633feb31d126882a90e69d14f30613f2bc19c6d4010de31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a compact disclosure chevron on workspace rows in push navigation, while keeping manual tap handling to avoid SwiftUI List swipe/delete conflicts. Improves clarity in compact stacks without breaking row actions.

- **New Features**
  - Adds a trailing chevron in push (`.push`) navigation to indicate disclosure.

- **Bug Fixes**
  - Replaces `NavigationLink(value:)` with a manual tap to keep swipe/context delete confirmation working in `List` (documented inline).

<sup>Written for commit 0e4257ef4ad4482c3c4f5e0b8dc4a55d2789f324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Workspace navigation rows now display visual directional indicators for push-style navigation interactions, providing clearer visual cues and helping users better understand available navigation options and their behavior throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->