### PR TITLE
Fix iOS TestFlight APNs entitlement export

### DIFF
--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -10,3 +10,7 @@ DEVELOPMENT_TEAM = 7WLXT3NR37
 // Distinguish the TestFlight beta on-device from a future App Store "cmux"
 // (overrides PRODUCT_DISPLAY_NAME = cmux from Shared.xcconfig). Debug stays "cmux".
 PRODUCT_DISPLAY_NAME = cmux BETA
+
+// TestFlight/App Store builds use production APNs. Debug keeps
+// Config/cmux.entitlements from Shared.xcconfig.
+CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -374,27 +374,49 @@ fi
 
 if [[ -z "$ARCHIVE_PATH" ]]; then
   ARCHIVE_PATH="$OUT_DIR/cmux.xcarchive"
-  # Archive WITHOUT signing. The export step below does all signing (manual cert
-  # or automatic cloud distribution). Signing the archive with automatic +
-  # -allowProvisioningUpdates makes Xcode mint a NEW Apple Development cert on
-  # every ephemeral CI runner, which exhausts the account's certificate cap and
-  # then fails ("maximum number of certificates" / "no profiles found"). An
-  # unsigned archive creates no certs; the reused (cloud-managed) distribution
-  # cert is applied only at export, where it does not churn.
-  xcodebuild archive \
-    -workspace "$WORKSPACE" \
-    -scheme "$SCHEME" \
-    -configuration Release \
-    -destination "generic/platform=iOS" \
-    -archivePath "$ARCHIVE_PATH" \
-    -derivedDataPath "$DERIVED_DATA" \
-    DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-    PRODUCT_BUNDLE_IDENTIFIER="$PRODUCT_BUNDLE_IDENTIFIER" \
-    CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
-    CODE_SIGNING_ALLOWED=NO \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGN_IDENTITY="" \
-    | tee "$OUT_DIR/archive.log"
+  if [[ "$SIGNING" == "automatic" ]]; then
+    # Automatic signing must archive a signed app so Xcode has the requested
+    # Release entitlements to preserve during App Store Connect export. An
+    # unsigned archive exports with only the profile baseline and drops
+    # aps-environment, which the gate below correctly refuses to upload.
+    xcodebuild archive \
+      -workspace "$WORKSPACE" \
+      -scheme "$SCHEME" \
+      -configuration Release \
+      -destination "generic/platform=iOS" \
+      -archivePath "$ARCHIVE_PATH" \
+      -derivedDataPath "$DERIVED_DATA" \
+      -allowProvisioningUpdates \
+      "${XCODE_AUTH_ARGS[@]}" \
+      DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+      PRODUCT_BUNDLE_IDENTIFIER="$PRODUCT_BUNDLE_IDENTIFIER" \
+      CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+      CODE_SIGN_STYLE=Automatic \
+      CODE_SIGN_ENTITLEMENTS="Config/cmux-release.entitlements" \
+      CODE_SIGN_IDENTITY="Apple Distribution" \
+      CODE_SIGNING_ALLOWED=YES \
+      CODE_SIGNING_REQUIRED=YES \
+      | tee "$OUT_DIR/archive.log"
+  else
+    # Manual signing archives WITHOUT signing. The export step signs with the
+    # installed distribution profile, then the manual path below re-signs with
+    # the full Release entitlements from the local Apple Distribution cert.
+    # This keeps signing material off shared fleet builders.
+    xcodebuild archive \
+      -workspace "$WORKSPACE" \
+      -scheme "$SCHEME" \
+      -configuration Release \
+      -destination "generic/platform=iOS" \
+      -archivePath "$ARCHIVE_PATH" \
+      -derivedDataPath "$DERIVED_DATA" \
+      DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
+      PRODUCT_BUNDLE_IDENTIFIER="$PRODUCT_BUNDLE_IDENTIFIER" \
+      CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+      CODE_SIGNING_ALLOWED=NO \
+      CODE_SIGNING_REQUIRED=NO \
+      CODE_SIGN_IDENTITY="" \
+      | tee "$OUT_DIR/archive.log"
+  fi
 else
   if [[ ! -d "$ARCHIVE_PATH" ]]; then
     echo "error: archive not found: $ARCHIVE_PATH" >&2
@@ -454,12 +476,13 @@ fi
 # Re-sign the exported app with the FULL entitlements (production aps-environment
 # et al.), then point $IPA_PATH at the re-signed IPA so the upload below ships it.
 #
-# Why this is necessary: the archive is built UNSIGNED (CODE_SIGNING_ALLOWED=NO,
-# see above) to avoid distribution-cert churn on ephemeral runners. An unsigned
-# archive carries NO entitlements, so `-exportArchive` re-adds only the profile
-# baseline (application-identifier, com.apple.developer.team-identifier,
-# get-task-allow, beta-reports-active) and SILENTLY DROPS app-capability
-# entitlements such as aps-environment. This regressed in
+# Why this is necessary for the manual path: the archive is built UNSIGNED
+# (CODE_SIGNING_ALLOWED=NO, see above) to keep distribution material off shared
+# fleet builders. An unsigned archive carries NO entitlements, so
+# `-exportArchive` re-adds only the profile baseline (application-identifier,
+# com.apple.developer.team-identifier, get-task-allow, beta-reports-active) and
+# SILENTLY DROPS app-capability entitlements such as aps-environment. This
+# regressed in
 # https://github.com/manaflow-ai/cmux/pull/5496 (June 2026): the signed beta IPA
 # had aps-environment absent entirely, so the device registered no push token and
 # beta/prod push was dead. The per-config entitlements file fix


### PR DESCRIPTION
## Summary
- Point the iOS Release config at `Config/cmux-release.entitlements` so TestFlight builds request production APNs entitlements.
- Make the automatic TestFlight lane archive a signed Release app with the production entitlement file before App Store Connect export.
- Keep the manual/fleet archive path unsigned, with the existing local re-sign gate unchanged.

## Why
Recent `iOS TestFlight (beta)` runs archive and export successfully, then fail the upload gate because the exported IPA contains only the profile baseline entitlements and is missing `aps-environment=production`. Uploading that artifact would break push notifications for TestFlight.

Latest observed failure:
- run `27490523868`
- exported IPA entitlements: `application-identifier`, `beta-reports-active`, `com.apple.developer.team-identifier`, `get-task-allow`
- missing: `aps-environment`

## Validation
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/cloud-testflight.sh ios/scripts/bump-ios-version.sh`
- `git diff --check`
- `plutil -lint ios/Config/cmux-release.entitlements ios/Config/cmux.entitlements ios/Config/Info.plist`

Local Mac note: local Xcode does not have the iOS 26.5 platform installed, so archive/export validation needs to run on the GitHub macOS runner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784056227&installation_id=133855650&pr_number=6131&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6131&signature=3e0ff9c7634c4bac3cfcb72b0d0c7cd20284d9260ae9a7eb99b53ccf2c194ac7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9283ac67571589cea18ceb1bd255b2985da70463. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TestFlight exports missing `aps-environment=production` by using the Release entitlements file and updating CI so automatic builds preserve production APNs. Restores push notifications and passes the upload gate.

- **Bug Fixes**
  - Set `CODE_SIGN_ENTITLEMENTS=Config/cmux-release.entitlements` in Release to request production APNs.
  - Automatic lane: archive a signed Release app with production entitlements so export preserves them.
  - Manual/fleet lane: keep archive unsigned; re-sign post-export with full Release entitlements (existing gate unchanged).
  - Updated `ios/Config/Release.xcconfig` and `ios/scripts/upload-testflight.sh`.

<sup>Written for commit 9283ac67571589cea18ceb1bd255b2985da70463. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS release build configuration with improved code signing entitlements for TestFlight and App Store distributions
  * Enhanced TestFlight upload script to properly handle automatic and manual signing workflows while preserving required app capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->