### PR TITLE
Remove compact workspace row tap gestures

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -90,9 +90,6 @@ struct WorkspaceGroupHeaderRow: View {
             NavigationLink(value: group.anchorWorkspaceID) {
                 nameLabel
             }
-            .simultaneousGesture(TapGesture().onEnded {
-                selectWorkspace(group.anchorWorkspaceID)
-            })
         case .sidebar:
             Button {
                 selectWorkspace(group.anchorWorkspaceID)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -95,9 +95,6 @@ struct WorkspaceNavigationRow: View {
             NavigationLink(value: workspace.id) {
                 rowLabel
             }
-            .simultaneousGesture(TapGesture().onEnded {
-                selectWorkspace(workspace.id)
-            })
         case .sidebar:
             Button {
                 selectWorkspace(workspace.id)

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -111,8 +111,11 @@ struct WorkspaceShellView: View {
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onChange(of: compactNavigationPath) { _, path in
-            guard let selectedWorkspaceID = path.last,
-                  store.selectedWorkspaceID != selectedWorkspaceID else {
+            guard let selectedWorkspaceID = path.last else {
+                return
+            }
+            pendingCompactCreateNavigationWorkspaceIDs = nil
+            guard store.selectedWorkspaceID != selectedWorkspaceID else {
                 return
             }
             store.selectedWorkspaceID = selectedWorkspaceID


### PR DESCRIPTION
## Summary
- Remove redundant `simultaneousGesture(TapGesture())` from compact workspace rows and group headers.
- Let `NavigationStack(path:)` drive compact navigation and sync `selectedWorkspaceID` from the parent path observer.

## Testing
- `./scripts/reload-cloud.sh --tag ntap` (cloud unavailable, local tagged macOS build succeeded)
- `ios/scripts/reload.sh --tag ntap` (iOS Simulator build/install succeeded on iPhone 17)
- `swift test --package-path Packages/CmuxMobileShellUI` (blocked before compile: missing local `GhosttyKit.xcframework` artifact in fresh worktree)

## Notes
- No user-facing strings changed; localization audit found no new UI text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784049850&installation_id=133855650&pr_number=6124&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6124&signature=2daac71ffd0c7bbbe80225249d2c36ff79ca3ea1f3f00f357da778e0beec259a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant tap gestures from compact workspace rows and group headers so `NavigationLink` fully controls navigation. This stops duplicate taps and keeps compact selection in sync with the parent navigation path.

- **Bug Fixes**
  - Removed `.simultaneousGesture(TapGesture())` from compact rows and headers to avoid duplicate selection.
  - Let `NavigationStack(path:)` updates drive compact selection; update `selectedWorkspaceID` from `compactNavigationPath`.
  - Clear `pendingCompactCreateNavigationWorkspaceIDs` on any compact path update to avoid stale navigation state.

<sup>Written for commit 09cefcbc3afdaf082fb5148ab5cd37a3acc6f713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace navigation behavior for “push” interactions so tapping a workspace header/row consistently selects the correct destination.
  * Fixed stale navigation state by clearing a pending “created workspace” selection intent when the compact navigation destination changes, preventing incorrect subsequent workspace selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->