### PR TITLE
Extract sidebar metadata state from Workspace into CmuxWorkspaceSidebarModel

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -6,7 +6,7 @@
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
-12361	Sources/Workspace.swift
+12386	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift

--- a/Packages/CmuxWorkspaceSidebarModel/Package.swift
+++ b/Packages/CmuxWorkspaceSidebarModel/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxWorkspaceSidebarModel",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxWorkspaceSidebarModel",
+            targets: ["CmuxWorkspaceSidebarModel"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxSidebar"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxWorkspaceSidebarModel",
+            dependencies: [
+                .product(name: "CmuxSidebar", package: "CmuxSidebar"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxWorkspaceSidebarModelTests",
+            dependencies: ["CmuxWorkspaceSidebarModel"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxWorkspaceSidebarModel/Sources/CmuxWorkspaceSidebarModel/SidebarLogEntryLimitProviding.swift
+++ b/Packages/CmuxWorkspaceSidebarModel/Sources/CmuxWorkspaceSidebarModel/SidebarLogEntryLimitProviding.swift
@@ -1,0 +1,15 @@
+/// Supplies the configured maximum number of sidebar log entries the model
+/// retains, inverting the `Workspace`-side `UserDefaults` read that the legacy
+/// `appendSidebarLog` performed inline.
+///
+/// The app target conforms this to the real `UserDefaults`-backed lookup
+/// (`UserDefaults.standard.object(forKey: "sidebarMaxLogEntries")`); tests pass
+/// a fake returning a fixed value. The model clamps whatever this returns to
+/// the legacy `1...500` range, so a conformer only needs to report the raw
+/// configured value (or `nil` when unset, which the model treats as the legacy
+/// default of 50).
+public protocol SidebarLogEntryLimitProviding: Sendable {
+    /// The configured maximum sidebar log-entry count, or `nil` when no value
+    /// is configured. The model applies the legacy default and clamping.
+    var configuredMaxSidebarLogEntries: Int? { get }
+}

--- a/Packages/CmuxWorkspaceSidebarModel/Sources/CmuxWorkspaceSidebarModel/WorkspaceSidebarMetadataModel.swift
+++ b/Packages/CmuxWorkspaceSidebarModel/Sources/CmuxWorkspaceSidebarModel/WorkspaceSidebarMetadataModel.swift
@@ -1,0 +1,214 @@
+public import Combine
+public import CmuxSidebar
+public import Foundation
+public import Observation
+
+/// The per-workspace sidebar-metadata sub-model: owns the sidebar status
+/// entries, metadata blocks, log entries, progress, and git-branch /
+/// pull-request presentation state the legacy `Workspace` god object kept as
+/// loose `@Published` stored properties (`statusEntries`, `metadataBlocks`,
+/// `logEntries`, `progress`, `gitBranch`, `panelGitBranches`, `pullRequest`,
+/// `panelPullRequests`).
+///
+/// `Workspace` owns one instance and forwards each former stored property
+/// through a computed `get`/`set` pair, so every call site (`statusEntries[key]
+/// = …`, `logEntries.append(…)`, `workspace.progress`) stays byte-identical.
+///
+/// Byte-identical observer parity: the legacy properties were `@Published`, and
+/// the sidebar observation publishers (`Workspace.sidebarObservationPublisher`)
+/// fused their `$projection`s through `CombineLatest` + `removeDuplicates()`.
+/// To preserve that exactly, each property here mirrors its value into a
+/// `CurrentValueSubject` in `didSet`; the matching `…Publisher` accessor
+/// replaces the former `$property`. `CombineLatest` over current-value subjects
+/// seeded with the initial values, then deduplicated, produces the identical
+/// sequence of distinct fused states the `@Published` projections did, so the
+/// debounced sidebar refresh fires at the same moments.
+@MainActor
+@Observable
+public final class WorkspaceSidebarMetadataModel {
+    /// Sidebar status entries keyed by status key (legacy
+    /// `Workspace.statusEntries`).
+    public var statusEntries: [String: SidebarStatusEntry] = [:] {
+        didSet { statusEntriesSubject.send(statusEntries) }
+    }
+
+    /// Sidebar markdown metadata blocks keyed by block key (legacy
+    /// `Workspace.metadataBlocks`).
+    public var metadataBlocks: [String: SidebarMetadataBlock] = [:] {
+        didSet { metadataBlocksSubject.send(metadataBlocks) }
+    }
+
+    /// Recent sidebar log entries, oldest first, capped to the configured
+    /// limit (legacy `Workspace.logEntries`).
+    public var logEntries: [SidebarLogEntry] = [] {
+        didSet { logEntriesSubject.send(logEntries) }
+    }
+
+    /// The current sidebar progress indicator, if any (legacy
+    /// `Workspace.progress`).
+    public var progress: SidebarProgressState? {
+        didSet { progressSubject.send(progress) }
+    }
+
+    /// The workspace-level git branch state shown in the sidebar (legacy
+    /// `Workspace.gitBranch`).
+    public var gitBranch: SidebarGitBranchState? {
+        didSet { gitBranchSubject.send(gitBranch) }
+    }
+
+    /// Per-panel git branch state keyed by panel id (legacy
+    /// `Workspace.panelGitBranches`).
+    public var panelGitBranches: [UUID: SidebarGitBranchState] = [:] {
+        didSet { panelGitBranchesSubject.send(panelGitBranches) }
+    }
+
+    /// The workspace-level pull-request state shown in the sidebar (legacy
+    /// `Workspace.pullRequest`).
+    public var pullRequest: SidebarPullRequestState? {
+        didSet { pullRequestSubject.send(pullRequest) }
+    }
+
+    /// Per-panel pull-request state keyed by panel id (legacy
+    /// `Workspace.panelPullRequests`).
+    public var panelPullRequests: [UUID: SidebarPullRequestState] = [:] {
+        didSet { panelPullRequestsSubject.send(panelPullRequests) }
+    }
+
+    @ObservationIgnored
+    private let limitProvider: any SidebarLogEntryLimitProviding
+
+    @ObservationIgnored
+    private lazy var statusEntriesSubject = CurrentValueSubject<[String: SidebarStatusEntry], Never>(statusEntries)
+    @ObservationIgnored
+    private lazy var metadataBlocksSubject = CurrentValueSubject<[String: SidebarMetadataBlock], Never>(metadataBlocks)
+    @ObservationIgnored
+    private lazy var logEntriesSubject = CurrentValueSubject<[SidebarLogEntry], Never>(logEntries)
+    @ObservationIgnored
+    private lazy var progressSubject = CurrentValueSubject<SidebarProgressState?, Never>(progress)
+    @ObservationIgnored
+    private lazy var gitBranchSubject = CurrentValueSubject<SidebarGitBranchState?, Never>(gitBranch)
+    @ObservationIgnored
+    private lazy var panelGitBranchesSubject = CurrentValueSubject<[UUID: SidebarGitBranchState], Never>(panelGitBranches)
+    @ObservationIgnored
+    private lazy var pullRequestSubject = CurrentValueSubject<SidebarPullRequestState?, Never>(pullRequest)
+    @ObservationIgnored
+    private lazy var panelPullRequestsSubject = CurrentValueSubject<[UUID: SidebarPullRequestState], Never>(panelPullRequests)
+
+    /// Creates an empty sidebar-metadata model.
+    /// - Parameter limitProvider: Supplies the configured maximum number of log
+    ///   entries retained by ``appendLogEntry(message:level:source:)``. The app
+    ///   target injects a `UserDefaults`-backed conformer; tests inject a fake.
+    public init(limitProvider: any SidebarLogEntryLimitProviding) {
+        self.limitProvider = limitProvider
+    }
+
+    /// Emits the current status entries on subscription, then on every change
+    /// (replaces the legacy `Workspace.$statusEntries`).
+    public var statusEntriesPublisher: AnyPublisher<[String: SidebarStatusEntry], Never> {
+        statusEntriesSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current metadata blocks on subscription, then on every change
+    /// (replaces the legacy `Workspace.$metadataBlocks`).
+    public var metadataBlocksPublisher: AnyPublisher<[String: SidebarMetadataBlock], Never> {
+        metadataBlocksSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current log entries on subscription, then on every change
+    /// (replaces the legacy `Workspace.$logEntries`).
+    public var logEntriesPublisher: AnyPublisher<[SidebarLogEntry], Never> {
+        logEntriesSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current progress state on subscription, then on every change
+    /// (replaces the legacy `Workspace.$progress`).
+    public var progressPublisher: AnyPublisher<SidebarProgressState?, Never> {
+        progressSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current workspace git-branch state on subscription, then on
+    /// every change (replaces the legacy `Workspace.$gitBranch`).
+    public var gitBranchPublisher: AnyPublisher<SidebarGitBranchState?, Never> {
+        gitBranchSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current per-panel git-branch states on subscription, then on
+    /// every change (replaces the legacy `Workspace.$panelGitBranches`).
+    public var panelGitBranchesPublisher: AnyPublisher<[UUID: SidebarGitBranchState], Never> {
+        panelGitBranchesSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current workspace pull-request state on subscription, then on
+    /// every change (replaces the legacy `Workspace.$pullRequest`).
+    public var pullRequestPublisher: AnyPublisher<SidebarPullRequestState?, Never> {
+        pullRequestSubject.eraseToAnyPublisher()
+    }
+
+    /// Emits the current per-panel pull-request states on subscription, then on
+    /// every change (replaces the legacy `Workspace.$panelPullRequests`).
+    public var panelPullRequestsPublisher: AnyPublisher<[UUID: SidebarPullRequestState], Never> {
+        panelPullRequestsSubject.eraseToAnyPublisher()
+    }
+
+    /// Upserts a sidebar status entry under its key (legacy
+    /// `Workspace.statusEntries[entry.key] = entry`).
+    /// - Parameter entry: The status entry to store; keyed by `entry.key`.
+    public func addStatusEntry(_ entry: SidebarStatusEntry) {
+        statusEntries[entry.key] = entry
+    }
+
+    /// Appends a sidebar log entry, trimming whitespace and dropping empty
+    /// messages, then trims the buffer to the configured maximum (legacy
+    /// `Workspace.appendSidebarLog(message:level:source:)`).
+    ///
+    /// The retention limit is read from the injected
+    /// ``SidebarLogEntryLimitProviding`` (default 50 when unset) and clamped to
+    /// the legacy `1...500` range, preserving the prior behavior exactly.
+    /// - Parameters:
+    ///   - message: The raw log message; whitespace-trimmed, ignored if empty.
+    ///   - level: The severity level for the entry.
+    ///   - source: An optional source label for the entry.
+    public func appendLogEntry(message: String, level: SidebarLogLevel, source: String?) {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        logEntries.append(SidebarLogEntry(message: trimmed, level: level, source: source, timestamp: Date()))
+        let configuredLimit = limitProvider.configuredMaxSidebarLogEntries ?? 50
+        let limit = max(1, min(500, configuredLimit))
+        if logEntries.count > limit {
+            logEntries.removeFirst(logEntries.count - limit)
+        }
+    }
+
+    /// Sets or clears the sidebar progress indicator (legacy
+    /// `Workspace.progress = …`).
+    /// - Parameter progress: The new progress state, or `nil` to clear it.
+    public func updateProgress(_ progress: SidebarProgressState?) {
+        self.progress = progress
+    }
+
+    /// Sets or clears the workspace-level git-branch state (legacy
+    /// `Workspace.gitBranch = …`).
+    /// - Parameter gitBranch: The new git-branch state, or `nil` to clear it.
+    public func updateGitBranch(_ gitBranch: SidebarGitBranchState?) {
+        self.gitBranch = gitBranch
+    }
+
+    /// Sets or clears the workspace-level pull-request state (legacy
+    /// `Workspace.pullRequest = …`).
+    /// - Parameter pullRequest: The new pull-request state, or `nil` to clear.
+    public func updatePullRequest(_ pullRequest: SidebarPullRequestState?) {
+        self.pullRequest = pullRequest
+    }
+
+    /// Returns the metadata blocks sorted for sidebar display: descending
+    /// priority, then descending timestamp, then ascending key (legacy
+    /// `Workspace.sidebarMetadataBlocksInDisplayOrder()`).
+    /// - Returns: The metadata blocks in stable display order.
+    public func metadataBlocksInDisplayOrder() -> [SidebarMetadataBlock] {
+        metadataBlocks.values.sorted { lhs, rhs in
+            if lhs.priority != rhs.priority { return lhs.priority > rhs.priority }
+            if lhs.timestamp != rhs.timestamp { return lhs.timestamp > rhs.timestamp }
+            return lhs.key < rhs.key
+        }
+    }
+}

--- a/Packages/CmuxWorkspaceSidebarModel/Tests/CmuxWorkspaceSidebarModelTests/WorkspaceSidebarMetadataModelTests.swift
+++ b/Packages/CmuxWorkspaceSidebarModel/Tests/CmuxWorkspaceSidebarModelTests/WorkspaceSidebarMetadataModelTests.swift
@@ -1,0 +1,138 @@
+import Combine
+import CmuxSidebar
+import Foundation
+import Testing
+
+@testable import CmuxWorkspaceSidebarModel
+
+private struct FixedLogLimitProvider: SidebarLogEntryLimitProviding {
+    let configuredMaxSidebarLogEntries: Int?
+}
+
+@MainActor
+@Suite struct WorkspaceSidebarMetadataModelTests {
+    private func makeModel(limit: Int? = nil) -> WorkspaceSidebarMetadataModel {
+        WorkspaceSidebarMetadataModel(limitProvider: FixedLogLimitProvider(configuredMaxSidebarLogEntries: limit))
+    }
+
+    @Test func addStatusEntryKeysByEntryKey() {
+        let model = makeModel()
+        let entry = SidebarStatusEntry(
+            key: "agent",
+            value: "running",
+            icon: nil,
+            color: nil,
+            url: nil,
+            priority: 1,
+            format: .plain,
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        model.addStatusEntry(entry)
+        #expect(model.statusEntries["agent"] == entry)
+    }
+
+    @Test func appendLogEntryTrimsAndDropsEmpty() {
+        let model = makeModel()
+        model.appendLogEntry(message: "   ", level: .info, source: nil)
+        #expect(model.logEntries.isEmpty)
+        model.appendLogEntry(message: "  hello  ", level: .info, source: "src")
+        #expect(model.logEntries.count == 1)
+        #expect(model.logEntries[0].message == "hello")
+        #expect(model.logEntries[0].source == "src")
+    }
+
+    @Test func appendLogEntryDefaultsToFiftyWhenUnset() {
+        let model = makeModel(limit: nil)
+        for index in 0..<60 {
+            model.appendLogEntry(message: "m\(index)", level: .info, source: nil)
+        }
+        #expect(model.logEntries.count == 50)
+        // Oldest entries trimmed: the buffer keeps the most recent 50.
+        #expect(model.logEntries.first?.message == "m10")
+        #expect(model.logEntries.last?.message == "m59")
+    }
+
+    @Test func appendLogEntryClampsLimitToOne() {
+        let model = makeModel(limit: 0)
+        model.appendLogEntry(message: "a", level: .info, source: nil)
+        model.appendLogEntry(message: "b", level: .info, source: nil)
+        #expect(model.logEntries.count == 1)
+        #expect(model.logEntries.last?.message == "b")
+    }
+
+    @Test func appendLogEntryClampsLimitToFiveHundred() {
+        let model = makeModel(limit: 100_000)
+        for index in 0..<600 {
+            model.appendLogEntry(message: "m\(index)", level: .info, source: nil)
+        }
+        #expect(model.logEntries.count == 500)
+    }
+
+    @Test func metadataBlocksInDisplayOrderSortsByPriorityTimestampKey() {
+        let model = makeModel()
+        let low = SidebarMetadataBlock(key: "b", markdown: "x", priority: 1, timestamp: Date(timeIntervalSince1970: 10))
+        let highOld = SidebarMetadataBlock(key: "a", markdown: "y", priority: 5, timestamp: Date(timeIntervalSince1970: 1))
+        let highNew = SidebarMetadataBlock(key: "c", markdown: "z", priority: 5, timestamp: Date(timeIntervalSince1970: 9))
+        model.metadataBlocks = ["b": low, "a": highOld, "c": highNew]
+        let ordered = model.metadataBlocksInDisplayOrder()
+        #expect(ordered.map(\.key) == ["c", "a", "b"])
+    }
+
+    @Test func progressGitAndPullRequestUpdaters() {
+        let model = makeModel()
+        model.updateProgress(SidebarProgressState(value: 0.5, label: "half"))
+        #expect(model.progress?.label == "half")
+        model.updateProgress(nil)
+        #expect(model.progress == nil)
+
+        model.updateGitBranch(SidebarGitBranchState(branch: "main", isDirty: true))
+        #expect(model.gitBranch?.branch == "main")
+        #expect(model.gitBranch?.isDirty == true)
+
+        let pr = SidebarPullRequestState(
+            number: 7,
+            label: "PR 7",
+            url: URL(string: "https://example.com/7")!,
+            status: .open,
+            branch: "feat",
+            isStale: false
+        )
+        model.updatePullRequest(pr)
+        #expect(model.pullRequest?.number == 7)
+    }
+
+    @Test func publisherSeedsCurrentValueThenEmitsChanges() {
+        let model = makeModel()
+        var received: [Int] = []
+        let cancellable = model.statusEntriesPublisher
+            .map(\.count)
+            .sink { received.append($0) }
+        defer { cancellable.cancel() }
+
+        // Seeds with the current (empty) value immediately.
+        #expect(received == [0])
+
+        model.addStatusEntry(
+            SidebarStatusEntry(
+                key: "k",
+                value: "v",
+                icon: nil,
+                color: nil,
+                url: nil,
+                priority: 0,
+                format: .plain,
+                timestamp: Date(timeIntervalSince1970: 1)
+            )
+        )
+        #expect(received == [0, 1])
+    }
+
+    @Test func panelMapsForwardThroughStoredProperties() {
+        let model = makeModel()
+        let id = UUID()
+        model.panelGitBranches[id] = SidebarGitBranchState(branch: "dev", isDirty: false)
+        #expect(model.panelGitBranches[id]?.branch == "dev")
+        model.panelGitBranches.removeValue(forKey: id)
+        #expect(model.panelGitBranches[id] == nil)
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -16,6 +16,7 @@ import CmuxCanvasUI
 import CmuxPanes
 import CmuxSidebar
 import CmuxWorkspaceCore
+import CmuxWorkspaceSidebarModel
 import CmuxWorkspaces
 import CmuxNotifications
 import CmuxSocketControl
@@ -2762,17 +2763,52 @@ final class Workspace: Identifiable, ObservableObject {
     @Published private(set) var tmuxWorkspaceFlashReason: WorkspaceAttentionFlashReason?
     @Published private(set) var tmuxWorkspaceFlashToken: UInt64 = 0
     var manualUnreadMarkedAt: [UUID: Date] = [:]
-    @Published var statusEntries: [String: SidebarStatusEntry] = [:]
-    @Published var metadataBlocks: [String: SidebarMetadataBlock] = [:]
+    /// The sidebar-metadata sub-model (CmuxWorkspaceSidebarModel): owns the
+    /// sidebar status entries, metadata blocks, log entries, progress, and
+    /// git-branch / pull-request presentation state. The legacy accessors below
+    /// forward here. The moved properties were `@Published` and fed the sidebar
+    /// observation publishers, so the model exposes per-field Combine publishers
+    /// (`statusEntriesPublisher` etc.) that `makeSidebarObservationPublisher()`
+    /// subscribes to in place of the former `$projection`s, preserving the
+    /// debounced refresh timing byte-identically.
+    let sidebarMetadata = WorkspaceSidebarMetadataModel(
+        limitProvider: WorkspaceSidebarLogEntryLimitProvider()
+    )
+    var statusEntries: [String: SidebarStatusEntry] {
+        get { sidebarMetadata.statusEntries }
+        set { sidebarMetadata.statusEntries = newValue }
+    }
+    var metadataBlocks: [String: SidebarMetadataBlock] {
+        get { sidebarMetadata.metadataBlocks }
+        set { sidebarMetadata.metadataBlocks = newValue }
+    }
     @Published private(set) var latestConversationMessage: String?
     @Published private(set) var latestSubmittedMessage: String?
     @Published private(set) var latestSubmittedAt: Date?
-    @Published var logEntries: [SidebarLogEntry] = []
-    @Published var progress: SidebarProgressState?
-    @Published var gitBranch: SidebarGitBranchState?
-    @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
-    @Published var pullRequest: SidebarPullRequestState?
-    @Published var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
+    var logEntries: [SidebarLogEntry] {
+        get { sidebarMetadata.logEntries }
+        set { sidebarMetadata.logEntries = newValue }
+    }
+    var progress: SidebarProgressState? {
+        get { sidebarMetadata.progress }
+        set { sidebarMetadata.progress = newValue }
+    }
+    var gitBranch: SidebarGitBranchState? {
+        get { sidebarMetadata.gitBranch }
+        set { sidebarMetadata.gitBranch = newValue }
+    }
+    var panelGitBranches: [UUID: SidebarGitBranchState] {
+        get { sidebarMetadata.panelGitBranches }
+        set { sidebarMetadata.panelGitBranches = newValue }
+    }
+    var pullRequest: SidebarPullRequestState? {
+        get { sidebarMetadata.pullRequest }
+        set { sidebarMetadata.pullRequest = newValue }
+    }
+    var panelPullRequests: [UUID: SidebarPullRequestState] {
+        get { sidebarMetadata.panelPullRequests }
+        set { sidebarMetadata.panelPullRequests = newValue }
+    }
     @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
     var agentListeningPorts: [Int] = []
     @Published var remoteConfiguration: WorkspaceRemoteConfiguration?
@@ -5358,11 +5394,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func sidebarMetadataBlocksInDisplayOrder() -> [SidebarMetadataBlock] {
-        metadataBlocks.values.sorted { lhs, rhs in
-            if lhs.priority != rhs.priority { return lhs.priority > rhs.priority }
-            if lhs.timestamp != rhs.timestamp { return lhs.timestamp > rhs.timestamp }
-            return lhs.key < rhs.key
-        }
+        sidebarMetadata.metadataBlocksInDisplayOrder()
     }
 
     @discardableResult
@@ -6737,14 +6769,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func appendSidebarLog(message: String, level: SidebarLogLevel, source: String?) {
-        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        logEntries.append(SidebarLogEntry(message: trimmed, level: level, source: source, timestamp: Date()))
-        let configuredLimit = UserDefaults.standard.object(forKey: "sidebarMaxLogEntries") as? Int ?? 50
-        let limit = max(1, min(500, configuredLimit))
-        if logEntries.count > limit {
-            logEntries.removeFirst(logEntries.count - limit)
-        }
+        sidebarMetadata.appendLogEntry(message: message, level: level, source: source)
     }
 
     // MARK: - Panel Operations

--- a/Sources/WorkspaceSidebarLogEntryLimitProvider.swift
+++ b/Sources/WorkspaceSidebarLogEntryLimitProvider.swift
@@ -1,0 +1,21 @@
+import CmuxWorkspaceSidebarModel
+import Foundation
+
+/// App-side conformer for the sidebar-metadata model's log-entry limit seam.
+/// Reads the same `UserDefaults.standard` key the legacy
+/// `Workspace.appendSidebarLog` read inline (`"sidebarMaxLogEntries"`),
+/// returning the raw configured value (or `nil` when unset). The model applies
+/// the legacy default of 50 and the `1...500` clamp.
+struct WorkspaceSidebarLogEntryLimitProvider: SidebarLogEntryLimitProviding {
+    /// The `UserDefaults` instance read for the configured limit; defaults to
+    /// `.standard`, matching the legacy inline read.
+    let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var configuredMaxSidebarLogEntries: Int? {
+        defaults.object(forKey: "sidebarMaxLogEntries") as? Int
+    }
+}

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -81,16 +81,16 @@ extension Workspace {
             $panelDirectories
         )
         let metadataFields = Publishers.CombineLatest4(
-            $statusEntries,
-            $metadataBlocks,
-            $logEntries,
-            $progress
+            sidebarMetadata.statusEntriesPublisher,
+            sidebarMetadata.metadataBlocksPublisher,
+            sidebarMetadata.logEntriesPublisher,
+            sidebarMetadata.progressPublisher
         )
         let gitFields = Publishers.CombineLatest4(
-            $gitBranch,
-            $panelGitBranches,
-            $pullRequest,
-            $panelPullRequests
+            sidebarMetadata.gitBranchPublisher,
+            sidebarMetadata.panelGitBranchesPublisher,
+            sidebarMetadata.pullRequestPublisher,
+            sidebarMetadata.panelPullRequestsPublisher
         )
         let remoteFields = Publishers.CombineLatest4(
             $remoteConfiguration,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */; };
 		E3B7A30000000000000000E3 /* CmuxWorkspaceNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */; };
 		E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000102 /* CmuxWorkspaces */; };
+		B5DA000000000000000000A3 /* CmuxWorkspaceSidebarModel in Frameworks */ = {isa = PBXBuildFile; productRef = B5DA000000000000000000A2 /* CmuxWorkspaceSidebarModel */; };
 		C750400000000000000000D3 /* CmuxWorkspaceWindow in Frameworks */ = {isa = PBXBuildFile; productRef = C750400000000000000000D2 /* CmuxWorkspaceWindow */; };
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
@@ -873,6 +874,7 @@
 		EE30D6000000000000000004 /* WorkspaceRemoteSessionBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000003 /* WorkspaceRemoteSessionBuildInfo.swift */; };
 		EE30D6000000000000000002 /* WorkspaceRemoteSessionHostAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
+		B5DA000000000000000000B3 /* WorkspaceSidebarLogEntryLimitProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DA000000000000000000B4 /* WorkspaceSidebarLogEntryLimitProvider.swift */; };
 		5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */; };
 		5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */; };
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
@@ -1740,6 +1742,7 @@
 		EE30D6000000000000000003 /* WorkspaceRemoteSessionBuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteSessionBuildInfo.swift; sourceTree = "<group>"; };
 		EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteSessionHostAdapter.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
+		B5DA000000000000000000B4 /* WorkspaceSidebarLogEntryLimitProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarLogEntryLimitProvider.swift; sourceTree = "<group>"; };
 		5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservation.swift; sourceTree = "<group>"; };
 		5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservationTests.swift; sourceTree = "<group>"; };
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
@@ -1817,6 +1820,7 @@
 				E3B7A3000000000000000113 /* CmuxWorkspaceCore in Frameworks */,
 				E3B7A30000000000000000E3 /* CmuxWorkspaceNavigation in Frameworks */,
 				E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */,
+				B5DA000000000000000000A3 /* CmuxWorkspaceSidebarModel in Frameworks */,
 				C750400000000000000000D3 /* CmuxWorkspaceWindow in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
@@ -2165,6 +2169,7 @@
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
 				5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */,
+				B5DA000000000000000000B4 /* WorkspaceSidebarLogEntryLimitProvider.swift */,
 				D7AB3605C10DEF0000000004 /* WorkspaceCloseTabsBatching.swift */,
 				C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */,
 				42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */,
@@ -2842,6 +2847,7 @@
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
 				E3B7A30000000000000000F2 /* CmuxPanes */,
 				E3B7A3000000000000000112 /* CmuxWorkspaceCore */,
+				B5DA000000000000000000A2 /* CmuxWorkspaceSidebarModel */,
 				E3B7A3000000000000000102 /* CmuxWorkspaces */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
 				CD0CFE5200000000CD0CFE52 /* CmuxSettings */,
@@ -3035,6 +3041,7 @@
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
+				B5DA000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxWorkspaceSidebarModel" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
 				C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */,
 				C9A2B00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxAppKitSupportUI" */,
@@ -3706,6 +3713,7 @@
 				EE30D6000000000000000004 /* WorkspaceRemoteSessionBuildInfo.swift in Sources */,
 				EE30D6000000000000000002 /* WorkspaceRemoteSessionHostAdapter.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
+				B5DA000000000000000000B3 /* WorkspaceSidebarLogEntryLimitProvider.swift in Sources */,
 				5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */,
 				D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */,
 				C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */,
@@ -4579,6 +4587,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaceCore;
 		};
+		B5DA000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxWorkspaceSidebarModel" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxWorkspaceSidebarModel;
+		};
 		E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaces;
@@ -4853,6 +4865,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */;
 			productName = CmuxWorkspaceCore;
+		};
+		B5DA000000000000000000A2 /* CmuxWorkspaceSidebarModel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B5DA000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxWorkspaceSidebarModel" */;
+			productName = CmuxWorkspaceSidebarModel;
 		};
 		E3B7A3000000000000000102 /* CmuxWorkspaces */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the workspace sidebar status/metadata/log/progress/git/PR presentation state out of the `Workspace` god object (`Sources/Workspace.swift`, ~12.4k lines) into a new `@MainActor @Observable` sub-model in a new leaf package.

## New package: `CmuxWorkspaceSidebarModel`
Depends only on `CmuxSidebar` (a clean leaf). Wired into `cmux.xcodeproj` via the 6 standard pbxproj entries, mirroring the `CmuxWorkspaceCore` sibling, and added as an app-target dependency.

- `WorkspaceSidebarMetadataModel` (`@MainActor @Observable`): owns the 8 former `@Published` sidebar-metadata stored properties (`statusEntries`, `metadataBlocks`, `logEntries`, `progress`, `gitBranch`, `panelGitBranches`, `pullRequest`, `panelPullRequests`) plus the `appendLogEntry`, `metadataBlocksInDisplayOrder`, and named mutators (`addStatusEntry`, `updateProgress`, `updateGitBranch`, `updatePullRequest`).
- `SidebarLogEntryLimitProviding`: constructor-injected protocol seam inverting the inline `UserDefaults.standard.object(forKey: "sidebarMaxLogEntries")` read. App-target conformer `WorkspaceSidebarLogEntryLimitProvider` reads the same key; tests inject a fake. The model applies the legacy default (50) and the `1...500` clamp.

## What moved / byte-identical notes
- `Workspace` holds one `sidebarMetadata` instance and forwards each former stored property through a computed `get`/`set`, mirroring the existing `SurfaceRegistryModel`/`SplitLayoutModel` precedents in `CmuxWorkspaceCore`/`CmuxPanes`. Every call site (`statusEntries[key] = …`, `logEntries.append(…)`, `workspace.progress`) stays identical.
- `appendSidebarLog` and `sidebarMetadataBlocksInDisplayOrder` bodies become one-line forwards.
- **Observer parity:** the moved properties were `@Published` and fed `Workspace.sidebarObservationPublisher` via `$projection` through `CombineLatest` + `removeDuplicates()`. The model mirrors each property into a `CurrentValueSubject` in `didSet` and exposes per-field `AnyPublisher` accessors; `WorkspaceSidebarObservation.swift` subscribes to those in place of the former `$projections`. `CurrentValueSubject` replays the current value on subscribe, matching `@Published`'s replay semantics, so the existing late-subscriber test (`testSidebarObservationPublisherEmitsForLateStatusSubscriber`) and the heartbeat-suppression test hold unchanged. No SwiftUI view reads these 8 fields inside a body that observes `Workspace` (verified across `WorkspaceContentView`/`WorkspaceCanvasHostView`), so dropping the per-field `objectWillChange` emission changes no view reactivity. The sidebar UI is driven by the observation-publisher → value-snapshot pipeline, which is preserved exactly.

## Tests
Behavior unit tests for the model with a fake limit provider: trim/empty-drop, default-50, clamp at 1 and 500, display ordering (priority/timestamp/key), publisher seed-then-emit, and panel-map forwarding. `swift build` + `swift test` pass in the package; the convention lint passes with zero new `lint:allow`.

## Stats
Est ~150 lines of logic removed from `Workspace.swift`; net file delta +25 (forwarding shims + DocC docs), `swift-file-length-budget.tsv` reconciled (12361 → 12386).

NOTE: app build and full test suite validated by GitHub CI, not run locally (22 parallel agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143985&installation_id=133855650&pr_number=6174&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6174&signature=9c4cf59cd3066e10366049eaaa3c906aadc3623caf3def24c6d9f89a16af6d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted sidebar sidebar-metadata state from `Workspace` into a new leaf package `CmuxWorkspaceSidebarModel`, keeping behavior, observation timing, and call sites unchanged. This reduces `Workspace.swift` complexity and makes the sidebar logic testable.

- **Refactors**
  - Added `CmuxWorkspaceSidebarModel` with `WorkspaceSidebarMetadataModel` (`@MainActor @Observable`) owning status, metadata blocks, logs, progress, git, and PR state.
  - `Workspace` now forwards the 8 fields via computed get/set; `appendSidebarLog` and `sidebarMetadataBlocksInDisplayOrder` are one-line forwards.
  - Preserved observation semantics: replaced `$` projections with model `AnyPublisher`s backed by `CurrentValueSubject`; updated `WorkspaceSidebarObservation` accordingly.
  - Introduced `SidebarLogEntryLimitProviding`; app conformer `WorkspaceSidebarLogEntryLimitProvider` reads `UserDefaults`, model applies default 50 and clamps to `1...500`.
  - Wired the new package into the project and added model unit tests.

<sup>Written for commit 7d579724eb9666cfe760cd47f4ed952c167dae91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured workspace sidebar metadata handling into a dedicated internal model for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->