### PR TITLE
Fix iOS email code sign-in nonce preservation

### DIFF
--- a/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthMagicLinkCode.swift
+++ b/Packages/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthMagicLinkCode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// The full magic-link verification code: the digits the user typed plus the
+/// The full magic-link verification code: the characters the user typed plus the
 /// opaque nonce the send-email call returned.
 ///
 /// Stack Auth verifies the concatenation, so both halves travel together:
@@ -21,7 +21,11 @@ public struct CMUXAuthMagicLinkCode: Equatable, Sendable {
     }
 
     /// The composed value Stack Auth verifies (`code` + `nonce`).
+    ///
+    /// Stack stores generated codes lowercase while email templates display the
+    /// visible prefix uppercase, so normalize the user-entered prefix before
+    /// appending the opaque nonce.
     public var composed: String {
-        code + nonce
+        code.lowercased() + nonce
     }
 }

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+SessionPriming.swift
@@ -126,7 +126,7 @@ extension AuthCoordinator {
             return
         }
 
-        clearAuthState()
+        clearAuthState(preservePendingCode: true)
     }
 
     /// Run the launch/dev auto-login, capturing the same staleness context as
@@ -275,6 +275,6 @@ extension AuthCoordinator {
         }
         guard generation == sessionGeneration,
               tokenStoreWriteHighWater == storeWriteHighWater else { return }
-        clearAuthState()
+        clearAuthState(preservePendingCode: true)
     }
 }

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator+Tokens.swift
@@ -47,7 +47,7 @@ extension AuthCoordinator {
         if await client.refreshToken() != nil {
             throw AuthError.networkError
         }
-        clearAuthState()
+        clearAuthState(preservePendingCode: true)
         throw AuthError.unauthorized
     }
 
@@ -101,7 +101,7 @@ extension AuthCoordinator {
         if await client.refreshToken() != nil {
             throw AuthError.networkError
         }
-        clearAuthState()
+        clearAuthState(preservePendingCode: true)
         throw AuthError.unauthorized
     }
 }

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -231,18 +231,12 @@ public final class AuthCoordinator {
 
     /// Re-validate the persisted session against the live token store.
     ///
-    /// Call this when the app returns to the foreground so a session that died
-    /// while backgrounded (the SDK definitively rejected the refresh token, or
-    /// the keychain was cleared) routes to the sign-in page on resume instead of
-    /// surfacing a stale signed-in shell that fails at connect time. Reuses the
-    /// same live-store probe as launch restore, which ends in
-    /// ``clearAuthState()`` when no usable token remains and otherwise preserves
-    /// the cached session on transient failures. A fully signed-out foreground
-    /// return is a no-op: there is no persisted session to check, and clearing
-    /// state there would discard in-progress email-code nonce state before the
-    /// user can enter the code they left the app to read. Re-entrant calls
-    /// (e.g. two rapid foreground transitions) coalesce: a second call while
-    /// one is in flight returns immediately.
+    /// Call this on foreground so a session that died while backgrounded (the
+    /// SDK rejected the refresh token, or the keychain was cleared) routes to
+    /// sign-in on resume instead of surfacing a stale shell. Reuses the same
+    /// live-store probe as launch restore. A fully signed-out foreground return
+    /// is a no-op so it can't discard an in-progress email-code nonce before the
+    /// user enters it; re-entrant foreground calls coalesce.
     public func revalidateSession() async {
         guard isAuthenticated || isRestoringSession || sessionCache.hasTokens else { return }
         await checkExistingSession()
@@ -638,9 +632,7 @@ public final class AuthCoordinator {
 
     func clearAuthState(preservePendingCode: Bool = false) {
         sessionGeneration &+= 1
-        if !preservePendingCode {
-            pendingNonce = nil
-        }
+        if !preservePendingCode { pendingNonce = nil }
         userCache.clear()
         sessionCache.clear()
         availableTeams = []

--- a/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -237,10 +237,14 @@ public final class AuthCoordinator {
     /// surfacing a stale signed-in shell that fails at connect time. Reuses the
     /// same live-store probe as launch restore, which ends in
     /// ``clearAuthState()`` when no usable token remains and otherwise preserves
-    /// the cached session on transient failures. Re-entrant calls (e.g. two
-    /// rapid foreground transitions) coalesce: a second call while one is in
-    /// flight returns immediately.
+    /// the cached session on transient failures. A fully signed-out foreground
+    /// return is a no-op: there is no persisted session to check, and clearing
+    /// state there would discard in-progress email-code nonce state before the
+    /// user can enter the code they left the app to read. Re-entrant calls
+    /// (e.g. two rapid foreground transitions) coalesce: a second call while
+    /// one is in flight returns immediately.
     public func revalidateSession() async {
+        guard isAuthenticated || isRestoringSession || sessionCache.hasTokens else { return }
         await checkExistingSession()
     }
 
@@ -632,9 +636,11 @@ public final class AuthCoordinator {
         return teams.first?.id
     }
 
-    func clearAuthState() {
+    func clearAuthState(preservePendingCode: Bool = false) {
         sessionGeneration &+= 1
-        pendingNonce = nil
+        if !preservePendingCode {
+            pendingNonce = nil
+        }
         userCache.clear()
         sessionCache.clear()
         availableTeams = []

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -64,6 +64,18 @@ import Testing
         #expect(didMagicLink)
     }
 
+    @Test func sendCodeThenVerifySubmitsLowercaseDisplayedOtpWithNonce() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(user: user)
+        await client.setNonce("nonce-abc")
+        let (coordinator, _) = makeCoordinator(client: client)
+
+        try await coordinator.sendCode(to: "a@b.com")
+        try await coordinator.verifyCode("Z13R81")
+
+        #expect(await client.lastMagicLinkCode == "z13r81nonce-abc")
+    }
+
     @Test func offlineFailsFast() async {
         let (coordinator, _) = makeCoordinator(client: FakeAuthClient(), isOnline: { false })
         await #expect(throws: AuthError.offline) {

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -76,6 +76,45 @@ import Testing
         #expect(await client.lastMagicLinkCode == "z13r81nonce-abc")
     }
 
+    @Test func foregroundRevalidationWhileWaitingForCodeKeepsPendingNonce() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(user: user)
+        await client.setNonce("nonce-abc")
+        let (coordinator, _) = makeCoordinator(client: client)
+
+        try await coordinator.sendCode(to: "a@b.com")
+
+        // Reading the email backgrounds the iOS app. Returning to cmux triggers
+        // foreground revalidation while no Stack session exists yet; that must
+        // not discard the pending OTP nonce needed to verify the emailed prefix.
+        await coordinator.revalidateSession()
+
+        try await coordinator.verifyCode("Z13R81")
+
+        #expect(await client.lastMagicLinkCode == "z13r81nonce-abc")
+        #expect(coordinator.isAuthenticated)
+    }
+
+    @Test func staleSessionCleanupWhileWaitingForCodeKeepsPendingNonce() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(user: user)
+        await client.setNonce("nonce-abc")
+        let (coordinator, _) = makeCoordinator(client: client)
+
+        try await coordinator.sendCode(to: "a@b.com")
+
+        await coordinator.clearStaleSessionState(
+            generation: coordinator.sessionGeneration,
+            storeWriteHighWater: coordinator.tokenStoreWriteHighWater,
+            expectedRefreshToken: nil
+        )
+
+        try await coordinator.verifyCode("Z13R81")
+
+        #expect(await client.lastMagicLinkCode == "z13r81nonce-abc")
+        #expect(coordinator.isAuthenticated)
+    }
+
     @Test func offlineFailsFast() async {
         let (coordinator, _) = makeCoordinator(client: FakeAuthClient(), isOnline: { false })
         await #expect(throws: AuthError.offline) {

--- a/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
+++ b/Packages/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/Fakes.swift
@@ -30,6 +30,7 @@ actor FakeAuthClient: AuthClient {
     var throwOnListTeams: (any Error)?
     var nonce = "nonce-123"
     private(set) var signedInWithMagicLink = false
+    private(set) var lastMagicLinkCode: String?
     private(set) var signedInWithCredential: (email: String, password: String)?
     private(set) var oauthProviders: [String] = []
     private(set) var clearLocalSessionCount = 0
@@ -58,6 +59,7 @@ actor FakeAuthClient: AuthClient {
     func setThrowOnCurrentUser(_ error: (any Error)?) { throwOnCurrentUser = error }
     func setTeams(_ teams: [CMUXAuthTeam]) { self.teams = teams }
     func setThrowOnListTeams(_ error: (any Error)?) { throwOnListTeams = error }
+    func setNonce(_ nonce: String) { self.nonce = nonce }
 
     func accessToken() async -> String? { access }
     func refreshToken() async -> String? { refresh }
@@ -82,6 +84,7 @@ actor FakeAuthClient: AuthClient {
 
     func signInWithMagicLink(code: String) async throws {
         signedInWithMagicLink = true
+        lastMagicLinkCode = code
         access = "access"
     }
 

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -179,7 +179,7 @@ struct SignInView: View {
                 }
 
                 GlassInputPill(height: 60, alignment: .center) {
-                    TextField(L10n.string("mobile.signIn.codePlaceholder", defaultValue: "000000"), text: $code)
+                    TextField(L10n.string("mobile.signIn.codePlaceholder", defaultValue: "ABC123"), text: $code)
                         .textFieldStyle(.plain)
                         .mobileOneTimeCodeInput()
                         .multilineTextAlignment(.center)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileTextInput.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileTextInput.swift
@@ -27,13 +27,15 @@ extension View {
         #endif
     }
 
-    /// Numeric one-time-code field with SMS autofill content type (iOS).
+    /// Alphanumeric one-time-code field with SMS autofill content type (iOS).
     @ViewBuilder
     func mobileOneTimeCodeInput() -> some View {
         #if os(iOS)
         self
-            .keyboardType(.numberPad)
+            .keyboardType(.asciiCapable)
             .textContentType(.oneTimeCode)
+            .textInputAutocapitalization(.characters)
+            .autocorrectionDisabled()
         #else
         self
         #endif

--- a/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/SignInCodeInputPolicy.swift
+++ b/Packages/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/SignInCodeInputPolicy.swift
@@ -18,11 +18,30 @@ public struct SignInCodeInputPolicy {
         return shouldVerifyAfterChange(normalized) ? .verify : .none
     }
 
-    /// Normalizes a code by trimming whitespace and clamping to ``maximumCodeLength``.
+    /// Normalizes a code by keeping ASCII letters/digits, uppercasing letters,
+    /// and clamping to ``maximumCodeLength``.
     /// - Parameter value: The raw code string.
     /// - Returns: The normalized code.
     public static func normalizedCode(_ value: String) -> String {
-        String(value.trimmingCharacters(in: .whitespacesAndNewlines).prefix(maximumCodeLength))
+        var normalized = ""
+        normalized.reserveCapacity(maximumCodeLength)
+
+        for scalar in value.unicodeScalars {
+            guard normalized.count < maximumCodeLength else { break }
+            switch scalar.value {
+            case 48...57:
+                normalized.unicodeScalars.append(scalar)
+            case 65...90:
+                normalized.unicodeScalars.append(scalar)
+            case 97...122:
+                guard let uppercase = UnicodeScalar(scalar.value - 32) else { continue }
+                normalized.unicodeScalars.append(uppercase)
+            default:
+                continue
+            }
+        }
+
+        return normalized
     }
 
     /// Whether a normalized code is complete and should trigger verification.

--- a/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/SignInCodeInputPolicyTests.swift
+++ b/Packages/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/SignInCodeInputPolicyTests.swift
@@ -9,4 +9,11 @@ import Testing
         #expect(SignInCodeInputPolicy.action(for: "123456\n") == .assign("123456"))
         #expect(SignInCodeInputPolicy.action(for: "1234567") == .assign("123456"))
     }
+
+    @Test func acceptsAlphanumericCodesFromStackAuthEmails() {
+        #expect(SignInCodeInputPolicy.action(for: "abc12") == .assign("ABC12"))
+        #expect(SignInCodeInputPolicy.action(for: "abc123") == .assign("ABC123"))
+        #expect(SignInCodeInputPolicy.action(for: "ABC123") == .verify)
+        #expect(SignInCodeInputPolicy.action(for: "ab c-123") == .assign("ABC123"))
+    }
 }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2013,13 +2013,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter the 6-digit code from your email."
+            "value": "Enter the 6-character code from your email."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "メールに届いた 6 桁のコードを入力してください。"
+            "value": "メールに届いた6文字のコードを入力してください。"
           }
         }
       }
@@ -2030,13 +2030,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "000000"
+            "value": "ABC123"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "000000"
+            "value": "ABC123"
           }
         }
       }


### PR DESCRIPTION
## Summary
- accept alphanumeric Stack email OTP prefixes on iOS and show an `ABC123` placeholder
- compose Stack verification codes from the visible OTP prefix plus the stored nonce
- preserve the pending OTP nonce across signed-out foreground/session cleanup so the code-entry screen verifies the email that was just sent

Fixes #6074

## Tests
- `swift test --package-path Packages/CmuxAuthRuntime --filter AuthCoordinatorTests`
- `swift test --package-path Packages/CmuxMobileWorkspace --filter SignInCodeInputPolicyTests`
- `git diff --check`
- `python3 -m json.tool ios/cmux/Resources/Localizable.xcstrings`
- `ios/scripts/reload.sh --tag issue-6074-ios-email-signin --no-launch`

## Notes
- Regression coverage is split into test-only commits followed by fix commits.
- The branch was published through the GitHub Git API because `git push` from this machine repeatedly failed with an HTTP sideband disconnect; the final remote tree matches the tested local tree exactly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784009202&installation_id=133855650&pr_number=6097&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6097&signature=0af4636a2f9c24f3e2bd7193644035d4663c35f4183151e93016398b6bcf4134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6074. iOS email code sign-in now accepts alphanumeric prefixes and preserves the pending OTP nonce across app returns and cleanup, preventing verification failures.

- **Bug Fixes**
  - Accept alphanumeric OTP prefixes in `CmuxMobileWorkspace` (`SignInCodeInputPolicy`): keep A–Z/0–9, uppercase, clamp to 6.
  - iOS input tweaks in `CmuxMobileShellUI`: "ABC123" placeholder, `.asciiCapable`, `.oneTimeCode`, caps, no autocorrect.
  - Compose code in `CMUXAuthCore`: lowercase the user-entered prefix before appending the stored nonce.
  - Preserve pending nonce in `CmuxAuthRuntime`: use `clearAuthState(preservePendingCode: true)` in cleanup; `revalidateSession` is a no-op when signed out.
  - Copy: switch to “6-character” in `ios/cmux/Resources/Localizable.xcstrings`.
  - Regression tests for alphanumeric input, lowercase composition, and nonce preservation.

- **Refactors**
  - Trimmed docs and a guard in `AuthCoordinator.swift` to meet the file-length budget; no behavior changes.

<sup>Written for commit ff657c3607e2113ee0b4a31c39037a86a5f429d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Magic link codes now support alphanumeric characters (letters and numbers)
  * Code input is normalized to uppercase for verification and processing

* **Bug Fixes**
  * Pending sign-in code is preserved during session revalidation and stale-session cleanup
  * Unauthorized token error handling no longer discards pending code

* **UI/UX Improvements**
  * Updated one-time code input keyboard to alphanumeric mode
  * Changed code placeholder from numeric to alphanumeric (e.g., `ABC123`)
  * Updated localized messaging to reference “6 characters”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->