### PR TITLE
fix: Founder's Edition welcome email — new thread per subscription

### DIFF
--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -10,6 +10,11 @@ import {
   withApiRouteSpan,
 } from "@/services/telemetry";
 
+import {
+  DEFAULT_FROM_EMAIL,
+  buildFoundersWelcomeEmail,
+} from "./welcome-email";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -17,14 +22,6 @@ export const dynamic = "force-dynamic";
 // carry this metadata key (copied automatically onto each session). We only send
 // the welcome email when it is present and truthy.
 const FOUNDERS_METADATA_KEY = "founders_edition";
-
-// Default sender/recipients. Sender is overridable via env so the verified Resend
-// domain can change without a code edit; the founders are always copied so both
-// see exactly what the customer received.
-const DEFAULT_FROM_EMAIL = "austin@manaflow.ai";
-const FOUNDER_CC = ["austin@manaflow.ai", "lawrence@manaflow.ai"];
-const REPLY_TO = "austin@manaflow.ai";
-const EMAIL_SUBJECT = "cmux Founder's Edition";
 
 // Stripe signs webhooks with a 5-minute default tolerance; reject older payloads
 // to blunt replay attempts.
@@ -99,30 +96,6 @@ function isValidStripeSignature(
   });
 }
 
-function firstName(fullName: string | null | undefined): string {
-  const trimmed = (fullName ?? "").trim();
-  if (!trimmed) {
-    return "there";
-  }
-  return trimmed.split(/\s+/)[0];
-}
-
-function buildBody(name: string): string {
-  return [
-    `Hi ${name}!`,
-    "",
-    "Thank you for being one of the first ever customers of cmux :)",
-    "",
-    "My number is +1(714) 699-0169 and Lawrence's number is +1(949) 302-0749. " +
-      "Our emails are austin@manaflow.ai and lawrence@manaflow.ai. Feel free to " +
-      "text me on iMessage or WhatsApp, or we can just continue talking here. " +
-      "I've CC'd my cofounder as well.",
-    "",
-    "Best,",
-    "Austin",
-  ].join("\n");
-}
-
 export async function POST(request: Request) {
   return withApiRouteSpan(
     request,
@@ -180,13 +153,16 @@ export async function POST(request: Request) {
         return NextResponse.json({ ok: true, skipped: "no_customer_email" });
       }
 
-      const name = firstName(session?.customer_details?.name);
       // Stripe delivers webhooks at least once and retries after a transient
       // failure (including one observed after Resend already accepted the
-      // message), so key the send by the checkout session id. Resend
-      // deduplicates identical sends for 24h, so redelivery of the same
-      // purchase will not send a second welcome email.
-      const idempotencyKey = `founders-welcome/${session?.id ?? event.id ?? customerEmail}`;
+      // message), so key the send by the checkout session id. This same ref
+      // both deduplicates the send (via the Resend idempotency key, which
+      // dedupes identical sends for 24h) and threads the email (via the
+      // X-Entity-Ref-ID header inside buildFoundersWelcomeEmail): redelivery of
+      // the same purchase neither sends a second welcome nor spawns a second
+      // Gmail thread, while a new subscription gets its own thread.
+      const sessionRef = session?.id ?? event.id ?? customerEmail;
+      const idempotencyKey = `founders-welcome/${sessionRef}`;
       // Only attach the personal display name to the default sender. If the
       // address is overridden to a shared/team inbox, send from the bare
       // address rather than a mismatched "Austin Wang" identity.
@@ -196,14 +172,12 @@ export async function POST(request: Request) {
           : config.fromEmail;
       const resend = new Resend(config.resendApiKey);
       const { error } = await resend.emails.send(
-        {
+        buildFoundersWelcomeEmail({
           from: fromAddress,
-          to: [customerEmail],
-          cc: FOUNDER_CC,
-          replyTo: REPLY_TO,
-          subject: EMAIL_SUBJECT,
-          text: buildBody(name),
-        },
+          to: customerEmail,
+          customerName: session?.customer_details?.name,
+          sessionRef,
+        }),
         { idempotencyKey },
       );
 

--- a/web/app/api/stripe/founders-welcome/welcome-email.ts
+++ b/web/app/api/stripe/founders-welcome/welcome-email.ts
@@ -1,0 +1,92 @@
+// Pure construction of the cmux Founder's Edition welcome email payload.
+//
+// Kept free of Stripe/Resend/env imports so it can be unit-tested directly
+// (web/tests/founders-welcome-email.test.ts) without booting the webhook route
+// or touching the network. The route handler (./route.ts) owns the I/O.
+
+// Default sender/recipients. Sender is overridable via env so the verified
+// Resend domain can change without a code edit; the founders are always copied
+// so both see exactly what the customer received.
+export const DEFAULT_FROM_EMAIL = "austin@manaflow.ai";
+export const FOUNDER_CC = ["austin@manaflow.ai", "lawrence@manaflow.ai"];
+export const REPLY_TO = "austin@manaflow.ai";
+export const EMAIL_SUBJECT = "cmux Founder's Edition";
+
+// Custom header that defeats Gmail's subject-based conversation grouping.
+// Gmail collapses messages that share a normalized subject among the same
+// participants into one conversation, so a unique value per message is what
+// keeps each send in its own thread. Resend forwards arbitrary headers via the
+// `headers` field on emails.send. See foundersThreadRef for why it is keyed to
+// the session id rather than a per-delivery random value.
+const THREAD_REF_HEADER = "X-Entity-Ref-ID";
+
+function firstName(fullName: string | null | undefined): string {
+  const trimmed = (fullName ?? "").trim();
+  if (!trimmed) {
+    return "there";
+  }
+  return trimmed.split(/\s+/)[0];
+}
+
+function buildBody(name: string): string {
+  return [
+    `Hi ${name}!`,
+    "",
+    "Thank you for being one of the first ever customers of cmux :)",
+    "",
+    "My number is +1(714) 699-0169 and Lawrence's number is +1(949) 302-0749. " +
+      "Our emails are austin@manaflow.ai and lawrence@manaflow.ai. Feel free to " +
+      "text me on iMessage or WhatsApp, or we can just continue talking here. " +
+      "I've CC'd my cofounder as well.",
+    "",
+    "Best,",
+    "Austin",
+  ].join("\n");
+}
+
+// Stable-per-session, unique-per-subscription thread identifier.
+//
+// Every founder welcome shares the same subject + from + cc, so in austin@ and
+// lawrence@'s inboxes (CC'd on every send) Gmail would collapse them all into a
+// single conversation. Setting X-Entity-Ref-ID to this value gives each
+// subscription its own thread.
+//
+// It is keyed to the Stripe checkout session id (the same id used for the
+// Resend idempotency key) so that Stripe's at-least-once redelivery of the SAME
+// session yields the SAME ref — the idempotent re-send stays in the single
+// existing thread instead of spawning a duplicate — while a DIFFERENT
+// subscription yields a DIFFERENT ref and therefore a new thread.
+export function foundersThreadRef(sessionRef: string): string {
+  return `founders-welcome/${sessionRef}`;
+}
+
+export type FoundersWelcomeEmail = {
+  from: string;
+  to: string[];
+  cc: string[];
+  replyTo: string;
+  subject: string;
+  text: string;
+  headers: Record<string, string>;
+};
+
+// Build the Resend payload for a founder welcome. The customer-facing subject
+// stays clean and constant across subscriptions; per-subscription threading is
+// carried entirely by the X-Entity-Ref-ID header so the recipient sees no
+// thread-key noise in the subject line.
+export function buildFoundersWelcomeEmail(params: {
+  from: string;
+  to: string;
+  customerName: string | null | undefined;
+  sessionRef: string;
+}): FoundersWelcomeEmail {
+  return {
+    from: params.from,
+    to: [params.to],
+    cc: FOUNDER_CC,
+    replyTo: REPLY_TO,
+    subject: EMAIL_SUBJECT,
+    text: buildBody(firstName(params.customerName)),
+    headers: { [THREAD_REF_HEADER]: foundersThreadRef(params.sessionRef) },
+  };
+}

--- a/web/tests/founders-welcome-email.test.ts
+++ b/web/tests/founders-welcome-email.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  EMAIL_SUBJECT,
+  FOUNDER_CC,
+  REPLY_TO,
+  buildFoundersWelcomeEmail,
+  foundersThreadRef,
+} from "../app/api/stripe/founders-welcome/welcome-email";
+
+// Regression coverage for the Founder's Edition welcome email collapsing into a
+// single Gmail conversation. Gmail threads messages that share a normalized
+// subject among the same participants, and every welcome uses the same subject
+// + from + cc, so without a unique per-message discriminator all welcomes stack
+// into one thread in austin@ and lawrence@'s inboxes (they are CC'd on every
+// send). The fix attaches a unique X-Entity-Ref-ID per subscription, keyed to
+// the Stripe checkout session id so it stays stable across Stripe's
+// at-least-once redelivery (idempotent re-send) yet differs across
+// subscriptions (new thread each).
+const THREAD_HEADER = "X-Entity-Ref-ID";
+
+const baseParams = {
+  from: "Austin Wang <austin@manaflow.ai>",
+  customerName: "Ada Lovelace",
+} as const;
+
+describe("foundersThreadRef", () => {
+  test("different sessions produce different thread keys (a new Gmail thread each)", () => {
+    expect(foundersThreadRef("cs_test_aaa")).not.toBe(
+      foundersThreadRef("cs_test_bbb"),
+    );
+  });
+
+  test("the same session id produces a stable thread key (idempotent re-send stays in one thread)", () => {
+    expect(foundersThreadRef("cs_test_aaa")).toBe(
+      foundersThreadRef("cs_test_aaa"),
+    );
+  });
+});
+
+describe("buildFoundersWelcomeEmail", () => {
+  test("X-Entity-Ref-ID differs across subscriptions but is stable per session", () => {
+    const first = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "c1@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+    const second = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "c2@example.com",
+      customerName: "Grace Hopper",
+      sessionRef: "cs_test_bbb",
+    });
+    // A Stripe redelivery of the SAME checkout session (same id) must reuse the
+    // same ref so it lands in the existing single thread, not a duplicate.
+    const redeliveredFirst = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "c1@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+
+    expect(first.headers[THREAD_HEADER]).not.toBe(second.headers[THREAD_HEADER]);
+    expect(first.headers[THREAD_HEADER]).toBe(
+      redeliveredFirst.headers[THREAD_HEADER],
+    );
+    expect(first.headers[THREAD_HEADER]).toBe(foundersThreadRef("cs_test_aaa"));
+  });
+
+  test("subject stays clean and constant across subscriptions (threading is header-only)", () => {
+    const first = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "c1@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+    const second = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "c2@example.com",
+      sessionRef: "cs_test_bbb",
+    });
+    expect(first.subject).toBe(EMAIL_SUBJECT);
+    expect(second.subject).toBe(EMAIL_SUBJECT);
+  });
+
+  test("recipients, sender, and reply-to are preserved unchanged", () => {
+    const email = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "customer@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+    expect(email.to).toEqual(["customer@example.com"]);
+    expect(email.cc).toEqual(FOUNDER_CC);
+    expect(email.replyTo).toBe(REPLY_TO);
+    expect(email.from).toBe("Austin Wang <austin@manaflow.ai>");
+  });
+
+  test("greets by first name and falls back to a friendly default", () => {
+    const named = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "customer@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+    const anonymous = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "customer@example.com",
+      customerName: null,
+      sessionRef: "cs_test_aaa",
+    });
+    expect(named.text.startsWith("Hi Ada!")).toBe(true);
+    expect(anonymous.text.startsWith("Hi there!")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (observed vs expected)

**Observed:** In the founders' inboxes (austin@ and lawrence@ are CC'd on every Founder's Edition welcome), all welcome emails collapse into **one** Gmail conversation. Each new subscription does **not** get its own thread.

**Expected:** Each new subscription lands in its **own** email thread.

## Root cause

`web/app/api/stripe/founders-welcome/route.ts` (the `checkout.session.completed` webhook) sends every welcome with:

- a **constant** subject — `EMAIL_SUBJECT = "cmux Founder's Edition"`
- a **constant** sender (`austin@manaflow.ai`) and **constant** cc (`austin@` + `lawrence@`)
- **no** custom threading headers

Gmail groups messages that share a *normalized subject* among the *same participants* into a single conversation. Because subject + from + cc are identical on every send, all welcomes thread together in the founders' inboxes.

Resend already auto-generates a unique `Message-ID` per send — but a unique `Message-ID` **alone does not** defeat Gmail's subject-based grouping, which is why the threads still collapsed.

## Fix (mechanism: `X-Entity-Ref-ID`)

Attach a **unique `X-Entity-Ref-ID` header per send**, keyed to the Stripe checkout **session id** (the same id already used for the Resend idempotency key). `X-Entity-Ref-ID` is the well-known header for defeating Gmail conversation grouping, and Resend forwards arbitrary headers via the `headers` option on `emails.send`.

- **Customer-facing subject stays clean** — threading is carried entirely by the header, not the subject line.
- **Stable per subscription:** keyed to the session id (not a per-delivery random value), so Stripe's at-least-once **redelivery of the same session** reuses the same ref → the idempotent re-send stays in the existing single thread instead of spawning a duplicate.
- **Distinct across subscriptions:** a different session id → a different ref → a new Gmail thread.

The pure email-payload construction is extracted into `welcome-email.ts` so the thread-key derivation is unit-testable without booting the webhook route, Resend, or Stripe.

### Verification performed (no live sends)
- **Resend SDK type** (`resend@6.9.3`): `CreateEmailOptions.headers?: Record<string, string>` ("Custom headers to add to the email").
- **Resend SDK runtime**: `parseEmailToApiOptions` maps `headers: email.headers` straight into the API request body.
- **Resend docs** explicitly list "Prevent threading on Gmail with the `X-Entity-Ref-ID` header"; no reserved-header restriction.
- **Gmail behavior** cross-checked: a unique `X-Entity-Ref-ID` per message reliably separates conversations.

**No real emails were sent during development** — real customers are CC'd to the founders. "Reproduction" here is code analysis (constant subject + constant cc → one Gmail thread vs. expected new-thread-per-subscription).

## Unchanged (by design)
Recipients (to/cc/replyTo), sender, signature verification, idempotency-by-session-id, and the email body are all unchanged except for the threading header.

## Test
`web/tests/founders-welcome-email.test.ts` (`bun test`) asserts:
- two **different** sessions → **different** thread keys (new thread each),
- the **same** session id → a **stable** thread key (idempotent re-send stays in one thread),
- the subject stays clean/constant and recipients/sender/reply-to are preserved.

No real network/Resend/Stripe calls.

## Scope
**Web-only** change (Next.js app under `web/`, deployed to Vercel). No macOS app build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784111710&installation_id=133855650&pr_number=6156&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6156&signature=02bc65c4bf191675c4206d4d986a46086f938f5e959d70d4ba56597cc3efd1f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Gmail threading for Founder's Edition welcomes so each new subscription starts its own email thread. Subject and recipients stay the same; retries remain idempotent.

- **Bug Fixes**
  - Add per-subscription `X-Entity-Ref-ID` header keyed to the Stripe checkout session id to prevent Gmail conversation grouping.
  - Reuse the same ref on Stripe redeliveries (stays in one thread); different sessions create new threads.
  - Keep subject/from/cc/reply-to unchanged.

- **Refactors**
  - Extract `buildFoundersWelcomeEmail` and `foundersThreadRef` into `welcome-email.ts`; route uses the builder and `sessionRef` for the idempotency key.
  - Add bun tests covering threading behavior and payload invariants.

<sup>Written for commit a9779c1426bba7fe4133ca9014c70c2c1287f646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved deduplication mechanism for founder welcome emails using session-based tracking to prevent duplicate messages.
  * Enhanced email threading for consistent message organization across retries.

* **Tests**
  * Added comprehensive test coverage for email helper functions including validation of threading behavior and recipient field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->