### PR TITLE
Remove split diff right gutter

### DIFF
--- a/Resources/markdown-viewer/webviews-app/chunks/diffSurface.mjs
+++ b/Resources/markdown-viewer/webviews-app/chunks/diffSurface.mjs
@@ -101,6 +101,9 @@ ${o}
     [data-expand-button] {
       font-family: var(--diffs-header-font-family, var(--diffs-header-font-fallback));
     }
+    [data-code] {
+      scrollbar-gutter: auto;
+    }
   `}function Fi(){return`
     :host {
       display: block;

--- a/webviews/src/pierre-options.ts
+++ b/webviews/src/pierre-options.ts
@@ -142,6 +142,9 @@ export function codeViewUnsafeCSS(): string {
     [data-expand-button] {
       font-family: var(--diffs-header-font-family, var(--diffs-header-font-fallback));
     }
+    [data-code] {
+      scrollbar-gutter: auto;
+    }
   `;
 }
 

--- a/webviews/test/pierre-options.test.ts
+++ b/webviews/test/pierre-options.test.ts
@@ -26,6 +26,8 @@ test("code view CSS gives Pierre diff body surfaces the editor background", () =
   expect(css).toContain("[data-line-type='change-deletion']:where([data-column-number], [data-gutter-buffer])");
   expect(css).toContain("[data-gutter-buffer='buffer']");
   expect(css).toContain("background-image: repeating-linear-gradient(");
+  expect(css).toContain("[data-code] {");
+  expect(css).toContain("scrollbar-gutter: auto");
   expect(css).not.toContain("[data-line-type='change-addition'] {");
   expect(css).not.toContain("[data-line-type='change-deletion'] {");
 });


### PR DESCRIPTION
Changed:\n- Override Pierre code columns to use `scrollbar-gutter: auto` inside the cmux diff viewer.\n- Rebuilt the bundled webview chunk.\n- Added a focused CSS regression assertion.\n\nChecks:\n- `bun test test/pierre-options.test.ts`\n- `bun run typecheck`\n- `./scripts/build-webviews-app.sh`\n- `./scripts/reload-cloud.sh --tag dgut`\n- agent-browser fixture verified split code columns compute `scrollbar-gutter: auto` and screenshot rendered.\n- Tagged app preflight opened `cmux diff --layout split` and verified two rendered code columns compute `scrollbar-gutter: auto`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784107405&installation_id=133855650&pr_number=6153&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6153&signature=4d18c9c7b501fdc26f974ef4e69daae9c808ad453c52b0aa33cceb9cd6588320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8557be7eed44bf296c6e5330874ac428a4114ead. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the extra right-side gutter in the split diff layout by setting `scrollbar-gutter: auto` on code columns. Aligns both panes and removes wasted space during scroll.

- **Bug Fixes**
  - Apply `[data-code] { scrollbar-gutter: auto }` in the diff viewer CSS and rebuild the webview bundle.
  - Add a focused CSS regression test to assert the rule is present.

<sup>Written for commit 8557be7eed44bf296c6e5330874ac428a4114ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced scrollbar handling in code viewing areas by implementing automatic scrollbar gutter spacing, improving overall layout stability and visual consistency when scrollbars appear or disappear.

* **Tests**
  * Extended test suite to verify that code view styling correctly includes and properly configures scrollbar gutter spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->