### PR TITLE
Fix Mermaid diagrams scaling in markdown viewer zoom

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1642,6 +1642,9 @@ html { scroll-behavior: smooth; }
         el.removeAttribute('srcset');
       });
     }
+    clone.querySelectorAll('.cmux-mermaid svg[data-cmux-mermaid-original-max-width]').forEach(function(el) {
+      mermaidRestoreOriginalSizing(el);
+    });
     clone.querySelectorAll('*').forEach(function(el) {
       Array.prototype.slice.call(el.attributes || []).forEach(function(attr) {
         var name = String(attr.name || '').toLowerCase();

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1119,6 +1119,7 @@ html { scroll-behavior: smooth; }
 
   var mermaidInitialized = false;
   var cmuxMarkdownZoom = 1;
+  var mermaidResizeObserver = null;
 
   function normalizedMarkdownZoom(value) {
     var zoom = Number(value);
@@ -1148,9 +1149,24 @@ html { scroll-behavior: smooth; }
     return { width: parts[2], height: parts[3] };
   }
 
-  function mermaidBaseSize(svg) {
-    var cachedWidth = Number(svg.getAttribute('data-cmux-mermaid-base-width'));
-    var cachedHeight = Number(svg.getAttribute('data-cmux-mermaid-base-height'));
+  function mermaidRememberOriginalSizing(svg) {
+    if (svg.hasAttribute('data-cmux-mermaid-original-max-width')) { return; }
+    svg.setAttribute('data-cmux-mermaid-original-max-width', svg.style.maxWidth || '');
+    svg.setAttribute('data-cmux-mermaid-original-width', svg.style.width || '');
+    svg.setAttribute('data-cmux-mermaid-original-height', svg.style.height || '');
+  }
+
+  function mermaidRestoreOriginalSizing(svg) {
+    mermaidRememberOriginalSizing(svg);
+    svg.style.maxWidth = svg.getAttribute('data-cmux-mermaid-original-max-width') || '';
+    svg.style.width = svg.getAttribute('data-cmux-mermaid-original-width') || '';
+    svg.style.height = svg.getAttribute('data-cmux-mermaid-original-height') || '';
+  }
+
+  function mermaidIntrinsicSize(svg) {
+    mermaidRememberOriginalSizing(svg);
+    var cachedWidth = Number(svg.getAttribute('data-cmux-mermaid-natural-width'));
+    var cachedHeight = Number(svg.getAttribute('data-cmux-mermaid-natural-height'));
     if (
       Number.isFinite(cachedWidth) &&
       cachedWidth > 0 &&
@@ -1161,19 +1177,10 @@ html { scroll-behavior: smooth; }
     }
 
     var viewBox = mermaidViewBoxSize(svg);
-    var rect = svg.getBoundingClientRect ? svg.getBoundingClientRect() : null;
-    var width = rect ? rect.width : NaN;
-    var height = rect ? rect.height : NaN;
-    if ((!Number.isFinite(height) || height <= 0) && viewBox && Number.isFinite(width) && width > 0) {
-      height = width * (viewBox.height / viewBox.width);
+    var width = mermaidNumericLength(svg.getAttribute('data-cmux-mermaid-original-max-width'));
+    if (!Number.isFinite(width) || width <= 0) {
+      width = mermaidNumericLength(svg.getAttribute('data-cmux-mermaid-original-width'));
     }
-    if (Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0) {
-      svg.setAttribute('data-cmux-mermaid-base-width', String(width));
-      svg.setAttribute('data-cmux-mermaid-base-height', String(height));
-      return { width: width, height: height };
-    }
-
-    width = mermaidNumericLength(svg.style.maxWidth);
     if (!Number.isFinite(width) || width <= 0) {
       width = mermaidNumericLength(svg.getAttribute('width'));
     }
@@ -1181,7 +1188,10 @@ html { scroll-behavior: smooth; }
       width = viewBox.width;
     }
 
-    var height = mermaidNumericLength(svg.getAttribute('height'));
+    var height = mermaidNumericLength(svg.getAttribute('data-cmux-mermaid-original-height'));
+    if (!Number.isFinite(height) || height <= 0) {
+      height = mermaidNumericLength(svg.getAttribute('height'));
+    }
     if ((!Number.isFinite(height) || height <= 0) && viewBox && Number.isFinite(width) && width > 0) {
       height = width * (viewBox.height / viewBox.width);
     }
@@ -1193,15 +1203,45 @@ html { scroll-behavior: smooth; }
       return null;
     }
 
-    svg.setAttribute('data-cmux-mermaid-base-width', String(width));
-    svg.setAttribute('data-cmux-mermaid-base-height', String(height));
+    svg.setAttribute('data-cmux-mermaid-natural-width', String(width));
+    svg.setAttribute('data-cmux-mermaid-natural-height', String(height));
     return { width: width, height: height };
+  }
+
+  function mermaidCurrentBaseSize(svg, natural) {
+    var container = svg.closest ? svg.closest('.cmux-mermaid') : svg.parentElement;
+    var rect = container && container.getBoundingClientRect ? container.getBoundingClientRect() : null;
+    var containerWidth = rect ? rect.width : NaN;
+    if (!Number.isFinite(containerWidth) || containerWidth <= 0) {
+      containerWidth = container ? container.clientWidth : NaN;
+    }
+    var width = natural.width;
+    if (Number.isFinite(containerWidth) && containerWidth > 0) {
+      width = Math.min(containerWidth, natural.width);
+    }
+    return { width: width, height: width * (natural.height / natural.width) };
+  }
+
+  function ensureMermaidResizeObserver() {
+    if (mermaidResizeObserver || typeof ResizeObserver === 'undefined' || !contentEl) { return; }
+    mermaidResizeObserver = new ResizeObserver(function() {
+      if (Math.abs(cmuxMarkdownZoom - 1) > 0.0001) {
+        applyMermaidZoom(contentEl);
+      }
+    });
+    mermaidResizeObserver.observe(contentEl);
   }
 
   function applyMermaidZoomToSVG(svg) {
     if (!svg) { return; }
-    var base = mermaidBaseSize(svg);
-    if (!base) { return; }
+    var natural = mermaidIntrinsicSize(svg);
+    if (!natural) { return; }
+    if (Math.abs(cmuxMarkdownZoom - 1) <= 0.0001) {
+      mermaidRestoreOriginalSizing(svg);
+      svg.setAttribute('data-cmux-mermaid-zoom', '1');
+      return;
+    }
+    var base = mermaidCurrentBaseSize(svg, natural);
     var width = Math.max(1, base.width * cmuxMarkdownZoom);
     var height = Math.max(1, base.height * cmuxMarkdownZoom);
     svg.style.maxWidth = 'none';
@@ -1211,6 +1251,7 @@ html { scroll-behavior: smooth; }
   }
 
   function applyMermaidZoom(root) {
+    ensureMermaidResizeObserver();
     var scope = root || contentEl;
     if (!scope || !scope.querySelectorAll) { return; }
     Array.prototype.forEach.call(scope.querySelectorAll('.cmux-mermaid svg'), applyMermaidZoomToSVG);

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -140,6 +140,8 @@ body {
   height: auto;
 }
 .cmux-mermaid svg[data-cmux-mermaid-scaled="1"] {
+  display: block;
+  margin-inline: auto;
   max-width: none;
 }
 .cmux-vega canvas, .cmux-vega svg {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -136,7 +136,7 @@ body {
   text-align: center;
 }
 .cmux-mermaid svg {
-  max-width: none;
+  max-width: 100%;
   height: auto;
 }
 .cmux-vega canvas, .cmux-vega svg {
@@ -1161,7 +1161,19 @@ html { scroll-behavior: smooth; }
     }
 
     var viewBox = mermaidViewBoxSize(svg);
-    var width = mermaidNumericLength(svg.style.maxWidth);
+    var rect = svg.getBoundingClientRect ? svg.getBoundingClientRect() : null;
+    var width = rect ? rect.width : NaN;
+    var height = rect ? rect.height : NaN;
+    if ((!Number.isFinite(height) || height <= 0) && viewBox && Number.isFinite(width) && width > 0) {
+      height = width * (viewBox.height / viewBox.width);
+    }
+    if (Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0) {
+      svg.setAttribute('data-cmux-mermaid-base-width', String(width));
+      svg.setAttribute('data-cmux-mermaid-base-height', String(height));
+      return { width: width, height: height };
+    }
+
+    width = mermaidNumericLength(svg.style.maxWidth);
     if (!Number.isFinite(width) || width <= 0) {
       width = mermaidNumericLength(svg.getAttribute('width'));
     }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -135,7 +135,11 @@ body {
   overflow-x: auto;
   text-align: center;
 }
-.cmux-mermaid svg, .cmux-vega canvas, .cmux-vega svg {
+.cmux-mermaid svg {
+  max-width: none;
+  height: auto;
+}
+.cmux-vega canvas, .cmux-vega svg {
   max-width: 100%;
   height: auto;
 }
@@ -1114,6 +1118,97 @@ html { scroll-behavior: smooth; }
   }
 
   var mermaidInitialized = false;
+  var cmuxMarkdownZoom = 1;
+
+  function normalizedMarkdownZoom(value) {
+    var zoom = Number(value);
+    if (!Number.isFinite(zoom) || zoom <= 0) { return 1; }
+    return Math.max(0.1, Math.min(zoom, 10));
+  }
+
+  function mermaidNumericLength(value) {
+    var raw = String(value || '').trim();
+    if (!raw || raw.charAt(raw.length - 1) === '%') { return NaN; }
+    var match = raw.match(/^([0-9]+(?:\.[0-9]+)?)(?:px)?$/i);
+    return match ? Number(match[1]) : NaN;
+  }
+
+  function mermaidViewBoxSize(svg) {
+    var raw = String(svg.getAttribute('viewBox') || '').trim();
+    if (!raw) { return null; }
+    var parts = raw.split(/[\s,]+/).map(Number);
+    if (
+      parts.length !== 4 ||
+      !parts.every(Number.isFinite) ||
+      parts[2] <= 0 ||
+      parts[3] <= 0
+    ) {
+      return null;
+    }
+    return { width: parts[2], height: parts[3] };
+  }
+
+  function mermaidBaseSize(svg) {
+    var cachedWidth = Number(svg.getAttribute('data-cmux-mermaid-base-width'));
+    var cachedHeight = Number(svg.getAttribute('data-cmux-mermaid-base-height'));
+    if (
+      Number.isFinite(cachedWidth) &&
+      cachedWidth > 0 &&
+      Number.isFinite(cachedHeight) &&
+      cachedHeight > 0
+    ) {
+      return { width: cachedWidth, height: cachedHeight };
+    }
+
+    var viewBox = mermaidViewBoxSize(svg);
+    var width = mermaidNumericLength(svg.style.maxWidth);
+    if (!Number.isFinite(width) || width <= 0) {
+      width = mermaidNumericLength(svg.getAttribute('width'));
+    }
+    if ((!Number.isFinite(width) || width <= 0) && viewBox) {
+      width = viewBox.width;
+    }
+
+    var height = mermaidNumericLength(svg.getAttribute('height'));
+    if ((!Number.isFinite(height) || height <= 0) && viewBox && Number.isFinite(width) && width > 0) {
+      height = width * (viewBox.height / viewBox.width);
+    }
+    if ((!Number.isFinite(height) || height <= 0) && viewBox) {
+      height = viewBox.height;
+    }
+
+    if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
+      return null;
+    }
+
+    svg.setAttribute('data-cmux-mermaid-base-width', String(width));
+    svg.setAttribute('data-cmux-mermaid-base-height', String(height));
+    return { width: width, height: height };
+  }
+
+  function applyMermaidZoomToSVG(svg) {
+    if (!svg) { return; }
+    var base = mermaidBaseSize(svg);
+    if (!base) { return; }
+    var width = Math.max(1, base.width * cmuxMarkdownZoom);
+    var height = Math.max(1, base.height * cmuxMarkdownZoom);
+    svg.style.maxWidth = 'none';
+    svg.style.width = width + 'px';
+    svg.style.height = height + 'px';
+    svg.setAttribute('data-cmux-mermaid-zoom', String(cmuxMarkdownZoom));
+  }
+
+  function applyMermaidZoom(root) {
+    var scope = root || contentEl;
+    if (!scope || !scope.querySelectorAll) { return; }
+    Array.prototype.forEach.call(scope.querySelectorAll('.cmux-mermaid svg'), applyMermaidZoomToSVG);
+  }
+
+  window.__cmuxSetMarkdownZoom = function(zoom) {
+    cmuxMarkdownZoom = normalizedMarkdownZoom(zoom);
+    applyMermaidZoom(contentEl);
+  };
+
   function renderMermaidBlocks() {
     if (typeof mermaid === 'undefined') { renderLibError('mermaid', 'library missing'); return; }
     try {
@@ -1137,6 +1232,7 @@ html { scroll-behavior: smooth; }
       try {
         mermaid.render(id, src).then(function(res) {
           el.innerHTML = res.svg;
+          applyMermaidZoom(el);
           if (res.bindFunctions) { try { res.bindFunctions(el); } catch (e) {} }
         }).catch(function(err) {
           el.innerHTML = '<div class="cmux-render-error">Mermaid: '

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -139,6 +139,9 @@ body {
   max-width: 100%;
   height: auto;
 }
+.cmux-mermaid svg[data-cmux-mermaid-scaled="1"] {
+  max-width: none;
+}
 .cmux-vega canvas, .cmux-vega svg {
   max-width: 100%;
   height: auto;
@@ -1158,6 +1161,7 @@ html { scroll-behavior: smooth; }
 
   function mermaidRestoreOriginalSizing(svg) {
     mermaidRememberOriginalSizing(svg);
+    svg.removeAttribute('data-cmux-mermaid-scaled');
     svg.style.maxWidth = svg.getAttribute('data-cmux-mermaid-original-max-width') || '';
     svg.style.width = svg.getAttribute('data-cmux-mermaid-original-width') || '';
     svg.style.height = svg.getAttribute('data-cmux-mermaid-original-height') || '';
@@ -1244,7 +1248,8 @@ html { scroll-behavior: smooth; }
     var base = mermaidCurrentBaseSize(svg, natural);
     var width = Math.max(1, base.width * cmuxMarkdownZoom);
     var height = Math.max(1, base.height * cmuxMarkdownZoom);
-    svg.style.maxWidth = 'none';
+    svg.style.maxWidth = '';
+    svg.setAttribute('data-cmux-mermaid-scaled', '1');
     svg.style.width = width + 'px';
     svg.style.height = height + 'px';
     svg.setAttribute('data-cmux-mermaid-zoom', String(cmuxMarkdownZoom));

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1123,6 +1123,7 @@ html { scroll-behavior: smooth; }
   var mermaidInitialized = false;
   var cmuxMarkdownZoom = 1;
   var mermaidResizeObserver = null;
+  var mermaidObservedWidth = 0;
 
   function normalizedMarkdownZoom(value) {
     var zoom = Number(value);
@@ -1228,10 +1229,19 @@ html { scroll-behavior: smooth; }
 
   function ensureMermaidResizeObserver() {
     if (mermaidResizeObserver || typeof ResizeObserver === 'undefined' || !contentEl) { return; }
-    mermaidResizeObserver = new ResizeObserver(function() {
-      if (Math.abs(cmuxMarkdownZoom - 1) > 0.0001) {
-        applyMermaidZoom(contentEl);
-      }
+    mermaidObservedWidth = Math.round(contentEl.getBoundingClientRect().width || contentEl.clientWidth || 0);
+    mermaidResizeObserver = new ResizeObserver(function(entries) {
+      if (Math.abs(cmuxMarkdownZoom - 1) <= 0.0001) { return; }
+      var entry = entries && entries[0];
+      var width = Math.round(
+        (entry && entry.contentRect && entry.contentRect.width) ||
+        contentEl.getBoundingClientRect().width ||
+        contentEl.clientWidth ||
+        0
+      );
+      if (width <= 0 || width === mermaidObservedWidth) { return; }
+      mermaidObservedWidth = width;
+      applyMermaidZoom(contentEl);
     });
     mermaidResizeObserver.observe(contentEl);
   }

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1227,19 +1227,26 @@ html { scroll-behavior: smooth; }
     return { width: width, height: width * (natural.height / natural.width) };
   }
 
+  function mermaidContentWidth(entry) {
+    return Math.round(
+      (entry && entry.contentRect && entry.contentRect.width) ||
+      contentEl.getBoundingClientRect().width ||
+      contentEl.clientWidth ||
+      0
+    );
+  }
+
   function ensureMermaidResizeObserver() {
     if (mermaidResizeObserver || typeof ResizeObserver === 'undefined' || !contentEl) { return; }
-    mermaidObservedWidth = Math.round(contentEl.getBoundingClientRect().width || contentEl.clientWidth || 0);
+    mermaidObservedWidth = mermaidContentWidth(null);
     mermaidResizeObserver = new ResizeObserver(function(entries) {
-      if (Math.abs(cmuxMarkdownZoom - 1) <= 0.0001) { return; }
-      var entry = entries && entries[0];
-      var width = Math.round(
-        (entry && entry.contentRect && entry.contentRect.width) ||
-        contentEl.getBoundingClientRect().width ||
-        contentEl.clientWidth ||
-        0
-      );
-      if (width <= 0 || width === mermaidObservedWidth) { return; }
+      var width = mermaidContentWidth(entries && entries[0]);
+      if (width <= 0) { return; }
+      if (Math.abs(cmuxMarkdownZoom - 1) <= 0.0001) {
+        mermaidObservedWidth = width;
+        return;
+      }
+      if (width === mermaidObservedWidth) { return; }
       mermaidObservedWidth = width;
       applyMermaidZoom(contentEl);
     });
@@ -1275,6 +1282,7 @@ html { scroll-behavior: smooth; }
 
   window.__cmuxSetMarkdownZoom = function(zoom) {
     cmuxMarkdownZoom = normalizedMarkdownZoom(zoom);
+    mermaidObservedWidth = mermaidContentWidth(null);
     applyMermaidZoom(contentEl);
   };
 

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1246,6 +1246,7 @@ html { scroll-behavior: smooth; }
       return;
     }
     var base = mermaidCurrentBaseSize(svg, natural);
+    // WKWebView pageZoom scales markdown text metrics here, but Mermaid SVG bounds stay fixed.
     var width = Math.max(1, base.width * cmuxMarkdownZoom);
     var height = Math.max(1, base.height * cmuxMarkdownZoom);
     svg.style.maxWidth = '';

--- a/Sources/Panels/MarkdownFontSizeSettings.swift
+++ b/Sources/Panels/MarkdownFontSizeSettings.swift
@@ -6,9 +6,10 @@ import Foundation
 /// The value is the `.markdown-body` font size in points. The web shell renders
 /// the body at `baseRenderPointSize` px intrinsically, so the panel applies
 /// `pointSize / baseRenderPointSize` as the WKWebView `pageZoom` to scale the
-/// whole rendered document (text, code, tables, diagrams, images) the way
-/// browser zoom does. Keep `baseRenderPointSize` in sync with the
-/// `.markdown-body { font-size: ... }` rule in `Resources/markdown-viewer/shell.html`.
+/// rendered document the way browser zoom does. Mermaid SVGs also receive this
+/// factor in the shell because Mermaid emits inline max-width values that
+/// WebKit text zoom does not resize. Keep `baseRenderPointSize` in sync with
+/// the `.markdown-body { font-size: ... }` rule in `Resources/markdown-viewer/shell.html`.
 enum MarkdownFontSizeSettings {
     /// UserDefaults / cmux.json key (`markdown.fontSize`).
     static let key = "markdown.fontSize"

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -12,9 +12,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
     let panelId: UUID
     let workspaceId: UUID
     let filePath: String
-    /// Body font size in points. Applied as WKWebView `pageZoom`; the web
-    /// shell also receives the same zoom factor for rendered SVGs whose inline
-    /// sizing would otherwise bypass WebKit text zoom.
+    /// Body font size in points, applied as `pageZoom` and to shell-managed SVG zoom.
     let fontSize: Double
     /// Body prose font-family name (empty = System). Applied as an inline
     /// `font-family` on the content.
@@ -188,15 +186,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             if abs(webView.pageZoom - zoom) > 0.0001 {
                 webView.pageZoom = zoom
             }
-            let zoomValue = Double(zoom)
-            let js = """
-            (function(zoom) {
-              if (window.__cmuxSetMarkdownZoom) {
-                window.__cmuxSetMarkdownZoom(zoom);
-              }
-            })(\(zoomValue));
-            """
-            webView.evaluateJavaScript(js, completionHandler: nil)
+            webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)));", completionHandler: nil)
         }
 
         /// Records the desired body prose font and applies it as an inline

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -12,8 +12,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
     let panelId: UUID
     let workspaceId: UUID
     let filePath: String
-    /// Body font size in points. Applied as WKWebView `pageZoom` so the whole
-    /// rendered document scales like browser zoom.
+    /// Body font size in points. Applied as WKWebView `pageZoom`; the web
+    /// shell also receives the same zoom factor for rendered SVGs whose inline
+    /// sizing would otherwise bypass WebKit text zoom.
     let fontSize: Double
     /// Body prose font-family name (empty = System). Applied as an inline
     /// `font-family` on the content.
@@ -187,6 +188,15 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             if abs(webView.pageZoom - zoom) > 0.0001 {
                 webView.pageZoom = zoom
             }
+            let zoomValue = Double(zoom)
+            let js = """
+            (function(zoom) {
+              if (window.__cmuxSetMarkdownZoom) {
+                window.__cmuxSetMarkdownZoom(zoom);
+              }
+            })(\(zoomValue));
+            """
+            webView.evaluateJavaScript(js, completionHandler: nil)
         }
 
         /// Records the desired body prose font and applies it as an inline

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -180,13 +180,12 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             applyFontSize()
         }
 
-        private func applyFontSize() {
+        private func applyFontSize(forceShellSync: Bool = false) {
             guard let webView else { return }
             let zoom = MarkdownFontSizeSettings.pageZoom(forPointSize: lastFontSize)
-            if abs(webView.pageZoom - zoom) > 0.0001 {
-                webView.pageZoom = zoom
-            }
-            webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)));", completionHandler: nil)
+            let shouldSyncShell = forceShellSync || abs(webView.pageZoom - zoom) > 0.0001
+            if abs(webView.pageZoom - zoom) > 0.0001 { webView.pageZoom = zoom }
+            if shouldSyncShell { webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)));", completionHandler: nil) }
         }
 
         /// Records the desired body prose font and applies it as an inline
@@ -677,7 +676,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             // pageZoom is a WKWebView-level property that survives loadHTMLString,
             // but re-apply defensively after a shell reload so a crash-recovery
             // path can never drop the configured zoom.
-            applyFontSize()
+            applyFontSize(forceShellSync: true)
             // font-family is a DOM inline style on a freshly-created #content,
             // so it MUST be re-applied after every shell (re)load.
             applyFontFamily()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		F5168A070000000000000001 /* MarkdownFontFamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */; };
 		F5168A030000000000000001 /* MarkdownFontSizeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */; };
 		F5168A050000000000000001 /* MarkdownMaxWidthSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */; };
+		D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
@@ -1288,6 +1289,7 @@
 		F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamilyCache.swift; sourceTree = "<group>"; };
 		F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontSizeSettings.swift; sourceTree = "<group>"; };
 		F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownMaxWidthSettings.swift; sourceTree = "<group>"; };
+		D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMermaidZoomTests.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
@@ -2517,6 +2519,7 @@
 				4C1A7E10B2D34F56A8C90014 /* MobileHostStatusVerificationLimiterTests.swift */,
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
+				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
 				C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */,
@@ -3711,6 +3714,7 @@
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
 				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
 				17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */,
+				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -1,0 +1,170 @@
+import AppKit
+import WebKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class MarkdownMermaidZoomTests: XCTestCase {
+    func testRenderedMermaidDiagramScalesWithViewerZoom() async throws {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-mermaid-zoom-\(UUID().uuidString).md")
+        let frame = NSRect(x: 0, y: 0, width: 720, height: 480)
+        let configuration = WKWebViewConfiguration()
+        let mermaidHandler = MarkdownMermaidStubHandler()
+        configuration.userContentController.add(mermaidHandler, name: "cmuxLib")
+        let webView = MarkdownWebView(frame: frame, configuration: configuration)
+        mermaidHandler.webView = webView
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        coordinator.webView = webView
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            coordinator.webView = nil
+            configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
+            window.close()
+        }
+
+        let loaded = expectation(description: "markdown shell loaded")
+        let loadDelegate = MermaidZoomShellLoadDelegate(expectation: loaded)
+        webView.navigationDelegate = loadDelegate
+        webView.loadHTMLString(MarkdownViewerAssets.shared.shellHTML(isDark: true), baseURL: markdownURL)
+        await fulfillment(of: [loaded], timeout: 5)
+        if let error = loadDelegate.error { throw error }
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
+        try await renderMarkdown(
+            """
+            Prose before the diagram.
+
+            ```mermaid
+            flowchart LR
+              host[Host process] --> backend[Backend]
+              backend --> worker[Worker]
+            ```
+            """,
+            in: webView
+        )
+
+        let baseline = try await waitForMermaidSnapshot(in: webView)
+        let baselineWidth = try XCTUnwrap(baseline["width"])
+        XCTAssertEqual(baseline["zoom"] ?? -1, 1, accuracy: 0.001)
+        XCTAssertEqual(baselineWidth, 240, accuracy: 2)
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
+        let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
+        XCTAssertGreaterThan(try XCTUnwrap(zoomed["width"]), baselineWidth * 1.8)
+        XCTAssertEqual(zoomed["inlineMaxWidthCleared"] ?? 0, 1, accuracy: 0.001)
+    }
+
+    private func renderMarkdown(_ markdown: String, in webView: WKWebView) async throws {
+        let data = try JSONSerialization.data(withJSONObject: [markdown])
+        let literal = try XCTUnwrap(String(data: data, encoding: .utf8))
+        _ = try await webView.evaluateJavaScript("window.__cmuxRenderMarkdown(\(literal)[0]);")
+    }
+
+    private func waitForMermaidSnapshot(
+        in webView: WKWebView,
+        expectedZoom: Double? = nil
+    ) async throws -> [String: Double] {
+        let deadline = Date().addingTimeInterval(3)
+        var lastSnapshot: [String: Double]?
+        while Date() < deadline {
+            if let snapshot = try await mermaidSnapshot(in: webView) {
+                lastSnapshot = snapshot
+                if let expectedZoom {
+                    if abs((snapshot["zoom"] ?? -1) - expectedZoom) <= 0.001 { return snapshot }
+                } else if (snapshot["width"] ?? 0) > 0 {
+                    return snapshot
+                }
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw NSError(
+            domain: "MarkdownMermaidZoomTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for Mermaid snapshot: \(String(describing: lastSnapshot))"]
+        )
+    }
+
+    private func mermaidSnapshot(in webView: WKWebView) async throws -> [String: Double]? {
+        let result = try await webView.evaluateJavaScript(
+            """
+            (function() {
+              var svg = document.querySelector('.cmux-mermaid svg');
+              if (!svg) { return null; }
+              var rect = svg.getBoundingClientRect();
+              var zoom = Number(svg.getAttribute('data-cmux-mermaid-zoom') || '1');
+              return {
+                width: rect.width || 0,
+                zoom: Number.isFinite(zoom) ? zoom : 1,
+                inlineMaxWidthCleared: svg.style.maxWidth === 'none' ? 1 : 0
+              };
+            })();
+            """
+        )
+        guard let raw = result as? [String: Any] else { return nil }
+        var snapshot: [String: Double] = [:]
+        for (key, value) in raw {
+            if let number = value as? NSNumber { snapshot[key] = number.doubleValue }
+        }
+        return snapshot
+    }
+}
+
+private final class MermaidZoomShellLoadDelegate: NSObject, WKNavigationDelegate {
+    let expectation: XCTestExpectation
+    var error: Error?
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        expectation.fulfill()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        self.error = error
+        expectation.fulfill()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        self.error = error
+        expectation.fulfill()
+    }
+}
+
+@MainActor
+private final class MarkdownMermaidStubHandler: NSObject, WKScriptMessageHandler {
+    weak var webView: WKWebView?
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == "cmuxLib",
+              let body = message.body as? [String: Any],
+              body["lib"] as? String == "mermaid" else { return }
+        webView?.evaluateJavaScript(
+            """
+            window.mermaid = {
+              initialize: function() {},
+              render: function() {
+                return Promise.resolve({
+                  svg: '<svg data-stub-mermaid="1" width="100%" style="max-width:240px;" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="240" height="120" fill="#d73a49"></rect><text x="20" y="65" font-size="18" fill="#ffffff">Mermaid label</text></svg>'
+                });
+              }
+            };
+            if (window.__cmuxLibLoaded) { window.__cmuxLibLoaded('mermaid'); }
+            """,
+            completionHandler: nil
+        )
+    }
+}

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -76,10 +76,23 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         let fittedWidth = try XCTUnwrap(fitted["width"])
         XCTAssertGreaterThan(fittedWidth, baselineWidth * 1.8)
         XCTAssertLessThanOrEqual(fittedWidth, (try XCTUnwrap(fitted["containerWidth"])) + 2)
+        XCTAssertEqual(fitted["inlineMaxWidthCleared"] ?? 1, 0, accuracy: 0.001)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
-        XCTAssertGreaterThan(try XCTUnwrap(fittedZoomed["width"]), fittedWidth * 1.8)
+        let fittedZoomedWidth = try XCTUnwrap(fittedZoomed["width"])
+        XCTAssertGreaterThan(fittedZoomedWidth, fittedWidth * 1.8)
+
+        let widerFrame = NSRect(x: 0, y: 0, width: 960, height: 480)
+        window.setFrame(widerFrame, display: true)
+        webView.frame = widerFrame
+        _ = try await webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom(2);")
+        let widened = try await waitForMermaidSnapshot(
+            in: webView,
+            expectedZoom: 2,
+            minimumWidth: fittedZoomedWidth * 1.1
+        )
+        XCTAssertGreaterThan(try XCTUnwrap(widened["width"]), fittedZoomedWidth * 1.1)
     }
 
     private func renderMarkdown(_ markdown: String, in webView: WKWebView) async throws {
@@ -90,16 +103,17 @@ final class MarkdownMermaidZoomTests: XCTestCase {
 
     private func waitForMermaidSnapshot(
         in webView: WKWebView,
-        expectedZoom: Double? = nil
+        expectedZoom: Double? = nil,
+        minimumWidth: Double? = nil
     ) async throws -> [String: Double] {
         let deadline = Date().addingTimeInterval(3)
         var lastSnapshot: [String: Double]?
         while Date() < deadline {
             if let snapshot = try await mermaidSnapshot(in: webView) {
                 lastSnapshot = snapshot
-                if let expectedZoom {
-                    if abs((snapshot["zoom"] ?? -1) - expectedZoom) <= 0.001 { return snapshot }
-                } else if (snapshot["width"] ?? 0) > 0 {
+                let zoomMatches = expectedZoom.map { abs((snapshot["zoom"] ?? -1) - $0) <= 0.001 } ?? true
+                let widthMatches = minimumWidth.map { (snapshot["width"] ?? 0) >= $0 } ?? ((snapshot["width"] ?? 0) > 0)
+                if zoomMatches && widthMatches {
                     return snapshot
                 }
             }

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -54,12 +54,16 @@ final class MarkdownMermaidZoomTests: XCTestCase {
 
         let baseline = try await waitForMermaidSnapshot(in: webView)
         let baselineWidth = try XCTUnwrap(baseline["width"])
+        let baselineProseHeight = try XCTUnwrap(baseline["proseHeight"])
         XCTAssertEqual(baseline["zoom"] ?? -1, 1, accuracy: 0.001)
         XCTAssertEqual(baselineWidth, 240, accuracy: 2)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
-        XCTAssertGreaterThan(try XCTUnwrap(zoomed["width"]), baselineWidth * 1.8)
+        let zoomedWidth = try XCTUnwrap(zoomed["width"])
+        let zoomedProseHeight = try XCTUnwrap(zoomed["proseHeight"])
+        XCTAssertGreaterThan(zoomedWidth, baselineWidth * 1.8)
+        XCTAssertEqual(zoomedWidth / baselineWidth, zoomedProseHeight / baselineProseHeight, accuracy: 0.25)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
         try await renderMarkdown(
@@ -133,10 +137,13 @@ final class MarkdownMermaidZoomTests: XCTestCase {
               var rect = svg.getBoundingClientRect();
               var container = svg.closest('.cmux-mermaid');
               var containerRect = container ? container.getBoundingClientRect() : null;
+              var prose = document.querySelector('.markdown-body p');
+              var proseRect = prose ? prose.getBoundingClientRect() : null;
               var zoom = Number(svg.getAttribute('data-cmux-mermaid-zoom') || '1');
               return {
                 width: rect.width || 0,
                 containerWidth: containerRect ? (containerRect.width || 0) : 0,
+                proseHeight: proseRect ? (proseRect.height || 0) : 0,
                 zoom: Number.isFinite(zoom) ? zoom : 1
               };
             })();

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -1,6 +1,6 @@
 import AppKit
+import Testing
 import WebKit
-import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -9,8 +9,10 @@ import XCTest
 #endif
 
 @MainActor
-final class MarkdownMermaidZoomTests: XCTestCase {
-    func testRenderedMermaidDiagramScalesWithViewerZoom() async throws {
+@Suite
+final class MarkdownMermaidZoomTests {
+    @Test
+    func renderedMermaidDiagramScalesWithViewerZoom() async throws {
         let markdownURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-mermaid-zoom-\(UUID().uuidString).md")
         let frame = NSRect(x: 0, y: 0, width: 720, height: 480)
@@ -31,12 +33,9 @@ final class MarkdownMermaidZoomTests: XCTestCase {
             window.close()
         }
 
-        let loaded = expectation(description: "markdown shell loaded")
-        let loadDelegate = MermaidZoomShellLoadDelegate(expectation: loaded)
+        let loadDelegate = MermaidZoomShellLoadDelegate()
         webView.navigationDelegate = loadDelegate
-        webView.loadHTMLString(MarkdownViewerAssets.shared.shellHTML(isDark: true), baseURL: markdownURL)
-        await fulfillment(of: [loaded], timeout: 5)
-        if let error = loadDelegate.error { throw error }
+        try await loadDelegate.load(MarkdownViewerAssets.shared.shellHTML(isDark: true), in: webView, baseURL: markdownURL)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
         try await renderMarkdown(
@@ -53,22 +52,22 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         )
 
         let baseline = try await waitForMermaidSnapshot(in: webView)
-        let baselineWidth = try XCTUnwrap(baseline["width"])
-        let baselineProseHeight = try XCTUnwrap(baseline["proseHeight"])
-        XCTAssertEqual(baseline["zoom"] ?? -1, 1, accuracy: 0.001)
-        XCTAssertEqual(baselineWidth, 240, accuracy: 2)
+        let baselineWidth = try #require(baseline["width"])
+        let baselineProseHeight = try #require(baseline["proseHeight"])
+        #expect(abs((baseline["zoom"] ?? -1) - 1) <= 0.001)
+        #expect(abs(baselineWidth - 240) <= 2)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
-        let zoomedWidth = try XCTUnwrap(zoomed["width"])
-        let zoomedProseHeight = try XCTUnwrap(zoomed["proseHeight"])
-        XCTAssertGreaterThan(zoomedWidth, baselineWidth * 1.8)
-        XCTAssertEqual(zoomedWidth / baselineWidth, zoomedProseHeight / baselineProseHeight, accuracy: 0.25)
+        let zoomedWidth = try #require(zoomed["width"])
+        let zoomedProseHeight = try #require(zoomed["proseHeight"])
+        #expect(zoomedWidth > baselineWidth * 1.8)
+        #expect(abs((zoomedWidth / baselineWidth) - (zoomedProseHeight / baselineProseHeight)) <= 0.25)
         let exported = try await exportedMermaidSnapshot(in: webView)
-        XCTAssertEqual(exported["width"], "")
-        XCTAssertEqual(exported["height"], "")
-        XCTAssertEqual(exported["maxWidth"], "240px")
-        XCTAssertEqual(exported["hasCmuxData"], "0")
+        #expect((exported["width"] ?? "missing") == "")
+        #expect((exported["height"] ?? "missing") == "")
+        #expect(exported["maxWidth"] == "240px")
+        #expect(exported["hasCmuxData"] == "0")
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
         try await renderMarkdown(
@@ -81,14 +80,15 @@ final class MarkdownMermaidZoomTests: XCTestCase {
             in: webView
         )
         let fitted = try await waitForMermaidSnapshot(in: webView)
-        let fittedWidth = try XCTUnwrap(fitted["width"])
-        XCTAssertGreaterThan(fittedWidth, baselineWidth * 1.8)
-        XCTAssertLessThanOrEqual(fittedWidth, (try XCTUnwrap(fitted["containerWidth"])) + 2)
+        let fittedWidth = try #require(fitted["width"])
+        let fittedContainerWidth = try #require(fitted["containerWidth"])
+        #expect(fittedWidth > baselineWidth * 1.8)
+        #expect(fittedWidth <= fittedContainerWidth + 2)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
-        let fittedZoomedWidth = try XCTUnwrap(fittedZoomed["width"])
-        XCTAssertGreaterThan(fittedZoomedWidth, fittedWidth * 1.8)
+        let fittedZoomedWidth = try #require(fittedZoomed["width"])
+        #expect(fittedZoomedWidth > fittedWidth * 1.8)
 
         let widerFrame = NSRect(x: 0, y: 0, width: 960, height: 480)
         window.setFrame(widerFrame, display: true)
@@ -99,12 +99,13 @@ final class MarkdownMermaidZoomTests: XCTestCase {
             expectedZoom: 2,
             minimumWidth: fittedZoomedWidth * 1.1
         )
-        XCTAssertGreaterThan(try XCTUnwrap(widened["width"]), fittedZoomedWidth * 1.1)
+        let widenedWidth = try #require(widened["width"])
+        #expect(widenedWidth > fittedZoomedWidth * 1.1)
     }
 
     private func renderMarkdown(_ markdown: String, in webView: WKWebView) async throws {
         let data = try JSONSerialization.data(withJSONObject: [markdown])
-        let literal = try XCTUnwrap(String(data: data, encoding: .utf8))
+        let literal = try #require(String(data: data, encoding: .utf8))
         _ = try await webView.evaluateJavaScript("window.__cmuxRenderMarkdown(\(literal)[0]);")
     }
 
@@ -126,11 +127,7 @@ final class MarkdownMermaidZoomTests: XCTestCase {
             }
             try await Task.sleep(nanoseconds: 100_000_000)
         }
-        throw NSError(
-            domain: "MarkdownMermaidZoomTests",
-            code: 1,
-            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for Mermaid snapshot: \(String(describing: lastSnapshot))"]
-        )
+        throw MermaidSnapshotTimeout(lastSnapshot: lastSnapshot)
     }
 
     private func mermaidSnapshot(in webView: WKWebView) async throws -> [String: Double]? {
@@ -189,25 +186,44 @@ final class MarkdownMermaidZoomTests: XCTestCase {
 }
 
 private final class MermaidZoomShellLoadDelegate: NSObject, WKNavigationDelegate {
-    let expectation: XCTestExpectation
-    var error: Error?
+    private var continuation: CheckedContinuation<Void, Error>?
 
-    init(expectation: XCTestExpectation) {
-        self.expectation = expectation
+    func load(_ html: String, in webView: WKWebView, baseURL: URL) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            webView.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        switch result {
+        case .success:
+            continuation.resume()
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        expectation.fulfill()
+        finish(.success(()))
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        self.error = error
-        expectation.fulfill()
+        finish(.failure(error))
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        self.error = error
-        expectation.fulfill()
+        finish(.failure(error))
+    }
+}
+
+private struct MermaidSnapshotTimeout: Error, CustomStringConvertible {
+    let lastSnapshot: [String: Double]?
+
+    var description: String {
+        "Timed out waiting for Mermaid snapshot: \(String(describing: lastSnapshot))"
     }
 }
 

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -64,6 +64,11 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         let zoomedProseHeight = try XCTUnwrap(zoomed["proseHeight"])
         XCTAssertGreaterThan(zoomedWidth, baselineWidth * 1.8)
         XCTAssertEqual(zoomedWidth / baselineWidth, zoomedProseHeight / baselineProseHeight, accuracy: 0.25)
+        let exported = try await exportedMermaidSnapshot(in: webView)
+        XCTAssertEqual(exported["width"], "")
+        XCTAssertEqual(exported["height"], "")
+        XCTAssertEqual(exported["maxWidth"], "240px")
+        XCTAssertEqual(exported["hasCmuxData"], "0")
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
         try await renderMarkdown(
@@ -155,6 +160,31 @@ final class MarkdownMermaidZoomTests: XCTestCase {
             if let number = value as? NSNumber { snapshot[key] = number.doubleValue }
         }
         return snapshot
+    }
+
+    private func exportedMermaidSnapshot(in webView: WKWebView) async throws -> [String: String] {
+        let result = try await webView.evaluateJavaScript(
+            """
+            (function() {
+              var wrapper = document.createElement('div');
+              wrapper.innerHTML = window.__cmuxRenderedHTML();
+              var svg = wrapper.querySelector('.cmux-mermaid svg');
+              if (!svg) { return {}; }
+              return {
+                width: svg.style.width || '',
+                height: svg.style.height || '',
+                maxWidth: svg.style.maxWidth || '',
+                hasCmuxData: Array.prototype.some.call(svg.attributes || [], function(attr) {
+                  return String(attr.name || '').indexOf('data-cmux-') === 0;
+                }) ? '1' : '0'
+              };
+            })();
+            """
+        )
+        guard let raw = result as? [String: Any] else { return [:] }
+        return raw.reduce(into: [String: String]()) { output, item in
+            output[item.key] = item.value as? String
+        }
     }
 }
 

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -61,6 +61,25 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         XCTAssertGreaterThan(try XCTUnwrap(zoomed["width"]), baselineWidth * 1.8)
         XCTAssertEqual(zoomed["inlineMaxWidthCleared"] ?? 0, 1, accuracy: 0.001)
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
+        try await renderMarkdown(
+            """
+            ```mermaid
+            flowchart LR
+              wideDiagram[Very wide diagram] --> wider[Still fits at one hundred percent]
+            ```
+            """,
+            in: webView
+        )
+        let fitted = try await waitForMermaidSnapshot(in: webView)
+        let fittedWidth = try XCTUnwrap(fitted["width"])
+        XCTAssertGreaterThan(fittedWidth, baselineWidth * 1.8)
+        XCTAssertLessThanOrEqual(fittedWidth, (try XCTUnwrap(fitted["containerWidth"])) + 2)
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
+        let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
+        XCTAssertGreaterThan(try XCTUnwrap(fittedZoomed["width"]), fittedWidth * 1.8)
     }
 
     private func renderMarkdown(_ markdown: String, in webView: WKWebView) async throws {
@@ -100,9 +119,12 @@ final class MarkdownMermaidZoomTests: XCTestCase {
               var svg = document.querySelector('.cmux-mermaid svg');
               if (!svg) { return null; }
               var rect = svg.getBoundingClientRect();
+              var container = svg.closest('.cmux-mermaid');
+              var containerRect = container ? container.getBoundingClientRect() : null;
               var zoom = Number(svg.getAttribute('data-cmux-mermaid-zoom') || '1');
               return {
                 width: rect.width || 0,
+                containerWidth: containerRect ? (containerRect.width || 0) : 0,
                 zoom: Number.isFinite(zoom) ? zoom : 1,
                 inlineMaxWidthCleared: svg.style.maxWidth === 'none' ? 1 : 0
               };
@@ -156,9 +178,12 @@ private final class MarkdownMermaidStubHandler: NSObject, WKScriptMessageHandler
             """
             window.mermaid = {
               initialize: function() {},
-              render: function() {
+              render: function(id, src) {
+                var isWide = String(src || '').indexOf('wideDiagram') !== -1;
+                var width = isWide ? 1200 : 240;
+                var height = isWide ? 600 : 120;
                 return Promise.resolve({
-                  svg: '<svg data-stub-mermaid="1" width="100%" style="max-width:240px;" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="240" height="120" fill="#d73a49"></rect><text x="20" y="65" font-size="18" fill="#ffffff">Mermaid label</text></svg>'
+                  svg: '<svg data-stub-mermaid="1" width="100%" style="max-width:' + width + 'px;" viewBox="0 0 ' + width + ' ' + height + '" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="' + width + '" height="' + height + '" fill="#d73a49"></rect><text x="20" y="65" font-size="18" fill="#ffffff">Mermaid label</text></svg>'
                 });
               }
             };

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -60,7 +60,6 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         XCTAssertGreaterThan(try XCTUnwrap(zoomed["width"]), baselineWidth * 1.8)
-        XCTAssertEqual(zoomed["inlineMaxWidthCleared"] ?? 0, 1, accuracy: 0.001)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
         try await renderMarkdown(
@@ -76,7 +75,6 @@ final class MarkdownMermaidZoomTests: XCTestCase {
         let fittedWidth = try XCTUnwrap(fitted["width"])
         XCTAssertGreaterThan(fittedWidth, baselineWidth * 1.8)
         XCTAssertLessThanOrEqual(fittedWidth, (try XCTUnwrap(fitted["containerWidth"])) + 2)
-        XCTAssertEqual(fitted["inlineMaxWidthCleared"] ?? 1, 0, accuracy: 0.001)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
@@ -139,8 +137,7 @@ final class MarkdownMermaidZoomTests: XCTestCase {
               return {
                 width: rect.width || 0,
                 containerWidth: containerRect ? (containerRect.width || 0) : 0,
-                zoom: Number.isFinite(zoom) ? zoom : 1,
-                inlineMaxWidthCleared: svg.style.maxWidth === 'none' ? 1 : 0
+                zoom: Number.isFinite(zoom) ? zoom : 1
               };
             })();
             """

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -89,6 +89,7 @@ final class MarkdownMermaidZoomTests {
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         let fittedZoomedWidth = try #require(fittedZoomed["width"])
         #expect(fittedZoomedWidth > fittedWidth * 1.8)
+        #expect((try #require(fittedZoomed["leftOffset"])) >= -1)
 
         let widerFrame = NSRect(x: 0, y: 0, width: 960, height: 480)
         window.setFrame(widerFrame, display: true)
@@ -145,6 +146,7 @@ final class MarkdownMermaidZoomTests {
               return {
                 width: rect.width || 0,
                 containerWidth: containerRect ? (containerRect.width || 0) : 0,
+                leftOffset: containerRect ? ((rect.left || 0) - (containerRect.left || 0)) : 0,
                 proseHeight: proseRect ? (proseRect.height || 0) : 0,
                 zoom: Number.isFinite(zoom) ? zoom : 1
               };

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -740,6 +740,67 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertTrue((image["src"] as? String ?? "").hasPrefix("data:image/png;base64,"))
     }
 
+    func testMarkdownRenderScalesRenderedMermaidDiagramWithViewerZoom() async throws {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-mermaid-zoom-\(UUID().uuidString).md")
+
+        let frame = NSRect(x: 0, y: 0, width: 720, height: 480)
+        let configuration = WKWebViewConfiguration()
+        let mermaidHandler = MarkdownMermaidStubHandler()
+        configuration.userContentController.add(mermaidHandler, name: "cmuxLib")
+        let webView = MarkdownWebView(frame: frame, configuration: configuration)
+        mermaidHandler.webView = webView
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        coordinator.webView = webView
+        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = webView
+        window.orderFrontRegardless()
+        defer {
+            webView.navigationDelegate = nil
+            coordinator.webView = nil
+            configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
+            window.close()
+        }
+
+        let loaded = expectation(description: "markdown shell loaded")
+        let loadDelegate = MarkdownShellLoadDelegate(expectation: loaded)
+        webView.navigationDelegate = loadDelegate
+        webView.loadHTMLString(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            baseURL: markdownURL
+        )
+        await fulfillment(of: [loaded], timeout: 5)
+        if let error = loadDelegate.error {
+            throw error
+        }
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
+        try await renderMarkdown(
+            """
+            Prose before the diagram.
+
+            ```mermaid
+            flowchart LR
+              host[Host process] --> backend[Backend]
+              backend --> worker[Worker]
+            ```
+            """,
+            in: webView
+        )
+
+        let baseline = try await waitForMermaidSnapshot(in: webView)
+        let baselineWidth = try XCTUnwrap(baseline["width"])
+        XCTAssertEqual(baseline["zoom"] ?? -1, 1, accuracy: 0.001)
+        XCTAssertEqual(baselineWidth, 240, accuracy: 2)
+
+        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
+        let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
+        let zoomedWidth = try XCTUnwrap(zoomed["width"])
+
+        XCTAssertGreaterThan(zoomedWidth, baselineWidth * 1.8)
+        XCTAssertEqual(zoomed["inlineMaxWidthCleared"] ?? 0, 1, accuracy: 0.001)
+    }
+
     func testMarkdownRenderBlocksRemoteImagesUntilUserAction() async throws {
         let markdownURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-remote-image-\(UUID().uuidString).md")
@@ -1367,6 +1428,59 @@ final class MarkdownPanelTests: XCTestCase {
         )
     }
 
+    private func waitForMermaidSnapshot(
+        in webView: WKWebView,
+        expectedZoom: Double? = nil
+    ) async throws -> [String: Double] {
+        let deadline = Date().addingTimeInterval(3)
+        var lastSnapshot: [String: Double]?
+
+        while Date() < deadline {
+            let result = try await webView.evaluateJavaScript(
+                """
+                (function() {
+                  var svg = document.querySelector('.cmux-mermaid svg');
+                  if (!svg) { return null; }
+                  var rect = svg.getBoundingClientRect();
+                  var computed = window.getComputedStyle(svg);
+                  var zoom = Number(svg.getAttribute('data-cmux-mermaid-zoom') || '1');
+                  return {
+                    width: rect.width || Number.parseFloat(computed.width) || 0,
+                    height: rect.height || Number.parseFloat(computed.height) || 0,
+                    zoom: Number.isFinite(zoom) ? zoom : 1,
+                    inlineMaxWidthCleared: svg.style.maxWidth === 'none' ? 1 : 0
+                  };
+                })();
+                """
+            )
+            if let raw = result as? [String: Any] {
+                var snapshot: [String: Double] = [:]
+                for (key, value) in raw {
+                    if let number = value as? NSNumber {
+                        snapshot[key] = number.doubleValue
+                    }
+                }
+                lastSnapshot = snapshot
+                if let expectedZoom {
+                    if abs((snapshot["zoom"] ?? -1) - expectedZoom) <= 0.001 {
+                        return snapshot
+                    }
+                } else if (snapshot["width"] ?? 0) > 0 {
+                    return snapshot
+                }
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        throw NSError(
+            domain: "MarkdownPanelTests",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Timed out waiting for Mermaid diagram snapshot. Last snapshot: \(String(describing: lastSnapshot))"
+            ]
+        )
+    }
+
     private func remoteImageSnapshot(in webView: WKWebView) async throws -> [String: Any] {
         let result = try await webView.evaluateJavaScript(
             """
@@ -1570,5 +1684,36 @@ private final class MarkdownRemoteImageHoldingSchemeHandler: NSObject, WKURLSche
         for task in openTasks {
             task.didFailWithError(error)
         }
+    }
+}
+
+@MainActor
+private final class MarkdownMermaidStubHandler: NSObject, WKScriptMessageHandler {
+    weak var webView: WKWebView?
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == "cmuxLib",
+              let body = message.body as? [String: Any],
+              body["lib"] as? String == "mermaid" else { return }
+
+        webView?.evaluateJavaScript(
+            """
+            (function() {
+              window.mermaid = {
+                initialize: function() {},
+                render: function() {
+                  return Promise.resolve({
+                    svg: '<svg data-stub-mermaid="1" width="100%" style="max-width:240px;" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="240" height="120" fill="#d73a49"></rect><text x="20" y="65" font-size="18" fill="#ffffff">Mermaid label</text></svg>'
+                  });
+                }
+              };
+              if (window.__cmuxLibLoaded) { window.__cmuxLibLoaded('mermaid'); }
+            })();
+            """,
+            completionHandler: nil
+        )
     }
 }

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -740,67 +740,6 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertTrue((image["src"] as? String ?? "").hasPrefix("data:image/png;base64,"))
     }
 
-    func testMarkdownRenderScalesRenderedMermaidDiagramWithViewerZoom() async throws {
-        let markdownURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-markdown-mermaid-zoom-\(UUID().uuidString).md")
-
-        let frame = NSRect(x: 0, y: 0, width: 720, height: 480)
-        let configuration = WKWebViewConfiguration()
-        let mermaidHandler = MarkdownMermaidStubHandler()
-        configuration.userContentController.add(mermaidHandler, name: "cmuxLib")
-        let webView = MarkdownWebView(frame: frame, configuration: configuration)
-        mermaidHandler.webView = webView
-        let coordinator = MarkdownWebRenderer.Coordinator()
-        coordinator.webView = webView
-        let window = NSWindow(contentRect: frame, styleMask: [.borderless], backing: .buffered, defer: false)
-        window.contentView = webView
-        window.orderFrontRegardless()
-        defer {
-            webView.navigationDelegate = nil
-            coordinator.webView = nil
-            configuration.userContentController.removeScriptMessageHandler(forName: "cmuxLib")
-            window.close()
-        }
-
-        let loaded = expectation(description: "markdown shell loaded")
-        let loadDelegate = MarkdownShellLoadDelegate(expectation: loaded)
-        webView.navigationDelegate = loadDelegate
-        webView.loadHTMLString(
-            MarkdownViewerAssets.shared.shellHTML(isDark: true),
-            baseURL: markdownURL
-        )
-        await fulfillment(of: [loaded], timeout: 5)
-        if let error = loadDelegate.error {
-            throw error
-        }
-
-        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize)
-        try await renderMarkdown(
-            """
-            Prose before the diagram.
-
-            ```mermaid
-            flowchart LR
-              host[Host process] --> backend[Backend]
-              backend --> worker[Worker]
-            ```
-            """,
-            in: webView
-        )
-
-        let baseline = try await waitForMermaidSnapshot(in: webView)
-        let baselineWidth = try XCTUnwrap(baseline["width"])
-        XCTAssertEqual(baseline["zoom"] ?? -1, 1, accuracy: 0.001)
-        XCTAssertEqual(baselineWidth, 240, accuracy: 2)
-
-        coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
-        let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
-        let zoomedWidth = try XCTUnwrap(zoomed["width"])
-
-        XCTAssertGreaterThan(zoomedWidth, baselineWidth * 1.8)
-        XCTAssertEqual(zoomed["inlineMaxWidthCleared"] ?? 0, 1, accuracy: 0.001)
-    }
-
     func testMarkdownRenderBlocksRemoteImagesUntilUserAction() async throws {
         let markdownURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-markdown-remote-image-\(UUID().uuidString).md")
@@ -1428,59 +1367,6 @@ final class MarkdownPanelTests: XCTestCase {
         )
     }
 
-    private func waitForMermaidSnapshot(
-        in webView: WKWebView,
-        expectedZoom: Double? = nil
-    ) async throws -> [String: Double] {
-        let deadline = Date().addingTimeInterval(3)
-        var lastSnapshot: [String: Double]?
-
-        while Date() < deadline {
-            let result = try await webView.evaluateJavaScript(
-                """
-                (function() {
-                  var svg = document.querySelector('.cmux-mermaid svg');
-                  if (!svg) { return null; }
-                  var rect = svg.getBoundingClientRect();
-                  var computed = window.getComputedStyle(svg);
-                  var zoom = Number(svg.getAttribute('data-cmux-mermaid-zoom') || '1');
-                  return {
-                    width: rect.width || Number.parseFloat(computed.width) || 0,
-                    height: rect.height || Number.parseFloat(computed.height) || 0,
-                    zoom: Number.isFinite(zoom) ? zoom : 1,
-                    inlineMaxWidthCleared: svg.style.maxWidth === 'none' ? 1 : 0
-                  };
-                })();
-                """
-            )
-            if let raw = result as? [String: Any] {
-                var snapshot: [String: Double] = [:]
-                for (key, value) in raw {
-                    if let number = value as? NSNumber {
-                        snapshot[key] = number.doubleValue
-                    }
-                }
-                lastSnapshot = snapshot
-                if let expectedZoom {
-                    if abs((snapshot["zoom"] ?? -1) - expectedZoom) <= 0.001 {
-                        return snapshot
-                    }
-                } else if (snapshot["width"] ?? 0) > 0 {
-                    return snapshot
-                }
-            }
-            try await Task.sleep(nanoseconds: 100_000_000)
-        }
-
-        throw NSError(
-            domain: "MarkdownPanelTests",
-            code: 2,
-            userInfo: [
-                NSLocalizedDescriptionKey: "Timed out waiting for Mermaid diagram snapshot. Last snapshot: \(String(describing: lastSnapshot))"
-            ]
-        )
-    }
-
     private func remoteImageSnapshot(in webView: WKWebView) async throws -> [String: Any] {
         let result = try await webView.evaluateJavaScript(
             """
@@ -1684,36 +1570,5 @@ private final class MarkdownRemoteImageHoldingSchemeHandler: NSObject, WKURLSche
         for task in openTasks {
             task.didFailWithError(error)
         }
-    }
-}
-
-@MainActor
-private final class MarkdownMermaidStubHandler: NSObject, WKScriptMessageHandler {
-    weak var webView: WKWebView?
-
-    func userContentController(
-        _ userContentController: WKUserContentController,
-        didReceive message: WKScriptMessage
-    ) {
-        guard message.name == "cmuxLib",
-              let body = message.body as? [String: Any],
-              body["lib"] as? String == "mermaid" else { return }
-
-        webView?.evaluateJavaScript(
-            """
-            (function() {
-              window.mermaid = {
-                initialize: function() {},
-                render: function() {
-                  return Promise.resolve({
-                    svg: '<svg data-stub-mermaid="1" width="100%" style="max-width:240px;" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="240" height="120" fill="#d73a49"></rect><text x="20" y="65" font-size="18" fill="#ffffff">Mermaid label</text></svg>'
-                  });
-                }
-              };
-              if (window.__cmuxLibLoaded) { window.__cmuxLibLoaded('mermaid'); }
-            })();
-            """,
-            completionHandler: nil
-        )
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #6069.
- Passes the markdown viewer zoom factor from the shared `MarkdownPanel.fontSize` path into the web shell.
- Normalizes rendered Mermaid SVG dimensions after render and on later zoom changes, clearing Mermaid's inline fixed `max-width` so diagrams scale with the AA / Cmd+= zoom level.
- Adds a WebKit regression test with a stub Mermaid renderer that reproduces an already-rendered SVG staying fixed under viewer zoom.

## Reproduction
Local isolated WKWebView check, no cmux build or default socket use:
- `pageZoom = 1`: prose height `22`, Mermaid-like SVG `240x120`.
- `pageZoom = 2`: prose height `45`, Mermaid-like SVG still `240x120`.

Observed: text scales while the Mermaid SVG remains fixed.
Expected: Mermaid SVG grows with the same viewer zoom factor.

## Validation
- `git diff --check`
- Regression test committed first (`test: cover markdown mermaid zoom scaling`), followed by the fix commit.
- Did not run `./scripts/reload.sh` or local `xcodebuild`/Xcode tests per workspace instructions; CI should run the test target.

## Localization
No user-facing strings were added or changed. Localization audit: changed surfaces are renderer behavior, comments, and test-only helper text; no Localizable entries required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993698&installation_id=133855650&pr_number=6072&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6072&signature=fbe1cce8a052100b623839ece7ba5a010de3dbb7d172308da345ee7cb9d32fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Mermaid diagrams scale with markdown viewer zoom and reflow with container width; at 1x they fit the container. Fixes #6069 by passing zoom to the web shell, resizing Mermaid SVGs from a cached base size, and restoring original sizing for exported HTML.

- **Bug Fixes**
  - Pass viewer zoom to the shell via `__cmuxSetMarkdownZoom`; clamp, apply after render and on zoom, avoid redundant shell syncs, and re-apply on width changes via a width-gated `ResizeObserver` that resets its baseline on zoom.
  - Cache intrinsic SVG size from `viewBox`/attributes. Base = min(container width, natural width). At 1x keep `.cmux-mermaid svg { max-width: 100% }`; when zoomed, clear `max-width`, set inline `width/height = base × zoom`, center when it fits, and align oversized diagrams to the scroll start.
  - On HTML export, restore original sizing and strip `data-cmux-*`/inline `width/height`. Added a Swift Testing WKWebView test that verifies scaling with prose, 1x fit, resize growth, clean export, and start alignment for oversized diagrams.

<sup>Written for commit f8f2a61bbc33897ddf75231481b6dd07ad55fb01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Markdown zoom support for Mermaid diagrams, keeping Mermaid SVG sizing in sync with the viewer’s font/zoom behavior.

* **Bug Fixes**
  * Improved Mermaid SVG rendering to use dedicated styling, apply correct intrinsic sizing, and re-apply zoom after rendering and layout changes.

* **Tests**
  * Added automated tests that verify Mermaid SVG scaling with font-size and zoom changes, including narrow vs. wide diagrams and resize behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->