### PR TITLE
uitests: de-flake control-socket readiness wait

### DIFF
--- a/cmuxUITests/ControlSocketReadinessUITestSupport.swift
+++ b/cmuxUITests/ControlSocketReadinessUITestSupport.swift
@@ -27,9 +27,25 @@ extension XCTestCase {
     /// absorbed by `listenerBindTimeout` and the ping confirmation always gets
     /// its full budget.
     ///
-    /// Both phases poll observable conditions through `XCTNSPredicateExpectation`
-    /// instead of a hand-rolled deadline loop, so each waits only as long as it
-    /// needs to and never longer than its bound.
+    /// Both phases poll their condition on a fixed cadence with a deterministic
+    /// deadline loop (``pollControlSocketCondition``), re-evaluating every
+    /// ``pollInterval`` until the bound elapses.
+    ///
+    /// This deliberately does *not* use `XCTNSPredicateExpectation`. That class
+    /// is unreliable here because the conditions are non-KVO closures that do
+    /// blocking socket I/O: the ping closure opens a connection and blocks up to
+    /// its response timeout on every evaluation. `XCTNSPredicateExpectation`
+    /// evaluates such a predicate once, then relies on a polling timer scheduled
+    /// on the run loop to re-evaluate; under `XCTWaiter.wait` that re-poll can be
+    /// starved, so a single early `false` (the listener bound but its accept
+    /// loop not yet answering, a sub-second window) makes the waiter sit on the
+    /// stale `false` for the full timeout even though the socket became
+    /// responsive almost immediately. That is the flake seen in CI on
+    /// `BrowserPaneNavigationKeybindUITests` (issue surfaced 2026-06-13): the
+    /// app's own sanity check reported `PONG` ~1s after launch, yet the test's
+    /// 12s ping wait failed. A plain deadline loop guarantees the ping is
+    /// actually retried for the whole budget. See also
+    /// https://github.com/manaflow-ai/cmux/issues/5414 for the two-phase split.
     ///
     /// - Parameters:
     ///   - listenerBindTimeout: Maximum time to wait for the socket file to
@@ -38,6 +54,7 @@ extension XCTestCase {
     ///     failure.
     ///   - pingTimeout: Fresh budget for the `ping` -> `PONG` round trip once
     ///     the listener has bound.
+    ///   - pollInterval: How long to wait between condition re-evaluations.
     ///   - socketFileExists: Returns true once the listener's socket file is on
     ///     disk. A closure (not a path) so callers that resolve among several
     ///     candidate paths can report "any candidate exists".
@@ -47,22 +64,41 @@ extension XCTestCase {
     func waitForControlSocketReady(
         listenerBindTimeout: TimeInterval = 60.0,
         pingTimeout: TimeInterval,
+        pollInterval: TimeInterval = 0.2,
         socketFileExists: @escaping () -> Bool,
         pingReturnsPong: @escaping () -> Bool
     ) -> Bool {
-        let bound = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in socketFileExists() },
-            object: nil
-        )
-        guard XCTWaiter().wait(for: [bound], timeout: listenerBindTimeout) == .completed else {
+        guard pollControlSocketCondition(
+            timeout: listenerBindTimeout,
+            pollInterval: pollInterval,
+            condition: socketFileExists
+        ) else {
             return false
         }
-
-        let responsive = XCTNSPredicateExpectation(
-            predicate: NSPredicate { _, _ in pingReturnsPong() },
-            object: nil
+        return pollControlSocketCondition(
+            timeout: pingTimeout,
+            pollInterval: pollInterval,
+            condition: pingReturnsPong
         )
-        return XCTWaiter().wait(for: [responsive], timeout: pingTimeout) == .completed
+    }
+
+    /// Polls `condition` until it returns true or `timeout` elapses, spinning
+    /// the current run loop for `pollInterval` between attempts so the app
+    /// process keeps making progress without busy-waiting. The condition may
+    /// block (e.g. a socket round trip); the deadline still bounds total wait.
+    private func pollControlSocketCondition(
+        timeout: TimeInterval,
+        pollInterval: TimeInterval,
+        condition: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        } while Date() < deadline
+        // One final attempt right at the deadline so a condition that became
+        // true during the last sleep is not missed.
+        return condition()
     }
 
     /// Convenience wrapper of ``waitForControlSocketReady(listenerBindTimeout:pingTimeout:socketFileExists:pingReturnsPong:)``


### PR DESCRIPTION
## Problem

`BrowserPaneNavigationKeybindUITests/testCmdFOpensBrowserFindAfterCmdDCmdLNavigation` flaked in CI: the setup assertion `XCTAssertTrue(waitForSocketPong(timeout: 12.0))` failed, yet the failure's own diagnostics showed `socketPingResponse: PONG`, `socketReady: 1`, `socketPathMatches: 1` — the control socket was up and answering. The app's in-process sanity check logged PONG ~1s after launch; the test's 12s ping wait still failed.

## Root cause

`waitForControlSocketReady` polled two non-KVO closure predicates via `XCTNSPredicateExpectation`. Those closures do blocking socket I/O (the ping opens a connection and blocks up to its response timeout on each evaluation). Under `XCTWaiter.wait`, the expectation's re-poll timer can be starved, so a single early `false` (listener bound but its accept loop not yet answering — a sub-second window) leaves the waiter sitting on the stale `false` for the full timeout even though the socket became responsive almost immediately.

## Fix

Replace both phases (listener-file-exists, then ping→PONG) with a deterministic deadline loop that re-evaluates the condition every `pollInterval` (0.2s) until the bound elapses, with a final check at the deadline. This guarantees the ping is actually retried for the whole budget. It's a shared helper (`ControlSocketReadinessUITestSupport`), so every UI test that waits on socket readiness de-flakes. The two-phase split from #5414 is preserved.

No product code changes; UI-test infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783975528&installation_id=133855650&pr_number=6062&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6062&signature=4787be120fc88e1bc2ca32835017aa7bb3fb95a8c9b67a3b1b2a9f2cec478042"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes UI tests by making the control-socket readiness wait deterministic. Replaces expectation-based polling with a deadline loop that retries pings on a fixed cadence.

- **Bug Fixes**
  - Replaced `XCTNSPredicateExpectation` with `pollControlSocketCondition` that retries every 0.2s and does a final check at the deadline.
  - Preserved the two phases: wait for socket file, then ping→PONG; added a `pollInterval` parameter.
  - Shared helper used by all UI tests; no product code changes.

<sup>Written for commit 3b10899cdf8d60ceea9a849e95623247c3bd993b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for socket readiness verification with more deterministic polling and better timeout handling.

**Note:** This is an internal testing infrastructure improvement with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->