### PR TITLE
Extract browser history persistence + omnibar scoring into CmuxBrowserHistory

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
-13358	Sources/Panels/BrowserPanel.swift
+13099	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Packages/CmuxBrowserHistory/Package.swift
+++ b/Packages/CmuxBrowserHistory/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserHistory",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserHistory",
+            targets: ["CmuxBrowserHistory"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "CmuxBrowserHistory",
+            dependencies: [],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserHistoryTests",
+            dependencies: ["CmuxBrowserHistory"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryEntry.swift
+++ b/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryEntry.swift
@@ -1,0 +1,69 @@
+public import Foundation
+
+/// One persisted browser-history record: a visited URL with its display title
+/// and the visit/typed statistics that feed omnibar frecency scoring.
+///
+/// The `Codable` shape is wire-compatible with the on-disk `browser_history.json`
+/// produced by earlier cmux builds: `typedCount` and `lastTypedAt` decode as
+/// `0`/`nil` when absent so histories written before typed-frecency landed keep
+/// loading unchanged.
+public struct BrowserHistoryEntry: Codable, Identifiable, Hashable, Sendable {
+    /// Stable identity for SwiftUI list diffing; persisted so re-decoding a
+    /// snapshot preserves row identity.
+    public let id: UUID
+    /// Absolute URL string exactly as recorded at visit time.
+    public var url: String
+    /// Page title, trimmed of surrounding whitespace, or `nil` when unknown.
+    public var title: String?
+    /// Timestamp of the most recent visit; histories are kept most-recent first.
+    public var lastVisited: Date
+    /// Total number of recorded visits to this URL.
+    public var visitCount: Int
+    /// Number of times the user typed (rather than followed a link to) this URL.
+    public var typedCount: Int
+    /// Timestamp of the most recent typed navigation, or `nil` if never typed.
+    public var lastTypedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case url
+        case title
+        case lastVisited
+        case visitCount
+        case typedCount
+        case lastTypedAt
+    }
+
+    /// Creates a history entry. `typedCount` and `lastTypedAt` default to the
+    /// "never typed" state so link-followed visits omit them.
+    public init(
+        id: UUID,
+        url: String,
+        title: String?,
+        lastVisited: Date,
+        visitCount: Int,
+        typedCount: Int = 0,
+        lastTypedAt: Date? = nil
+    ) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.lastVisited = lastVisited
+        self.visitCount = visitCount
+        self.typedCount = typedCount
+        self.lastTypedAt = lastTypedAt
+    }
+
+    /// Decodes an entry, defaulting `typedCount` to `0` and `lastTypedAt` to
+    /// `nil` for snapshots written before those fields existed.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        url = try container.decode(String.self, forKey: .url)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        lastVisited = try container.decode(Date.self, forKey: .lastVisited)
+        visitCount = try container.decode(Int.self, forKey: .visitCount)
+        typedCount = try container.decodeIfPresent(Int.self, forKey: .typedCount) ?? 0
+        lastTypedAt = try container.decodeIfPresent(Date.self, forKey: .lastTypedAt)
+    }
+}

--- a/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryFileRepository.swift
+++ b/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryFileRepository.swift
@@ -1,0 +1,78 @@
+public import Foundation
+
+/// Mediates the on-disk `browser_history.json` snapshot: synchronous first-load
+/// decode, atomic debounced persist, legacy-file migration, and delete-on-clear.
+///
+/// All filesystem access goes through an injected `FileManager`, and the JSON
+/// shape is fixed (`JSONEncoder` with `.withoutEscapingSlashes`, plain
+/// `JSONDecoder`) so snapshots stay wire-compatible with files written by the
+/// pre-package store. The static ``persist(_:to:)`` helper captures no instance
+/// state, so the store's detached debounce task can write a snapshot without
+/// touching this repository (which is `@MainActor`-owned, not `Sendable`, since
+/// it holds a `FileManager`).
+public struct BrowserHistoryFileRepository {
+    private let fileManager: FileManager
+
+    /// Creates a repository over `fileManager` (inject a scoped manager in
+    /// tests; pass `.default` at the app composition root).
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    /// Decodes the persisted snapshot at `fileURL`, returning `nil` when the
+    /// file is missing or cannot be decoded (the store then starts empty,
+    /// matching the prior silent-failure behavior).
+    public func loadSnapshot(from fileURL: URL) -> [BrowserHistoryEntry]? {
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch {
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode([BrowserHistoryEntry].self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Copies a legacy raw-bundle-identifier history file to `targetURL` when
+    /// the target does not yet exist and a distinct legacy file is present.
+    /// Best-effort: any error leaves the target absent so first-load starts
+    /// empty.
+    public func migrateLegacyFileIfNeeded(legacyURL: URL?, to targetURL: URL) {
+        guard !fileManager.fileExists(atPath: targetURL.path) else { return }
+        guard let legacyURL,
+              legacyURL != targetURL,
+              fileManager.fileExists(atPath: legacyURL.path) else {
+            return
+        }
+        do {
+            let dir = targetURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+            try fileManager.copyItem(at: legacyURL, to: targetURL)
+        } catch {
+            return
+        }
+    }
+
+    /// Removes the persisted history file at `fileURL`, ignoring errors (a
+    /// missing file is already the cleared state).
+    public func removeFile(at fileURL: URL) {
+        try? fileManager.removeItem(at: fileURL)
+    }
+
+    /// Atomically writes `snapshot` to `fileURL`, creating the parent directory.
+    /// Uses `JSONEncoder` with `.withoutEscapingSlashes` to keep the on-disk
+    /// JSON byte-identical to prior builds. Static + `Sendable` so the store's
+    /// detached debounce task can call it directly with a captured snapshot.
+    public static func persist(_ snapshot: [BrowserHistoryEntry], to fileURL: URL) throws {
+        let dir = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        let data = try encoder.encode(snapshot)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryLocation.swift
+++ b/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistoryLocation.swift
@@ -1,0 +1,56 @@
+public import Foundation
+
+/// Resolves where a profile's `browser_history.json` lives on disk and how the
+/// per-build namespace folds debug/staging bundle identifiers together.
+///
+/// All filesystem inputs are injected (the Application Support directory and
+/// bundle identifier), so callers at the app composition root pass the live
+/// `FileManager`/`Bundle` values while tests pass fixtures. The store keeps the
+/// resolved file URL; this type owns only the pure path math.
+public struct BrowserHistoryLocation: Sendable {
+    /// Application Support root used as the parent of the history namespace
+    /// folder. Injected so tests can point at a temporary directory.
+    public let applicationSupportDirectory: URL
+    /// The current process bundle identifier, used to derive the namespace.
+    public let bundleIdentifier: String
+
+    /// Creates a location resolver over an explicit Application Support root and
+    /// bundle identifier.
+    public init(applicationSupportDirectory: URL, bundleIdentifier: String) {
+        self.applicationSupportDirectory = applicationSupportDirectory
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    /// Folds tagged debug/staging bundle identifiers down to a shared namespace
+    /// so every dev build of the same lane reuses one history file, while
+    /// production identifiers pass through unchanged.
+    public static func normalizedNamespace(bundleIdentifier: String) -> String {
+        if bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.") {
+            return "com.cmuxterm.app.debug"
+        }
+        if bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.") {
+            return "com.cmuxterm.app.staging"
+        }
+        return bundleIdentifier
+    }
+
+    /// The normalized namespace for ``bundleIdentifier``.
+    public var namespace: String {
+        Self.normalizedNamespace(bundleIdentifier: bundleIdentifier)
+    }
+
+    /// The `browser_history.json` URL under the normalized namespace folder.
+    public var historyFileURL: URL {
+        let dir = applicationSupportDirectory.appendingPathComponent(namespace, isDirectory: true)
+        return dir.appendingPathComponent("browser_history.json", isDirectory: false)
+    }
+
+    /// The pre-namespace (raw bundle identifier) history URL that older tagged
+    /// builds wrote, or `nil` when the namespace already equals the raw
+    /// identifier (so there is nothing legacy to migrate from).
+    public var legacyTaggedHistoryFileURL: URL? {
+        guard namespace != bundleIdentifier else { return nil }
+        let dir = applicationSupportDirectory.appendingPathComponent(bundleIdentifier, isDirectory: true)
+        return dir.appendingPathComponent("browser_history.json", isDirectory: false)
+    }
+}

--- a/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistorySuggestionCandidate.swift
+++ b/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistorySuggestionCandidate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A history entry with its match fields precomputed (lowercased URL, host,
+/// path+query, title) so omnibar scoring avoids re-parsing the URL and
+/// re-lowercasing on every keystroke.
+///
+/// The owning store builds these lazily for all entries and caches them,
+/// rebuilding only when the entry list changes; steady-state typing then pays
+/// only the cheap substring scoring in
+/// ``BrowserHistorySuggestionEngine/score(candidate:query:queryTokens:now:)``.
+public struct BrowserHistorySuggestionCandidate: Sendable {
+    /// The source history entry this candidate scores.
+    public let entry: BrowserHistoryEntry
+    /// Full lowercased URL string.
+    public let urlLower: String
+    /// Lowercased URL with any `http://`/`https://` prefix removed.
+    public let urlSansSchemeLower: String
+    /// Lowercased host component.
+    public let hostLower: String
+    /// Lowercased path joined with the query (`path?query`), percent-encoded.
+    public let pathAndQueryLower: String
+    /// Lowercased, whitespace-trimmed page title.
+    public let titleLower: String
+
+    /// Creates a candidate from already-computed match fields.
+    public init(
+        entry: BrowserHistoryEntry,
+        urlLower: String,
+        urlSansSchemeLower: String,
+        hostLower: String,
+        pathAndQueryLower: String,
+        titleLower: String
+    ) {
+        self.entry = entry
+        self.urlLower = urlLower
+        self.urlSansSchemeLower = urlSansSchemeLower
+        self.hostLower = hostLower
+        self.pathAndQueryLower = pathAndQueryLower
+        self.titleLower = titleLower
+    }
+}

--- a/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistorySuggestionEngine.swift
+++ b/Packages/CmuxBrowserHistory/Sources/CmuxBrowserHistory/BrowserHistorySuggestionEngine.swift
@@ -1,0 +1,203 @@
+public import Foundation
+
+/// Pure omnibar matching/scoring over browser history. Stateless: every method
+/// is a deterministic transform of its inputs (entry fields plus the query and
+/// a `now` for recency decay), so it is `Sendable` and trivially unit-testable
+/// with fixed clocks and no filesystem.
+///
+/// The owning store builds candidates once via ``candidate(for:)``, caches
+/// them, then ranks each keystroke through
+/// ``score(candidate:query:queryTokens:now:)`` using the tokens from
+/// ``tokenize(query:)``. Scoring blends literal/prefix/substring matches on
+/// host, URL, path, and title with a frecency component (recency decay plus
+/// log-scaled visit and typed counts).
+public struct BrowserHistorySuggestionEngine: Sendable {
+    /// Creates a scoring engine. The engine holds no state.
+    public init() {}
+
+    /// Precomputes the lowercased/parsed match fields for `entry`.
+    public func candidate(for entry: BrowserHistoryEntry) -> BrowserHistorySuggestionCandidate {
+        let urlLower = entry.url.lowercased()
+        let urlSansSchemeLower = Self.strippingHTTPSSchemePrefix(urlLower)
+        let components = URLComponents(string: entry.url)
+        let hostLower = components?.host?.lowercased() ?? ""
+        let path = (components?.percentEncodedPath ?? components?.path ?? "").lowercased()
+        let query = (components?.percentEncodedQuery ?? components?.query ?? "").lowercased()
+        let pathAndQueryLower: String
+        if query.isEmpty {
+            pathAndQueryLower = path
+        } else {
+            pathAndQueryLower = "\(path)?\(query)"
+        }
+        let titleLower = (entry.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return BrowserHistorySuggestionCandidate(
+            entry: entry,
+            urlLower: urlLower,
+            urlSansSchemeLower: urlSansSchemeLower,
+            hostLower: hostLower,
+            pathAndQueryLower: pathAndQueryLower,
+            titleLower: titleLower
+        )
+    }
+
+    /// Scores `candidate` against a normalized lowercased `query` and its
+    /// `queryTokens`, returning `nil` when the candidate does not match.
+    /// Single-character queries require a strong (prefix) match; otherwise any
+    /// substring or all-token match qualifies. `now` drives the recency decay.
+    public func score(
+        candidate: BrowserHistorySuggestionCandidate,
+        query: String,
+        queryTokens: [String],
+        now: Date
+    ) -> Double? {
+        let queryIncludesScheme = query.hasPrefix("http://") || query.hasPrefix("https://")
+        let urlMatchValue = queryIncludesScheme ? candidate.urlLower : candidate.urlSansSchemeLower
+        let isSingleCharacterQuery = query.count == 1
+        if isSingleCharacterQuery {
+            let hasSingleCharStrongMatch =
+                candidate.hostLower.hasPrefix(query) ||
+                candidate.titleLower.hasPrefix(query) ||
+                urlMatchValue.hasPrefix(query)
+            guard hasSingleCharStrongMatch else { return nil }
+        }
+
+        let queryMatches =
+            urlMatchValue.contains(query) ||
+            candidate.hostLower.contains(query) ||
+            candidate.pathAndQueryLower.contains(query) ||
+            candidate.titleLower.contains(query)
+
+        let tokenMatches = !queryTokens.isEmpty && queryTokens.allSatisfy { token in
+            candidate.urlSansSchemeLower.contains(token) ||
+            candidate.hostLower.contains(token) ||
+            candidate.pathAndQueryLower.contains(token) ||
+            candidate.titleLower.contains(token)
+        }
+
+        guard queryMatches || tokenMatches else { return nil }
+
+        var score = 0.0
+
+        if urlMatchValue == query { score += 1200 }
+        if candidate.hostLower == query { score += 980 }
+        if candidate.hostLower.hasPrefix(query) { score += 680 }
+        if urlMatchValue.hasPrefix(query) { score += 560 }
+        if candidate.titleLower.hasPrefix(query) { score += 420 }
+        if candidate.pathAndQueryLower.hasPrefix(query) { score += 300 }
+
+        if candidate.hostLower.contains(query) { score += 210 }
+        if candidate.pathAndQueryLower.contains(query) { score += 165 }
+        if candidate.titleLower.contains(query) { score += 145 }
+
+        for token in queryTokens {
+            if candidate.hostLower == token { score += 260 }
+            else if candidate.hostLower.hasPrefix(token) { score += 170 }
+            else if candidate.hostLower.contains(token) { score += 110 }
+
+            if candidate.pathAndQueryLower.hasPrefix(token) { score += 80 }
+            else if candidate.pathAndQueryLower.contains(token) { score += 52 }
+
+            if candidate.titleLower.hasPrefix(token) { score += 74 }
+            else if candidate.titleLower.contains(token) { score += 48 }
+        }
+
+        // Blend recency and repeat visits so history feels closer to browser frecency.
+        let ageHours = max(0, now.timeIntervalSince(candidate.entry.lastVisited) / 3600)
+        let recencyScore = max(0, 110 - (ageHours / 3))
+        let frequencyScore = min(120, log1p(Double(max(1, candidate.entry.visitCount))) * 38)
+        let typedFrequencyScore = min(190, log1p(Double(max(0, candidate.entry.typedCount))) * 80)
+        let typedRecencyScore: Double
+        if let lastTypedAt = candidate.entry.lastTypedAt {
+            let typedAgeHours = max(0, now.timeIntervalSince(lastTypedAt) / 3600)
+            typedRecencyScore = max(0, 85 - (typedAgeHours / 4))
+        } else {
+            typedRecencyScore = 0
+        }
+        score += recencyScore + frequencyScore + typedFrequencyScore + typedRecencyScore
+
+        return score
+    }
+
+    /// Splits a query into unique, order-preserving tokens on whitespace,
+    /// punctuation, and symbols.
+    public func tokenize(query: String) -> [String] {
+        var tokens: [String] = []
+        var seen = Set<String>()
+        let separators = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters).union(.symbols)
+        for raw in query.components(separatedBy: separators) {
+            let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !token.isEmpty else { continue }
+            guard !seen.contains(token) else { continue }
+            seen.insert(token)
+            tokens.append(token)
+        }
+        return tokens
+    }
+
+    /// Removes a leading `https://` or `http://` from `value`, returning it
+    /// unchanged when neither prefix is present.
+    public static func strippingHTTPSSchemePrefix(_ value: String) -> String {
+        if value.hasPrefix("https://") {
+            return String(value.dropFirst("https://".count))
+        }
+        if value.hasPrefix("http://") {
+            return String(value.dropFirst("http://".count))
+        }
+        return value
+    }
+
+    /// The dedup key for an `http`/`https` `URL`: scheme, host with a leading
+    /// `www.` stripped, default port dropped, trailing-slash-normalized path,
+    /// and lowercased query. Returns `nil` for non-http(s) URLs or URLs without
+    /// a host, matching the visit-dedup semantics of the history store.
+    public func normalizedHistoryKey(url: URL) -> String? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil }
+        return Self.normalizedHistoryKey(components: &components)
+    }
+
+    /// The dedup key for a URL string, parsed via `URLComponents`. See
+    /// ``normalizedHistoryKey(url:)``.
+    public func normalizedHistoryKey(urlString: String) -> String? {
+        guard var components = URLComponents(string: urlString) else { return nil }
+        return Self.normalizedHistoryKey(components: &components)
+    }
+
+    private static func normalizedHistoryKey(components: inout URLComponents) -> String? {
+        guard let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              var host = components.host?.lowercased() else {
+            return nil
+        }
+
+        if host.hasPrefix("www.") {
+            host.removeFirst(4)
+        }
+
+        if (scheme == "http" && components.port == 80) ||
+            (scheme == "https" && components.port == 443) {
+            components.port = nil
+        }
+
+        let portPart: String
+        if let port = components.port {
+            portPart = ":\(port)"
+        } else {
+            portPart = ""
+        }
+
+        var path = components.percentEncodedPath
+        if path.isEmpty { path = "/" }
+        while path.count > 1, path.hasSuffix("/") {
+            path.removeLast()
+        }
+
+        let queryPart: String
+        if let query = components.percentEncodedQuery, !query.isEmpty {
+            queryPart = "?\(query.lowercased())"
+        } else {
+            queryPart = ""
+        }
+
+        return "\(scheme)://\(host)\(portPart)\(path)\(queryPart)"
+    }
+}

--- a/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryEntryTests.swift
+++ b/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryEntryTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserHistory
+
+@Suite struct BrowserHistoryEntryTests {
+    @Test func decodesLegacySnapshotWithoutTypedFields() throws {
+        let json = """
+        [{"id":"\(UUID().uuidString)","url":"https://go.dev/","title":"Go","lastVisited":0,"visitCount":3}]
+        """
+        let entries = try JSONDecoder().decode([BrowserHistoryEntry].self, from: Data(json.utf8))
+        #expect(entries.count == 1)
+        #expect(entries[0].typedCount == 0)
+        #expect(entries[0].lastTypedAt == nil)
+        #expect(entries[0].visitCount == 3)
+    }
+
+    @Test func roundTripsThroughCodable() throws {
+        let entry = BrowserHistoryEntry(
+            id: UUID(),
+            url: "https://example.com/foo",
+            title: "Foo",
+            lastVisited: Date(timeIntervalSince1970: 1000),
+            visitCount: 2,
+            typedCount: 1,
+            lastTypedAt: Date(timeIntervalSince1970: 900)
+        )
+        let data = try JSONEncoder().encode([entry])
+        let decoded = try JSONDecoder().decode([BrowserHistoryEntry].self, from: data)
+        #expect(decoded == [entry])
+    }
+}

--- a/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryFileRepositoryTests.swift
+++ b/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryFileRepositoryTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserHistory
+
+@Suite struct BrowserHistoryFileRepositoryTests {
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrowserHistoryFileRepositoryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func entry(_ url: String) -> BrowserHistoryEntry {
+        BrowserHistoryEntry(id: UUID(), url: url, title: nil, lastVisited: Date(timeIntervalSince1970: 5), visitCount: 1)
+    }
+
+    @Test func persistThenLoadRoundTrips() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fileURL = dir.appendingPathComponent("browser_history.json")
+        let repo = BrowserHistoryFileRepository()
+        let snapshot = [entry("https://a.example/"), entry("https://b.example/")]
+
+        try BrowserHistoryFileRepository.persist(snapshot, to: fileURL)
+        let loaded = repo.loadSnapshot(from: fileURL)
+        #expect(loaded == snapshot)
+    }
+
+    @Test func persistUsesUnescapedSlashes() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fileURL = dir.appendingPathComponent("browser_history.json")
+        try BrowserHistoryFileRepository.persist([entry("https://x.example/p")], to: fileURL)
+        let text = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(text.contains("https://x.example/p"))
+        #expect(!text.contains("https:\\/\\/"))
+    }
+
+    @Test func loadMissingFileReturnsNil() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let repo = BrowserHistoryFileRepository()
+        #expect(repo.loadSnapshot(from: dir.appendingPathComponent("absent.json")) == nil)
+    }
+
+    @Test func removeFileDeletesSnapshot() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let fileURL = dir.appendingPathComponent("browser_history.json")
+        try BrowserHistoryFileRepository.persist([entry("https://a.example/")], to: fileURL)
+        let repo = BrowserHistoryFileRepository()
+        repo.removeFile(at: fileURL)
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test func migrateCopiesLegacyFileOnlyWhenTargetAbsent() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let legacyURL = dir.appendingPathComponent("legacy/browser_history.json")
+        let targetURL = dir.appendingPathComponent("current/browser_history.json")
+        try BrowserHistoryFileRepository.persist([entry("https://legacy.example/")], to: legacyURL)
+
+        let repo = BrowserHistoryFileRepository()
+        repo.migrateLegacyFileIfNeeded(legacyURL: legacyURL, to: targetURL)
+        #expect(repo.loadSnapshot(from: targetURL)?.first?.url == "https://legacy.example/")
+
+        // A second migration must not clobber the now-present target.
+        try BrowserHistoryFileRepository.persist([entry("https://current.example/")], to: targetURL)
+        repo.migrateLegacyFileIfNeeded(legacyURL: legacyURL, to: targetURL)
+        #expect(repo.loadSnapshot(from: targetURL)?.first?.url == "https://current.example/")
+    }
+}

--- a/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryLocationTests.swift
+++ b/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistoryLocationTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserHistory
+
+@Suite struct BrowserHistoryLocationTests {
+    @Test func foldsDebugAndStagingNamespaces() {
+        #expect(BrowserHistoryLocation.normalizedNamespace(bundleIdentifier: "com.cmuxterm.app.debug.my-tag") == "com.cmuxterm.app.debug")
+        #expect(BrowserHistoryLocation.normalizedNamespace(bundleIdentifier: "com.cmuxterm.app.staging.rc") == "com.cmuxterm.app.staging")
+        #expect(BrowserHistoryLocation.normalizedNamespace(bundleIdentifier: "com.cmuxterm.app") == "com.cmuxterm.app")
+    }
+
+    @Test func historyFileURLNestsUnderNamespace() {
+        let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
+        let location = BrowserHistoryLocation(applicationSupportDirectory: root, bundleIdentifier: "com.cmuxterm.app.debug.tag")
+        #expect(location.namespace == "com.cmuxterm.app.debug")
+        #expect(location.historyFileURL.path == "/tmp/appsupport/com.cmuxterm.app.debug/browser_history.json")
+    }
+
+    @Test func legacyURLPresentOnlyWhenNamespaceDiffers() {
+        let root = URL(fileURLWithPath: "/tmp/appsupport", isDirectory: true)
+        let tagged = BrowserHistoryLocation(applicationSupportDirectory: root, bundleIdentifier: "com.cmuxterm.app.debug.tag")
+        #expect(tagged.legacyTaggedHistoryFileURL?.path == "/tmp/appsupport/com.cmuxterm.app.debug.tag/browser_history.json")
+
+        let prod = BrowserHistoryLocation(applicationSupportDirectory: root, bundleIdentifier: "com.cmuxterm.app")
+        #expect(prod.legacyTaggedHistoryFileURL == nil)
+    }
+}

--- a/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistorySuggestionEngineTests.swift
+++ b/Packages/CmuxBrowserHistory/Tests/CmuxBrowserHistoryTests/BrowserHistorySuggestionEngineTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserHistory
+
+@Suite struct BrowserHistorySuggestionEngineTests {
+    private let engine = BrowserHistorySuggestionEngine()
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    private func entry(_ url: String, title: String? = nil, visitCount: Int = 1, typedCount: Int = 0) -> BrowserHistoryEntry {
+        BrowserHistoryEntry(id: UUID(), url: url, title: title, lastVisited: now, visitCount: visitCount, typedCount: typedCount)
+    }
+
+    @Test func candidateStripsSchemeAndLowercases() {
+        let c = engine.candidate(for: entry("HTTPS://Example.COM/Foo?A=B", title: "  Foo  "))
+        #expect(c.urlLower == "https://example.com/foo?a=b")
+        #expect(c.urlSansSchemeLower == "example.com/foo?a=b")
+        #expect(c.hostLower == "example.com")
+        #expect(c.pathAndQueryLower == "/foo?a=b")
+        #expect(c.titleLower == "foo")
+    }
+
+    @Test func exactHostQueryOutranksSubstringMatch() {
+        let exact = engine.candidate(for: entry("https://go.dev/", title: "Go"))
+        let other = engine.candidate(for: entry("https://golang.org/doc", title: "Golang Docs"))
+        let tokens = engine.tokenize(query: "go.dev")
+        let exactScore = engine.score(candidate: exact, query: "go.dev", queryTokens: tokens, now: now)
+        let otherScore = engine.score(candidate: other, query: "go.dev", queryTokens: tokens, now: now)
+        #expect(exactScore != nil)
+        #expect((exactScore ?? 0) > (otherScore ?? 0))
+    }
+
+    @Test func singleCharacterQueryRequiresPrefixMatch() {
+        let prefix = engine.candidate(for: entry("https://github.com/", title: "GitHub"))
+        let substringOnly = engine.candidate(for: entry("https://example.com/g", title: "Example"))
+        #expect(engine.score(candidate: prefix, query: "g", queryTokens: ["g"], now: now) != nil)
+        #expect(engine.score(candidate: substringOnly, query: "g", queryTokens: ["g"], now: now) == nil)
+    }
+
+    @Test func nonMatchScoresNil() {
+        let c = engine.candidate(for: entry("https://example.com/", title: "Example"))
+        #expect(engine.score(candidate: c, query: "zzzznomatch", queryTokens: ["zzzznomatch"], now: now) == nil)
+    }
+
+    @Test func tokenizeDedupesAndSplitsOnPunctuation() {
+        #expect(engine.tokenize(query: "foo bar foo, baz") == ["foo", "bar", "baz"])
+    }
+
+    @Test func normalizedKeyDropsWWWDefaultPortAndTrailingSlash() {
+        #expect(engine.normalizedHistoryKey(urlString: "https://www.example.com:443/path/") == "https://example.com/path")
+        #expect(engine.normalizedHistoryKey(urlString: "http://example.com:80/") == "http://example.com/")
+        #expect(engine.normalizedHistoryKey(urlString: "ftp://example.com/") == nil)
+    }
+
+    @Test func typedFrequencyRaisesScore() {
+        let typed = engine.candidate(for: entry("https://typed.example/", title: "T", typedCount: 5))
+        let untyped = engine.candidate(for: entry("https://typed.example/", title: "T", typedCount: 0))
+        let tokens = engine.tokenize(query: "typed")
+        let typedScore = engine.score(candidate: typed, query: "typed", queryTokens: tokens, now: now) ?? 0
+        let untypedScore = engine.score(candidate: untyped, query: "typed", queryTokens: tokens, now: now) ?? 0
+        #expect(typedScore > untypedScore)
+    }
+}

--- a/Sources/Panels/BrowserOmnibarPerformanceSupport.swift
+++ b/Sources/Panels/BrowserOmnibarPerformanceSupport.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Observation
+import CmuxBrowserHistory
 
 struct BrowserOpenTabSuggestionSnapshot: Equatable {
     let workspaceId: UUID

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CmuxCore
+import CmuxBrowserHistory
 import CmuxSettings
 import Combine
 import WebKit
@@ -1388,13 +1389,7 @@ enum BrowserUserAgentSettings {
 }
 
 func normalizedBrowserHistoryNamespace(bundleIdentifier: String) -> String {
-    if bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.") {
-        return "com.cmuxterm.app.debug"
-    }
-    if bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.") {
-        return "com.cmuxterm.app.staging"
-    }
-    return bundleIdentifier
+    BrowserHistoryLocation.normalizedNamespace(bundleIdentifier: bundleIdentifier)
 }
 
 func browserIsTemporaryHistoryURL(_ url: URL?) -> Bool {
@@ -1418,54 +1413,10 @@ func browserIsTemporaryHistoryURL(_ url: URL?) -> Bool {
 final class BrowserHistoryStore: ObservableObject {
     static let shared = BrowserHistoryStore()
 
-    struct Entry: Codable, Identifiable, Hashable {
-        let id: UUID
-        var url: String
-        var title: String?
-        var lastVisited: Date
-        var visitCount: Int
-        var typedCount: Int
-        var lastTypedAt: Date?
-
-        private enum CodingKeys: String, CodingKey {
-            case id
-            case url
-            case title
-            case lastVisited
-            case visitCount
-            case typedCount
-            case lastTypedAt
-        }
-
-        init(
-            id: UUID,
-            url: String,
-            title: String?,
-            lastVisited: Date,
-            visitCount: Int,
-            typedCount: Int = 0,
-            lastTypedAt: Date? = nil
-        ) {
-            self.id = id
-            self.url = url
-            self.title = title
-            self.lastVisited = lastVisited
-            self.visitCount = visitCount
-            self.typedCount = typedCount
-            self.lastTypedAt = lastTypedAt
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            id = try container.decode(UUID.self, forKey: .id)
-            url = try container.decode(String.self, forKey: .url)
-            title = try container.decodeIfPresent(String.self, forKey: .title)
-            lastVisited = try container.decode(Date.self, forKey: .lastVisited)
-            visitCount = try container.decode(Int.self, forKey: .visitCount)
-            typedCount = try container.decodeIfPresent(Int.self, forKey: .typedCount) ?? 0
-            lastTypedAt = try container.decodeIfPresent(Date.self, forKey: .lastTypedAt)
-        }
-    }
+    /// Persisted history record. Owned by `CmuxBrowserHistory`; this alias keeps
+    /// existing `BrowserHistoryStore.Entry` call sites byte-identical after the
+    /// value type moved into the package.
+    typealias Entry = BrowserHistoryEntry
 
     // Single source of truth for history. `private(set)` + `@MainActor` means
     // every mutation runs through this setter, so dropping the derived
@@ -1485,18 +1436,17 @@ final class BrowserHistoryStore: ObservableObject {
     private let maxEntries: Int = 5000
     private let saveDebounceNanoseconds: UInt64 = 120_000_000
 
+    // Pure suggestion matching/scoring and persistence I/O live in
+    // `CmuxBrowserHistory`; the store owns only the @Published entry list, the
+    // first-load lifecycle, and the debounced-save scheduling.
+    private let suggestionEngine = BrowserHistorySuggestionEngine()
+    private let fileRepository = BrowserHistoryFileRepository()
+
     var isLoaded: Bool {
         didLoad
     }
 
-    private struct SuggestionCandidate {
-        let entry: Entry
-        let urlLower: String
-        let urlSansSchemeLower: String
-        let hostLower: String
-        let pathAndQueryLower: String
-        let titleLower: String
-    }
+    private typealias SuggestionCandidate = BrowserHistorySuggestionCandidate
 
     private struct ScoredSuggestion {
         let entry: Entry
@@ -1519,7 +1469,7 @@ final class BrowserHistoryStore: ObservableObject {
 
     private func suggestionCandidates() -> [SuggestionCandidate] {
         if let cached = cachedSuggestionCandidates { return cached }
-        let built = entries.map(makeSuggestionCandidate)
+        let built = entries.map(suggestionEngine.candidate(for:))
         cachedSuggestionCandidates = built
         return built
     }
@@ -1537,17 +1487,7 @@ final class BrowserHistoryStore: ObservableObject {
 
         // Load synchronously on first access so the first omnibar query can use
         // persisted history immediately (important for deterministic UI behavior).
-        let data: Data
-        do {
-            data = try Data(contentsOf: fileURL)
-        } catch {
-            return
-        }
-
-        let decoded: [Entry]
-        do {
-            decoded = try JSONDecoder().decode([Entry].self, from: data)
-        } catch {
+        guard let decoded = fileRepository.loadSnapshot(from: fileURL) else {
             return
         }
 
@@ -1582,11 +1522,11 @@ final class BrowserHistoryStore: ObservableObject {
 
         let urlString = url.absoluteString
         guard urlString != "about:blank" else { return }
-        let normalizedKey = normalizedHistoryKey(url: url)
+        let normalizedKey = suggestionEngine.normalizedHistoryKey(url: url)
 
         if let idx = entries.firstIndex(where: {
             if $0.url == urlString { return true }
-            return normalizedHistoryKey(urlString: $0.url) == normalizedKey
+            return suggestionEngine.normalizedHistoryKey(urlString: $0.url) == normalizedKey
         }) {
             entries[idx].lastVisited = Date()
             entries[idx].visitCount += 1
@@ -1630,10 +1570,10 @@ final class BrowserHistoryStore: ObservableObject {
         guard urlString != "about:blank" else { return }
 
         let now = Date()
-        let normalizedKey = normalizedHistoryKey(url: url)
+        let normalizedKey = suggestionEngine.normalizedHistoryKey(url: url)
         if let idx = entries.firstIndex(where: {
             if $0.url == urlString { return true }
-            return normalizedHistoryKey(urlString: $0.url) == normalizedKey
+            return suggestionEngine.normalizedHistoryKey(urlString: $0.url) == normalizedKey
         }) {
             entries[idx].typedCount += 1
             entries[idx].lastTypedAt = now
@@ -1664,11 +1604,11 @@ final class BrowserHistoryStore: ObservableObject {
 
         let q = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !q.isEmpty else { return [] }
-        let queryTokens = tokenizeSuggestionQuery(q)
+        let queryTokens = suggestionEngine.tokenize(query: q)
         let now = Date()
 
         let matched = suggestionCandidates().compactMap { candidate -> ScoredSuggestion? in
-            guard let score = suggestionScore(candidate: candidate, query: q, queryTokens: queryTokens, now: now) else {
+            guard let score = suggestionEngine.score(candidate: candidate, query: q, queryTokens: queryTokens, now: now) else {
                 return nil
             }
             return ScoredSuggestion(entry: candidate.entry, score: score)
@@ -1722,7 +1662,7 @@ final class BrowserHistoryStore: ObservableObject {
 
             let urlString = parsedURL.absoluteString
             guard urlString != "about:blank" else { continue }
-            let normalizedKey = normalizedHistoryKey(url: parsedURL)
+            let normalizedKey = suggestionEngine.normalizedHistoryKey(url: parsedURL)
 
             let importedTitle = imported.title?.trimmingCharacters(in: .whitespacesAndNewlines)
             let importedLastVisited = imported.lastVisited
@@ -1733,7 +1673,7 @@ final class BrowserHistoryStore: ObservableObject {
             if let idx = entries.firstIndex(where: {
                 if $0.url == urlString { return true }
                 guard let normalizedKey else { return false }
-                return normalizedHistoryKey(urlString: $0.url) == normalizedKey
+                return suggestionEngine.normalizedHistoryKey(urlString: $0.url) == normalizedKey
             }) {
                 var didMutate = false
                 if importedLastVisited > entries[idx].lastVisited {
@@ -1802,7 +1742,7 @@ final class BrowserHistoryStore: ObservableObject {
         saveTask = nil
         entries = []
         guard let fileURL else { return }
-        try? FileManager.default.removeItem(at: fileURL)
+        fileRepository.removeFile(at: fileURL)
     }
 
     func clearHistoryWithoutLoadingPersistedFile() {
@@ -1820,12 +1760,12 @@ final class BrowserHistoryStore: ObservableObject {
     @discardableResult
     func removeHistoryEntry(urlString: String) -> Bool {
         loadIfNeeded()
-        let normalized = normalizedHistoryKey(urlString: urlString)
+        let normalized = suggestionEngine.normalizedHistoryKey(urlString: urlString)
         let originalCount = entries.count
         entries.removeAll { entry in
             if entry.url == urlString { return true }
             guard let normalized else { return false }
-            return normalizedHistoryKey(urlString: entry.url) == normalized
+            return suggestionEngine.normalizedHistoryKey(urlString: entry.url) == normalized
         }
         let didRemove = entries.count != originalCount
         if didRemove {
@@ -1839,7 +1779,7 @@ final class BrowserHistoryStore: ObservableObject {
         saveTask?.cancel()
         saveTask = nil
         guard let fileURL else { return }
-        try? Self.persistSnapshot(entries, to: fileURL)
+        try? BrowserHistoryFileRepository.persist(entries, to: fileURL)
     }
 
     private func scheduleSave() {
@@ -1858,7 +1798,7 @@ final class BrowserHistoryStore: ObservableObject {
             if Task.isCancelled { return }
 
             do {
-                try Self.persistSnapshot(snapshot, to: fileURL)
+                try BrowserHistoryFileRepository.persist(snapshot, to: fileURL)
             } catch {
                 return
             }
@@ -1866,225 +1806,26 @@ final class BrowserHistoryStore: ObservableObject {
     }
 
     private func migrateLegacyTaggedHistoryFileIfNeeded(to targetURL: URL) {
-        let fm = FileManager.default
-        guard !fm.fileExists(atPath: targetURL.path) else { return }
-        guard let legacyURL = Self.legacyTaggedHistoryFileURL(),
-              legacyURL != targetURL,
-              fm.fileExists(atPath: legacyURL.path) else {
-            return
-        }
-
-        do {
-            let dir = targetURL.deletingLastPathComponent()
-            try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
-            try fm.copyItem(at: legacyURL, to: targetURL)
-        } catch {
-            return
-        }
-    }
-
-    private func makeSuggestionCandidate(entry: Entry) -> SuggestionCandidate {
-        let urlLower = entry.url.lowercased()
-        let urlSansSchemeLower = stripHTTPSSchemePrefix(urlLower)
-        let components = URLComponents(string: entry.url)
-        let hostLower = components?.host?.lowercased() ?? ""
-        let path = (components?.percentEncodedPath ?? components?.path ?? "").lowercased()
-        let query = (components?.percentEncodedQuery ?? components?.query ?? "").lowercased()
-        let pathAndQueryLower: String
-        if query.isEmpty {
-            pathAndQueryLower = path
-        } else {
-            pathAndQueryLower = "\(path)?\(query)"
-        }
-        let titleLower = (entry.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return SuggestionCandidate(
-            entry: entry,
-            urlLower: urlLower,
-            urlSansSchemeLower: urlSansSchemeLower,
-            hostLower: hostLower,
-            pathAndQueryLower: pathAndQueryLower,
-            titleLower: titleLower
+        fileRepository.migrateLegacyFileIfNeeded(
+            legacyURL: Self.location()?.legacyTaggedHistoryFileURL,
+            to: targetURL
         )
     }
 
-    private func suggestionScore(
-        candidate: SuggestionCandidate,
-        query: String,
-        queryTokens: [String],
-        now: Date
-    ) -> Double? {
-        let queryIncludesScheme = query.hasPrefix("http://") || query.hasPrefix("https://")
-        let urlMatchValue = queryIncludesScheme ? candidate.urlLower : candidate.urlSansSchemeLower
-        let isSingleCharacterQuery = query.count == 1
-        if isSingleCharacterQuery {
-            let hasSingleCharStrongMatch =
-                candidate.hostLower.hasPrefix(query) ||
-                candidate.titleLower.hasPrefix(query) ||
-                urlMatchValue.hasPrefix(query)
-            guard hasSingleCharStrongMatch else { return nil }
-        }
-
-        let queryMatches =
-            urlMatchValue.contains(query) ||
-            candidate.hostLower.contains(query) ||
-            candidate.pathAndQueryLower.contains(query) ||
-            candidate.titleLower.contains(query)
-
-        let tokenMatches = !queryTokens.isEmpty && queryTokens.allSatisfy { token in
-            candidate.urlSansSchemeLower.contains(token) ||
-            candidate.hostLower.contains(token) ||
-            candidate.pathAndQueryLower.contains(token) ||
-            candidate.titleLower.contains(token)
-        }
-
-        guard queryMatches || tokenMatches else { return nil }
-
-        var score = 0.0
-
-        if urlMatchValue == query { score += 1200 }
-        if candidate.hostLower == query { score += 980 }
-        if candidate.hostLower.hasPrefix(query) { score += 680 }
-        if urlMatchValue.hasPrefix(query) { score += 560 }
-        if candidate.titleLower.hasPrefix(query) { score += 420 }
-        if candidate.pathAndQueryLower.hasPrefix(query) { score += 300 }
-
-        if candidate.hostLower.contains(query) { score += 210 }
-        if candidate.pathAndQueryLower.contains(query) { score += 165 }
-        if candidate.titleLower.contains(query) { score += 145 }
-
-        for token in queryTokens {
-            if candidate.hostLower == token { score += 260 }
-            else if candidate.hostLower.hasPrefix(token) { score += 170 }
-            else if candidate.hostLower.contains(token) { score += 110 }
-
-            if candidate.pathAndQueryLower.hasPrefix(token) { score += 80 }
-            else if candidate.pathAndQueryLower.contains(token) { score += 52 }
-
-            if candidate.titleLower.hasPrefix(token) { score += 74 }
-            else if candidate.titleLower.contains(token) { score += 48 }
-        }
-
-        // Blend recency and repeat visits so history feels closer to browser frecency.
-        let ageHours = max(0, now.timeIntervalSince(candidate.entry.lastVisited) / 3600)
-        let recencyScore = max(0, 110 - (ageHours / 3))
-        let frequencyScore = min(120, log1p(Double(max(1, candidate.entry.visitCount))) * 38)
-        let typedFrequencyScore = min(190, log1p(Double(max(0, candidate.entry.typedCount))) * 80)
-        let typedRecencyScore: Double
-        if let lastTypedAt = candidate.entry.lastTypedAt {
-            let typedAgeHours = max(0, now.timeIntervalSince(lastTypedAt) / 3600)
-            typedRecencyScore = max(0, 85 - (typedAgeHours / 4))
-        } else {
-            typedRecencyScore = 0
-        }
-        score += recencyScore + frequencyScore + typedFrequencyScore + typedRecencyScore
-
-        return score
-    }
-
-    private func stripHTTPSSchemePrefix(_ value: String) -> String {
-        if value.hasPrefix("https://") {
-            return String(value.dropFirst("https://".count))
-        }
-        if value.hasPrefix("http://") {
-            return String(value.dropFirst("http://".count))
-        }
-        return value
-    }
-
-    private func normalizedHistoryKey(url: URL) -> String? {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else { return nil }
-        return normalizedHistoryKey(components: &components)
-    }
-
-    private func normalizedHistoryKey(urlString: String) -> String? {
-        guard var components = URLComponents(string: urlString) else { return nil }
-        return normalizedHistoryKey(components: &components)
-    }
-
-    private func normalizedHistoryKey(components: inout URLComponents) -> String? {
-        guard let scheme = components.scheme?.lowercased(),
-              scheme == "http" || scheme == "https",
-              var host = components.host?.lowercased() else {
-            return nil
-        }
-
-        if host.hasPrefix("www.") {
-            host.removeFirst(4)
-        }
-
-        if (scheme == "http" && components.port == 80) ||
-            (scheme == "https" && components.port == 443) {
-            components.port = nil
-        }
-
-        let portPart: String
-        if let port = components.port {
-            portPart = ":\(port)"
-        } else {
-            portPart = ""
-        }
-
-        var path = components.percentEncodedPath
-        if path.isEmpty { path = "/" }
-        while path.count > 1, path.hasSuffix("/") {
-            path.removeLast()
-        }
-
-        let queryPart: String
-        if let query = components.percentEncodedQuery, !query.isEmpty {
-            queryPart = "?\(query.lowercased())"
-        } else {
-            queryPart = ""
-        }
-
-        return "\(scheme)://\(host)\(portPart)\(path)\(queryPart)"
-    }
-
-    private func tokenizeSuggestionQuery(_ query: String) -> [String] {
-        var tokens: [String] = []
-        var seen = Set<String>()
-        let separators = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters).union(.symbols)
-        for raw in query.components(separatedBy: separators) {
-            let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !token.isEmpty else { continue }
-            guard !seen.contains(token) else { continue }
-            seen.insert(token)
-            tokens.append(token)
-        }
-        return tokens
-    }
-
-    nonisolated private static func defaultHistoryFileURL() -> URL? {
+    /// Builds the location resolver from the live Application Support directory
+    /// and process bundle identifier, or `nil` when Application Support is
+    /// unavailable (matching the prior `defaultHistoryFileURL` nil path).
+    nonisolated private static func location() -> BrowserHistoryLocation? {
         let fm = FileManager.default
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
         let bundleId = Bundle.main.bundleIdentifier ?? "cmux"
-        let namespace = normalizedBrowserHistoryNamespace(bundleIdentifier: bundleId)
-        let dir = appSupport.appendingPathComponent(namespace, isDirectory: true)
-        return dir.appendingPathComponent("browser_history.json", isDirectory: false)
+        return BrowserHistoryLocation(applicationSupportDirectory: appSupport, bundleIdentifier: bundleId)
     }
 
-    nonisolated private static func legacyTaggedHistoryFileURL() -> URL? {
-        guard let bundleId = Bundle.main.bundleIdentifier else { return nil }
-        let namespace = normalizedBrowserHistoryNamespace(bundleIdentifier: bundleId)
-        guard namespace != bundleId else { return nil }
-        let fm = FileManager.default
-        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let dir = appSupport.appendingPathComponent(bundleId, isDirectory: true)
-        return dir.appendingPathComponent("browser_history.json", isDirectory: false)
-    }
-
-    nonisolated private static func persistSnapshot(_ snapshot: [Entry], to fileURL: URL) throws {
-        let dir = fileURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true, attributes: nil)
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.withoutEscapingSlashes]
-        let data = try encoder.encode(snapshot)
-        try data.write(to: fileURL, options: [.atomic])
+    nonisolated private static func defaultHistoryFileURL() -> URL? {
+        location()?.historyFileURL
     }
 
     nonisolated static func defaultHistoryFileURLForCurrentBundle() -> URL? {
@@ -2092,7 +1833,7 @@ final class BrowserHistoryStore: ObservableObject {
     }
 
     nonisolated static func normalizedBrowserHistoryNamespaceForBundleIdentifier(_ bundleIdentifier: String) -> String {
-        normalizedBrowserHistoryNamespace(bundleIdentifier: bundleIdentifier)
+        BrowserHistoryLocation.normalizedNamespace(bundleIdentifier: bundleIdentifier)
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
+		E3B7A300000000000000BH03 /* CmuxBrowserHistory in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A300000000000000BH02 /* CmuxBrowserHistory */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
@@ -1768,6 +1769,7 @@
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
+				E3B7A300000000000000BH03 /* CmuxBrowserHistory in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
@@ -2838,6 +2840,7 @@
 				C5B6A10000000000000000A2 /* CmuxSidebarGit */,
 				E3B7A30000000000000000B2 /* CmuxSidebar */,
 				E3B7A30000000000000000C2 /* CmuxBrowser */,
+				E3B7A300000000000000BH02 /* CmuxBrowserHistory */,
 				E3B7A30000000000000000D2 /* CmuxNotifications */,
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
 				E3B7A30000000000000000F2 /* CmuxPanes */,
@@ -3031,6 +3034,7 @@
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
+				E3B7A300000000000000BH01 /* XCLocalSwiftPackageReference "CmuxBrowserHistory" */,
 				E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */,
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
@@ -4563,6 +4567,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowser;
 		};
+		E3B7A300000000000000BH01 /* XCLocalSwiftPackageReference "CmuxBrowserHistory" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserHistory;
+		};
 		E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxNotifications;
@@ -4833,6 +4841,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */;
 			productName = CmuxBrowser;
+		};
+		E3B7A300000000000000BH02 /* CmuxBrowserHistory */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E3B7A300000000000000BH01 /* XCLocalSwiftPackageReference "CmuxBrowserHistory" */;
+			productName = CmuxBrowserHistory;
 		};
 		E3B7A30000000000000000D2 /* CmuxNotifications */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Pulls the durable, side-effect-isolated parts of `BrowserHistoryStore` out of the 13k-line `Sources/Panels/BrowserPanel.swift` god file into a new leaf package `CmuxBrowserHistory`, behind constructor-injected seams. ~259 lines removed from the giant.

## What moved (pure / I/O, zero god-type coupling)
- `BrowserHistoryEntry` — the persisted `Entry` value type (`Sendable`). Byte-identical `Codable`: same `CodingKeys`, same custom decoder defaulting `typedCount`/`lastTypedAt` for pre-typed-frecency files. `BrowserHistoryStore.Entry` is now a `typealias` so every call site (app + tests) stays identical.
- `BrowserHistorySuggestionEngine` — stateless omnibar matcher/scorer: candidate building, `score`, `tokenize`, scheme stripping, and the three `normalizedHistoryKey` overloads. `now` is injected per call.
- `BrowserHistorySuggestionCandidate` — the precomputed lowercased match-field value type the store caches.
- `BrowserHistoryLocation` — namespace folding (`debug.`/`staging.` collapse) plus history and legacy file-URL math, over an injected Application Support dir + bundle identifier.
- `BrowserHistoryFileRepository` — load / persist / migrate / remove over an injected `FileManager`. The static `persist(_:to:)` keeps `JSONEncoder(.withoutEscapingSlashes)` + atomic write and is callable from the detached debounce task with a captured snapshot.

## Seams (dependency inversion)
`FileManager`, the Application Support directory, the bundle identifier, and the suggestion clock (`now`) are all injected. `BrowserHistoryStore` stays in the app target as the `@MainActor ObservableObject` because it owns `@Published entries` (consumed via `.onReceive($entries)` in `BrowserPanelView` and the `shared` singleton — neither can cross a module boundary). It now holds a `BrowserHistorySuggestionEngine` + `BrowserHistoryFileRepository` and forwards to them. The free `normalizedBrowserHistoryNamespace` and the static `BrowserHistoryStore` URL/namespace helpers forward to the package.

## Byte-identical behavior
Same JSON wire format, same dedup keys, same scoring weights and tie-break ordering, same 120ms debounce, same namespace + legacy-migration paths, same nil edge cases (including the `Bundle.main.bundleIdentifier == nil` legacy-URL path, which still resolves to `nil`). The moved bodies were replaced with thin one-line forwards.

## Packaging
Wired `CmuxBrowserHistory` into `cmux.xcodeproj` with the 6 pbxproj entries mirroring the `CmuxBrowser` sibling, and added it as an app-target dependency. Manifest mirrors `CmuxBrowser` (`swift-tools-version: 6.0`, `.macOS(.v14)`, v6 language mode + ExistentialAny + InternalImportsByDefault). Every public symbol has DocC `///` docs; one major type per file; no free functions, no caseless-enum namespaces, no `lint:allow`.

## Tests
17 Swift Testing unit tests with `FileManager`/clock fakes: Codable legacy/round-trip, namespace + file-URL math, scoring (exact-host outranks substring, single-char prefix gate, non-match nil, typed-frecency lift), tokenization, normalized-key normalization, and repository persist/load/migrate/remove round-trips. `swift build` + `swift test` green in the package; `scripts/lint-ios-package-conventions.sh` prints OK; file-length budget reconciled (13358 -> 13099).

NOTE: the full app build + XCUITests are validated by GitHub CI after push (not run locally).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144018&installation_id=133855650&pr_number=6176&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6176&signature=43d5ad09089c70ea18944bc4c6cb3e3b12aeb63513eb901a442e98fec54df619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted browser history persistence and omnibar scoring into a new leaf package `CmuxBrowserHistory`, keeping behavior and on-disk JSON identical. This trims `BrowserPanel.swift` by ~259 LOC and improves testability.

- **Refactors**
  - Moved: `BrowserHistoryEntry`, `BrowserHistorySuggestionEngine`, `BrowserHistorySuggestionCandidate`, `BrowserHistoryLocation`, `BrowserHistoryFileRepository`.
  - `BrowserHistoryStore.Entry` is now a typealias to `BrowserHistoryEntry`; call sites unchanged.
  - Injected `FileManager`, Application Support dir, bundle identifier, and clock (`now`) for pure logic and I/O seams.
  - `BrowserHistoryStore` stays as `@MainActor ObservableObject` and forwards to the engine/repository.
  - Behavior preserved: same dedup keys, scoring weights/order, 120ms debounce, namespace folding, legacy migration, and edge cases. Persist uses `JSONEncoder(.withoutEscapingSlashes)` with atomic writes.
  - Added focused unit tests for Codable round-trips, namespace/file URL math, scoring, tokenization, normalized keys, and repository load/persist/migrate/remove.

- **Dependencies**
  - Added local Swift package `CmuxBrowserHistory` to the project and app target.
  - Package: swift-tools 6.0, `.macOS(.v14)`, language mode v6 with `ExistentialAny` and `InternalImportsByDefault`.

<sup>Written for commit 96a6143a485a3964e6fc11e61c3525c5458b724a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

