### PR TITLE
[codex] Skip stale cmux Claude shims during resolution

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -23,6 +23,9 @@ cmux_claude_wrapper_is_self_or_shim() {
         return 0
     fi
     case "$candidate" in
+        */cmux-cli-shims/*/claude)
+            return 0
+            ;;
         */Contents/Resources/bin/claude|*/Resources/bin/claude)
             return 0
             ;;

--- a/tests/test_claude_wrapper_user_binary_resolution.py
+++ b/tests/test_claude_wrapper_user_binary_resolution.py
@@ -79,6 +79,71 @@ exec "{wrapper}" "$@"
             failures.append(f"expected user claude, got {output!r}")
 
 
+def test_wrapper_skips_stale_cmux_shims(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-stale-shim-") as td:
+        root = Path(td)
+        bundle_bin = root / "cmux.app" / "Contents" / "Resources" / "bin"
+        tmp_root = root / "tmp"
+        shim_root = tmp_root / "cmux-cli-shims"
+        current_shim_bin = shim_root / "current-surface"
+        stale_shim_bin = shim_root / "stale-surface"
+        real_bin = root / "real-bin"
+        for directory in (bundle_bin, current_shim_bin, stale_shim_bin, real_bin):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        wrapper = bundle_bin / "cmux-claude-wrapper"
+        wrapper.write_bytes(WRAPPER.read_bytes())
+        wrapper.chmod(0o755)
+
+        write_executable(
+            bundle_bin / "claude",
+            """#!/bin/sh
+echo bundled-claude "$@"
+""",
+        )
+        write_executable(
+            real_bin / "claude",
+            """#!/bin/sh
+echo real-claude "$@"
+""",
+        )
+        stale_shim = stale_shim_bin / "claude"
+        write_executable(
+            stale_shim,
+            """#!/bin/sh
+echo stale-shim "$@"
+""",
+        )
+        current_shim = current_shim_bin / "claude"
+        write_executable(
+            current_shim,
+            f"""#!/bin/sh
+export CMUX_CLAUDE_WRAPPER_SHIM="{current_shim}"
+export CMUX_CLAUDE_WRAPPER_SHIM_ROOT="{current_shim_bin}"
+exec "{wrapper}" "$@"
+""",
+        )
+
+        env = dict(os.environ)
+        env["PATH"] = (
+            f"{stale_shim_bin}:{current_shim_bin}:{bundle_bin}:{real_bin}:"
+            "/usr/bin:/bin"
+        )
+        env["TMPDIR"] = f"{tmp_root}/"
+        env["CMUX_CLAUDE_WRAPPER_SHIM"] = str(current_shim)
+        env["CMUX_CLAUDE_WRAPPER_SHIM_ROOT"] = str(current_shim_bin)
+        env["CMUX_CUSTOM_CLAUDE_PATH"] = str(bundle_bin / "claude")
+        env.pop("CMUX_SURFACE_ID", None)
+        env.pop("CMUX_SOCKET_PATH", None)
+
+        result = run_wrapper([str(current_shim), "--version"], env)
+        output = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            failures.append(f"stale shim check exited {result.returncode}: {output}")
+        if output != "real-claude --version":
+            failures.append(f"expected user claude after stale shim, got {output!r}")
+
+
 def test_shell_integration_does_not_shim_grok(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-grok-wrapper-resolution-") as td:
         root = Path(td)
@@ -174,6 +239,7 @@ def test_shell_integration_preserves_empty_path_components(failures: list[str]) 
 def main() -> int:
     failures: list[str] = []
     test_wrapper_skips_cmux_shims_and_bundled_claude(failures)
+    test_wrapper_skips_stale_cmux_shims(failures)
     test_shell_integration_does_not_shim_grok(failures)
     test_shell_integration_preserves_empty_path_components(failures)
     if failures:


### PR DESCRIPTION
## Summary

- reject every per-surface `cmux-cli-shims/*/claude` entry while resolving the real Claude binary
- add a behavioral regression test with current and stale surface shim directories

## Root cause

If cmux is launched from a cmux terminal, its process can inherit that surface's Claude shim in `PATH`. A new terminal prepends its own shim, but the wrapper previously excluded only the shim named by the current `CMUX_CLAUDE_WRAPPER_SHIM` variables. It could therefore select the inherited stale shim as `REAL_CLAUDE`, causing the wrappers to invoke each other until the growing argument list failed with `E2BIG`.

## Validation

- regression-only commit fails with `expected user claude after stale shim, got 'stale-shim --version'`
- `python3 tests/test_claude_wrapper_user_binary_resolution.py`
- `python3 tests/test_claude_wrapper_hooks.py`
- `python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py`
- `bash -n Resources/bin/cmux-claude-wrapper`
- `CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig ./scripts/reload.sh --tag fix-stale-claude-shim`

No user-facing strings or localization resources changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784139348&installation_id=133855650&pr_number=6163&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6163&signature=413ce92d20532eeaed2746626c1b7ee152a32a4f1eaa0250a549d6d0b92e90a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip stale per-surface Claude shims during wrapper resolution to prevent shim recursion. Fixes the loop that could end with E2BIG when `PATH` includes an older shim.

- **Bug Fixes**
  - Exclude all `cmux-cli-shims/*/claude` candidates when resolving the real `claude` (not just `CMUX_CLAUDE_WRAPPER_SHIM`).
  - Add a regression test that places a stale shim ahead of the current shim and bundled binary, and verifies the user `claude` is selected.

<sup>Written for commit 30cf49fc96a01870e32900efb8df59ba8f9bb934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the wrapper's binary resolution detection to properly identify and skip stale or cached shims, ensuring the correct user binary is resolved and executed regardless of how many shim versions are present in the system.

* **Tests**
  * Added test coverage validating correct wrapper behavior when multiple shim versions coexist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->