### PR TITLE
[codex] Bound closed item history persistence and avoid scrollback capture

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -16254,7 +16254,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // cache has not loaded yet (see closedPanelHistoryEntry).
         let snapshot = sessionWindowSnapshot(
             for: context,
-            includeScrollback: true,
+            includeScrollback: false,
             restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
                 ?? RestorableAgentSessionIndex.load()
         )

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -126,8 +126,12 @@ enum ClosedWindowRestoreValidation {
 
 @MainActor
 final class ClosedItemHistoryStore: ObservableObject {
+    private static let defaultCapacity = 50
+    private static let maxPersistedRecordCount = 50
+    private static let maxPersistedDataBytes = 5 * 1024 * 1024
+
     static let shared = ClosedItemHistoryStore(
-        capacity: nil,
+        capacity: defaultCapacity,
         fileURL: defaultHistoryFileURL()
     )
 
@@ -183,7 +187,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     func push(_ record: ClosedItemHistoryRecord) {
-        records.append(record)
+        records.append(Self.storageSafeRecord(record))
         trimToCapacityIfNeeded()
         revision &+= 1
         persistRecords()
@@ -240,7 +244,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     func insert(_ record: ClosedItemHistoryRecord, at index: Int) {
-        records.insert(record, at: min(max(0, index), records.count))
+        records.insert(Self.storageSafeRecord(record), at: min(max(0, index), records.count))
         if let capacity, records.count > capacity {
             let protectedRecordId = record.id
             let overflow = records.count - capacity
@@ -573,6 +577,7 @@ final class ClosedItemHistoryStore: ObservableObject {
 
     private func mergeLoadedPersistedRecords(_ loadedRecords: [ClosedItemHistoryRecord]) {
         guard !loadedRecords.isEmpty else { return }
+        let loadedRecords = loadedRecords.map(Self.storageSafeRecord)
         if records.isEmpty {
             records = loadedRecords
         } else {
@@ -586,13 +591,20 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     nonisolated fileprivate static func loadRecords(fileURL: URL) -> [ClosedItemHistoryRecord] {
+        if let fileSize = persistedFileSize(fileURL), fileSize > maxPersistedDataBytes {
+            closedItemHistoryLogger.debug(
+                "closedItemHistory.load.skippedOversize file=\(fileURL.path, privacy: .public) bytes=\(fileSize)"
+            )
+            return []
+        }
         guard let data = try? Data(contentsOf: fileURL) else { return [] }
         let decoder = JSONDecoder()
         if let snapshot = try? decoder.decode(ClosedItemHistoryPersistenceSnapshot.self, from: data),
            snapshot.version == ClosedItemHistoryPersistenceSnapshot.currentVersion {
-            return snapshot.records
+            return Array(snapshot.records.suffix(maxPersistedRecordCount)).map(storageSafeRecord)
         }
-        return (try? decoder.decode([ClosedItemHistoryRecord].self, from: data)) ?? []
+        let legacyRecords = (try? decoder.decode([ClosedItemHistoryRecord].self, from: data)) ?? []
+        return Array(legacyRecords.suffix(maxPersistedRecordCount)).map(storageSafeRecord)
     }
 
     nonisolated fileprivate static func saveRecords(_ records: [ClosedItemHistoryRecord], fileURL: URL) {
@@ -618,8 +630,17 @@ final class ClosedItemHistoryStore: ObservableObject {
             let snapshot = ClosedItemHistoryPersistenceSnapshot(records: records)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
-            let data = try encoder.encode(snapshot)
-            if let existingData = try? Data(contentsOf: fileURL), existingData == data {
+            guard let data = try persistenceData(for: snapshot.records, encoder: encoder) else {
+                try? FileManager.default.removeItem(at: fileURL)
+                closedItemHistoryLogger.debug(
+                    "closedItemHistory.save.skippedOversize file=\(fileURL.path, privacy: .public) records=\(records.count)"
+                )
+                return
+            }
+            let existingFileIsComparable = persistedFileSize(fileURL).map { $0 <= maxPersistedDataBytes } ?? true
+            if existingFileIsComparable,
+               let existingData = try? Data(contentsOf: fileURL),
+               existingData == data {
                 return
             }
             try data.write(to: fileURL, options: .atomic)
@@ -629,6 +650,90 @@ final class ClosedItemHistoryStore: ObservableObject {
             )
             return
         }
+    }
+
+    nonisolated private static func persistedFileSize(_ fileURL: URL) -> Int? {
+        if let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey]),
+           let fileSize = values.fileSize {
+            return fileSize
+        }
+        return nil
+    }
+
+    nonisolated private static func persistenceData(
+        for records: [ClosedItemHistoryRecord],
+        encoder: JSONEncoder
+    ) throws -> Data? {
+        var persistedRecords = Array(records.suffix(maxPersistedRecordCount)).map(storageSafeRecord)
+        while !persistedRecords.isEmpty {
+            let snapshot = ClosedItemHistoryPersistenceSnapshot(records: persistedRecords)
+            let data = try encoder.encode(snapshot)
+            if data.count <= maxPersistedDataBytes {
+                return data
+            }
+            persistedRecords.removeFirst()
+        }
+        return nil
+    }
+
+    nonisolated private static func storageSafeRecord(_ record: ClosedItemHistoryRecord) -> ClosedItemHistoryRecord {
+        ClosedItemHistoryRecord(
+            id: record.id,
+            closedAt: record.closedAt,
+            entry: storageSafeEntry(record.entry)
+        )
+    }
+
+    nonisolated private static func storageSafeEntry(_ entry: ClosedItemHistoryEntry) -> ClosedItemHistoryEntry {
+        switch entry {
+        case .panel(let panelEntry):
+            return .panel(ClosedPanelHistoryEntry(
+                workspaceId: panelEntry.workspaceId,
+                paneId: panelEntry.paneId,
+                paneAnchorPanelId: panelEntry.paneAnchorPanelId,
+                restoreInOriginalPane: panelEntry.restoreInOriginalPane,
+                tabIndex: panelEntry.tabIndex,
+                snapshot: storageSafePanelSnapshot(panelEntry.snapshot),
+                fallbackSplitPlacement: panelEntry.fallbackSplitPlacement
+            ))
+        case .workspace(let workspaceEntry):
+            return .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: workspaceEntry.workspaceId,
+                windowId: workspaceEntry.windowId,
+                workspaceIndex: workspaceEntry.workspaceIndex,
+                snapshot: storageSafeWorkspaceSnapshot(workspaceEntry.snapshot)
+            ))
+        case .window(let windowEntry):
+            return .window(ClosedWindowHistoryEntry(
+                windowId: windowEntry.windowId,
+                snapshot: storageSafeWindowSnapshot(windowEntry.snapshot),
+                workspaceIds: windowEntry.workspaceIds
+            ))
+        }
+    }
+
+    nonisolated private static func storageSafeWindowSnapshot(
+        _ snapshot: SessionWindowSnapshot
+    ) -> SessionWindowSnapshot {
+        var snapshot = snapshot
+        snapshot.tabManager.workspaces = snapshot.tabManager.workspaces.map(storageSafeWorkspaceSnapshot)
+        return snapshot
+    }
+
+    nonisolated private static func storageSafeWorkspaceSnapshot(
+        _ snapshot: SessionWorkspaceSnapshot
+    ) -> SessionWorkspaceSnapshot {
+        var snapshot = snapshot
+        snapshot.panels = snapshot.panels.map(storageSafePanelSnapshot)
+        return snapshot
+    }
+
+    nonisolated private static func storageSafePanelSnapshot(
+        _ snapshot: SessionPanelSnapshot
+    ) -> SessionPanelSnapshot {
+        var snapshot = snapshot
+        snapshot.terminal?.scrollback = nil
+        return snapshot
     }
 
     nonisolated private static func defaultHistoryFileURL(

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -31,6 +31,7 @@ enum SessionPersistencePolicy {
     static let maxPanelsPerWorkspace: Int = 512
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
+    static let maxScrollbackCaptureBytesPerTerminal: Int = 2 * 1024 * 1024
 
     static func sanitizedSidebarWidth(_ candidate: Double?, defaults: UserDefaults = .standard) -> Double {
         let resolvedMinimum = resolvedMinimumSidebarWidth(defaults: defaults)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5328,7 +5328,7 @@ class TabManager: ObservableObject {
             // workspace does not freeze the main thread; fall back to a fresh load only
             // while the cache has not loaded yet. See closedPanelHistoryEntry.
             let snapshot = workspace.sessionSnapshot(
-                includeScrollback: true,
+                includeScrollback: false,
                 restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
                     ?? RestorableAgentSessionIndex.load()
             )

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4915,6 +4915,11 @@ class TerminalController {
             }
         }
 
+        if let fileSize = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize,
+           fileSize > SessionPersistencePolicy.maxScrollbackCaptureBytesPerTerminal {
+            return ""
+        }
+
         guard let data = try? Data(contentsOf: fileURL),
               let rawOutput = String(data: data, encoding: .utf8) else {
             return nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -775,7 +775,7 @@ extension Workspace {
         let restorableAgent = agentIndex.snapshot(workspaceId: id, panelId: panelId)
         guard let snapshot = sessionPanelSnapshot(
             panelId: panelId,
-            includeScrollback: true,
+            includeScrollback: false,
             restorableAgent: restorableAgent,
             resumeBinding: effectiveSurfaceResumeBinding(
                 panelId: panelId,

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -1112,6 +1112,55 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: historyURL.path))
     }
 
+    func testClosedItemHistoryDropsTerminalScrollbackBeforePersisting() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-closed-history-scrollback-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let historyURL = tempDir.appendingPathComponent("history.json", isDirectory: false)
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let store = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadPersisted: false,
+            persistsRecordsSynchronously: true
+        )
+
+        var workspaceSnapshot = workspace.sessionSnapshot(includeScrollback: false)
+        XCTAssertFalse(workspaceSnapshot.panels.isEmpty)
+        if workspaceSnapshot.panels[0].terminal == nil {
+            workspaceSnapshot.panels[0].terminal = SessionTerminalPanelSnapshot()
+        }
+        workspaceSnapshot.panels[0].terminal?.scrollback = String(repeating: "x", count: 100_000)
+        let recordId = UUID()
+
+        store.push(ClosedItemHistoryRecord(
+            id: recordId,
+            closedAt: Date(timeIntervalSince1970: 1),
+            entry: .workspace(ClosedWorkspaceHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: nil,
+                workspaceIndex: 0,
+                snapshot: workspaceSnapshot
+            ))
+        ))
+
+        let restoredStore = ClosedItemHistoryStore(
+            capacity: nil,
+            fileURL: historyURL,
+            loadsPersistedRecordsSynchronously: true,
+            persistsRecordsSynchronously: true
+        )
+        let restoredRecord = try XCTUnwrap(restoredStore.removeRecord(id: recordId)?.record)
+        guard case .workspace(let restoredEntry) = restoredRecord.entry else {
+            XCTFail("Expected restored workspace history entry")
+            return
+        }
+        XCTAssertNil(restoredEntry.snapshot.panels.first?.terminal?.scrollback)
+    }
+
     func testClosedItemHistoryAsyncLoadMergesEarlyMutation() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-closed-history-merge-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

This bounds recently closed item history persistence and prevents terminal scrollback from being stored in that history path.

The closed history store now uses a finite shared capacity, strips terminal `scrollback` before records are stored or persisted, caps loaded persisted records, skips oversized persisted history files, and trims encoded history JSON to a 5 MB ceiling before writing. Closed panel, workspace, and window history snapshots now avoid requesting scrollback at capture time. VT export scrollback capture also checks file size before reading the export into memory.

## Why

Large terminal/Codex sessions can put full scrollback into closed item history snapshots. With an unbounded shared history store, cmux can repeatedly encode and write very large history JSON, creating memory and disk pressure when sessions are closed or restored.

## Validation

- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8 CMUX_SKIP_ZIG_BUILD=1 ./scripts/ci/xcodebuild_noninteractive.py xcodebuild -workspace cmux.xcworkspace -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/TabManagerSessionSnapshotTests/testClosedItemHistoryDropsTerminalScrollbackBeforePersisting test`
- `LC_ALL=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 LANG=en_US.UTF-8 CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag oom-history-bound`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784046795&installation_id=133855650&pr_number=6122&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6122&signature=f6555fdba5ba7370a39c7b601ec00853633918fe3015cf81058aede1649c2fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound closed item history and removed terminal scrollback from snapshots to prevent oversized history files and memory/disk pressure during close/restore. Adds size caps and skip logic across persistence and scrollback capture.

- **Bug Fixes**
  - Bounded `ClosedItemHistoryStore` with a default capacity of 50 and capped persisted loads to 50 records.
  - Dropped terminal scrollback from closed panel/workspace/window snapshots and storage; capture now avoids scrollback.
  - Limited history JSON to 5 MB, skipped reading/writing files over 5 MB, and trimmed persisted records to fit.
  - Added a 2 MB guard for VT export scrollback via `SessionPersistencePolicy.maxScrollbackCaptureBytesPerTerminal`.
  - Added a test to ensure scrollback is removed before persisting.

<sup>Written for commit 63c98004fb92c2f9346c21dadc2984dad8920255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

