### PR TITLE
Extract browser-search settings into CmuxSettings (Wave-2 store, no namespace enum)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -62,7 +62,7 @@
 1497	cmuxTests/OmnibarAndToolsTests.swift
 1496	cmuxUITests/MultiWindowNotificationsUITests.swift
 1446	Sources/FileExplorerStore.swift
-1382	cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+1384	cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
 1380	cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
 1373	cmuxTests/AppDelegateIssue2907RoutingTests.swift
 1366	Sources/Feed/FeedButtonStyleDebugWindowController.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,12 +5,12 @@
 17914	Sources/AppDelegate.swift
 16705	Sources/ContentView.swift
 14682	Sources/TerminalController.swift
-13595	Sources/Panels/BrowserPanel.swift
+13358	Sources/Panels/BrowserPanel.swift
 12223	Sources/Workspace.swift
 12088	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
-7911	Sources/Panels/BrowserPanelView.swift
+7912	Sources/Panels/BrowserPanelView.swift
 7354	cmuxTests/WorkspaceUnitTests.swift
 7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6363	cmuxTests/GhosttyConfigTests.swift
@@ -19,7 +19,7 @@
 6091	Sources/TabManager.swift
 6074	Sources/TextBoxInput.swift
 5925	cmuxTests/TerminalAndGhosttyTests.swift
-5522	cmuxTests/BrowserConfigTests.swift
+5526	cmuxTests/BrowserConfigTests.swift
 5113	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 4921	Sources/cmuxApp.swift
 4467	Sources/Panels/FilePreviewPanel.swift
@@ -47,7 +47,7 @@
 2117	cmuxTests/CmuxConfigTests.swift
 2095	cmuxTests/ShortcutAndCommandPaletteTests.swift
 2062	Sources/SessionPersistence.swift
-2055	Sources/KeyboardShortcutSettingsFileStore.swift
+2057	Sources/KeyboardShortcutSettingsFileStore.swift
 1949	Sources/Panels/BrowserWebAuthnSupport.swift
 1860	cmuxTests/NotificationAndMenuBarTests.swift
 1794	Sources/SessionIndexStore.swift

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/BrowserCatalogSection.swift
@@ -4,26 +4,26 @@ import Foundation
 public struct BrowserCatalogSection: SettingCatalogSection {
     public let defaultSearchEngine = DefaultsKey<BrowserSearchEngine>(
         id: "browser.defaultSearchEngine",
-        defaultValue: .google,
-        userDefaultsKey: "browserSearchEngine"
+        defaultValue: BrowserSearchSettingsStore.defaultSearchEngine,
+        userDefaultsKey: BrowserSearchSettingsStore.searchEngineKey
     )
 
     public let customSearchEngineName = DefaultsKey<String>(
         id: "browser.customSearchEngineName",
-        defaultValue: "",
-        userDefaultsKey: "browserCustomSearchEngineName"
+        defaultValue: BrowserSearchSettingsStore.defaultCustomSearchEngineName,
+        userDefaultsKey: BrowserSearchSettingsStore.customSearchEngineNameKey
     )
 
     public let customSearchEngineURLTemplate = DefaultsKey<String>(
         id: "browser.customSearchEngineURLTemplate",
-        defaultValue: "",
-        userDefaultsKey: "browserCustomSearchEngineURLTemplate"
+        defaultValue: BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate,
+        userDefaultsKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey
     )
 
     public let showSearchSuggestions = DefaultsKey<Bool>(
         id: "browser.showSearchSuggestions",
-        defaultValue: true,
-        userDefaultsKey: "browserSearchSuggestionsEnabled"
+        defaultValue: BrowserSearchSettingsStore.defaultSearchSuggestionsEnabled,
+        userDefaultsKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey
     )
 
     public let theme = DefaultsKey<BrowserThemeMode>(

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/BrowserSearchSettingsReading.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/BrowserSearchSettingsReading.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Read access to the browser search settings.
+///
+/// Consumers depend on this seam instead of the concrete
+/// ``BrowserSearchSettingsStore`` so tests can inject an isolated
+/// `UserDefaults` suite.
+public protocol BrowserSearchSettingsReading: Sendable {
+    /// The currently selected browser search engine.
+    var currentSearchEngine: BrowserSearchEngine { get }
+
+    /// The resolved browser search configuration.
+    var currentConfiguration: BrowserSearchConfiguration { get }
+
+    /// Whether address-bar search suggestions are enabled.
+    var currentSearchSuggestionsEnabled: Bool { get }
+
+    /// Resolves a browser search configuration from raw stored values.
+    ///
+    /// - Parameters:
+    ///   - engineRaw: Stored raw search engine value.
+    ///   - customName: Stored custom engine display name.
+    ///   - customURLTemplate: Stored custom search URL template.
+    /// - Returns: A configuration with legacy fallbacks applied.
+    func configuration(
+        engineRaw: String?,
+        customName: String?,
+        customURLTemplate: String?
+    ) -> BrowserSearchConfiguration
+
+    /// Normalizes a custom search engine name.
+    ///
+    /// - Parameter raw: The stored or entered name.
+    /// - Returns: The trimmed name, or `nil` when it is empty.
+    func normalizedCustomSearchEngineName(_ raw: String) -> String?
+
+    /// Validates whether a custom search URL template can render a search URL.
+    ///
+    /// - Parameter raw: The stored or entered template.
+    /// - Returns: `true` when the template can produce an allowed search URL.
+    func isValidSearchURLTemplate(_ raw: String) -> Bool
+
+    /// Renders a search URL from a template and raw query.
+    ///
+    /// - Parameters:
+    ///   - rawTemplate: The URL template, optionally containing `{query}` or `%s`.
+    ///   - rawQuery: The raw search query.
+    /// - Returns: An allowed `http` or `https` URL, or `nil`.
+    func searchURL(fromTemplate rawTemplate: String, query rawQuery: String) -> URL?
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Stores/BrowserSearchSettingsStore.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Stores/BrowserSearchSettingsStore.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Repository for browser search settings persisted in `UserDefaults`.
+///
+/// Isolation: a stateless `Sendable` struct, not an actor. Browser search
+/// readers are synchronous call paths such as address-bar resolution and
+/// settings-file import validation; the struct holds no mutable state, and
+/// `UserDefaults` is documented thread-safe.
+public struct BrowserSearchSettingsStore: BrowserSearchSettingsReading {
+    /// Defaults key storing the selected search engine raw value.
+    public static let searchEngineKey = "browserSearchEngine"
+
+    /// Defaults key storing the custom search engine display name.
+    public static let customSearchEngineNameKey = "browserCustomSearchEngineName"
+
+    /// Defaults key storing the custom search URL template.
+    public static let customSearchEngineURLTemplateKey = "browserCustomSearchEngineURLTemplate"
+
+    /// Defaults key storing whether search suggestions are enabled.
+    public static let searchSuggestionsEnabledKey = "browserSearchSuggestionsEnabled"
+
+    /// Legacy default selected search engine.
+    public static let defaultSearchEngine: BrowserSearchEngine = .google
+
+    /// Legacy default custom search engine display name.
+    public static let defaultCustomSearchEngineName = ""
+
+    /// Legacy default custom search URL template.
+    public static let defaultCustomSearchEngineURLTemplate = "https://www.google.com/search?q={query}"
+
+    /// Legacy default search suggestions toggle value.
+    public static let defaultSearchSuggestionsEnabled: Bool = true
+
+    // UserDefaults is documented thread-safe and the reference is immutable.
+    private nonisolated(unsafe) let defaults: UserDefaults
+
+    /// Creates a store reading the given defaults suite.
+    ///
+    /// - Parameter defaults: The defaults suite holding browser search settings.
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public var currentSearchEngine: BrowserSearchEngine {
+        guard let raw = defaults.string(forKey: Self.searchEngineKey),
+              let engine = BrowserSearchEngine(rawValue: raw) else {
+            return Self.defaultSearchEngine
+        }
+        return engine
+    }
+
+    public var currentConfiguration: BrowserSearchConfiguration {
+        configuration(
+            engineRaw: defaults.string(forKey: Self.searchEngineKey),
+            customName: defaults.string(forKey: Self.customSearchEngineNameKey),
+            customURLTemplate: defaults.string(forKey: Self.customSearchEngineURLTemplateKey)
+        )
+    }
+
+    public var currentSearchSuggestionsEnabled: Bool {
+        // Mirror @AppStorage behavior: bool(forKey:) returns false if key doesn't exist.
+        // Default to enabled unless user explicitly set a value.
+        if defaults.object(forKey: Self.searchSuggestionsEnabledKey) == nil {
+            return Self.defaultSearchSuggestionsEnabled
+        }
+        return defaults.bool(forKey: Self.searchSuggestionsEnabledKey)
+    }
+
+    public func configuration(
+        engineRaw: String?,
+        customName: String?,
+        customURLTemplate: String?
+    ) -> BrowserSearchConfiguration {
+        let engine = engineRaw.flatMap(BrowserSearchEngine.init(rawValue:)) ?? Self.defaultSearchEngine
+        let resolvedCustomURLTemplate = customURLTemplate
+            .flatMap { isValidSearchURLTemplate($0) ? $0 : nil }
+            ?? Self.defaultCustomSearchEngineURLTemplate
+        return BrowserSearchConfiguration(
+            engine: engine,
+            customName: customName ?? Self.defaultCustomSearchEngineName,
+            customURLTemplate: resolvedCustomURLTemplate
+        )
+    }
+
+    public func normalizedCustomSearchEngineName(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public func isValidSearchURLTemplate(_ raw: String) -> Bool {
+        searchURL(fromTemplate: raw, query: "cmux search") != nil
+    }
+
+    public func searchURL(fromTemplate rawTemplate: String, query rawQuery: String) -> URL? {
+        let template = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !template.isEmpty, !query.isEmpty else { return nil }
+
+        if template.contains("{query}") || template.contains("%s") {
+            let encodedQuery = percentEncodedSearchQuery(query)
+            let rendered = template
+                .replacingOccurrences(of: "{query}", with: encodedQuery)
+                .replacingOccurrences(of: "%s", with: encodedQuery)
+            guard let url = URL(string: rendered), isAllowedSearchURL(url) else { return nil }
+            return url
+        }
+
+        guard var components = URLComponents(string: template) else { return nil }
+        let encodedQuery = percentEncodedSearchQuery(query)
+        let existingQuery = components.percentEncodedQuery ?? ""
+        components.percentEncodedQuery = existingQuery.isEmpty
+            ? "q=\(encodedQuery)"
+            : "\(existingQuery)&q=\(encodedQuery)"
+        guard let url = components.url, isAllowedSearchURL(url) else { return nil }
+        return url
+    }
+
+    private func percentEncodedSearchQuery(_ query: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return query.addingPercentEncoding(withAllowedCharacters: allowed) ?? query
+    }
+
+    private func isAllowedSearchURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              url.host?.isEmpty == false else {
+            return false
+        }
+        return true
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/BrowserSearchConfiguration.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/BrowserSearchConfiguration.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Resolved browser search settings used by the address bar.
+public struct BrowserSearchConfiguration: Equatable, Sendable {
+    /// The selected search engine.
+    public let engine: BrowserSearchEngine
+
+    /// The stored custom search engine display name.
+    public let customName: String
+
+    /// The stored custom search URL template.
+    public let customURLTemplate: String
+
+    /// Creates a resolved browser search configuration.
+    ///
+    /// - Parameters:
+    ///   - engine: The selected search engine.
+    ///   - customName: The custom search engine display name.
+    ///   - customURLTemplate: The custom search URL template.
+    public init(
+        engine: BrowserSearchEngine,
+        customName: String,
+        customURLTemplate: String
+    ) {
+        self.engine = engine
+        self.customName = customName
+        self.customURLTemplate = customURLTemplate
+    }
+
+    /// Display name to show for the resolved engine.
+    public var displayName: String {
+        guard engine == .custom else { return engine.displayName }
+        return BrowserSearchSettingsStore().normalizedCustomSearchEngineName(customName)
+            ?? engine.displayName
+    }
+
+    /// Built-in engine to query for remote suggestions, if supported.
+    public var remoteSuggestionsEngine: BrowserSearchEngine? {
+        guard engine.supportsRemoteSuggestions else { return nil }
+        return engine
+    }
+
+    /// Renders a search URL for the given query.
+    ///
+    /// - Parameter query: The raw search query.
+    /// - Returns: An allowed `http` or `https` URL, or `nil` when the
+    ///   configured template cannot produce one.
+    public func searchURL(query: String) -> URL? {
+        if engine == .custom {
+            return BrowserSearchSettingsStore().searchURL(fromTemplate: customURLTemplate, query: query)
+        }
+        return engine.searchURL(query: query)
+    }
+}

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Values/BrowserSearchEngine.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Values/BrowserSearchEngine.swift
@@ -1,7 +1,158 @@
 import Foundation
 
 /// Default search engine the cmux browser uses for address-bar queries.
-public enum BrowserSearchEngine: String, CaseIterable, Sendable, SettingCodable {
-    case google, duckduckgo, bing, kagi, startpage, brave, perplexity, exa,
-         yahoo, ecosia, qwant, mojeek, wikipedia, github, baidu, yandex, custom
+public enum BrowserSearchEngine: String, CaseIterable, Identifiable, Sendable, SettingCodable {
+    /// Google Search.
+    case google
+
+    /// DuckDuckGo search.
+    case duckduckgo
+
+    /// Microsoft Bing search.
+    case bing
+
+    /// Kagi search.
+    case kagi
+
+    /// Startpage search.
+    case startpage
+
+    /// Brave Search.
+    case brave
+
+    /// Perplexity search.
+    case perplexity
+
+    /// Exa search.
+    case exa
+
+    /// Yahoo Search.
+    case yahoo
+
+    /// Ecosia search.
+    case ecosia
+
+    /// Qwant search.
+    case qwant
+
+    /// Mojeek search.
+    case mojeek
+
+    /// Wikipedia search.
+    case wikipedia
+
+    /// GitHub search.
+    case github
+
+    /// Baidu search.
+    case baidu
+
+    /// Yandex search.
+    case yandex
+
+    /// User-provided search engine details.
+    case custom
+
+    /// Stable identifier matching the stored raw value.
+    public var id: String { rawValue }
+
+    /// Localized display name shown in browser and settings UI.
+    public var displayName: String {
+        switch self {
+        case .google:
+            return String(localized: "settings.browser.searchEngine.google", defaultValue: "Google")
+        case .duckduckgo:
+            return String(localized: "settings.browser.searchEngine.duckduckgo", defaultValue: "DuckDuckGo")
+        case .bing:
+            return String(localized: "settings.browser.searchEngine.bing", defaultValue: "Bing")
+        case .kagi:
+            return String(localized: "settings.browser.searchEngine.kagi", defaultValue: "Kagi")
+        case .startpage:
+            return String(localized: "settings.browser.searchEngine.startpage", defaultValue: "Startpage")
+        case .brave:
+            return String(localized: "settings.browser.searchEngine.brave", defaultValue: "Brave Search")
+        case .perplexity:
+            return String(localized: "settings.browser.searchEngine.perplexity", defaultValue: "Perplexity")
+        case .exa:
+            return String(localized: "settings.browser.searchEngine.exa", defaultValue: "Exa")
+        case .yahoo:
+            return String(localized: "settings.browser.searchEngine.yahoo", defaultValue: "Yahoo")
+        case .ecosia:
+            return String(localized: "settings.browser.searchEngine.ecosia", defaultValue: "Ecosia")
+        case .qwant:
+            return String(localized: "settings.browser.searchEngine.qwant", defaultValue: "Qwant")
+        case .mojeek:
+            return String(localized: "settings.browser.searchEngine.mojeek", defaultValue: "Mojeek")
+        case .wikipedia:
+            return String(localized: "settings.browser.searchEngine.wikipedia", defaultValue: "Wikipedia")
+        case .github:
+            return String(localized: "settings.browser.searchEngine.github", defaultValue: "GitHub")
+        case .baidu:
+            return String(localized: "settings.browser.searchEngine.baidu", defaultValue: "Baidu")
+        case .yandex:
+            return String(localized: "settings.browser.searchEngine.yandex", defaultValue: "Yandex")
+        case .custom:
+            return String(localized: "settings.browser.searchEngine.custom", defaultValue: "Custom")
+        }
+    }
+
+    /// URL template used to render searches for built-in engines.
+    public var searchURLTemplate: String? {
+        switch self {
+        case .google:
+            return "https://www.google.com/search?q={query}"
+        case .duckduckgo:
+            return "https://duckduckgo.com/?q={query}"
+        case .bing:
+            return "https://www.bing.com/search?q={query}"
+        case .kagi:
+            return "https://kagi.com/search?q={query}"
+        case .startpage:
+            return "https://www.startpage.com/do/dsearch?q={query}"
+        case .brave:
+            return "https://search.brave.com/search?q={query}"
+        case .perplexity:
+            return "https://www.perplexity.ai/search?q={query}"
+        case .exa:
+            return "https://exa.ai/search?q={query}"
+        case .yahoo:
+            return "https://search.yahoo.com/search?p={query}"
+        case .ecosia:
+            return "https://www.ecosia.org/search?q={query}"
+        case .qwant:
+            return "https://www.qwant.com/?q={query}"
+        case .mojeek:
+            return "https://www.mojeek.com/search?q={query}"
+        case .wikipedia:
+            return "https://en.wikipedia.org/w/index.php?search={query}"
+        case .github:
+            return "https://github.com/search?q={query}"
+        case .baidu:
+            return "https://www.baidu.com/s?wd={query}"
+        case .yandex:
+            return "https://yandex.com/search/?text={query}"
+        case .custom:
+            return nil
+        }
+    }
+
+    /// Whether the engine can be queried for remote search suggestions.
+    public var supportsRemoteSuggestions: Bool {
+        switch self {
+        case .google, .duckduckgo, .bing, .kagi, .startpage:
+            return true
+        case .brave, .perplexity, .exa, .yahoo, .ecosia, .qwant, .mojeek, .wikipedia, .github, .baidu, .yandex, .custom:
+            return false
+        }
+    }
+
+    /// Renders a search URL for `query` using the engine's built-in template.
+    ///
+    /// - Parameter query: The raw search query.
+    /// - Returns: An allowed `http` or `https` URL, or `nil` when the engine
+    ///   has no built-in template.
+    public func searchURL(query: String) -> URL? {
+        guard let template = searchURLTemplate else { return nil }
+        return BrowserSearchSettingsStore().searchURL(fromTemplate: template, query: query)
+    }
 }

--- a/Packages/CmuxSettings/Tests/CmuxSettingsTests/BrowserSearchSettingsStoreTests.swift
+++ b/Packages/CmuxSettings/Tests/CmuxSettingsTests/BrowserSearchSettingsStoreTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+@Suite("BrowserSearchSettingsStore")
+struct BrowserSearchSettingsStoreTests {
+    @Test func configurationUsesInjectedDefaultsAndCustomProvider() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(BrowserSearchEngine.custom.rawValue, forKey: BrowserSearchSettingsStore.searchEngineKey)
+        defaults.set("Kagi Fast", forKey: BrowserSearchSettingsStore.customSearchEngineNameKey)
+        defaults.set(
+            "https://kagi.com/search?q={query}",
+            forKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey
+        )
+
+        let configuration = BrowserSearchSettingsStore(defaults: defaults).currentConfiguration
+        let url = try #require(configuration.searchURL(query: "swift actors"))
+
+        #expect(configuration.engine == .custom)
+        #expect(configuration.displayName == "Kagi Fast")
+        #expect(configuration.remoteSuggestionsEngine == nil)
+        #expect(url.host == "kagi.com")
+        #expect(url.absoluteString.contains("q=swift%20actors"))
+    }
+
+    @Test func configurationFactoryFallsBackForInvalidCustomURLTemplate() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = BrowserSearchSettingsStore(defaults: defaults)
+        let configuration = store.configuration(
+            engineRaw: BrowserSearchEngine.custom.rawValue,
+            customName: "",
+            customURLTemplate: "ftp://search.example.test?q={query}"
+        )
+        let url = try #require(configuration.searchURL(query: "swift actors"))
+
+        #expect(configuration.engine == .custom)
+        #expect(configuration.displayName == BrowserSearchEngine.custom.displayName)
+        #expect(configuration.customURLTemplate == BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate)
+        #expect(url.host == "www.google.com")
+        #expect(url.absoluteString.contains("q=swift%20actors"))
+    }
+
+    @Test func validatesAndRendersSearchURLTemplates() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = BrowserSearchSettingsStore(defaults: defaults)
+        let placeholderURL = try #require(store.searchURL(
+            fromTemplate: "https://search.example.test/find?q={query}&src=cmux",
+            query: "hello world"
+        ))
+        let appendedURL = try #require(store.searchURL(
+            fromTemplate: "https://search.example.test/find?source=cmux",
+            query: "c++ && swift"
+        ))
+
+        #expect(placeholderURL.absoluteString.contains("q=hello%20world"))
+        #expect(placeholderURL.absoluteString.contains("src=cmux"))
+        #expect(appendedURL.absoluteString.contains("source=cmux"))
+        #expect(appendedURL.absoluteString.contains("q=c%2B%2B%20%26%26%20swift"))
+        #expect(!appendedURL.absoluteString.contains("q=c++"))
+        #expect(store.isValidSearchURLTemplate("https://search.example.test/find?q={query}"))
+        #expect(!store.isValidSearchURLTemplate("cmux://search?q={query}"))
+        #expect(store.searchURL(fromTemplate: "file:///tmp/search?q={query}", query: "hello world") == nil)
+    }
+
+    @Test func normalizesCustomSearchEngineNames() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = BrowserSearchSettingsStore(defaults: defaults)
+
+        #expect(store.normalizedCustomSearchEngineName("  Kagi Fast\n") == "Kagi Fast")
+        #expect(store.normalizedCustomSearchEngineName(" \n\t ") == nil)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "cmux.browserSearchSettingsStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -823,8 +823,8 @@ enum CommandPaletteSettingsToggleCommands {
                 },
                 sectionTitle: browser,
                 keywords: ["browser.showSearchSuggestions", "browser", "search", "suggestions", "autocomplete", "address", "bar"],
-                defaultValue: BrowserSearchSettings.defaultSearchSuggestionsEnabled,
-                defaultsKey: BrowserSearchSettings.searchSuggestionsEnabledKey
+                defaultValue: BrowserSearchSettingsStore.defaultSearchSuggestionsEnabled,
+                defaultsKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey
             ),
             CommandPaletteSettingToggleDescriptor(
                 commandId: commandIdPrefix + "openTerminalLinksInCmuxBrowser",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -183,10 +183,10 @@ extension CmuxSettingsFileStore {
             ],
             [
                 "browser": [
-                    "defaultSearchEngine": BrowserSearchSettings.defaultSearchEngine.rawValue,
-                    "customSearchEngineName": BrowserSearchSettings.defaultCustomSearchEngineName,
-                    "customSearchEngineURLTemplate": BrowserSearchSettings.defaultCustomSearchEngineURLTemplate,
-                    "showSearchSuggestions": BrowserSearchSettings.defaultSearchSuggestionsEnabled,
+                    "defaultSearchEngine": BrowserSearchSettingsStore.defaultSearchEngine.rawValue,
+                    "customSearchEngineName": BrowserSearchSettingsStore.defaultCustomSearchEngineName,
+                    "customSearchEngineURLTemplate": BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate,
+                    "showSearchSuggestions": BrowserSearchSettingsStore.defaultSearchSuggestionsEnabled,
                     "theme": BrowserThemeSettings.defaultMode.rawValue,
                     "discardHiddenWebViews": BrowserHiddenWebViewDiscardPolicy.defaultEnabled,
                     "hiddenWebViewDiscardDelaySeconds": BrowserHiddenWebViewDiscardPolicy.defaultHiddenDelay,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -986,28 +986,30 @@ final class CmuxSettingsFileStore {
         sourcePath: String,
         snapshot: inout ResolvedSettingsSnapshot
     ) {
+        let browserSearchSettings = BrowserSearchSettingsStore()
+
         if let raw = jsonString(section["defaultSearchEngine"]) {
             guard let engine = BrowserSearchEngine(rawValue: raw) else {
                 logInvalid("browser.defaultSearchEngine", sourcePath: sourcePath)
                 return
             }
-            snapshot.managedUserDefaults[BrowserSearchSettings.searchEngineKey] = .string(engine.rawValue)
+            snapshot.managedUserDefaults[BrowserSearchSettingsStore.searchEngineKey] = .string(engine.rawValue)
         }
         if let raw = jsonString(section["customSearchEngineName"]) {
-            snapshot.managedUserDefaults[BrowserSearchSettings.customSearchEngineNameKey] = .string(
-                BrowserSearchSettings.normalizedCustomSearchEngineName(raw)
-                    ?? BrowserSearchSettings.defaultCustomSearchEngineName
+            snapshot.managedUserDefaults[BrowserSearchSettingsStore.customSearchEngineNameKey] = .string(
+                browserSearchSettings.normalizedCustomSearchEngineName(raw)
+                    ?? BrowserSearchSettingsStore.defaultCustomSearchEngineName
             )
         }
         if let raw = jsonString(section["customSearchEngineURLTemplate"]) {
-            if BrowserSearchSettings.isValidSearchURLTemplate(raw) {
-                snapshot.managedUserDefaults[BrowserSearchSettings.customSearchEngineURLTemplateKey] = .string(raw)
+            if browserSearchSettings.isValidSearchURLTemplate(raw) {
+                snapshot.managedUserDefaults[BrowserSearchSettingsStore.customSearchEngineURLTemplateKey] = .string(raw)
             } else {
                 logInvalid("browser.customSearchEngineURLTemplate", sourcePath: sourcePath)
             }
         }
         if let value = jsonBool(section["showSearchSuggestions"]) {
-            snapshot.managedUserDefaults[BrowserSearchSettings.searchSuggestionsEnabledKey] = .bool(value)
+            snapshot.managedUserDefaults[BrowserSearchSettingsStore.searchSuggestionsEnabledKey] = .bool(value)
         }
         if let raw = jsonString(section["theme"]) {
             guard let mode = BrowserThemeMode(rawValue: raw) else {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CmuxCore
+import CmuxSettings
 import Combine
 import WebKit
 import AppKit
@@ -106,244 +107,6 @@ enum GhosttyBackgroundTheme {
             backgroundColor: GhosttyApp.shared.defaultBackgroundColor,
             opacity: GhosttyApp.shared.defaultBackgroundOpacity
         )
-    }
-}
-
-enum BrowserSearchEngine: String, CaseIterable, Identifiable {
-    case google
-    case duckduckgo
-    case bing
-    case kagi
-    case startpage
-    case brave
-    case perplexity
-    case exa
-    case yahoo
-    case ecosia
-    case qwant
-    case mojeek
-    case wikipedia
-    case github
-    case baidu
-    case yandex
-    case custom
-
-    var id: String { rawValue }
-
-    var displayName: String {
-        switch self {
-        case .google:
-            return String(localized: "settings.browser.searchEngine.google", defaultValue: "Google")
-        case .duckduckgo:
-            return String(localized: "settings.browser.searchEngine.duckduckgo", defaultValue: "DuckDuckGo")
-        case .bing:
-            return String(localized: "settings.browser.searchEngine.bing", defaultValue: "Bing")
-        case .kagi:
-            return String(localized: "settings.browser.searchEngine.kagi", defaultValue: "Kagi")
-        case .startpage:
-            return String(localized: "settings.browser.searchEngine.startpage", defaultValue: "Startpage")
-        case .brave:
-            return String(localized: "settings.browser.searchEngine.brave", defaultValue: "Brave Search")
-        case .perplexity:
-            return String(localized: "settings.browser.searchEngine.perplexity", defaultValue: "Perplexity")
-        case .exa:
-            return String(localized: "settings.browser.searchEngine.exa", defaultValue: "Exa")
-        case .yahoo:
-            return String(localized: "settings.browser.searchEngine.yahoo", defaultValue: "Yahoo")
-        case .ecosia:
-            return String(localized: "settings.browser.searchEngine.ecosia", defaultValue: "Ecosia")
-        case .qwant:
-            return String(localized: "settings.browser.searchEngine.qwant", defaultValue: "Qwant")
-        case .mojeek:
-            return String(localized: "settings.browser.searchEngine.mojeek", defaultValue: "Mojeek")
-        case .wikipedia:
-            return String(localized: "settings.browser.searchEngine.wikipedia", defaultValue: "Wikipedia")
-        case .github:
-            return String(localized: "settings.browser.searchEngine.github", defaultValue: "GitHub")
-        case .baidu:
-            return String(localized: "settings.browser.searchEngine.baidu", defaultValue: "Baidu")
-        case .yandex:
-            return String(localized: "settings.browser.searchEngine.yandex", defaultValue: "Yandex")
-        case .custom:
-            return String(localized: "settings.browser.searchEngine.custom", defaultValue: "Custom")
-        }
-    }
-
-    var searchURLTemplate: String? {
-        switch self {
-        case .google:
-            return "https://www.google.com/search?q={query}"
-        case .duckduckgo:
-            return "https://duckduckgo.com/?q={query}"
-        case .bing:
-            return "https://www.bing.com/search?q={query}"
-        case .kagi:
-            return "https://kagi.com/search?q={query}"
-        case .startpage:
-            return "https://www.startpage.com/do/dsearch?q={query}"
-        case .brave:
-            return "https://search.brave.com/search?q={query}"
-        case .perplexity:
-            return "https://www.perplexity.ai/search?q={query}"
-        case .exa:
-            return "https://exa.ai/search?q={query}"
-        case .yahoo:
-            return "https://search.yahoo.com/search?p={query}"
-        case .ecosia:
-            return "https://www.ecosia.org/search?q={query}"
-        case .qwant:
-            return "https://www.qwant.com/?q={query}"
-        case .mojeek:
-            return "https://www.mojeek.com/search?q={query}"
-        case .wikipedia:
-            return "https://en.wikipedia.org/w/index.php?search={query}"
-        case .github:
-            return "https://github.com/search?q={query}"
-        case .baidu:
-            return "https://www.baidu.com/s?wd={query}"
-        case .yandex:
-            return "https://yandex.com/search/?text={query}"
-        case .custom:
-            return nil
-        }
-    }
-
-    var supportsRemoteSuggestions: Bool {
-        switch self {
-        case .google, .duckduckgo, .bing, .kagi, .startpage:
-            return true
-        case .brave, .perplexity, .exa, .yahoo, .ecosia, .qwant, .mojeek, .wikipedia, .github, .baidu, .yandex, .custom:
-            return false
-        }
-    }
-
-    func searchURL(query: String) -> URL? {
-        guard let template = searchURLTemplate else { return nil }
-        return BrowserSearchSettings.searchURL(fromTemplate: template, query: query)
-    }
-}
-
-struct BrowserSearchConfiguration: Equatable {
-    let engine: BrowserSearchEngine
-    let customName: String
-    let customURLTemplate: String
-
-    var displayName: String {
-        guard engine == .custom else { return engine.displayName }
-        return BrowserSearchSettings.normalizedCustomSearchEngineName(customName)
-            ?? engine.displayName
-    }
-
-    var remoteSuggestionsEngine: BrowserSearchEngine? {
-        guard engine.supportsRemoteSuggestions else { return nil }
-        return engine
-    }
-
-    func searchURL(query: String) -> URL? {
-        if engine == .custom {
-            return BrowserSearchSettings.searchURL(fromTemplate: customURLTemplate, query: query)
-        }
-        return engine.searchURL(query: query)
-    }
-}
-
-enum BrowserSearchSettings {
-    static let searchEngineKey = "browserSearchEngine"
-    static let customSearchEngineNameKey = "browserCustomSearchEngineName"
-    static let customSearchEngineURLTemplateKey = "browserCustomSearchEngineURLTemplate"
-    static let searchSuggestionsEnabledKey = "browserSearchSuggestionsEnabled"
-    static let defaultSearchEngine: BrowserSearchEngine = .google
-    static let defaultCustomSearchEngineName = ""
-    static let defaultCustomSearchEngineURLTemplate = "https://www.google.com/search?q={query}"
-    static let defaultSearchSuggestionsEnabled: Bool = true
-
-    static func currentSearchEngine(defaults: UserDefaults = .standard) -> BrowserSearchEngine {
-        guard let raw = defaults.string(forKey: searchEngineKey),
-              let engine = BrowserSearchEngine(rawValue: raw) else {
-            return defaultSearchEngine
-        }
-        return engine
-    }
-
-    static func currentConfiguration(defaults: UserDefaults = .standard) -> BrowserSearchConfiguration {
-        configuration(
-            engineRaw: defaults.string(forKey: searchEngineKey),
-            customName: defaults.string(forKey: customSearchEngineNameKey),
-            customURLTemplate: defaults.string(forKey: customSearchEngineURLTemplateKey)
-        )
-    }
-
-    static func configuration(
-        engineRaw: String?,
-        customName: String?,
-        customURLTemplate: String?
-    ) -> BrowserSearchConfiguration {
-        let engine = engineRaw.flatMap(BrowserSearchEngine.init(rawValue:)) ?? defaultSearchEngine
-        let resolvedCustomURLTemplate = customURLTemplate
-            .flatMap { isValidSearchURLTemplate($0) ? $0 : nil }
-            ?? defaultCustomSearchEngineURLTemplate
-        return BrowserSearchConfiguration(
-            engine: engine,
-            customName: customName ?? defaultCustomSearchEngineName,
-            customURLTemplate: resolvedCustomURLTemplate
-        )
-    }
-
-    static func normalizedCustomSearchEngineName(_ raw: String) -> String? {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    static func isValidSearchURLTemplate(_ raw: String) -> Bool {
-        searchURL(fromTemplate: raw, query: "cmux search") != nil
-    }
-
-    static func searchURL(fromTemplate rawTemplate: String, query rawQuery: String) -> URL? {
-        let template = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines)
-        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !template.isEmpty, !query.isEmpty else { return nil }
-
-        if template.contains("{query}") || template.contains("%s") {
-            let encodedQuery = percentEncodedSearchQuery(query)
-            let rendered = template
-                .replacingOccurrences(of: "{query}", with: encodedQuery)
-                .replacingOccurrences(of: "%s", with: encodedQuery)
-            guard let url = URL(string: rendered), isAllowedSearchURL(url) else { return nil }
-            return url
-        }
-
-        guard var components = URLComponents(string: template) else { return nil }
-        let encodedQuery = percentEncodedSearchQuery(query)
-        let existingQuery = components.percentEncodedQuery ?? ""
-        components.percentEncodedQuery = existingQuery.isEmpty
-            ? "q=\(encodedQuery)"
-            : "\(existingQuery)&q=\(encodedQuery)"
-        guard let url = components.url, isAllowedSearchURL(url) else { return nil }
-        return url
-    }
-
-    private static func percentEncodedSearchQuery(_ query: String) -> String {
-        var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "-._~")
-        return query.addingPercentEncoding(withAllowedCharacters: allowed) ?? query
-    }
-
-    private static func isAllowedSearchURL(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased(),
-              scheme == "https" || scheme == "http",
-              url.host?.isEmpty == false else {
-            return false
-        }
-        return true
-    }
-
-    static func currentSearchSuggestionsEnabled(defaults: UserDefaults = .standard) -> Bool {
-        // Mirror @AppStorage behavior: bool(forKey:) returns false if key doesn't exist.
-        // Default to enabled unless user explicitly set a value.
-        if defaults.object(forKey: searchSuggestionsEnabledKey) == nil {
-            return defaultSearchSuggestionsEnabled
-        }
-        return defaults.bool(forKey: searchSuggestionsEnabledKey)
     }
 }
 
@@ -4311,10 +4074,10 @@ final class BrowserPanel: Panel, ObservableObject {
     /// a scratch `UserDefaults(suiteName:)` without touching `UserDefaults.standard`.
     static func normalizeBrowserDefaults(defaults: UserDefaults) {
         defaults.register(defaults: [
-            BrowserSearchSettings.searchEngineKey: BrowserSearchSettings.defaultSearchEngine.rawValue,
-            BrowserSearchSettings.customSearchEngineNameKey: BrowserSearchSettings.defaultCustomSearchEngineName,
-            BrowserSearchSettings.customSearchEngineURLTemplateKey: BrowserSearchSettings.defaultCustomSearchEngineURLTemplate,
-            BrowserSearchSettings.searchSuggestionsEnabledKey: BrowserSearchSettings.defaultSearchSuggestionsEnabled,
+            BrowserSearchSettingsStore.searchEngineKey: BrowserSearchSettingsStore.defaultSearchEngine.rawValue,
+            BrowserSearchSettingsStore.customSearchEngineNameKey: BrowserSearchSettingsStore.defaultCustomSearchEngineName,
+            BrowserSearchSettingsStore.customSearchEngineURLTemplateKey: BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate,
+            BrowserSearchSettingsStore.searchSuggestionsEnabledKey: BrowserSearchSettingsStore.defaultSearchSuggestionsEnabled,
             BrowserToolbarAccessorySpacingDebugSettings.key: BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing,
             BrowserProfilePopoverDebugSettings.horizontalPaddingKey: BrowserProfilePopoverDebugSettings.defaultHorizontalPadding,
             BrowserProfilePopoverDebugSettings.verticalPaddingKey: BrowserProfilePopoverDebugSettings.defaultVerticalPadding,
@@ -6209,7 +5972,7 @@ final class BrowserPanel: Panel, ObservableObject {
             return
         }
 
-        let searchConfiguration = BrowserSearchSettings.currentConfiguration()
+        let searchConfiguration = BrowserSearchSettingsStore().currentConfiguration
         guard let searchURL = searchConfiguration.searchURL(query: trimmed) else { return }
         navigate(to: searchURL)
     }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1,5 +1,6 @@
 import Bonsplit
 import CmuxFoundation
+import CmuxSettings
 import SwiftUI
 import WebKit
 import AppKit
@@ -423,10 +424,10 @@ struct BrowserPanelView: View {
     @Environment(\.paneDropZone) private var paneDropZone
     @State private var omnibarState = OmnibarState()
     @State private var addressBarFocused: Bool = false
-    @AppStorage(BrowserSearchSettings.searchEngineKey) private var searchEngineRaw = BrowserSearchSettings.defaultSearchEngine.rawValue
-    @AppStorage(BrowserSearchSettings.customSearchEngineNameKey) private var customSearchEngineName = BrowserSearchSettings.defaultCustomSearchEngineName
-    @AppStorage(BrowserSearchSettings.customSearchEngineURLTemplateKey) private var customSearchEngineURLTemplate = BrowserSearchSettings.defaultCustomSearchEngineURLTemplate
-    @AppStorage(BrowserSearchSettings.searchSuggestionsEnabledKey) private var searchSuggestionsEnabledStorage = BrowserSearchSettings.defaultSearchSuggestionsEnabled
+    @AppStorage(BrowserSearchSettingsStore.searchEngineKey) private var searchEngineRaw = BrowserSearchSettingsStore.defaultSearchEngine.rawValue
+    @AppStorage(BrowserSearchSettingsStore.customSearchEngineNameKey) private var customSearchEngineName = BrowserSearchSettingsStore.defaultCustomSearchEngineName
+    @AppStorage(BrowserSearchSettingsStore.customSearchEngineURLTemplateKey) private var customSearchEngineURLTemplate = BrowserSearchSettingsStore.defaultCustomSearchEngineURLTemplate
+    @AppStorage(BrowserSearchSettingsStore.searchSuggestionsEnabledKey) private var searchSuggestionsEnabledStorage = BrowserSearchSettingsStore.defaultSearchSuggestionsEnabled
     @AppStorage(BrowserDevToolsButtonDebugSettings.iconNameKey) private var devToolsIconNameRaw = BrowserDevToolsButtonDebugSettings.defaultIcon.rawValue
     @AppStorage(BrowserDevToolsButtonDebugSettings.iconColorKey) private var devToolsIconColorRaw = BrowserDevToolsButtonDebugSettings.defaultColor.rawValue
     @AppStorage(BrowserToolbarAccessorySpacingDebugSettings.key) private var browserToolbarAccessorySpacingRaw = BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
@@ -521,7 +522,7 @@ struct BrowserPanelView: View {
     }
 
     private var searchConfiguration: BrowserSearchConfiguration {
-        BrowserSearchSettings.configuration(
+        BrowserSearchSettingsStore().configuration(
             engineRaw: searchEngineRaw,
             customName: customSearchEngineName,
             customURLTemplate: customSearchEngineURLTemplate
@@ -531,7 +532,7 @@ struct BrowserPanelView: View {
     private var searchSuggestionsEnabled: Bool {
         // Touch @AppStorage so SwiftUI invalidates this view when settings change.
         _ = searchSuggestionsEnabledStorage
-        return BrowserSearchSettings.currentSearchSuggestionsEnabled(defaults: .standard)
+        return BrowserSearchSettingsStore(defaults: .standard).currentSearchSuggestionsEnabled
     }
 
     private var remoteSuggestionsEnabled: Bool {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6163,7 +6163,7 @@ class TerminalController {
                 // diff-viewer-registration paths act on the original URL; only scheme-less,
                 // non-navigable input should fall through to a search query.
                 url = parsed
-            } else if let search = BrowserSearchSettings.currentConfiguration().searchURL(query: urlStr) {
+            } else if let search = BrowserSearchSettingsStore().currentConfiguration.searchURL(query: urlStr) {
                 url = search
             } else {
                 return .err(

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -15,16 +15,15 @@ import CmuxSidebar
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
-// The app target still declares legacy duplicates of these CmuxSettings
-// value types; with CmuxSettings imported unconditionally the names are
-// ambiguous. These tests exercise the app-side BrowserThemeSettings /
-// BrowserSearchSettings paths, so pin the app types.
+// The app target still declares a legacy duplicate of BrowserThemeMode; with
+// CmuxSettings imported unconditionally the name is ambiguous. Pin the app
+// type for theme tests and the package type for browser search settings.
 private typealias BrowserThemeMode = cmux_DEV.BrowserThemeMode
-private typealias BrowserSearchEngine = cmux_DEV.BrowserSearchEngine
+private typealias BrowserSearchEngine = CmuxSettings.BrowserSearchEngine
 #elseif canImport(cmux)
 @testable import cmux
 private typealias BrowserThemeMode = cmux.BrowserThemeMode
-private typealias BrowserSearchEngine = cmux.BrowserSearchEngine
+private typealias BrowserSearchEngine = CmuxSettings.BrowserSearchEngine
 #endif
 
 var cmuxUnitTestInspectorAssociationKey: UInt8 = 0
@@ -4922,7 +4921,8 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCustomSearchURLTemplateReplacesQueryPlaceholder() throws {
-        let url = try XCTUnwrap(BrowserSearchSettings.searchURL(
+        let store = BrowserSearchSettingsStore()
+        let url = try XCTUnwrap(store.searchURL(
             fromTemplate: "https://search.example.test/find?q={query}&src=cmux",
             query: "hello world"
         ))
@@ -4933,7 +4933,8 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCustomSearchURLTemplateReplacesPercentPlaceholder() throws {
-        let url = try XCTUnwrap(BrowserSearchSettings.searchURL(
+        let store = BrowserSearchSettingsStore()
+        let url = try XCTUnwrap(store.searchURL(
             fromTemplate: "https://search.example.test/find?term=%s",
             query: "c++ && swift"
         ))
@@ -4943,7 +4944,8 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCustomSearchURLTemplateAppendsQueryItemWhenPlaceholderIsMissing() throws {
-        let url = try XCTUnwrap(BrowserSearchSettings.searchURL(
+        let store = BrowserSearchSettingsStore()
+        let url = try XCTUnwrap(store.searchURL(
             fromTemplate: "https://search.example.test/find?source=cmux",
             query: "hello world"
         ))
@@ -4954,7 +4956,8 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCustomSearchURLTemplateFallbackEscapesPlusSigns() throws {
-        let url = try XCTUnwrap(BrowserSearchSettings.searchURL(
+        let store = BrowserSearchSettingsStore()
+        let url = try XCTUnwrap(store.searchURL(
             fromTemplate: "https://search.example.test/find?source=cmux",
             query: "c++ && swift"
         ))
@@ -4966,11 +4969,12 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCustomSearchURLTemplateRejectsNonHTTPURLs() {
-        XCTAssertNil(BrowserSearchSettings.searchURL(
+        let store = BrowserSearchSettingsStore()
+        XCTAssertNil(store.searchURL(
             fromTemplate: "file:///tmp/search?q={query}",
             query: "hello world"
         ))
-        XCTAssertFalse(BrowserSearchSettings.isValidSearchURLTemplate("cmux://search?q={query}"))
+        XCTAssertFalse(store.isValidSearchURLTemplate("cmux://search?q={query}"))
     }
 
     func testCurrentSearchConfigurationUsesCustomProvider() throws {
@@ -4983,11 +4987,11 @@ final class BrowserSearchEngineTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        defaults.set(BrowserSearchEngine.custom.rawValue, forKey: BrowserSearchSettings.searchEngineKey)
-        defaults.set("Kagi Fast", forKey: BrowserSearchSettings.customSearchEngineNameKey)
-        defaults.set("https://kagi.com/search?q={query}", forKey: BrowserSearchSettings.customSearchEngineURLTemplateKey)
+        defaults.set(BrowserSearchEngine.custom.rawValue, forKey: BrowserSearchSettingsStore.searchEngineKey)
+        defaults.set("Kagi Fast", forKey: BrowserSearchSettingsStore.customSearchEngineNameKey)
+        defaults.set("https://kagi.com/search?q={query}", forKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey)
 
-        let configuration = BrowserSearchSettings.currentConfiguration(defaults: defaults)
+        let configuration = BrowserSearchSettingsStore(defaults: defaults).currentConfiguration
         let url = try XCTUnwrap(configuration.searchURL(query: "swift actors"))
 
         XCTAssertEqual(configuration.displayName, "Kagi Fast")
@@ -4997,7 +5001,7 @@ final class BrowserSearchEngineTests: XCTestCase {
     }
 
     func testCurrentSearchConfigurationFallsBackForInvalidCustomURLTemplate() throws {
-        let configuration = BrowserSearchSettings.configuration(
+        let configuration = BrowserSearchSettingsStore().configuration(
             engineRaw: BrowserSearchEngine.custom.rawValue,
             customName: "",
             customURLTemplate: "ftp://search.example.test?q={query}"
@@ -5033,8 +5037,8 @@ final class BrowserSearchSettingsTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        defaults.removeObject(forKey: BrowserSearchSettings.searchSuggestionsEnabledKey)
-        XCTAssertTrue(BrowserSearchSettings.currentSearchSuggestionsEnabled(defaults: defaults))
+        defaults.removeObject(forKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey)
+        XCTAssertTrue(BrowserSearchSettingsStore(defaults: defaults).currentSearchSuggestionsEnabled)
     }
 
     func testCurrentSearchSuggestionsEnabledHonorsExplicitValue() {
@@ -5047,11 +5051,11 @@ final class BrowserSearchSettingsTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        defaults.set(false, forKey: BrowserSearchSettings.searchSuggestionsEnabledKey)
-        XCTAssertFalse(BrowserSearchSettings.currentSearchSuggestionsEnabled(defaults: defaults))
+        defaults.set(false, forKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey)
+        XCTAssertFalse(BrowserSearchSettingsStore(defaults: defaults).currentSearchSuggestionsEnabled)
 
-        defaults.set(true, forKey: BrowserSearchSettings.searchSuggestionsEnabledKey)
-        XCTAssertTrue(BrowserSearchSettings.currentSearchSuggestionsEnabled(defaults: defaults))
+        defaults.set(true, forKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey)
+        XCTAssertTrue(BrowserSearchSettingsStore(defaults: defaults).currentSearchSuggestionsEnabled)
     }
 }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2304,7 +2304,7 @@ final class BrowserDefaultsNormalizationTests: XCTestCase {
         XCTAssertEqual(defaults.double(forKey: BrowserProfilePopoverDebugSettings.verticalPaddingKey), BrowserProfilePopoverDebugSettings.defaultVerticalPadding, accuracy: 0.0001)
 
         // Registered fallbacks are available for keys that were never set.
-        XCTAssertEqual(defaults.string(forKey: BrowserSearchSettings.searchEngineKey), BrowserSearchSettings.defaultSearchEngine.rawValue)
+        XCTAssertEqual(defaults.string(forKey: BrowserSearchSettingsStore.searchEngineKey), BrowserSearchSettingsStore.defaultSearchEngine.rawValue)
     }
 
     /// Already-canonical, in-range values must be left untouched (no clobbering of

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -1201,15 +1201,15 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
     func testSettingsFileStoreAppliesCustomBrowserSearchEngine() throws {
         let defaults = UserDefaults.standard
         try preservingDefaults(keys: [
-            BrowserSearchSettings.searchEngineKey,
-            BrowserSearchSettings.customSearchEngineNameKey,
-            BrowserSearchSettings.customSearchEngineURLTemplateKey,
+            BrowserSearchSettingsStore.searchEngineKey,
+            BrowserSearchSettingsStore.customSearchEngineNameKey,
+            BrowserSearchSettingsStore.customSearchEngineURLTemplateKey,
             settingsFileBackupsDefaultsKey,
             importedManagedDefaultsKey,
         ]) {
-            defaults.removeObject(forKey: BrowserSearchSettings.searchEngineKey)
-            defaults.removeObject(forKey: BrowserSearchSettings.customSearchEngineNameKey)
-            defaults.removeObject(forKey: BrowserSearchSettings.customSearchEngineURLTemplateKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.searchEngineKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.customSearchEngineNameKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey)
             defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
             defaults.removeObject(forKey: importedManagedDefaultsKey)
 
@@ -1237,7 +1237,7 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 startWatching: false
             )
 
-            let configuration = BrowserSearchSettings.currentConfiguration(defaults: defaults)
+            let configuration = BrowserSearchSettingsStore(defaults: defaults).currentConfiguration
             let url = try XCTUnwrap(configuration.searchURL(query: "browser settings"))
 
             XCTAssertEqual(configuration.engine, .custom)
@@ -1250,18 +1250,18 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
     func testSettingsFileStoreAppliesBlankCustomBrowserSearchNameAndIgnoresInvalidCustomURLWithoutAbortingBrowserSection() throws {
         let defaults = UserDefaults.standard
         try preservingDefaults(keys: [
-            BrowserSearchSettings.searchEngineKey,
-            BrowserSearchSettings.customSearchEngineNameKey,
-            BrowserSearchSettings.customSearchEngineURLTemplateKey,
-            BrowserSearchSettings.searchSuggestionsEnabledKey,
+            BrowserSearchSettingsStore.searchEngineKey,
+            BrowserSearchSettingsStore.customSearchEngineNameKey,
+            BrowserSearchSettingsStore.customSearchEngineURLTemplateKey,
+            BrowserSearchSettingsStore.searchSuggestionsEnabledKey,
             BrowserThemeSettings.modeKey,
             settingsFileBackupsDefaultsKey,
             importedManagedDefaultsKey,
         ]) {
-            defaults.removeObject(forKey: BrowserSearchSettings.searchEngineKey)
-            defaults.removeObject(forKey: BrowserSearchSettings.customSearchEngineNameKey)
-            defaults.removeObject(forKey: BrowserSearchSettings.customSearchEngineURLTemplateKey)
-            defaults.removeObject(forKey: BrowserSearchSettings.searchSuggestionsEnabledKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.searchEngineKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.customSearchEngineNameKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey)
+            defaults.removeObject(forKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey)
             defaults.removeObject(forKey: BrowserThemeSettings.modeKey)
             defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
             defaults.removeObject(forKey: importedManagedDefaultsKey)
@@ -1292,16 +1292,16 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 startWatching: false
             )
 
-            XCTAssertEqual(defaults.string(forKey: BrowserSearchSettings.searchEngineKey), BrowserSearchEngine.google.rawValue)
+            XCTAssertEqual(defaults.string(forKey: BrowserSearchSettingsStore.searchEngineKey), BrowserSearchEngine.google.rawValue)
             XCTAssertEqual(
-                defaults.string(forKey: BrowserSearchSettings.customSearchEngineNameKey),
-                BrowserSearchSettings.defaultCustomSearchEngineName
+                defaults.string(forKey: BrowserSearchSettingsStore.customSearchEngineNameKey),
+                BrowserSearchSettingsStore.defaultCustomSearchEngineName
             )
             XCTAssertNotEqual(
-                defaults.string(forKey: BrowserSearchSettings.customSearchEngineURLTemplateKey),
+                defaults.string(forKey: BrowserSearchSettingsStore.customSearchEngineURLTemplateKey),
                 "ftp://search.example.test?q={query}"
             )
-            XCTAssertEqual(defaults.object(forKey: BrowserSearchSettings.searchSuggestionsEnabledKey) as? Bool, false)
+            XCTAssertEqual(defaults.object(forKey: BrowserSearchSettingsStore.searchSuggestionsEnabledKey) as? Bool, false)
             XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeMode.dark.rawValue)
         }
     }

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -6,6 +6,8 @@ import AppKit
 import struct CmuxSettings.AppCatalogSection
 import struct CmuxSettings.QuitConfirmationStore
 import enum CmuxSettings.ConfirmQuitMode
+import enum CmuxSettings.BrowserSearchEngine
+import struct CmuxSettings.BrowserSearchSettingsStore
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV


### PR DESCRIPTION
## Summary

Extracts the browser-search settings domain from `Sources/Panels/BrowserPanel.swift` into `Packages/CmuxSettings` using the Wave-2 settings-store shape:

- `BrowserSearchEngine` now lives in `CmuxSettings` with the same cases, display names, built-in templates, remote-suggestion support, and search URL rendering behavior.
- `BrowserSearchConfiguration` now lives in `CmuxSettings` as its own value type.
- Replaces the app-target caseless namespace enum with `BrowserSearchSettingsReading` and `BrowserSearchSettingsStore`, with constructor-injected `UserDefaults` and instance methods for reads, configuration construction, URL-template validation/rendering, and custom-name normalization.
- Updates app and test call sites to use `BrowserSearchSettingsStore` constants or constructed stores.
- Adds package-level Swift Testing coverage for configuration factory output, URL-template validation/rendering, and custom-engine normalization with injected in-memory `UserDefaults` suites.

## Defaults / wire format

Defaults key strings are preserved byte-identically:

- `browserSearchEngine`
- `browserCustomSearchEngineName`
- `browserCustomSearchEngineURLTemplate`
- `browserSearchSuggestionsEnabled`

Legacy default values are preserved in `BrowserSearchSettingsStore`:

- default engine: `google`
- default custom name: empty string
- default custom URL template: `https://www.google.com/search?q={query}`
- default search suggestions enabled: `true`

## Destination decision

Destination is `CmuxSettings` because this code owns settings keys/defaults, defaults-backed reads, and settings-file validation behavior. That matches the prior Wave-2 settings cutover. If owners prefer a future browser-domain package for runtime-only search behavior, this PR keeps the settings storage seam isolated enough to split later without changing the persisted wire format.

## BrowserPanel.swift reduction

`BrowserPanel.swift` budget was ratcheted from 13,595 to 13,358 lines: net -237 lines. The commit diff for that file is 6 additions and 243 deletions.

## Validation

- `scripts/lint-ios-package-conventions.sh` -> OK, no new `lint:allow` suppressions.
- `swift build` in `Packages/CmuxSettings` -> passed.
- `swift test` in `Packages/CmuxSettings` -> passed, 133 tests total including 4 new `BrowserSearchSettingsStore` tests.
- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-browsersearch build` -> `** BUILD SUCCEEDED **`.
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-browsersearch-unit build` -> `** BUILD SUCCEEDED **`.
- `python3 scripts/swift_file_length_budget.py` -> budget respected.
- Localization audit: moved search-engine display strings reuse the existing 17 `settings.browser.searchEngine.*` keys; verified each has `en` and `ja` entries in `Resources/Localizable.xcstrings`.

Do not merge; leaving this for owner review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784079864&installation_id=133855650&pr_number=6143&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6143&signature=1075009895cabc09c01fe7b43b368b55938da1afdcec358c2a2e4d340fa1e644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted browser-search settings into `CmuxSettings` with a Wave-2 store and protocol, preserving behavior, keys, and defaults. This isolates persistence and URL rendering, reduces `BrowserPanel.swift` by 237 lines, and improves testability.

- **Refactors**
  - Moved `BrowserSearchEngine` and `BrowserSearchConfiguration` to `CmuxSettings`; same cases, display names, templates, suggestion support, and URL rendering; `BrowserSearchEngine` is now `Identifiable`.
  - Added `BrowserSearchSettingsReading` and `BrowserSearchSettingsStore` (injected `UserDefaults`) with current engine/config/suggestions and helpers for config factory, template validation/rendering, and custom-name normalization.
  - Updated app/tests to use `BrowserSearchSettingsStore` constants/APIs across `BrowserPanel`, `BrowserPanelView`, `TerminalController`, command-palette toggles, settings-file import, and catalog defaults.
  - Fixed test imports by pinning `BrowserSearchEngine` to `CmuxSettings`; added Swift tests in `CmuxSettings` for config factory, template validation/rendering, and normalization.

- **Migration**
  - No changes required; existing preferences continue to work.
  - For new code, import `CmuxSettings`, depend on `BrowserSearchSettingsReading`, and replace `BrowserSearchSettings.*` calls with `BrowserSearchSettingsStore`.

<sup>Written for commit a4970eba063ab51725a9b59d92966ee0add59c9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized browser search settings handling, ensuring consistent defaults, custom search engine naming, and custom URL-template behavior across the app.
  * Browser smart navigation and URL/search fallbacks now use the same resolved search configuration.
  * Updated command palette and keyboard shortcut settings templates to use the unified search-suggestions default.
* **Bug Fixes**
  * Improved validation for custom search URL templates (scheme/host checks) and correct query encoding/substitution.
* **Tests**
  * Expanded/updated coverage for settings resolution, template validation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->