### PR TITLE
Polish iOS workspace empty states

### DIFF
--- a/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListEmptyState.swift
+++ b/Packages/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceListEmptyState.swift
@@ -1,0 +1,47 @@
+/// The empty state a workspace-list surface should show for its current
+/// workspace count, search query, and filter.
+public enum MobileWorkspaceListEmptyState: Equatable, Sendable {
+    /// The Mac reported no workspaces at all.
+    case noWorkspaces
+    /// The user has a non-empty search query and no visible rows match it.
+    case noSearchResults
+    /// The current filter hides every workspace.
+    case filterNoMatches(MobileWorkspaceListFilter)
+
+    /// Returns the empty state for a workspace-list snapshot, or `nil` when at
+    /// least one visible row should render. Keeping this decision outside
+    /// SwiftUI makes the flat workspace list and device tree easier to keep
+    /// aligned.
+    ///
+    /// - Parameters:
+    ///   - workspaceCount: Total workspace rows before search/filter narrowing.
+    ///   - visibleWorkspaceCount: Rows visible after search/filter narrowing.
+    ///   - queryMatchedWorkspaceCount: Rows that match the search query before
+    ///     filter narrowing.
+    ///   - trimmedQuery: Search query after whitespace trimming.
+    ///   - filter: Active workspace filter.
+    public static func state(
+        workspaceCount: Int,
+        visibleWorkspaceCount: Int,
+        queryMatchedWorkspaceCount: Int,
+        trimmedQuery: String,
+        filter: MobileWorkspaceListFilter
+    ) -> MobileWorkspaceListEmptyState? {
+        if workspaceCount == 0 {
+            return .noWorkspaces
+        }
+        if visibleWorkspaceCount > 0 {
+            return nil
+        }
+        if !trimmedQuery.isEmpty && filter.isActive && queryMatchedWorkspaceCount > 0 {
+            return .filterNoMatches(filter)
+        }
+        if !trimmedQuery.isEmpty {
+            return .noSearchResults
+        }
+        if filter.isActive {
+            return .filterNoMatches(filter)
+        }
+        return nil
+    }
+}

--- a/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListEmptyStateTests.swift
+++ b/Packages/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileWorkspaceListEmptyStateTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import CmuxMobileShellModel
+
+@Suite struct MobileWorkspaceListEmptyStateTests {
+    @Test func noWorkspacesWinsBeforeSearchOrFilter() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 0,
+                visibleWorkspaceCount: 0,
+                queryMatchedWorkspaceCount: 0,
+                trimmedQuery: "build",
+                filter: .unread
+            ) == .noWorkspaces
+        )
+    }
+
+    @Test func visibleRowsSuppressEmptyState() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 4,
+                visibleWorkspaceCount: 1,
+                queryMatchedWorkspaceCount: 3,
+                trimmedQuery: "build",
+                filter: .unread
+            ) == nil
+        )
+    }
+
+    @Test func searchNoMatchesWinsWhenQueryIsPresent() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 4,
+                visibleWorkspaceCount: 0,
+                queryMatchedWorkspaceCount: 0,
+                trimmedQuery: "release",
+                filter: .unread
+            ) == .noSearchResults
+        )
+    }
+
+    @Test func filterNoMatchesWinsWhenFilterHidesSearchMatches() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 4,
+                visibleWorkspaceCount: 0,
+                queryMatchedWorkspaceCount: 2,
+                trimmedQuery: "release",
+                filter: .unread
+            ) == .filterNoMatches(.unread)
+        )
+    }
+
+    @Test func activeFilterNoMatchesRendersFilterEmptyState() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 4,
+                visibleWorkspaceCount: 0,
+                queryMatchedWorkspaceCount: 4,
+                trimmedQuery: "",
+                filter: .unread
+            ) == .filterNoMatches(.unread)
+        )
+    }
+
+    @Test func allFilterWithNoVisibleRowsHasNoSpecialState() {
+        #expect(
+            MobileWorkspaceListEmptyState.state(
+                workspaceCount: 4,
+                visibleWorkspaceCount: 0,
+                queryMatchedWorkspaceCount: 4,
+                trimmedQuery: "",
+                filter: .all
+            ) == nil
+        )
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -131,6 +131,9 @@ struct WorkspaceDetailView: View {
             } else {
                 TerminalPalette.background
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .overlay {
+                        terminalEmptyState
+                    }
             }
             #else
             TerminalPalette.background
@@ -206,6 +209,45 @@ struct WorkspaceDetailView: View {
         newWorkspaceToolbarButton
         terminalPickerToolbarButton
     }
+
+    #if os(iOS)
+    private var terminalEmptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "terminal")
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(TerminalPalette.foreground.opacity(0.6))
+                .accessibilityHidden(true)
+
+            VStack(spacing: 4) {
+                Text(L10n.string(
+                    "mobile.terminal.empty.title",
+                    defaultValue: "No terminals in this workspace"
+                ))
+                .font(.headline)
+                .foregroundStyle(TerminalPalette.foreground)
+
+                Text(L10n.string(
+                    "mobile.terminal.empty.message",
+                    defaultValue: "Create a terminal to start sending commands from your phone."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(TerminalPalette.foreground.opacity(0.68))
+            }
+            .multilineTextAlignment(.center)
+
+            Button(action: createTerminalFromToolbar) {
+                Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .accessibilityIdentifier("MobileTerminalEmptyCreateButton")
+        }
+        .padding(24)
+        .frame(maxWidth: 320)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("MobileTerminalEmptyState")
+    }
+    #endif
 
     private var newWorkspaceToolbarButton: some View {
         Button(action: createWorkspaceFromToolbar) {
@@ -297,8 +339,10 @@ struct WorkspaceDetailView: View {
 
             #if DEBUG
             Button(action: copyDebugLogsFromMenu) {
-                // DEV-only debug tooling; not shipped, so not localized.
-                Label("Copy Debug Logs", systemImage: "doc.on.clipboard")
+                Label(
+                    L10n.string("mobile.debug.copyLogs", defaultValue: "Copy Debug Logs"),
+                    systemImage: "doc.on.clipboard"
+                )
             }
             .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
             #endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -131,9 +131,7 @@ struct WorkspaceDetailView: View {
             } else {
                 TerminalPalette.background
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .overlay {
-                        terminalEmptyState
-                    }
+                    .overlay { WorkspaceTerminalEmptyStateView(createTerminal: createTerminalFromToolbar) }
             }
             #else
             TerminalPalette.background
@@ -209,45 +207,6 @@ struct WorkspaceDetailView: View {
         newWorkspaceToolbarButton
         terminalPickerToolbarButton
     }
-
-    #if os(iOS)
-    private var terminalEmptyState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "terminal")
-                .font(.system(size: 30, weight: .semibold))
-                .foregroundStyle(TerminalPalette.foreground.opacity(0.6))
-                .accessibilityHidden(true)
-
-            VStack(spacing: 4) {
-                Text(L10n.string(
-                    "mobile.terminal.empty.title",
-                    defaultValue: "No terminals in this workspace"
-                ))
-                .font(.headline)
-                .foregroundStyle(TerminalPalette.foreground)
-
-                Text(L10n.string(
-                    "mobile.terminal.empty.message",
-                    defaultValue: "Create a terminal to start sending commands from your phone."
-                ))
-                .font(.subheadline)
-                .foregroundStyle(TerminalPalette.foreground.opacity(0.68))
-            }
-            .multilineTextAlignment(.center)
-
-            Button(action: createTerminalFromToolbar) {
-                Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.regular)
-            .accessibilityIdentifier("MobileTerminalEmptyCreateButton")
-        }
-        .padding(24)
-        .frame(maxWidth: 320)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("MobileTerminalEmptyState")
-    }
-    #endif
 
     private var newWorkspaceToolbarButton: some View {
         Button(action: createWorkspaceFromToolbar) {
@@ -339,10 +298,7 @@ struct WorkspaceDetailView: View {
 
             #if DEBUG
             Button(action: copyDebugLogsFromMenu) {
-                Label(
-                    L10n.string("mobile.debug.copyLogs", defaultValue: "Copy Debug Logs"),
-                    systemImage: "doc.on.clipboard"
-                )
+                Label(L10n.string("mobile.debug.copyLogs", defaultValue: "Copy Debug Logs"), systemImage: "doc.on.clipboard")
             }
             .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
             #endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListEmptyRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListEmptyRow.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// A centered workspace-list recovery row for genuinely empty list states.
+struct WorkspaceListEmptyRow: View {
+    let systemImage: String
+    let title: String
+    let message: String
+    let actionTitle: String
+    let actionSystemImage: String
+    let action: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .multilineTextAlignment(.center)
+
+            Button(action: action) {
+                Label(actionTitle, systemImage: actionSystemImage)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -95,17 +95,31 @@ struct WorkspaceListView: View {
             || workspace.terminals.contains { $0.name.localizedCaseInsensitiveContains(query) }
     }
 
-    /// Workspaces after the row filter (Unread) and search filtering, pinned
-    /// ones first (stable within each group so the Mac's order is otherwise
-    /// preserved). Used for the flat (ungrouped, filtering, or searching)
-    /// presentation.
-    private var filteredWorkspaces: [MobileWorkspacePreview] {
+    /// Workspaces after the row filter (Unread) and search filtering, plus the
+    /// empty-state decision that falls out of the same scan. The flat
+    /// presentation is the search/filter hot path, so keep filtering, counting,
+    /// and pinned sorting in one projection instead of recomputing each in
+    /// separate body helpers.
+    private var flatListProjection: (
+        workspaces: [MobileWorkspacePreview],
+        emptyState: MobileWorkspaceListEmptyState?
+    ) {
         let query = trimmedQuery
-        let matches = workspaces.filter { workspace in
-            filter.matches(workspace)
-                && (query.isEmpty || matchesQuery(workspace, query: query))
+        var visibleWorkspaces: [MobileWorkspacePreview] = []
+        visibleWorkspaces.reserveCapacity(workspaces.count)
+        var queryMatchedWorkspaceCount = 0
+
+        for workspace in workspaces {
+            let queryMatches = query.isEmpty || matchesQuery(workspace, query: query)
+            if queryMatches {
+                queryMatchedWorkspaceCount += 1
+            }
+            if filter.matches(workspace) && queryMatches {
+                visibleWorkspaces.append(workspace)
+            }
         }
-        return matches.enumerated()
+
+        let sortedWorkspaces = visibleWorkspaces.enumerated()
             .sorted { lhs, rhs in
                 if lhs.element.isPinned != rhs.element.isPinned {
                     return lhs.element.isPinned && !rhs.element.isPinned
@@ -113,38 +127,15 @@ struct WorkspaceListView: View {
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
-    }
 
-    private var emptyState: MobileWorkspaceListEmptyState? {
-        if workspaces.isEmpty {
-            return .noWorkspaces
-        }
-        let query = trimmedQuery
-        if query.isEmpty && !filter.isActive {
-            return nil
-        }
-        let visibleWorkspaceCount = workspaces.reduce(into: 0) { count, workspace in
-            guard filter.matches(workspace),
-                  query.isEmpty || matchesQuery(workspace, query: query) else {
-                return
-            }
-            count += 1
-        }
-        if visibleWorkspaceCount > 0 {
-            return nil
-        }
-        let queryMatchedWorkspaceCount = query.isEmpty ? workspaces.count : workspaces.reduce(into: 0) { count, workspace in
-            if matchesQuery(workspace, query: query) {
-                count += 1
-            }
-        }
-        return MobileWorkspaceListEmptyState.state(
+        let emptyState = MobileWorkspaceListEmptyState.state(
             workspaceCount: workspaces.count,
-            visibleWorkspaceCount: visibleWorkspaceCount,
+            visibleWorkspaceCount: sortedWorkspaces.count,
             queryMatchedWorkspaceCount: queryMatchedWorkspaceCount,
             trimmedQuery: query,
             filter: filter
         )
+        return (workspaces: sortedWorkspaces, emptyState: emptyState)
     }
 
     /// Ordered drawable items for the grouped presentation. Preserves the Mac's
@@ -164,12 +155,12 @@ struct WorkspaceListView: View {
                 }
             }
             Section {
-                if let emptyState {
-                    emptyRow(for: emptyState)
+                if workspaces.isEmpty {
+                    emptyRow(for: .noWorkspaces)
                 } else if rendersGroupedSections {
                     groupedRows
                 } else {
-                    flatRows
+                    flatContent
                 }
             }
         }
@@ -239,8 +230,18 @@ struct WorkspaceListView: View {
     /// Flat presentation: a pinned-first list with no group headers. Used when the
     /// Mac has no groups (or lacks the capability) or while searching.
     @ViewBuilder
-    private var flatRows: some View {
-        ForEach(filteredWorkspaces) { workspace in
+    private var flatContent: some View {
+        let projection = flatListProjection
+        if let emptyState = projection.emptyState {
+            emptyRow(for: emptyState)
+        } else {
+            flatRows(projection.workspaces)
+        }
+    }
+
+    @ViewBuilder
+    private func flatRows(_ workspaces: [MobileWorkspacePreview]) -> some View {
+        ForEach(workspaces) { workspace in
             workspaceRow(workspace, indented: false)
         }
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -108,11 +108,43 @@ struct WorkspaceListView: View {
         return matches.enumerated()
             .sorted { lhs, rhs in
                 if lhs.element.isPinned != rhs.element.isPinned {
-                    return lhs.element.isPinned
+                    return lhs.element.isPinned && !rhs.element.isPinned
                 }
                 return lhs.offset < rhs.offset
             }
             .map(\.element)
+    }
+
+    private var emptyState: MobileWorkspaceListEmptyState? {
+        if workspaces.isEmpty {
+            return .noWorkspaces
+        }
+        let query = trimmedQuery
+        if query.isEmpty && !filter.isActive {
+            return nil
+        }
+        let visibleWorkspaceCount = workspaces.reduce(into: 0) { count, workspace in
+            guard filter.matches(workspace),
+                  query.isEmpty || matchesQuery(workspace, query: query) else {
+                return
+            }
+            count += 1
+        }
+        if visibleWorkspaceCount > 0 {
+            return nil
+        }
+        let queryMatchedWorkspaceCount = query.isEmpty ? workspaces.count : workspaces.reduce(into: 0) { count, workspace in
+            if matchesQuery(workspace, query: query) {
+                count += 1
+            }
+        }
+        return MobileWorkspaceListEmptyState.state(
+            workspaceCount: workspaces.count,
+            visibleWorkspaceCount: visibleWorkspaceCount,
+            queryMatchedWorkspaceCount: queryMatchedWorkspaceCount,
+            trimmedQuery: query,
+            filter: filter
+        )
     }
 
     /// Ordered drawable items for the grouped presentation. Preserves the Mac's
@@ -132,15 +164,10 @@ struct WorkspaceListView: View {
                 }
             }
             Section {
-                if rendersGroupedSections {
+                if let emptyState {
+                    emptyRow(for: emptyState)
+                } else if rendersGroupedSections {
                     groupedRows
-                } else if filter.isActive && trimmedQuery.isEmpty && filteredWorkspaces.isEmpty && !workspaces.isEmpty {
-                    // The filter alone (not the Mac, and not a search query)
-                    // emptied the list; offer the way back. While searching, the
-                    // standard empty search result is shown instead, since "Show
-                    // All" would not resolve a query that matches nothing.
-                    WorkspaceListFilterEmptyRow(filter: filter) { filter = .all }
-                        .listRowSeparator(.hidden)
                 } else {
                     flatRows
                 }
@@ -263,6 +290,49 @@ struct WorkspaceListView: View {
         )
         .listRowInsets(EdgeInsets(top: 4, leading: indented ? 32 : 12, bottom: 4, trailing: 12))
         .listRowSeparator(.hidden)
+    }
+
+    @ViewBuilder
+    private func emptyRow(for emptyState: MobileWorkspaceListEmptyState) -> some View {
+        switch emptyState {
+        case .noWorkspaces:
+            WorkspaceListEmptyRow(
+                systemImage: "rectangle.stack.badge.plus",
+                title: L10n.string("mobile.workspaces.empty.title", defaultValue: "No workspaces yet"),
+                message: L10n.string(
+                    "mobile.workspaces.empty.message",
+                    defaultValue: "Create a workspace to start a terminal session."
+                ),
+                actionTitle: L10n.string("mobile.workspace.new", defaultValue: "New Workspace"),
+                actionSystemImage: "plus",
+                action: createWorkspace
+            )
+            .accessibilityIdentifier("MobileWorkspaceListEmpty")
+            .listRowSeparator(.hidden)
+        case .noSearchResults:
+            WorkspaceListEmptyRow(
+                systemImage: "magnifyingglass",
+                title: L10n.string(
+                    "mobile.workspaces.search.empty.title",
+                    defaultValue: "No matching workspaces"
+                ),
+                message: L10n.string(
+                    "mobile.workspaces.search.empty.message",
+                    defaultValue: "Try a different workspace name, terminal, or recent activity."
+                ),
+                actionTitle: L10n.string("mobile.workspaces.search.clear", defaultValue: "Clear Search"),
+                actionSystemImage: "xmark",
+                action: { searchText = "" }
+            )
+            .accessibilityIdentifier("MobileWorkspaceSearchEmpty")
+            .listRowSeparator(.hidden)
+        case .filterNoMatches(let filter):
+            // The filter alone (not the Mac, and not a search query) emptied
+            // the list; offer the way back. Search empties get a separate row,
+            // since "Show All" would not resolve a query that matches nothing.
+            WorkspaceListFilterEmptyRow(filter: filter) { self.filter = .all }
+                .listRowSeparator(.hidden)
+        }
     }
 
     private var newWorkspaceButton: some View {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTerminalEmptyStateView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTerminalEmptyStateView.swift
@@ -1,0 +1,45 @@
+import CmuxMobileSupport
+import SwiftUI
+
+#if os(iOS)
+struct WorkspaceTerminalEmptyStateView: View {
+    let createTerminal: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "terminal")
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(TerminalPalette.foreground.opacity(0.6))
+                .accessibilityHidden(true)
+
+            VStack(spacing: 4) {
+                Text(L10n.string(
+                    "mobile.terminal.empty.title",
+                    defaultValue: "No terminals in this workspace"
+                ))
+                .font(.headline)
+                .foregroundStyle(TerminalPalette.foreground)
+
+                Text(L10n.string(
+                    "mobile.terminal.empty.message",
+                    defaultValue: "Create a terminal to start sending commands from your phone."
+                ))
+                .font(.subheadline)
+                .foregroundStyle(TerminalPalette.foreground.opacity(0.68))
+            }
+            .multilineTextAlignment(.center)
+
+            Button(action: createTerminal) {
+                Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .accessibilityIdentifier("MobileTerminalEmptyCreateButton")
+        }
+        .padding(24)
+        .frame(maxWidth: 320)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("MobileTerminalEmptyState")
+    }
+}
+#endif

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6222,6 +6222,142 @@
           }
         }
       }
+    },
+    "mobile.workspaces.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No workspaces yet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースはまだありません"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.empty.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a workspace to start a terminal session."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを作成してターミナルセッションを開始してください。"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.search.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching workspaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するワークスペースはありません"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.search.empty.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try a different workspace name, terminal, or recent activity."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のワークスペース名、ターミナル、または最近のアクティビティで検索してください。"
+          }
+        }
+      }
+    },
+    "mobile.workspaces.search.clear": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索をクリア"
+          }
+        }
+      }
+    },
+    "mobile.terminal.empty.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No terminals in this workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このワークスペースにはターミナルがありません"
+          }
+        }
+      }
+    },
+    "mobile.terminal.empty.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a terminal to start sending commands from your phone."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルを作成して、iPhone からコマンドを送信できるようにしてください。"
+          }
+        }
+      }
+    },
+    "mobile.debug.copyLogs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Debug Logs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバッグログをコピー"
+          }
+        }
+      }
     }
   },
   "version": "1.0"


### PR DESCRIPTION
## Summary
- Add shared mobile workspace-list empty-state policy and Swift Testing coverage for no-workspace, search-empty, and filter-empty states.
- Add polished iOS empty/recovery rows for workspace list and terminal detail, with localized English and Japanese strings.
- Fix pinned workspace sorting to use a strict comparator when search/filter narrows the flat list.

## Testing
- swift test --package-path Packages/CmuxMobileShellModel
- jq empty ios/cmux/Resources/Localizable.xcstrings
- rg -n 'Text\("|Button\("|Label\("|navigationTitle\("' Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListEmptyRow.swift (no matches)
- xcodebuild build -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination 'platform=iOS Simulator,id=C9D82663-886D-4EBD-92A0-96CF38A42FF3' -derivedDataPath /tmp/cmux-ios-wsux-build5
- /Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main

## Notes
- Local simulator UI launch/screenshot proof is blocked by an existing launch spinner state in the harness, captured locally under /tmp/cmux-wsux-proof/ during development.
- Physical iPhone verification is not run because the task explicitly marked the physical iPhone unavailable.

## Issues
- None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784008805&installation_id=133855650&pr_number=6095&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6095&signature=9e6ce2d92e4209143ef67afdc37e4bbc0de66145090d2f9b68d8b303487aac91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes iOS empty states for the workspace list and terminal detail using shared model logic and localized copy. Avoids duplicate scans, fixes pinned-first ordering, and keeps the terminal empty state lightweight.

- **New Features**
  - Added `MobileWorkspaceListEmptyState` in `CmuxMobileShellModel` with tests.
  - Workspace list shows contextual empty rows (no workspaces, no search results, filter hides all) via `WorkspaceListEmptyRow`, with “Show All” for filter cases.
  - iOS terminal detail adds a lightweight empty overlay with a “New Terminal” action; EN/JA localizations.

- **Refactors**
  - Consolidated workspace filtering/search/pinned sorting into a single-pass flat-list projection that also computes the empty state.
  - Localized the “Copy Debug Logs” menu item.

<sup>Written for commit 340de5b4424c1e03712b85d6d854973bbbe1aaba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workspace list empty-state handling with distinct states for no workspaces, no search results, and filter/no-match recovery.
  * Added a terminal area empty-state overlay with a “New Terminal” action when nothing is selected.
  * Introduced reusable empty-state row components for consistent recovery actions.
* **Bug Fixes**
  * Refined workspace list projection so pinned workspaces are prioritized correctly.
* **Documentation**
  * Added localized (English/Japanese) strings for new empty states, search-clear action, and debug log copying.
* **Tests**
  * Added tests covering empty-state selection across search/filter combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->