### PR TITLE
iOS changelog + auto TestFlight "What to Test" notes

### DIFF
--- a/docs/ios-release-notes.md
+++ b/docs/ios-release-notes.md
@@ -1,0 +1,89 @@
+# iOS release notes & "What's New"
+
+How cmux tells iOS TestFlight testers what changed in a build, so an install or
+auto-update is never an opaque timestamp.
+
+## The problem
+
+TestFlight shows a build as `MARKETING_VERSION (CURRENT_PROJECT_VERSION)`, e.g.
+`1.0.3 (20260613120501)`. The marketing version is human (`X.Y.Z`); the number in
+parens is a 14-digit UTC build timestamp, unique and monotonic but unreadable.
+With no "What to Test" text, a tester who installs or auto-updates sees only that
+timestamp and has no idea what changed. That is the confusion this fixes.
+
+## Source of truth
+
+`ios/CHANGELOG.md`. Newest version on top. Each entry carries two blocks:
+
+- **Internal**: terse, dev-facing, per-build. What changed in THIS build, including
+  rough edges and a dogfood-focus line. Pushed on `ship ios` (internal beta).
+- **External**: a curated, user-facing summary since the founder's last build. No
+  jargon, no PR numbers, no "should fix". Pushed on `ship ios founders`.
+
+Every cut updates this file first (top entry = the build being uploaded).
+
+## Channel 1 — TestFlight "What to Test" (shipped)
+
+After a successful upload, `ios/scripts/upload-testflight.sh` reads the top
+`ios/CHANGELOG.md` entry and sets the build's `betaBuildLocalizations.whatsNew`
+(en-US) via the App Store Connect API. Internal cut uses the Internal block;
+`--external` uses the External block.
+
+Mechanism:
+
+1. `set-testflight-notes.sh` extracts the chosen block's bullets from the top
+   entry (awk, stops at the second version heading).
+2. `asc_set_testflight_notes.py` mints an ES256 JWT from the ASC API key
+   (`ios/Config/AppStoreConnect.local.plist`, key id `4WN4S8ANN4`), resolves the
+   app by bundle id, finds the build by CFBundleVersion, then creates or PATCHes
+   the en-US `betaBuildLocalizations` with the notes.
+3. A just-uploaded build is not addressable until App Store Connect ingests it, so
+   the build lookup polls (default 900s, 20s interval). It is non-fatal: the binary
+   is already uploaded, and notes can be re-applied later with
+   `set-testflight-notes.sh --build-number <n> --audience internal|external`.
+
+This is the per-build text testers see in TestFlight on install and auto-update.
+
+## Channel 2 — in-app "What's New" sheet (PHASE 2, not built)
+
+External/founders testers should also see a "What's New" sheet on first launch
+after an update, so the summary reaches them inside the app, not only in
+TestFlight (which many testers never read).
+
+Spec for phase 2:
+
+- **Trigger**: on launch, compare the running `CFBundleShortVersionString`
+  (MARKETING_VERSION) against the last version the user has seen, persisted in
+  `UserDefaults` (e.g. `cmux.whatsNew.lastSeenVersion`). If the running version is
+  newer, present the sheet once, then write the running version back. First-ever
+  install does NOT show it (seed lastSeenVersion at install so onboarding owns the
+  first run).
+- **Content source**: the External block of the matching `ios/CHANGELOG.md` entry,
+  bundled into the app at build time as a small JSON/plist (a build step parses
+  the changelog so the app has no markdown parser). Key by marketing version. If
+  there is no entry for the running version, do not show the sheet.
+- **UI**: a SwiftUI sheet, title `What's new in <version>`, the External bullets as
+  a simple list, one "Got it" dismiss. No network. Localized via
+  `Resources/Localizable.xcstrings` (en + ja), matching the repo's localization
+  rule. A "What's New" entry in Settings re-opens the latest sheet on demand.
+- **Versioning shown**: the sheet shows the marketing version only (`1.0.3`), never
+  the build timestamp.
+- **Scope**: this is iOS app runtime code, so it requires a tagged dogfood build
+  (macOS + simulator + best-effort iPhone) and explicit dogfood approval before
+  merge. It is intentionally deferred out of the changelog/scripts PR so that PR
+  stays script + docs + skill only and can merge after CI without dogfood.
+
+Follow-up issue should track: the build-time changelog→bundle parse step, the
+UserDefaults gate behind a small tested helper (no raw `useEffect`-style launch
+side effects scattered in views), the SwiftUI sheet, the Settings re-open entry,
+and the localization audit.
+
+## How to cut a release with notes (summary)
+
+1. Edit `ios/CHANGELOG.md`: add the new version as the top entry with an Internal
+   and an External block. Never cut a beta without this.
+2. `ship ios` (internal) or `ship ios founders` (external). The upload sets the
+   matching "What to Test" block automatically.
+3. If the notes step warns (build still processing), re-run
+   `ios/scripts/set-testflight-notes.sh --build-number <shipped> --audience <a>`
+   once it finishes.

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -1,0 +1,85 @@
+# cmux iOS changelog
+
+Single source of truth for what each cmux iOS TestFlight build changed. Every
+beta cut updates this file FIRST (top entry = the build you are about to upload),
+and the upload pushes the top entry's notes to TestFlight "What to Test" so the
+build is no longer an opaque timestamp on install or auto-update.
+
+## How testers see a build
+
+TestFlight shows each build as `MARKETING_VERSION (CURRENT_PROJECT_VERSION)`, for
+example `1.0.3 (20260613120501)`. `MARKETING_VERSION` is the human version
+(`ios/Config/Shared.xcconfig`, semver `X.Y.Z`); the number in parens is the build
+id, a 14-digit UTC timestamp stamped at upload time (unique and monotonic, but not
+meant to be read). Testers should track the marketing version; the timestamp only
+distinguishes rapid internal iterations of the same version.
+
+Two audiences, two notes per entry:
+
+- **Internal** (`ship ios`, the `cmux beta` group): terse, dev-facing, per-build.
+  Lists what changed in THIS build, including rough edges, so internal dogfood
+  knows what to hit. Pushed to "What to Test" on every internal cut.
+- **External / founders** (`ship ios founders`): a curated, user-facing summary of
+  what is new since the founder's last build. No internal jargon, no "should fix",
+  no PR numbers. Pushed to "What to Test" on external cuts.
+
+The upload script (`ios/scripts/upload-testflight.sh`) reads the matching block
+from the top entry and sets the build's `betaBuildLocalizations` whatsNew (en-US)
+via the App Store Connect API after the upload processes. Internal cut uses the
+Internal block; `--external` uses the External block.
+
+Phase 2 (not built yet): external/founders builds also get an in-app "What's New"
+sheet on first launch after an update, sourced from the External block. Spec in
+`docs/ios-release-notes.md`.
+
+Keep entries short. No fluff, no AI rhetorical patterns, no em dashes (repo rule).
+Newest version on top.
+
+The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
+`ios/Config/Shared.xcconfig`. `upload-testflight.sh` enforces this before upload
+(it refuses to attach notes for a different version), so bump the version with
+`ios/scripts/bump-ios-version.sh` in the SAME change that adds the top entry.
+
+---
+
+## [1.0.3] - 2026-06-13
+
+### Internal
+
+- Composer: iMessage-style terminal composer, open by default, inline send, drafts saved per terminal (#5876).
+- View as Text sheet for copy-pasting raw terminal output (#5875).
+- Pairing QR is now minimal and full-width (routes-only payload, Copy IP/Port, no expiry); scans faster (#5872, #5727).
+- Notifications forward to the phone only while you are away from the Mac (#5912); push tap deep-links to the right workspace once it can be navigated to (#5927); cross-device dismiss-sync with an authoritative unread badge (#5916).
+- Sign-out is local-first and works offline; revocation is best-effort and bounded (#5776).
+- Workspace list: groups, unread dots, last-activity previews, shared Unread filter (#5726).
+- Watchdog fix: render-grid liveness probes before teardown, fixing a false-fire replay loop (#5869).
+- Dogfood focus: hit the composer (send + drafts), View as Text, pair a Mac via the new QR, lock the phone and confirm a forwarded notification taps through to the right workspace, sign out with airplane mode on.
+
+### External
+
+- New terminal composer: type and send like a message, with drafts saved per terminal.
+- View as Text: copy raw terminal output from a clean sheet.
+- Faster, simpler Mac pairing QR, with Copy IP/Port if scanning is awkward.
+- Smarter notifications: your phone only buzzes when you are away from your Mac, tapping a notification opens the right workspace, and unread state stays in sync across devices.
+- Sign-out now works offline.
+- Polished workspace list with groups, unread dots, and recent-activity previews.
+
+## [1.0.2] - 2026-06-10
+
+### Internal
+
+- Mobile terminal foundation: faithful render-grid replay over the cmux SPM core (#5079).
+- Multi-Mac host switcher with a hierarchical device tree; workspaces from all Mac windows; rename and pin from the phone (#5513, #5648, #5565, #5512).
+- Customizable terminal toolbar: data-driven custom actions, reorderable built-ins, redesigned default layout (#5510, #5532, #5579).
+- Paste images from the phone clipboard into the terminal (#5546).
+- First-run onboarding, Tailscale-off detection, actionable pairing failures, cancellable sign-in, pull-to-refresh on the workspace list (#5655, #5714, #5722, #5713, #5728, #5654).
+- Pairing window shows a connected state when the phone attaches; QR slimmed v1 (#5542, #5727).
+- Early browser panes (WKWebView) and a Send Feedback flow (#5652, #5653).
+
+### External
+
+- Mobile terminal: drive your Mac's cmux terminals from your phone.
+- Switch between multiple Macs, see workspaces from every window, and rename or pin from the phone.
+- Customizable terminal toolbar with your own actions.
+- Paste images straight from the phone clipboard.
+- Smoother first run: onboarding, clearer pairing errors, and pull-to-refresh.

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -13,7 +13,7 @@ PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
 // release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
 // tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
 // (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
-MARKETING_VERSION = 1.0.0
+MARKETING_VERSION = 1.0.3
 CURRENT_PROJECT_VERSION = 1
 
 // Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood

--- a/ios/scripts/asc_set_testflight_notes.py
+++ b/ios/scripts/asc_set_testflight_notes.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Set a TestFlight build's "What to Test" notes via the App Store Connect API.
+
+Testers see this text in TestFlight on install and on auto-update. Without it a
+build is an opaque `MARKETING_VERSION (timestamp)` with no explanation of what
+changed; this script fills that in from ios/CHANGELOG.md (see set-testflight-notes.sh).
+
+It resolves the app from its bundle id, finds the build by CFBundleVersion
+(the 14-digit upload timestamp), then creates or updates the build's en-US
+`betaBuildLocalizations.whatsNew`. A just-uploaded build is not addressable until
+App Store Connect finishes ingesting it, so the build lookup polls/retries.
+
+Dependency-free on purpose (same constraint as asc_max_build.py): the only third
+party is `openssl` (preinstalled on macOS), invoked via subprocess for the ES256
+JWT signature. The TestFlight credential must not pull unverified pip packages.
+
+Auth comes from the environment (the same vars the upload script already sets):
+  ASC_API_KEY_ID, ASC_API_ISSUER_ID, and either ASC_API_KEY_PATH (a .p8 file) or
+  ASC_API_KEY_P8_BASE64 (the base64-encoded .p8 contents).
+
+Usage:
+  asc_set_testflight_notes.py --bundle-id dev.cmux.app.beta \
+      --build-number 20260613120501 --notes-file /tmp/notes.txt \
+      [--locale en-US] [--timeout-seconds 900] [--poll-seconds 20]
+
+Exit codes:
+  0  notes set (created or updated).
+  3  build not found within the timeout (App Store Connect still processing).
+  1  any other error (auth, network, API shape).
+
+The caller decides how fatal a non-zero exit is. The upload script treats a
+failure here as a WARNING, not an upload failure: the binary is already on
+TestFlight and the notes can be re-applied later with set-testflight-notes.sh.
+"""
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+
+# App Store Connect caps What to Test at 4000 characters. Truncate defensively so
+# a long changelog block never makes the PATCH/POST fail with a validation error.
+MAX_WHATS_NEW = 4000
+
+
+def _b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=")
+
+
+def _der_ecdsa_to_raw(der):
+    """Convert a DER-encoded ECDSA signature (openssl) to JOSE raw r||s (64 bytes)."""
+    if not der or der[0] != 0x30:
+        raise RuntimeError("malformed ECDSA signature from openssl")
+    idx = 2
+    if der[1] & 0x80:
+        idx = 2 + (der[1] & 0x7F)
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (r)")
+    rlen = der[idx + 1]
+    idx += 2
+    r = int.from_bytes(der[idx:idx + rlen], "big")
+    idx += rlen
+    if der[idx] != 0x02:
+        raise RuntimeError("malformed ECDSA signature (s)")
+    slen = der[idx + 1]
+    idx += 2
+    s = int.from_bytes(der[idx:idx + slen], "big")
+    return r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+
+def _sign_es256(signing_input, key_path):
+    proc = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", key_path],
+        input=signing_input,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("openssl signing failed")
+    return _der_ecdsa_to_raw(proc.stdout)
+
+
+def _token():
+    key_id = os.environ.get("ASC_API_KEY_ID")
+    issuer_id = os.environ.get("ASC_API_ISSUER_ID")
+    if not key_id or not issuer_id:
+        raise RuntimeError("set ASC_API_KEY_ID and ASC_API_ISSUER_ID")
+    hdr = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    now = int(time.time())
+    pld = {"iss": issuer_id, "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"}
+    signing_input = _b64u(json.dumps(hdr).encode()) + b"." + _b64u(json.dumps(pld).encode())
+
+    key_path = os.environ.get("ASC_API_KEY_PATH")
+    if key_path:
+        sig = _sign_es256(signing_input, key_path)
+    elif os.environ.get("ASC_API_KEY_P8_BASE64"):
+        fd, tmp = tempfile.mkstemp(suffix=".p8")
+        try:
+            os.write(fd, base64.b64decode(os.environ["ASC_API_KEY_P8_BASE64"]))
+            os.close(fd)
+            sig = _sign_es256(signing_input, tmp)
+        finally:
+            os.unlink(tmp)
+    else:
+        raise RuntimeError("set ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64")
+    return (signing_input + b"." + _b64u(sig)).decode()
+
+
+def _asc_error_code(body):
+    try:
+        return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
+    except Exception:
+        return "unknown"
+
+
+def _request(token, method, path, payload=None):
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode()
+    req = urllib.request.Request(API_BASE + path, method=method, data=data)
+    req.add_header("Authorization", "Bearer " + token)
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read() or b"{}"
+            return resp.status, json.loads(raw)
+    except urllib.error.HTTPError as e:
+        try:
+            body = json.loads(e.read() or b"{}")
+        except Exception:
+            body = {}
+        return e.code, body
+
+
+def _resolve_app_id(token, bundle_id):
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/apps?filter[bundleId]={bundle_id}&fields[apps]=bundleId&limit=1",
+    )
+    if status != 200:
+        raise RuntimeError(f"apps lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data", [])
+    if not data:
+        raise RuntimeError(f"no app found for bundle id {bundle_id}")
+    return data[0]["id"]
+
+
+def _find_build(token, app_id, build_number):
+    """Return the build id whose version == build_number, or None if not present yet.
+
+    Uses the version filter so a single request resolves the build without paging
+    the whole list. App Store Connect's version is the CFBundleVersion string.
+    """
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/builds?filter[app]={app_id}"
+        f"&filter[version]={build_number}"
+        f"&fields[builds]=version,processingState&limit=1",
+    )
+    if status != 200:
+        raise RuntimeError(f"builds lookup HTTP {status} (code={_asc_error_code(body)})")
+    data = body.get("data", [])
+    if not data:
+        return None
+    return data[0]["id"]
+
+
+def _existing_localization(token, build_id, locale):
+    """Return (localization_id or None) for the given locale on the build."""
+    status, body = _request(
+        token,
+        "GET",
+        f"/v1/builds/{build_id}/betaBuildLocalizations"
+        f"?fields[betaBuildLocalizations]=locale&limit=50",
+    )
+    if status != 200:
+        raise RuntimeError(
+            f"betaBuildLocalizations lookup HTTP {status} (code={_asc_error_code(body)})"
+        )
+    for item in body.get("data", []):
+        if (item.get("attributes") or {}).get("locale") == locale:
+            return item["id"]
+    return None
+
+
+def _set_notes(token, build_id, locale, whats_new):
+    loc_id = _existing_localization(token, build_id, locale)
+    if loc_id:
+        payload = {
+            "data": {
+                "type": "betaBuildLocalizations",
+                "id": loc_id,
+                "attributes": {"whatsNew": whats_new},
+            }
+        }
+        status, body = _request(
+            token, "PATCH", f"/v1/betaBuildLocalizations/{loc_id}", payload
+        )
+        action = "updated"
+    else:
+        payload = {
+            "data": {
+                "type": "betaBuildLocalizations",
+                "attributes": {"locale": locale, "whatsNew": whats_new},
+                "relationships": {
+                    "build": {"data": {"type": "builds", "id": build_id}}
+                },
+            }
+        }
+        status, body = _request(token, "POST", "/v1/betaBuildLocalizations", payload)
+        action = "created"
+    if status not in (200, 201):
+        raise RuntimeError(
+            f"set notes HTTP {status} (code={_asc_error_code(body)}) while {action[:-1]}ing localization"
+        )
+    return action
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--build-number", required=True, help="CFBundleVersion of the uploaded build")
+    parser.add_argument("--notes-file", required=True, help="file containing the What to Test text")
+    parser.add_argument("--locale", default="en-US")
+    parser.add_argument("--timeout-seconds", type=int, default=900,
+                        help="how long to wait for App Store Connect to ingest the build")
+    parser.add_argument("--poll-seconds", type=int, default=20)
+    args = parser.parse_args()
+
+    with open(args.notes_file, "r", encoding="utf-8") as f:
+        whats_new = f.read().strip()
+    if not whats_new:
+        raise RuntimeError(f"notes file is empty: {args.notes_file}")
+    if len(whats_new) > MAX_WHATS_NEW:
+        whats_new = whats_new[:MAX_WHATS_NEW - 1].rstrip() + "…"
+
+    token = _token()
+    app_id = _resolve_app_id(token, args.bundle_id)
+
+    deadline = time.time() + max(0, args.timeout_seconds)
+    build_id = None
+    while True:
+        # Re-mint the token each loop in case the wait outlives the 600s expiry.
+        token = _token()
+        build_id = _find_build(token, app_id, args.build_number)
+        if build_id:
+            break
+        if time.time() >= deadline:
+            print(
+                f"asc_set_testflight_notes: build {args.build_number} not visible on "
+                f"App Store Connect within {args.timeout_seconds}s; notes not set",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        print(
+            f"asc_set_testflight_notes: build {args.build_number} not processed yet; "
+            f"retrying in {args.poll_seconds}s",
+            file=sys.stderr,
+        )
+        time.sleep(max(1, args.poll_seconds))
+
+    action = _set_notes(token, build_id, args.locale, whats_new)
+    print(f"asc_set_testflight_notes: {action} {args.locale} What to Test for build {args.build_number}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(f"asc_set_testflight_notes: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -54,6 +54,10 @@ MARKETING_VERSION_OVERRIDE="${IOS_BETA_MARKETING_VERSION:-}"
 NO_UPLOAD=0
 EXTERNAL=0
 KEEP_ARTIFACTS=0
+# After a successful upload, upload-testflight.sh sets the build's TestFlight
+# "What to Test" notes from the top ios/CHANGELOG.md entry. --skip-notes turns
+# that off (passed straight through).
+SKIP_NOTES=0
 HOST_FILTER=""
 # When the fleet is busy, wait for a cloud slot rather than degrading to a local
 # Release archive on this Mac (which is slow and eats the user's CPU). Mirrors
@@ -90,6 +94,10 @@ download it, then export/re-sign/verify/upload via upload-testflight.sh.
                      falling back to a local build (default 1200).
   --local            Build the Release archive locally on this Mac instead of the
                      fleet. Used automatically when no hq cloud script is present.
+  --skip-notes       Do not set the build's TestFlight "What to Test" notes after
+                     upload. By default a successful upload pushes the top
+                     ios/CHANGELOG.md entry (Internal block, or External with
+                     --external) so testers see what changed.
   --keep-artifacts   Keep the downloaded archive + export dir.
 
 Signing/upload credentials are resolved by upload-testflight.sh (ASC API key via
@@ -104,6 +112,7 @@ while [[ $# -gt 0 ]]; do
     --no-upload) NO_UPLOAD=1; shift ;;
     --marketing-version) MARKETING_VERSION_OVERRIDE="${2:-}"; shift 2 ;;
     --external) EXTERNAL=1; shift ;;
+    --skip-notes) SKIP_NOTES=1; shift ;;
     --tag) TAG="${2:-}"; shift 2 ;;
     --host) HOST_FILTER="${2:-}"; shift 2 ;;
     --wait) WAIT_SECONDS="${2:-}"; shift 2 ;;
@@ -267,6 +276,7 @@ UPLOAD="$IOS_DIR/scripts/upload-testflight.sh"
 
 upload_args=( --lane "$LANE" --archive-path "$ARCHIVE_PATH" )
 [[ "$EXTERNAL" -eq 1 ]] && upload_args+=( --external )
+[[ "$SKIP_NOTES" -eq 1 ]] && upload_args+=( --skip-notes )
 # --no-upload maps to --export-only: upload-testflight.sh exports the IPA,
 # re-signs it with the full Release entitlements, and gates it on
 # aps-environment=production before exiting ahead of altool. The re-sign +

--- a/ios/scripts/set-testflight-notes.sh
+++ b/ios/scripts/set-testflight-notes.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Push a TestFlight build's "What to Test" notes from ios/CHANGELOG.md.
+#
+# Testers see this text in TestFlight on install and auto-update; without it a
+# build is just an opaque MARKETING_VERSION (timestamp). upload-testflight.sh
+# calls this automatically after a successful upload, but it is also a standalone
+# tool: re-apply or fix notes on any already-uploaded build by build number.
+#
+# Notes source: the TOP entry of ios/CHANGELOG.md. The audience selects the block:
+#   --audience internal  -> the "### Internal" block (terse, dev-facing). Default.
+#   --audience external  -> the "### External" block (curated, user-facing).
+#
+# Auth: ASC_API_KEY_ID / ASC_API_ISSUER_ID / ASC_API_KEY_PATH from the env, else
+# ios/Config/AppStoreConnect.local.plist (same resolution as upload-testflight.sh).
+#
+# Usage:
+#   ios/scripts/set-testflight-notes.sh --build-number 20260613120501 \
+#       [--audience internal|external] [--bundle-id dev.cmux.app.beta] \
+#       [--changelog <path>] [--locale en-US] \
+#       [--expect-marketing-version X.Y.Z] \
+#       [--notes "literal override text"] [--timeout-seconds 900]
+#
+# --expect-marketing-version asserts the changelog TOP entry's version equals the
+# build's marketing version, so notes for the wrong version are never published
+# (upload-testflight.sh passes the archived CFBundleShortVersionString).
+#
+# --validate-only checks the LOCAL preconditions (changelog present, top version
+# matches, audience block has bullets) and exits WITHOUT contacting App Store
+# Connect; no --build-number or credentials needed. upload-testflight.sh runs this
+# before the archive so bad notes inputs fail fast instead of after the upload.
+#
+# Exit codes mirror asc_set_testflight_notes.py: 0 set/valid, 3 build not yet
+# visible, 1 other error (incl. validation failure).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() { sed -n '3,35p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+BUILD_NUMBER=""
+AUDIENCE="internal"
+BUNDLE_ID="${IOS_BETA_BUNDLE_ID:-dev.cmux.app.beta}"
+CHANGELOG="$IOS_DIR/CHANGELOG.md"
+LOCALE="en-US"
+NOTES_OVERRIDE=""
+TIMEOUT_SECONDS="900"
+# When set, the TOP changelog version MUST equal this (the MARKETING_VERSION of
+# the build being annotated). Guards against attaching e.g. 1.0.3 notes to a build
+# archived as 1.0.0 when a cut forgets to bump the version. upload-testflight.sh
+# passes the archived CFBundleShortVersionString here.
+EXPECT_MARKETING_VERSION=""
+# Validate-only: run the LOCAL preconditions (changelog present, top version
+# matches, the audience block has bullets) and exit WITHOUT contacting App Store
+# Connect. upload-testflight.sh runs this BEFORE the archive so a deterministic
+# local error (missing entry, version mismatch) fails fast instead of being
+# discovered only after the build is already uploaded. No --build-number or ASC
+# credentials are needed in this mode.
+VALIDATE_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-number) BUILD_NUMBER="${2:-}"; shift 2 ;;
+    --audience) AUDIENCE="${2:-}"; shift 2 ;;
+    --bundle-id) BUNDLE_ID="${2:-}"; shift 2 ;;
+    --changelog) CHANGELOG="${2:-}"; shift 2 ;;
+    --locale) LOCALE="${2:-}"; shift 2 ;;
+    --notes) NOTES_OVERRIDE="${2:-}"; shift 2 ;;
+    --expect-marketing-version) EXPECT_MARKETING_VERSION="${2:-}"; shift 2 ;;
+    --validate-only) VALIDATE_ONLY=1; shift ;;
+    --timeout-seconds) TIMEOUT_SECONDS="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unexpected argument $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$AUDIENCE" in
+  internal|external) ;;
+  *) echo "error: --audience must be internal or external (got '$AUDIENCE')" >&2; exit 2 ;;
+esac
+
+if [[ "$VALIDATE_ONLY" -ne 1 ]]; then
+  [[ -n "$BUILD_NUMBER" ]] || { echo "error: --build-number is required" >&2; usage >&2; exit 2; }
+
+  # Resolve ASC API auth: env first, then the local plist (same as upload-testflight.sh).
+  LOCAL_ASC_CONFIG="$IOS_DIR/Config/AppStoreConnect.local.plist"
+  if [[ -f "$LOCAL_ASC_CONFIG" ]]; then
+    ASC_API_KEY_ID="${ASC_API_KEY_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
+    ASC_API_ISSUER_ID="${ASC_API_ISSUER_ID:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_ISSUER_ID' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
+    ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-$(/usr/libexec/PlistBuddy -c 'Print :ASC_API_KEY_PATH' "$LOCAL_ASC_CONFIG" 2>/dev/null || true)}"
+  fi
+
+  if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" ]] \
+     || [[ -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ]]; then
+    echo "error: missing App Store Connect API credentials (ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64), and none found in ${LOCAL_ASC_CONFIG:-ios/Config/AppStoreConnect.local.plist}" >&2
+    exit 1
+  fi
+fi
+
+NOTES_FILE="$(mktemp "${TMPDIR:-/tmp}/cmux-testflight-notes.XXXXXX")"
+trap 'rm -f "$NOTES_FILE"' EXIT
+
+if [[ -n "$NOTES_OVERRIDE" ]]; then
+  printf '%s\n' "$NOTES_OVERRIDE" > "$NOTES_FILE"
+else
+  [[ -f "$CHANGELOG" ]] || { echo "error: changelog not found: $CHANGELOG" >&2; exit 1; }
+
+  # The TOP entry must describe the build we are annotating. Read the top version
+  # heading (## [X.Y.Z] - date) and, when the caller told us the build's marketing
+  # version, refuse to attach notes for a different version. This is the guard for
+  # the "archived 1.0.0 but changelog top is 1.0.3" mismatch: better to skip notes
+  # (the binary is already uploaded; the caller treats this as non-fatal) than to
+  # publish release notes for the wrong version.
+  TOP_VERSION="$(sed -n 's/^## \[\([^]]*\)\].*/\1/p' "$CHANGELOG" | head -n1)"
+  [[ -n "$TOP_VERSION" ]] || { echo "error: no '## [version]' entry found in $CHANGELOG" >&2; exit 1; }
+  if [[ -n "$EXPECT_MARKETING_VERSION" && "$TOP_VERSION" != "$EXPECT_MARKETING_VERSION" ]]; then
+    echo "error: changelog top entry is [$TOP_VERSION] but the build's marketing version is $EXPECT_MARKETING_VERSION; refusing to attach mismatched What to Test notes. Add a [$EXPECT_MARKETING_VERSION] entry to the top of $CHANGELOG (or bump MARKETING_VERSION to $TOP_VERSION before cutting)." >&2
+    exit 1
+  fi
+
+  # Extract the bullet items of the requested block from the TOP version entry.
+  # The top entry is everything from the first "## [" version heading up to the
+  # next "## [" heading. Within it, the "### Internal" / "### External" block runs
+  # until the next "### " or "## " heading. We emit each "- " bullet as a clean
+  # line (one leading "- ") so TestFlight shows a readable list.
+  AUDIENCE="$AUDIENCE" awk '
+    BEGIN { want = toupper(substr(ENVIRON["AUDIENCE"],1,1)) tolower(substr(ENVIRON["AUDIENCE"],2)); }
+    /^## \[/ { vers++; if (vers > 1) exit; next }   # stop at the 2nd version
+    vers != 1 { next }
+    /^### / {
+      sect = $0; sub(/^### +/, "", sect);
+      insect = (sect == want) ? 1 : 0;
+      next
+    }
+    insect && /^- / {
+      line = $0; sub(/^- +/, "", line);
+      print "- " line;
+    }
+  ' "$CHANGELOG" > "$NOTES_FILE"
+
+  if [[ ! -s "$NOTES_FILE" ]]; then
+    TOP_VER="$(grep -m1 '^## \[' "$CHANGELOG" || true)"
+    echo "error: no '### ${AUDIENCE^}' bullet items found in the top entry ($TOP_VER) of $CHANGELOG" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$VALIDATE_ONLY" -eq 1 ]]; then
+  # All deterministic local preconditions passed (changelog present, top version
+  # matches if --expect-marketing-version was given, audience block has bullets).
+  # Show what WILL be published and exit without touching App Store Connect.
+  echo "set-testflight-notes: validate-only OK; $AUDIENCE notes that will be published:" >&2
+  sed 's/^/  /' "$NOTES_FILE" >&2
+  exit 0
+fi
+
+echo "set-testflight-notes: $AUDIENCE notes for build $BUILD_NUMBER ($BUNDLE_ID, $LOCALE):" >&2
+sed 's/^/  /' "$NOTES_FILE" >&2
+
+ASC_API_KEY_ID="$ASC_API_KEY_ID" \
+ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
+ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" \
+ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
+python3 "$SCRIPT_DIR/asc_set_testflight_notes.py" \
+  --bundle-id "$BUNDLE_ID" \
+  --build-number "$BUILD_NUMBER" \
+  --notes-file "$NOTES_FILE" \
+  --locale "$LOCALE" \
+  --timeout-seconds "$TIMEOUT_SECONDS"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -121,6 +121,11 @@ Options:
                             CMUX_TESTFLIGHT_EXTERNAL=1.
   --archive-path <path>     Reuse an existing archive instead of archiving.
   --export-only             Stop after exporting the signed IPA.
+  --skip-notes              Do not set the TestFlight "What to Test" notes after
+                            upload. By default a successful upload pushes the top
+                            ios/CHANGELOG.md entry to the build (the Internal block,
+                            or the External block with --external). Also via
+                            CMUX_TESTFLIGHT_SKIP_NOTES=1.
   -h, --help                Show this help.
 EOF
 }
@@ -163,6 +168,13 @@ EXTERNAL_TESTING=0
 if [[ "${CMUX_TESTFLIGHT_EXTERNAL:-}" == "1" ]]; then
   EXTERNAL_TESTING=1
 fi
+# After a successful upload, push the top ios/CHANGELOG.md entry to the build's
+# TestFlight "What to Test" so testers see what changed instead of an opaque
+# timestamp. Set to 1 by --skip-notes or CMUX_TESTFLIGHT_SKIP_NOTES=1.
+SKIP_NOTES=0
+if [[ "${CMUX_TESTFLIGHT_SKIP_NOTES:-}" == "1" ]]; then
+  SKIP_NOTES=1
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -193,6 +205,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --export-only)
       EXPORT_ONLY=1
+      shift
+      ;;
+    --skip-notes)
+      SKIP_NOTES=1
       shift
       ;;
     -h|--help)
@@ -233,6 +249,25 @@ IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-7WLXT3NR37}"
+
+# Notes audience is driven by the testing lane (External block for --external).
+NOTES_AUDIENCE="internal"
+[[ "$EXTERNAL_TESTING" == "1" ]] && NOTES_AUDIENCE="external"
+
+# Preflight the TestFlight "What to Test" notes BEFORE the expensive archive, so a
+# deterministic local error (missing ios/CHANGELOG.md, empty audience block) fails
+# fast here instead of being discovered only AFTER the build is already uploaded
+# (where the notes step is non-fatal). This validate-only call contacts NO network
+# and needs no ASC credentials. The version-match check (changelog top == the
+# build's marketing version) happens later for a reused --archive-path / post-build,
+# where the actual marketing version is known. Skipped when there is no upload to
+# annotate (--export-only) or notes are turned off (--skip-notes).
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 ]]; then
+  if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only --audience "$NOTES_AUDIENCE"; then
+    echo "error: TestFlight What to Test notes preflight failed (see above). Fix ios/CHANGELOG.md before uploading, or pass --skip-notes to upload without notes." >&2
+    exit 1
+  fi
+fi
 
 # Resolve App Store Connect API auth (env, else local plist) BEFORE the
 # monotonic guard and output-path computation below: the guard may finalize
@@ -421,6 +456,25 @@ else
   if [[ ! -d "$ARCHIVE_PATH" ]]; then
     echo "error: archive not found: $ARCHIVE_PATH" >&2
     exit 1
+  fi
+fi
+
+# Now that the archive exists, its marketing version (CFBundleShortVersionString)
+# is the version testers will see. Re-run the notes preflight WITH that version so
+# a deterministic mismatch (changelog top is 1.0.3 but the archived build is 1.0.0)
+# fails BEFORE the export/upload, not after (when the notes step is non-fatal and
+# would just ship an opaque build). Skipped for --export-only / --skip-notes. If the
+# archive's version is unreadable, the version-match guard simply does not run.
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 ]]; then
+  ARCHIVE_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
+  if [[ "$ARCHIVE_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+    if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only \
+        --audience "$NOTES_AUDIENCE" --expect-marketing-version "$ARCHIVE_MARKETING_VERSION"; then
+      echo "error: ios/CHANGELOG.md top entry does not match the archived marketing version $ARCHIVE_MARKETING_VERSION (see above); refusing to upload a build whose What to Test notes would be for the wrong version. Update ios/CHANGELOG.md, or pass --skip-notes." >&2
+      exit 1
+    fi
+  else
+    echo "note: could not read the archive's marketing version; deferring the notes version-match guard to the post-upload step" >&2
   fi
 fi
 
@@ -696,4 +750,49 @@ APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_PROVIDER_PUBLIC_ID. You can
 also create ios/Config/AppStoreConnect.local.plist with the ASC_* keys.
 EOF
   exit 2
+fi
+
+# Set the TestFlight "What to Test" notes from the top ios/CHANGELOG.md entry so
+# the build is not an opaque MARKETING_VERSION (timestamp) on install/update.
+#
+# Non-fatal by design: the binary is already on TestFlight at this point. A failure
+# to set notes (build still processing past the timeout, transient API error) must
+# NOT fail the upload, so a `set -e` script must not let a non-zero exit propagate.
+# The notes can always be re-applied later with set-testflight-notes.sh. The notes
+# API needs the ASC API key (JWT); the Apple ID upload path has no key, so notes are
+# only attempted when the ASC API creds are present.
+#
+# Audience: --external uses the curated External block; the default internal cut uses
+# the terse Internal block. SHIPPED_BUILD_NUMBER is the CFBundleVersion that actually
+# shipped (post-guard, or the reused archive's embedded version).
+if [[ "$SKIP_NOTES" -eq 1 ]]; then
+  echo "note: --skip-notes set; not setting TestFlight What to Test notes" >&2
+elif [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+  echo "note: no ASC API key (JWT) available; skipping TestFlight What to Test notes (set ASC_API_KEY_ID/ASC_API_ISSUER_ID/ASC_API_KEY_PATH, or run ios/scripts/set-testflight-notes.sh later)" >&2
+else
+  # The local preconditions (changelog present, audience block non-empty, top
+  # version == the archived marketing version) were already enforced FATALLY before
+  # the upload. This post-upload step is the ONLY non-fatal part: it just performs
+  # the App Store Connect mutation, which can legitimately fail transiently (build
+  # still processing past the timeout, network/API hiccup) without that meaning the
+  # release is broken. The binary is already on TestFlight; the notes can be
+  # re-applied later. NOTES_AUDIENCE was set early. Re-read the archived marketing
+  # version so the mutation still carries the version-match guard.
+  NOTES_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
+  NOTES_VERSION_ARGS=()
+  if [[ "$NOTES_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+    NOTES_VERSION_ARGS=( --expect-marketing-version "$NOTES_MARKETING_VERSION" )
+  fi
+  echo "setting TestFlight '$NOTES_AUDIENCE' What to Test notes for build $SHIPPED_BUILD_NUMBER (${NOTES_MARKETING_VERSION:-unknown version}) from ios/CHANGELOG.md" >&2
+  if ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
+     ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
+     "$SCRIPT_DIR/set-testflight-notes.sh" \
+       --build-number "$SHIPPED_BUILD_NUMBER" \
+       --audience "$NOTES_AUDIENCE" \
+       --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER" \
+       "${NOTES_VERSION_ARGS[@]}"; then
+    echo "TestFlight What to Test notes set for build $SHIPPED_BUILD_NUMBER" >&2
+  else
+    echo "warning: could not set TestFlight What to Test notes for build $SHIPPED_BUILD_NUMBER (the upload succeeded; re-run ios/scripts/set-testflight-notes.sh --build-number $SHIPPED_BUILD_NUMBER --audience $NOTES_AUDIENCE once the build finishes processing)" >&2
+  fi
 fi


### PR DESCRIPTION
## Why

iOS TestFlight testers get an opaque `MARKETING_VERSION (timestamp)` build with no notes on every install and auto-update, so there's no way to tell what changed. This adds a per-build iOS changelog and wires it into the upload so every TestFlight build shows its "What to Test" notes.

## The changelog system

`ios/CHANGELOG.md` is the single source of truth, newest version on top (mirrors the macOS `CHANGELOG.md` `## [X.Y.Z] - date` shape so it could feed a docs page later). Each version entry has two blocks:

- **Internal** (`ship ios`, the `cmux beta` group): terse, dev-facing, per-build, includes a dogfood-focus line.
- **External / founders** (`ship ios founders`): a curated, user-facing summary, no jargon or PR numbers.

Seeded with the real shipped 1.0.2 and 1.0.3 history (composer, View as Text, minimal QR, presence-gated + deep-linking notifications with a synced unread badge, offline sign-out, workspace-list polish, the render-grid watchdog fix), attributed from the merged PR list.

The top entry's version must equal the checked-in `MARKETING_VERSION` in `ios/Config/Shared.xcconfig`; this PR bumps it to `1.0.3` so the two agree.

## How "What to Test" gets set (the ASC API call + when)

After a successful `altool` upload, `upload-testflight.sh` runs `set-testflight-notes.sh`, which awk-extracts the top entry's chosen block and calls `asc_set_testflight_notes.py`. That helper is dependency-free (ES256 JWT via `openssl`, same pattern as `asc_max_build.py`): it mints the JWT from the ASC API key (`ios/Config/AppStoreConnect.local.plist`, key id `4WN4S8ANN4`), resolves the app by bundle id, finds the build by `CFBundleVersion`, then `POST`/`PATCH`es the en-US `betaBuildLocalizations.whatsNew`. A just-uploaded build isn't addressable until App Store Connect ingests it, so the build lookup polls (default 900s / 20s).

Audience is driven by the lane: internal cut -> Internal block; `--external` -> External block. `--skip-notes` (or `CMUX_TESTFLIGHT_SKIP_NOTES=1`) opts out; `cloud-testflight.sh` passes `--external` / `--skip-notes` through.

Fatal vs non-fatal split (from review): the deterministic local preconditions (changelog present, audience block non-empty, top version == the archived `CFBundleShortVersionString`) are checked **before** the archive and again right after it, and **fail the upload**. Only the App Store Connect mutation itself is **non-fatal** after upload (the binary is already on TestFlight; transient processing/API errors just warn, and notes can be re-applied with `set-testflight-notes.sh --build-number <n> --audience <a>`).

## Internal vs external presentation design

Documented in `docs/ios-release-notes.md`: the version scheme testers see (`MARKETING_VERSION (CURRENT_PROJECT_VERSION)`, the parens being the UTC build timestamp), and why there are two notes blocks per entry.

## Phase 2 (spec only, deferred)

`docs/ios-release-notes.md` specs an in-app "What's New" sheet on first launch after an update for external/founders builds, sourced from the External block: a `UserDefaults` last-seen-version gate, the changelog parsed into a bundled resource at build time, a localized SwiftUI sheet, and a Settings re-open entry. That is iOS app runtime code (needs a tagged dogfood build + approval), so it's intentionally out of this PR to keep it scripts + docs only.

## How to cut a release with notes going forward

1. Edit `ios/CHANGELOG.md`: add the new version as the top entry (Internal + External blocks) and bump `ios/scripts/bump-ios-version.sh X.Y.Z` to match. Never cut a beta without a changelog entry.
2. `ship ios` (internal) or `ship ios founders` (external). The upload sets the matching "What to Test" block automatically.
3. If the notes step warns that the build is still processing, re-run `ios/scripts/set-testflight-notes.sh --build-number <shipped> --audience internal|external`.

The hq `cmux-ios-release` skill is updated with this step (not in this repo).

## Verification

- `shellcheck` clean on all three bash scripts; `py_compile` clean; `bash -n` clean.
- The notes helper was exercised against the **live** ASC API in read mode: app resolution (`dev.cmux.app.beta`), build lookup by version, and existing en-US localization lookup all returned real IDs without mutating any build.
- `--validate-only` verified: passes valid input (with/without version, no creds/build-number), fails on version mismatch and missing changelog.
- `autoreview` clean (Codex), cmux-policy clean.

This is workflow/docs/script-only (no app/runtime behavior change), so it can merge after CI green with no dogfood per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784109166&installation_id=133855650&pr_number=6154&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6154&signature=fca2cc529ea9642ff4ccca3c9d286af7c75d6816e98bbcd149ab156e998d4bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scripts and docs only; no iOS app runtime changes. Release workflow now depends on changelog/version alignment and ASC API for notes (upload still succeeds if notes fail).
> 
> **Overview**
> Adds **`ios/CHANGELOG.md`** as the per-build source of truth (Internal vs External blocks per audience) and bumps **`MARKETING_VERSION`** to **1.0.3** so the top entry matches **`Shared.xcconfig`**.
> 
> After a successful TestFlight upload, **`upload-testflight.sh`** now pushes the top changelog block to App Store Connect **What to Test** via new **`set-testflight-notes.sh`** (awk extract) and **`asc_set_testflight_notes.py`** (dependency-free ASC JWT + `betaBuildLocalizations.whatsNew`, with build-ingest polling). **`--skip-notes`** / **`CMUX_TESTFLIGHT_SKIP_NOTES`** opt out; **`cloud-testflight.sh`** forwards **`--skip-notes`**. Internal cuts use the Internal block; **`--external`** uses External.
> 
> **Fatal pre-upload:** changelog present, non-empty audience block, and top version equals the archive marketing version (**`--validate-only`** before archive and again after). **Non-fatal post-upload:** ASC mutation failures warn only; notes can be re-applied with **`set-testflight-notes.sh`**.
> 
> **`docs/ios-release-notes.md`** documents the workflow and defers in-app What's New (phase 2) to a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05759246677bbd5d13d9df2a3387d8644d51190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-build iOS changelog and auto-publishes it to TestFlight “What to Test” so testers see what changed on install and auto-update. No runtime app changes.

- **New Features**
  - `ios/CHANGELOG.md` is the single source of truth; each top entry has “Internal” and “External” blocks.
  - Upload sets TestFlight notes from the top entry via the ASC API (`asc_set_testflight_notes.py`), driven by lane: `ship ios` → Internal, `--external` → External; `--skip-notes` to opt out.
  - Preflight validation in `upload-testflight.sh` fails fast on missing/empty notes or version mismatch; post-upload notes are non-fatal and can be re-applied with `ios/scripts/set-testflight-notes.sh`.
  - `cloud-testflight.sh` passes `--external`/`--skip-notes` through; `MARKETING_VERSION` bumped to `1.0.3`; added `docs/ios-release-notes.md`.

<sup>Written for commit a05759246677bbd5d13d9df2a3387d8644d51190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive iOS release notes documentation outlining TestFlight delivery processes and planned in-app "What's New" sheet feature.

* **Chores**
  * Updated iOS app version to 1.0.3.
  * Established structured changelog as the single source of truth for TestFlight release notes.
  * Enhanced release automation tooling to streamline TestFlight notes publication workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->