### PR TITLE
Extract sidebar drag state machine from ContentView into CmuxSidebarDragCoordinator

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,9 +2,9 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34202	CLI/cmux.swift
-17778	Sources/AppDelegate.swift
-16674	Sources/ContentView.swift
-14785	Sources/TerminalController.swift
+17788	Sources/AppDelegate.swift
+16562	Sources/ContentView.swift
+14786	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift

--- a/Packages/CmuxSidebarDragCoordinator/Package.swift
+++ b/Packages/CmuxSidebarDragCoordinator/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxSidebarDragCoordinator",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxSidebarDragCoordinator",
+            targets: ["CmuxSidebarDragCoordinator"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxFoundation"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxSidebarDragCoordinator",
+            dependencies: [
+                .product(name: "CmuxFoundation", package: "CmuxFoundation"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxSidebarDragCoordinatorTests",
+            dependencies: [
+                "CmuxSidebarDragCoordinator",
+                .product(name: "CmuxFoundation", package: "CmuxFoundation"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarDragState.swift
+++ b/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarDragState.swift
@@ -1,0 +1,101 @@
+public import Foundation
+public import Observation
+public import CmuxFoundation
+
+/// Transient sidebar drag/drop state, owned by the sidebar view and passed by
+/// reference into rows and drop delegates. `@Observable` gives per-property
+/// tracking: writing `draggedTabId` or `dropIndicator` during a drag invalidates
+/// only the views that read those properties (the dragged row's opacity and the
+/// drop-indicator overlays), never the sidebar body or the `LazyVStack` itself.
+/// That invariant is what prevents the layout-invalidation loop that caused
+/// https://github.com/manaflow-ai/cmux/issues/2586.
+///
+/// Begin/clear of a drag also drive the process-wide cross-window identity
+/// through the injected ``SidebarWorkspaceDragRegistering`` seam so a destination
+/// window can resolve a drag that originated elsewhere.
+@MainActor
+@Observable
+public final class SidebarDragState {
+    /// The workspace currently dragged in this window, or `nil` when no local
+    /// drag is in flight. A destination window mirrors a foreign id here to drive
+    /// the cross-window drop machinery.
+    public var draggedTabId: UUID?
+
+    /// Where the sidebar should currently render the drop indicator, or `nil`.
+    public var dropIndicator: SidebarDropIndicator?
+
+    /// Whether the active indicator is positioned against top-level (group-folded)
+    /// rows rather than raw rows, so the overlay aligns to the same coordinate
+    /// space the planner reasoned in.
+    public var dropIndicatorUsesTopLevelRows = false
+
+    /// True while the `debug.sidebar.simulate_drag` debug-only method is driving
+    /// the drag state. Lifecycle observers honor this by not starting the
+    /// failsafe monitor (which would otherwise post a `mouse_up_failsafe` clear
+    /// immediately since no real mouse is pressed during simulation). DEBUG-only
+    /// by convention; never set in release flows.
+    public var isSimulated: Bool = false
+
+    /// True only in the window that *originated* the current drag (set via
+    /// ``beginDragging(tabId:)``). A destination window that mirrors a foreign
+    /// drag id into ``draggedTabId`` for cross-window rendering does not own the
+    /// process-wide registry entry, so it must not clear it when its own local
+    /// drag state is reset.
+    private var originatedActiveDrag = false
+
+    /// Pin state of a foreign (cross-window) dragged workspace, resolved once
+    /// when the drag is mirrored into this window and reused for every hover
+    /// update. A workspace's pin state can't change mid-drag, so this avoids a
+    /// cross-window scan on each pointer-move. `nil` when no foreign drag is
+    /// mirrored here.
+    public var foreignDraggedIsPinned: Bool?
+
+    private let workspaceDragRegistry: any SidebarWorkspaceDragRegistering
+
+    /// Creates a drag state wired to the process-wide cross-window registry.
+    /// - Parameter workspaceDragRegistry: The shared registry that records which
+    ///   workspace is being dragged across all windows.
+    public init(workspaceDragRegistry: any SidebarWorkspaceDragRegistering) {
+        self.workspaceDragRegistry = workspaceDragRegistry
+    }
+
+    /// The workspace currently being sidebar-dragged anywhere in the process,
+    /// used by the drop path to resolve a drag that originated in another window.
+    public var currentWorkspaceDragId: UUID? {
+        workspaceDragRegistry.currentWorkspaceId
+    }
+
+    /// Marks `tabId` as this window's dragged workspace and records it as the
+    /// process-wide in-flight drag.
+    public func beginDragging(tabId: UUID) {
+        draggedTabId = tabId
+        clearDropIndicator()
+        originatedActiveDrag = true
+        workspaceDragRegistry.begin(workspaceId: tabId)
+    }
+
+    /// Sets the current drop indicator and whether it is positioned in top-level
+    /// row space.
+    public func setDropIndicator(_ indicator: SidebarDropIndicator?, usesTopLevelRows: Bool = false) {
+        dropIndicator = indicator
+        dropIndicatorUsesTopLevelRows = indicator != nil && usesTopLevelRows
+    }
+
+    /// Clears any visible drop indicator.
+    public func clearDropIndicator() {
+        setDropIndicator(nil)
+    }
+
+    /// Resets all drag state. Clears the process-wide registry entry only if this
+    /// window originated the drag, so a destination window that merely mirrored a
+    /// foreign id does not cancel the originating window's drag.
+    public func clearDrag() {
+        if originatedActiveDrag, let draggedTabId {
+            workspaceDragRegistry.end(workspaceId: draggedTabId)
+        }
+        originatedActiveDrag = false
+        foreignDraggedIsPinned = nil
+        draggedTabId = nil
+        clearDropIndicator()
+    }
+}

--- a/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarDragStateRegistry.swift
+++ b/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarDragStateRegistry.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+public import Foundation
+
+/// Debug-only registry that exposes the live ``SidebarDragState`` of each mounted
+/// sidebar keyed by `windowId`.
+///
+/// The debug-socket `debug.sidebar.simulate_drag` handler reads from this so
+/// external profiling tools (e.g. the `profile-pr` skill driving `xctrace`) can
+/// generate deterministic drag-state mutations against the running app without
+/// HID synthesis. One instance is owned by the app composition root and injected
+/// where windows register their drag state.
+@MainActor
+public final class SidebarDragStateRegistry {
+    private var statesByWindowId: [UUID: SidebarDragState] = [:]
+
+    /// Creates an empty registry with no sidebars registered.
+    public init() {}
+
+    /// Records the drag state for a mounted sidebar window.
+    public func register(windowId: UUID, dragState: SidebarDragState) {
+        statesByWindowId[windowId] = dragState
+    }
+
+    /// Removes the drag state for an unmounted sidebar window.
+    public func unregister(windowId: UUID) {
+        statesByWindowId.removeValue(forKey: windowId)
+    }
+
+    /// The live drag state for `windowId`, or `nil` if no sidebar is registered.
+    public func state(forWindowId windowId: UUID) -> SidebarDragState? {
+        statesByWindowId[windowId]
+    }
+
+    /// The window ids of every currently registered sidebar.
+    public func registeredWindowIds() -> [UUID] {
+        Array(statesByWindowId.keys)
+    }
+}
+#endif

--- a/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarWorkspaceDragRegistry.swift
+++ b/Packages/CmuxSidebarDragCoordinator/Sources/CmuxSidebarDragCoordinator/SidebarWorkspaceDragRegistry.swift
@@ -1,0 +1,55 @@
+public import Foundation
+
+/// Read/write seam for the process-wide identity of the workspace currently
+/// being sidebar-dragged in any window.
+///
+/// A sidebar drag is a single, process-global event: at most one workspace is
+/// being dragged at a time. The originating window records it here synchronously
+/// at drag start and clears it when that drag ends. A *destination* window, which
+/// has no local dragged id because the drag began elsewhere, reads this to
+/// resolve the dragged workspace for a cross-window move.
+///
+/// This is deliberately not sourced from `NSPasteboard(name: .drag)`: SwiftUI's
+/// `.onDrag` registers the payload through an `NSItemProvider` whose data
+/// representation is delivered asynchronously, so a synchronous pasteboard read
+/// inside a `DropDelegate` can race and return `nil`. A plain in-process value,
+/// set synchronously on the main actor, has no such materialization race.
+@MainActor
+public protocol SidebarWorkspaceDragRegistering: AnyObject {
+    /// The workspace currently being sidebar-dragged anywhere in the process,
+    /// or `nil` when no sidebar drag is in flight.
+    var currentWorkspaceId: UUID? { get }
+
+    /// Record the start of a sidebar drag. Called by the originating window.
+    func begin(workspaceId: UUID)
+
+    /// Clear the active drag, but only if `workspaceId` still matches the
+    /// in-flight drag, so a stale clear from a superseded drag is a no-op.
+    func end(workspaceId: UUID)
+}
+
+/// Process-wide registry of the workspace currently being dragged in any
+/// window's sidebar.
+///
+/// One instance is constructed at the app composition root and injected into
+/// every ``SidebarDragState`` (and read by the sidebar's drop delegate) so all
+/// windows agree on the single in-flight drag without a shared global.
+@MainActor
+public final class SidebarWorkspaceDragRegistry: SidebarWorkspaceDragRegistering {
+    private var activeWorkspaceId: UUID?
+
+    /// Creates an empty registry with no drag in flight.
+    public init() {}
+
+    public var currentWorkspaceId: UUID? { activeWorkspaceId }
+
+    public func begin(workspaceId: UUID) {
+        activeWorkspaceId = workspaceId
+    }
+
+    public func end(workspaceId: UUID) {
+        if activeWorkspaceId == workspaceId {
+            activeWorkspaceId = nil
+        }
+    }
+}

--- a/Packages/CmuxSidebarDragCoordinator/Tests/CmuxSidebarDragCoordinatorTests/SidebarDragStateTests.swift
+++ b/Packages/CmuxSidebarDragCoordinator/Tests/CmuxSidebarDragCoordinatorTests/SidebarDragStateTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+import CmuxFoundation
+@testable import CmuxSidebarDragCoordinator
+
+/// In-memory fake of the cross-window registry seam that records the calls the
+/// coordinator makes, so tests assert the begin/end protocol without a real
+/// process-wide instance.
+@MainActor
+private final class FakeWorkspaceDragRegistry: SidebarWorkspaceDragRegistering {
+    var current: UUID?
+    private(set) var beginCalls: [UUID] = []
+    private(set) var endCalls: [UUID] = []
+
+    var currentWorkspaceId: UUID? { current }
+
+    func begin(workspaceId: UUID) {
+        beginCalls.append(workspaceId)
+        current = workspaceId
+    }
+
+    func end(workspaceId: UUID) {
+        endCalls.append(workspaceId)
+        if current == workspaceId { current = nil }
+    }
+}
+
+@MainActor
+@Suite struct SidebarDragStateTests {
+    @Test func beginDraggingSetsLocalAndProcessWideIdentity() {
+        let registry = FakeWorkspaceDragRegistry()
+        let state = SidebarDragState(workspaceDragRegistry: registry)
+        let id = UUID()
+
+        state.setDropIndicator(SidebarDropIndicator(tabId: UUID(), edge: .bottom))
+        state.beginDragging(tabId: id)
+
+        #expect(state.draggedTabId == id)
+        #expect(registry.beginCalls == [id])
+        #expect(registry.current == id)
+        // Begin clears any stale indicator.
+        #expect(state.dropIndicator == nil)
+    }
+
+    @Test func clearDragEndsRegistryOnlyForOriginatingWindow() {
+        let registry = FakeWorkspaceDragRegistry()
+        let origin = SidebarDragState(workspaceDragRegistry: registry)
+        let id = UUID()
+        origin.beginDragging(tabId: id)
+
+        origin.clearDrag()
+
+        #expect(origin.draggedTabId == nil)
+        #expect(registry.endCalls == [id])
+        #expect(registry.current == nil)
+    }
+
+    @Test func mirroredForeignDragDoesNotEndRegistryOnClear() {
+        let registry = FakeWorkspaceDragRegistry()
+        // Originating window starts a drag.
+        let origin = SidebarDragState(workspaceDragRegistry: registry)
+        let id = UUID()
+        origin.beginDragging(tabId: id)
+
+        // Destination window mirrors the foreign id directly (no beginDragging),
+        // then resets its own state.
+        let destination = SidebarDragState(workspaceDragRegistry: registry)
+        destination.draggedTabId = id
+        destination.foreignDraggedIsPinned = true
+        destination.clearDrag()
+
+        // Destination cleared its local state but must not end the originating
+        // window's registry entry.
+        #expect(destination.draggedTabId == nil)
+        #expect(destination.foreignDraggedIsPinned == nil)
+        #expect(registry.endCalls.isEmpty)
+        #expect(registry.current == id)
+    }
+
+    @Test func setDropIndicatorTracksTopLevelFlag() {
+        let registry = FakeWorkspaceDragRegistry()
+        let state = SidebarDragState(workspaceDragRegistry: registry)
+
+        state.setDropIndicator(SidebarDropIndicator(tabId: nil, edge: .top), usesTopLevelRows: true)
+        #expect(state.dropIndicatorUsesTopLevelRows == true)
+
+        // A nil indicator never claims top-level positioning.
+        state.setDropIndicator(nil, usesTopLevelRows: true)
+        #expect(state.dropIndicator == nil)
+        #expect(state.dropIndicatorUsesTopLevelRows == false)
+    }
+
+    @Test func currentWorkspaceDragIdReadsThroughRegistry() {
+        let registry = FakeWorkspaceDragRegistry()
+        let state = SidebarDragState(workspaceDragRegistry: registry)
+        #expect(state.currentWorkspaceDragId == nil)
+
+        let id = UUID()
+        registry.current = id
+        #expect(state.currentWorkspaceDragId == id)
+    }
+}
+
+@MainActor
+@Suite struct SidebarWorkspaceDragRegistryTests {
+    @Test func endIgnoresStaleClearFromSupersededDrag() {
+        let registry = SidebarWorkspaceDragRegistry()
+        let first = UUID()
+        let second = UUID()
+
+        registry.begin(workspaceId: first)
+        registry.begin(workspaceId: second)
+        // A late clear from the superseded first drag is a no-op.
+        registry.end(workspaceId: first)
+        #expect(registry.currentWorkspaceId == second)
+
+        registry.end(workspaceId: second)
+        #expect(registry.currentWorkspaceId == nil)
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -28,6 +28,7 @@ import Combine
 import ObjectiveC.runtime
 import Darwin
 import CmuxFoundation
+import CmuxSidebarDragCoordinator
 import CmuxSession
 import CmuxTerminal
 
@@ -773,6 +774,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserWebViewFirstResponderObserver: NSObjectProtocol?
     let updateLog = UpdateLogStore()
     let focusLog = FocusLogStore()
+    /// Process-wide identity of the workspace currently being sidebar-dragged in
+    /// any window. Owned here (the composition root) and injected into every
+    /// window's `SidebarDragState` so cross-window drops resolve a single drag.
+    let sidebarWorkspaceDragRegistry = SidebarWorkspaceDragRegistry()
+    #if DEBUG
+    /// Debug-only registry mapping each mounted sidebar's window id to its live
+    /// `SidebarDragState`, read by the `debug.sidebar.simulate_drag` handler.
+    let sidebarDragStateRegistry = SidebarDragStateRegistry()
+    #endif
     private lazy var updateController = UpdateController(log: updateLog)
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(updateLog: updateLog, settingsRuntime: settingsRuntime)
     private let windowDecorationsController = WindowDecorationsController()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -19,6 +19,7 @@ import CmuxFileOpen
 import CmuxSettings
 import CmuxSettingsUI
 import CmuxSidebar
+import CmuxSidebarDragCoordinator
 import CmuxSidebarRemoteRender
 import CmuxSwiftRender
 import CmuxSwiftRenderUI
@@ -10059,135 +10060,22 @@ private final class SidebarTabItemSettingsStore: ObservableObject {
     }
 }
 
-/// Transient sidebar drag/drop state, owned by `VerticalTabsSidebar` and passed
-/// by reference into rows and drop delegates. `@Observable` gives per-property
-/// tracking: writing `draggedTabId` or `dropIndicator` during drag invalidates
-/// only the views that read those properties (the dragged row's opacity and the
-/// drop-indicator overlays), never the sidebar body or the `LazyVStack` itself.
-/// That invariant is what prevents the layout-invalidation loop that caused
-/// https://github.com/manaflow-ai/cmux/issues/2586.
-@MainActor
-@Observable
-final class SidebarDragState {
-    var draggedTabId: UUID?
-    var dropIndicator: SidebarDropIndicator?
-    var dropIndicatorUsesTopLevelRows = false
-    /// True while the `debug.sidebar.simulate_drag` debug-only V2 method is
-    /// driving the drag state. The lifecycle observers honor this by not
-    /// starting `SidebarDragFailsafeMonitor` (which would otherwise post a
-    /// `mouse_up_failsafe` clear request immediately since no real mouse is
-    /// pressed during simulation). DEBUG-only by convention; never set in
-    /// release flows.
-    var isSimulated: Bool = false
-
-    /// True only in the window that *originated* the current drag (set via
-    /// ``beginDragging(tabId:)``). A destination window that mirrors a foreign
-    /// drag id into ``draggedTabId`` for cross-window rendering does not own the
-    /// process-wide ``SidebarWorkspaceDragRegistry`` entry, so it must not clear
-    /// it when its own local drag state is reset.
-    private var originatedActiveDrag = false
-
-    /// Pin state of a foreign (cross-window) dragged workspace, resolved once
-    /// when the drag is mirrored into this window and reused for every hover
-    /// update. A workspace's pin state can't change mid-drag, so this avoids an
-    /// `AppDelegate.tabManagerFor(tabId:)` scan over every window on each
-    /// pointer-move. `nil` when no foreign drag is mirrored here.
-    var foreignDraggedIsPinned: Bool?
-
-    init() {}
-
-    func beginDragging(tabId: UUID) {
-        draggedTabId = tabId
-        clearDropIndicator()
-        originatedActiveDrag = true
-        SidebarWorkspaceDragRegistry.begin(workspaceId: tabId)
-    }
-
-    func setDropIndicator(_ indicator: SidebarDropIndicator?, usesTopLevelRows: Bool = false) {
-        dropIndicator = indicator
-        dropIndicatorUsesTopLevelRows = indicator != nil && usesTopLevelRows
-    }
-
-    func clearDropIndicator() {
-        setDropIndicator(nil)
-    }
-
-    func clearDrag() {
-        if originatedActiveDrag, let draggedTabId {
-            SidebarWorkspaceDragRegistry.end(workspaceId: draggedTabId)
-        }
-        originatedActiveDrag = false
-        foreignDraggedIsPinned = nil
-        draggedTabId = nil
-        clearDropIndicator()
+// `SidebarDragState`, `SidebarWorkspaceDragRegistry`, and the DEBUG-only
+// `SidebarDragStateRegistry` now live in the `CmuxSidebarDragCoordinator`
+// package. This app-side convenience keeps the `SidebarDragState()` call site
+// unchanged by injecting the process-wide cross-window registry the app owns
+// at its composition root (`AppDelegate`).
+extension SidebarDragState {
+    /// Builds a drag state wired to the app's process-wide cross-window drag
+    /// registry. Falls back to a fresh registry only if `AppDelegate.shared` is
+    /// not yet available (never the case once a sidebar has mounted).
+    convenience init() {
+        self.init(
+            workspaceDragRegistry: AppDelegate.shared?.sidebarWorkspaceDragRegistry
+                ?? SidebarWorkspaceDragRegistry()
+        )
     }
 }
-
-/// Process-wide identity of the workspace currently being dragged in any
-/// window's sidebar.
-///
-/// A sidebar drag is a single, process-global event: at most one workspace is
-/// being dragged at a time. The originating window records it here synchronously
-/// at drag start (``SidebarDragState/beginDragging(tabId:)``) and clears it when
-/// that drag ends. A *destination* window — which has no local
-/// ``SidebarDragState/draggedTabId`` because the drag began elsewhere — reads
-/// this to resolve the dragged workspace for a cross-window move.
-///
-/// This is deliberately not sourced from `NSPasteboard(name: .drag)`: SwiftUI's
-/// `.onDrag` registers the payload through an `NSItemProvider` whose data
-/// representation is delivered asynchronously, so a synchronous pasteboard read
-/// inside a `DropDelegate` can race and return `nil`. A plain in-process value,
-/// set synchronously on the main actor, has no such materialization race.
-@MainActor
-enum SidebarWorkspaceDragRegistry {
-    private static var activeWorkspaceId: UUID?
-
-    /// The workspace currently being sidebar-dragged anywhere in the process,
-    /// or `nil` when no sidebar drag is in flight.
-    static var currentWorkspaceId: UUID? { activeWorkspaceId }
-
-    /// Record the start of a sidebar drag. Called by the originating window.
-    static func begin(workspaceId: UUID) {
-        activeWorkspaceId = workspaceId
-    }
-
-    /// Clear the active drag, but only if `workspaceId` still matches the
-    /// in-flight drag, so a stale clear from a superseded drag is a no-op.
-    static func end(workspaceId: UUID) {
-        if activeWorkspaceId == workspaceId {
-            activeWorkspaceId = nil
-        }
-    }
-}
-
-#if DEBUG
-/// Debug-only registry that exposes the live `SidebarDragState` of each
-/// mounted `VerticalTabsSidebar` keyed by `windowId`. The debug-socket
-/// `debug.sidebar.simulate_drag` handler reads from this so external
-/// profiling tools (e.g. the `profile-pr` skill driving `xctrace`) can
-/// generate deterministic drag-state mutations against the running app
-/// without HID synthesis.
-@MainActor
-enum SidebarDragStateRegistry {
-    private static var statesByWindowId: [UUID: SidebarDragState] = [:]
-
-    static func register(windowId: UUID, dragState: SidebarDragState) {
-        statesByWindowId[windowId] = dragState
-    }
-
-    static func unregister(windowId: UUID) {
-        statesByWindowId.removeValue(forKey: windowId)
-    }
-
-    static func state(forWindowId windowId: UUID) -> SidebarDragState? {
-        statesByWindowId[windowId]
-    }
-
-    static func registeredWindowIds() -> [UUID] {
-        Array(statesByWindowId.keys)
-    }
-}
-#endif
 
 /// Per-row drop-indicator visibility, computed by the parent from value
 /// inputs only. Takes UUIDs (not `Tab` objects or `SidebarDragState`) so it's
@@ -10709,7 +10597,7 @@ struct VerticalTabsSidebar: View {
             // re-mount, which would silently bypass the real-drag failsafe.
             dragState.isSimulated = false
             #if DEBUG
-            SidebarDragStateRegistry.register(windowId: windowId, dragState: dragState)
+            AppDelegate.shared?.sidebarDragStateRegistry.register(windowId: windowId, dragState: dragState)
             #endif
             SidebarDragLifecycleNotification().postStateDidChange(
                 tabId: nil,
@@ -10726,7 +10614,7 @@ struct VerticalTabsSidebar: View {
             // inherit a stale bypass and skip the real-drag failsafe monitor.
             dragState.isSimulated = false
             #if DEBUG
-            SidebarDragStateRegistry.unregister(windowId: windowId)
+            AppDelegate.shared?.sidebarDragStateRegistry.unregister(windowId: windowId)
             #endif
             SidebarDragLifecycleNotification().postStateDidChange(
                 tabId: nil,
@@ -15549,7 +15437,7 @@ struct SidebarTabDropDelegate: DropDelegate {
     /// keys on, so an intra-window reorder and a cross-window move share the same
     /// code instead of forking into parallel drop delegates.
     private var effectiveDraggedTabId: UUID? {
-        dragState.draggedTabId ?? SidebarWorkspaceDragRegistry.currentWorkspaceId
+        dragState.draggedTabId ?? dragState.currentWorkspaceDragId
     }
 
     /// Whether `draggedTabId` belongs to a *different* window than this drop
@@ -15622,7 +15510,7 @@ struct SidebarTabDropDelegate: DropDelegate {
     /// mouse-up (and `performDrop` clears it on a successful drop).
     private func activateForeignDragIfNeeded() {
         guard dragState.draggedTabId == nil,
-              let foreignId = SidebarWorkspaceDragRegistry.currentWorkspaceId,
+              let foreignId = dragState.currentWorkspaceDragId,
               isCrossWindowDrag(foreignId),
               !isCrossWindowGroupAnchorDrag(foreignId) else { return }
         // Resolve the foreign workspace's pin state once; it can't change while

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CmuxAppKitSupportUI
 import CmuxFoundation
+import CmuxSidebarDragCoordinator
 import SwiftUI
 import CmuxSettings
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -20,6 +20,7 @@ import Foundation
 import Bonsplit
 import WebKit
 import CmuxSidebar
+import CmuxSidebarDragCoordinator
 import CmuxTerminal
 import CmuxWorkspaceCore
 
@@ -10247,7 +10248,7 @@ class TerminalController {
             } else {
                 requestedSteps = nil
             }
-            guard SidebarDragStateRegistry.state(forWindowId: windowId) != nil else {
+            guard AppDelegate.shared?.sidebarDragStateRegistry.state(forWindowId: windowId) != nil else {
                 return .err(
                     code: "not_found",
                     message: "No mounted sidebar for window_id",
@@ -10331,7 +10332,7 @@ class TerminalController {
         // Start the drag. If the sidebar has already unregistered, fail loud
         // instead of silently sleeping through a no-op simulation.
         let startedOK: Bool = v2MainSync {
-            guard let dragState = SidebarDragStateRegistry.state(forWindowId: windowId) else { return false }
+            guard let dragState = AppDelegate.shared?.sidebarDragStateRegistry.state(forWindowId: windowId) else { return false }
             // Mark the drag as simulator-driven so VerticalTabsSidebar skips
             // starting SidebarDragFailsafeMonitor — it would otherwise post
             // mouse_up_failsafe immediately because no real mouse is pressed.
@@ -10357,7 +10358,7 @@ class TerminalController {
                 pathSample.append(targetTabId.uuidString)
             }
             let tickOK: Bool = v2MainSync {
-                guard let dragState = SidebarDragStateRegistry.state(forWindowId: windowId) else { return false }
+                guard let dragState = AppDelegate.shared?.sidebarDragStateRegistry.state(forWindowId: windowId) else { return false }
                 dragState.setDropIndicator(SidebarDropIndicator(tabId: targetTabId, edge: edge))
                 return true
             }
@@ -10371,7 +10372,7 @@ class TerminalController {
         }
 
         v2MainSync {
-            guard let dragState = SidebarDragStateRegistry.state(forWindowId: windowId) else { return }
+            guard let dragState = AppDelegate.shared?.sidebarDragStateRegistry.state(forWindowId: windowId) else { return }
             dragState.clearDrag()
             dragState.isSimulated = false
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */ = {isa = PBXBuildFile; productRef = CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */; };
 		E3B7A30000000000000000B3 /* CmuxSidebar in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000B2 /* CmuxSidebar */; };
 		DC5DC5DC0000000000000001 /* CmuxSidebarActionDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5DC5DC0000000000000002 /* CmuxSidebarActionDispatch.swift */; };
+		C5DA6C0000000000000000A3 /* CmuxSidebarDragCoordinator in Frameworks */ = {isa = PBXBuildFile; productRef = C5DA6C0000000000000000A2 /* CmuxSidebarDragCoordinator */; };
 		C0DE46030000000000000001 /* CMUXSidebarExtensionBrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46030000000000000002 /* CMUXSidebarExtensionBrowserPanel.swift */; };
 		C5B6A10000000000000000A3 /* CmuxSidebarGit in Frameworks */ = {isa = PBXBuildFile; productRef = C5B6A10000000000000000A2 /* CmuxSidebarGit */; };
 		C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1FED200000000000000E3 /* CmuxSidebarInterpreterClient */; };
@@ -1798,6 +1799,7 @@
 				CD0CFE5300000000CD0CFE53 /* CmuxSettings in Frameworks */,
 				CD0CFE5600000000CD0CFE56 /* CmuxSettingsUI in Frameworks */,
 				E3B7A30000000000000000B3 /* CmuxSidebar in Frameworks */,
+				C5DA6C0000000000000000A3 /* CmuxSidebarDragCoordinator in Frameworks */,
 				C5B6A10000000000000000A3 /* CmuxSidebarGit in Frameworks */,
 				C5A1FED200000000000000E1 /* CmuxSidebarInterpreterClient in Frameworks */,
 				C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */,
@@ -2836,6 +2838,7 @@
 				C8000312C8000312C8000312 /* CmuxFileWatch */,
 				C617000000000000000000A2 /* CmuxGit */,
 				C5B6A10000000000000000A2 /* CmuxSidebarGit */,
+				C5DA6C0000000000000000A2 /* CmuxSidebarDragCoordinator */,
 				E3B7A30000000000000000B2 /* CmuxSidebar */,
 				E3B7A30000000000000000C2 /* CmuxBrowser */,
 				E3B7A30000000000000000D2 /* CmuxNotifications */,
@@ -3029,6 +3032,7 @@
 				C8000311C8000311C8000311 /* XCLocalSwiftPackageReference "CmuxFileWatch" */,
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
+				C5DA6C0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarDragCoordinator" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
 				E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */,
@@ -4555,6 +4559,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSidebarGit;
 		};
+		C5DA6C0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarDragCoordinator" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSidebarDragCoordinator;
+		};
 		E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSidebar;
@@ -4823,6 +4831,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */;
 			productName = CmuxSidebarGit;
+		};
+		C5DA6C0000000000000000A2 /* CmuxSidebarDragCoordinator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5DA6C0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarDragCoordinator" */;
+			productName = CmuxSidebarDragCoordinator;
 		};
 		E3B7A30000000000000000B2 /* CmuxSidebar */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## What moved

The sidebar drag/drop **state machine** moves out of the `ContentView.swift` god file into a new domain package `Packages/CmuxSidebarDragCoordinator` (depends only on `CmuxFoundation`):

- **`SidebarDragState`** — `@MainActor @Observable` Coordinator owning transient drag state (`draggedTabId`, `dropIndicator`, `isSimulated`, `foreignDraggedIsPinned`; `beginDragging`/`setDropIndicator`/`clearDrag`). Its former static reach into the cross-window registry is inverted via a constructor-injected `any SidebarWorkspaceDragRegistering`.
- **`SidebarWorkspaceDragRegistry`** — the process-wide cross-window dragged-workspace identity, converted from a caseless static-namespace `enum` into a real `@MainActor final class` behind a protocol seam, owned by `AppDelegate` (the composition root) and injected.
- **`SidebarDragStateRegistry`** (`#if DEBUG`) — the `windowId -> SidebarDragState` map read by the `debug.sidebar.simulate_drag` profiling handler, likewise converted from a static-namespace `enum` to an `AppDelegate`-owned instance.

## Seams inverted

- `SidebarTabDropDelegate`'s former `SidebarWorkspaceDragRegistry.currentWorkspaceId` reads now go through the injected coordinator (`dragState.currentWorkspaceDragId`).
- The DEBUG `SidebarDragStateRegistry.{register,unregister,state}` calls in `ContentView`/`TerminalController` forward to `AppDelegate.shared?.sidebar*Registry`.
- An app-side `SidebarDragState.convenience init()` keeps the `@State var dragState = SidebarDragState()` call site byte-identical by injecting `AppDelegate`'s shared registry (fresh-registry fallback only if `AppDelegate.shared` is nil, never the case once a sidebar has mounted).

## Byte-identical notes

No `Defaults` keys, `NotificationCenter` names, wire formats, or logic changed. The only change is the declaration site of these types plus injection of an already-process-wide value (a singleton in all but name). `clearDrag`'s originated-vs-foreign guard, the `end()` stale-clear no-op, and the simulate-drag flow are preserved exactly.

## Scope decision

The pure drop predicates/planner (`SidebarTabDropIndicatorPredicate`, `SidebarDropPlanner`, `SidebarDropIndicator`, `SidebarWorkspaceSelectionSyncPolicy` in `CmuxFoundation`) and the autoscroll service (`SidebarDragAutoScroll*` in `CmuxAppKitSupportUI`) were already extracted by prior refactor waves, so this PR takes the remaining clean subset: the state machine + cross-window identity. The SwiftUI `SidebarTabDropDelegate` is a `DropDelegate` welded to `TabManager`, `AppDelegate.shared` cross-window methods, `@Binding`s, and `DropInfo`; moving it would require inverting ~10 collaborator methods at high behavior-drift risk, so it is intentionally left in the app target (it now consumes the package types).

## Tests

6 behavior unit tests with a fake `SidebarWorkspaceDragRegistering` seam covering begin/clear, originating-vs-mirrored-foreign clear semantics, the top-level indicator flag, and the registry stale-clear no-op. `swift build` + `swift test` pass in the package.

## Verification

- `scripts/lint-ios-package-conventions.sh`: OK, zero new `lint:allow`.
- `Packages/CmuxSidebarDragCoordinator` `swift build` + `swift test`: pass.
- `.github/swift-file-length-budget.tsv` reconciled (ContentView.swift ratcheted down ~112 lines).
- Package wired into `cmux.xcodeproj` (6 pbxproj entries mirroring `CmuxSidebarGit`) and added as an app-target dependency.

Est. lines removed from the ContentView giant: ~112.

NOTE: the full app build + XCUITests are validated by GitHub CI; per refactor protocol they were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143979&installation_id=133855650&pr_number=6172&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6172&signature=a4fbec2e24ff70c9785a2e7eb4475da77a33e9ad2d66a625844520f08b3c0994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the sidebar drag/drop state machine into a new `CmuxSidebarDragCoordinator` package and replaced static globals with injected registries for better modularity and cross-window drag handling. Behavior is unchanged.

- **Refactors**
  - Moved `SidebarDragState`, `SidebarWorkspaceDragRegistry`, and DEBUG `SidebarDragStateRegistry` to `CmuxSidebarDragCoordinator`.
  - Introduced `SidebarWorkspaceDragRegistering` and `SidebarWorkspaceDragRegistry` (`@MainActor`); owned by `AppDelegate` and injected.
  - `SidebarTabDropDelegate` now reads cross-window drag via `dragState.currentWorkspaceDragId`.
  - Added app-side `SidebarDragState` convenience init to keep `@State var dragState = SidebarDragState()` call sites unchanged.
  - Trimmed `ContentView.swift` by ~112 lines.

- **Dependencies**
  - Added `Packages/CmuxSidebarDragCoordinator` (depends on `CmuxFoundation`) and wired it into `cmux.xcodeproj`.
  - Added 6 unit tests in the new package; `swift build` and `swift test` pass.

<sup>Written for commit 8f2fe2782981cd1ff8380b0171bbd337cecb71b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted sidebar drag-and-drop coordination logic into a dedicated package for improved code maintainability and cross-window functionality.

* **Tests**
  * Added comprehensive test coverage for drag-and-drop state management and cross-window workspace coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->