### PR TITLE
Extract browser omnibar selection-repeat into CmuxBrowserFocus package

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34202	CLI/cmux.swift
-17778	Sources/AppDelegate.swift
+17694	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift

--- a/Packages/CmuxBrowserFocus/Package.swift
+++ b/Packages/CmuxBrowserFocus/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserFocus",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserFocus",
+            targets: ["CmuxBrowserFocus"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserFocus",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserFocusTests",
+            dependencies: ["CmuxBrowserFocus"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserFocus/Sources/CmuxBrowserFocus/BrowserOmnibarRepeatKey.swift
+++ b/Packages/CmuxBrowserFocus/Sources/CmuxBrowserFocus/BrowserOmnibarRepeatKey.swift
@@ -1,0 +1,31 @@
+public import Foundation
+
+/// Immutable identity of an in-flight browser omnibar selection-repeat run.
+///
+/// The repeat coordinator compares the incoming key against the currently armed
+/// key to decide whether to keep an existing repeat (when the same panel, key
+/// code, and direction are still held) or to re-arm a fresh one. The three
+/// fields together are the full identity of a repeat: which browser panel owns
+/// the omnibar, which physical key is held, and which direction the selection
+/// is moving.
+public struct BrowserOmnibarRepeatKey: Sendable, Equatable {
+    /// Identifier of the browser panel whose omnibar selection is repeating.
+    public let panelID: UUID
+
+    /// `keyCode` of the held key that drives the repeat.
+    public let keyCode: UInt16
+
+    /// Signed selection-move delta applied on each repeat tick.
+    public let delta: Int
+
+    /// Creates a repeat key from its panel, key code, and selection delta.
+    /// - Parameters:
+    ///   - panelID: Identifier of the owning browser panel.
+    ///   - keyCode: `keyCode` of the held key.
+    ///   - delta: Signed selection-move delta per tick.
+    public init(panelID: UUID, keyCode: UInt16, delta: Int) {
+        self.panelID = panelID
+        self.keyCode = keyCode
+        self.delta = delta
+    }
+}

--- a/Packages/CmuxBrowserFocus/Sources/CmuxBrowserFocus/BrowserOmnibarSelectionRepeatCoordinator.swift
+++ b/Packages/CmuxBrowserFocus/Sources/CmuxBrowserFocus/BrowserOmnibarSelectionRepeatCoordinator.swift
@@ -1,0 +1,196 @@
+public import Foundation
+import Observation
+
+/// Drives the auto-repeat of a browser omnibar selection move while the user
+/// holds a Control-navigation key (for example Ctrl+arrow) with the address bar
+/// focused.
+///
+/// The coordinator owns the small state machine that the cmux app delegate used
+/// to inline: arm a repeat for a `(panel, keyCode, delta)` identity, fire the
+/// first synthetic move after a 250 ms hold delay, then tick every 55 ms until
+/// the key is released, the modifiers change, or focus is cleared. It does no
+/// AppKit work itself; every outside-world effect is a constructor-injected
+/// seam:
+///
+/// - ``selectionMove`` posts the per-tick selection move (the app forwards it to
+///   `NotificationCenter` under `.browserMoveOmnibarSelection`).
+/// - ``sleep`` is the timing source. The default is `ContinuousClock`; tests
+///   inject a deterministic clock. This replaces the previous
+///   `DispatchQueue.main.asyncAfter` work items, which were not cancellable in a
+///   structured way and were untestable.
+/// - ``debugLog`` mirrors the original `#if DEBUG` trace lines verbatim so the
+///   debug-event log is byte-identical to the pre-extraction behavior.
+///
+/// All state is `@MainActor`-isolated, matching the app delegate that owns the
+/// single instance.
+@MainActor
+@Observable
+public final class BrowserOmnibarSelectionRepeatCoordinator {
+    /// Sink invoked once per repeat tick to dispatch a selection move for a
+    /// panel by a signed delta.
+    public typealias SelectionMove = @MainActor (_ panelID: UUID, _ delta: Int) -> Void
+
+    /// Sink invoked with each debug-trace line (active only when the host passes
+    /// a logger; production passes `nil`).
+    public typealias DebugLog = @MainActor (_ line: String) -> Void
+
+    /// Suspends for `duration` and is cancelled when the owning repeat task is
+    /// cancelled, giving the same hold-then-tick cadence the work items had.
+    public typealias Sleep = @Sendable (_ duration: Duration) async throws -> Void
+
+    /// Hold delay before the first repeat tick fires (matches the original
+    /// 0.25 s `asyncAfter` deadline).
+    public static let startDelay: Duration = .milliseconds(250)
+
+    /// Interval between repeat ticks once repeating (matches the original
+    /// 0.055 s `asyncAfter` deadline).
+    public static let tickInterval: Duration = .milliseconds(55)
+
+    private let selectionMove: SelectionMove
+    private let sleep: Sleep
+    private let debugLog: DebugLog?
+
+    private var repeatKey: BrowserOmnibarRepeatKey?
+    private var repeatTask: Task<Void, Never>?
+
+    /// Creates a repeat coordinator with its effect seams injected.
+    /// - Parameters:
+    ///   - selectionMove: Dispatches a selection move for a panel by a delta.
+    ///   - sleep: Cancellable timing source; defaults to `ContinuousClock`.
+    ///   - debugLog: Optional trace sink; pass `nil` outside debug builds.
+    public init(
+        selectionMove: @escaping SelectionMove,
+        sleep: @escaping Sleep = { try await ContinuousClock().sleep(for: $0) },
+        debugLog: DebugLog? = nil
+    ) {
+        self.selectionMove = selectionMove
+        self.sleep = sleep
+        self.debugLog = debugLog
+    }
+
+    /// Identifier of the panel whose omnibar selection is currently repeating,
+    /// or `nil` when no repeat is armed.
+    public var repeatingPanelID: UUID? { repeatKey?.panelID }
+
+    /// `keyCode` of the held key driving the active repeat, or `nil` when no
+    /// repeat is armed.
+    public var repeatingKeyCode: UInt16? { repeatKey?.keyCode }
+
+    /// Dispatches a single selection move immediately, outside the repeat
+    /// cadence. A zero delta is a no-op.
+    /// - Parameters:
+    ///   - panelID: Panel whose omnibar selection should move.
+    ///   - delta: Signed selection-move delta.
+    public func dispatchSelectionMove(panelID: UUID, delta: Int) {
+        guard delta != 0 else { return }
+        debugLog?(
+            "browser.focus.omnibar.selectionMove panel=\(panelID.uuidString.prefix(5)) " +
+            "delta=\(delta) repeatKey=\(repeatKey?.keyCode.description ?? "nil")"
+        )
+        selectionMove(panelID, delta)
+    }
+
+    /// Arms an auto-repeat for the given panel/key/delta if one is not already
+    /// running for the same identity. A zero delta is a no-op. Re-arming with a
+    /// different identity cancels the prior repeat first.
+    /// - Parameters:
+    ///   - panelID: Panel whose omnibar selection should repeat.
+    ///   - keyCode: `keyCode` of the held key.
+    ///   - delta: Signed selection-move delta per tick.
+    public func startRepeatIfNeeded(panelID: UUID, keyCode: UInt16, delta: Int) {
+        guard delta != 0 else { return }
+
+        let incoming = BrowserOmnibarRepeatKey(panelID: panelID, keyCode: keyCode, delta: delta)
+        if repeatKey == incoming {
+            debugLog?(
+                "browser.focus.omnibar.repeat.start panel=\(panelID.uuidString.prefix(5)) " +
+                "key=\(keyCode) delta=\(delta) result=reuse"
+            )
+            return
+        }
+
+        stopRepeat()
+        repeatKey = incoming
+        debugLog?(
+            "browser.focus.omnibar.repeat.start panel=\(panelID.uuidString.prefix(5)) " +
+            "key=\(keyCode) delta=\(delta) result=armed"
+        )
+
+        repeatTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.sleep(Self.startDelay)
+            } catch {
+                return
+            }
+            await self.runRepeatLoop()
+        }
+    }
+
+    /// Cancels any in-flight repeat and clears the armed identity, emitting the
+    /// stop trace line when a repeat was active.
+    public func stopRepeat() {
+        let previous = repeatKey
+        repeatTask?.cancel()
+        repeatTask = nil
+        repeatKey = nil
+        if let previous, previous.keyCode != 0 || previous.delta != 0 {
+            debugLog?(
+                "browser.focus.omnibar.repeat.stop panel=\(previous.panelID.uuidString.prefix(5)) " +
+                "key=\(previous.keyCode) " +
+                "delta=\(previous.delta)"
+            )
+        }
+    }
+
+    /// Stops the repeat when the released key matches the held key.
+    /// - Parameter keyCode: `keyCode` of the key-up event.
+    public func noteKeyUp(keyCode: UInt16) {
+        guard repeatKey != nil else { return }
+        if keyCode == repeatKey?.keyCode {
+            debugLog?(
+                "browser.focus.omnibar.repeat.lifecycle event=keyUp key=\(keyCode) " +
+                "action=stop"
+            )
+            stopRepeat()
+        }
+    }
+
+    /// Stops the repeat when a modifier change no longer satisfies the
+    /// Control-navigation hold.
+    /// - Parameters:
+    ///   - shouldContinue: Whether the new modifier state still drives a repeat.
+    ///   - flagsRawValue: Raw modifier value for the trace line.
+    public func noteFlagsChanged(shouldContinue: Bool, flagsRawValue: UInt) {
+        guard repeatKey != nil else { return }
+        if !shouldContinue {
+            debugLog?(
+                "browser.focus.omnibar.repeat.lifecycle event=flagsChanged " +
+                "flags=\(flagsRawValue) action=stop"
+            )
+            stopRepeat()
+        }
+    }
+
+    private func runRepeatLoop() async {
+        while !Task.isCancelled {
+            guard let key = repeatKey else {
+                debugLog?("browser.focus.omnibar.repeat.tick result=stop_no_focused_address_bar")
+                stopRepeat()
+                return
+            }
+
+            debugLog?(
+                "browser.focus.omnibar.repeat.tick panel=\(key.panelID.uuidString.prefix(5)) " +
+                "delta=\(key.delta)"
+            )
+            dispatchSelectionMove(panelID: key.panelID, delta: key.delta)
+
+            do {
+                try await sleep(Self.tickInterval)
+            } catch {
+                return
+            }
+        }
+    }
+}

--- a/Packages/CmuxBrowserFocus/Tests/CmuxBrowserFocusTests/BrowserOmnibarSelectionRepeatCoordinatorTests.swift
+++ b/Packages/CmuxBrowserFocus/Tests/CmuxBrowserFocusTests/BrowserOmnibarSelectionRepeatCoordinatorTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserFocus
+
+/// A deterministic, manually advanced clock for repeat-cadence tests.
+///
+/// Each `sleep(_:)` suspends until the test explicitly releases the next waiter
+/// via ``advance()``, so the coordinator's hold-then-tick cadence is driven step
+/// by step without real time.
+private actor StepClock {
+    private var waiters: [CheckedContinuation<Void, Error>] = []
+
+    func sleep() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func advance() {
+        guard !waiters.isEmpty else { return }
+        let next = waiters.removeFirst()
+        next.resume()
+    }
+
+    func pendingCount() -> Int { waiters.count }
+}
+
+@MainActor
+private struct Recorder {
+    final class Box {
+        var moves: [(UUID, Int)] = []
+    }
+    let box = Box()
+    func sink() -> BrowserOmnibarSelectionRepeatCoordinator.SelectionMove {
+        { panelID, delta in self.box.moves.append((panelID, delta)) }
+    }
+}
+
+@MainActor
+@Suite struct BrowserOmnibarSelectionRepeatCoordinatorTests {
+    @Test func dispatchSelectionMoveZeroDeltaIsNoOp() {
+        let recorder = Recorder()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(selectionMove: recorder.sink())
+        coordinator.dispatchSelectionMove(panelID: UUID(), delta: 0)
+        #expect(recorder.box.moves.isEmpty)
+    }
+
+    @Test func dispatchSelectionMoveForwardsNonZeroDelta() {
+        let recorder = Recorder()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(selectionMove: recorder.sink())
+        let panel = UUID()
+        coordinator.dispatchSelectionMove(panelID: panel, delta: -1)
+        #expect(recorder.box.moves.count == 1)
+        #expect(recorder.box.moves[0].0 == panel)
+        #expect(recorder.box.moves[0].1 == -1)
+    }
+
+    @Test func startRepeatZeroDeltaDoesNotArm() {
+        let recorder = Recorder()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(selectionMove: recorder.sink())
+        coordinator.startRepeatIfNeeded(panelID: UUID(), keyCode: 5, delta: 0)
+        #expect(coordinator.repeatingPanelID == nil)
+        #expect(coordinator.repeatingKeyCode == nil)
+    }
+
+    @Test func startRepeatArmsIdentity() {
+        let recorder = Recorder()
+        let clock = StepClock()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() }
+        )
+        let panel = UUID()
+        coordinator.startRepeatIfNeeded(panelID: panel, keyCode: 124, delta: 1)
+        #expect(coordinator.repeatingPanelID == panel)
+        #expect(coordinator.repeatingKeyCode == 124)
+        coordinator.stopRepeat()
+    }
+
+    @Test func repeatTicksAfterStartDelay() async {
+        let recorder = Recorder()
+        let clock = StepClock()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() }
+        )
+        let panel = UUID()
+        coordinator.startRepeatIfNeeded(panelID: panel, keyCode: 124, delta: 2)
+
+        // Let the start-delay sleep register, then release it -> first tick.
+        try? await waitFor { await clock.pendingCount() == 1 }
+        await clock.advance()
+        try? await waitFor { recorder.box.moves.count == 1 }
+        #expect(recorder.box.moves[0].1 == 2)
+
+        // Release the tick-interval sleep -> second tick.
+        try? await waitFor { await clock.pendingCount() == 1 }
+        await clock.advance()
+        try? await waitFor { recorder.box.moves.count == 2 }
+        #expect(recorder.box.moves[1].1 == 2)
+        coordinator.stopRepeat()
+    }
+
+    @Test func reuseDoesNotRearmSameIdentity() {
+        let recorder = Recorder()
+        let clock = StepClock()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() }
+        )
+        var armedCount = 0
+        let logged = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() },
+            debugLog: { line in if line.contains("result=armed") { armedCount += 1 } }
+        )
+        let panel = UUID()
+        logged.startRepeatIfNeeded(panelID: panel, keyCode: 124, delta: 1)
+        logged.startRepeatIfNeeded(panelID: panel, keyCode: 124, delta: 1)
+        #expect(armedCount == 1)
+        logged.stopRepeat()
+        coordinator.stopRepeat()
+    }
+
+    @Test func noteKeyUpStopsMatchingKey() {
+        let recorder = Recorder()
+        let clock = StepClock()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() }
+        )
+        coordinator.startRepeatIfNeeded(panelID: UUID(), keyCode: 124, delta: 1)
+        coordinator.noteKeyUp(keyCode: 99)
+        #expect(coordinator.repeatingKeyCode == 124)
+        coordinator.noteKeyUp(keyCode: 124)
+        #expect(coordinator.repeatingKeyCode == nil)
+    }
+
+    @Test func noteFlagsChangedStopsWhenShouldNotContinue() {
+        let recorder = Recorder()
+        let clock = StepClock()
+        let coordinator = BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: recorder.sink(),
+            sleep: { _ in try await clock.sleep() }
+        )
+        coordinator.startRepeatIfNeeded(panelID: UUID(), keyCode: 124, delta: 1)
+        coordinator.noteFlagsChanged(shouldContinue: true, flagsRawValue: 0)
+        #expect(coordinator.repeatingKeyCode == 124)
+        coordinator.noteFlagsChanged(shouldContinue: false, flagsRawValue: 0)
+        #expect(coordinator.repeatingKeyCode == nil)
+    }
+
+    private func waitFor(
+        _ condition: @escaping () async -> Bool,
+        attempts: Int = 200
+    ) async throws {
+        for _ in 0..<attempts {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        throw CancellationError()
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxAuthRuntime
+import CmuxBrowserFocus
 import CmuxBrowserPanel
 import CmuxCommandPalette
 import CmuxCommandPaletteUI
@@ -763,11 +764,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var ghosttyGotoSplitUpShortcut: StoredShortcut?
     private var ghosttyGotoSplitDownShortcut: StoredShortcut?
     private var browserAddressBarFocusedPanelId: UUID?
-    private var browserOmnibarRepeatStartWorkItem: DispatchWorkItem?
-    private var browserOmnibarRepeatTickWorkItem: DispatchWorkItem?
-    private var browserOmnibarRepeatPanelId: UUID?
-    private var browserOmnibarRepeatKeyCode: UInt16?
-    private var browserOmnibarRepeatDelta: Int = 0
+    /// Owns the browser omnibar selection-repeat state machine, extracted into
+    /// `CmuxBrowserFocus`. The app delegate is the composition root: it injects
+    /// the `NotificationCenter` selection-move sink and the debug-trace sink.
+    private lazy var browserOmnibarSelectionRepeat: BrowserOmnibarSelectionRepeatCoordinator = {
+        let debugLog: BrowserOmnibarSelectionRepeatCoordinator.DebugLog?
+#if DEBUG
+        debugLog = { line in cmuxDebugLog(line) }
+#else
+        debugLog = nil
+#endif
+        return BrowserOmnibarSelectionRepeatCoordinator(
+            selectionMove: { panelId, delta in
+                NotificationCenter.default.post(
+                    name: .browserMoveOmnibarSelection,
+                    object: panelId,
+                    userInfo: ["delta": delta]
+                )
+            },
+            debugLog: debugLog
+        )
+    }()
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
     private var browserWebViewFirstResponderObserver: NSObjectProtocol?
@@ -13992,128 +14009,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func dispatchBrowserOmnibarSelectionMove(panelId: UUID, delta: Int) {
-        guard delta != 0 else { return }
-#if DEBUG
-        cmuxDebugLog(
-            "browser.focus.omnibar.selectionMove panel=\(panelId.uuidString.prefix(5)) " +
-            "delta=\(delta) repeatKey=\(browserOmnibarRepeatKeyCode.map(String.init) ?? "nil")"
-        )
-#endif
-        NotificationCenter.default.post(
-            name: .browserMoveOmnibarSelection,
-            object: panelId,
-            userInfo: ["delta": delta]
-        )
+        browserOmnibarSelectionRepeat.dispatchSelectionMove(panelID: panelId, delta: delta)
     }
 
     private func startBrowserOmnibarSelectionRepeatIfNeeded(panelId: UUID, keyCode: UInt16, delta: Int) {
-        guard delta != 0 else { return }
-
-        if browserOmnibarRepeatPanelId == panelId,
-           browserOmnibarRepeatKeyCode == keyCode,
-           browserOmnibarRepeatDelta == delta {
-#if DEBUG
-            cmuxDebugLog(
-                "browser.focus.omnibar.repeat.start panel=\(panelId.uuidString.prefix(5)) " +
-                "key=\(keyCode) delta=\(delta) result=reuse"
-            )
-#endif
-            return
-        }
-
-        stopBrowserOmnibarSelectionRepeat()
-        browserOmnibarRepeatPanelId = panelId
-        browserOmnibarRepeatKeyCode = keyCode
-        browserOmnibarRepeatDelta = delta
-#if DEBUG
-        cmuxDebugLog(
-            "browser.focus.omnibar.repeat.start panel=\(panelId.uuidString.prefix(5)) " +
-            "key=\(keyCode) delta=\(delta) result=armed"
-        )
-#endif
-
-        let start = DispatchWorkItem { [weak self] in
-            self?.scheduleBrowserOmnibarSelectionRepeatTick()
-        }
-        browserOmnibarRepeatStartWorkItem = start
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: start)
-    }
-
-    private func scheduleBrowserOmnibarSelectionRepeatTick() {
-        browserOmnibarRepeatStartWorkItem = nil
-        guard let panelId = browserOmnibarRepeatPanelId else {
-#if DEBUG
-            cmuxDebugLog("browser.focus.omnibar.repeat.tick result=stop_no_focused_address_bar")
-#endif
-            stopBrowserOmnibarSelectionRepeat()
-            return
-        }
-        guard browserOmnibarRepeatKeyCode != nil else { return }
-
-#if DEBUG
-        cmuxDebugLog(
-            "browser.focus.omnibar.repeat.tick panel=\(panelId.uuidString.prefix(5)) " +
-            "delta=\(browserOmnibarRepeatDelta)"
-        )
-#endif
-        dispatchBrowserOmnibarSelectionMove(panelId: panelId, delta: browserOmnibarRepeatDelta)
-
-        let tick = DispatchWorkItem { [weak self] in
-            self?.scheduleBrowserOmnibarSelectionRepeatTick()
-        }
-        browserOmnibarRepeatTickWorkItem = tick
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.055, execute: tick)
+        browserOmnibarSelectionRepeat.startRepeatIfNeeded(panelID: panelId, keyCode: keyCode, delta: delta)
     }
 
     private func stopBrowserOmnibarSelectionRepeat() {
-#if DEBUG
-        let previousPanelId = browserOmnibarRepeatPanelId
-        let previousKeyCode = browserOmnibarRepeatKeyCode
-        let previousDelta = browserOmnibarRepeatDelta
-#endif
-        browserOmnibarRepeatStartWorkItem?.cancel()
-        browserOmnibarRepeatTickWorkItem?.cancel()
-        browserOmnibarRepeatStartWorkItem = nil
-        browserOmnibarRepeatTickWorkItem = nil
-        browserOmnibarRepeatPanelId = nil
-        browserOmnibarRepeatKeyCode = nil
-        browserOmnibarRepeatDelta = 0
-#if DEBUG
-        if previousKeyCode != nil || previousDelta != 0 {
-            cmuxDebugLog(
-                "browser.focus.omnibar.repeat.stop panel=\(previousPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil") " +
-                "key=\(previousKeyCode.map(String.init) ?? "nil") " +
-                "delta=\(previousDelta)"
-            )
-        }
-#endif
+        browserOmnibarSelectionRepeat.stopRepeat()
     }
 
     private func handleBrowserOmnibarSelectionRepeatLifecycleEvent(_ event: NSEvent) {
-        guard browserOmnibarRepeatKeyCode != nil else { return }
-
         switch event.type {
         case .keyUp:
-            if event.keyCode == browserOmnibarRepeatKeyCode {
-#if DEBUG
-                cmuxDebugLog(
-                    "browser.focus.omnibar.repeat.lifecycle event=keyUp key=\(event.keyCode) " +
-                    "action=stop"
-                )
-#endif
-                stopBrowserOmnibarSelectionRepeat()
-            }
+            browserOmnibarSelectionRepeat.noteKeyUp(keyCode: event.keyCode)
         case .flagsChanged:
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if !browserOmnibarShouldContinueControlNavigationRepeat(flags: flags) {
-#if DEBUG
-                cmuxDebugLog(
-                    "browser.focus.omnibar.repeat.lifecycle event=flagsChanged " +
-                    "flags=\(flags.rawValue) action=stop"
-                )
-#endif
-                stopBrowserOmnibarSelectionRepeat()
-            }
+            browserOmnibarSelectionRepeat.noteFlagsChanged(
+                shouldContinue: browserOmnibarShouldContinueControlNavigationRepeat(flags: flags),
+                flagsRawValue: flags.rawValue
+            )
         default:
             break
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
+		BF0CA0000000000000000F3 /* CmuxBrowserFocus in Frameworks */ = {isa = PBXBuildFile; productRef = BF0CA0000000000000000F2 /* CmuxBrowserFocus */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
@@ -1768,6 +1769,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
+				BF0CA0000000000000000F3 /* CmuxBrowserFocus in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
@@ -3022,6 +3024,7 @@
 				C19C5E0100000000000000A1 /* XCLocalSwiftPackageReference "CmuxIPCService" */,
 				5E55100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSession" */,
 				5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */,
+				BF0CA0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxBrowserFocus" */,
 				5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */,
 				5E55300000000000000000C1 /* XCLocalSwiftPackageReference "CmuxCommandPaletteUI" */,
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
@@ -4527,6 +4530,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowserPanel;
 		};
+		BF0CA0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxBrowserFocus" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserFocus;
+		};
 		5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWindowing;
@@ -4893,6 +4900,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */;
 			productName = CmuxBrowserPanel;
+		};
+		BF0CA0000000000000000F2 /* CmuxBrowserFocus */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF0CA0000000000000000F1 /* XCLocalSwiftPackageReference "CmuxBrowserFocus" */;
+			productName = CmuxBrowserFocus;
 		};
 		5E55200000000000000000B2 /* CmuxWindowing */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Pulls the browser omnibar selection-repeat state machine out of the 17.7k-line `Sources/AppDelegate.swift` into a new `CmuxBrowserFocus` package as a `@MainActor @Observable` Coordinator with constructor-injected protocol seams.

## What moved
- Five stored repeat properties (`browserOmnibarRepeatStartWorkItem` / `TickWorkItem` / `PanelId` / `KeyCode` / `Delta`) collapse into one `BrowserOmnibarSelectionRepeatCoordinator` instance.
- `dispatchBrowserOmnibarSelectionMove`, `startBrowserOmnibarSelectionRepeatIfNeeded`, `scheduleBrowserOmnibarSelectionRepeatTick`, `stopBrowserOmnibarSelectionRepeat`, and `handleBrowserOmnibarSelectionRepeatLifecycleEvent` become thin one-line forwards. **Call sites are byte-identical.**

## Seams (dependency inversion, injected at the AppDelegate composition root)
- `selectionMove` sink inverts the `NotificationCenter.post(.browserMoveOmnibarSelection)` reach; wire format (name, `object=panelId`, `userInfo["delta"]`) preserved.
- `sleep` is a cancellable timing source (default `ContinuousClock`); tests inject a deterministic step clock. This replaces the banned, untestable `DispatchQueue.main.asyncAfter` work items with a structured cancellable `Task`, keeping the same 0.25 s hold delay + 0.055 s tick cadence.
- `debugLog` mirrors the prior `#if DEBUG` trace lines verbatim, so the debug-event log is byte-identical.

## Byte-identical notes
Same cadence, same NotificationCenter wire format, same reuse/armed/stop semantics, same trace strings. The lifecycle handler now computes `deviceIndependentFlagsMask` even when no repeat is armed, but the coordinator early-returns when idle, so there is no observable difference.

## What stayed (and why)
The wider address-bar focus-state machine (`focusBrowserAddressBar`, `focusedBrowserAddressBarPanelIdForShortcutEvent`, etc.) stays in `AppDelegate`: it is deeply entangled with `BrowserPanel` / `Workspace` / `MainWindowContext` / `OmnibarNativeTextField` AppKit responder-chain traversal and welded `#if DEBUG` logging, none of which have a package home and would require a brittle, byte-identical lift of `BrowserPanel`'s full focus-intent API. The repeat timing machine is the largest clean, self-contained subset.

## Package
New `CmuxBrowserFocus` (zero external deps): `Package.swift`, value type `BrowserOmnibarRepeatKey`, the coordinator, and 8 behavior unit tests (seam fakes + a deterministic step clock). Wired into `cmux.xcodeproj` (6 pbxproj entries mirroring `CmuxBrowserPanel`) and added as an app-target dependency.

## Verification
- `scripts/lint-ios-package-conventions.sh`: OK, zero new `lint:allow`.
- `swift build` + `swift test` in `Packages/CmuxBrowserFocus`: pass (8 tests).
- Ratchets `Sources/AppDelegate.swift` budget 17778 -> 17694 (-84 lines).
- `plutil -lint` + `scripts/check-pbxproj.sh`: OK.

NOTE: full app build validated by CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143871&installation_id=133855650&pr_number=6166&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6166&signature=ff60ae252e038210a072d41f87429233ab14363218a107086ea68a5d52ef2202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the browser omnibar selection-repeat into a new `CmuxBrowserFocus` package as a `@MainActor @Observable` coordinator. Behavior and debug logs are unchanged; `AppDelegate` is smaller and the logic is now unit-tested.

- **Refactors**
  - Replaced five repeat-related fields and work items with `BrowserOmnibarSelectionRepeatCoordinator`.
  - `AppDelegate` methods now forward to the coordinator; call sites are unchanged.
  - Preserved `NotificationCenter` wire format (name, `object=panelID`, `userInfo["delta"]`).
  - Swapped `DispatchQueue.main.asyncAfter` for a cancellable `Task` with injectable `sleep` (default `ContinuousClock`); same 250 ms start delay and 55 ms tick.
  - Added `BrowserOmnibarRepeatKey` and 8 unit tests with a deterministic step clock; reduced `Sources/AppDelegate.swift` by 84 lines.

- **Dependencies**
  - Added local package `CmuxBrowserFocus` (no external deps) and linked it in `cmux.xcodeproj`.

<sup>Written for commit 8620d61d6eba7717f3e209499e0c9e660b0df418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refactored address-bar omnibar selection repeat functionality with improved timing: 250ms initial delay and 55ms repeat intervals.
  * Introduced new coordinator-based architecture for enhanced repeat state management.

* **Tests**
  * Added comprehensive test suite with deterministic timing controls for selection repeat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->