### PR TITLE
Extract sidebar-metadata argument parser from TerminalController into CmuxSidebarMetadata

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,7 +4,7 @@
 34202	CLI/cmux.swift
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
-14785	Sources/TerminalController.swift
+14632	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift

--- a/Packages/CmuxSidebarMetadata/Package.swift
+++ b/Packages/CmuxSidebarMetadata/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxSidebarMetadata",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxSidebarMetadata",
+            targets: ["CmuxSidebarMetadata"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxSidebar"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxSidebarMetadata",
+            dependencies: [
+                .product(name: "CmuxSidebar", package: "CmuxSidebar"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxSidebarMetadataTests",
+            dependencies: ["CmuxSidebarMetadata"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarMetadataArgumentParser.swift
+++ b/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarMetadataArgumentParser.swift
@@ -1,0 +1,277 @@
+import Foundation
+public import CmuxSidebar
+
+/// Stateless parser for sidebar-metadata and sidebar-mutation control-socket commands.
+///
+/// All methods are pure transforms over the raw argument string: shell-like
+/// tokenization, `--key[=value]` option parsing, metadata-format token parsing,
+/// option-value normalization, and `--tab`/`--panel` target parsing. The parser
+/// holds no state and reaches no app singletons; resolving a parsed target to a
+/// concrete tab is the caller's job. Behavior is byte-identical to the legacy
+/// `TerminalController` parsers it replaces, so the control-socket wire format is
+/// preserved exactly.
+public struct SidebarMetadataArgumentParser: Sendable {
+    /// Creates a parser. The parser is stateless; a fresh instance is cheap.
+    public init() {}
+
+    /// Splits a raw argument string into tokens using shell-like quoting.
+    ///
+    /// Single and double quotes group tokens; inside double quotes, the escapes
+    /// `\n`, `\r`, `\t`, `\"`, `\'`, and `\\` are interpreted. Unescaped
+    /// whitespace separates tokens. Empty input yields no tokens.
+    /// - Parameter args: The raw argument string.
+    /// - Returns: The parsed tokens in order.
+    public func tokenize(_ args: String) -> [String] {
+        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var tokens: [String] = []
+        var current = ""
+        var inQuote = false
+        var quoteChar: Character = "\""
+        var cursor = trimmed.startIndex
+
+        while cursor < trimmed.endIndex {
+            let char = trimmed[cursor]
+            if inQuote {
+                if char == quoteChar {
+                    inQuote = false
+                    cursor = trimmed.index(after: cursor)
+                    continue
+                }
+                if char == "\\" {
+                    let nextIndex = trimmed.index(after: cursor)
+                    if nextIndex < trimmed.endIndex {
+                        let next = trimmed[nextIndex]
+                        switch next {
+                        case "n":
+                            current.append("\n")
+                            cursor = trimmed.index(after: nextIndex)
+                            continue
+                        case "r":
+                            current.append("\r")
+                            cursor = trimmed.index(after: nextIndex)
+                            continue
+                        case "t":
+                            current.append("\t")
+                            cursor = trimmed.index(after: nextIndex)
+                            continue
+                        case "\"", "'", "\\":
+                            current.append(next)
+                            cursor = trimmed.index(after: nextIndex)
+                            continue
+                        default:
+                            break
+                        }
+                    }
+                }
+                current.append(char)
+                cursor = trimmed.index(after: cursor)
+                continue
+            }
+
+            if char == "'" || char == "\"" {
+                inQuote = true
+                quoteChar = char
+                cursor = trimmed.index(after: cursor)
+                continue
+            }
+
+            if char.isWhitespace {
+                if !current.isEmpty {
+                    tokens.append(current)
+                    current = ""
+                }
+                cursor = trimmed.index(after: cursor)
+                continue
+            }
+
+            current.append(char)
+            cursor = trimmed.index(after: cursor)
+        }
+
+        if !current.isEmpty {
+            tokens.append(current)
+        }
+        return tokens
+    }
+
+    /// Parses `--key[=value]` options and positional arguments, stopping option
+    /// parsing at a bare `--` (everything after is positional).
+    ///
+    /// `--key value` consumes the next token as the value unless that token
+    /// starts with `--`, in which case the option's value is the empty string.
+    /// - Parameter args: The raw argument string.
+    /// - Returns: The positional arguments and the option dictionary.
+    public func parseOptions(_ args: String) -> (positional: [String], options: [String: String]) {
+        let tokens = tokenize(args)
+        guard !tokens.isEmpty else { return ([], [:]) }
+
+        var positional: [String] = []
+        var options: [String: String] = [:]
+        var stopParsingOptions = false
+        var i = 0
+        while i < tokens.count {
+            let token = tokens[i]
+            if stopParsingOptions {
+                positional.append(token)
+            } else if token == "--" {
+                stopParsingOptions = true
+            } else if token.hasPrefix("--") {
+                if let eqIndex = token.firstIndex(of: "=") {
+                    let key = String(token[token.index(token.startIndex, offsetBy: 2)..<eqIndex])
+                    let value = String(token[token.index(after: eqIndex)...])
+                    options[key] = value
+                } else {
+                    let key = String(token.dropFirst(2))
+                    if i + 1 < tokens.count && !tokens[i + 1].hasPrefix("--") {
+                        options[key] = tokens[i + 1]
+                        i += 1
+                    } else {
+                        options[key] = ""
+                    }
+                }
+            } else {
+                positional.append(token)
+            }
+            i += 1
+        }
+        return (positional, options)
+    }
+
+    /// Parses `--key[=value]` options and positional arguments, treating a bare
+    /// `--` as a no-op separator that is dropped rather than a stop marker.
+    ///
+    /// Tokens after a `--` continue to be parsed as options. Used by commands
+    /// whose value text may itself contain `--`.
+    /// - Parameter args: The raw argument string.
+    /// - Returns: The positional arguments and the option dictionary.
+    public func parseOptionsNoStop(_ args: String) -> (positional: [String], options: [String: String]) {
+        let tokens = tokenize(args)
+        guard !tokens.isEmpty else { return ([], [:]) }
+
+        var positional: [String] = []
+        var options: [String: String] = [:]
+        var i = 0
+        while i < tokens.count {
+            let token = tokens[i]
+            if token == "--" {
+                i += 1
+                continue
+            }
+            if token.hasPrefix("--") {
+                if let eqIndex = token.firstIndex(of: "=") {
+                    let key = String(token[token.index(token.startIndex, offsetBy: 2)..<eqIndex])
+                    let value = String(token[token.index(after: eqIndex)...])
+                    options[key] = value
+                } else {
+                    let key = String(token.dropFirst(2))
+                    if i + 1 < tokens.count && !tokens[i + 1].hasPrefix("--") {
+                        options[key] = tokens[i + 1]
+                        i += 1
+                    } else {
+                        options[key] = ""
+                    }
+                }
+            } else {
+                positional.append(token)
+            }
+            i += 1
+        }
+        return (positional, options)
+    }
+
+    /// Parses a metadata-format token into a ``SidebarMetadataFormat``.
+    ///
+    /// Accepts `plain`, `markdown`, and the `md` alias (case-insensitive).
+    /// - Parameter raw: The raw format token.
+    /// - Returns: The format, or `nil` for an unknown token.
+    public func parseMetadataFormat(_ raw: String) -> SidebarMetadataFormat? {
+        switch raw.lowercased() {
+        case "plain":
+            return .plain
+        case "markdown", "md":
+            return .markdown
+        default:
+            return nil
+        }
+    }
+
+    /// Normalizes an optional option value: trims whitespace and maps an empty
+    /// result to `nil`.
+    /// - Parameter value: The raw option value, or `nil`.
+    /// - Returns: The trimmed non-empty value, or `nil`.
+    public func normalizedOptionValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Parses the `--tab` option into a ``SidebarMutationTabTargetResolution``.
+    ///
+    /// Absent `--tab` resolves to ``SidebarMutationTabTarget/selected``. A UUID
+    /// resolves to ``SidebarMutationTabTarget/workspace(_:)``; a non-negative
+    /// integer resolves to ``SidebarMutationTabTarget/index(_:)``; anything else
+    /// (including an empty value) yields the verbatim `ERROR: Tab not found`.
+    /// - Parameter options: The parsed option dictionary.
+    /// - Returns: The resolution carrying a target or an error.
+    public func parseMutationTabTarget(
+        options: [String: String]
+    ) -> SidebarMutationTabTargetResolution {
+        if let rawTabArg = options["tab"] {
+            let tabArg = rawTabArg.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !tabArg.isEmpty else {
+                return SidebarMutationTabTargetResolution(target: nil, error: "ERROR: Tab not found")
+            }
+            if let tabId = UUID(uuidString: tabArg) {
+                return SidebarMutationTabTargetResolution(target: .workspace(tabId), error: nil)
+            }
+            if let index = Int(tabArg), index >= 0 {
+                return SidebarMutationTabTargetResolution(target: .index(index), error: nil)
+            }
+            return SidebarMutationTabTargetResolution(target: nil, error: "ERROR: Tab not found")
+        }
+        return SidebarMutationTabTargetResolution(target: .selected, error: nil)
+    }
+
+    /// Parses the optional `--panel`/`--surface` id option.
+    ///
+    /// `--surface` is honored as an alias when `--panel` is absent. An empty value
+    /// yields `ERROR: Missing panel id — usage: <usage>`; a non-UUID value yields
+    /// `ERROR: Invalid panel id '<raw>'`; an absent option yields a `nil` id with no
+    /// error. Error strings are returned verbatim to preserve the legacy responses.
+    /// - Parameters:
+    ///   - options: The parsed option dictionary.
+    ///   - usage: The usage string interpolated into the missing-id error.
+    /// - Returns: The parsed panel id or a verbatim error.
+    public func parseOptionalPanelId(
+        options: [String: String],
+        usage: String
+    ) -> SidebarOptionalPanelId {
+        guard let rawPanelArg = options["panel"] ?? options["surface"] else {
+            return SidebarOptionalPanelId(panelId: nil, error: nil)
+        }
+        let panelArg = rawPanelArg.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !panelArg.isEmpty else {
+            return SidebarOptionalPanelId(panelId: nil, error: "ERROR: Missing panel id — usage: \(usage)")
+        }
+        guard let panelId = UUID(uuidString: panelArg) else {
+            return SidebarOptionalPanelId(panelId: nil, error: "ERROR: Invalid panel id '\(rawPanelArg)'")
+        }
+        return SidebarOptionalPanelId(panelId: panelId, error: nil)
+    }
+
+    /// Splits a metadata-block argument string at the first ` -- ` separator into
+    /// an options part and an optional trailing markdown part.
+    /// - Parameter args: The raw argument string.
+    /// - Returns: The options substring and the markdown substring (`nil` if no
+    ///   separator was present).
+    public func splitMetadataBlockArgs(_ args: String) -> (optionsPart: String, markdownPart: String?) {
+        guard let separatorRange = args.range(of: " -- ") else {
+            return (args, nil)
+        }
+        let optionsPart = String(args[..<separatorRange.lowerBound])
+        let markdownPart = String(args[separatorRange.upperBound...])
+        return (optionsPart, markdownPart)
+    }
+}

--- a/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarMutationTabTarget.swift
+++ b/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarMutationTabTarget.swift
@@ -1,0 +1,37 @@
+public import Foundation
+
+/// Which tab a sidebar-metadata mutation or report command addresses.
+///
+/// Parsed from a command's `--tab` option by ``SidebarMetadataArgumentParser``.
+/// Resolving a target to a concrete tab is the app target's responsibility
+/// (it owns `Tab`/`TabManager`); this value type only carries the parsed intent.
+public enum SidebarMutationTabTarget: Sendable, Equatable {
+    /// No `--tab` option was supplied; address the currently selected tab.
+    case selected
+    /// `--tab=<uuid>`: address the workspace/tab with this identifier, searching
+    /// every window if it is not in the local tab manager.
+    case workspace(UUID)
+    /// `--tab=<n>`: address the tab at this zero-based index in the local tab manager.
+    case index(Int)
+}
+
+/// The outcome of parsing a `--tab` option into a ``SidebarMutationTabTarget``.
+///
+/// At most one of ``target`` and ``error`` is non-`nil`. A `nil` target paired
+/// with a non-`nil` error is the caller's signal to return the error string
+/// verbatim, preserving the legacy wire responses.
+public struct SidebarMutationTabTargetResolution: Sendable, Equatable {
+    /// The parsed target, or `nil` when the `--tab` option was malformed.
+    public let target: SidebarMutationTabTarget?
+    /// The error string to return verbatim, or `nil` on success.
+    public let error: String?
+
+    /// Creates a resolution from a parsed target and/or an error string.
+    /// - Parameters:
+    ///   - target: The parsed target, or `nil` on failure.
+    ///   - error: The verbatim error string, or `nil` on success.
+    public init(target: SidebarMutationTabTarget?, error: String?) {
+        self.target = target
+        self.error = error
+    }
+}

--- a/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarOptionalPanelId.swift
+++ b/Packages/CmuxSidebarMetadata/Sources/CmuxSidebarMetadata/SidebarOptionalPanelId.swift
@@ -1,0 +1,23 @@
+public import Foundation
+
+/// The outcome of parsing an optional `--panel`/`--surface` id option.
+///
+/// Produced by ``SidebarMetadataArgumentParser/parseOptionalPanelId(options:usage:)``.
+/// At most one of ``panelId`` and ``error`` is non-`nil`. A `nil` panel id with a
+/// `nil` error means the option was absent (which is valid); a non-`nil` error is
+/// returned verbatim by the caller to preserve the legacy wire responses.
+public struct SidebarOptionalPanelId: Sendable, Equatable {
+    /// The parsed panel id, or `nil` when the option was absent or malformed.
+    public let panelId: UUID?
+    /// The verbatim error string, or `nil` when the option was absent or valid.
+    public let error: String?
+
+    /// Creates a result from a parsed panel id and/or an error string.
+    /// - Parameters:
+    ///   - panelId: The parsed panel id, or `nil`.
+    ///   - error: The verbatim error string, or `nil`.
+    public init(panelId: UUID?, error: String?) {
+        self.panelId = panelId
+        self.error = error
+    }
+}

--- a/Packages/CmuxSidebarMetadata/Tests/CmuxSidebarMetadataTests/SidebarMetadataArgumentParserTests.swift
+++ b/Packages/CmuxSidebarMetadata/Tests/CmuxSidebarMetadataTests/SidebarMetadataArgumentParserTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+import CmuxSidebar
+@testable import CmuxSidebarMetadata
+
+@Suite("SidebarMetadataArgumentParser")
+struct SidebarMetadataArgumentParserTests {
+    let parser = SidebarMetadataArgumentParser()
+
+    @Test("tokenize splits on unquoted whitespace")
+    func tokenizeWhitespace() {
+        #expect(parser.tokenize("  a   b\tc ") == ["a", "b", "c"])
+        #expect(parser.tokenize("") == [])
+        #expect(parser.tokenize("   ") == [])
+    }
+
+    @Test("tokenize groups quoted spans and interprets escapes")
+    func tokenizeQuotes() {
+        #expect(parser.tokenize("'a b' c") == ["a b", "c"])
+        #expect(parser.tokenize("\"x\\ny\"") == ["x\ny"])
+        #expect(parser.tokenize("\"a\\tb\\r\"") == ["a\tb\r"])
+        #expect(parser.tokenize("\"q\\\"q\"") == ["q\"q"])
+        // Unknown escape is preserved literally (backslash kept).
+        #expect(parser.tokenize("\"a\\zb\"") == ["a\\zb"])
+    }
+
+    @Test("parseOptions handles --key=value, --key value, and stop marker")
+    func parseOptionsBasics() {
+        let r = parser.parseOptions("pos1 --a=1 --b 2 -- --c not-an-option")
+        #expect(r.positional == ["pos1", "--c", "not-an-option"])
+        #expect(r.options == ["a": "1", "b": "2"])
+    }
+
+    @Test("parseOptions treats trailing flag with no value as empty string")
+    func parseOptionsEmptyFlag() {
+        let r = parser.parseOptions("--flag")
+        #expect(r.options["flag"] == "")
+        let r2 = parser.parseOptions("--flag --next")
+        #expect(r2.options["flag"] == "")
+        #expect(r2.options["next"] == "")
+    }
+
+    @Test("parseOptionsNoStop drops -- but keeps parsing options after it")
+    func parseOptionsNoStop() {
+        let r = parser.parseOptionsNoStop("k v -- --a 1")
+        #expect(r.positional == ["k", "v"])
+        #expect(r.options == ["a": "1"])
+    }
+
+    @Test("parseMetadataFormat accepts plain, markdown, md; rejects others")
+    func metadataFormat() {
+        #expect(parser.parseMetadataFormat("plain") == .plain)
+        #expect(parser.parseMetadataFormat("PLAIN") == .plain)
+        #expect(parser.parseMetadataFormat("markdown") == .markdown)
+        #expect(parser.parseMetadataFormat("md") == .markdown)
+        #expect(parser.parseMetadataFormat("html") == nil)
+    }
+
+    @Test("normalizedOptionValue trims and maps empty to nil")
+    func normalizedValue() {
+        #expect(parser.normalizedOptionValue("  x  ") == "x")
+        #expect(parser.normalizedOptionValue("   ") == nil)
+        #expect(parser.normalizedOptionValue(nil) == nil)
+    }
+
+    @Test("parseMutationTabTarget maps absent/uuid/index/invalid")
+    func tabTarget() {
+        #expect(parser.parseMutationTabTarget(options: [:]).target == .selected)
+
+        let uuid = UUID()
+        let byUUID = parser.parseMutationTabTarget(options: ["tab": uuid.uuidString])
+        #expect(byUUID.target == .workspace(uuid))
+        #expect(byUUID.error == nil)
+
+        let byIndex = parser.parseMutationTabTarget(options: ["tab": "3"])
+        #expect(byIndex.target == .index(3))
+
+        let empty = parser.parseMutationTabTarget(options: ["tab": "  "])
+        #expect(empty.target == nil)
+        #expect(empty.error == "ERROR: Tab not found")
+
+        let bad = parser.parseMutationTabTarget(options: ["tab": "nope"])
+        #expect(bad.target == nil)
+        #expect(bad.error == "ERROR: Tab not found")
+
+        let negative = parser.parseMutationTabTarget(options: ["tab": "-1"])
+        #expect(negative.target == nil)
+        #expect(negative.error == "ERROR: Tab not found")
+    }
+
+    @Test("parseOptionalPanelId honors panel, surface alias, and error shapes")
+    func optionalPanelId() {
+        let usage = "USAGE"
+        #expect(parser.parseOptionalPanelId(options: [:], usage: usage).panelId == nil)
+        #expect(parser.parseOptionalPanelId(options: [:], usage: usage).error == nil)
+
+        let uuid = UUID()
+        let byPanel = parser.parseOptionalPanelId(options: ["panel": uuid.uuidString], usage: usage)
+        #expect(byPanel.panelId == uuid)
+
+        let bySurface = parser.parseOptionalPanelId(options: ["surface": uuid.uuidString], usage: usage)
+        #expect(bySurface.panelId == uuid)
+
+        let emptyPanel = parser.parseOptionalPanelId(options: ["panel": "  "], usage: usage)
+        #expect(emptyPanel.panelId == nil)
+        #expect(emptyPanel.error == "ERROR: Missing panel id — usage: USAGE")
+
+        let badPanel = parser.parseOptionalPanelId(options: ["panel": "nope"], usage: usage)
+        #expect(badPanel.panelId == nil)
+        #expect(badPanel.error == "ERROR: Invalid panel id 'nope'")
+    }
+
+    @Test("splitMetadataBlockArgs splits at first ' -- ' only")
+    func splitBlock() {
+        let none = parser.splitMetadataBlockArgs("--a 1")
+        #expect(none.optionsPart == "--a 1")
+        #expect(none.markdownPart == nil)
+
+        let split = parser.splitMetadataBlockArgs("--a 1 -- body -- more")
+        #expect(split.optionsPart == "--a 1")
+        #expect(split.markdownPart == "body -- more")
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20,6 +20,7 @@ import Foundation
 import Bonsplit
 import WebKit
 import CmuxSidebar
+import CmuxSidebarMetadata
 import CmuxTerminal
 import CmuxWorkspaceCore
 
@@ -129,6 +130,10 @@ class TerminalController {
     // with the legacy dispatcher), so the former `nonisolated` is gone. The
     // package type keeps its internal lock for its own tested contract.
     let socketFastPathState = SocketFastPathState()
+    // Stateless sidebar-metadata/command argument parser (CmuxSidebarMetadata).
+    // Pure transforms over the raw arg string; holds no state and reaches no
+    // app singletons, so the `report_*`/sidebar-mutation handlers forward to it.
+    private nonisolated let sidebarMetadataArgumentParser = SidebarMetadataArgumentParser()
     private nonisolated let myPid = getpid()
     private nonisolated static let socketCommandFocusAllowanceStackKey = "cmux.socketCommandFocusAllowanceStack"
     private nonisolated static let socketListenerFailureCaptureCooldown: TimeInterval = 60
@@ -12980,149 +12985,15 @@ class TerminalController {
     // MARK: - Option Parsing (sidebar metadata commands)
 
     private nonisolated static func tokenizeArgs(_ args: String) -> [String] {
-        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return [] }
-
-        var tokens: [String] = []
-        var current = ""
-        var inQuote = false
-        var quoteChar: Character = "\""
-        var cursor = trimmed.startIndex
-
-        while cursor < trimmed.endIndex {
-            let char = trimmed[cursor]
-            if inQuote {
-                if char == quoteChar {
-                    inQuote = false
-                    cursor = trimmed.index(after: cursor)
-                    continue
-                }
-                if char == "\\" {
-                    let nextIndex = trimmed.index(after: cursor)
-                    if nextIndex < trimmed.endIndex {
-                        let next = trimmed[nextIndex]
-                        switch next {
-                        case "n":
-                            current.append("\n")
-                            cursor = trimmed.index(after: nextIndex)
-                            continue
-                        case "r":
-                            current.append("\r")
-                            cursor = trimmed.index(after: nextIndex)
-                            continue
-                        case "t":
-                            current.append("\t")
-                            cursor = trimmed.index(after: nextIndex)
-                            continue
-                        case "\"", "'", "\\":
-                            current.append(next)
-                            cursor = trimmed.index(after: nextIndex)
-                            continue
-                        default:
-                            break
-                        }
-                    }
-                }
-                current.append(char)
-                cursor = trimmed.index(after: cursor)
-                continue
-            }
-
-            if char == "'" || char == "\"" {
-                inQuote = true
-                quoteChar = char
-                cursor = trimmed.index(after: cursor)
-                continue
-            }
-
-            if char.isWhitespace {
-                if !current.isEmpty {
-                    tokens.append(current)
-                    current = ""
-                }
-                cursor = trimmed.index(after: cursor)
-                continue
-            }
-
-            current.append(char)
-            cursor = trimmed.index(after: cursor)
-        }
-
-        if !current.isEmpty {
-            tokens.append(current)
-        }
-        return tokens
+        SidebarMetadataArgumentParser().tokenize(args)
     }
 
     private func parseOptions(_ args: String) -> (positional: [String], options: [String: String]) {
-        let tokens = Self.tokenizeArgs(args)
-        guard !tokens.isEmpty else { return ([], [:]) }
-
-        var positional: [String] = []
-        var options: [String: String] = [:]
-        var stopParsingOptions = false
-        var i = 0
-        while i < tokens.count {
-            let token = tokens[i]
-            if stopParsingOptions {
-                positional.append(token)
-            } else if token == "--" {
-                stopParsingOptions = true
-            } else if token.hasPrefix("--") {
-                if let eqIndex = token.firstIndex(of: "=") {
-                    let key = String(token[token.index(token.startIndex, offsetBy: 2)..<eqIndex])
-                    let value = String(token[token.index(after: eqIndex)...])
-                    options[key] = value
-                } else {
-                    let key = String(token.dropFirst(2))
-                    if i + 1 < tokens.count && !tokens[i + 1].hasPrefix("--") {
-                        options[key] = tokens[i + 1]
-                        i += 1
-                    } else {
-                        options[key] = ""
-                    }
-                }
-            } else {
-                positional.append(token)
-            }
-            i += 1
-        }
-        return (positional, options)
+        sidebarMetadataArgumentParser.parseOptions(args)
     }
 
     private func parseOptionsNoStop(_ args: String) -> (positional: [String], options: [String: String]) {
-        let tokens = Self.tokenizeArgs(args)
-        guard !tokens.isEmpty else { return ([], [:]) }
-
-        var positional: [String] = []
-        var options: [String: String] = [:]
-        var i = 0
-        while i < tokens.count {
-            let token = tokens[i]
-            if token == "--" {
-                i += 1
-                continue
-            }
-            if token.hasPrefix("--") {
-                if let eqIndex = token.firstIndex(of: "=") {
-                    let key = String(token[token.index(token.startIndex, offsetBy: 2)..<eqIndex])
-                    let value = String(token[token.index(after: eqIndex)...])
-                    options[key] = value
-                } else {
-                    let key = String(token.dropFirst(2))
-                    if i + 1 < tokens.count && !tokens[i + 1].hasPrefix("--") {
-                        options[key] = tokens[i + 1]
-                        i += 1
-                    } else {
-                        options[key] = ""
-                    }
-                }
-            } else {
-                positional.append(token)
-            }
-            i += 1
-        }
-        return (positional, options)
+        sidebarMetadataArgumentParser.parseOptionsNoStop(args)
     }
 
     private func resolveTabForReport(_ args: String) -> Tab? {
@@ -13155,20 +13026,19 @@ class TerminalController {
     private func parseSidebarMutationTabTarget(
         options: [String: String]
     ) -> (target: SidebarMutationTabTarget?, error: String?) {
-        if let rawTabArg = options["tab"] {
-            let tabArg = rawTabArg.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !tabArg.isEmpty else {
-                return (nil, "ERROR: Tab not found")
-            }
-            if let tabId = UUID(uuidString: tabArg) {
-                return (.workspace(tabId), nil)
-            }
-            if let index = Int(tabArg), index >= 0 {
-                return (.index(index), nil)
-            }
-            return (nil, "ERROR: Tab not found")
+        let resolution = sidebarMetadataArgumentParser.parseMutationTabTarget(options: options)
+        let target: SidebarMutationTabTarget?
+        switch resolution.target {
+        case nil:
+            target = nil
+        case .selected:
+            target = .selected
+        case .workspace(let id):
+            target = .workspace(id)
+        case .index(let index):
+            target = .index(index)
         }
-        return (.selected, nil)
+        return (target, resolution.error)
     }
 
     private func resolveSidebarMutationTab(_ target: SidebarMutationTabTarget) -> Tab? {
@@ -13201,37 +13071,19 @@ class TerminalController {
     }
 
     private func parseSidebarMetadataFormat(_ raw: String) -> SidebarMetadataFormat? {
-        switch raw.lowercased() {
-        case "plain":
-            return .plain
-        case "markdown", "md":
-            return .markdown
-        default:
-            return nil
-        }
+        sidebarMetadataArgumentParser.parseMetadataFormat(raw)
     }
 
     private func normalizedOptionValue(_ value: String?) -> String? {
-        guard let value else { return nil }
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        sidebarMetadataArgumentParser.normalizedOptionValue(value)
     }
 
     private func parseOptionalPanelIdOption(
         options: [String: String],
         usage: String
     ) -> (panelId: UUID?, error: String?) {
-        guard let rawPanelArg = options["panel"] ?? options["surface"] else {
-            return (nil, nil)
-        }
-        let panelArg = rawPanelArg.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !panelArg.isEmpty else {
-            return (nil, "ERROR: Missing panel id — usage: \(usage)")
-        }
-        guard let panelId = UUID(uuidString: panelArg) else {
-            return (nil, "ERROR: Invalid panel id '\(rawPanelArg)'")
-        }
-        return (panelId, nil)
+        let result = sidebarMetadataArgumentParser.parseOptionalPanelId(options: options, usage: usage)
+        return (result.panelId, result.error)
     }
 
     private func scheduleSidebarMutation(
@@ -13465,12 +13317,7 @@ class TerminalController {
     }
 
     private func splitMetadataBlockArgs(_ args: String) -> (optionsPart: String, markdownPart: String?) {
-        guard let separatorRange = args.range(of: " -- ") else {
-            return (args, nil)
-        }
-        let optionsPart = String(args[..<separatorRange.lowerBound])
-        let markdownPart = String(args[separatorRange.upperBound...])
-        return (optionsPart, markdownPart)
+        sidebarMetadataArgumentParser.splitMetadataBlockArgs(args)
     }
 
     private func sidebarMetadataBlockLine(_ block: SidebarMetadataBlock) -> String {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		C5B6A10000000000000000A3 /* CmuxSidebarGit in Frameworks */ = {isa = PBXBuildFile; productRef = C5B6A10000000000000000A2 /* CmuxSidebarGit */; };
 		C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */; };
 		C5A1FED200000000000000E2 /* CmuxSidebarInterpreterClient in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */; };
+		E5DA7A0000000000000000F3 /* CmuxSidebarMetadata in Frameworks */ = {isa = PBXBuildFile; productRef = E5DA7A0000000000000000F2 /* CmuxSidebarMetadata */; };
 		C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE4A000000000000000002 /* CmuxSidebarProviderKit */; };
 		C0DE4A000000000000000005 /* CmuxSidebarProviderKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE4A000000000000000004 /* CmuxSidebarProviderKit */; };
 		C5A1FED200000000000000E5 /* CmuxSidebarRemoteRender in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E6 /* CmuxSidebarRemoteRender */; };
@@ -1800,6 +1801,7 @@
 				E3B7A30000000000000000B3 /* CmuxSidebar in Frameworks */,
 				C5B6A10000000000000000A3 /* CmuxSidebarGit in Frameworks */,
 				C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */,
+				E5DA7A0000000000000000F3 /* CmuxSidebarMetadata in Frameworks */,
 				C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */,
 				C5A1FED200000000000000E5 /* CmuxSidebarRemoteRender in Frameworks */,
 				A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */,
@@ -2837,6 +2839,7 @@
 				C617000000000000000000A2 /* CmuxGit */,
 				C5B6A10000000000000000A2 /* CmuxSidebarGit */,
 				E3B7A30000000000000000B2 /* CmuxSidebar */,
+				E5DA7A0000000000000000F2 /* CmuxSidebarMetadata */,
 				E3B7A30000000000000000C2 /* CmuxBrowser */,
 				E3B7A30000000000000000D2 /* CmuxNotifications */,
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
@@ -3030,6 +3033,7 @@
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
+				E5DA7A0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxSidebarMetadata" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
 				E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */,
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
@@ -4559,6 +4563,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSidebar;
 		};
+		E5DA7A0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxSidebarMetadata" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSidebarMetadata;
+		};
 		E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowser;
@@ -4828,6 +4836,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */;
 			productName = CmuxSidebar;
+		};
+		E5DA7A0000000000000000F2 /* CmuxSidebarMetadata */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5DA7A0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxSidebarMetadata" */;
+			productName = CmuxSidebarMetadata;
 		};
 		E3B7A30000000000000000C2 /* CmuxBrowser */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the stateless sidebar-metadata / sidebar-mutation command argument parsers out of the `TerminalController` god file into a new `CmuxSidebarMetadata` package.

## What moved
A new `SidebarMetadataArgumentParser` value type plus two result value objects (`SidebarMutationTabTarget` + `SidebarMutationTabTargetResolution`, `SidebarOptionalPanelId`). Moved methods (all pure transforms over the raw arg string):

- `tokenizeArgs` -> `tokenize` (shell-like quoting/escapes)
- `parseOptions` / `parseOptionsNoStop`
- `parseSidebarMetadataFormat` -> `parseMetadataFormat` (returns `CmuxSidebar.SidebarMetadataFormat`)
- `normalizedOptionValue`
- `parseSidebarMutationTabTarget` -> `parseMutationTabTarget`
- `parseOptionalPanelIdOption` -> `parseOptionalPanelId`
- `splitMetadataBlockArgs`

## Seams
None required. Every moved method is a pure function over the raw argument string; none reached `AppDelegate.shared` / `TabManager` / `Workspace` / `NSWindow` / `MainWindowContext`. The tab-*resolution* methods that DO reach those singletons (`resolveTabForReport`, `resolveSidebarMutationTab`, `tabForSidebarMutation`) intentionally stay in the app target and call the parser only for the parse step.

The package is a clean leaf depending on `CmuxSidebar` for the frozen-wire-format `SidebarMetadataFormat`. The DAG stays acyclic (`CmuxSidebar` has zero deps).

## Byte-identical behavior
`TerminalController` holds one stateless `nonisolated SidebarMetadataArgumentParser` and forwards each former body as a one-line call. Control-socket wire format, the exact error strings (`ERROR: Tab not found`, `ERROR: Missing panel id — usage: ...`, `ERROR: Invalid panel id '...'`), option semantics (`--key=value`, `--key value`, `--` stop marker, `--surface` alias), tokenizer escapes, and metadata-format tokens (`plain`/`markdown`/`md`) are preserved exactly. The app keeps its private `SidebarMutationTabTarget` enum (used in app-only signatures); `parseSidebarMutationTabTarget` maps the package result onto it 1:1.

## Tests
Behavior unit tests (`import Testing`, fakes not needed since the parser is pure) for tokenize, option parsing (both variants), metadata format, option-value normalization, tab-target parsing (absent/uuid/index/empty/invalid/negative), optional panel id (panel/surface alias + error shapes), and metadata-block split. `swift test` green (10 tests).

## Stats
Removed ~203 lines from `Sources/TerminalController.swift` (14785 -> 14632); file-length budget ratcheted down. `scripts/lint-ios-package-conventions.sh` prints OK with zero new `lint:allow`.

NOTE: full app build + XCUITests validated by CI; not run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143841&installation_id=133855650&pr_number=6165&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6165&signature=6aee48513a06a513a3e11546951ee110efcaf84598f37722578b35e3f5f6862b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the stateless sidebar argument parsers from `TerminalController` into a new `CmuxSidebarMetadata` package. Behavior is unchanged and the control-socket wire format and errors remain byte-identical.

- **Refactors**
  - Introduced `CmuxSidebarMetadata` (depends on `CmuxSidebar`) with `SidebarMetadataArgumentParser` plus `SidebarMutationTabTarget` and `SidebarOptionalPanelId`.
  - Moved tokenization, option parsing (with/without `--`), metadata format, tab-target, panel-id, and block-split logic out of `TerminalController`; it now forwards and keeps only tab resolution.
  - Preserved behavior exactly: same error strings, aliases, and tokenizer semantics.
  - Reduced `TerminalController.swift` by ~203 LOC and updated the project wiring; added 10 unit tests for the parser.

<sup>Written for commit 62777e6a99e1ac3495fd8f91204a57fe3e6158e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized sidebar metadata and mutation control argument parsing into a dedicated Swift package to improve code reusability and maintainability.

* **Tests**
  * Added comprehensive test coverage for sidebar metadata parsing functionality, including tokenization, option parsing, format validation, and tab target resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->