### PR TITLE
Extract About Titlebar Debug subsystem from cmuxApp.swift into CmuxDebugWindowsUI

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34202	CLI/cmux.swift
-17778	Sources/AppDelegate.swift
+17789	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
@@ -21,7 +21,7 @@
 5925	cmuxTests/TerminalAndGhosttyTests.swift
 5526	cmuxTests/BrowserConfigTests.swift
 5113	Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
-4920	Sources/cmuxApp.swift
+4515	Sources/cmuxApp.swift
 4467	Sources/Panels/FilePreviewPanel.swift
 4400	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift

--- a/Packages/CmuxDebugWindowsUI/Package.swift
+++ b/Packages/CmuxDebugWindowsUI/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxDebugWindowsUI",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxDebugWindowsUI",
+            targets: ["CmuxDebugWindowsUI"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxDebugWindowsUI",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxDebugWindowsUITests",
+            dependencies: ["CmuxDebugWindowsUI"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Coordinator/DebugWindowsCoordinator.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Coordinator/DebugWindowsCoordinator.swift
@@ -1,0 +1,49 @@
+#if canImport(AppKit)
+
+import AppKit
+public import Observation
+
+/// Owns and sequences the About Titlebar Debug subsystem on behalf of the app.
+///
+/// The app composition root constructs one coordinator, injecting the
+/// ``WindowDecorating`` seam, and forwards its existing call sites (the Debug
+/// menu, the `About`/`Acknowledgments` window controllers, and "open all debug
+/// windows") into this type. The coordinator owns the ``AboutTitlebarDebugStore``
+/// and lazily owns the editor window controller, so the app target no longer
+/// declares the underlying types.
+@MainActor
+@Observable
+public final class DebugWindowsCoordinator {
+    /// The store backing the About Titlebar Debug options. Exposed so the app's
+    /// `About`/`Acknowledgments` window controllers can apply current options to
+    /// their windows as they build them.
+    public let aboutTitlebarStore: AboutTitlebarDebugStore
+
+    @ObservationIgnored
+    private weak var decorator: (any WindowDecorating)?
+
+    @ObservationIgnored
+    private var aboutTitlebarController: AboutTitlebarDebugWindowController?
+
+    /// Creates the coordinator.
+    ///
+    /// - Parameter decorator: The window-decoration seam. Held weakly because the
+    ///   app-side conformer (`AppDelegate`) is a singleton that also owns this
+    ///   coordinator.
+    public init(decorator: (any WindowDecorating)?) {
+        self.decorator = decorator
+        self.aboutTitlebarStore = AboutTitlebarDebugStore(decorator: decorator)
+    }
+
+    /// Presents the About Titlebar Debug editor, creating its window on first use.
+    public func showAboutTitlebarDebugWindow() {
+        let controller = aboutTitlebarController ?? AboutTitlebarDebugWindowController(
+            store: aboutTitlebarStore,
+            decorator: decorator
+        )
+        aboutTitlebarController = controller
+        controller.show()
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Seams/WindowDecorating.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Seams/WindowDecorating.swift
@@ -1,0 +1,21 @@
+#if canImport(AppKit)
+
+public import AppKit
+
+/// Applies the app's standard window chrome (background, blur, traffic-light
+/// placement, and related decorations) to a freshly built or reconfigured
+/// `NSWindow`.
+///
+/// This inverts the `AboutTitlebarDebug*` types' previous reach into
+/// `AppDelegate.shared`: the app target's `AppDelegate` conforms and is injected
+/// into ``DebugWindowsCoordinator`` at the composition root, so this package owns
+/// no reference to the application delegate.
+@MainActor
+public protocol WindowDecorating: AnyObject {
+    /// Applies the standard cmux window decorations to `window`.
+    ///
+    /// - Parameter window: The window whose chrome should be normalized.
+    func applyWindowDecorations(to window: NSWindow)
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Stores/AboutTitlebarDebugStore.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Stores/AboutTitlebarDebugStore.swift
@@ -1,0 +1,160 @@
+#if canImport(AppKit)
+
+public import AppKit
+public import Observation
+
+/// Holds the live ``AboutTitlebarDebugOptions`` for each ``AboutWindowKind`` and
+/// applies them to matching open windows.
+///
+/// This is the single writer of the debug options. Editing ``aboutOptions``
+/// (directly or via ``update(_:for:)``) immediately reapplies the new treatment
+/// to any open window with the matching identifier, preserving the original
+/// `didSet`-driven behavior. Window decoration is delegated to an injected
+/// ``WindowDecorating`` seam rather than reaching into the app delegate.
+@MainActor
+@Observable
+public final class AboutTitlebarDebugStore {
+    /// The current options for the About window. Setting this reapplies them to
+    /// every open About window.
+    public var aboutOptions = AboutTitlebarDebugOptions.defaults(for: .about) {
+        didSet { applyToOpenWindows(for: .about) }
+    }
+
+    @ObservationIgnored
+    private weak var decorator: (any WindowDecorating)?
+
+    /// Creates a store.
+    ///
+    /// - Parameter decorator: The seam used to apply standard window chrome after
+    ///   a debug option change. Held weakly because the app-side conformer
+    ///   (`AppDelegate`) is a singleton that also owns this store, so a strong
+    ///   reference would form a retain cycle.
+    public init(decorator: (any WindowDecorating)?) {
+        self.decorator = decorator
+    }
+
+    /// Returns the current options for a window kind.
+    public func options(for kind: AboutWindowKind) -> AboutTitlebarDebugOptions {
+        switch kind {
+        case .about:
+            return aboutOptions
+        }
+    }
+
+    /// Replaces the current options for a window kind.
+    public func update(_ newValue: AboutTitlebarDebugOptions, for kind: AboutWindowKind) {
+        switch kind {
+        case .about:
+            aboutOptions = newValue
+        }
+    }
+
+    /// Resets a window kind to its non-overriding defaults.
+    public func reset(_ kind: AboutWindowKind) {
+        update(AboutTitlebarDebugOptions.defaults(for: kind), for: kind)
+    }
+
+    /// Reapplies the current options to every open window of the given kind.
+    ///
+    /// A nil `NSApp` (no running application, e.g. a headless unit-test process)
+    /// is a no-op; in the running app `NSApp` is always present, so this is
+    /// behavior-preserving.
+    public func applyToOpenWindows(for kind: AboutWindowKind) {
+        guard let app = NSApp else { return }
+        for window in app.windows where window.identifier?.rawValue == kind.windowIdentifier {
+            apply(options(for: kind), to: window, for: kind)
+        }
+    }
+
+    /// Reapplies the current options to every open About window.
+    public func applyToOpenWindows() {
+        applyToOpenWindows(for: .about)
+    }
+
+    /// Applies the current options for `kind` to a specific window. Used by the
+    /// About/Acknowledgments window controllers as they build their windows.
+    public func applyCurrentOptions(to window: NSWindow, for kind: AboutWindowKind) {
+        apply(options(for: kind), to: window, for: kind)
+    }
+
+    /// Copies a human-readable snapshot of the current About options to the
+    /// general pasteboard.
+    public func copyConfigToPasteboard() {
+        let about = options(for: .about)
+        let payload = """
+        # About Titlebar Debug
+        about.overridesEnabled=\(about.overridesEnabled)
+        about.title=\(about.windowTitle)
+        about.titleVisibility=\(about.titleVisibility.rawValue)
+        about.titlebarAppearsTransparent=\(about.titlebarAppearsTransparent)
+        about.movableByWindowBackground=\(about.movableByWindowBackground)
+        about.titled=\(about.titled)
+        about.closable=\(about.closable)
+        about.miniaturizable=\(about.miniaturizable)
+        about.resizable=\(about.resizable)
+        about.fullSizeContentView=\(about.fullSizeContentView)
+        about.showToolbar=\(about.showToolbar)
+        about.toolbarStyle=\(about.toolbarStyle.rawValue)
+        """
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(payload, forType: .string)
+    }
+
+    private func apply(_ options: AboutTitlebarDebugOptions, to window: NSWindow, for kind: AboutWindowKind) {
+        let effective = options.overridesEnabled ? options : AboutTitlebarDebugOptions.defaults(for: kind)
+        let resolvedTitle = effective.windowTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        window.title = resolvedTitle.isEmpty ? kind.fallbackTitle : resolvedTitle
+        window.titleVisibility = effective.titleVisibility.windowValue
+        window.titlebarAppearsTransparent = effective.titlebarAppearsTransparent
+        window.isMovableByWindowBackground = effective.movableByWindowBackground
+        window.toolbarStyle = effective.toolbarStyle.windowValue
+
+        if effective.showToolbar {
+            ensureToolbar(on: window, kind: kind)
+        } else if window.toolbar != nil {
+            window.toolbar = nil
+        }
+
+        var styleMask = window.styleMask
+        setStyleMaskBit(&styleMask, .titled, enabled: effective.titled)
+        setStyleMaskBit(&styleMask, .closable, enabled: effective.closable)
+        setStyleMaskBit(&styleMask, .miniaturizable, enabled: effective.miniaturizable)
+        setStyleMaskBit(&styleMask, .resizable, enabled: effective.resizable)
+        setStyleMaskBit(&styleMask, .fullSizeContentView, enabled: effective.fullSizeContentView)
+        window.styleMask = styleMask
+
+        let maxSize = effective.resizable ? NSSize(width: 8192, height: 8192) : kind.minimumSize
+        window.minSize = kind.minimumSize
+        window.maxSize = maxSize
+        window.contentMinSize = kind.minimumSize
+        window.contentMaxSize = maxSize
+        window.invalidateShadow()
+        decorator?.applyWindowDecorations(to: window)
+    }
+
+    private func ensureToolbar(on window: NSWindow, kind: AboutWindowKind) {
+        guard window.toolbar == nil else { return }
+        let identifier = NSToolbar.Identifier("cmux.debug.titlebar.\(kind.rawValue)")
+        let toolbar = NSToolbar(identifier: identifier)
+        toolbar.allowsUserCustomization = false
+        toolbar.autosavesConfiguration = false
+        toolbar.displayMode = .iconOnly
+        toolbar.showsBaselineSeparator = false
+        window.toolbar = toolbar
+    }
+
+    private func setStyleMaskBit(
+        _ styleMask: inout NSWindow.StyleMask,
+        _ bit: NSWindow.StyleMask,
+        enabled: Bool
+    ) {
+        if enabled {
+            styleMask.insert(bit)
+        } else {
+            styleMask.remove(bit)
+        }
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/AboutTitlebarDebugOptions.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/AboutTitlebarDebugOptions.swift
@@ -1,0 +1,90 @@
+#if canImport(AppKit)
+
+public import AppKit
+
+/// A complete, editable description of the titlebar treatment applied to an
+/// About-family window by the About Titlebar Debug subsystem.
+///
+/// When ``overridesEnabled`` is `false`, the store falls back to ``defaults(for:)``
+/// so the window keeps its normal appearance; the remaining fields only take
+/// effect once overrides are enabled.
+public struct AboutTitlebarDebugOptions: Equatable, Sendable {
+    /// Whether the debug overrides in this value are applied at all.
+    public var overridesEnabled: Bool
+    /// The window title text (trimmed; empty falls back to the kind's title).
+    public var windowTitle: String
+    /// Whether the title text is shown or hidden.
+    public var titleVisibility: TitlebarVisibilityOption
+    /// Whether the titlebar background is transparent.
+    public var titlebarAppearsTransparent: Bool
+    /// Whether the window is draggable by its background.
+    public var movableByWindowBackground: Bool
+    /// Whether the `.titled` style-mask bit is set.
+    public var titled: Bool
+    /// Whether the `.closable` style-mask bit is set.
+    public var closable: Bool
+    /// Whether the `.miniaturizable` style-mask bit is set.
+    public var miniaturizable: Bool
+    /// Whether the `.resizable` style-mask bit is set.
+    public var resizable: Bool
+    /// Whether the `.fullSizeContentView` style-mask bit is set.
+    public var fullSizeContentView: Bool
+    /// Whether a toolbar is attached to the window.
+    public var showToolbar: Bool
+    /// The toolbar style applied when ``showToolbar`` is `true`.
+    public var toolbarStyle: TitlebarToolbarStyleOption
+
+    /// Creates an options value with every field specified.
+    public init(
+        overridesEnabled: Bool,
+        windowTitle: String,
+        titleVisibility: TitlebarVisibilityOption,
+        titlebarAppearsTransparent: Bool,
+        movableByWindowBackground: Bool,
+        titled: Bool,
+        closable: Bool,
+        miniaturizable: Bool,
+        resizable: Bool,
+        fullSizeContentView: Bool,
+        showToolbar: Bool,
+        toolbarStyle: TitlebarToolbarStyleOption
+    ) {
+        self.overridesEnabled = overridesEnabled
+        self.windowTitle = windowTitle
+        self.titleVisibility = titleVisibility
+        self.titlebarAppearsTransparent = titlebarAppearsTransparent
+        self.movableByWindowBackground = movableByWindowBackground
+        self.titled = titled
+        self.closable = closable
+        self.miniaturizable = miniaturizable
+        self.resizable = resizable
+        self.fullSizeContentView = fullSizeContentView
+        self.showToolbar = showToolbar
+        self.toolbarStyle = toolbarStyle
+    }
+
+    /// The default, non-overriding options for a given window kind. This matches
+    /// the window's normal appearance, so applying it with overrides disabled is
+    /// a no-op relative to the system defaults.
+    public static func defaults(for kind: AboutWindowKind) -> AboutTitlebarDebugOptions {
+        switch kind {
+        case .about:
+            return AboutTitlebarDebugOptions(
+                overridesEnabled: false,
+                windowTitle: "About cmux",
+                titleVisibility: .hidden,
+                titlebarAppearsTransparent: true,
+                movableByWindowBackground: false,
+                titled: true,
+                closable: true,
+                miniaturizable: true,
+                resizable: false,
+                fullSizeContentView: false,
+                showToolbar: false,
+                toolbarStyle: .automatic
+            )
+        }
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/AboutWindowKind.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/AboutWindowKind.swift
@@ -1,0 +1,52 @@
+#if canImport(AppKit)
+
+public import AppKit
+
+/// Identifies an About-family window whose titlebar can be tuned by the
+/// About Titlebar Debug subsystem.
+///
+/// Today there is a single case, ``about``, but the kind is modeled as an enum so
+/// the debug store, window controller, and editor view can scale to additional
+/// About-style windows without changing their shapes.
+public enum AboutWindowKind: String, CaseIterable, Identifiable, Sendable {
+    /// The primary "About cmux" window.
+    case about
+
+    /// Stable identity for SwiftUI list iteration.
+    public var id: String { rawValue }
+
+    /// Human-readable label shown as the editor section title.
+    public var displayTitle: String {
+        switch self {
+        case .about:
+            return "About Window"
+        }
+    }
+
+    /// `NSWindow.identifier` value used to find the live window when reapplying
+    /// debug options to already-open windows.
+    public var windowIdentifier: String {
+        switch self {
+        case .about:
+            return "cmux.about"
+        }
+    }
+
+    /// Title used when the debug-overridden title resolves to empty.
+    public var fallbackTitle: String {
+        switch self {
+        case .about:
+            return "About cmux"
+        }
+    }
+
+    /// Minimum content size enforced on the window for this kind.
+    public var minimumSize: NSSize {
+        switch self {
+        case .about:
+            return NSSize(width: 360, height: 520)
+        }
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/TitlebarToolbarStyleOption.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/TitlebarToolbarStyleOption.swift
@@ -1,0 +1,55 @@
+#if canImport(AppKit)
+
+public import AppKit
+
+/// Selectable toolbar-style modes for the About Titlebar Debug editor,
+/// mapping directly onto `NSWindow.ToolbarStyle`.
+public enum TitlebarToolbarStyleOption: String, CaseIterable, Identifiable, Sendable {
+    /// System-chosen toolbar style.
+    case automatic
+    /// Expanded toolbar style.
+    case expanded
+    /// Preference-window toolbar style.
+    case preference
+    /// Unified toolbar style.
+    case unified
+    /// Unified compact toolbar style.
+    case unifiedCompact
+
+    /// Stable identity for SwiftUI list iteration.
+    public var id: String { rawValue }
+
+    /// Human-readable label shown in the picker.
+    public var displayTitle: String {
+        switch self {
+        case .automatic:
+            return "Automatic"
+        case .expanded:
+            return "Expanded"
+        case .preference:
+            return "Preference"
+        case .unified:
+            return "Unified"
+        case .unifiedCompact:
+            return "Unified Compact"
+        }
+    }
+
+    /// The corresponding AppKit `NSWindow.ToolbarStyle` value.
+    public var windowValue: NSWindow.ToolbarStyle {
+        switch self {
+        case .automatic:
+            return .automatic
+        case .expanded:
+            return .expanded
+        case .preference:
+            return .preference
+        case .unified:
+            return .unified
+        case .unifiedCompact:
+            return .unifiedCompact
+        }
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/TitlebarVisibilityOption.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Values/TitlebarVisibilityOption.swift
@@ -1,0 +1,37 @@
+#if canImport(AppKit)
+
+public import AppKit
+
+/// Selectable title-visibility modes for the About Titlebar Debug editor,
+/// mapping directly onto `NSWindow.TitleVisibility`.
+public enum TitlebarVisibilityOption: String, CaseIterable, Identifiable, Sendable {
+    /// Hide the window title text.
+    case hidden
+    /// Show the window title text.
+    case visible
+
+    /// Stable identity for SwiftUI list iteration.
+    public var id: String { rawValue }
+
+    /// Human-readable label shown in the picker.
+    public var displayTitle: String {
+        switch self {
+        case .hidden:
+            return "Hidden"
+        case .visible:
+            return "Visible"
+        }
+    }
+
+    /// The corresponding AppKit `NSWindow.TitleVisibility` value.
+    public var windowValue: NSWindow.TitleVisibility {
+        switch self {
+        case .hidden:
+            return .hidden
+        case .visible:
+            return .visible
+        }
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Views/AboutTitlebarDebugView.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Views/AboutTitlebarDebugView.swift
@@ -1,0 +1,130 @@
+#if canImport(AppKit)
+
+public import SwiftUI
+
+/// The editor surface for the About Titlebar Debug window.
+///
+/// Every control reads from and writes through an injected
+/// ``AboutTitlebarDebugStore``; the view holds no other state.
+public struct AboutTitlebarDebugView: View {
+    private let store: AboutTitlebarDebugStore
+
+    /// Creates the editor view bound to a store.
+    ///
+    /// - Parameter store: The store whose options the editor reads and mutates.
+    public init(store: AboutTitlebarDebugStore) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Text(String(localized: "debug.aboutTitlebarDebug.title", defaultValue: "About Titlebar Debug"))
+                    .font(.headline)
+
+                editor(for: .about)
+
+                GroupBox("Actions") {
+                    HStack(spacing: 10) {
+                        Button("Reset All") {
+                            store.reset(.about)
+                        }
+                        Button("Reapply to Open Windows") {
+                            store.applyToOpenWindows()
+                        }
+                        Button("Copy Config") {
+                            store.copyConfigToPasteboard()
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 2)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func editor(for kind: AboutWindowKind) -> some View {
+        let overridesEnabled = binding(for: kind, keyPath: \.overridesEnabled)
+
+        return GroupBox(kind.displayTitle) {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle("Enable Debug Overrides", isOn: overridesEnabled)
+
+                Text("When disabled, cmux uses normal default titlebar behavior for this window.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 8) {
+                        Text("Window Title")
+                        TextField("", text: binding(for: kind, keyPath: \.windowTitle))
+                    }
+
+                    HStack(spacing: 10) {
+                        Picker("Title Visibility", selection: binding(for: kind, keyPath: \.titleVisibility)) {
+                            ForEach(TitlebarVisibilityOption.allCases) { option in
+                                Text(option.displayTitle).tag(option)
+                            }
+                        }
+                        Picker("Toolbar Style", selection: binding(for: kind, keyPath: \.toolbarStyle)) {
+                            ForEach(TitlebarToolbarStyleOption.allCases) { option in
+                                Text(option.displayTitle).tag(option)
+                            }
+                        }
+                    }
+
+                    Toggle("Show Toolbar", isOn: binding(for: kind, keyPath: \.showToolbar))
+                    Toggle("Transparent Titlebar", isOn: binding(for: kind, keyPath: \.titlebarAppearsTransparent))
+                    Toggle("Movable by Window Background", isOn: binding(for: kind, keyPath: \.movableByWindowBackground))
+
+                    Divider()
+
+                    Text("Style Mask")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Toggle("Titled", isOn: binding(for: kind, keyPath: \.titled))
+                    Toggle("Closable", isOn: binding(for: kind, keyPath: \.closable))
+                    Toggle("Miniaturizable", isOn: binding(for: kind, keyPath: \.miniaturizable))
+                    Toggle("Resizable", isOn: binding(for: kind, keyPath: \.resizable))
+                    Toggle("Full Size Content View", isOn: binding(for: kind, keyPath: \.fullSizeContentView))
+
+                    HStack(spacing: 10) {
+                        Button(String(localized: "debug.aboutTitlebarDebug.resetAbout", defaultValue: "Reset About")) {
+                            store.reset(kind)
+                        }
+                        Button("Apply Now") {
+                            store.applyToOpenWindows(for: kind)
+                        }
+                    }
+                }
+                .disabled(!overridesEnabled.wrappedValue)
+                .opacity(overridesEnabled.wrappedValue ? 1 : 0.75)
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func binding<Value>(
+        for kind: AboutWindowKind,
+        keyPath: WritableKeyPath<AboutTitlebarDebugOptions, Value>
+    ) -> Binding<Value> {
+        Binding(
+            get: { store.options(for: kind)[keyPath: keyPath] },
+            set: { newValue in
+                var updated = store.options(for: kind)
+                updated[keyPath: keyPath] = newValue
+                store.update(updated, for: kind)
+            }
+        )
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Windows/AboutTitlebarDebugWindowController.swift
+++ b/Packages/CmuxDebugWindowsUI/Sources/CmuxDebugWindowsUI/Windows/AboutTitlebarDebugWindowController.swift
@@ -1,0 +1,56 @@
+#if canImport(AppKit)
+
+public import AppKit
+public import SwiftUI
+
+/// Hosts the ``AboutTitlebarDebugView`` editor in a floating utility panel.
+///
+/// The controller is built around an injected ``AboutTitlebarDebugStore`` (the
+/// single source of truth for the options) and a ``WindowDecorating`` seam used
+/// to normalize the panel's own chrome.
+public final class AboutTitlebarDebugWindowController: NSWindowController, NSWindowDelegate {
+    private let store: AboutTitlebarDebugStore
+
+    /// Creates the controller and builds its panel.
+    ///
+    /// - Parameters:
+    ///   - store: The store the editor view reads and mutates.
+    ///   - decorator: The seam used to decorate the editor panel itself.
+    public init(store: AboutTitlebarDebugStore, decorator: (any WindowDecorating)?) {
+        self.store = store
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 470, height: 690),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(
+            localized: "debug.aboutTitlebarDebug.title",
+            defaultValue: "About Titlebar Debug"
+        )
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.aboutTitlebarDebug")
+        window.center()
+        window.contentView = NSHostingView(rootView: AboutTitlebarDebugView(store: store))
+        decorator?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Centers, presents, and reapplies options to open About windows.
+    public func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+        store.applyToOpenWindows()
+    }
+}
+
+#endif

--- a/Packages/CmuxDebugWindowsUI/Tests/CmuxDebugWindowsUITests/AboutTitlebarDebugStoreTests.swift
+++ b/Packages/CmuxDebugWindowsUI/Tests/CmuxDebugWindowsUITests/AboutTitlebarDebugStoreTests.swift
@@ -1,0 +1,137 @@
+#if canImport(AppKit)
+
+import AppKit
+import Testing
+@testable import CmuxDebugWindowsUI
+
+/// A test double recording every window passed to the decoration seam.
+@MainActor
+private final class FakeWindowDecorator: WindowDecorating {
+    private(set) var decoratedCount = 0
+    private(set) var lastWindow: NSWindow?
+
+    func applyWindowDecorations(to window: NSWindow) {
+        decoratedCount += 1
+        lastWindow = window
+    }
+}
+
+@MainActor
+private func makeAboutWindow() -> NSWindow {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 360, height: 520),
+        styleMask: [.titled, .closable, .miniaturizable],
+        backing: .buffered,
+        defer: false
+    )
+    window.isReleasedWhenClosed = false
+    window.identifier = NSUserInterfaceItemIdentifier(AboutWindowKind.about.windowIdentifier)
+    return window
+}
+
+@MainActor
+@Suite struct AboutTitlebarDebugStoreTests {
+    @Test func defaultsAreNonOverriding() {
+        let store = AboutTitlebarDebugStore(decorator: nil)
+        #expect(store.options(for: .about).overridesEnabled == false)
+        #expect(store.aboutOptions == AboutTitlebarDebugOptions.defaults(for: .about))
+    }
+
+    @Test func disabledOverridesUseKindDefaults() {
+        let decorator = FakeWindowDecorator()
+        let store = AboutTitlebarDebugStore(decorator: decorator)
+        let window = makeAboutWindow()
+
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = false
+        options.windowTitle = "Ignored"
+        options.resizable = true
+        store.update(options, for: .about)
+
+        store.applyCurrentOptions(to: window, for: .about)
+
+        // Overrides disabled -> defaults: title falls back, not resizable.
+        #expect(window.title == "About cmux")
+        #expect(window.styleMask.contains(.resizable) == false)
+        #expect(decorator.decoratedCount >= 1)
+    }
+
+    @Test func enabledOverridesApplyTitleAndStyleMask() {
+        let decorator = FakeWindowDecorator()
+        let store = AboutTitlebarDebugStore(decorator: decorator)
+        let window = makeAboutWindow()
+
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = true
+        options.windowTitle = "Custom Title"
+        options.resizable = true
+        options.titleVisibility = .visible
+        store.update(options, for: .about)
+        store.applyCurrentOptions(to: window, for: .about)
+
+        #expect(window.title == "Custom Title")
+        #expect(window.styleMask.contains(.resizable))
+        #expect(window.titleVisibility == .visible)
+        #expect(decorator.lastWindow === window)
+    }
+
+    @Test func emptyTitleFallsBackToKindFallback() {
+        let store = AboutTitlebarDebugStore(decorator: nil)
+        let window = makeAboutWindow()
+
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = true
+        options.windowTitle = "   "
+        store.update(options, for: .about)
+        store.applyCurrentOptions(to: window, for: .about)
+
+        #expect(window.title == AboutWindowKind.about.fallbackTitle)
+    }
+
+    @Test func showToolbarTogglesWindowToolbar() {
+        let store = AboutTitlebarDebugStore(decorator: nil)
+        let window = makeAboutWindow()
+
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = true
+        options.showToolbar = true
+        store.update(options, for: .about)
+        store.applyCurrentOptions(to: window, for: .about)
+        #expect(window.toolbar != nil)
+
+        options.showToolbar = false
+        store.update(options, for: .about)
+        store.applyCurrentOptions(to: window, for: .about)
+        #expect(window.toolbar == nil)
+    }
+
+    @Test func resetRestoresDefaults() {
+        let store = AboutTitlebarDebugStore(decorator: nil)
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = true
+        options.windowTitle = "Changed"
+        store.update(options, for: .about)
+        #expect(store.aboutOptions.overridesEnabled)
+
+        store.reset(.about)
+        #expect(store.aboutOptions == AboutTitlebarDebugOptions.defaults(for: .about))
+    }
+
+    @Test func copyConfigPayloadContainsCurrentValues() {
+        let store = AboutTitlebarDebugStore(decorator: nil)
+        var options = AboutTitlebarDebugOptions.defaults(for: .about)
+        options.overridesEnabled = true
+        options.windowTitle = "Snapshot Title"
+        options.toolbarStyle = .unifiedCompact
+        store.update(options, for: .about)
+
+        store.copyConfigToPasteboard()
+        let payload = NSPasteboard.general.string(forType: .string) ?? ""
+
+        #expect(payload.contains("about.overridesEnabled=true"))
+        #expect(payload.contains("about.title=Snapshot Title"))
+        #expect(payload.contains("about.toolbarStyle=unifiedCompact"))
+    }
+}
+
+#endif

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CmuxAuthRuntime
+import CmuxDebugWindowsUI
 import CmuxBrowserPanel
 import CmuxCommandPalette
 import CmuxCommandPaletteUI
@@ -508,6 +509,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     nonisolated(unsafe) static var shared: AppDelegate?
     /// Stateless control-socket syscall layer (CmuxControlSocket); composition-root owned.
     nonisolated let socketTransport = SocketTransport()
+    /// Owns the About Titlebar Debug subsystem (CmuxDebugWindowsUI); composition-root
+    /// owned and created lazily so the window-decoration seam can point back at `self`.
+    lazy var debugWindowsCoordinator = DebugWindowsCoordinator(decorator: self)
+    /// About Titlebar Debug options store, applied by the About/Acknowledgments windows.
+    var aboutTitlebarDebugStore: AboutTitlebarDebugStore { debugWindowsCoordinator.aboutTitlebarStore }
     private static let reloadConfigurationMenuItemIdentifier = NSUserInterfaceItemIdentifier("com.cmux.reloadConfiguration")
 
     private static let cachedIsRunningUnderXCTest = detectRunningUnderXCTest(ProcessInfo.processInfo.environment)
@@ -11755,6 +11761,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         titlebarAccessoryController.attach(to: window)
     }
 
+    // Satisfies CmuxDebugWindowsUI's WindowDecorating seam (see extension below).
     func applyWindowDecorations(to window: NSWindow) {
         windowDecorationsController.apply(to: window)
     }
@@ -17776,3 +17783,7 @@ extension AppDelegate {
         window.setFrame(frame, display: true, animate: false)
     }
 }
+
+// MARK: - CmuxDebugWindowsUI seam conformance
+
+extension AppDelegate: WindowDecorating {}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxDebugWindowsUI
 import CmuxFoundation
 import CmuxPanes
 import CmuxSidebarInterpreterClient
@@ -611,7 +612,7 @@ struct cmuxApp: App {
                             defaultValue: "About Titlebar Debug…"
                         )
                     ) {
-                        AboutTitlebarDebugWindowController.shared.show()
+                        AppDelegate.shared?.debugWindowsCoordinator.showAboutTitlebarDebugWindow()
                     }
                     Button(
                         String(
@@ -1415,7 +1416,7 @@ struct cmuxApp: App {
         DebugWindowControlsWindowController.shared.show()
         BrowserImportHintDebugWindowController.shared.show()
         BrowserProfilePopoverDebugWindowController.shared.show()
-        AboutTitlebarDebugWindowController.shared.show()
+        AppDelegate.shared?.debugWindowsCoordinator.showAboutTitlebarDebugWindow()
         TitlebarLayoutDebugWindowController.shared.show()
         SidebarDebugWindowController.shared.show()
         BackgroundDebugWindowController.shared.show()
@@ -1484,412 +1485,6 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
 func cmuxWindowShouldOwnCloseShortcut(_ window: NSWindow?) -> Bool {
     guard let identifier = window?.identifier?.rawValue else { return false }
     return cmuxAuxiliaryWindowIdentifiers.contains(identifier)
-}
-
-private enum AboutWindowKind: String, CaseIterable, Identifiable {
-    case about
-
-    var id: String { rawValue }
-
-    var displayTitle: String {
-        switch self {
-        case .about:
-            return "About Window"
-        }
-    }
-
-    var windowIdentifier: String {
-        switch self {
-        case .about:
-            return "cmux.about"
-        }
-    }
-
-    var fallbackTitle: String {
-        switch self {
-        case .about:
-            return "About cmux"
-        }
-    }
-
-    var minimumSize: NSSize {
-        switch self {
-        case .about:
-            return NSSize(width: 360, height: 520)
-        }
-    }
-}
-
-private enum TitlebarVisibilityOption: String, CaseIterable, Identifiable {
-    case hidden
-    case visible
-
-    var id: String { rawValue }
-
-    var displayTitle: String {
-        switch self {
-        case .hidden:
-            return "Hidden"
-        case .visible:
-            return "Visible"
-        }
-    }
-
-    var windowValue: NSWindow.TitleVisibility {
-        switch self {
-        case .hidden:
-            return .hidden
-        case .visible:
-            return .visible
-        }
-    }
-}
-
-private enum TitlebarToolbarStyleOption: String, CaseIterable, Identifiable {
-    case automatic
-    case expanded
-    case preference
-    case unified
-    case unifiedCompact
-
-    var id: String { rawValue }
-
-    var displayTitle: String {
-        switch self {
-        case .automatic:
-            return "Automatic"
-        case .expanded:
-            return "Expanded"
-        case .preference:
-            return "Preference"
-        case .unified:
-            return "Unified"
-        case .unifiedCompact:
-            return "Unified Compact"
-        }
-    }
-
-    var windowValue: NSWindow.ToolbarStyle {
-        switch self {
-        case .automatic:
-            return .automatic
-        case .expanded:
-            return .expanded
-        case .preference:
-            return .preference
-        case .unified:
-            return .unified
-        case .unifiedCompact:
-            return .unifiedCompact
-        }
-    }
-}
-
-private struct AboutTitlebarDebugOptions: Equatable {
-    var overridesEnabled: Bool
-    var windowTitle: String
-    var titleVisibility: TitlebarVisibilityOption
-    var titlebarAppearsTransparent: Bool
-    var movableByWindowBackground: Bool
-    var titled: Bool
-    var closable: Bool
-    var miniaturizable: Bool
-    var resizable: Bool
-    var fullSizeContentView: Bool
-    var showToolbar: Bool
-    var toolbarStyle: TitlebarToolbarStyleOption
-
-    static func defaults(for kind: AboutWindowKind) -> AboutTitlebarDebugOptions {
-        switch kind {
-        case .about:
-            return AboutTitlebarDebugOptions(
-                overridesEnabled: false,
-                windowTitle: "About cmux",
-                titleVisibility: .hidden,
-                titlebarAppearsTransparent: true,
-                movableByWindowBackground: false,
-                titled: true,
-                closable: true,
-                miniaturizable: true,
-                resizable: false,
-                fullSizeContentView: false,
-                showToolbar: false,
-                toolbarStyle: .automatic
-            )
-        }
-    }
-}
-
-@MainActor
-private final class AboutTitlebarDebugStore: ObservableObject {
-    static let shared = AboutTitlebarDebugStore()
-
-    @Published var aboutOptions = AboutTitlebarDebugOptions.defaults(for: .about) {
-        didSet { applyToOpenWindows(for: .about) }
-    }
-
-    private init() {}
-
-    func options(for kind: AboutWindowKind) -> AboutTitlebarDebugOptions {
-        switch kind {
-        case .about:
-            return aboutOptions
-        }
-    }
-
-    func update(_ newValue: AboutTitlebarDebugOptions, for kind: AboutWindowKind) {
-        switch kind {
-        case .about:
-            aboutOptions = newValue
-        }
-    }
-
-    func reset(_ kind: AboutWindowKind) {
-        update(AboutTitlebarDebugOptions.defaults(for: kind), for: kind)
-    }
-
-    func applyToOpenWindows(for kind: AboutWindowKind) {
-        for window in NSApp.windows where window.identifier?.rawValue == kind.windowIdentifier {
-            apply(options(for: kind), to: window, for: kind)
-        }
-    }
-
-    func applyToOpenWindows() {
-        applyToOpenWindows(for: .about)
-    }
-
-    func applyCurrentOptions(to window: NSWindow, for kind: AboutWindowKind) {
-        apply(options(for: kind), to: window, for: kind)
-    }
-
-    func copyConfigToPasteboard() {
-        let about = options(for: .about)
-        let payload = """
-        # About Titlebar Debug
-        about.overridesEnabled=\(about.overridesEnabled)
-        about.title=\(about.windowTitle)
-        about.titleVisibility=\(about.titleVisibility.rawValue)
-        about.titlebarAppearsTransparent=\(about.titlebarAppearsTransparent)
-        about.movableByWindowBackground=\(about.movableByWindowBackground)
-        about.titled=\(about.titled)
-        about.closable=\(about.closable)
-        about.miniaturizable=\(about.miniaturizable)
-        about.resizable=\(about.resizable)
-        about.fullSizeContentView=\(about.fullSizeContentView)
-        about.showToolbar=\(about.showToolbar)
-        about.toolbarStyle=\(about.toolbarStyle.rawValue)
-        """
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(payload, forType: .string)
-    }
-
-    private func apply(_ options: AboutTitlebarDebugOptions, to window: NSWindow, for kind: AboutWindowKind) {
-        let effective = options.overridesEnabled ? options : AboutTitlebarDebugOptions.defaults(for: kind)
-        let resolvedTitle = effective.windowTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        window.title = resolvedTitle.isEmpty ? kind.fallbackTitle : resolvedTitle
-        window.titleVisibility = effective.titleVisibility.windowValue
-        window.titlebarAppearsTransparent = effective.titlebarAppearsTransparent
-        window.isMovableByWindowBackground = effective.movableByWindowBackground
-        window.toolbarStyle = effective.toolbarStyle.windowValue
-
-        if effective.showToolbar {
-            ensureToolbar(on: window, kind: kind)
-        } else if window.toolbar != nil {
-            window.toolbar = nil
-        }
-
-        var styleMask = window.styleMask
-        setStyleMaskBit(&styleMask, .titled, enabled: effective.titled)
-        setStyleMaskBit(&styleMask, .closable, enabled: effective.closable)
-        setStyleMaskBit(&styleMask, .miniaturizable, enabled: effective.miniaturizable)
-        setStyleMaskBit(&styleMask, .resizable, enabled: effective.resizable)
-        setStyleMaskBit(&styleMask, .fullSizeContentView, enabled: effective.fullSizeContentView)
-        window.styleMask = styleMask
-
-        let maxSize = effective.resizable ? NSSize(width: 8192, height: 8192) : kind.minimumSize
-        window.minSize = kind.minimumSize
-        window.maxSize = maxSize
-        window.contentMinSize = kind.minimumSize
-        window.contentMaxSize = maxSize
-        window.invalidateShadow()
-        AppDelegate.shared?.applyWindowDecorations(to: window)
-    }
-
-    private func ensureToolbar(on window: NSWindow, kind: AboutWindowKind) {
-        guard window.toolbar == nil else { return }
-        let identifier = NSToolbar.Identifier("cmux.debug.titlebar.\(kind.rawValue)")
-        let toolbar = NSToolbar(identifier: identifier)
-        toolbar.allowsUserCustomization = false
-        toolbar.autosavesConfiguration = false
-        toolbar.displayMode = .iconOnly
-        toolbar.showsBaselineSeparator = false
-        window.toolbar = toolbar
-    }
-
-    private func setStyleMaskBit(
-        _ styleMask: inout NSWindow.StyleMask,
-        _ bit: NSWindow.StyleMask,
-        enabled: Bool
-    ) {
-        if enabled {
-            styleMask.insert(bit)
-        } else {
-            styleMask.remove(bit)
-        }
-    }
-}
-
-private final class AboutTitlebarDebugWindowController: NSWindowController, NSWindowDelegate {
-    static let shared = AboutTitlebarDebugWindowController()
-
-    private init() {
-        let window = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 470, height: 690),
-            styleMask: [.titled, .closable, .resizable, .utilityWindow],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = String(
-            localized: "debug.aboutTitlebarDebug.title",
-            defaultValue: "About Titlebar Debug"
-        )
-        window.titleVisibility = .visible
-        window.titlebarAppearsTransparent = false
-        window.isMovableByWindowBackground = true
-        window.isReleasedWhenClosed = false
-        window.identifier = NSUserInterfaceItemIdentifier("cmux.aboutTitlebarDebug")
-        window.center()
-        window.contentView = NSHostingView(rootView: AboutTitlebarDebugView())
-        AppDelegate.shared?.applyWindowDecorations(to: window)
-        super.init(window: window)
-        window.delegate = self
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func show() {
-        window?.center()
-        window?.makeKeyAndOrderFront(nil)
-        AboutTitlebarDebugStore.shared.applyToOpenWindows()
-    }
-}
-
-private struct AboutTitlebarDebugView: View {
-    @ObservedObject private var store = AboutTitlebarDebugStore.shared
-
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                Text(String(localized: "debug.aboutTitlebarDebug.title", defaultValue: "About Titlebar Debug"))
-                    .font(.headline)
-
-                editor(for: .about)
-
-                GroupBox("Actions") {
-                    HStack(spacing: 10) {
-                        Button("Reset All") {
-                            store.reset(.about)
-                        }
-                        Button("Reapply to Open Windows") {
-                            store.applyToOpenWindows()
-                        }
-                        Button("Copy Config") {
-                            store.copyConfigToPasteboard()
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 2)
-                }
-
-                Spacer(minLength: 0)
-            }
-            .padding(16)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private func editor(for kind: AboutWindowKind) -> some View {
-        let overridesEnabled = binding(for: kind, keyPath: \.overridesEnabled)
-
-        return GroupBox(kind.displayTitle) {
-            VStack(alignment: .leading, spacing: 10) {
-                Toggle("Enable Debug Overrides", isOn: overridesEnabled)
-
-                Text("When disabled, cmux uses normal default titlebar behavior for this window.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Divider()
-
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 8) {
-                        Text("Window Title")
-                        TextField("", text: binding(for: kind, keyPath: \.windowTitle))
-                    }
-
-                    HStack(spacing: 10) {
-                        Picker("Title Visibility", selection: binding(for: kind, keyPath: \.titleVisibility)) {
-                            ForEach(TitlebarVisibilityOption.allCases) { option in
-                                Text(option.displayTitle).tag(option)
-                            }
-                        }
-                        Picker("Toolbar Style", selection: binding(for: kind, keyPath: \.toolbarStyle)) {
-                            ForEach(TitlebarToolbarStyleOption.allCases) { option in
-                                Text(option.displayTitle).tag(option)
-                            }
-                        }
-                    }
-
-                    Toggle("Show Toolbar", isOn: binding(for: kind, keyPath: \.showToolbar))
-                    Toggle("Transparent Titlebar", isOn: binding(for: kind, keyPath: \.titlebarAppearsTransparent))
-                    Toggle("Movable by Window Background", isOn: binding(for: kind, keyPath: \.movableByWindowBackground))
-
-                    Divider()
-
-                    Text("Style Mask")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    Toggle("Titled", isOn: binding(for: kind, keyPath: \.titled))
-                    Toggle("Closable", isOn: binding(for: kind, keyPath: \.closable))
-                    Toggle("Miniaturizable", isOn: binding(for: kind, keyPath: \.miniaturizable))
-                    Toggle("Resizable", isOn: binding(for: kind, keyPath: \.resizable))
-                    Toggle("Full Size Content View", isOn: binding(for: kind, keyPath: \.fullSizeContentView))
-
-                    HStack(spacing: 10) {
-                        Button(String(localized: "debug.aboutTitlebarDebug.resetAbout", defaultValue: "Reset About")) {
-                            store.reset(kind)
-                        }
-                        Button("Apply Now") {
-                            store.applyToOpenWindows(for: kind)
-                        }
-                    }
-                }
-                .disabled(!overridesEnabled.wrappedValue)
-                .opacity(overridesEnabled.wrappedValue ? 1 : 0.75)
-            }
-            .padding(.top, 2)
-        }
-    }
-
-    private func binding<Value>(
-        for kind: AboutWindowKind,
-        keyPath: WritableKeyPath<AboutTitlebarDebugOptions, Value>
-    ) -> Binding<Value> {
-        Binding(
-            get: { store.options(for: kind)[keyPath: keyPath] },
-            set: { newValue in
-                var updated = store.options(for: kind)
-                updated[keyPath: keyPath] = newValue
-                store.update(updated, for: kind)
-            }
-        )
-    }
 }
 
 private enum DebugWindowConfigSnapshot {
@@ -2054,7 +1649,7 @@ private struct DebugWindowControlsView: View {
                                 defaultValue: "About Titlebar Debug…"
                             )
                         ) {
-                            AboutTitlebarDebugWindowController.shared.show()
+                            AppDelegate.shared?.debugWindowsCoordinator.showAboutTitlebarDebugWindow()
                         }
                         Button(
                             String(
@@ -2117,7 +1712,7 @@ private struct DebugWindowControlsView: View {
                             DebugWindowControlsWindowController.shared.show()
                             BrowserImportHintDebugWindowController.shared.show()
                             BrowserProfilePopoverDebugWindowController.shared.show()
-                            AboutTitlebarDebugWindowController.shared.show()
+                            AppDelegate.shared?.debugWindowsCoordinator.showAboutTitlebarDebugWindow()
                             TitlebarLayoutDebugWindowController.shared.show()
                             SidebarDebugWindowController.shared.show()
                             BackgroundDebugWindowController.shared.show()
@@ -2649,7 +2244,7 @@ private final class AboutWindowController: NSWindowController, NSWindowDelegate 
         window.identifier = NSUserInterfaceItemIdentifier("cmux.about")
         window.center()
         window.contentView = NSHostingView(rootView: AboutPanelView())
-        AboutTitlebarDebugStore.shared.applyCurrentOptions(to: window, for: .about)
+        AppDelegate.shared?.aboutTitlebarDebugStore.applyCurrentOptions(to: window, for: .about)
         AppDelegate.shared?.applyWindowDecorations(to: window)
         super.init(window: window)
         window.delegate = self
@@ -2662,7 +2257,7 @@ private final class AboutWindowController: NSWindowController, NSWindowDelegate 
 
     func show() {
         guard let window else { return }
-        AboutTitlebarDebugStore.shared.applyCurrentOptions(to: window, for: .about)
+        AppDelegate.shared?.aboutTitlebarDebugStore.applyCurrentOptions(to: window, for: .about)
         window.center()
         window.makeKeyAndOrderFront(nil)
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		C750100000000000000000A3 /* CmuxControlSocket in Frameworks */ = {isa = PBXBuildFile; productRef = C750100000000000000000A2 /* CmuxControlSocket */; };
 		CC0DE00000000000000000A3 /* CmuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = CC0DE00000000000000000A2 /* CmuxCore */; };
 		CC0DE00000000000000000A4 /* CmuxCore in Frameworks */ = {isa = PBXBuildFile; productRef = CC0DE00000000000000000A2 /* CmuxCore */; };
+		DBW0DEBD00000000DBW0DEBD /* CmuxDebugWindowsUI in Frameworks */ = {isa = PBXBuildFile; productRef = DBW0DEBE00000000DBW0DEBE /* CmuxDebugWindowsUI */; };
 		D1320AA0D1320AA0D1320AA2 /* CmuxDockTilePlugin.plugin in Copy Dock Tile Plugin */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E7E000000000000000000005 /* CmuxEventBus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000006 /* CmuxEventBus.swift */; };
 		E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E000000000000000000004 /* CmuxEventBusTests.swift */; };
@@ -1775,6 +1776,7 @@
 				5E55300000000000000000C3 /* CmuxCommandPaletteUI in Frameworks */,
 				C750100000000000000000A3 /* CmuxControlSocket in Frameworks */,
 				CC0DE00000000000000000A3 /* CmuxCore in Frameworks */,
+				DBW0DEBD00000000DBW0DEBD /* CmuxDebugWindowsUI in Frameworks */,
 				C0DE46000000000000000001 /* CMUXExtensionHostSupport in Frameworks */,
 				C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */,
 				C0DE49000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */,
@@ -2848,6 +2850,7 @@
 				CFF11E0000000000000000A2 /* CmuxFileOpen */,
 				CFF12E0000000000000000A2 /* CmuxTestSupport */,
 				CD0CFE5500000000CD0CFE55 /* CmuxSettingsUI */,
+				DBW0DEBE00000000DBW0DEBE /* CmuxDebugWindowsUI */,
 				CDFEED0200000000CDFEED02 /* CmuxUpdater */,
 				CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */,
 				CF00F00000000000000000A2 /* CmuxFoundation */,
@@ -3049,6 +3052,7 @@
 				CFF11E0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFileOpen" */,
 				CFF12E0000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTestSupport" */,
 				CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */,
+				DBW0DEBF00000000DBW0DEBF /* XCLocalSwiftPackageReference "CmuxDebugWindowsUI" */,
 				CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */,
 				CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */,
 				CF00F00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFoundation" */,
@@ -4635,6 +4639,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxSettingsUI;
 		};
+		DBW0DEBF00000000DBW0DEBF /* XCLocalSwiftPackageReference "CmuxDebugWindowsUI" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxDebugWindowsUI;
+		};
 		CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxUpdater;
@@ -4958,6 +4966,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */;
 			productName = CmuxSettingsUI;
+		};
+		DBW0DEBE00000000DBW0DEBE /* CmuxDebugWindowsUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DBW0DEBF00000000DBW0DEBF /* XCLocalSwiftPackageReference "CmuxDebugWindowsUI" */;
+			productName = CmuxDebugWindowsUI;
 		};
 		CDFEED0200000000CDFEED02 /* CmuxUpdater */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Pulls the self-contained About-titlebar debug cluster out of the `cmuxApp.swift` god file into a new domain UI package, `CmuxDebugWindowsUI`, as a Coordinator plus value types, an `@Observable` store, an `NSWindowController`, and a SwiftUI view.

## What moved (`Sources/cmuxApp.swift` -> `Packages/CmuxDebugWindowsUI`)
- `AboutWindowKind`, `TitlebarVisibilityOption`, `TitlebarToolbarStyleOption` value enums
- `AboutTitlebarDebugOptions` value type
- `AboutTitlebarDebugStore` (was a singleton `ObservableObject` -> `@MainActor @Observable`, single writer of the options)
- `AboutTitlebarDebugWindowController` (`NSWindowController`)
- `AboutTitlebarDebugView` (SwiftUI editor)

New: `DebugWindowsCoordinator` (`@MainActor @Observable`) owns the store and lazily owns the window controller; `WindowDecorating` protocol seam. One major public type per file, DocC `///` on every public symbol, `swiftLanguageMode(.v6)` + `ExistentialAny`/`InternalImportsByDefault`.

## Seams (constructor-injected; every god-type reach inverted)
- `AppDelegate.shared?.applyWindowDecorations(to:)` -> `WindowDecorating` protocol. `AppDelegate` conforms directly (it already exposes the matching method) and is injected into `DebugWindowsCoordinator` at the composition root. The coordinator and store hold the decorator **weakly** to avoid a retain cycle, since `AppDelegate` is the singleton that owns the coordinator.
- The `.shared` singleton store/controller are gone; the app owns one coordinator on `AppDelegate` (`debugWindowsCoordinator` / `aboutTitlebarDebugStore`). The concrete conformer stays in the app target.

## Byte-identical behavior
- Window identifiers, titles, style-mask bits, toolbar identifier, min/max sizes, the copy-config payload text, and the `didSet`-driven reapply are preserved exactly. Every call site (Debug menu, `openAllDebugWindows`, `DebugWindowControlsView`, the `About`/`Acknowledgments` window controllers) is a thin forward to the app-owned coordinator/store, so the runtime sequence is unchanged.
- `applyToOpenWindows` now guards a nil `NSApp` (no-op only in a headless unit-test process; `NSApp` is always present in the running app), which is what lets the store be unit-tested.

## Tests
7 Swift-Testing behavior tests with a fake `WindowDecorating`: defaults are non-overriding, disabled overrides fall back to kind defaults, enabled overrides apply title/style-mask/visibility, empty title falls back, toolbar toggles, reset restores defaults, copy-config payload contains current values. `swift build` + `swift test` green in the package.

## Stats
- Est. lines removed from giant: **405** (`cmuxApp.swift` 4920 -> 4515).
- `AppDelegate.swift` +11 for composition-root wiring; `.github/swift-file-length-budget.tsv` reconciled (cmuxApp ratcheted down, AppDelegate bumped).
- `scripts/lint-ios-package-conventions.sh` -> OK, zero new `lint:allow`.

## Left behind (intentional, not a clean leaf)
The `#if DEBUG` controllers still in `cmuxApp.swift` (SidebarDebug, MenuBarExtraDebug, BackgroundDebug, StartupAppearance, SplitButtonLayout, TabBarBackdropLab, BrowserProfilePopover/ImportHint, FileExplorerStyle, DebugWindowControls, `DebugWindowConfigSnapshot`) reach into many app-target settings/catalog/`*Option` types and `Workspace`/`GhosttyApp` statics across multiple files, so extracting them needs multi-file seam inversion beyond this PR. The About-titlebar cluster is the one fully self-contained, non-DEBUG leaf.

NOTE: the full app build is validated by CI; per refactor policy it was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143986&installation_id=133855650&pr_number=6175&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6175&signature=fce6b85649d252f39cc50e58e795cdb6b10ab2fc7c31f04f0f391a71cbca37bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the About titlebar debug subsystem from `Sources/cmuxApp.swift` into a new package, `CmuxDebugWindowsUI`, to decouple it from the app and make it testable. Behavior is unchanged; existing debug menu actions and About/Acknowledgments windows work as before.

- **Refactors**
  - Added `CmuxDebugWindowsUI` with `DebugWindowsCoordinator`, `AboutTitlebarDebugStore` (`@MainActor @Observable`), `AboutTitlebarDebugWindowController`, `AboutTitlebarDebugView`, and value types.
  - Introduced `WindowDecorating` protocol; `AppDelegate` conforms and is injected into the coordinator; references held weakly to avoid cycles.
  - Replaced previous singletons with app-owned instances on `AppDelegate` (`debugWindowsCoordinator`, `aboutTitlebarDebugStore`); updated call sites to forward to them.
  - Preserved window IDs, titles, style-mask bits, toolbar behavior, and didSet-driven reapply.
  - `applyToOpenWindows` now no-ops if `NSApp` is nil to enable unit tests.
  - Added 7 behavior tests; new package uses Swift 6 (`swiftLanguageMode(.v6)`) and enables `ExistentialAny`/`InternalImportsByDefault`.

<sup>Written for commit c98f409c22553029325465d930949ed1762daa31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "About Titlebar Debug" window enabling users to test and configure window titlebar appearance settings, including title visibility, toolbar styles, and window decorations
  * Ability to copy debug configuration to clipboard for sharing settings

* **Tests**
  * Added test coverage for debug window functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->