### PR TITLE
Extract restored browser session-history state machine into CmuxBrowserNavigation

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
-13358	Sources/Panels/BrowserPanel.swift
+13285	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Packages/CmuxBrowserNavigation/Package.swift
+++ b/Packages/CmuxBrowserNavigation/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserNavigation",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserNavigation",
+            targets: ["CmuxBrowserNavigation"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserNavigation",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserNavigationTests",
+            dependencies: ["CmuxBrowserNavigation"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/NavigationAvailability.swift
+++ b/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/NavigationAvailability.swift
@@ -1,0 +1,21 @@
+public import Foundation
+
+/// The resolved back/forward availability for a browser surface.
+///
+/// Combines the live WebKit `canGoBack`/`canGoForward` flags with any restored
+/// session-history stacks. A surface can go back either because WebKit's native
+/// back-forward list has a prior entry or because a restored back stack still
+/// holds replayable URLs; the same holds symmetrically for forward.
+public struct NavigationAvailability: Sendable, Equatable {
+    /// Whether back navigation is possible from the current entry.
+    public var canGoBack: Bool
+
+    /// Whether forward navigation is possible from the current entry.
+    public var canGoForward: Bool
+
+    /// Creates an availability value.
+    public init(canGoBack: Bool, canGoForward: Bool) {
+        self.canGoBack = canGoBack
+        self.canGoForward = canGoForward
+    }
+}

--- a/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/RestoredSessionHistory.swift
+++ b/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/RestoredSessionHistory.swift
@@ -1,0 +1,280 @@
+public import Foundation
+
+/// The replayable back/forward history a browser surface restores from a prior
+/// launch, plus the native WebKit availability flags it is reconciled against.
+///
+/// WebKit cannot rehydrate a `WKBackForwardList` from serialized URLs, so cmux
+/// keeps its own restored stacks and replays them by issuing fresh navigations.
+/// Once the live page accumulates native history, traversal defers to WebKit and
+/// the restored stacks are realigned to track the live current entry. This type
+/// is a pure value-semantics state machine: it owns the stacks and flags and is
+/// driven by the surface, which supplies the live current URL and performs the
+/// resulting `WKWebView` calls. It reaches no WebKit, AppKit, or app-target type.
+///
+/// Storage convention: `back` is ordered oldest-first; `forward` is ordered with
+/// the nearest-forward entry at the end so traversal is a `removeLast()` pop.
+public struct RestoredSessionHistory: Sendable {
+    /// Whether restored session-history replay is currently active. When `false`
+    /// the surface uses WebKit's native back-forward list exclusively.
+    public private(set) var usesRestoredSessionHistory: Bool = false
+
+    /// Back-list URLs, oldest first.
+    public private(set) var back: [URL] = []
+
+    /// Forward-list URLs with the nearest-forward entry last.
+    public private(set) var forward: [URL] = []
+
+    /// The URL of the entry the restored history currently points at.
+    public private(set) var current: URL?
+
+    private let sanitizer: SessionHistoryURLSanitizer
+
+    /// Creates an empty, inactive restored history.
+    ///
+    /// - Parameter sanitizer: Normalizes URLs for persistence and replay.
+    public init(sanitizer: SessionHistoryURLSanitizer) {
+        self.sanitizer = sanitizer
+    }
+
+    /// Computes back/forward availability by combining native WebKit flags with
+    /// any restored stacks. When restored history is inactive the native flags
+    /// pass through unchanged.
+    public func availability(nativeCanGoBack: Bool, nativeCanGoForward: Bool) -> NavigationAvailability {
+        if usesRestoredSessionHistory {
+            return NavigationAvailability(
+                canGoBack: nativeCanGoBack || !back.isEmpty,
+                canGoForward: nativeCanGoForward || !forward.isEmpty
+            )
+        }
+        return NavigationAvailability(canGoBack: nativeCanGoBack, canGoForward: nativeCanGoForward)
+    }
+
+    /// Whether anything would need clearing if the surface's workspace context
+    /// changes (any restored state present).
+    public var hasRestoredState: Bool {
+        current != nil || !back.isEmpty || !forward.isEmpty
+    }
+
+    /// Returns whether the resolved live current URL matches the restored current
+    /// entry. Treats either side being non-serializable as aligned, matching the
+    /// surface's reconciliation contract.
+    public func isLiveAligned(withLiveCurrentURL liveCurrentURL: URL?) -> Bool {
+        let liveCurrent = sanitizer.serializableSessionHistoryURLString(liveCurrentURL)
+        let restoredCurrent = sanitizer.serializableSessionHistoryURLString(current)
+        guard let liveCurrent, let restoredCurrent else { return true }
+        return liveCurrent == restoredCurrent
+    }
+
+    /// Loads restored stacks from persisted strings. Activates replay only when
+    /// at least one eligible URL survives sanitization. `forwardHistoryURLStrings`
+    /// is supplied nearest-forward-first and stored reversed so traversal pops
+    /// from the end.
+    ///
+    /// - Returns: `true` when replay became active (the caller should refresh
+    ///   availability), `false` when nothing eligible was restored.
+    @discardableResult
+    public mutating func restore(
+        backHistoryURLStrings: [String],
+        forwardHistoryURLStrings: [String],
+        currentURLString: String?
+    ) -> Bool {
+        let restoredBack = sanitizer.sanitizedSessionHistoryURLs(backHistoryURLStrings)
+        let restoredForward = sanitizer.sanitizedSessionHistoryURLs(forwardHistoryURLStrings)
+        let restoredCurrent = sanitizer.sanitizedSessionHistoryURL(currentURLString)
+        guard !restoredBack.isEmpty || !restoredForward.isEmpty || restoredCurrent != nil else {
+            return false
+        }
+
+        usesRestoredSessionHistory = true
+        back = restoredBack
+        forward = Array(restoredForward.reversed())
+        current = restoredCurrent
+        return true
+    }
+
+    /// Captures the current back/forward URLs for persistence, given the native
+    /// WebKit back/forward lists and the live alignment.
+    ///
+    /// - Parameters:
+    ///   - nativeBackURLs: WebKit `backForwardList.backList` URLs, oldest first.
+    ///   - nativeForwardURLs: WebKit `backForwardList.forwardList` URLs.
+    ///   - isLiveAligned: Whether the live current entry matches the restored
+    ///     current entry (typically the result of a preceding realign).
+    public func snapshot(
+        nativeBackURLs: [URL],
+        nativeForwardURLs: [URL],
+        isLiveAligned: Bool
+    ) -> SessionNavigationHistorySnapshot {
+        let nativeBack = nativeBackURLs.compactMap { sanitizer.serializableSessionHistoryURLString($0) }
+        let nativeForward = nativeForwardURLs.compactMap { sanitizer.serializableSessionHistoryURLString($0) }
+
+        if usesRestoredSessionHistory {
+            let backStrings = back.compactMap { sanitizer.serializableSessionHistoryURLString($0) }
+            let restoredForward = forward.reversed().compactMap {
+                sanitizer.serializableSessionHistoryURLString($0)
+            }
+
+            if isLiveAligned {
+                return SessionNavigationHistorySnapshot(
+                    backHistoryURLStrings: backStrings,
+                    forwardHistoryURLStrings: restoredForward.isEmpty ? nativeForward : restoredForward
+                )
+            }
+
+            return SessionNavigationHistorySnapshot(
+                backHistoryURLStrings: backStrings + nativeBack,
+                forwardHistoryURLStrings: nativeForward
+            )
+        }
+
+        return SessionNavigationHistorySnapshot(
+            backHistoryURLStrings: nativeBack,
+            forwardHistoryURLStrings: nativeForward
+        )
+    }
+
+    /// The outcome of realigning the restored stacks to a live current URL.
+    public enum RealignOutcome: Sendable, Equatable {
+        /// Replay inactive or live current unresolved/already current: no change.
+        case noChange
+        /// Stacks were rebalanced around the live current entry.
+        case rebalanced
+        /// The live current was not found in either stack and the forward stack
+        /// was cleared. The caller should emit the forward-clear debug log.
+        case clearedForward(liveCurrentString: String)
+    }
+
+    /// Realigns the restored stacks when WebKit navigated to an entry that is not
+    /// the restored current (e.g. an in-page link from a replayed page). If the
+    /// live entry is found in the back stack, entries after it move to forward;
+    /// if found in the forward stack, entries before it move to back; otherwise
+    /// the now-stale forward stack is cleared.
+    ///
+    /// - Parameter liveCurrentURL: The surface's resolved live current URL.
+    /// - Returns: A `RealignOutcome` describing what changed so the caller can
+    ///   refresh availability and log identically to the pre-extraction code.
+    @discardableResult
+    public mutating func realign(toLiveCurrentURL liveCurrentURL: URL?) -> RealignOutcome {
+        guard usesRestoredSessionHistory else { return .noChange }
+        guard let liveCurrentString = sanitizer.serializableSessionHistoryURLString(liveCurrentURL) else {
+            return .noChange
+        }
+        guard sanitizer.serializableSessionHistoryURLString(current) != liveCurrentString else {
+            return .noChange
+        }
+
+        let restoredBack = back.compactMap { sanitizer.serializableSessionHistoryURLString($0) }
+        let restoredForward = forward.reversed().compactMap {
+            sanitizer.serializableSessionHistoryURLString($0)
+        }
+        let restoredCurrent = sanitizer.serializableSessionHistoryURLString(current)
+
+        if let backIndex = restoredBack.lastIndex(of: liveCurrentString) {
+            let newBack = Array(restoredBack[..<backIndex])
+            var newForward = Array(restoredBack[(backIndex + 1)...])
+            if let restoredCurrent {
+                newForward.append(restoredCurrent)
+            }
+            newForward.append(contentsOf: restoredForward)
+
+            back = sanitizer.sanitizedSessionHistoryURLs(newBack)
+            forward = Array(sanitizer.sanitizedSessionHistoryURLs(newForward).reversed())
+            current = liveCurrentURL
+            return .rebalanced
+        }
+
+        if let forwardIndex = restoredForward.firstIndex(of: liveCurrentString) {
+            var newBack = restoredBack
+            if let restoredCurrent {
+                newBack.append(restoredCurrent)
+            }
+            newBack.append(contentsOf: restoredForward[..<forwardIndex])
+            let newForward = Array(restoredForward[(forwardIndex + 1)...])
+
+            back = sanitizer.sanitizedSessionHistoryURLs(newBack)
+            forward = Array(sanitizer.sanitizedSessionHistoryURLs(newForward).reversed())
+            current = liveCurrentURL
+            return .rebalanced
+        }
+
+        guard !forward.isEmpty else { return .noChange }
+        forward.removeAll(keepingCapacity: false)
+        return .clearedForward(liveCurrentString: liveCurrentString)
+    }
+
+    /// Decides how to satisfy a back request while replay is active.
+    ///
+    /// - Parameters:
+    ///   - isLiveAligned: Whether the live current matches the restored current.
+    ///   - nativeCanGoBack: WebKit's `canGoBack`.
+    ///   - resolvedCurrentURL: The surface's resolved current URL, pushed onto
+    ///     the forward stack when a restored back entry is popped.
+    /// - Returns: The traversal decision the surface should apply.
+    public mutating func decideGoBack(
+        isLiveAligned: Bool,
+        nativeCanGoBack: Bool,
+        resolvedCurrentURL: URL?
+    ) -> SessionHistoryTraversalDecision {
+        if (isLiveAligned || !nativeCanGoBack), let targetURL = popBack() {
+            if let resolvedCurrentURL {
+                forward.append(resolvedCurrentURL)
+            }
+            current = targetURL
+            return .navigate(targetURL)
+        }
+
+        if nativeCanGoBack {
+            return .nativeGoBack
+        }
+
+        return .refreshOnly
+    }
+
+    /// Decides how to satisfy a forward request while replay is active.
+    ///
+    /// - Parameters:
+    ///   - nativeCanGoForward: WebKit's `canGoForward`.
+    ///   - resolvedCurrentURL: The surface's resolved current URL, pushed onto
+    ///     the back stack when a restored forward entry is popped.
+    /// - Returns: The traversal decision the surface should apply.
+    public mutating func decideGoForward(
+        nativeCanGoForward: Bool,
+        resolvedCurrentURL: URL?
+    ) -> SessionHistoryTraversalDecision {
+        if nativeCanGoForward {
+            return .nativeGoForward
+        }
+
+        guard let targetURL = popForward() else {
+            return .refreshOnly
+        }
+        if let resolvedCurrentURL {
+            back.append(resolvedCurrentURL)
+        }
+        current = targetURL
+        return .navigate(targetURL)
+    }
+
+    /// Deactivates replay and clears every restored stack. No-op when replay is
+    /// already inactive.
+    ///
+    /// - Returns: `true` when replay was active and is now cleared (the caller
+    ///   should refresh availability), `false` otherwise.
+    @discardableResult
+    public mutating func abandon() -> Bool {
+        guard usesRestoredSessionHistory else { return false }
+        usesRestoredSessionHistory = false
+        back.removeAll(keepingCapacity: false)
+        forward.removeAll(keepingCapacity: false)
+        current = nil
+        return true
+    }
+
+    private mutating func popBack() -> URL? {
+        back.popLast()
+    }
+
+    private mutating func popForward() -> URL? {
+        forward.popLast()
+    }
+}

--- a/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionHistoryTraversalDecision.swift
+++ b/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionHistoryTraversalDecision.swift
@@ -1,0 +1,24 @@
+public import Foundation
+
+/// The action a browser surface should take to satisfy a back/forward request
+/// while restored session history is active.
+///
+/// Restored session history is a replay cache: it remembers the back/forward
+/// URLs from a prior launch and walks them by issuing fresh navigations, while
+/// deferring to WebKit's native back-forward list once the live page accumulates
+/// real history. The state machine returns this decision and the surface applies
+/// it against its `WKWebView`, so no WebKit object is reached for inside the
+/// navigation package.
+public enum SessionHistoryTraversalDecision: Sendable, Equatable {
+    /// Pop the restored stack and navigate to `url` as a non-typed, history-preserving load.
+    case navigate(URL)
+
+    /// Defer to WebKit's native `goBack()`.
+    case nativeGoBack
+
+    /// Defer to WebKit's native `goForward()`.
+    case nativeGoForward
+
+    /// No traversal is possible; the caller should only refresh availability.
+    case refreshOnly
+}

--- a/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionHistoryURLSanitizer.swift
+++ b/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionHistoryURLSanitizer.swift
@@ -1,0 +1,57 @@
+public import Foundation
+
+/// Normalizes URLs for session-history persistence and replay.
+///
+/// Restored browser session history stores a list of URL strings. Two rules
+/// govern which URLs are eligible: a URL must be non-empty and not `about:blank`,
+/// and it must not be a *temporary* URL (a diff-viewer custom-scheme URL or a
+/// remote loopback proxy alias) whose backing server is gone after a restart.
+/// The temporary-URL classification depends on app-target types
+/// (`CmuxDiffViewerURLSchemeHandler`, `RemoteLoopbackProxyAlias`), so it is
+/// inverted into the injected `isTemporary` seam rather than reached for here.
+public struct SessionHistoryURLSanitizer: Sendable {
+    private let isTemporary: @Sendable (URL?) -> Bool
+
+    /// Creates a sanitizer.
+    ///
+    /// - Parameter isTemporary: Returns `true` when a URL is a transient
+    ///   session-history URL (diff viewer or remote loopback proxy alias) that
+    ///   must never be persisted or replayed across restarts.
+    public init(isTemporary: @escaping @Sendable (URL?) -> Bool) {
+        self.isTemporary = isTemporary
+    }
+
+    /// Returns whether a URL is a transient session-history URL.
+    public func isTemporarySessionHistoryURL(_ url: URL?) -> Bool {
+        isTemporary(url)
+    }
+
+    /// Returns the serialized string for a URL, or `nil` when the URL is not
+    /// eligible for session-history persistence.
+    public func serializableSessionHistoryURLString(_ url: URL?) -> String? {
+        guard let url else { return nil }
+        guard !isTemporary(url) else { return nil }
+        let value = url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, value != "about:blank" else { return nil }
+        return value
+    }
+
+    /// Parses a stored history string into an eligible URL, or `nil` when the
+    /// string is empty, `about:blank`, unparseable, or temporary.
+    public func sanitizedSessionHistoryURL(_ raw: String?) -> URL? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "about:blank" else { return nil }
+        guard let url = URL(string: trimmed),
+              !isTemporary(url) else {
+            return nil
+        }
+        return url
+    }
+
+    /// Maps a list of stored history strings to eligible URLs, dropping any that
+    /// fail `sanitizedSessionHistoryURL`.
+    public func sanitizedSessionHistoryURLs(_ values: [String]) -> [URL] {
+        values.compactMap { sanitizedSessionHistoryURL($0) }
+    }
+}

--- a/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionNavigationHistorySnapshot.swift
+++ b/Packages/CmuxBrowserNavigation/Sources/CmuxBrowserNavigation/SessionNavigationHistorySnapshot.swift
@@ -1,0 +1,22 @@
+public import Foundation
+
+/// The back/forward URL strings captured for session persistence.
+///
+/// `backHistoryURLStrings` is ordered oldest-first (the same order WebKit's
+/// `backForwardList.backList` uses); `forwardHistoryURLStrings` is ordered
+/// nearest-forward-first. Restoring these via
+/// `RestoredSessionHistory.restore(backHistoryURLStrings:forwardHistoryURLStrings:currentURLString:)`
+/// reproduces the traversal state.
+public struct SessionNavigationHistorySnapshot: Sendable, Equatable {
+    /// Back-list URLs, oldest first.
+    public var backHistoryURLStrings: [String]
+
+    /// Forward-list URLs, nearest-forward first.
+    public var forwardHistoryURLStrings: [String]
+
+    /// Creates a snapshot.
+    public init(backHistoryURLStrings: [String], forwardHistoryURLStrings: [String]) {
+        self.backHistoryURLStrings = backHistoryURLStrings
+        self.forwardHistoryURLStrings = forwardHistoryURLStrings
+    }
+}

--- a/Packages/CmuxBrowserNavigation/Tests/CmuxBrowserNavigationTests/RestoredSessionHistoryTests.swift
+++ b/Packages/CmuxBrowserNavigation/Tests/CmuxBrowserNavigationTests/RestoredSessionHistoryTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserNavigation
+
+@Suite("RestoredSessionHistory")
+struct RestoredSessionHistoryTests {
+    /// A sanitizer that treats `cmux-diff://` URLs as temporary, mirroring the
+    /// app-side diff-viewer classification without depending on app types.
+    private func makeSanitizer() -> SessionHistoryURLSanitizer {
+        SessionHistoryURLSanitizer { url in
+            url?.scheme?.lowercased() == "cmux-diff"
+        }
+    }
+
+    private func url(_ string: String) -> URL { URL(string: string)! }
+
+    @Test("restore activates replay and stores forward reversed")
+    func restoreActivates() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        let became = history.restore(
+            backHistoryURLStrings: ["https://a.test", "https://b.test"],
+            forwardHistoryURLStrings: ["https://d.test", "https://e.test"],
+            currentURLString: "https://c.test"
+        )
+        #expect(became)
+        #expect(history.usesRestoredSessionHistory)
+        #expect(history.back == [url("https://a.test"), url("https://b.test")])
+        // forward stored nearest-forward-last
+        #expect(history.forward == [url("https://e.test"), url("https://d.test")])
+        #expect(history.current == url("https://c.test"))
+    }
+
+    @Test("restore with only temporary/empty entries does not activate")
+    func restoreRejectsTemporary() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        let became = history.restore(
+            backHistoryURLStrings: ["cmux-diff://token", "about:blank", "  "],
+            forwardHistoryURLStrings: [],
+            currentURLString: "cmux-diff://token"
+        )
+        #expect(!became)
+        #expect(!history.usesRestoredSessionHistory)
+        #expect(history.back.isEmpty)
+        #expect(history.current == nil)
+    }
+
+    @Test("availability passes native flags through when inactive")
+    func availabilityInactive() {
+        let history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        #expect(history.availability(nativeCanGoBack: true, nativeCanGoForward: false)
+            == NavigationAvailability(canGoBack: true, canGoForward: false))
+    }
+
+    @Test("availability ORs restored stacks with native flags when active")
+    func availabilityActive() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://c.test"
+        )
+        #expect(history.availability(nativeCanGoBack: false, nativeCanGoForward: false)
+            == NavigationAvailability(canGoBack: true, canGoForward: false))
+        #expect(history.availability(nativeCanGoBack: false, nativeCanGoForward: true)
+            == NavigationAvailability(canGoBack: true, canGoForward: true))
+    }
+
+    @Test("goBack pops restored back and pushes current to forward")
+    func goBackPops() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test", "https://b.test"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://c.test"
+        )
+        let decision = history.decideGoBack(
+            isLiveAligned: true,
+            nativeCanGoBack: false,
+            resolvedCurrentURL: url("https://c.test")
+        )
+        #expect(decision == .navigate(url("https://b.test")))
+        #expect(history.current == url("https://b.test"))
+        #expect(history.back == [url("https://a.test")])
+        #expect(history.forward == [url("https://c.test")])
+    }
+
+    @Test("goBack defers to native when not aligned and native can go back")
+    func goBackNative() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://c.test"
+        )
+        let decision = history.decideGoBack(
+            isLiveAligned: false,
+            nativeCanGoBack: true,
+            resolvedCurrentURL: url("https://c.test")
+        )
+        #expect(decision == .nativeGoBack)
+        #expect(history.back == [url("https://a.test")])
+    }
+
+    @Test("goBack with empty stack and no native history refreshes only")
+    func goBackRefreshOnly() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: [],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let decision = history.decideGoBack(
+            isLiveAligned: true,
+            nativeCanGoBack: false,
+            resolvedCurrentURL: url("https://c.test")
+        )
+        #expect(decision == .refreshOnly)
+    }
+
+    @Test("goForward prefers native when available")
+    func goForwardNative() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: [],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let decision = history.decideGoForward(
+            nativeCanGoForward: true,
+            resolvedCurrentURL: url("https://c.test")
+        )
+        #expect(decision == .nativeGoForward)
+        #expect(history.forward == [url("https://d.test")])
+    }
+
+    @Test("goForward pops restored forward and pushes current to back")
+    func goForwardPops() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: [],
+            forwardHistoryURLStrings: ["https://d.test", "https://e.test"],
+            currentURLString: "https://c.test"
+        )
+        // forward stack: [e, d] (d is nearest-forward, last)
+        let decision = history.decideGoForward(
+            nativeCanGoForward: false,
+            resolvedCurrentURL: url("https://c.test")
+        )
+        #expect(decision == .navigate(url("https://d.test")))
+        #expect(history.current == url("https://d.test"))
+        #expect(history.back == [url("https://c.test")])
+        #expect(history.forward == [url("https://e.test")])
+    }
+
+    @Test("snapshot when aligned returns restored back and forward")
+    func snapshotAligned() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let snap = history.snapshot(
+            nativeBackURLs: [url("https://native-b.test")],
+            nativeForwardURLs: [url("https://native-f.test")],
+            isLiveAligned: true
+        )
+        #expect(snap == SessionNavigationHistorySnapshot(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: ["https://d.test"]
+        ))
+    }
+
+    @Test("snapshot when not aligned concatenates restored back with native back")
+    func snapshotMisaligned() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let snap = history.snapshot(
+            nativeBackURLs: [url("https://native-b.test")],
+            nativeForwardURLs: [url("https://native-f.test")],
+            isLiveAligned: false
+        )
+        #expect(snap == SessionNavigationHistorySnapshot(
+            backHistoryURLStrings: ["https://a.test", "https://native-b.test"],
+            forwardHistoryURLStrings: ["https://native-f.test"]
+        ))
+    }
+
+    @Test("snapshot inactive returns native lists")
+    func snapshotInactive() {
+        let history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        let snap = history.snapshot(
+            nativeBackURLs: [url("https://native-b.test")],
+            nativeForwardURLs: [url("https://native-f.test")],
+            isLiveAligned: true
+        )
+        #expect(snap == SessionNavigationHistorySnapshot(
+            backHistoryURLStrings: ["https://native-b.test"],
+            forwardHistoryURLStrings: ["https://native-f.test"]
+        ))
+    }
+
+    @Test("realign moves entries after a back-list match into forward")
+    func realignFromBack() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test", "https://b.test"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://c.test"
+        )
+        // live navigated back to a.test
+        let outcome = history.realign(toLiveCurrentURL: url("https://a.test"))
+        #expect(outcome == .rebalanced)
+        #expect(history.back.isEmpty)
+        #expect(history.current == url("https://a.test"))
+        // forward (nearest-last) should hold b then c: stored reversed -> [c, b]
+        #expect(history.forward == [url("https://c.test"), url("https://b.test")])
+    }
+
+    @Test("realign clears stale forward when live current not found")
+    func realignClearsForward() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let outcome = history.realign(toLiveCurrentURL: url("https://elsewhere.test"))
+        #expect(outcome == .clearedForward(liveCurrentString: "https://elsewhere.test"))
+        #expect(history.forward.isEmpty)
+    }
+
+    @Test("realign is a no-op when already aligned")
+    func realignNoChange() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: [],
+            currentURLString: "https://c.test"
+        )
+        let outcome = history.realign(toLiveCurrentURL: url("https://c.test"))
+        #expect(outcome == .noChange)
+    }
+
+    @Test("abandon clears all restored state")
+    func abandonClears() {
+        var history = RestoredSessionHistory(sanitizer: makeSanitizer())
+        history.restore(
+            backHistoryURLStrings: ["https://a.test"],
+            forwardHistoryURLStrings: ["https://d.test"],
+            currentURLString: "https://c.test"
+        )
+        let abandoned = history.abandon()
+        #expect(abandoned)
+        #expect(!history.usesRestoredSessionHistory)
+        #expect(history.back.isEmpty)
+        #expect(history.forward.isEmpty)
+        #expect(history.current == nil)
+        // second abandon is a no-op
+        let abandonedAgain = history.abandon()
+        #expect(!abandonedAgain)
+    }
+}
+
+@Suite("SessionHistoryURLSanitizer")
+struct SessionHistoryURLSanitizerTests {
+    private func makeSanitizer() -> SessionHistoryURLSanitizer {
+        SessionHistoryURLSanitizer { $0?.scheme?.lowercased() == "cmux-diff" }
+    }
+
+    @Test("serializable rejects temporary, empty, and about:blank")
+    func serializableRejects() {
+        let s = makeSanitizer()
+        #expect(s.serializableSessionHistoryURLString(URL(string: "cmux-diff://x")) == nil)
+        #expect(s.serializableSessionHistoryURLString(URL(string: "about:blank")) == nil)
+        #expect(s.serializableSessionHistoryURLString(nil) == nil)
+        #expect(s.serializableSessionHistoryURLString(URL(string: "https://ok.test")) == "https://ok.test")
+    }
+
+    @Test("sanitized parses eligible strings only")
+    func sanitizedParses() {
+        let s = makeSanitizer()
+        #expect(s.sanitizedSessionHistoryURL("  ") == nil)
+        #expect(s.sanitizedSessionHistoryURL("about:blank") == nil)
+        #expect(s.sanitizedSessionHistoryURL("cmux-diff://x") == nil)
+        #expect(s.sanitizedSessionHistoryURL("https://ok.test") == URL(string: "https://ok.test"))
+        #expect(s.sanitizedSessionHistoryURLs(["https://a.test", "about:blank", "https://b.test"])
+            == [URL(string: "https://a.test")!, URL(string: "https://b.test")!])
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6,6 +6,7 @@ import WebKit
 import AppKit
 import Bonsplit
 import CmuxBrowserPanel
+import CmuxBrowserNavigation
 import CmuxTerminalCore
 import Network
 import CFNetwork
@@ -3178,10 +3179,23 @@ final class BrowserPanel: Panel, ObservableObject {
 
     private var nativeCanGoBack: Bool = false
     private var nativeCanGoForward: Bool = false
-    private var usesRestoredSessionHistory: Bool = false
-    private var restoredBackHistoryStack: [URL] = []
-    private var restoredForwardHistoryStack: [URL] = []
-    private var restoredHistoryCurrentURL: URL?
+
+    /// The replayable back/forward session history this surface restores from a
+    /// prior launch. The pure stack state machine lives in `CmuxBrowserNavigation`;
+    /// this surface owns the instance, feeds it the resolved live current URL,
+    /// and performs the `WKWebView` calls its decisions return. The temporary-URL
+    /// classification (diff viewer + remote loopback proxy alias) is inverted into
+    /// the injected sanitizer seam.
+    private var restoredSessionHistory = RestoredSessionHistory(
+        sanitizer: SessionHistoryURLSanitizer { browserIsTemporaryHistoryURL($0) }
+    )
+
+    private var usesRestoredSessionHistory: Bool {
+        restoredSessionHistory.usesRestoredSessionHistory
+    }
+    private var restoredHistoryCurrentURL: URL? {
+        restoredSessionHistory.current
+    }
     private var isMainFrameProvisionalNavigationActive: Bool = false
 
     /// Published estimated progress (0.0 - 1.0)
@@ -4673,31 +4687,12 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
-        let nativeBack = webView.backForwardList.backList.compactMap {
-            Self.serializableSessionHistoryURLString($0.url)
-        }
-        let nativeForward = webView.backForwardList.forwardList.compactMap {
-            Self.serializableSessionHistoryURLString($0.url)
-        }
-
-        if usesRestoredSessionHistory {
-            let back = restoredBackHistoryStack.compactMap { Self.serializableSessionHistoryURLString($0) }
-            // `restoredForwardHistoryStack` stores nearest-forward entries at the end.
-            let restoredForward = restoredForwardHistoryStack.reversed().compactMap {
-                Self.serializableSessionHistoryURLString($0)
-            }
-
-            if isLiveSessionHistoryAlignedWithRestoredCurrent {
-                return (
-                    back,
-                    restoredForward.isEmpty ? nativeForward : restoredForward
-                )
-            }
-
-            return (back + nativeBack, nativeForward)
-        }
-
-        return (nativeBack, nativeForward)
+        let snapshot = restoredSessionHistory.snapshot(
+            nativeBackURLs: webView.backForwardList.backList.map { $0.url },
+            nativeForwardURLs: webView.backForwardList.forwardList.map { $0.url },
+            isLiveAligned: isLiveSessionHistoryAlignedWithRestoredCurrent
+        )
+        return (snapshot.backHistoryURLStrings, snapshot.forwardHistoryURLStrings)
     }
 
     private func resolvedLiveSessionHistoryURL() -> URL? {
@@ -4713,67 +4708,24 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private var isLiveSessionHistoryAlignedWithRestoredCurrent: Bool {
-        let liveCurrent = Self.serializableSessionHistoryURLString(resolvedLiveSessionHistoryURL())
-        let restoredCurrent = Self.serializableSessionHistoryURLString(restoredHistoryCurrentURL)
-        guard let liveCurrent, let restoredCurrent else { return true }
-        return liveCurrent == restoredCurrent
+        restoredSessionHistory.isLiveAligned(withLiveCurrentURL: resolvedLiveSessionHistoryURL())
     }
 
     private func realignRestoredSessionHistoryToLiveCurrentIfPossible() {
-        guard usesRestoredSessionHistory else { return }
-        guard let liveCurrent = resolvedLiveSessionHistoryURL(),
-              let liveCurrentString = Self.serializableSessionHistoryURLString(liveCurrent) else {
+        switch restoredSessionHistory.realign(toLiveCurrentURL: resolvedLiveSessionHistoryURL()) {
+        case .noChange:
             return
-        }
-        guard Self.serializableSessionHistoryURLString(restoredHistoryCurrentURL) != liveCurrentString else {
-            return
-        }
-
-        let restoredBack = restoredBackHistoryStack.compactMap { Self.serializableSessionHistoryURLString($0) }
-        let restoredForward = restoredForwardHistoryStack.reversed().compactMap {
-            Self.serializableSessionHistoryURLString($0)
-        }
-        let restoredCurrent = Self.serializableSessionHistoryURLString(restoredHistoryCurrentURL)
-
-        if let backIndex = restoredBack.lastIndex(of: liveCurrentString) {
-            let newBack = Array(restoredBack[..<backIndex])
-            var newForward = Array(restoredBack[(backIndex + 1)...])
-            if let restoredCurrent {
-                newForward.append(restoredCurrent)
-            }
-            newForward.append(contentsOf: restoredForward)
-
-            restoredBackHistoryStack = Self.sanitizedSessionHistoryURLs(newBack)
-            restoredForwardHistoryStack = Array(Self.sanitizedSessionHistoryURLs(newForward).reversed())
-            restoredHistoryCurrentURL = liveCurrent
+        case .rebalanced:
             refreshNavigationAvailability()
-            return
-        }
-
-        if let forwardIndex = restoredForward.firstIndex(of: liveCurrentString) {
-            var newBack = restoredBack
-            if let restoredCurrent {
-                newBack.append(restoredCurrent)
-            }
-            newBack.append(contentsOf: restoredForward[..<forwardIndex])
-            let newForward = Array(restoredForward[(forwardIndex + 1)...])
-
-            restoredBackHistoryStack = Self.sanitizedSessionHistoryURLs(newBack)
-            restoredForwardHistoryStack = Array(Self.sanitizedSessionHistoryURLs(newForward).reversed())
-            restoredHistoryCurrentURL = liveCurrent
-            refreshNavigationAvailability()
-            return
-        }
-
-        guard !restoredForwardHistoryStack.isEmpty else { return }
+        case .clearedForward(let liveCurrentString):
 #if DEBUG
-        cmuxDebugLog(
-            "browser.history.restore.forward.clear panel=\(id.uuidString.prefix(5)) " +
-            "current=\(liveCurrentString)"
-        )
+            cmuxDebugLog(
+                "browser.history.restore.forward.clear panel=\(id.uuidString.prefix(5)) " +
+                "current=\(liveCurrentString)"
+            )
 #endif
-        restoredForwardHistoryStack.removeAll(keepingCapacity: false)
-        refreshNavigationAvailability()
+            refreshNavigationAvailability()
+        }
     }
 
     func restoreSessionNavigationHistory(
@@ -4781,16 +4733,12 @@ final class BrowserPanel: Panel, ObservableObject {
         forwardHistoryURLStrings: [String],
         currentURLString: String?
     ) {
-        let restoredBack = Self.sanitizedSessionHistoryURLs(backHistoryURLStrings)
-        let restoredForward = Self.sanitizedSessionHistoryURLs(forwardHistoryURLStrings)
-        let restoredCurrent = Self.sanitizedSessionHistoryURL(currentURLString)
-        guard !restoredBack.isEmpty || !restoredForward.isEmpty || restoredCurrent != nil else { return }
-
-        usesRestoredSessionHistory = true
-        restoredBackHistoryStack = restoredBack
-        // Store nearest-forward entries at the end to make stack pop operations trivial.
-        restoredForwardHistoryStack = Array(restoredForward.reversed())
-        restoredHistoryCurrentURL = restoredCurrent
+        let activated = restoredSessionHistory.restore(
+            backHistoryURLStrings: backHistoryURLStrings,
+            forwardHistoryURLStrings: forwardHistoryURLStrings,
+            currentURLString: currentURLString
+        )
+        guard activated else { return }
         refreshNavigationAvailability()
     }
 
@@ -6159,9 +6107,7 @@ extension BrowserPanel {
         isBrowserFocusModeExitArmed ||
         nativeCanGoBack ||
         nativeCanGoForward ||
-        restoredHistoryCurrentURL != nil ||
-        !restoredBackHistoryStack.isEmpty ||
-        !restoredForwardHistoryStack.isEmpty ||
+        restoredSessionHistory.hasRestoredState ||
         estimatedProgress > 0 ||
         isLoading ||
         isDownloading ||
@@ -6365,27 +6311,24 @@ extension BrowserPanel {
         if usesRestoredSessionHistory {
             realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
-            if (isLiveSessionHistoryAlignedWithRestoredCurrent || !nativeCanGoBack),
-               let targetURL = restoredBackHistoryStack.popLast() {
-                if let current = resolvedCurrentSessionHistoryURL() {
-                    restoredForwardHistoryStack.append(current)
-                }
-                restoredHistoryCurrentURL = targetURL
+            let decision = restoredSessionHistory.decideGoBack(
+                isLiveAligned: isLiveSessionHistoryAlignedWithRestoredCurrent,
+                nativeCanGoBack: nativeCanGoBack,
+                resolvedCurrentURL: resolvedCurrentSessionHistoryURL()
+            )
+            switch decision {
+            case .navigate(let targetURL):
                 refreshNavigationAvailability()
                 navigateWithoutInsecureHTTPPrompt(
                     to: targetURL,
                     recordTypedNavigation: false,
                     preserveRestoredSessionHistory: true
                 )
-                return
-            }
-
-            if nativeCanGoBack {
+            case .nativeGoBack:
                 webView.goBack()
-                return
+            case .nativeGoForward, .refreshOnly:
+                refreshNavigationAvailability()
             }
-
-            refreshNavigationAvailability()
             return
         }
 
@@ -6400,25 +6343,23 @@ extension BrowserPanel {
         if usesRestoredSessionHistory {
             realignRestoredSessionHistoryToLiveCurrentIfPossible()
 
-            if nativeCanGoForward {
-                webView.goForward()
-                return
-            }
-
-            guard let targetURL = restoredForwardHistoryStack.popLast() else {
-                refreshNavigationAvailability()
-                return
-            }
-            if let current = resolvedCurrentSessionHistoryURL() {
-                restoredBackHistoryStack.append(current)
-            }
-            restoredHistoryCurrentURL = targetURL
-            refreshNavigationAvailability()
-            navigateWithoutInsecureHTTPPrompt(
-                to: targetURL,
-                recordTypedNavigation: false,
-                preserveRestoredSessionHistory: true
+            let decision = restoredSessionHistory.decideGoForward(
+                nativeCanGoForward: nativeCanGoForward,
+                resolvedCurrentURL: resolvedCurrentSessionHistoryURL()
             )
+            switch decision {
+            case .nativeGoForward:
+                webView.goForward()
+            case .navigate(let targetURL):
+                refreshNavigationAvailability()
+                navigateWithoutInsecureHTTPPrompt(
+                    to: targetURL,
+                    recordTypedNavigation: false,
+                    preserveRestoredSessionHistory: true
+                )
+            case .nativeGoBack, .refreshOnly:
+                refreshNavigationAvailability()
+            }
             return
         }
 
@@ -8166,58 +8107,44 @@ extension BrowserPanel {
     }
 
     private func refreshNavigationAvailability() {
-        let resolvedCanGoBack: Bool
-        let resolvedCanGoForward: Bool
-        if usesRestoredSessionHistory {
-            resolvedCanGoBack = nativeCanGoBack || !restoredBackHistoryStack.isEmpty
-            resolvedCanGoForward = nativeCanGoForward || !restoredForwardHistoryStack.isEmpty
-        } else {
-            resolvedCanGoBack = nativeCanGoBack
-            resolvedCanGoForward = nativeCanGoForward
-        }
+        let availability = restoredSessionHistory.availability(
+            nativeCanGoBack: nativeCanGoBack,
+            nativeCanGoForward: nativeCanGoForward
+        )
 
-        if canGoBack != resolvedCanGoBack {
-            canGoBack = resolvedCanGoBack
+        if canGoBack != availability.canGoBack {
+            canGoBack = availability.canGoBack
         }
-        if canGoForward != resolvedCanGoForward {
-            canGoForward = resolvedCanGoForward
+        if canGoForward != availability.canGoForward {
+            canGoForward = availability.canGoForward
         }
     }
 
     private func abandonRestoredSessionHistoryIfNeeded() {
-        guard usesRestoredSessionHistory else { return }
-        usesRestoredSessionHistory = false
-        restoredBackHistoryStack.removeAll(keepingCapacity: false)
-        restoredForwardHistoryStack.removeAll(keepingCapacity: false)
-        restoredHistoryCurrentURL = nil
+        guard restoredSessionHistory.abandon() else { return }
         refreshNavigationAvailability()
     }
 
+    /// Shared sanitizer mirroring the restored-session-history URL rules, used by
+    /// the surface's WebKit-touching resolution helpers.
+    private static let sessionHistoryURLSanitizer = SessionHistoryURLSanitizer {
+        browserIsTemporaryHistoryURL($0)
+    }
+
     private static func serializableSessionHistoryURLString(_ url: URL?) -> String? {
-        guard let url else { return nil }
-        guard !isTemporarySessionHistoryURL(url) else { return nil }
-        let value = url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !value.isEmpty, value != "about:blank" else { return nil }
-        return value
+        sessionHistoryURLSanitizer.serializableSessionHistoryURLString(url)
     }
 
     private static func sanitizedSessionHistoryURL(_ raw: String?) -> URL? {
-        guard let raw else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed != "about:blank" else { return nil }
-        guard let url = URL(string: trimmed),
-              !isTemporarySessionHistoryURL(url) else {
-            return nil
-        }
-        return url
+        sessionHistoryURLSanitizer.sanitizedSessionHistoryURL(raw)
     }
 
     private static func sanitizedSessionHistoryURLs(_ values: [String]) -> [URL] {
-        values.compactMap { sanitizedSessionHistoryURL($0) }
+        sessionHistoryURLSanitizer.sanitizedSessionHistoryURLs(values)
     }
 
     private static func isTemporarySessionHistoryURL(_ url: URL?) -> Bool {
-        browserIsTemporaryHistoryURL(url)
+        sessionHistoryURLSanitizer.isTemporarySessionHistoryURL(url)
     }
 
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
+		CB17A00000000000000000B3 /* CmuxBrowserNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = CB17A00000000000000000B2 /* CmuxBrowserNavigation */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
@@ -1768,6 +1769,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
+				CB17A00000000000000000B3 /* CmuxBrowserNavigation in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
@@ -2829,6 +2831,7 @@
 				C19C5E0200000000000000A2 /* CmuxIPCService */,
 				5E55100000000000000000A2 /* CmuxSession */,
 				5E55100000000000000000B2 /* CmuxBrowserPanel */,
+				CB17A00000000000000000B2 /* CmuxBrowserNavigation */,
 				5E55200000000000000000B2 /* CmuxWindowing */,
 				5E55300000000000000000C2 /* CmuxCommandPaletteUI */,
 				5E55500000000000000000E2 /* CmuxCommandPalette */,
@@ -3022,6 +3025,7 @@
 				C19C5E0100000000000000A1 /* XCLocalSwiftPackageReference "CmuxIPCService" */,
 				5E55100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSession" */,
 				5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */,
+				CB17A00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserNavigation" */,
 				5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */,
 				5E55300000000000000000C1 /* XCLocalSwiftPackageReference "CmuxCommandPaletteUI" */,
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
@@ -4527,6 +4531,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowserPanel;
 		};
+		CB17A00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserNavigation" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserNavigation;
+		};
 		5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWindowing;
@@ -4893,6 +4901,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */;
 			productName = CmuxBrowserPanel;
+		};
+		CB17A00000000000000000B2 /* CmuxBrowserNavigation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CB17A00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserNavigation" */;
+			productName = CmuxBrowserNavigation;
 		};
 		5E55200000000000000000B2 /* CmuxWindowing */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the restored back/forward session-history replay logic out of the ~13.3k-line `Sources/Panels/BrowserPanel.swift` god file into a new `CmuxBrowserNavigation` package, as a pure value-semantics state machine. Behavior is byte-identical; `BrowserPanel`'s public methods keep their signatures as thin forwards.

## What moved
- `RestoredSessionHistory` (Coordinator-shaped pure state machine): owns `usesRestoredSessionHistory` plus the back/forward/current URL stacks and sequences `restore`, `snapshot`, `realign`, `decideGoBack`/`decideGoForward`, `availability`, and `abandon` as pure mutating methods.
- `SessionHistoryURLSanitizer`: the serialize/sanitize/temporary-URL eligibility rules.
- `NavigationAvailability`, `SessionNavigationHistorySnapshot`, `SessionHistoryTraversalDecision`: `Sendable` value/result types.

## Seams (constructor-injected, inverting every god-type reach)
- The temporary-URL classification (which reaches `CmuxDiffViewerURLSchemeHandler` and `RemoteLoopbackProxyAlias`) is inverted into an injected `isTemporary: @Sendable (URL?) -> Bool`, so the package touches no WebKit, AppKit, or app-target type.
- The resolved live current `URL?` (from `webView.url`/`currentURL`) and the native WebKit `canGoBack`/`canGoForward` flags are passed in per call.
- `WKWebView.goBack()`/`goForward()`/`reload()` stay on `BrowserPanel`, driven by the returned `SessionHistoryTraversalDecision`.

## Byte-identical notes
The moved logic is reproduced exactly: forward stack stored nearest-forward-last; the same short-circuit so `goBack` only pops when `(isLiveAligned || !nativeCanGoBack)`; the same `refreshNavigationAvailability()` ordering (refresh-then-navigate); the same `#if DEBUG` `browser.history.restore.forward.clear` log still emitted on the app side via the returned `RealignOutcome`. Public `BrowserPanel` methods (`restoreSessionNavigationHistory`, `sessionNavigationHistorySnapshot`, `goBack`, `goForward`, `reload`) are unchanged forwards, so existing call sites and `BrowserConfigTests`/`GhosttyConfigTests`/`CmuxWebViewMouseNavigationButtonTests` stay valid.

## Tests
18 behavior unit tests in `CmuxBrowserNavigationTests` with a fake temporary-URL seam, covering restore activation/rejection, availability, traversal (pop/native/refresh), snapshot (aligned/misaligned/inactive), realign (back-match/forward-match/clear/no-op), and abandon. `swift build` + `swift test` pass in the package.

## Wiring + budget
Added the package to `cmux.xcodeproj` (6 pbxproj entries, mirroring `CmuxBrowserPanel`) and as an app-target dependency. Ratcheted the `BrowserPanel.swift` file-length budget 13358 -> 13285 (est. ~73 lines removed from the giant). Package convention linter is clean (zero `lint:allow`).

NOTE: app build + full XCUITest/unit suite validated by CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143966&installation_id=133855650&pr_number=6171&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6171&signature=e367e0edaa9eb37df90f9d57b89fbcc591c0056c68cf2ed4d50d9cf15cd0276b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted restored back/forward session-history replay from `BrowserPanel.swift` into a new `CmuxBrowserNavigation` package as a pure value-state machine. Behavior is unchanged; `BrowserPanel` methods keep the same signatures and now forward to the state machine.

- **Refactors**
  - Added `RestoredSessionHistory` with `restore`, `snapshot`, `realign`, `decideGoBack`/`decideGoForward`, `availability`, and `abandon`.
  - Introduced `SessionHistoryURLSanitizer` and value types: `NavigationAvailability`, `SessionNavigationHistorySnapshot`, `SessionHistoryTraversalDecision`.
  - Inverted app/WebKit reach via injected `isTemporary: (URL?) -> Bool` and per-call native flags/live URL; `WKWebView` calls remain in `BrowserPanel`.
  - Preserved byte-identical behavior (stack order, goBack short-circuit, refresh ordering, DEBUG forward-clear log). Reduced `BrowserPanel.swift` budget 13358 → 13285.

- **Dependencies**
  - Added `CmuxBrowserNavigation` to the project and app target.
  - Added 18 tests in `CmuxBrowserNavigationTests`; package builds and tests pass.

<sup>Written for commit a9bfdad2072546947f44b0ff219c26e8e7262add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session history restoration framework for improved browser navigation state management.
  * Enhanced back/forward navigation with support for restored session history.
  * Implemented URL sanitization for session history preservation and replay.

* **Tests**
  * Added comprehensive test coverage for session history restoration and navigation.

* **Chores**
  * Integrated new navigation package into build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->