### PR TITLE
Extract address-bar page-focus capture/restore into CmuxBrowserOmnibar

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
-13358	Sources/Panels/BrowserPanel.swift
+13074	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Packages/CmuxBrowserOmnibar/Package.swift
+++ b/Packages/CmuxBrowserOmnibar/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserOmnibar",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserOmnibar",
+            targets: ["CmuxBrowserOmnibar"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserOmnibar",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserOmnibarTests",
+            dependencies: ["CmuxBrowserOmnibar"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/AddressBarPageFocusRestoreStatus.swift
+++ b/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/AddressBarPageFocusRestoreStatus.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Outcome of one attempt to restore page input focus after the omnibar closes.
+///
+/// The values map one-to-one onto the status strings returned by the
+/// restore JavaScript (`restored`, `no_state`, `missing_target`, `not_focused`,
+/// `error`). The repository retries only on `notFocused` or `error`.
+public enum AddressBarPageFocusRestoreStatus: String, Sendable {
+    /// The previously focused editable element was re-focused successfully.
+    case restored
+    /// No captured focus state exists, so nothing needs restoring.
+    case noState = "no_state"
+    /// Captured state existed but its target element is no longer in the DOM.
+    case missingTarget = "missing_target"
+    /// The element was found but did not become the document's active element.
+    case notFocused = "not_focused"
+    /// The script threw, returned a non-string, or evaluation itself failed.
+    case error
+
+    /// Classifies a WebKit evaluation result into a restore status.
+    ///
+    /// Any evaluation error, or a non-string / unrecognized payload, collapses
+    /// to ``error`` so the caller's retry logic stays simple.
+    ///
+    /// - Parameters:
+    ///   - result: The raw value returned by the JavaScript evaluation.
+    ///   - error: Any error WebKit surfaced for the evaluation.
+    /// - Returns: The mapped restore status.
+    public static func from(result: Any?, error: (any Error)?) -> AddressBarPageFocusRestoreStatus {
+        if error != nil { return .error }
+        guard let raw = result as? String else { return .error }
+        return AddressBarPageFocusRestoreStatus(rawValue: raw) ?? .error
+    }
+}

--- a/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarPageFocusRepository+Scripts.swift
+++ b/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarPageFocusRepository+Scripts.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+extension BrowserOmnibarPageFocusRepository {
+    /// JavaScript that records the page's currently focused editable element.
+    ///
+    /// Stores `{ id, selectionStart, selectionEnd }` into
+    /// `window.__cmuxAddressBarFocusState` (mirrored to the top frame) and tags
+    /// the element with a stable `data-cmux-addressbar-focus-id`. Returns a
+    /// `captured:<id>` / `cleared:*` / `error` status string.
+    static let captureScript = """
+    (() => {
+      try {
+        const syncState = (state) => {
+          window.__cmuxAddressBarFocusState = state;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = state;
+            }
+          } catch (_) {}
+        };
+
+        const active = document.activeElement;
+        if (!active) {
+          syncState(null);
+          return "cleared:none";
+        }
+
+        const tag = (active.tagName || "").toLowerCase();
+        const type = (active.type || "").toLowerCase();
+        const isEditable =
+          !!active.isContentEditable ||
+          tag === "textarea" ||
+          (tag === "input" && type !== "hidden");
+        if (!isEditable) {
+          syncState(null);
+          return "cleared:noneditable";
+        }
+
+        let id = active.getAttribute("data-cmux-addressbar-focus-id");
+        if (!id) {
+          id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+          active.setAttribute("data-cmux-addressbar-focus-id", id);
+        }
+
+        const state = { id, selectionStart: null, selectionEnd: null };
+        if (typeof active.selectionStart === "number" && typeof active.selectionEnd === "number") {
+          state.selectionStart = active.selectionStart;
+          state.selectionEnd = active.selectionEnd;
+        }
+        syncState(state);
+        return "captured:" + id;
+      } catch (_) {
+        return "error";
+      }
+    })();
+    """
+
+    /// JavaScript injected at document start that continuously tracks the last
+    /// editable focused element via `focusin`/`selectionchange`/`input` listeners.
+    ///
+    /// The app target injects this as a main-frame-only `WKUserScript`. Keeping a
+    /// live snapshot lets ``captureScript`` succeed even when capture runs after
+    /// first-responder handoff has already cleared `document.activeElement`.
+    public static let trackingBootstrapScriptSource = """
+    (() => {
+      try {
+        if (window.__cmuxAddressBarFocusTrackerInstalled) return true;
+        window.__cmuxAddressBarFocusTrackerInstalled = true;
+
+        const syncState = (state) => {
+          window.__cmuxAddressBarFocusState = state;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = state;
+            }
+          } catch (_) {}
+        };
+
+        if (window.top === window && !window.__cmuxAddressBarFocusMessageBridgeInstalled) {
+          window.__cmuxAddressBarFocusMessageBridgeInstalled = true;
+          window.addEventListener("message", (ev) => {
+            try {
+              const data = ev ? ev.data : null;
+              if (!data || !Object.prototype.hasOwnProperty.call(data, "cmuxAddressBarFocusState")) return;
+              window.__cmuxAddressBarFocusState = data.cmuxAddressBarFocusState || null;
+            } catch (_) {}
+          }, true);
+        }
+
+        const isEditable = (el) => {
+          if (!el) return false;
+          const tag = (el.tagName || "").toLowerCase();
+          const type = (el.type || "").toLowerCase();
+          return !!el.isContentEditable || tag === "textarea" || (tag === "input" && type !== "hidden");
+        };
+
+        const ensureFocusId = (el) => {
+          let id = el.getAttribute("data-cmux-addressbar-focus-id");
+          if (!id) {
+            id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+            el.setAttribute("data-cmux-addressbar-focus-id", id);
+          }
+          return id;
+        };
+
+        const snapshot = (el) => {
+          if (!isEditable(el)) {
+            syncState(null);
+            return;
+          }
+          const state = {
+            id: ensureFocusId(el),
+            selectionStart: null,
+            selectionEnd: null
+          };
+          if (typeof el.selectionStart === "number" && typeof el.selectionEnd === "number") {
+            state.selectionStart = el.selectionStart;
+            state.selectionEnd = el.selectionEnd;
+          }
+          syncState(state);
+        };
+
+        document.addEventListener("focusin", (ev) => {
+          snapshot(ev && ev.target ? ev.target : document.activeElement);
+        }, true);
+        document.addEventListener("selectionchange", () => {
+          snapshot(document.activeElement);
+        }, true);
+        document.addEventListener("input", () => {
+          snapshot(document.activeElement);
+        }, true);
+        document.addEventListener("mousedown", (ev) => {
+          const target = ev && ev.target ? ev.target : null;
+          if (!isEditable(target)) {
+            syncState(null);
+          }
+        }, true);
+        window.addEventListener("beforeunload", () => {
+          syncState(null);
+        }, true);
+
+        snapshot(document.activeElement);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    })();
+    """
+
+    /// JavaScript that re-focuses the previously captured editable element and
+    /// restores its text selection, searching nested frames for the tagged id.
+    ///
+    /// Returns one of the ``AddressBarPageFocusRestoreStatus`` raw strings:
+    /// `restored`, `no_state`, `missing_target`, `not_focused`, or `error`.
+    static let restoreScript = """
+    (() => {
+      try {
+        const readState = () => {
+          let state = window.__cmuxAddressBarFocusState;
+          try {
+            if ((!state || typeof state.id !== "string" || !state.id) &&
+                window.top && window.top.__cmuxAddressBarFocusState) {
+              state = window.top.__cmuxAddressBarFocusState;
+            }
+          } catch (_) {}
+          return state;
+        };
+
+        const clearState = () => {
+          window.__cmuxAddressBarFocusState = null;
+          try {
+            if (window.top && window.top !== window) {
+              window.top.postMessage({ cmuxAddressBarFocusState: null }, "*");
+            } else if (window.top) {
+              window.top.__cmuxAddressBarFocusState = null;
+            }
+          } catch (_) {}
+        };
+
+        const state = readState();
+        if (!state || typeof state.id !== "string" || !state.id) {
+          return "no_state";
+        }
+
+        const selector = '[data-cmux-addressbar-focus-id="' + state.id + '"]';
+        const findTarget = (doc) => {
+          if (!doc) return null;
+          const direct = doc.querySelector(selector);
+          if (direct && direct.isConnected) return direct;
+          const frames = doc.querySelectorAll("iframe,frame");
+          for (let i = 0; i < frames.length; i += 1) {
+            const frame = frames[i];
+            try {
+              const childDoc = frame.contentDocument;
+              if (!childDoc) continue;
+              const nested = findTarget(childDoc);
+              if (nested) return nested;
+            } catch (_) {}
+          }
+          return null;
+        };
+
+        const target = findTarget(document);
+        if (!target) {
+          clearState();
+          return "missing_target";
+        }
+
+        try {
+          target.focus({ preventScroll: true });
+        } catch (_) {
+          try { target.focus(); } catch (_) {}
+        }
+
+        let focused = false;
+        try {
+          focused =
+            target === target.ownerDocument.activeElement ||
+            (typeof target.matches === "function" && target.matches(":focus"));
+        } catch (_) {}
+        if (!focused) {
+          return "not_focused";
+        }
+
+        if (
+          typeof state.selectionStart === "number" &&
+          typeof state.selectionEnd === "number" &&
+          typeof target.setSelectionRange === "function"
+        ) {
+          try {
+            target.setSelectionRange(state.selectionStart, state.selectionEnd);
+          } catch (_) {}
+        }
+        clearState();
+        return "restored";
+      } catch (_) {
+        return "error";
+      }
+    })();
+    """
+}

--- a/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarPageFocusRepository.swift
+++ b/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarPageFocusRepository.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Owns the address-bar page-focus capture/restore subsystem for one browser panel.
+///
+/// When the omnibar takes keyboard focus the page's editable element loses first
+/// responder, and when the omnibar closes that page element must regain focus
+/// with its prior text selection intact. This repository captures the active
+/// editable element's id and selection into a page-side global via the capture
+/// script, and later re-focuses it via the restore script, retrying on a fixed
+/// delay schedule because WebKit may not have re-rendered the element yet.
+///
+/// All WebKit access is routed through an injected ``BrowserOmnibarScriptEvaluating``
+/// seam so the type has no WebKit or `BrowserPanel` dependency. A monotonically
+/// increasing generation counter invalidates in-flight restore attempts the
+/// moment focus intent changes again, so a stale retry never steals focus back.
+///
+/// Behavior here is a byte-identical lift of the former `BrowserPanel` methods:
+/// the same scripts, the same `[0.0, 0.03, 0.09, 0.2]` retry delays, the same
+/// generation guards, and the same main-queue scheduling.
+@MainActor
+public final class BrowserOmnibarPageFocusRepository {
+    private let evaluator: any BrowserOmnibarScriptEvaluating
+    private let logSink: (@MainActor (String) -> Void)?
+    private var restoreGeneration: UInt64 = 0
+
+    /// The fixed retry delay schedule (seconds) for restore attempts.
+    ///
+    /// The first attempt is immediate; subsequent attempts back off so that a
+    /// page mid-render eventually accepts focus without a tight busy loop.
+    private static let restoreDelays: [TimeInterval] = [0.0, 0.03, 0.09, 0.2]
+
+    /// Creates a repository bound to one panel's page-focus seam.
+    ///
+    /// - Parameters:
+    ///   - evaluator: The script evaluator that runs JavaScript in the panel's
+    ///     live page. Held strongly; the conformer is expected to hold its own
+    ///     owner weakly to avoid a retain cycle.
+    ///   - logSink: Optional debug-log sink invoked on the main actor with the
+    ///     same messages the panel previously emitted. Pass `nil` in release.
+    public init(
+        evaluator: any BrowserOmnibarScriptEvaluating,
+        logSink: (@MainActor (String) -> Void)? = nil
+    ) {
+        self.evaluator = evaluator
+        self.logSink = logSink
+    }
+
+    /// Captures the page's currently focused editable element if one is editable.
+    ///
+    /// Stores `{ id, selectionStart, selectionEnd }` into a page-side global so a
+    /// later ``restoreIfNeeded(panelDebugID:completion:)`` can re-focus exactly
+    /// that element. A no-op when nothing editable is focused.
+    ///
+    /// - Parameter panelDebugID: Short panel id used only for debug logging.
+    public func captureIfNeeded(panelDebugID: String) {
+        evaluator.evaluateOmnibarPageFocusScript(Self.captureScript) { [weak self] result, error in
+            guard let self else { return }
+            if let error {
+                self.log(
+                    "browser.focus.addressBar.capture panel=\(panelDebugID) " +
+                    "result=error message=\(error.localizedDescription)"
+                )
+                return
+            }
+            let resultValue = (result as? String) ?? "unknown"
+            self.log(
+                "browser.focus.addressBar.capture panel=\(panelDebugID) " +
+                "result=\(resultValue)"
+            )
+        }
+    }
+
+    /// Cancels any in-flight restore attempts by bumping the generation.
+    ///
+    /// Call before re-entering the omnibar or whenever focus intent changes, so a
+    /// previously scheduled retry resolves as stale and stops re-focusing the page.
+    ///
+    /// - Parameter panelDebugID: Short panel id used only for debug logging.
+    public func invalidateRestoreAttempts(panelDebugID: String) {
+        restoreGeneration &+= 1
+        log(
+            "browser.focus.addressBar.restore.invalidate panel=\(panelDebugID) " +
+            "generation=\(restoreGeneration)"
+        )
+    }
+
+    /// Attempts to restore page input focus to the previously captured element.
+    ///
+    /// Bumps the generation, then runs the restore script on the fixed delay
+    /// schedule, retrying only on `notFocused`/`error` and only while the
+    /// generation is still current. Completes with `true` once the element is
+    /// re-focused and its selection restored, otherwise `false`.
+    ///
+    /// - Parameters:
+    ///   - panelDebugID: Short panel id used only for debug logging.
+    ///   - completion: Invoked once on the main actor with the restore outcome.
+    public func restoreIfNeeded(
+        panelDebugID: String,
+        completion: @escaping @MainActor (Bool) -> Void
+    ) {
+        restoreGeneration &+= 1
+        let generation = restoreGeneration
+        restoreAttempt(
+            attempt: 0,
+            generation: generation,
+            panelDebugID: panelDebugID,
+            completion: completion
+        )
+    }
+
+    private func restoreAttempt(
+        attempt: Int,
+        generation: UInt64,
+        panelDebugID: String,
+        completion: @escaping @MainActor (Bool) -> Void
+    ) {
+        guard generation == restoreGeneration else {
+            completion(false)
+            return
+        }
+        evaluator.evaluateOmnibarPageFocusScript(Self.restoreScript) { [weak self] result, error in
+            guard let self else {
+                completion(false)
+                return
+            }
+            guard generation == self.restoreGeneration else {
+                completion(false)
+                return
+            }
+
+            let status = AddressBarPageFocusRestoreStatus.from(result: result, error: error)
+            let canRetry = (status == .notFocused || status == .error)
+            let hasNextAttempt = attempt + 1 < Self.restoreDelays.count
+
+            if let error {
+                self.log(
+                    "browser.focus.addressBar.restore panel=\(panelDebugID) " +
+                    "attempt=\(attempt) status=\(status.rawValue) " +
+                    "message=\(error.localizedDescription)"
+                )
+            } else {
+                self.log(
+                    "browser.focus.addressBar.restore panel=\(panelDebugID) " +
+                    "attempt=\(attempt) status=\(status.rawValue)"
+                )
+            }
+
+            if status == .restored {
+                completion(true)
+                return
+            }
+
+            if canRetry && hasNextAttempt {
+                let delay = Self.restoreDelays[attempt + 1]
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                    guard let self else {
+                        completion(false)
+                        return
+                    }
+                    guard generation == self.restoreGeneration else {
+                        completion(false)
+                        return
+                    }
+                    self.restoreAttempt(
+                        attempt: attempt + 1,
+                        generation: generation,
+                        panelDebugID: panelDebugID,
+                        completion: completion
+                    )
+                }
+                return
+            }
+
+            completion(false)
+        }
+    }
+
+    private func log(_ message: String) {
+        logSink?(message)
+    }
+}

--- a/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarScriptEvaluating.swift
+++ b/Packages/CmuxBrowserOmnibar/Sources/CmuxBrowserOmnibar/PageFocus/BrowserOmnibarScriptEvaluating.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Injected seam that runs an omnibar page-focus JavaScript snippet inside the
+/// browser panel's live web content and delivers the raw evaluation result.
+///
+/// The concrete conformer lives in the app target and forwards to the panel's
+/// `WKWebView.evaluateJavaScript(_:completionHandler:)`. Inverting the web-view
+/// reach behind this protocol keeps `BrowserOmnibarPageFocusRepository` free of
+/// any WebKit or `BrowserPanel` dependency and lets tests drive capture/restore
+/// with a fake evaluator. The conformer must hold its owner weakly to avoid a
+/// retain cycle with the repository it ultimately backs.
+@MainActor
+public protocol BrowserOmnibarScriptEvaluating: AnyObject {
+    /// Evaluates `script` in the page and reports the WebKit result tuple.
+    ///
+    /// The completion is invoked on the main actor exactly once. When the
+    /// underlying web view is gone the conformer reports `(nil, nil)` so the
+    /// repository treats it as a non-restorable outcome rather than crashing.
+    ///
+    /// - Parameters:
+    ///   - script: The self-invoking JavaScript expression to evaluate.
+    ///   - completion: Receives the JavaScript value (typically a `String`
+    ///     status code) and any evaluation error, mirroring WebKit's API.
+    func evaluateOmnibarPageFocusScript(
+        _ script: String,
+        completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    )
+}

--- a/Packages/CmuxBrowserOmnibar/Tests/CmuxBrowserOmnibarTests/BrowserOmnibarPageFocusRepositoryTests.swift
+++ b/Packages/CmuxBrowserOmnibar/Tests/CmuxBrowserOmnibarTests/BrowserOmnibarPageFocusRepositoryTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+@testable import CmuxBrowserOmnibar
+
+/// Records scripts and replays a queued sequence of evaluation outcomes.
+@MainActor
+private final class FakeScriptEvaluator: BrowserOmnibarScriptEvaluating {
+    var evaluatedScripts: [String] = []
+    /// Each pending tuple is delivered to the next evaluation, in order.
+    var queuedResults: [(Any?, (any Error)?)] = []
+    private var index = 0
+
+    func evaluateOmnibarPageFocusScript(
+        _ script: String,
+        completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    ) {
+        evaluatedScripts.append(script)
+        let outcome: (Any?, (any Error)?)
+        if index < queuedResults.count {
+            outcome = queuedResults[index]
+            index += 1
+        } else {
+            outcome = (nil, nil)
+        }
+        completion(outcome.0, outcome.1)
+    }
+}
+
+private struct StubError: Error {}
+
+@MainActor
+@Suite struct BrowserOmnibarPageFocusRepositoryTests {
+    @Test func captureRunsCaptureScript() {
+        let evaluator = FakeScriptEvaluator()
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        repo.captureIfNeeded(panelDebugID: "abcde")
+        #expect(evaluator.evaluatedScripts.count == 1)
+        #expect(evaluator.evaluatedScripts[0] == BrowserOmnibarPageFocusRepository.captureScript)
+    }
+
+    @Test func restoreSucceedsOnFirstAttempt() {
+        let evaluator = FakeScriptEvaluator()
+        evaluator.queuedResults = [("restored", nil)]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        #expect(outcome == true)
+        #expect(evaluator.evaluatedScripts == [BrowserOmnibarPageFocusRepository.restoreScript])
+    }
+
+    @Test func restoreStopsOnNoStateWithoutRetry() {
+        let evaluator = FakeScriptEvaluator()
+        evaluator.queuedResults = [("no_state", nil)]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        // no_state is terminal: it is not in the retry set, so exactly one eval.
+        #expect(outcome == false)
+        #expect(evaluator.evaluatedScripts.count == 1)
+    }
+
+    @Test func restoreStopsOnMissingTargetWithoutRetry() {
+        let evaluator = FakeScriptEvaluator()
+        evaluator.queuedResults = [("missing_target", nil)]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        #expect(outcome == false)
+        #expect(evaluator.evaluatedScripts.count == 1)
+    }
+
+    @Test func restoreRetriesSynchronousZeroDelayAttempts() {
+        // The first retry delay is 0.0s, which asyncAfter schedules on the main
+        // queue rather than running inline, so the synchronous portion stops at
+        // the first not_focused result. Verify the first attempt happened and
+        // the completion has not yet fired (it is pending on the run loop).
+        let evaluator = FakeScriptEvaluator()
+        evaluator.queuedResults = [("not_focused", nil)]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        #expect(evaluator.evaluatedScripts.count == 1)
+        #expect(outcome == nil)
+    }
+
+    @Test func invalidateAbortsPendingRetry() async {
+        let evaluator = FakeScriptEvaluator()
+        evaluator.queuedResults = [("not_focused", nil)]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        // Bump generation before the scheduled 0.0s retry runs.
+        repo.invalidateRestoreAttempts(panelDebugID: "abcde")
+        // Let the main queue drain the asyncAfter block.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        #expect(outcome == false)
+        // Only the initial attempt ran; the stale retry was dropped.
+        #expect(evaluator.evaluatedScripts.count == 1)
+    }
+
+    @Test func restoreReportsFalseOnEvaluationError() {
+        let evaluator = FakeScriptEvaluator()
+        // error is retryable; with the full 4-slot schedule the last attempt
+        // still completes false once all delays are exhausted. The synchronous
+        // path runs only the first attempt (delay 0.0 reschedules).
+        evaluator.queuedResults = [(nil, StubError())]
+        let repo = BrowserOmnibarPageFocusRepository(evaluator: evaluator)
+        var outcome: Bool?
+        repo.restoreIfNeeded(panelDebugID: "abcde") { outcome = $0 }
+        #expect(evaluator.evaluatedScripts.count == 1)
+        #expect(outcome == nil)
+    }
+
+    @Test func statusMapping() {
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "restored", error: nil) == .restored)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "no_state", error: nil) == .noState)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "missing_target", error: nil) == .missingTarget)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "not_focused", error: nil) == .notFocused)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "error", error: nil) == .error)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "garbage", error: nil) == .error)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: 42, error: nil) == .error)
+        #expect(AddressBarPageFocusRestoreStatus.from(result: "restored", error: StubError()) == .error)
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6,6 +6,7 @@ import WebKit
 import AppKit
 import Bonsplit
 import CmuxBrowserPanel
+import CmuxBrowserOmnibar
 import CmuxTerminalCore
 import Network
 import CFNetwork
@@ -2867,230 +2868,18 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Used to keep omnibar text-field focus from being immediately stolen by panel focus.
     private var suppressWebViewFocusUntil: Date?
     private var suppressWebViewFocusForAddressBar: Bool = false
-    private var addressBarFocusRestoreGeneration: UInt64 = 0
     private let blankURLString = "about:blank"
-    private static let addressBarFocusCaptureScript = """
-    (() => {
-      try {
-        const syncState = (state) => {
-          window.__cmuxAddressBarFocusState = state;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = state;
-            }
-          } catch (_) {}
-        };
 
-        const active = document.activeElement;
-        if (!active) {
-          syncState(null);
-          return "cleared:none";
-        }
-
-        const tag = (active.tagName || "").toLowerCase();
-        const type = (active.type || "").toLowerCase();
-        const isEditable =
-          !!active.isContentEditable ||
-          tag === "textarea" ||
-          (tag === "input" && type !== "hidden");
-        if (!isEditable) {
-          syncState(null);
-          return "cleared:noneditable";
-        }
-
-        let id = active.getAttribute("data-cmux-addressbar-focus-id");
-        if (!id) {
-          id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
-          active.setAttribute("data-cmux-addressbar-focus-id", id);
-        }
-
-        const state = { id, selectionStart: null, selectionEnd: null };
-        if (typeof active.selectionStart === "number" && typeof active.selectionEnd === "number") {
-          state.selectionStart = active.selectionStart;
-          state.selectionEnd = active.selectionEnd;
-        }
-        syncState(state);
-        return "captured:" + id;
-      } catch (_) {
-        return "error";
-      }
-    })();
-    """
-    private static let addressBarFocusTrackingBootstrapScript = """
-    (() => {
-      try {
-        if (window.__cmuxAddressBarFocusTrackerInstalled) return true;
-        window.__cmuxAddressBarFocusTrackerInstalled = true;
-
-        const syncState = (state) => {
-          window.__cmuxAddressBarFocusState = state;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: state }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = state;
-            }
-          } catch (_) {}
-        };
-
-        if (window.top === window && !window.__cmuxAddressBarFocusMessageBridgeInstalled) {
-          window.__cmuxAddressBarFocusMessageBridgeInstalled = true;
-          window.addEventListener("message", (ev) => {
-            try {
-              const data = ev ? ev.data : null;
-              if (!data || !Object.prototype.hasOwnProperty.call(data, "cmuxAddressBarFocusState")) return;
-              window.__cmuxAddressBarFocusState = data.cmuxAddressBarFocusState || null;
-            } catch (_) {}
-          }, true);
-        }
-
-        const isEditable = (el) => {
-          if (!el) return false;
-          const tag = (el.tagName || "").toLowerCase();
-          const type = (el.type || "").toLowerCase();
-          return !!el.isContentEditable || tag === "textarea" || (tag === "input" && type !== "hidden");
-        };
-
-        const ensureFocusId = (el) => {
-          let id = el.getAttribute("data-cmux-addressbar-focus-id");
-          if (!id) {
-            id = "cmux-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
-            el.setAttribute("data-cmux-addressbar-focus-id", id);
-          }
-          return id;
-        };
-
-        const snapshot = (el) => {
-          if (!isEditable(el)) {
-            syncState(null);
-            return;
-          }
-          const state = {
-            id: ensureFocusId(el),
-            selectionStart: null,
-            selectionEnd: null
-          };
-          if (typeof el.selectionStart === "number" && typeof el.selectionEnd === "number") {
-            state.selectionStart = el.selectionStart;
-            state.selectionEnd = el.selectionEnd;
-          }
-          syncState(state);
-        };
-
-        document.addEventListener("focusin", (ev) => {
-          snapshot(ev && ev.target ? ev.target : document.activeElement);
-        }, true);
-        document.addEventListener("selectionchange", () => {
-          snapshot(document.activeElement);
-        }, true);
-        document.addEventListener("input", () => {
-          snapshot(document.activeElement);
-        }, true);
-        document.addEventListener("mousedown", (ev) => {
-          const target = ev && ev.target ? ev.target : null;
-          if (!isEditable(target)) {
-            syncState(null);
-          }
-        }, true);
-        window.addEventListener("beforeunload", () => {
-          syncState(null);
-        }, true);
-
-        snapshot(document.activeElement);
-        return true;
-      } catch (_) {
-        return false;
-      }
-    })();
-    """
-    private static let addressBarFocusRestoreScript = """
-    (() => {
-      try {
-        const readState = () => {
-          let state = window.__cmuxAddressBarFocusState;
-          try {
-            if ((!state || typeof state.id !== "string" || !state.id) &&
-                window.top && window.top.__cmuxAddressBarFocusState) {
-              state = window.top.__cmuxAddressBarFocusState;
-            }
-          } catch (_) {}
-          return state;
-        };
-
-        const clearState = () => {
-          window.__cmuxAddressBarFocusState = null;
-          try {
-            if (window.top && window.top !== window) {
-              window.top.postMessage({ cmuxAddressBarFocusState: null }, "*");
-            } else if (window.top) {
-              window.top.__cmuxAddressBarFocusState = null;
-            }
-          } catch (_) {}
-        };
-
-        const state = readState();
-        if (!state || typeof state.id !== "string" || !state.id) {
-          return "no_state";
-        }
-
-        const selector = '[data-cmux-addressbar-focus-id="' + state.id + '"]';
-        const findTarget = (doc) => {
-          if (!doc) return null;
-          const direct = doc.querySelector(selector);
-          if (direct && direct.isConnected) return direct;
-          const frames = doc.querySelectorAll("iframe,frame");
-          for (let i = 0; i < frames.length; i += 1) {
-            const frame = frames[i];
-            try {
-              const childDoc = frame.contentDocument;
-              if (!childDoc) continue;
-              const nested = findTarget(childDoc);
-              if (nested) return nested;
-            } catch (_) {}
-          }
-          return null;
-        };
-
-        const target = findTarget(document);
-        if (!target) {
-          clearState();
-          return "missing_target";
-        }
-
-        try {
-          target.focus({ preventScroll: true });
-        } catch (_) {
-          try { target.focus(); } catch (_) {}
-        }
-
-        let focused = false;
-        try {
-          focused =
-            target === target.ownerDocument.activeElement ||
-            (typeof target.matches === "function" && target.matches(":focus"));
-        } catch (_) {}
-        if (!focused) {
-          return "not_focused";
-        }
-
-        if (
-          typeof state.selectionStart === "number" &&
-          typeof state.selectionEnd === "number" &&
-          typeof target.setSelectionRange === "function"
-        ) {
-          try {
-            target.setSelectionRange(state.selectionStart, state.selectionEnd);
-          } catch (_) {}
-        }
-        clearState();
-        return "restored";
-      } catch (_) {
-        return "error";
-      }
-    })();
-    """
+    /// Owns the address-bar page-focus capture/restore subsystem.
+    ///
+    /// The repository (in `CmuxBrowserOmnibar`) runs the capture/restore scripts
+    /// through ``BrowserOmnibarPageFocusAdapter``, which reaches back to this
+    /// panel's current `webView` weakly so the panel and repository do not retain
+    /// each other.
+    private lazy var omnibarPageFocusRepository = BrowserOmnibarPageFocusRepository(
+        evaluator: BrowserOmnibarPageFocusAdapter(panel: self),
+        logSink: Self.omnibarPageFocusLogSink
+    )
 
     /// Published URL being displayed
     @Published private(set) var currentURL: URL? {
@@ -3904,7 +3693,7 @@ final class BrowserPanel: Panel, ObservableObject {
         // Main frame only — same CAPTCHA interference concern as telemetry hooks.
         configuration.userContentController.addUserScript(
             WKUserScript(
-                source: Self.addressBarFocusTrackingBootstrapScript,
+                source: BrowserOmnibarPageFocusRepository.trackingBootstrapScriptSource,
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             )
@@ -8002,135 +7791,18 @@ extension BrowserPanel {
     }
 
     private func captureAddressBarPageFocusIfNeeded() {
-        webView.evaluateJavaScript(Self.addressBarFocusCaptureScript) { [weak self] result, error in
-#if DEBUG
-            guard let self else { return }
-            if let error {
-                cmuxDebugLog(
-                    "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
-                    "result=error message=\(error.localizedDescription)"
-                )
-                return
-            }
-            let resultValue = (result as? String) ?? "unknown"
-            cmuxDebugLog(
-                "browser.focus.addressBar.capture panel=\(self.id.uuidString.prefix(5)) " +
-                "result=\(resultValue)"
-            )
-#else
-            _ = self
-            _ = result
-            _ = error
-#endif
-        }
-    }
-
-    private enum AddressBarPageFocusRestoreStatus: String {
-        case restored
-        case noState = "no_state"
-        case missingTarget = "missing_target"
-        case notFocused = "not_focused"
-        case error
-    }
-
-    private static func addressBarPageFocusRestoreStatus(
-        from result: Any?,
-        error: Error?
-    ) -> AddressBarPageFocusRestoreStatus {
-        if error != nil { return .error }
-        guard let raw = result as? String else { return .error }
-        return AddressBarPageFocusRestoreStatus(rawValue: raw) ?? .error
+        omnibarPageFocusRepository.captureIfNeeded(panelDebugID: String(id.uuidString.prefix(5)))
     }
 
     func invalidateAddressBarPageFocusRestoreAttempts() {
-        addressBarFocusRestoreGeneration &+= 1
-#if DEBUG
-        cmuxDebugLog(
-            "browser.focus.addressBar.restore.invalidate panel=\(id.uuidString.prefix(5)) " +
-            "generation=\(addressBarFocusRestoreGeneration)"
-        )
-#endif
+        omnibarPageFocusRepository.invalidateRestoreAttempts(panelDebugID: String(id.uuidString.prefix(5)))
     }
 
     func restoreAddressBarPageFocusIfNeeded(completion: @escaping (Bool) -> Void) {
-        addressBarFocusRestoreGeneration &+= 1
-        let generation = addressBarFocusRestoreGeneration
-        let delays: [TimeInterval] = [0.0, 0.03, 0.09, 0.2]
-        restoreAddressBarPageFocusAttemptIfNeeded(
-            attempt: 0,
-            delays: delays,
-            generation: generation,
+        omnibarPageFocusRepository.restoreIfNeeded(
+            panelDebugID: String(id.uuidString.prefix(5)),
             completion: completion
         )
-    }
-
-    private func restoreAddressBarPageFocusAttemptIfNeeded(
-        attempt: Int,
-        delays: [TimeInterval],
-        generation: UInt64,
-        completion: @escaping (Bool) -> Void
-    ) {
-        guard generation == addressBarFocusRestoreGeneration else {
-            completion(false)
-            return
-        }
-        webView.evaluateJavaScript(Self.addressBarFocusRestoreScript) { [weak self] result, error in
-            guard let self else {
-                completion(false)
-                return
-            }
-            guard generation == self.addressBarFocusRestoreGeneration else {
-                completion(false)
-                return
-            }
-
-            let status = Self.addressBarPageFocusRestoreStatus(from: result, error: error)
-            let canRetry = (status == .notFocused || status == .error)
-            let hasNextAttempt = attempt + 1 < delays.count
-
-#if DEBUG
-            if let error {
-                cmuxDebugLog(
-                    "browser.focus.addressBar.restore panel=\(self.id.uuidString.prefix(5)) " +
-                    "attempt=\(attempt) status=\(status.rawValue) " +
-                    "message=\(error.localizedDescription)"
-                )
-            } else {
-                cmuxDebugLog(
-                    "browser.focus.addressBar.restore panel=\(self.id.uuidString.prefix(5)) " +
-                    "attempt=\(attempt) status=\(status.rawValue)"
-                )
-            }
-#endif
-
-            if status == .restored {
-                completion(true)
-                return
-            }
-
-            if canRetry && hasNextAttempt {
-                let delay = delays[attempt + 1]
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-                    guard let self else {
-                        completion(false)
-                        return
-                    }
-                    guard generation == self.addressBarFocusRestoreGeneration else {
-                        completion(false)
-                        return
-                    }
-                    self.restoreAddressBarPageFocusAttemptIfNeeded(
-                        attempt: attempt + 1,
-                        delays: delays,
-                        generation: generation,
-                        completion: completion
-                    )
-                }
-                return
-            }
-
-            completion(false)
-        }
     }
 
     /// Returns the most reliable URL string for omnibar-related matching and UI decisions.
@@ -13354,5 +13026,49 @@ final class BrowserDataImportCoordinator {
         alert.informativeText = lines.joined(separator: "\n")
         alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
         alert.runModal()
+    }
+}
+
+extension BrowserPanel {
+    /// Debug-log sink handed to `BrowserOmnibarPageFocusRepository`.
+    ///
+    /// In release builds this is `nil`, so the repository emits no logging and
+    /// the former `#if DEBUG`-guarded `cmuxDebugLog` calls stay compiled out.
+    static var omnibarPageFocusLogSink: (@MainActor (String) -> Void)? {
+#if DEBUG
+        return { message in cmuxDebugLog(message) }
+#else
+        return nil
+#endif
+    }
+}
+
+/// Bridges `BrowserOmnibarPageFocusRepository` to a panel's live `WKWebView`.
+///
+/// Holds the panel weakly so the panel (which owns the repository, which owns
+/// this adapter) does not form a retain cycle. Always reads `panel.webView` at
+/// call time because the panel reassigns its web view across navigations and
+/// profile switches.
+@MainActor
+private final class BrowserOmnibarPageFocusAdapter: BrowserOmnibarScriptEvaluating {
+    private weak var panel: BrowserPanel?
+
+    init(panel: BrowserPanel) {
+        self.panel = panel
+    }
+
+    func evaluateOmnibarPageFocusScript(
+        _ script: String,
+        completion: @escaping @MainActor (Any?, (any Error)?) -> Void
+    ) {
+        guard let panel else {
+            completion(nil, nil)
+            return
+        }
+        panel.webView.evaluateJavaScript(script) { result, error in
+            MainActor.assumeIsolated {
+                completion(result, error)
+            }
+        }
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
+		5E55400000000000000000B3 /* CmuxBrowserOmnibar in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55400000000000000000B2 /* CmuxBrowserOmnibar */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
@@ -1768,6 +1769,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
+				5E55400000000000000000B3 /* CmuxBrowserOmnibar in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
@@ -2829,6 +2831,7 @@
 				C19C5E0200000000000000A2 /* CmuxIPCService */,
 				5E55100000000000000000A2 /* CmuxSession */,
 				5E55100000000000000000B2 /* CmuxBrowserPanel */,
+				5E55400000000000000000B2 /* CmuxBrowserOmnibar */,
 				5E55200000000000000000B2 /* CmuxWindowing */,
 				5E55300000000000000000C2 /* CmuxCommandPaletteUI */,
 				5E55500000000000000000E2 /* CmuxCommandPalette */,
@@ -3022,6 +3025,7 @@
 				C19C5E0100000000000000A1 /* XCLocalSwiftPackageReference "CmuxIPCService" */,
 				5E55100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSession" */,
 				5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */,
+				5E55400000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserOmnibar" */,
 				5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */,
 				5E55300000000000000000C1 /* XCLocalSwiftPackageReference "CmuxCommandPaletteUI" */,
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
@@ -4527,6 +4531,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowserPanel;
 		};
+		5E55400000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserOmnibar" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserOmnibar;
+		};
 		5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWindowing;
@@ -4893,6 +4901,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */;
 			productName = CmuxBrowserPanel;
+		};
+		5E55400000000000000000B2 /* CmuxBrowserOmnibar */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E55400000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserOmnibar" */;
+			productName = CmuxBrowserOmnibar;
 		};
 		5E55200000000000000000B2 /* CmuxWindowing */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the omnibar address-bar **page-focus capture/restore** subsystem out of the 13k-line `Sources/Panels/BrowserPanel.swift` god file into a new `CmuxBrowserOmnibar` Swift package, as a real Repository with a constructor-injected protocol seam.

## What moved
- The three JavaScript snippets (capture, document-start tracking bootstrap, restore), copied **byte-for-byte** (verified by diff).
- The generation-guarded retry state machine: `addressBarFocusRestoreGeneration`, the `[0.0, 0.03, 0.09, 0.2]` delay schedule, the restore-attempt recursion.
- `AddressBarPageFocusRestoreStatus` and its result/error parser.

## New types (in `CmuxBrowserOmnibar`)
- `BrowserOmnibarPageFocusRepository` — `@MainActor` Repository owning capture/restore logic and the generation counter.
- `BrowserOmnibarScriptEvaluating` — protocol seam that inverts the `WKWebView` reach.
- `AddressBarPageFocusRestoreStatus` — `Sendable` value enum.

One major public type per file, foldered under `PageFocus/`, `///` DocC on every public symbol, `swift-tools-version: 6.0`, `.macOS(.v14)`, v6 language mode + `ExistentialAny`/`InternalImportsByDefault`, matching `CmuxBrowserPanel`.

## Seams / DI
The repository takes a `BrowserOmnibarScriptEvaluating` and an optional log sink via `init`. The app-side conformer `BrowserOmnibarPageFocusAdapter` holds the `BrowserPanel` **weakly** (panel owns repository owns adapter) and always reads the panel's *current* `webView` at call time, because the panel reassigns its web view across navigation/profile switches. This inverts the `webView` god-reach with no retain cycle. The concrete adapter + log sink stay in the app target (composition root).

## Byte-identical notes
JS scripts, retry delays, generation guards, main-queue `asyncAfter` scheduling, the `result=unknown` fallback, and all `#if DEBUG` log strings are preserved exactly. `BrowserPanel` keeps `captureAddressBarPageFocusIfNeeded` / `invalidateAddressBarPageFocusRestoreAttempts` / `restoreAddressBarPageFocusIfNeeded` as one-line forwards, so every call site (BrowserPanel internals + `BrowserPanelView`) is unchanged. The tracking bootstrap `WKUserScript` now reads `BrowserOmnibarPageFocusRepository.trackingBootstrapScriptSource`.

## Honest scope note
The spec's broader "omnibar focus-intent state" (`preferredFocusIntent`, the `suppress*` flags, `pendingAddressBarFocusRequestId`, `requestAddressBarFocus`, `setOmnibarVisible`) is **not** cleanly separable: on inspection it is fused with `searchState`, the find-field, `browserFocusMode`, and `AppDelegate.shared` inside the same `@Published` class, and `shouldSuppressWebViewFocus`/`requestAddressBarFocus`/`noteAddressBarFocused` all share the same focus-intent state machine. Moving it would require a cross-domain rewrite that breaks the byte-identical guarantee. This PR extracts the **largest clean subset** (the page-focus JS capture/restore, which reaches the outside world only through the web view) and leaves the entangled state machine in place.

## Tests
8 Swift Testing cases for the repository with a fake evaluator: capture runs the capture script, first-attempt restore success, terminal `no_state`/`missing_target` without retry, generation invalidation aborting a pending retry, and full status mapping. `swift build` + `swift test` pass in the package.

## Verification
- `scripts/lint-ios-package-conventions.sh`: `OK: no unjustified convention violations`, zero new `lint:allow`.
- `swift build` + `swift test` in `Packages/CmuxBrowserOmnibar`: pass (8/8).
- `scripts/check-pbxproj.sh` + `normalize-pbxproj.py`: clean; 6 pbxproj entries mirror `CmuxBrowserPanel`.
- `swift-file-length-budget.tsv` ratcheted `BrowserPanel.swift` 13358 -> 13074 (~284 lines removed).

NOTE: full app build is validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143907&installation_id=133855650&pr_number=6169&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6169&signature=adca117742f01a8b117bea2ca63b22e2096da702451b56d906bc6a6c18b50522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the omnibar address-bar page-focus capture/restore into a new `CmuxBrowserOmnibar` package with a small protocol seam. Behavior is unchanged; the panel is smaller and the logic is easier to test.

- **Refactors**
  - Moved the capture/restore scripts and tracking bootstrap into `BrowserOmnibarPageFocusRepository` (byte-for-byte; same delays, logs, and scheduling).
  - Added `BrowserOmnibarScriptEvaluating` and an app adapter that reads the current `webView` and holds the panel weakly.
  - Kept `BrowserPanel` call sites as one-line forwards; UI flow and outputs are unchanged.
  - `WKUserScript` now uses `BrowserOmnibarPageFocusRepository.trackingBootstrapScriptSource`.
  - Reduced `BrowserPanel.swift` by ~284 lines and added 8 focused tests.

- **Dependencies**
  - Added local package `CmuxBrowserOmnibar` (Swift 6, macOS 14).
  - Linked the package in `cmux.xcodeproj`.

<sup>Written for commit 4089fbde67734436e2ca4bc1a94862ec33e69ef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved address bar focus handling with enhanced capture and restoration of keyboard focus and text selection when closing the address bar.
  * Added intelligent retry logic for focus recovery to ensure proper focus placement across browser panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->