### PR TITLE
ContentView drain: lift WorkspaceMountPolicy trio to CmuxFoundation

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -3,7 +3,7 @@
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 33454	CLI/cmux.swift
 17914	Sources/AppDelegate.swift
-16827	Sources/ContentView.swift
+16740	Sources/ContentView.swift
 14612	Sources/TerminalController.swift
 13595	Sources/Panels/BrowserPanel.swift
 12088	Sources/GhosttyTerminalView.swift

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/MountedWorkspacePresentation.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/MountedWorkspacePresentation.swift
@@ -1,0 +1,17 @@
+/// The resolved visibility/opacity a mounted workspace should present with.
+/// Pure value type; computed by `MountedWorkspacePresentationPolicy`.
+public struct MountedWorkspacePresentation: Equatable {
+    public let isRenderedVisible: Bool
+    public let isPanelVisible: Bool
+    public let renderOpacity: Double
+
+    public init(
+        isRenderedVisible: Bool,
+        isPanelVisible: Bool,
+        renderOpacity: Double
+    ) {
+        self.isRenderedVisible = isRenderedVisible
+        self.isPanelVisible = isPanelVisible
+        self.renderOpacity = renderOpacity
+    }
+}

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/MountedWorkspacePresentationPolicy.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/MountedWorkspacePresentationPolicy.swift
@@ -1,0 +1,17 @@
+/// Pure policy resolving how a mounted workspace should present based on whether
+/// it is the selected or retiring workspace. Holds no state and touches no UI.
+// lint:allow namespace-type — pure stateless policy/value namespace lifted verbatim from ContentView; no natural receiver, modernization deferred.
+public enum MountedWorkspacePresentationPolicy {
+    public static func resolve(
+        isSelectedWorkspace: Bool,
+        isRetiringWorkspace: Bool
+    ) -> MountedWorkspacePresentation {
+        let isRenderedVisible = isSelectedWorkspace || isRetiringWorkspace
+
+        return MountedWorkspacePresentation(
+            isRenderedVisible: isRenderedVisible,
+            isPanelVisible: isRenderedVisible,
+            renderOpacity: isRenderedVisible ? 1 : 0
+        )
+    }
+}

--- a/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspaceMountPolicy.swift
+++ b/Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace/WorkspaceMountPolicy.swift
@@ -1,0 +1,78 @@
+public import Foundation
+
+/// Pure policy deciding which workspaces stay mounted to minimize layer-tree
+/// traversal. Operates only on workspace UUIDs, ordering, and pinning flags;
+/// holds no state and touches no UI.
+// lint:allow namespace-type — pure stateless policy/value namespace lifted verbatim from ContentView; no natural receiver, modernization deferred.
+public enum WorkspaceMountPolicy {
+    // Keep only the selected workspace mounted to minimize layer-tree traversal.
+    public static let maxMountedWorkspaces = 1
+    // During workspace cycling, keep only a minimal handoff pair (selected + retiring).
+    public static let maxMountedWorkspacesDuringCycle = 2
+
+    public static func nextMountedWorkspaceIds(
+        current: [UUID],
+        selected: UUID?,
+        pinnedIds: Set<UUID>,
+        orderedTabIds: [UUID],
+        isCycleHot: Bool,
+        maxMounted: Int
+    ) -> [UUID] {
+        let existing = Set(orderedTabIds)
+        let clampedMax = max(1, maxMounted)
+        var ordered = current.filter { existing.contains($0) }
+
+        if let selected, existing.contains(selected) {
+            ordered.removeAll { $0 == selected }
+            ordered.insert(selected, at: 0)
+        }
+
+        if isCycleHot, let selected {
+            let warmIds = cycleWarmIds(selected: selected, orderedTabIds: orderedTabIds)
+            for id in warmIds.reversed() {
+                ordered.removeAll { $0 == id }
+                ordered.insert(id, at: 0)
+            }
+        }
+
+        if isCycleHot,
+           pinnedIds.isEmpty,
+           let selected {
+            ordered.removeAll { $0 != selected }
+        }
+
+        // Ensure pinned ids (retiring handoff workspaces) are always retained at highest priority.
+        // This runs after warming to prevent neighbor warming from evicting the retiring workspace.
+        let prioritizedPinnedIds = pinnedIds
+            .filter { existing.contains($0) && $0 != selected }
+            .sorted { lhs, rhs in
+                let lhsIndex = orderedTabIds.firstIndex(of: lhs) ?? .max
+                let rhsIndex = orderedTabIds.firstIndex(of: rhs) ?? .max
+                return lhsIndex < rhsIndex
+            }
+        if let selected, existing.contains(selected) {
+            ordered.removeAll { $0 == selected }
+            ordered.insert(selected, at: 0)
+        }
+        var pinnedInsertionIndex = (selected != nil) ? 1 : 0
+        for pinnedId in prioritizedPinnedIds {
+            ordered.removeAll { $0 == pinnedId }
+            let insertionIndex = min(pinnedInsertionIndex, ordered.count)
+            ordered.insert(pinnedId, at: insertionIndex)
+            pinnedInsertionIndex += 1
+        }
+
+        if ordered.count > clampedMax {
+            ordered.removeSubrange(clampedMax...)
+        }
+
+        return ordered
+    }
+
+    private static func cycleWarmIds(selected: UUID, orderedTabIds: [UUID]) -> [UUID] {
+        guard orderedTabIds.contains(selected) else { return [selected] }
+        // Keep warming focused to the selected workspace. Retiring/target workspaces are
+        // pinned by handoff logic, so warming adjacent neighbors here just adds layout work.
+        return [selected]
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -783,99 +783,12 @@ private func commandPaletteOwningWebView(for responder: NSResponder?) -> WKWebVi
     return nil
 }
 
-enum WorkspaceMountPolicy {
-    // Keep only the selected workspace mounted to minimize layer-tree traversal.
-    static let maxMountedWorkspaces = 1
-    // During workspace cycling, keep only a minimal handoff pair (selected + retiring).
-    static let maxMountedWorkspacesDuringCycle = 2
-
-    static func nextMountedWorkspaceIds(
-        current: [UUID],
-        selected: UUID?,
-        pinnedIds: Set<UUID>,
-        orderedTabIds: [UUID],
-        isCycleHot: Bool,
-        maxMounted: Int
-    ) -> [UUID] {
-        let existing = Set(orderedTabIds)
-        let clampedMax = max(1, maxMounted)
-        var ordered = current.filter { existing.contains($0) }
-
-        if let selected, existing.contains(selected) {
-            ordered.removeAll { $0 == selected }
-            ordered.insert(selected, at: 0)
-        }
-
-        if isCycleHot, let selected {
-            let warmIds = cycleWarmIds(selected: selected, orderedTabIds: orderedTabIds)
-            for id in warmIds.reversed() {
-                ordered.removeAll { $0 == id }
-                ordered.insert(id, at: 0)
-            }
-        }
-
-        if isCycleHot,
-           pinnedIds.isEmpty,
-           let selected {
-            ordered.removeAll { $0 != selected }
-        }
-
-        // Ensure pinned ids (retiring handoff workspaces) are always retained at highest priority.
-        // This runs after warming to prevent neighbor warming from evicting the retiring workspace.
-        let prioritizedPinnedIds = pinnedIds
-            .filter { existing.contains($0) && $0 != selected }
-            .sorted { lhs, rhs in
-                let lhsIndex = orderedTabIds.firstIndex(of: lhs) ?? .max
-                let rhsIndex = orderedTabIds.firstIndex(of: rhs) ?? .max
-                return lhsIndex < rhsIndex
-            }
-        if let selected, existing.contains(selected) {
-            ordered.removeAll { $0 == selected }
-            ordered.insert(selected, at: 0)
-        }
-        var pinnedInsertionIndex = (selected != nil) ? 1 : 0
-        for pinnedId in prioritizedPinnedIds {
-            ordered.removeAll { $0 == pinnedId }
-            let insertionIndex = min(pinnedInsertionIndex, ordered.count)
-            ordered.insert(pinnedId, at: insertionIndex)
-            pinnedInsertionIndex += 1
-        }
-
-        if ordered.count > clampedMax {
-            ordered.removeSubrange(clampedMax...)
-        }
-
-        return ordered
-    }
-
-    private static func cycleWarmIds(selected: UUID, orderedTabIds: [UUID]) -> [UUID] {
-        guard orderedTabIds.contains(selected) else { return [selected] }
-        // Keep warming focused to the selected workspace. Retiring/target workspaces are
-        // pinned by handoff logic, so warming adjacent neighbors here just adds layout work.
-        return [selected]
-    }
-}
-
-struct MountedWorkspacePresentation: Equatable {
-    let isRenderedVisible: Bool
-    let isPanelVisible: Bool
-    let renderOpacity: Double
-}
-
-enum MountedWorkspacePresentationPolicy {
-    static func resolve(
-        isSelectedWorkspace: Bool,
-        isRetiringWorkspace: Bool
-    ) -> MountedWorkspacePresentation {
-        let isRenderedVisible = isSelectedWorkspace || isRetiringWorkspace
-
-        return MountedWorkspacePresentation(
-            isRenderedVisible: isRenderedVisible,
-            isPanelVisible: isRenderedVisible,
-            renderOpacity: isRenderedVisible ? 1 : 0
-        )
-    }
-}
+// Lifted to `CmuxFoundation.WorkspaceMountPolicy` / `MountedWorkspacePresentation`
+// / `MountedWorkspacePresentationPolicy` (ContentView decomposition). These
+// typealiases keep call sites byte-identical.
+typealias WorkspaceMountPolicy = CmuxFoundation.WorkspaceMountPolicy
+typealias MountedWorkspacePresentation = CmuxFoundation.MountedWorkspacePresentation
+typealias MountedWorkspacePresentationPolicy = CmuxFoundation.MountedWorkspacePresentationPolicy
 
 /// Installs a FileDropOverlayView on the window's theme frame for Finder file drag support.
 private func findFileDropOverlayView(in root: NSView?) -> FileDropOverlayView? {


### PR DESCRIPTION
Faithful lift of three pure workspace-mount policy types out of `ContentView.swift` into `CmuxFoundation/Workspace`, typealias-in-place so call sites and the existing `WorkspaceMountPolicyTests` / `WorkspaceContentViewVisibilityTests` stay byte-identical:

- `WorkspaceMountPolicy` — UUID-only mount/cycle ordering policy (no god-type reach)
- `MountedWorkspacePresentation` — pure value type
- `MountedWorkspacePresentationPolicy` — pure `resolve(isSelectedWorkspace:isRetiringWorkspace:)`

No behavior change; wire format/Defaults untouched. ContentView.swift 16827→16740. Logic machine-diffed byte-identical to the originals.

Part of the god-file decomposition program (continues 6029/6080/5922).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017723&installation_id=133855650&pr_number=6115&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6115&signature=629472fccdadac3811cf2b3c0ce320f7e37b8225db9b059f5729ded5eca35ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted three workspace-mount policy types out of `ContentView.swift` into `CmuxFoundation/Workspace` to isolate policy logic and shrink the file. No behavior changes; call sites and tests remain byte-identical via typealiases.

- **Refactors**
  - Moved `WorkspaceMountPolicy`, `MountedWorkspacePresentation`, and `MountedWorkspacePresentationPolicy` into `Packages/CmuxFoundation/Sources/CmuxFoundation/Workspace`.
  - Added typealiases in `ContentView.swift` to preserve existing call sites and tests.
  - No wire format or Defaults changes; `ContentView.swift` reduced by 87 lines (16827 → 16740).

<sup>Written for commit 35f73e6d8323919e598dba31e11b82d5365fc81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated workspace presentation and mounting policies into the shared foundation package for improved code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->