### PR TITLE
Lock native auth URL against locale-prefixed paths

### DIFF
--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -75,6 +75,13 @@ enum AuthEnvironment {
         URL(string: "\(callbackScheme)://auth-callback")!
     }
 
+    static func resolvedCallbackURL(
+        environment: [String: String],
+        bundleIdentifier: String?
+    ) -> URL {
+        URL(string: "\(callbackScheme(environment: environment, bundleIdentifier: bundleIdentifier))://auth-callback")!
+    }
+
     static var websiteOrigin: URL {
         resolvedURL(
             environmentKey: "CMUX_WWW_ORIGIN",
@@ -146,11 +153,21 @@ enum AuthEnvironment {
     }
 
     private static var cmuxPort: String {
-        environmentPort("CMUX_PORT") ?? environmentPort("PORT") ?? "3777"
+        resolvedCmuxPort(environment: ProcessInfo.processInfo.environment)
+    }
+
+    private static func resolvedCmuxPort(environment: [String: String]) -> String {
+        environmentPort("CMUX_PORT", environment: environment)
+            ?? environmentPort("PORT", environment: environment)
+            ?? "3777"
     }
 
     private static func environmentPort(_ key: String) -> String? {
-        guard let port = ProcessInfo.processInfo.environment[key]?
+        environmentPort(key, environment: ProcessInfo.processInfo.environment)
+    }
+
+    private static func environmentPort(_ key: String, environment: [String: String]) -> String? {
+        guard let port = environment[key]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             let value = UInt16(port),
             value > 0
@@ -161,13 +178,17 @@ enum AuthEnvironment {
     }
 
     private static var defaultWebOrigin: String {
-        if let origin = ProcessInfo.processInfo.environment["CMUX_WWW_ORIGIN"]?
+        resolvedDefaultWebOrigin(environment: ProcessInfo.processInfo.environment)
+    }
+
+    private static func resolvedDefaultWebOrigin(environment: [String: String]) -> String {
+        if let origin = environment["CMUX_WWW_ORIGIN"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !origin.isEmpty {
             return origin
         }
         #if DEBUG
-        return "http://localhost:\(cmuxPort)"
+        return "http://localhost:\(resolvedCmuxPort(environment: environment))"
         #else
         return "https://cmux.com"
         #endif
@@ -231,13 +252,38 @@ enum AuthEnvironment {
 
     /// The website origin used for the after-sign-in handler.
     static var afterSignInOrigin: URL {
+        resolvedAfterSignInOrigin(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func resolvedAfterSignInOrigin(environment: [String: String]) -> URL {
         resolvedURL(
             environmentKey: "CMUX_AUTH_WWW_ORIGIN",
-            fallback: defaultWebOrigin
+            fallback: resolvedDefaultWebOrigin(environment: environment),
+            environment: environment
         )
     }
 
     static func signInURL(callbackState: String? = nil) -> URL {
+        signInURL(callbackState: callbackState, afterSignInOrigin: afterSignInOrigin, callbackURL: callbackURL)
+    }
+
+    static func signInURL(
+        callbackState: String? = nil,
+        environment: [String: String],
+        bundleIdentifier: String? = nil
+    ) -> URL {
+        signInURL(
+            callbackState: callbackState,
+            afterSignInOrigin: resolvedAfterSignInOrigin(environment: environment),
+            callbackURL: resolvedCallbackURL(environment: environment, bundleIdentifier: bundleIdentifier)
+        )
+    }
+
+    private static func signInURL(
+        callbackState: String?,
+        afterSignInOrigin: URL,
+        callbackURL: URL
+    ) -> URL {
         // Build the after-sign-in callback URL that includes the native app return scheme.
         // The after-sign-in handler extracts tokens from the Stack Auth session
         // and redirects to the native app via the cmux:// callback scheme.
@@ -275,7 +321,18 @@ enum AuthEnvironment {
     }
 
     private static func resolvedURL(environmentKey: String, fallback: String) -> URL {
-        let environment = ProcessInfo.processInfo.environment
+        resolvedURL(
+            environmentKey: environmentKey,
+            fallback: fallback,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    private static func resolvedURL(
+        environmentKey: String,
+        fallback: String,
+        environment: [String: String]
+    ) -> URL {
         if let overridden = environment[environmentKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty,

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -39,8 +40,102 @@ struct AuthEnvironmentTests {
 
     @Test("sign-in URL enters native wrapper")
     func signInURLEntersNativeWrapper() {
-        let url = AuthEnvironment.signInURL(callbackState: "state-1")
-        #expect(url.path == "/handler/native-sign-in")
-        #expect(url.query?.contains("after_auth_return_to=") == true)
+        // Regression coverage for #5720: the client must not derive auth URL
+        // path segments from the user's system locale, such as /ru/.
+        let url = AuthEnvironment.signInURL(
+            callbackState: "state-1",
+            environment: [
+                "AppleLanguages": "(ru)",
+                "LANG": "ru_RU.UTF-8",
+                "LC_ALL": "ru_RU.UTF-8",
+                "CMUX_AUTH_WWW_ORIGIN": "https://cmux.com",
+                "CMUX_AUTH_CALLBACK_SCHEME": "cmux",
+            ],
+            bundleIdentifier: "com.cmuxterm.app"
+        )
+
+        assertNativeSignInURL(url)
+    }
+
+    @Test("sign-in URL ignores locale-like environment values")
+    func signInURLIgnoresLocaleLikeEnvironmentValues() {
+        let englishURL = AuthEnvironment.signInURL(
+            callbackState: "state-1",
+            environment: [
+                "AppleLanguages": "(en)",
+                "LANG": "en_US.UTF-8",
+                "LC_ALL": "en_US.UTF-8",
+                "CMUX_AUTH_WWW_ORIGIN": "https://cmux.com",
+                "CMUX_AUTH_CALLBACK_SCHEME": "cmux",
+            ],
+            bundleIdentifier: "com.cmuxterm.app"
+        )
+        let russianURL = AuthEnvironment.signInURL(
+            callbackState: "state-1",
+            environment: [
+                "AppleLanguages": "(ru)",
+                "LANG": "ru_RU.UTF-8",
+                "LC_ALL": "ru_RU.UTF-8",
+                "CMUX_AUTH_WWW_ORIGIN": "https://cmux.com",
+                "CMUX_AUTH_CALLBACK_SCHEME": "cmux",
+            ],
+            bundleIdentifier: "com.cmuxterm.app"
+        )
+
+        #expect(russianURL == englishURL)
+    }
+}
+
+private func assertNativeSignInURL(_ url: URL) {
+    #expect(url.scheme == "https")
+    #expect(url.host == "cmux.com")
+    #expect(url.path == "/handler/native-sign-in")
+    #expect(!urlHasLeadingLocaleSegment(url))
+
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let afterAuthReturnTo = components.queryItems?.first(where: { $0.name == "after_auth_return_to" })?.value,
+          let afterSignInURL = URL(string: afterAuthReturnTo)
+    else {
+        Issue.record("sign-in URL must include an after_auth_return_to URL")
+        return
+    }
+
+    #expect(afterSignInURL.scheme == "https")
+    #expect(afterSignInURL.host == "cmux.com")
+    #expect(afterSignInURL.path == "/handler/after-sign-in")
+    #expect(!urlHasLeadingLocaleSegment(afterSignInURL))
+
+    guard let afterSignInComponents = URLComponents(url: afterSignInURL, resolvingAgainstBaseURL: false),
+          let nativeReturnTo = afterSignInComponents.queryItems?.first(where: { $0.name == "native_app_return_to" })?.value,
+          let nativeCallbackURL = URL(string: nativeReturnTo)
+    else {
+        Issue.record("after-sign-in URL must include a native_app_return_to URL")
+        return
+    }
+
+    #expect(nativeCallbackURL.scheme == "cmux")
+    #expect(nativeCallbackURL.host == "auth-callback")
+
+    let nativeCallbackComponents = URLComponents(url: nativeCallbackURL, resolvingAgainstBaseURL: false)
+    #expect(nativeCallbackComponents?.queryItems?.first { $0.name == "cmux_auth_state" }?.value == "state-1")
+}
+
+private func urlHasLeadingLocaleSegment(_ url: URL) -> Bool {
+    guard let firstSegment = url.pathComponents.dropFirst().first else {
+        return false
+    }
+    return isLocalePathSegment(firstSegment)
+}
+
+private func isLocalePathSegment(_ segment: String) -> Bool {
+    let parts = segment.split(separator: "-")
+    guard let language = parts.first,
+          (2...3).contains(language.count),
+          language.allSatisfy(\.isLetter)
+    else {
+        return false
+    }
+    return parts.dropFirst().allSatisfy { subtag in
+        (2...4).contains(subtag.count) && subtag.allSatisfy(\.isLetter)
     }
 }


### PR DESCRIPTION
## Summary
- Verified #5720 no longer reproduces on current main: native auth URL construction now enters `https://cmux.com/handler/native-sign-in?...` instead of the removed `/auth/password/sign-in` path family.
- Added an injected environment seam for `AuthEnvironment.signInURL` so tests can verify production cmux.com URL construction without mutating process-global environment.
- Hardened `AuthEnvironmentTests` to assert the native sign-in URL stays on `https://cmux.com/handler/native-sign-in`, carries a nested `/handler/after-sign-in` return URL, ignores locale-like environment values, and has no leading locale segment such as `/ru/`.
- Confirmed GUI and CLI auth entrypoints share this builder: `MacAuthComposition` injects `AuthEnvironment.signInURL`, `HostBrowserSignInFlow.manualSignInURL` uses that closure, and `cmux auth login` retrieves it through the `auth.sign_in_url` app RPC.

## Verification
- Read issue #5720: reporter confirms stable 0.64.14 failed under Russian locale, but NIGHTLY did not reproduce.
- Repo search found no auth path construction from `Locale.current`, `preferredLanguages`, `languageCode`, `NSLocale`, or Accept-Language. Locale handling found in the web after-sign-in route only selects localized page copy, not auth URL paths.
- Live sanity check with Russian `Accept-Language`: `/handler/native-sign-in` redirects to unprefixed `/handler/sign-in` and lands 200; old `/auth/password/sign-in` and `/ru/auth/password/sign-in` both return 404.
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`

## Notes
This appears fixed on main by the auth URL construction rewrite and should be safe to close as fixed-on-nightly once this regression test lands.

Fixes #5720

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784002964&installation_id=133855650&pr_number=6075&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6075&signature=fbd31ec092b98481a2342cf716f3663f0ad4506f2292b1f1132109773a8ca730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication Updates**
  * Enhanced sign-in URL generation to accept an explicit environment context, producing consistent callback and after-sign-in origin values.
  * Strengthened redirect URL construction, including correct formation of `after_auth_return_to` and the embedded `native_app_return_to` with `cmux_auth_state`.
* **Tests**
  * Enhanced test coverage for authentication URL construction, including locale-sensitive cases and ensuring locale-like environment values don’t alter the URL path.
  * Added regression testing for authentication redirect flows and callback parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->