### PR TITLE
Extract browser-control JS builders/diagnostics from TerminalController into CmuxBrowserControl

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,7 +4,7 @@
 34202	CLI/cmux.swift
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
-14785	Sources/TerminalController.swift
+14498	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift

--- a/Packages/CmuxBrowserControl/Package.swift
+++ b/Packages/CmuxBrowserControl/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserControl",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserControl",
+            targets: ["CmuxBrowserControl"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserControl",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserControlTests",
+            dependencies: ["CmuxBrowserControl"]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserControlService+Scripts.swift
+++ b/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserControlService+Scripts.swift
@@ -1,0 +1,340 @@
+import Foundation
+
+/// JavaScript builders for the browser-control element locators and diagnostics.
+///
+/// Every string returned here is byte-identical to the script the corresponding
+/// `v2Browser*` method previously assembled inline; only the assembly moved.
+extension BrowserControlService {
+    /// JavaScript probe that reports how a CSS `selector` resolves on the page:
+    /// match count, visible-match count, a small descriptor sample, a snapshot
+    /// excerpt, and page title/url/body context. Used to build the rich
+    /// element-not-found diagnostics payload.
+    /// - Parameter selector: the selector to probe.
+    /// - Returns: a self-invoking JavaScript expression.
+    public func notFoundDiagnosticsScript(selector: String) -> String {
+        let selectorLiteral = jsonLiteral(selector)
+        return """
+        (() => {
+          const __selector = \(selectorLiteral);
+          const __normalize = (s) => String(s || '').replace(/\\s+/g, ' ').trim();
+          const __isVisible = (el) => {
+            try {
+              if (!el) return false;
+              const style = getComputedStyle(el);
+              const rect = el.getBoundingClientRect();
+              if (!style || !rect) return false;
+              if (rect.width <= 0 || rect.height <= 0) return false;
+              if (style.display === 'none' || style.visibility === 'hidden') return false;
+              if (parseFloat(style.opacity || '1') <= 0.01) return false;
+              return true;
+            } catch (_) {
+              return false;
+            }
+          };
+          const __describe = (el) => {
+            const tag = String(el.tagName || '').toLowerCase();
+            const id = __normalize(el.id || '');
+            const klass = __normalize(el.className || '').split(/\\s+/).filter(Boolean).slice(0, 2).join('.');
+            let out = tag || 'element';
+            if (id) out += '#' + id;
+            if (klass) out += '.' + klass;
+            return out;
+          };
+          try {
+            const __nodes = Array.from(document.querySelectorAll(__selector));
+            const __visible = __nodes.filter(__isVisible);
+            const __sample = __nodes.slice(0, 6).map((el, idx) => ({
+              index: idx,
+              descriptor: __describe(el),
+              role: __normalize(el.getAttribute('role') || ''),
+              visible: __isVisible(el),
+              text: __normalize(el.innerText || el.textContent || '').slice(0, 120)
+            }));
+            const __snapshotExcerpt = __sample.map((row) => {
+              const suffix = row.text ? ` \"${row.text}\"` : '';
+              return `- ${row.descriptor}${suffix}`;
+            }).join('\\n');
+            return {
+              ok: true,
+              selector: __selector,
+              count: __nodes.length,
+              visible_count: __visible.length,
+              sample: __sample,
+              snapshot_excerpt: __snapshotExcerpt,
+              title: __normalize(document.title || ''),
+              url: String(location.href || ''),
+              body_excerpt: document.body ? __normalize(document.body.innerText || '').slice(0, 400) : ''
+            };
+          } catch (err) {
+            return {
+              ok: false,
+              selector: __selector,
+              error: 'invalid_selector',
+              details: String((err && err.message) || err || '')
+            };
+          }
+        })()
+        """
+    }
+
+    /// Wraps a `find.*` finder body in the shared CSS-path harness that returns
+    /// `{ ok, selector, tag, text }` for the matched element. The finder body must
+    /// evaluate to an `Element` or `null`.
+    /// - Parameter finderBody: the locator-specific JavaScript that selects an element.
+    /// - Returns: a self-invoking JavaScript expression.
+    public func findScript(finderBody: String) -> String {
+        return """
+        (() => {
+          const __cmuxCssPath = (el) => {
+            if (!el || el.nodeType !== 1) return null;
+            if (el.id) return '#' + CSS.escape(el.id);
+            const parts = [];
+            let cur = el;
+            while (cur && cur.nodeType === 1) {
+              let part = String(cur.tagName || '').toLowerCase();
+              if (!part) break;
+              if (cur.id) {
+                part += '#' + CSS.escape(cur.id);
+                parts.unshift(part);
+                break;
+              }
+              const tag = part;
+              let siblings = cur.parentElement ? Array.from(cur.parentElement.children).filter((n) => String(n.tagName || '').toLowerCase() === tag) : [];
+              if (siblings.length > 1) {
+                const pos = siblings.indexOf(cur) + 1;
+                part += `:nth-of-type(${pos})`;
+              }
+              parts.unshift(part);
+              cur = cur.parentElement;
+            }
+            return parts.join(' > ');
+          };
+
+          const __cmuxFound = (() => {
+        \(finderBody)
+          })();
+          if (!__cmuxFound) return { ok: false, error: 'not_found' };
+          const selector = __cmuxCssPath(__cmuxFound);
+          if (!selector) return { ok: false, error: 'not_found' };
+          return {
+            ok: true,
+            selector,
+            tag: String(__cmuxFound.tagName || '').toLowerCase(),
+            text: String(__cmuxFound.textContent || '').trim()
+          };
+        })()
+        """
+    }
+
+    /// Finder body for `find.role`: matches by explicit or implicit ARIA role,
+    /// optionally filtered by accessible name.
+    /// - Parameters:
+    ///   - role: the lowercased target role.
+    ///   - name: the optional lowercased accessible name.
+    ///   - exact: whether the name must match exactly.
+    /// - Returns: a JavaScript finder body for ``findScript(finderBody:)``.
+    public func findRoleFinderBody(role: String, name: String?, exact: Bool) -> String {
+        let roleLiteral = jsonLiteral(role)
+        let nameLiteral = name.map(jsonLiteral) ?? "null"
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __targetRole = String(\(roleLiteral)).toLowerCase();
+                const __targetName = \(nameLiteral);
+                const __exact = \(exactLiteral);
+                const __implicitRole = (el) => {
+                  const tag = String(el.tagName || '').toLowerCase();
+                  if (tag === 'button') return 'button';
+                  if (tag === 'a' && el.hasAttribute('href')) return 'link';
+                  if (tag === 'input') {
+                    const type = String(el.getAttribute('type') || 'text').toLowerCase();
+                    if (type === 'checkbox') return 'checkbox';
+                    if (type === 'radio') return 'radio';
+                    if (type === 'submit' || type === 'button') return 'button';
+                    return 'textbox';
+                  }
+                  if (tag === 'textarea') return 'textbox';
+                  if (tag === 'select') return 'combobox';
+                  return null;
+                };
+                const __nameFor = (el) => {
+                  const aria = String(el.getAttribute('aria-label') || '').trim();
+                  if (aria) return aria.toLowerCase();
+                  const labelledBy = String(el.getAttribute('aria-labelledby') || '').trim();
+                  if (labelledBy) {
+                    const text = labelledBy.split(/\\s+/).map((id) => document.getElementById(id)).filter(Boolean).map((n) => String(n.textContent || '').trim()).join(' ').trim();
+                    if (text) return text.toLowerCase();
+                  }
+                  const txt = String(el.innerText || el.textContent || '').trim();
+                  if (txt) return txt.toLowerCase();
+                  if ('value' in el) {
+                    const v = String(el.value || '').trim();
+                    if (v) return v.toLowerCase();
+                  }
+                  return '';
+                };
+                const __nodes = Array.from(document.querySelectorAll('*'));
+                return __nodes.find((el) => {
+                  const explicit = String(el.getAttribute('role') || '').toLowerCase();
+                  const resolved = explicit || __implicitRole(el) || '';
+                  if (resolved !== __targetRole) return false;
+                  if (__targetName == null) return true;
+                  const currentName = __nameFor(el);
+                  return __exact ? (currentName === __targetName) : currentName.includes(__targetName);
+                }) || null;
+        """
+    }
+
+    /// Finder body for `find.text`: matches the first element whose normalized
+    /// text contains (or equals, when `exact`) the target.
+    public func findTextFinderBody(text: String, exact: Bool) -> String {
+        let textLiteral = jsonLiteral(text)
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __target = String(\(textLiteral));
+                const __exact = \(exactLiteral);
+                const __norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+                const __nodes = Array.from(document.querySelectorAll('body *'));
+                return __nodes.find((el) => {
+                  const v = __norm(el.innerText || el.textContent || '');
+                  if (!v) return false;
+                  return __exact ? (v === __target) : v.includes(__target);
+                }) || null;
+        """
+    }
+
+    /// Finder body for `find.label`: resolves the form control associated with a
+    /// matching `<label>` via its `for` attribute or nested control.
+    public func findLabelFinderBody(label: String, exact: Bool) -> String {
+        let labelLiteral = jsonLiteral(label)
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __target = String(\(labelLiteral));
+                const __exact = \(exactLiteral);
+                const __norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+                const __labels = Array.from(document.querySelectorAll('label'));
+                const __label = __labels.find((el) => {
+                  const v = __norm(el.innerText || el.textContent || '');
+                  return __exact ? (v === __target) : v.includes(__target);
+                });
+                if (!__label) return null;
+                const htmlFor = String(__label.getAttribute('for') || '').trim();
+                if (htmlFor) {
+                  return document.getElementById(htmlFor);
+                }
+                return __label.querySelector('input,textarea,select,button,[contenteditable="true"]');
+        """
+    }
+
+    /// Finder body for `find.placeholder`: matches by `placeholder` attribute.
+    public func findPlaceholderFinderBody(placeholder: String, exact: Bool) -> String {
+        let placeholderLiteral = jsonLiteral(placeholder)
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __target = String(\(placeholderLiteral));
+                const __exact = \(exactLiteral);
+                const __nodes = Array.from(document.querySelectorAll('[placeholder]'));
+                return __nodes.find((el) => {
+                  const p = String(el.getAttribute('placeholder') || '').trim().toLowerCase();
+                  if (!p) return false;
+                  return __exact ? (p === __target) : p.includes(__target);
+                }) || null;
+        """
+    }
+
+    /// Finder body for `find.alt`: matches by `alt` attribute.
+    public func findAltFinderBody(alt: String, exact: Bool) -> String {
+        let altLiteral = jsonLiteral(alt)
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __target = String(\(altLiteral));
+                const __exact = \(exactLiteral);
+                const __nodes = Array.from(document.querySelectorAll('[alt]'));
+                return __nodes.find((el) => {
+                  const a = String(el.getAttribute('alt') || '').trim().toLowerCase();
+                  if (!a) return false;
+                  return __exact ? (a === __target) : a.includes(__target);
+                }) || null;
+        """
+    }
+
+    /// Finder body for `find.title`: matches by `title` attribute.
+    public func findTitleFinderBody(title: String, exact: Bool) -> String {
+        let titleLiteral = jsonLiteral(title)
+        let exactLiteral = exact ? "true" : "false"
+        return """
+                const __target = String(\(titleLiteral));
+                const __exact = \(exactLiteral);
+                const __nodes = Array.from(document.querySelectorAll('[title]'));
+                return __nodes.find((el) => {
+                  const t = String(el.getAttribute('title') || '').trim().toLowerCase();
+                  if (!t) return false;
+                  return __exact ? (t === __target) : t.includes(__target);
+                }) || null;
+        """
+    }
+
+    /// Finder body for `find.testid`: matches `data-testid`/`data-test-id`/`data-test`.
+    public func findTestIdFinderBody(testId: String) -> String {
+        let testIdLiteral = jsonLiteral(testId)
+        return """
+                const __target = String(\(testIdLiteral));
+                const __selectors = ['[data-testid]', '[data-test-id]', '[data-test]'];
+                for (const sel of __selectors) {
+                  const nodes = Array.from(document.querySelectorAll(sel));
+                  const found = nodes.find((el) => {
+                    return String(el.getAttribute('data-testid') || el.getAttribute('data-test-id') || el.getAttribute('data-test') || '') === __target;
+                  });
+                  if (found) return found;
+                }
+                return null;
+        """
+    }
+
+    /// Script for `find.first`: resolves the first match of `selector` and echoes
+    /// its trimmed text.
+    public func findFirstScript(selector: String) -> String {
+        let selectorLiteral = jsonLiteral(selector)
+        return """
+        (() => {
+          const el = document.querySelector(\(selectorLiteral));
+          if (!el) return { ok: false, error: 'not_found' };
+          return { ok: true, selector: \(selectorLiteral), text: String(el.textContent || '').trim() };
+        })()
+        """
+    }
+
+    /// Script for `find.last`: resolves the last match of `selector`, returning a
+    /// `:nth-of-type` selector for it.
+    public func findLastScript(selector: String) -> String {
+        let selectorLiteral = jsonLiteral(selector)
+        return """
+        (() => {
+          const list = document.querySelectorAll(\(selectorLiteral));
+          if (!list || list.length === 0) return { ok: false, error: 'not_found' };
+          const idx = list.length - 1;
+          const el = list[idx];
+          const finalSelector = `${\(selectorLiteral)}:nth-of-type(${idx + 1})`;
+          return { ok: true, selector: finalSelector, text: String(el.textContent || '').trim() };
+        })()
+        """
+    }
+
+    /// Script for `find.nth`: resolves the `index`-th match of `selector`
+    /// (negative indices count from the end), returning a `:nth-of-type` selector.
+    public func findNthScript(selector: String, index: Int) -> String {
+        let selectorLiteral = jsonLiteral(selector)
+        return """
+        (() => {
+          const list = Array.from(document.querySelectorAll(\(selectorLiteral)));
+          if (!list.length) return { ok: false, error: 'not_found' };
+          let idx = \(index);
+          if (idx < 0) idx = list.length + idx;
+          if (idx < 0 || idx >= list.length) return { ok: false, error: 'not_found' };
+          const el = list[idx];
+          const nth = idx + 1;
+          const finalSelector = `${\(selectorLiteral)}:nth-of-type(${nth})`;
+          return { ok: true, selector: finalSelector, index: idx, text: String(el.textContent || '').trim() };
+        })()
+        """
+    }
+}

--- a/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserControlService.swift
+++ b/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserControlService.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Stateless browser-control logic shared by the cmux v2 browser RPC methods.
+///
+/// This is the `Sendable` Service half of the browser-control domain: it owns the
+/// pure pieces of `browser` RPC handling that touch neither workspace/pane/surface
+/// lifecycle nor any AppKit/WebKit object. Specifically it builds the JavaScript
+/// strings for the semantic element locators (`find.role`, `find.text`, and the
+/// other `find.*` actions), the not-found diagnostics probe, and the
+/// `find.first`/`find.last`/`find.nth` selector scripts; it normalizes raw
+/// JavaScript results into JSON-serializable values; it classifies JavaScript
+/// failures; and it composes the human-readable element-not-found message.
+///
+/// The owning `@MainActor` controller keeps the per-surface mutable state
+/// (element-ref table, dialog queue, init scripts) and the WebKit evaluation seam;
+/// it forwards into this service for the stateless work, so the RPC wire output is
+/// byte-for-byte identical to the previous inlined implementation.
+public struct BrowserControlService: Sendable {
+    /// Envelope constants for the `browser eval` undefined/value distinction.
+    public let evalEnvelope: BrowserEvalEnvelope
+
+    /// Creates a browser-control service.
+    /// - Parameter evalEnvelope: wire constants for the eval envelope. Defaults to
+    ///   the standard cmux v2 values.
+    public init(evalEnvelope: BrowserEvalEnvelope = BrowserEvalEnvelope()) {
+        self.evalEnvelope = evalEnvelope
+    }
+
+    // MARK: - Value helpers
+
+    /// Renders a value as a bare JavaScript literal (no surrounding brackets),
+    /// suitable for interpolation into a generated script.
+    ///
+    /// Serializes the value via `JSONSerialization` wrapped in a one-element array
+    /// and strips the array brackets; falls back to a manually escaped string
+    /// literal, then to `null`. Byte-identical to the previous `v2JSONLiteral`.
+    /// - Parameter value: the value to encode.
+    /// - Returns: a JavaScript literal expression.
+    public func jsonLiteral(_ value: Any) -> String {
+        if let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
+           let text = String(data: data, encoding: .utf8),
+           text.count >= 2 {
+            return String(text.dropFirst().dropLast())
+        }
+        if let s = value as? String {
+            return "\"\(s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+        }
+        return "null"
+    }
+
+    /// Recursively converts a raw JavaScript evaluation result into a
+    /// JSON-serializable value, re-materializing the `undefined` sentinel into the
+    /// eval envelope shape.
+    ///
+    /// - Parameters:
+    ///   - value: the raw value returned by the WebKit evaluator.
+    ///   - isUndefinedSentinel: predicate identifying the owner's `undefined`
+    ///     sentinel object. The sentinel type lives in the app target, so it is
+    ///     injected here as a closure seam.
+    /// - Returns: a value safe to hand to `JSONSerialization`.
+    public func normalizeJSValue(_ value: Any?, isUndefinedSentinel: (Any) -> Bool) -> Any {
+        guard let value else { return NSNull() }
+        if isUndefinedSentinel(value) {
+            return [
+                evalEnvelope.typeKey: evalEnvelope.typeUndefined,
+                evalEnvelope.valueKey: NSNull()
+            ]
+        }
+        if value is NSNull { return NSNull() }
+        if let v = value as? String { return v }
+        if let v = value as? NSNumber { return v }
+        if let v = value as? Bool { return v }
+        if let dict = value as? [String: Any] {
+            var out: [String: Any] = [:]
+            for (k, v) in dict {
+                out[k] = normalizeJSValue(v, isUndefinedSentinel: isUndefinedSentinel)
+            }
+            return out
+        }
+        if let arr = value as? [Any] {
+            return arr.map { normalizeJSValue($0, isUndefinedSentinel: isUndefinedSentinel) }
+        }
+        return String(describing: value)
+    }
+
+    // MARK: - Failure classification
+
+    /// True when a page-world JavaScript failure looks like a Content Security
+    /// Policy block of `eval`/`Function` construction (`script-src` without
+    /// `'unsafe-eval'`). Gating the isolated-world retry on this avoids re-running a
+    /// script that already failed for an ordinary reason. Byte-identical to the
+    /// previous `v2BrowserFailureLooksLikeCSPEvalBlock`.
+    /// - Parameter message: the failure message.
+    /// - Returns: whether the message indicates a CSP eval block.
+    public func failureLooksLikeCSPEvalBlock(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("unsafe-eval")
+            || lower.contains("content security policy")
+            || lower.contains("blocked by csp")
+            || lower.contains("refused to evaluate")
+    }
+
+    /// Extracts the real JavaScript exception text from a `WKError`.
+    ///
+    /// `WKError.localizedDescription` for JS exceptions is the useless generic
+    /// "A JavaScript exception occurred"; the real text lives in `userInfo` under
+    /// `WKJavaScriptExceptionMessage`, with the line number under
+    /// `WKJavaScriptExceptionLineNumber`. Byte-identical to the previous
+    /// `v2DescribeJavaScriptError`.
+    /// - Parameter error: the error thrown by the evaluator.
+    /// - Returns: a human-readable description.
+    public func describeJavaScriptError(_ error: any Error) -> String {
+        let nsError = error as NSError
+        guard let exceptionMessage = nsError.userInfo["WKJavaScriptExceptionMessage"] as? String,
+              !exceptionMessage.isEmpty else {
+            return error.localizedDescription
+        }
+        var detail = exceptionMessage
+        if let line = nsError.userInfo["WKJavaScriptExceptionLineNumber"] as? Int, line > 0 {
+            detail += " (line \(line))"
+        }
+        return detail
+    }
+
+    // MARK: - Not-found message
+
+    /// Composes the human-readable element-not-found message from the match counts
+    /// already gathered by the diagnostics probe. Byte-identical to the message
+    /// branches previously inlined in `v2BrowserElementNotFoundResult`.
+    /// - Parameters:
+    ///   - selector: the selector that failed to resolve.
+    ///   - matchCount: total DOM matches for the selector.
+    ///   - visibleCount: visible matches for the selector.
+    /// - Returns: the user-facing not-found message.
+    public func elementNotFoundMessage(selector: String, matchCount: Int, visibleCount: Int) -> String {
+        if matchCount > 0 && visibleCount == 0 {
+            return "Element \"\(selector)\" is present but not visible."
+        } else if matchCount > 1 {
+            return "Selector \"\(selector)\" matched multiple elements."
+        } else {
+            return "Element \"\(selector)\" not found or not visible. Run 'browser snapshot' to see current page elements."
+        }
+    }
+}

--- a/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserEvalEnvelope.swift
+++ b/Packages/CmuxBrowserControl/Sources/CmuxBrowserControl/BrowserEvalEnvelope.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Wire-format constants for the `browser eval` undefined/value envelope.
+///
+/// When a page-world script returns `undefined`, WebKit collapses it to `nil`,
+/// which is indistinguishable from a script that returned JSON `null`. The
+/// browser eval path therefore wraps every result in a small JSON object whose
+/// `typeKey` is either `typeUndefined` or `typeValue`, with the real payload (for
+/// the value case) under `valueKey`. ``BrowserControlService/normalizeJSValue(_:isUndefinedSentinel:)``
+/// re-materializes the `undefined` sentinel back into this envelope shape so the
+/// RPC reply distinguishes the two.
+///
+/// The default values are the exact strings the cmux v2 browser RPC wire format
+/// has always used; do not change them without a coordinated protocol bump.
+public struct BrowserEvalEnvelope: Sendable, Equatable {
+    /// JSON key carrying the envelope discriminator (`typeUndefined` or `typeValue`).
+    public let typeKey: String
+    /// JSON key carrying the real value when the discriminator is `typeValue`.
+    public let valueKey: String
+    /// Discriminator value indicating the script produced JavaScript `undefined`.
+    public let typeUndefined: String
+    /// Discriminator value indicating the script produced a concrete value.
+    public let typeValue: String
+
+    /// Creates an envelope descriptor.
+    /// - Parameters:
+    ///   - typeKey: JSON key for the discriminator. Defaults to the wire value `"__cmux_t"`.
+    ///   - valueKey: JSON key for the payload. Defaults to the wire value `"__cmux_v"`.
+    ///   - typeUndefined: discriminator for `undefined`. Defaults to `"undefined"`.
+    ///   - typeValue: discriminator for a concrete value. Defaults to `"value"`.
+    public init(
+        typeKey: String = "__cmux_t",
+        valueKey: String = "__cmux_v",
+        typeUndefined: String = "undefined",
+        typeValue: String = "value"
+    ) {
+        self.typeKey = typeKey
+        self.valueKey = valueKey
+        self.typeUndefined = typeUndefined
+        self.typeValue = typeValue
+    }
+}

--- a/Packages/CmuxBrowserControl/Tests/CmuxBrowserControlTests/BrowserControlServiceTests.swift
+++ b/Packages/CmuxBrowserControl/Tests/CmuxBrowserControlTests/BrowserControlServiceTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserControl
+
+private final class FakeUndefined {}
+
+@Suite("BrowserControlService")
+struct BrowserControlServiceTests {
+    let service = BrowserControlService()
+
+    @Test("jsonLiteral encodes strings with escaping and strips array brackets")
+    func jsonLiteralString() {
+        #expect(service.jsonLiteral("hi") == "\"hi\"")
+        #expect(service.jsonLiteral("a\"b") == "\"a\\\"b\"")
+        #expect(service.jsonLiteral(42) == "42")
+        #expect(service.jsonLiteral(true) == "true")
+    }
+
+    @Test("normalizeJSValue maps undefined sentinel to the eval envelope")
+    func normalizeUndefined() {
+        let sentinel = FakeUndefined()
+        let result = service.normalizeJSValue(sentinel) { $0 is FakeUndefined }
+        let dict = try? #require(result as? [String: Any])
+        #expect(dict?["__cmux_t"] as? String == "undefined")
+        #expect(dict?["__cmux_v"] is NSNull)
+    }
+
+    @Test("normalizeJSValue passes through scalars, nil, and nested containers")
+    func normalizePassthrough() {
+        #expect(service.normalizeJSValue(nil) { _ in false } is NSNull)
+        #expect(service.normalizeJSValue("x") { _ in false } as? String == "x")
+        let nested = service.normalizeJSValue(["a": [1, 2]]) { _ in false } as? [String: Any]
+        #expect((nested?["a"] as? [Any])?.count == 2)
+    }
+
+    @Test("normalizeJSValue honors a custom envelope")
+    func normalizeCustomEnvelope() {
+        let custom = BrowserControlService(
+            evalEnvelope: BrowserEvalEnvelope(typeKey: "T", valueKey: "V", typeUndefined: "U", typeValue: "VAL")
+        )
+        let dict = custom.normalizeJSValue(FakeUndefined()) { $0 is FakeUndefined } as? [String: Any]
+        #expect(dict?["T"] as? String == "U")
+        #expect(dict?["V"] is NSNull)
+    }
+
+    @Test("failureLooksLikeCSPEvalBlock matches CSP phrasings")
+    func cspDetection() {
+        #expect(service.failureLooksLikeCSPEvalBlock("blocked: unsafe-eval"))
+        #expect(service.failureLooksLikeCSPEvalBlock("Refused to evaluate a string"))
+        #expect(service.failureLooksLikeCSPEvalBlock("violates the Content Security Policy"))
+        #expect(service.failureLooksLikeCSPEvalBlock("blocked by CSP"))
+        #expect(!service.failureLooksLikeCSPEvalBlock("ReferenceError: x is not defined"))
+    }
+
+    @Test("describeJavaScriptError prefers the WK exception message and line")
+    func describeError() {
+        let withLine = NSError(domain: "WK", code: 1, userInfo: [
+            "WKJavaScriptExceptionMessage": "boom",
+            "WKJavaScriptExceptionLineNumber": 7
+        ])
+        #expect(service.describeJavaScriptError(withLine) == "boom (line 7)")
+
+        let noLine = NSError(domain: "WK", code: 1, userInfo: [
+            "WKJavaScriptExceptionMessage": "boom"
+        ])
+        #expect(service.describeJavaScriptError(noLine) == "boom")
+
+        let generic = NSError(domain: "WK", code: 1, userInfo: [NSLocalizedDescriptionKey: "fallback"])
+        #expect(service.describeJavaScriptError(generic) == "fallback")
+    }
+
+    @Test("elementNotFoundMessage chooses the branch by counts")
+    func notFoundMessages() {
+        #expect(service.elementNotFoundMessage(selector: "#x", matchCount: 2, visibleCount: 0)
+            == "Element \"#x\" is present but not visible.")
+        #expect(service.elementNotFoundMessage(selector: "#x", matchCount: 3, visibleCount: 2)
+            == "Selector \"#x\" matched multiple elements.")
+        #expect(service.elementNotFoundMessage(selector: "#x", matchCount: 0, visibleCount: 0)
+            == "Element \"#x\" not found or not visible. Run 'browser snapshot' to see current page elements.")
+    }
+
+    @Test("script builders interpolate literals and stay self-invoking")
+    func scriptBuilders() {
+        let diag = service.notFoundDiagnosticsScript(selector: "#x")
+        #expect(diag.contains("const __selector = \"#x\""))
+        #expect(diag.hasPrefix("(() => {"))
+
+        let role = service.findRoleFinderBody(role: "button", name: "save", exact: true)
+        #expect(role.contains("const __targetRole = String(\"button\").toLowerCase();"))
+        #expect(role.contains("const __targetName = \"save\";"))
+        #expect(role.contains("const __exact = true;"))
+
+        let roleNoName = service.findRoleFinderBody(role: "link", name: nil, exact: false)
+        #expect(roleNoName.contains("const __targetName = null;"))
+        #expect(roleNoName.contains("const __exact = false;"))
+
+        let wrapped = service.findScript(finderBody: role)
+        #expect(wrapped.contains("const __cmuxFound = (() => {"))
+        #expect(wrapped.contains("const __targetRole"))
+
+        let nth = service.findNthScript(selector: ".row", index: -1)
+        #expect(nth.contains("let idx = -1;"))
+        #expect(nth.contains("document.querySelectorAll(\".row\")"))
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3,6 +3,7 @@ import CmuxRemoteSession
 import CmuxCore
 import CmuxAuthRuntime
 import CmuxFeedback
+import CmuxBrowserControl
 import CmuxControlSocket
 import CmuxFoundation
 import CmuxPanes
@@ -258,6 +259,17 @@ class TerminalController {
     private var v2BrowserDownloadEventsBySurface: [UUID: [[String: Any]]] = [:]
     private var v2BrowserUnsupportedNetworkRequestsBySurface: [UUID: [[String: Any]]] = [:]
     private nonisolated let v2BrowserUndefinedSentinel = V2BrowserUndefinedSentinel()
+    /// Stateless browser-control logic (JS builders, value normalization,
+    /// diagnostics, failure classification) extracted to `CmuxBrowserControl`.
+    /// The per-surface mutable state and WebKit evaluation seam stay here.
+    private nonisolated let v2BrowserControl = BrowserControlService(
+        evalEnvelope: BrowserEvalEnvelope(
+            typeKey: TerminalController.v2BrowserEvalEnvelopeTypeKey,
+            valueKey: TerminalController.v2BrowserEvalEnvelopeValueKey,
+            typeUndefined: TerminalController.v2BrowserEvalEnvelopeTypeUndefined,
+            typeValue: TerminalController.v2BrowserEvalEnvelopeTypeValue
+        )
+    )
     private var browserDownloadObserver: NSObjectProtocol?
 
     func cleanupSurfaceState(surfaceIds: [UUID]) {
@@ -5526,40 +5538,11 @@ class TerminalController {
     }
 
     private nonisolated func v2JSONLiteral(_ value: Any) -> String {
-        if let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
-           let text = String(data: data, encoding: .utf8),
-           text.count >= 2 {
-            return String(text.dropFirst().dropLast())
-        }
-        if let s = value as? String {
-            return "\"\(s.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
-        }
-        return "null"
+        v2BrowserControl.jsonLiteral(value)
     }
 
     private nonisolated func v2NormalizeJSValue(_ value: Any?) -> Any {
-        guard let value else { return NSNull() }
-        if value is V2BrowserUndefinedSentinel {
-            return [
-                Self.v2BrowserEvalEnvelopeTypeKey: Self.v2BrowserEvalEnvelopeTypeUndefined,
-                Self.v2BrowserEvalEnvelopeValueKey: NSNull()
-            ]
-        }
-        if value is NSNull { return NSNull() }
-        if let v = value as? String { return v }
-        if let v = value as? NSNumber { return v }
-        if let v = value as? Bool { return v }
-        if let dict = value as? [String: Any] {
-            var out: [String: Any] = [:]
-            for (k, v) in dict {
-                out[k] = v2NormalizeJSValue(v)
-            }
-            return out
-        }
-        if let arr = value as? [Any] {
-            return arr.map { v2NormalizeJSValue($0) }
-        }
-        return String(describing: value)
+        v2BrowserControl.normalizeJSValue(value) { $0 is V2BrowserUndefinedSentinel }
     }
 
     enum V2JavaScriptResult {
@@ -5570,16 +5553,7 @@ class TerminalController {
     /// WKError's localizedDescription for JS exceptions is the useless generic
     /// "A JavaScript exception occurred"; the real exception text lives in userInfo.
     private static func v2DescribeJavaScriptError(_ error: Error) -> String {
-        let nsError = error as NSError
-        guard let exceptionMessage = nsError.userInfo["WKJavaScriptExceptionMessage"] as? String,
-              !exceptionMessage.isEmpty else {
-            return error.localizedDescription
-        }
-        var detail = exceptionMessage
-        if let line = nsError.userInfo["WKJavaScriptExceptionLineNumber"] as? Int, line > 0 {
-            detail += " (line \(line))"
-        }
-        return detail
+        BrowserControlService().describeJavaScriptError(error)
     }
 
     /// True when a page-world JS failure looks like a CSP block of eval/function
@@ -5590,11 +5564,7 @@ class TerminalController {
     /// script performed before throwing and could return a value from the wrong
     /// JS context.
     private nonisolated static func v2BrowserFailureLooksLikeCSPEvalBlock(_ message: String) -> Bool {
-        let lower = message.lowercased()
-        return lower.contains("unsafe-eval")
-            || lower.contains("content security policy")
-            || lower.contains("blocked by csp")
-            || lower.contains("refused to evaluate")
+        BrowserControlService().failureLooksLikeCSPEvalBlock(message)
     }
 
     /// Sendable stand-in for `WKContentWorld` so nonisolated callers can pick a world without
@@ -6497,69 +6467,7 @@ class TerminalController {
         browserPanel: BrowserPanel,
         selector: String
     ) -> [String: Any] {
-        let selectorLiteral = v2JSONLiteral(selector)
-        let script = """
-        (() => {
-          const __selector = \(selectorLiteral);
-          const __normalize = (s) => String(s || '').replace(/\\s+/g, ' ').trim();
-          const __isVisible = (el) => {
-            try {
-              if (!el) return false;
-              const style = getComputedStyle(el);
-              const rect = el.getBoundingClientRect();
-              if (!style || !rect) return false;
-              if (rect.width <= 0 || rect.height <= 0) return false;
-              if (style.display === 'none' || style.visibility === 'hidden') return false;
-              if (parseFloat(style.opacity || '1') <= 0.01) return false;
-              return true;
-            } catch (_) {
-              return false;
-            }
-          };
-          const __describe = (el) => {
-            const tag = String(el.tagName || '').toLowerCase();
-            const id = __normalize(el.id || '');
-            const klass = __normalize(el.className || '').split(/\\s+/).filter(Boolean).slice(0, 2).join('.');
-            let out = tag || 'element';
-            if (id) out += '#' + id;
-            if (klass) out += '.' + klass;
-            return out;
-          };
-          try {
-            const __nodes = Array.from(document.querySelectorAll(__selector));
-            const __visible = __nodes.filter(__isVisible);
-            const __sample = __nodes.slice(0, 6).map((el, idx) => ({
-              index: idx,
-              descriptor: __describe(el),
-              role: __normalize(el.getAttribute('role') || ''),
-              visible: __isVisible(el),
-              text: __normalize(el.innerText || el.textContent || '').slice(0, 120)
-            }));
-            const __snapshotExcerpt = __sample.map((row) => {
-              const suffix = row.text ? ` \"${row.text}\"` : '';
-              return `- ${row.descriptor}${suffix}`;
-            }).join('\\n');
-            return {
-              ok: true,
-              selector: __selector,
-              count: __nodes.length,
-              visible_count: __visible.length,
-              sample: __sample,
-              snapshot_excerpt: __snapshotExcerpt,
-              title: __normalize(document.title || ''),
-              url: String(location.href || ''),
-              body_excerpt: document.body ? __normalize(document.body.innerText || '').slice(0, 400) : ''
-            };
-          } catch (err) {
-            return {
-              ok: false,
-              selector: __selector,
-              error: 'invalid_selector',
-              details: String((err && err.message) || err || '')
-            };
-          }
-        })()
-        """
+        let script = v2BrowserControl.notFoundDiagnosticsScript(selector: selector)
 
         switch v2RunBrowserJavaScript(v2MainSync { browserPanel.webView }, surfaceId: surfaceId, script: script, timeout: 4.0) {
         case .failure(let message):
@@ -6600,14 +6508,11 @@ class TerminalController {
         let count = (data["match_count"] as? Int) ?? (data["match_count"] as? NSNumber)?.intValue ?? 0
         let visibleCount = (data["visible_match_count"] as? Int) ?? (data["visible_match_count"] as? NSNumber)?.intValue ?? 0
 
-        let message: String
-        if count > 0 && visibleCount == 0 {
-            message = "Element \"\(selector)\" is present but not visible."
-        } else if count > 1 {
-            message = "Selector \"\(selector)\" matched multiple elements."
-        } else {
-            message = "Element \"\(selector)\" not found or not visible. Run 'browser snapshot' to see current page elements."
-        }
+        let message = v2BrowserControl.elementNotFoundMessage(
+            selector: selector,
+            matchCount: count,
+            visibleCount: visibleCount
+        )
 
         return .err(code: "not_found", message: message, data: data)
     }
@@ -8261,47 +8166,7 @@ class TerminalController {
     ) -> V2CallResult {
         return v2BrowserWithPanelContext(params: params) { ctx in
             let surfaceId = ctx.surfaceId
-            let script = """
-            (() => {
-              const __cmuxCssPath = (el) => {
-                if (!el || el.nodeType !== 1) return null;
-                if (el.id) return '#' + CSS.escape(el.id);
-                const parts = [];
-                let cur = el;
-                while (cur && cur.nodeType === 1) {
-                  let part = String(cur.tagName || '').toLowerCase();
-                  if (!part) break;
-                  if (cur.id) {
-                    part += '#' + CSS.escape(cur.id);
-                    parts.unshift(part);
-                    break;
-                  }
-                  const tag = part;
-                  let siblings = cur.parentElement ? Array.from(cur.parentElement.children).filter((n) => String(n.tagName || '').toLowerCase() === tag) : [];
-                  if (siblings.length > 1) {
-                    const pos = siblings.indexOf(cur) + 1;
-                    part += `:nth-of-type(${pos})`;
-                  }
-                  parts.unshift(part);
-                  cur = cur.parentElement;
-                }
-                return parts.join(' > ');
-              };
-
-              const __cmuxFound = (() => {
-            \(finderBody)
-              })();
-              if (!__cmuxFound) return { ok: false, error: 'not_found' };
-              const selector = __cmuxCssPath(__cmuxFound);
-              if (!selector) return { ok: false, error: 'not_found' };
-              return {
-                ok: true,
-                selector,
-                tag: String(__cmuxFound.tagName || '').toLowerCase(),
-                text: String(__cmuxFound.textContent || '').trim()
-              };
-            })()
-            """
+            let script = v2BrowserControl.findScript(finderBody: finderBody)
 
             switch v2RunBrowserJavaScript(ctx.webView, surfaceId: surfaceId, script: script) {
             case .failure(let message):
@@ -8346,55 +8211,8 @@ class TerminalController {
         }
         let name = v2String(params, "name")?.lowercased()
         let exact = v2Bool(params, "exact") ?? false
-        let roleLiteral = v2JSONLiteral(role)
-        let nameLiteral = name.map(v2JSONLiteral) ?? "null"
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __targetRole = String(\(roleLiteral)).toLowerCase();
-                const __targetName = \(nameLiteral);
-                const __exact = \(exactLiteral);
-                const __implicitRole = (el) => {
-                  const tag = String(el.tagName || '').toLowerCase();
-                  if (tag === 'button') return 'button';
-                  if (tag === 'a' && el.hasAttribute('href')) return 'link';
-                  if (tag === 'input') {
-                    const type = String(el.getAttribute('type') || 'text').toLowerCase();
-                    if (type === 'checkbox') return 'checkbox';
-                    if (type === 'radio') return 'radio';
-                    if (type === 'submit' || type === 'button') return 'button';
-                    return 'textbox';
-                  }
-                  if (tag === 'textarea') return 'textbox';
-                  if (tag === 'select') return 'combobox';
-                  return null;
-                };
-                const __nameFor = (el) => {
-                  const aria = String(el.getAttribute('aria-label') || '').trim();
-                  if (aria) return aria.toLowerCase();
-                  const labelledBy = String(el.getAttribute('aria-labelledby') || '').trim();
-                  if (labelledBy) {
-                    const text = labelledBy.split(/\\s+/).map((id) => document.getElementById(id)).filter(Boolean).map((n) => String(n.textContent || '').trim()).join(' ').trim();
-                    if (text) return text.toLowerCase();
-                  }
-                  const txt = String(el.innerText || el.textContent || '').trim();
-                  if (txt) return txt.toLowerCase();
-                  if ('value' in el) {
-                    const v = String(el.value || '').trim();
-                    if (v) return v.toLowerCase();
-                  }
-                  return '';
-                };
-                const __nodes = Array.from(document.querySelectorAll('*'));
-                return __nodes.find((el) => {
-                  const explicit = String(el.getAttribute('role') || '').toLowerCase();
-                  const resolved = explicit || __implicitRole(el) || '';
-                  if (resolved !== __targetRole) return false;
-                  if (__targetName == null) return true;
-                  const currentName = __nameFor(el);
-                  return __exact ? (currentName === __targetName) : currentName.includes(__targetName);
-                }) || null;
-        """
+        let finder = v2BrowserControl.findRoleFinderBody(role: role, name: name, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8413,20 +8231,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing text", data: nil)
         }
         let exact = v2Bool(params, "exact") ?? false
-        let textLiteral = v2JSONLiteral(text)
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __target = String(\(textLiteral));
-                const __exact = \(exactLiteral);
-                const __norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const __nodes = Array.from(document.querySelectorAll('body *'));
-                return __nodes.find((el) => {
-                  const v = __norm(el.innerText || el.textContent || '');
-                  if (!v) return false;
-                  return __exact ? (v === __target) : v.includes(__target);
-                }) || null;
-        """
+        let finder = v2BrowserControl.findTextFinderBody(text: text, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8441,25 +8247,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing label", data: nil)
         }
         let exact = v2Bool(params, "exact") ?? false
-        let labelLiteral = v2JSONLiteral(label)
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __target = String(\(labelLiteral));
-                const __exact = \(exactLiteral);
-                const __norm = (s) => String(s || '').replace(/\\s+/g, ' ').trim().toLowerCase();
-                const __labels = Array.from(document.querySelectorAll('label'));
-                const __label = __labels.find((el) => {
-                  const v = __norm(el.innerText || el.textContent || '');
-                  return __exact ? (v === __target) : v.includes(__target);
-                });
-                if (!__label) return null;
-                const htmlFor = String(__label.getAttribute('for') || '').trim();
-                if (htmlFor) {
-                  return document.getElementById(htmlFor);
-                }
-                return __label.querySelector('input,textarea,select,button,[contenteditable="true"]');
-        """
+        let finder = v2BrowserControl.findLabelFinderBody(label: label, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8474,19 +8263,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing placeholder", data: nil)
         }
         let exact = v2Bool(params, "exact") ?? false
-        let placeholderLiteral = v2JSONLiteral(placeholder)
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __target = String(\(placeholderLiteral));
-                const __exact = \(exactLiteral);
-                const __nodes = Array.from(document.querySelectorAll('[placeholder]'));
-                return __nodes.find((el) => {
-                  const p = String(el.getAttribute('placeholder') || '').trim().toLowerCase();
-                  if (!p) return false;
-                  return __exact ? (p === __target) : p.includes(__target);
-                }) || null;
-        """
+        let finder = v2BrowserControl.findPlaceholderFinderBody(placeholder: placeholder, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8501,19 +8279,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing alt text", data: nil)
         }
         let exact = v2Bool(params, "exact") ?? false
-        let altLiteral = v2JSONLiteral(alt)
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __target = String(\(altLiteral));
-                const __exact = \(exactLiteral);
-                const __nodes = Array.from(document.querySelectorAll('[alt]'));
-                return __nodes.find((el) => {
-                  const a = String(el.getAttribute('alt') || '').trim().toLowerCase();
-                  if (!a) return false;
-                  return __exact ? (a === __target) : a.includes(__target);
-                }) || null;
-        """
+        let finder = v2BrowserControl.findAltFinderBody(alt: alt, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8528,19 +8295,8 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing title", data: nil)
         }
         let exact = v2Bool(params, "exact") ?? false
-        let titleLiteral = v2JSONLiteral(title)
-        let exactLiteral = exact ? "true" : "false"
 
-        let finder = """
-                const __target = String(\(titleLiteral));
-                const __exact = \(exactLiteral);
-                const __nodes = Array.from(document.querySelectorAll('[title]'));
-                return __nodes.find((el) => {
-                  const t = String(el.getAttribute('title') || '').trim().toLowerCase();
-                  if (!t) return false;
-                  return __exact ? (t === __target) : t.includes(__target);
-                }) || null;
-        """
+        let finder = v2BrowserControl.findTitleFinderBody(title: title, exact: exact)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8554,20 +8310,7 @@ class TerminalController {
         guard let testId = v2String(params, "testid") ?? v2String(params, "test_id") ?? v2String(params, "value") else {
             return .err(code: "invalid_params", message: "Missing testid", data: nil)
         }
-        let testIdLiteral = v2JSONLiteral(testId)
-
-        let finder = """
-                const __target = String(\(testIdLiteral));
-                const __selectors = ['[data-testid]', '[data-test-id]', '[data-test]'];
-                for (const sel of __selectors) {
-                  const nodes = Array.from(document.querySelectorAll(sel));
-                  const found = nodes.find((el) => {
-                    return String(el.getAttribute('data-testid') || el.getAttribute('data-test-id') || el.getAttribute('data-test') || '') === __target;
-                  });
-                  if (found) return found;
-                }
-                return null;
-        """
+        let finder = v2BrowserControl.findTestIdFinderBody(testId: testId)
 
         return v2BrowserFindWithScript(
             params: params,
@@ -8586,14 +8329,7 @@ class TerminalController {
             guard let selector = v2BrowserResolveSelector(selectorRaw, surfaceId: surfaceId) else {
                 return .err(code: "not_found", message: "Element reference not found", data: ["selector": selectorRaw])
             }
-            let selectorLiteral = v2JSONLiteral(selector)
-            let script = """
-            (() => {
-              const el = document.querySelector(\(selectorLiteral));
-              if (!el) return { ok: false, error: 'not_found' };
-              return { ok: true, selector: \(selectorLiteral), text: String(el.textContent || '').trim() };
-            })()
-            """
+            let script = v2BrowserControl.findFirstScript(selector: selector)
             switch v2RunBrowserJavaScript(ctx.webView, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
@@ -8627,17 +8363,7 @@ class TerminalController {
             guard let selector = v2BrowserResolveSelector(selectorRaw, surfaceId: surfaceId) else {
                 return .err(code: "not_found", message: "Element reference not found", data: ["selector": selectorRaw])
             }
-            let selectorLiteral = v2JSONLiteral(selector)
-            let script = """
-            (() => {
-              const list = document.querySelectorAll(\(selectorLiteral));
-              if (!list || list.length === 0) return { ok: false, error: 'not_found' };
-              const idx = list.length - 1;
-              const el = list[idx];
-              const finalSelector = `${\(selectorLiteral)}:nth-of-type(${idx + 1})`;
-              return { ok: true, selector: finalSelector, text: String(el.textContent || '').trim() };
-            })()
-            """
+            let script = v2BrowserControl.findLastScript(selector: selector)
             switch v2RunBrowserJavaScript(ctx.webView, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)
@@ -8677,20 +8403,7 @@ class TerminalController {
             guard let selector = v2BrowserResolveSelector(selectorRaw, surfaceId: surfaceId) else {
                 return .err(code: "not_found", message: "Element reference not found", data: ["selector": selectorRaw])
             }
-            let selectorLiteral = v2JSONLiteral(selector)
-            let script = """
-            (() => {
-              const list = Array.from(document.querySelectorAll(\(selectorLiteral)));
-              if (!list.length) return { ok: false, error: 'not_found' };
-              let idx = \(index);
-              if (idx < 0) idx = list.length + idx;
-              if (idx < 0 || idx >= list.length) return { ok: false, error: 'not_found' };
-              const el = list[idx];
-              const nth = idx + 1;
-              const finalSelector = `${\(selectorLiteral)}:nth-of-type(${nth})`;
-              return { ok: true, selector: finalSelector, index: idx, text: String(el.textContent || '').trim() };
-            })()
-            """
+            let script = v2BrowserControl.findNthScript(selector: selector, index: index)
             switch v2RunBrowserJavaScript(ctx.webView, surfaceId: surfaceId, script: script) {
             case .failure(let message):
                 return .err(code: "js_error", message: message, data: nil)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
+		B0C0DEF00000000000000A3 /* CmuxBrowserControl in Frameworks */ = {isa = PBXBuildFile; productRef = B0C0DEF00000000000000A2 /* CmuxBrowserControl */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
@@ -1768,6 +1769,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
+				B0C0DEF00000000000000A3 /* CmuxBrowserControl in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
@@ -2851,6 +2853,7 @@
 				CDFEED0200000000CDFEED02 /* CmuxUpdater */,
 				CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */,
 				CF00F00000000000000000A2 /* CmuxFoundation */,
+				B0C0DEF00000000000000A2 /* CmuxBrowserControl */,
 				CC0DE00000000000000000A2 /* CmuxCore */,
 				CC0DE10000000000000000A2 /* CmuxRemoteDaemon */,
 				CC0DE20000000000000000A2 /* CmuxRemoteWorkspace */,
@@ -3036,6 +3039,7 @@
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
+				B0C0DEF00000000000000A1 /* XCLocalSwiftPackageReference "CmuxBrowserControl" */,
 				C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */,
 				C9A2B00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxAppKitSupportUI" */,
 				C9A2C00000000000000000C1 /* XCLocalSwiftPackageReference "CmuxFeedback" */,
@@ -4583,6 +4587,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaces;
 		};
+		B0C0DEF00000000000000A1 /* XCLocalSwiftPackageReference "CmuxBrowserControl" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserControl;
+		};
 		C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxControlSocket;
@@ -4858,6 +4866,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */;
 			productName = CmuxWorkspaces;
+		};
+		B0C0DEF00000000000000A2 /* CmuxBrowserControl */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B0C0DEF00000000000000A1 /* XCLocalSwiftPackageReference "CmuxBrowserControl" */;
+			productName = CmuxBrowserControl;
 		};
 		C750100000000000000000A2 /* CmuxControlSocket */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## What

Introduces the new **CmuxBrowserControl** package and pulls the stateless half of the `TerminalController` v2 browser RPC domain into a `Sendable` `BrowserControlService`, matching the audit spec's shape: "a nonisolated BrowserControlService (Sendable) wraps the stateless JavaScript evaluation, element finding, and diagnostics."

## What moved (pure, zero god-type reach)

- `jsonLiteral` / `normalizeJSValue` — the latter takes an injected `isUndefinedSentinel` closure seam, since the sentinel type stays in the app target
- `failureLooksLikeCSPEvalBlock`, `describeJavaScriptError`
- `elementNotFoundMessage` (the count-driven message branches)
- the not-found diagnostics JS probe builder (`notFoundDiagnosticsScript`)
- the `find.*` harness (`findScript`) + the seven semantic finder bodies (role/text/label/placeholder/alt/title/testid) + `findFirst`/`findLast`/`findNth` selector scripts

## Seams / inversion

`TerminalController` keeps all per-surface mutable state (element-ref table, dialog queue, init scripts), the WebKit evaluation path, and the `Workspace`/`TabManager`/`BrowserPanel`/`WKWebView` resolvers — these are stored state and app-owned types that section-6.3 forbids moving. It owns a `nonisolated let v2BrowserControl` service instance; the moved method bodies are now **thin one-line forwards**, so call sites are unchanged.

The eval-envelope wire constants (`__cmux_t`/`__cmux_v`/`undefined`/`value`) are injected from the existing `TerminalController` statics via a `BrowserEvalEnvelope` value object, so the service is byte-identical without re-declaring the constants.

## Byte-identical

The generated JavaScript strings, the eval envelope keys, the error/CSP classification, and the not-found message are produced by the same code, just relocated. No `Defaults` key, `NotificationCenter` name, wire format, or ordering changed.

## Scope note

The larger stateful/WebKit-bound browser methods (navigate/click/screenshot/eval/tabs/cookies/storage/dialogs/downloads) were intentionally left in place: they reach `TerminalController`'s private `v2` infrastructure (`v2MainSync`, `v2RunBrowserJavaScript`, `v2Resolve*`, `v2Ref`) and app-only types, and could not move in one PR without inverting ~15 seams or relocating non-browser infrastructure, which would jeopardize byte-identity. This PR extracts the **largest clean subset** of the domain.

## Conventions

- `swift-tools-version: 6.0`, v6 language mode, `ExistentialAny` + `InternalImportsByDefault`
- one major public type per file, conformances/feature in `+Scripts.swift`, full DocC `///` on every public symbol
- wired into `cmux.xcodeproj` (6 pbxproj entries mirroring `CmuxControlSocket`/`CmuxFoundation`); added as an app-target dependency
- behavior unit tests added (logic is pure; a closure seam stands in for the app-target sentinel)
- package convention lint OK, zero new `lint:allow`

## Stats

- `Sources/TerminalController.swift`: **-287 lines** (14785 → 14498); file-length budget ratcheted down to match
- New package: 4 source/test files

`swift build` + `swift test` green inside the package. **NOTE: full app build + tests validated by GitHub CI.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143979&installation_id=133855650&pr_number=6173&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6173&signature=2182fceed17c0a7516d8f33585afe1c31bdcf8da5d319b1aaca5d8f0f6fc0506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the stateless browser-control logic from `TerminalController` into a new `CmuxBrowserControl` package with a `Sendable` `BrowserControlService`. Behavior and RPC wire format stay byte-identical; call sites are unchanged.

- **Refactors**
  - Moved JS builders: not-found diagnostics, `find.*` harness and bodies (role/text/label/placeholder/alt/title/testid), and `find.first`/`last`/`nth`.
  - Centralized helpers: `jsonLiteral`, `normalizeJSValue` (with injected `isUndefinedSentinel`), CSP error detection, and JS error description.
  - Kept all stateful/WebKit paths in `TerminalController`; added a thin forwarding `v2BrowserControl` instance.
  - Injected eval-envelope wire constants via `BrowserEvalEnvelope` to keep output identical.
  - Reduced `Sources/TerminalController.swift` by 287 lines; file-length budget updated.

- **Dependencies**
  - Added `CmuxBrowserControl` Swift package (`swift-tools-version: 6.0`, v6 mode, `ExistentialAny`, `InternalImportsByDefault`) and wired it into the app target.
  - Added unit tests for pure logic; `swift build` + `swift test` pass.

<sup>Written for commit 6d087c4b52222522a8ff88a0f8016ede396ee709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced browser element locating with multiple search strategies (by role, text, label, placeholder, alt text, title, and test IDs).
  * Improved error diagnostics with detailed messages when elements cannot be located, including visibility and match count information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->