### PR TITLE
Extract Ghostty config-file discovery from GhosttyTerminalView into CmuxGhosttyConfigLoader

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,8 +7,8 @@
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
-12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift
+11691	Sources/GhosttyTerminalView.swift
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7925	Sources/Panels/BrowserPanelView.swift
 7355	cmuxTests/WorkspaceUnitTests.swift
@@ -170,6 +170,7 @@
 568	Packages/CMUXMobileCore/Sources/CMUXMobileCore/MobileTerminalRenderGrid.swift
 566	Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
 562	cmuxTests/AgentExecutableResolverTests.swift
+561	Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyConfigDiscovery.swift
 561	cmuxTests/GhosttyConfigPathResolverTests.swift
 558	Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 554	Sources/Panels/BrowserAutomation.swift

--- a/Packages/CmuxGhosttyConfigLoader/Package.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxGhosttyConfigLoader",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxGhosttyConfigLoader",
+            targets: ["CmuxGhosttyConfigLoader"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../CmuxFoundation"),
+        .package(path: "../CmuxTerminalCore"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxGhosttyConfigLoader",
+            dependencies: [
+                .product(name: "CmuxFoundation", package: "CmuxFoundation"),
+                .product(name: "CmuxTerminalCore", package: "CmuxTerminalCore"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        // Test-only stand-in for the @_silgen_name libghostty symbols bound by
+        // CmuxTerminalCore's GhosttyRuntimeCInterop: SwiftPM cannot link the
+        // GhosttyKit macOS archive (its binary lacks the lib prefix), so the
+        // test runner satisfies the link with a stub. The app links the real
+        // GhosttyKit.
+        .target(
+            name: "GhosttyRuntimeTestStubs",
+            path: "Tests/GhosttyRuntimeTestStubs"
+        ),
+        .testTarget(
+            name: "CmuxGhosttyConfigLoaderTests",
+            dependencies: [
+                "CmuxGhosttyConfigLoader",
+                "GhosttyRuntimeTestStubs",
+                .product(name: "CmuxTerminalCore", package: "CmuxTerminalCore"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyConfigDiscovery.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyConfigDiscovery.swift
@@ -1,0 +1,561 @@
+public import Foundation
+public import CoreText
+public import CmuxTerminalCore
+public import CmuxFoundation
+
+/// Resolves where cmux's Ghostty configuration lives and what it should inject,
+/// without touching the live `ghostty_config_t`. It discovers the ordered
+/// top-level config scan paths, scans those files (following `config-file`
+/// includes) for the font and appearance directives that drive cmux's
+/// managed-default-theme and CJK-fallback decisions, decides whether to load the
+/// legacy `config` file, and computes the conditional-theme override text.
+///
+/// All work is pure with respect to the injected ``GhosttyConfigFileReading``
+/// and ``GhosttyFontProbing`` seams, so the C-API config-load methods that stay
+/// in the app target call these to decide *what* to load, then perform the
+/// actual `ghostty_config_load_*` calls themselves. The type is a value with
+/// injected collaborators (no globals), constructed at the composition root.
+public struct GhosttyConfigDiscovery {
+    /// The release bundle identifier whose Application Support config directory
+    /// is always included in the scan paths, regardless of the running build's
+    /// own identifier.
+    public static let releaseBundleIdentifier = CmuxGhosttyConfigPathResolver.releaseBundleIdentifier
+
+    private let fileReader: any GhosttyConfigFileReading
+    private let fontProbe: any GhosttyFontProbing
+    private let pathResolver: CmuxGhosttyConfigPathResolver
+
+    /// Creates a discovery value with the given filesystem and font seams.
+    ///
+    /// Defaults reproduce the app's prior behavior exactly: a
+    /// `FileManager.default`-backed reader and a CoreText-backed font probe.
+    public init(
+        fileReader: any GhosttyConfigFileReading = FileManagerGhosttyConfigFileReader(),
+        fontProbe: any GhosttyFontProbing = CoreTextGhosttyFontProbe(),
+        pathResolver: CmuxGhosttyConfigPathResolver = CmuxGhosttyConfigPathResolver()
+    ) {
+        self.fileReader = fileReader
+        self.fontProbe = fontProbe
+        self.pathResolver = pathResolver
+    }
+
+    // MARK: - CJK font fallback ranges
+
+    /// Unicode ranges shared by all CJK languages (Han ideographs, symbols,
+    /// fullwidth forms).
+    public static let sharedCJKRanges = [
+        "U+3000-U+303F",  // CJK Symbols and Punctuation
+        "U+4E00-U+9FFF",  // CJK Unified Ideographs
+        "U+F900-U+FAFF",  // CJK Compatibility Ideographs
+        "U+FF00-U+FFEF",  // Halfwidth and Fullwidth Forms
+        "U+3400-U+4DBF",  // CJK Unified Ideographs Extension A
+    ]
+
+    /// Unicode ranges specific to Japanese (kana).
+    public static let japaneseRanges = [
+        "U+3040-U+309F",  // Hiragana
+        "U+30A0-U+30FF",  // Katakana
+    ]
+
+    /// Representative scalars used to detect whether the configured primary font
+    /// already covers the ranges cmux would otherwise auto-map.
+    public static let cjkCoverageSampleCharactersByRange: [String: [UniChar]] = [
+        "U+3000-U+303F": [0x3001, 0x300C],
+        "U+4E00-U+9FFF": [0x4E00, 0x65E5, 0x6C34],
+        "U+F900-U+FAFF": [0xF900],
+        "U+FF00-U+FFEF": [0xFF10, 0xFF21],
+        "U+3400-U+4DBF": [0x3400],
+        "U+1100-U+11FF": [0x1100, 0x1161],
+        "U+3130-U+318F": [0x3131, 0x314F],
+        "U+3040-U+309F": [0x3042, 0x3093],
+        "U+30A0-U+30FF": [0x30A2, 0x30F3],
+        "U+AC00-U+D7AF": [0xAC00, 0xD55C],
+    ]
+
+    // MARK: - CJK font mappings
+
+    /// Returns `(range, font)` pairs for CJK font fallback based on the system's
+    /// preferred languages, or `nil` if no CJK language is detected. Each
+    /// language only maps its own script ranges to avoid assigning glyphs to a
+    /// font that lacks coverage (e.g. Hangul to Hiragino Sans).
+    public func cjkFontMappings(
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) -> [(String, String)]? {
+        var mappings: [(String, String)] = []
+        var coveredShared = false
+
+        for lang in preferredLanguages {
+            let lower = lang.lowercased()
+            let font: String
+            var langRanges: [String] = []
+
+            if lower.hasPrefix("ja") {
+                font = "Hiragino Sans"
+                langRanges = Self.japaneseRanges
+            } else if lower.hasPrefix("zh-hant") || lower.hasPrefix("zh-tw") || lower.hasPrefix("zh-hk") {
+                font = "PingFang TC"
+            } else if lower.hasPrefix("zh") {
+                font = "PingFang SC"
+            } else {
+                continue
+            }
+
+            if !coveredShared {
+                for range in Self.sharedCJKRanges {
+                    mappings.append((range, font))
+                }
+                coveredShared = true
+            }
+
+            for range in langRanges {
+                mappings.append((range, font))
+            }
+        }
+
+        return mappings.isEmpty ? nil : mappings
+    }
+
+    /// Returns only the CJK mappings cmux should auto-inject after respecting
+    /// explicit user overrides and the glyph coverage of the configured primary
+    /// font family.
+    public func autoInjectedCJKFontMappings(
+        preferredLanguages: [String] = Locale.preferredLanguages,
+        configPaths: [String]? = nil,
+        rangeCoverageProbe: ((String, String) -> Bool)? = nil
+    ) -> [(String, String)]? {
+        let configPaths = configPaths ?? loadedCJKScanPaths()
+        guard var mappings = cjkFontMappings(preferredLanguages: preferredLanguages) else { return nil }
+
+        let summary = userFontConfigSummary(configPaths: configPaths)
+        if summary.containsCodepointMap || summary.hasExplicitFontFamilyFallbackChain {
+            return nil
+        }
+
+        guard let configuredFontFamily = summary.effectiveFontFamilies.first else {
+            return mappings
+        }
+
+        if let rangeCoverageProbe {
+            mappings.removeAll { range, _ in
+                rangeCoverageProbe(configuredFontFamily, range)
+            }
+        } else if let configuredFont = fontProbe.configuredFont(named: configuredFontFamily, size: 12) {
+            mappings.removeAll { range, _ in
+                Self.fontContainsGlyphs(configuredFont, forRange: range)
+            }
+        }
+
+        return mappings.isEmpty ? nil : mappings
+    }
+
+    /// Whether the user's Ghostty config files already contain a
+    /// `font-codepoint-map` entry covering CJK ranges, following
+    /// application-support config paths cmux may load at runtime.
+    public func userConfigContainsCJKCodepointMap(
+        configPaths: [String]? = nil
+    ) -> Bool {
+        let configPaths = configPaths ?? loadedGhosttyConfigScanPaths()
+        return userFontConfigSummary(configPaths: configPaths).containsCodepointMap
+    }
+
+    /// Whether the user provided an explicit multi-entry `font-family` fallback
+    /// chain across the resolved config paths.
+    public func userConfigHasExplicitFontFamilyFallbackChain(
+        configPaths: [String]? = nil
+    ) -> Bool {
+        let configPaths = configPaths ?? loadedGhosttyConfigScanPaths()
+        return userFontConfigSummary(configPaths: configPaths).hasExplicitFontFamilyFallbackChain
+    }
+
+    /// Whether cmux should inject its managed CJK `font-codepoint-map` fallback.
+    public func shouldInjectCJKFontFallback(
+        preferredLanguages: [String] = Locale.preferredLanguages,
+        configPaths: [String]? = nil,
+        rangeCoverageProbe: ((String, String) -> Bool)? = nil
+    ) -> Bool {
+        let configPaths = configPaths ?? loadedCJKScanPaths()
+        return autoInjectedCJKFontMappings(
+            preferredLanguages: preferredLanguages,
+            configPaths: configPaths,
+            rangeCoverageProbe: rangeCoverageProbe
+        ) != nil
+    }
+
+    /// Whether cmux should apply its managed default appearance across the
+    /// resolved config paths (delegates to ``GhosttyConfig``).
+    public func shouldApplyManagedDefaultAppearance(
+        configPaths: [String]? = nil
+    ) -> Bool {
+        let configPaths = configPaths ?? loadedGhosttyConfigScanPaths()
+        return GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: configPaths)
+    }
+
+    /// Computes the resolved plain-theme override cmux must inject when the
+    /// user's last `theme` directive uses Ghostty's conditional
+    /// `light:…`/`dark:…` syntax, returning `nil` when no override is needed.
+    public func conditionalThemeOverrideConfigContents(
+        preferredColorScheme: GhosttyConfig.ColorSchemePreference,
+        configPaths: [String]? = nil
+    ) -> String? {
+        let configPaths = configPaths ?? loadedGhosttyConfigScanPaths()
+        let summary = GhosttyConfig.userAppearanceConfigSummary(configPaths: configPaths)
+        guard let rawThemeValue = summary.lastThemeDirective else { return nil }
+
+        // Inject a resolved plain theme whenever the requested appearance side is
+        // explicitly named via ghostty's conditional `light:...`/`dark:...`
+        // syntax, even when both sides resolve to the same theme. `cmux themes
+        // set` always encodes the selection with this syntax (a single theme
+        // becomes `light:X,dark:X`), and ghostty mis-applies the conditional form
+        // — the background lands but the foreground/palette stay at the default
+        // white colors, producing the white-on-light terminals reported in
+        // https://github.com/manaflow-ai/cmux/issues/3459. Only override sides the
+        // value explicitly specifies: a one-sided `light:X` must not force the
+        // light theme onto dark appearances (which would clobber the inherited or
+        // default dark theme). Plain (non-conditional) theme values are applied
+        // correctly by ghostty, so they need no override.
+        guard let explicitTheme = GhosttyConfig.explicitConditionalThemeName(
+            from: rawThemeValue,
+            preferredColorScheme: preferredColorScheme
+        ) else {
+            return nil
+        }
+
+        let resolvedTheme = explicitTheme.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !resolvedTheme.isEmpty,
+              resolvedTheme.rangeOfCharacter(from: .newlines) == nil else {
+            return nil
+        }
+
+        return "theme = \(resolvedTheme)"
+    }
+
+    // MARK: - Font resolution
+
+    /// Resolves auto-injected CJK families through the regular-weight descriptor
+    /// path first so locale-sensitive families such as Hiragino Sans don't fall
+    /// back to ultra-light faces like W0 when Ghostty later matches by name.
+    public func resolvedInjectedCJKFontName(
+        named name: String,
+        size: CGFloat = 12
+    ) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return name }
+        guard let regularWeightFont = fontProbe.discoveredFont(named: trimmed, size: size, weightTrait: 0.0) else {
+            return trimmed
+        }
+
+        let candidateNames = [
+            CTFontCopyName(regularWeightFont, kCTFontFullNameKey) as String?,
+            CTFontCopyName(regularWeightFont, kCTFontPostScriptNameKey) as String?,
+        ].compactMap { $0 }
+        let expectedFullName = CTFontCopyFullName(regularWeightFont) as String
+        let expectedPostScriptName = CTFontCopyPostScriptName(regularWeightFont) as String
+
+        for candidate in candidateNames {
+            guard let verifiedFont = fontProbe.discoveredFont(named: candidate, size: size, weightTrait: nil) else { continue }
+            let verifiedNames = [
+                CTFontCopyName(verifiedFont, kCTFontFamilyNameKey) as String?,
+                CTFontCopyName(verifiedFont, kCTFontFullNameKey) as String?,
+                CTFontCopyName(verifiedFont, kCTFontPostScriptNameKey) as String?,
+            ].compactMap { $0 }
+            let matchesRegularWeightFace = verifiedNames.contains {
+                Self.normalizedFontName($0) == Self.normalizedFontName(expectedFullName) ||
+                Self.normalizedFontName($0) == Self.normalizedFontName(expectedPostScriptName)
+            }
+            if matchesRegularWeightFace {
+                return candidate
+            }
+        }
+
+        return trimmed
+    }
+
+    /// Resolves a font by family name through the injected probe, mirroring
+    /// Ghostty's CoreText family-name discovery path.
+    public func discoveredFont(
+        named name: String,
+        size: CGFloat = 12,
+        weightTrait: CGFloat? = nil
+    ) -> CTFont? {
+        fontProbe.discoveredFont(named: name, size: size, weightTrait: weightTrait)
+    }
+
+    static func fontContainsGlyphs(
+        _ font: CTFont,
+        forRange range: String
+    ) -> Bool {
+        guard let characters = cjkCoverageSampleCharactersByRange[range] else {
+            return false
+        }
+
+        var glyphs = Array(repeating: CGGlyph(), count: characters.count)
+        let hasGlyphs = CTFontGetGlyphsForCharacters(font, characters, &glyphs, characters.count)
+        return hasGlyphs && !glyphs.contains(0)
+    }
+
+    static func normalizedFontName(_ name: String) -> String {
+        name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .folding(options: [.diacriticInsensitive, .widthInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased()
+    }
+
+    // MARK: - Config file scanning
+
+    /// Scans the resolved config files (following `config-file` includes) and
+    /// summarizes the font directives relevant to cmux's injected CJK fallback.
+    public func userFontConfigSummary(
+        configPaths: [String]? = nil
+    ) -> UserFontConfigSummary {
+        let configPaths = configPaths ?? loadedCJKScanPaths()
+        var summary = UserFontConfigSummary()
+        var recursiveConfigPaths: [String] = []
+
+        for path in configPaths.map({ NSString(string: $0).expandingTildeInPath }) {
+            scanFontConfigFile(
+                atPath: path,
+                summary: &summary,
+                recursiveConfigPaths: &recursiveConfigPaths
+            )
+        }
+
+        var loadedRecursivePaths = Set<String>()
+        while !recursiveConfigPaths.isEmpty {
+            let path = recursiveConfigPaths.removeFirst()
+            let resolved = (path as NSString).standardizingPath
+            guard !loadedRecursivePaths.contains(resolved) else { continue }
+            loadedRecursivePaths.insert(resolved)
+
+            scanFontConfigFile(
+                atPath: path,
+                summary: &summary,
+                recursiveConfigPaths: &recursiveConfigPaths
+            )
+        }
+
+        return summary
+    }
+
+    private func scanFontConfigFile(
+        atPath path: String,
+        summary: inout UserFontConfigSummary,
+        recursiveConfigPaths: inout [String]
+    ) {
+        let resolved = (path as NSString).standardizingPath
+        guard let contents = fileReader.contents(atPath: resolved) else {
+            return
+        }
+        let parentDir = (resolved as NSString).deletingLastPathComponent
+
+        for line in contents.components(separatedBy: .newlines) {
+            guard let entry = Self.parsedConfigEntry(from: line) else { continue }
+
+            switch entry.key {
+            case "font-codepoint-map":
+                guard let value = entry.value else { continue }
+                summary.applyFontCodepointMap(value)
+            case "font-family":
+                guard let value = entry.value else { continue }
+                summary.recordFontFamily(value)
+            case "config-file":
+                guard let value = entry.value else { continue }
+                Self.applyConfigFileDirective(
+                    value,
+                    valueWasQuoted: entry.valueWasQuoted,
+                    parentDir: parentDir,
+                    recursiveConfigPaths: &recursiveConfigPaths
+                )
+            default:
+                continue
+            }
+        }
+    }
+
+    static func parsedConfigEntry(
+        from rawLine: String
+    ) -> (key: String, value: String?, valueWasQuoted: Bool)? {
+        var trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("\u{FEFF}") {
+            trimmed.removeFirst()
+        }
+        if trimmed.isEmpty || trimmed.hasPrefix("#") { return nil }
+
+        guard let separatorIndex = trimmed.firstIndex(of: "=") else {
+            return (trimmed.trimmingCharacters(in: .whitespacesAndNewlines), nil, false)
+        }
+
+        let key = trimmed[..<separatorIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+        var value = trimmed[trimmed.index(after: separatorIndex)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let valueWasQuoted = value.count >= 2 && value.hasPrefix("\"") && value.hasSuffix("\"")
+
+        if valueWasQuoted {
+            value.removeFirst()
+            value.removeLast()
+        }
+
+        return (String(key), String(value), valueWasQuoted)
+    }
+
+    static func applyConfigFileDirective(
+        _ value: String,
+        valueWasQuoted: Bool,
+        parentDir: String,
+        recursiveConfigPaths: inout [String]
+    ) {
+        if value.isEmpty {
+            recursiveConfigPaths.removeAll()
+            return
+        }
+
+        var includePath = value
+        if !valueWasQuoted, includePath.hasPrefix("?") {
+            includePath.removeFirst()
+            if includePath.count >= 2,
+               includePath.hasPrefix("\""),
+               includePath.hasSuffix("\"") {
+                includePath.removeFirst()
+                includePath.removeLast()
+            }
+        }
+        guard !includePath.isEmpty else { return }
+
+        let expanded = NSString(string: includePath).expandingTildeInPath
+        let absolute = (expanded as NSString).isAbsolutePath
+            ? expanded
+            : (parentDir as NSString).appendingPathComponent(expanded)
+        recursiveConfigPaths.append(absolute)
+    }
+
+    // MARK: - Scan paths and legacy config
+
+    /// Returns the top-level Ghostty config paths cmux may load before recursive
+    /// `config-file` processing, including native Ghostty, legacy, and cmux
+    /// Application Support locations.
+    public func loadedGhosttyConfigScanPaths(
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> [String] {
+        var paths = [
+            "~/.config/ghostty/config",
+            "~/.config/ghostty/config.ghostty",
+        ]
+
+        guard let appSupportDirectory else { return paths }
+
+        let ghosttyDir = appSupportDirectory.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+        let nativeLegacyConfig = ghosttyDir.appendingPathComponent("config", isDirectory: false)
+        let nativeConfig = ghosttyDir.appendingPathComponent("config.ghostty", isDirectory: false)
+        paths.append(nativeConfig.path)
+        if Self.shouldIncludeLegacyGhosttyConfigInScanPaths(
+            newConfigFileSize: fileReader.fileSize(atPath: nativeConfig.path),
+            legacyConfigFileSize: fileReader.fileSize(atPath: nativeLegacyConfig.path)
+        ) {
+            paths.append(nativeLegacyConfig.path)
+        }
+
+        guard let bundleId = currentBundleIdentifier,
+              !bundleId.isEmpty else { return paths }
+
+        let appSupportConfigURLs = cmuxAppSupportConfigURLs(
+            currentBundleIdentifier: bundleId,
+            appSupportDirectory: appSupportDirectory
+        )
+        paths.append(contentsOf: appSupportConfigURLs.map(\.path))
+
+        let releaseDir = appSupportDirectory.appendingPathComponent(Self.releaseBundleIdentifier, isDirectory: true)
+        let releaseLegacyConfig = releaseDir.appendingPathComponent("config", isDirectory: false)
+        let releaseConfig = releaseDir.appendingPathComponent("config.ghostty", isDirectory: false)
+
+        let releaseConfigSize = fileReader.fileSize(atPath: releaseConfig.path)
+        let releaseLegacyConfigSize = fileReader.fileSize(atPath: releaseLegacyConfig.path)
+
+        if Self.shouldIncludeLegacyGhosttyConfigInScanPaths(
+            newConfigFileSize: releaseConfigSize,
+            legacyConfigFileSize: releaseLegacyConfigSize
+        ), !paths.contains(releaseLegacyConfig.path) {
+            paths.append(releaseLegacyConfig.path)
+        }
+
+        return paths
+    }
+
+    /// The config paths scanned for CJK font directives (identical to
+    /// ``loadedGhosttyConfigScanPaths(currentBundleIdentifier:appSupportDirectory:)``).
+    public func loadedCJKScanPaths(
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> [String] {
+        loadedGhosttyConfigScanPaths(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        )
+    }
+
+    /// Whether cmux should load the legacy `config` file because the new
+    /// `config.ghostty` is empty (size 0). Only true when the legacy file is
+    /// non-empty and the new file is exactly empty.
+    public static func shouldLoadLegacyGhosttyConfig(
+        newConfigFileSize: Int?,
+        legacyConfigFileSize: Int?
+    ) -> Bool {
+        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
+        return newConfigFileSize == 0
+    }
+
+    /// Whether the legacy `config` path should be included in the scan paths:
+    /// true when the legacy file is non-empty and the new file is absent or
+    /// empty.
+    public static func shouldIncludeLegacyGhosttyConfigInScanPaths(
+        newConfigFileSize: Int?,
+        legacyConfigFileSize: Int?
+    ) -> Bool {
+        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
+        guard let newConfigFileSize else { return true }
+        return newConfigFileSize == 0
+    }
+
+    /// Whether the native Ghostty legacy baseline should be ignored when
+    /// resolving unparsed appearance: true only when both the native legacy and
+    /// native new config files are present and non-empty.
+    public func shouldIgnoreNativeLegacyBaselineForUnparsedAppearance(
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> Bool {
+        guard let appSupportDirectory else { return false }
+        let ghosttyDir = appSupportDirectory.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
+        let nativeLegacyConfig = ghosttyDir.appendingPathComponent("config", isDirectory: false)
+        let nativeConfig = ghosttyDir.appendingPathComponent("config.ghostty", isDirectory: false)
+        guard let legacyConfigSize = fileReader.fileSize(atPath: nativeLegacyConfig.path), legacyConfigSize > 0 else {
+            return false
+        }
+        guard let nativeConfigSize = fileReader.fileSize(atPath: nativeConfig.path), nativeConfigSize > 0 else {
+            return false
+        }
+        return true
+    }
+
+    /// Resolves the cmux Application Support Ghostty config file URLs for the
+    /// running build, via the shared ``CmuxGhosttyConfigPathResolver``.
+    public func cmuxAppSupportConfigURLs(
+        currentBundleIdentifier: String?,
+        appSupportDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        pathResolver.loadConfigURLs(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        )
+    }
+}

--- a/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyConfigFileReading.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyConfigFileReading.swift
@@ -1,0 +1,46 @@
+public import Foundation
+
+/// Filesystem seam used by ``GhosttyConfigDiscovery`` for every config-file read
+/// it performs while resolving Ghostty config scan paths and scanning their
+/// contents. Injecting this inverts the `FileManager.default` /
+/// `String(contentsOfFile:)` globals the discovery logic used to reach for
+/// directly, so tests can drive it against fixtures without touching the real
+/// home directory.
+///
+/// The discovery logic runs synchronously on the launch path (inside the
+/// Ghostty C-API config-load sequence) and on the test thread, so this seam is
+/// intentionally not `Sendable`: it never crosses an actor or task boundary.
+public protocol GhosttyConfigFileReading {
+    /// Returns the byte size of the file at `path`, or `nil` when it does not
+    /// exist or its attributes cannot be read.
+    func fileSize(atPath path: String) -> Int?
+
+    /// Returns the UTF-8 contents of the file at `path`, or `nil` when it cannot
+    /// be read.
+    func contents(atPath path: String) -> String?
+}
+
+/// Default ``GhosttyConfigFileReading`` conformer backed by a `FileManager`.
+///
+/// Reads file sizes through `FileManager.attributesOfItem(atPath:)` and file
+/// contents through `String(contentsOfFile:encoding:)`, byte-identical to the
+/// inline reads the discovery logic previously performed in the app target.
+public struct FileManagerGhosttyConfigFileReader: GhosttyConfigFileReading {
+    private let fileManager: FileManager
+
+    /// Creates a reader backed by the given `FileManager` (defaults to
+    /// `FileManager.default`).
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    public func fileSize(atPath path: String) -> Int? {
+        guard let attrs = try? fileManager.attributesOfItem(atPath: path),
+              let size = attrs[.size] as? NSNumber else { return nil }
+        return size.intValue
+    }
+
+    public func contents(atPath path: String) -> String? {
+        try? String(contentsOfFile: path, encoding: .utf8)
+    }
+}

--- a/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyFontProbing.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/GhosttyFontProbing.swift
@@ -1,0 +1,71 @@
+public import CoreText
+
+/// Font-resolution seam used by ``GhosttyConfigDiscovery`` to mirror Ghostty's
+/// CoreText family-name discovery when validating and resolving the CJK
+/// `font-codepoint-map` fallback it auto-injects.
+///
+/// Injecting this inverts the direct CoreText `CTFont*` global calls the
+/// discovery logic used to perform, so tests can supply deterministic font
+/// answers instead of depending on the installed system fonts.
+public protocol GhosttyFontProbing {
+    /// Resolves a font by family name and optional weight trait, mirroring
+    /// Ghostty's `CTFontCollection` family-name discovery path. Returns `nil`
+    /// when no matching family is found.
+    func discoveredFont(named name: String, size: CGFloat, weightTrait: CGFloat?) -> CTFont?
+
+    /// Returns a `CTFont` for `name` only when one of its resolved family,
+    /// full, or PostScript names matches the requested name (normalized);
+    /// otherwise `nil`.
+    func configuredFont(named name: String, size: CGFloat) -> CTFont?
+}
+
+/// Default ``GhosttyFontProbing`` conformer backed by CoreText.
+///
+/// Performs the exact `CTFontDescriptor` / `CTFontCollection` / `CTFontCopyName`
+/// lookups the discovery logic previously inlined, so injected CJK font names
+/// resolve identically to the app's prior behavior.
+public struct CoreTextGhosttyFontProbe: GhosttyFontProbing {
+    /// Creates a CoreText-backed font probe.
+    public init() {}
+
+    public func discoveredFont(named name: String, size: CGFloat, weightTrait: CGFloat?) -> CTFont? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var attributes: [CFString: Any] = [
+            kCTFontFamilyNameAttribute: trimmed,
+            kCTFontSizeAttribute: size,
+        ]
+        if let weightTrait {
+            attributes[kCTFontTraitsAttribute] = [
+                kCTFontWeightTrait: weightTrait,
+            ] as CFDictionary
+        }
+
+        let descriptor = CTFontDescriptorCreateWithAttributes(attributes as CFDictionary)
+        let collection = CTFontCollectionCreateWithFontDescriptors([descriptor] as CFArray, nil)
+        guard let match = (CTFontCollectionCreateMatchingFontDescriptors(collection) as? [CTFontDescriptor])?.first else {
+            return nil
+        }
+        return CTFontCreateWithFontDescriptor(match, size, nil)
+    }
+
+    public func configuredFont(named name: String, size: CGFloat) -> CTFont? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let font = CTFontCreateWithName(trimmed as CFString, size, nil)
+        let normalizedRequestedName = GhosttyConfigDiscovery.normalizedFontName(trimmed)
+        let resolvedNames = [
+            kCTFontFamilyNameKey,
+            kCTFontFullNameKey,
+            kCTFontPostScriptNameKey,
+        ].compactMap { CTFontCopyName(font, $0) as String? }
+
+        guard resolvedNames.contains(where: { GhosttyConfigDiscovery.normalizedFontName($0) == normalizedRequestedName }) else {
+            return nil
+        }
+
+        return font
+    }
+}

--- a/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/UserFontConfigSummary.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Sources/CmuxGhosttyConfigLoader/UserFontConfigSummary.swift
@@ -1,0 +1,53 @@
+/// Aggregated view of the font-related directives found while scanning a user's
+/// Ghostty config files, used by ``GhosttyConfigDiscovery`` to decide whether to
+/// auto-inject a CJK `font-codepoint-map` fallback.
+public struct UserFontConfigSummary: Equatable, Sendable {
+    /// Whether any non-empty `font-codepoint-map` directive was seen.
+    public var containsCodepointMap = false
+    /// The ordered, de-duplicated list of effective `font-family` values; an
+    /// empty `font-family` clears the accumulated list (Ghostty reset
+    /// semantics).
+    public var effectiveFontFamilies: [String] = []
+
+    /// Creates an empty summary.
+    public init() {}
+
+    /// Whether the user provided an explicit multi-entry `font-family` fallback
+    /// chain (more than one effective family), which suppresses cmux's injected
+    /// CJK fallback.
+    public var hasExplicitFontFamilyFallbackChain: Bool {
+        effectiveFontFamilies.count > 1
+    }
+
+    /// Records a `font-codepoint-map` directive value, clearing the flag on an
+    /// empty value and otherwise setting it only when the value contains a
+    /// range/font separator.
+    public mutating func applyFontCodepointMap(_ value: String) {
+        if value.isEmpty {
+            containsCodepointMap = false
+            return
+        }
+
+        guard value.contains("=") else {
+            return
+        }
+
+        containsCodepointMap = true
+    }
+
+    /// Records a `font-family` directive value, resetting the accumulated list
+    /// on an empty value and otherwise appending the value when not already
+    /// present.
+    public mutating func recordFontFamily(_ value: String) {
+        if value.isEmpty {
+            effectiveFontFamilies.removeAll()
+            return
+        }
+
+        guard !effectiveFontFamilies.contains(value) else {
+            return
+        }
+
+        effectiveFontFamilies.append(value)
+    }
+}

--- a/Packages/CmuxGhosttyConfigLoader/Tests/CmuxGhosttyConfigLoaderTests/GhosttyConfigDiscoveryTests.swift
+++ b/Packages/CmuxGhosttyConfigLoader/Tests/CmuxGhosttyConfigLoaderTests/GhosttyConfigDiscoveryTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import CoreText
+import Testing
+import CmuxTerminalCore
+@testable import CmuxGhosttyConfigLoader
+
+/// In-memory ``GhosttyConfigFileReading`` fake driven by a path -> contents map.
+private struct FakeFileReader: GhosttyConfigFileReading {
+    var contentsByPath: [String: String] = [:]
+
+    func fileSize(atPath path: String) -> Int? {
+        guard let contents = contentsByPath[path] else { return nil }
+        return contents.lengthOfBytes(using: .utf8)
+    }
+
+    func contents(atPath path: String) -> String? {
+        contentsByPath[path]
+    }
+}
+
+/// Font probe fake that resolves nothing, so coverage filtering is bypassed.
+private struct NoFontProbe: GhosttyFontProbing {
+    func discoveredFont(named _: String, size _: CGFloat, weightTrait _: CGFloat?) -> CTFont? { nil }
+    func configuredFont(named _: String, size _: CGFloat) -> CTFont? { nil }
+}
+
+@Suite struct GhosttyConfigDiscoveryCJKTests {
+    private let discovery = GhosttyConfigDiscovery(fileReader: FakeFileReader(), fontProbe: NoFontProbe())
+
+    @Test func japaneseMapsKanaAndSharedRanges() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["ja-JP", "en-US"]))
+        let fonts = Set(mappings.map(\.1))
+        #expect(fonts == ["Hiragino Sans"])
+        let ranges = Set(mappings.map(\.0))
+        #expect(ranges.isSuperset(of: GhosttyConfigDiscovery.sharedCJKRanges))
+        #expect(ranges.isSuperset(of: GhosttyConfigDiscovery.japaneseRanges))
+    }
+
+    @Test func koreanOnlyYieldsNoMappings() {
+        #expect(discovery.cjkFontMappings(preferredLanguages: ["ko-KR"]) == nil)
+    }
+
+    @Test func traditionalChineseUsesPingFangTC() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["zh-Hant-TW"]))
+        #expect(Set(mappings.map(\.1)) == ["PingFang TC"])
+    }
+
+    @Test func simplifiedChineseUsesPingFangSC() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["zh-Hans-CN"]))
+        #expect(Set(mappings.map(\.1)) == ["PingFang SC"])
+    }
+
+    @Test func sharedRangesCoveredOnlyOnceByFirstLanguage() throws {
+        let mappings = try #require(discovery.cjkFontMappings(preferredLanguages: ["ja-JP", "zh-Hans-CN"]))
+        let sharedForJa = mappings.filter { GhosttyConfigDiscovery.sharedCJKRanges.contains($0.0) }
+        #expect(sharedForJa.allSatisfy { $0.1 == "Hiragino Sans" })
+    }
+}
+
+@Suite struct GhosttyConfigDiscoveryFontSummaryTests {
+    @Test func detectsCodepointMapDirective() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [path: "font-codepoint-map = U+4E00-U+9FFF=Foo"])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(discovery.userConfigContainsCJKCodepointMap(configPaths: [path]))
+    }
+
+    @Test func emptyCodepointMapClearsFlag() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [
+            path: "font-codepoint-map = U+4E00=Foo\nfont-codepoint-map = ",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(!discovery.userConfigContainsCJKCodepointMap(configPaths: [path]))
+    }
+
+    @Test func multipleFontFamiliesAreExplicitFallbackChain() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [
+            path: "font-family = JetBrains Mono\nfont-family = Hiragino Sans",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(discovery.userConfigHasExplicitFontFamilyFallbackChain(configPaths: [path]))
+    }
+
+    @Test func emptyFontFamilyResetsChain() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [
+            path: "font-family = A\nfont-family = B\nfont-family = \nfont-family = C",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(!discovery.userConfigHasExplicitFontFamilyFallbackChain(configPaths: [path]))
+    }
+
+    @Test func commentsAndBlankLinesIgnored() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [
+            path: "# comment\n\n  # font-codepoint-map = ignored\nfont-family = Mono",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        let summary = discovery.userFontConfigSummary(configPaths: [path])
+        #expect(!summary.containsCodepointMap)
+        #expect(summary.effectiveFontFamilies == ["Mono"])
+    }
+
+    @Test func followsConfigFileIncludeRelativeToParent() {
+        let main = "/cfg/config"
+        let included = "/cfg/extra.conf"
+        let reader = FakeFileReader(contentsByPath: [
+            main: "config-file = extra.conf",
+            included: "font-codepoint-map = U+4E00=Foo",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(discovery.userConfigContainsCJKCodepointMap(configPaths: [main]))
+    }
+}
+
+@Suite struct GhosttyConfigDiscoveryLegacyTests {
+    @Test func loadLegacyOnlyWhenNewIsEmptyAndLegacyNonEmpty() {
+        #expect(GhosttyConfigDiscovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 0, legacyConfigFileSize: 10))
+        #expect(!GhosttyConfigDiscovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 5, legacyConfigFileSize: 10))
+        #expect(!GhosttyConfigDiscovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: 0, legacyConfigFileSize: 0))
+        #expect(!GhosttyConfigDiscovery.shouldLoadLegacyGhosttyConfig(newConfigFileSize: nil, legacyConfigFileSize: 10))
+    }
+
+    @Test func includeLegacyInScanPathsWhenNewMissingOrEmpty() {
+        #expect(GhosttyConfigDiscovery.shouldIncludeLegacyGhosttyConfigInScanPaths(newConfigFileSize: nil, legacyConfigFileSize: 10))
+        #expect(GhosttyConfigDiscovery.shouldIncludeLegacyGhosttyConfigInScanPaths(newConfigFileSize: 0, legacyConfigFileSize: 10))
+        #expect(!GhosttyConfigDiscovery.shouldIncludeLegacyGhosttyConfigInScanPaths(newConfigFileSize: 5, legacyConfigFileSize: 10))
+        #expect(!GhosttyConfigDiscovery.shouldIncludeLegacyGhosttyConfigInScanPaths(newConfigFileSize: 0, legacyConfigFileSize: 0))
+    }
+}
+
+@Suite struct GhosttyConfigDiscoveryScanPathsTests {
+    @Test func scanPathsIncludeNativeAndUserConfigLocations() throws {
+        let appSupport = URL(fileURLWithPath: "/AppSupport", isDirectory: true)
+        let reader = FakeFileReader()
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        let paths = discovery.loadedGhosttyConfigScanPaths(
+            currentBundleIdentifier: "com.cmuxterm.app",
+            appSupportDirectory: appSupport
+        )
+        #expect(paths.contains("~/.config/ghostty/config"))
+        #expect(paths.contains("~/.config/ghostty/config.ghostty"))
+        #expect(paths.contains("/AppSupport/com.mitchellh.ghostty/config.ghostty"))
+    }
+
+    @Test func nativeLegacyIncludedWhenNewEmpty() {
+        let appSupport = URL(fileURLWithPath: "/AppSupport", isDirectory: true)
+        let reader = FakeFileReader(contentsByPath: [
+            "/AppSupport/com.mitchellh.ghostty/config": "theme = foo",
+            "/AppSupport/com.mitchellh.ghostty/config.ghostty": "",
+        ])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        let paths = discovery.loadedGhosttyConfigScanPaths(
+            currentBundleIdentifier: "com.cmuxterm.app",
+            appSupportDirectory: appSupport
+        )
+        #expect(paths.contains("/AppSupport/com.mitchellh.ghostty/config"))
+    }
+}
+
+@Suite struct GhosttyConfigDiscoveryThemeOverrideTests {
+    @Test func nonConditionalThemeNeedsNoOverride() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [path: "theme = Dracula"])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(discovery.conditionalThemeOverrideConfigContents(
+            preferredColorScheme: .dark,
+            configPaths: [path]
+        ) == nil)
+    }
+
+    @Test func noThemeDirectiveYieldsNil() {
+        let path = "/cfg/config"
+        let reader = FakeFileReader(contentsByPath: [path: "font-family = Mono"])
+        let discovery = GhosttyConfigDiscovery(fileReader: reader, fontProbe: NoFontProbe())
+        #expect(discovery.conditionalThemeOverrideConfigContents(
+            preferredColorScheme: .dark,
+            configPaths: [path]
+        ) == nil)
+    }
+}

--- a/Packages/CmuxGhosttyConfigLoader/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/CmuxGhosttyConfigLoader/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -1,0 +1,11 @@
+#include "include/GhosttyRuntimeTestStubs.h"
+
+bool ghostty_surface_clear_selection(void *surface) {
+    (void)surface;
+    return false;
+}
+
+void *ghostty_surface_quicklook_font(void *surface) {
+    (void)surface;
+    return 0;
+}

--- a/Packages/CmuxGhosttyConfigLoader/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/CmuxGhosttyConfigLoader/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -1,0 +1,16 @@
+#ifndef GHOSTTY_RUNTIME_TEST_STUBS_H
+#define GHOSTTY_RUNTIME_TEST_STUBS_H
+
+#include <stdbool.h>
+
+// Test-only stand-in for the libghostty symbol bound by @_silgen_name in
+// GhosttyRuntimeCInterop. SwiftPM cannot link the GhosttyKit macOS archive
+// (its binary is not lib-prefixed), so the test runner provides this stub to
+// satisfy the link; no test calls it.
+bool ghostty_surface_clear_selection(void *surface);
+
+// Test-only stand-in for the GhosttyKit symbol referenced by
+// GhosttySurfaceRuntimeProbe.currentSurfaceFontSizePoints; no test calls it.
+void *ghostty_surface_quicklook_font(void *surface);
+
+#endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4,6 +4,7 @@ import CmuxFoundation
 import CmuxPanes
 import CmuxTerminalCore
 import CmuxTerminalEngine
+import CmuxGhosttyConfigLoader
 import CmuxTerminalServices
 import CmuxTerminalCopyMode
 import CmuxSocketControl
@@ -416,6 +417,11 @@ class GhosttyApp {
     )
 
     private static let releaseBundleIdentifier = "com.cmuxterm.app"
+    /// Shared config-file discovery seam. Resolves Ghostty config scan paths,
+    /// scans them for font/appearance directives, and decides legacy/CJK/theme
+    /// overrides. The C-API config-load methods below call it to decide *what*
+    /// to load; it performs no `ghostty_config_t` mutation itself.
+    private static let configDiscovery = GhosttyConfigDiscovery()
     private static let fallbackAppearanceConfig = GhosttyConfig()
     private static let initializationLogger = Logger(
         subsystem: releaseBundleIdentifier,
@@ -1333,356 +1339,91 @@ class GhosttyApp {
         )
     }
 
-    /// Unicode ranges shared by all CJK languages (Han ideographs, symbols, fullwidth forms).
-    private static let sharedCJKRanges = [
-        "U+3000-U+303F",  // CJK Symbols and Punctuation
-        "U+4E00-U+9FFF",  // CJK Unified Ideographs
-        "U+F900-U+FAFF",  // CJK Compatibility Ideographs
-        "U+FF00-U+FFEF",  // Halfwidth and Fullwidth Forms
-        "U+3400-U+4DBF",  // CJK Unified Ideographs Extension A
-    ]
-
-    /// Unicode ranges specific to Japanese (kana).
-    private static let japaneseRanges = [
-        "U+3040-U+309F",  // Hiragana
-        "U+30A0-U+30FF",  // Katakana
-    ]
-
-    /// Representative scalars used to detect whether the configured primary
-    /// font already covers the ranges cmux would otherwise auto-map.
-    private static let cjkCoverageSampleCharactersByRange: [String: [UniChar]] = [
-        "U+3000-U+303F": [0x3001, 0x300C],
-        "U+4E00-U+9FFF": [0x4E00, 0x65E5, 0x6C34],
-        "U+F900-U+FAFF": [0xF900],
-        "U+FF00-U+FFEF": [0xFF10, 0xFF21],
-        "U+3400-U+4DBF": [0x3400],
-        "U+1100-U+11FF": [0x1100, 0x1161],
-        "U+3130-U+318F": [0x3131, 0x314F],
-        "U+3040-U+309F": [0x3042, 0x3093],
-        "U+30A0-U+30FF": [0x30A2, 0x30F3],
-        "U+AC00-U+D7AF": [0xAC00, 0xD55C],
-    ]
-
-    private struct UserFontConfigSummary {
-        var containsCodepointMap = false
-        var effectiveFontFamilies: [String] = []
-
-        var hasExplicitFontFamilyFallbackChain: Bool {
-            effectiveFontFamilies.count > 1
-        }
-
-        mutating func applyFontCodepointMap(_ value: String) {
-            if value.isEmpty {
-                containsCodepointMap = false
-                return
-            }
-
-            guard value.contains("=") else {
-                return
-            }
-
-            containsCodepointMap = true
-        }
-
-        mutating func recordFontFamily(_ value: String) {
-            if value.isEmpty {
-                effectiveFontFamilies.removeAll()
-                return
-            }
-
-            guard !effectiveFontFamilies.contains(value) else {
-                return
-            }
-
-            effectiveFontFamilies.append(value)
-        }
-    }
-
     /// Returns (range, font) pairs for CJK font fallback based on the system's
-    /// preferred languages, or nil if no CJK language is detected. Each language
-    /// only maps its own script ranges to avoid assigning glyphs to a font that
-    /// lacks coverage (e.g. Hangul to Hiragino Sans).
+    /// preferred languages. Forwards to ``GhosttyConfigDiscovery``.
     static func cjkFontMappings(
         preferredLanguages: [String] = Locale.preferredLanguages
     ) -> [(String, String)]? {
-        var mappings: [(String, String)] = []
-        var coveredShared = false
-
-        for lang in preferredLanguages {
-            let lower = lang.lowercased()
-            let font: String
-            var langRanges: [String] = []
-
-            if lower.hasPrefix("ja") {
-                font = "Hiragino Sans"
-                langRanges = japaneseRanges
-            } else if lower.hasPrefix("zh-hant") || lower.hasPrefix("zh-tw") || lower.hasPrefix("zh-hk") {
-                font = "PingFang TC"
-            } else if lower.hasPrefix("zh") {
-                font = "PingFang SC"
-            } else {
-                continue
-            }
-
-            if !coveredShared {
-                for range in sharedCJKRanges {
-                    mappings.append((range, font))
-                }
-                coveredShared = true
-            }
-
-            for range in langRanges {
-                mappings.append((range, font))
-            }
-        }
-
-        return mappings.isEmpty ? nil : mappings
+        configDiscovery.cjkFontMappings(preferredLanguages: preferredLanguages)
     }
 
-    /// Returns only the CJK mappings cmux should auto-inject after respecting
-    /// explicit user overrides and the glyph coverage of the configured
-    /// primary font family.
+    /// Returns only the CJK mappings cmux should auto-inject. Forwards to
+    /// ``GhosttyConfigDiscovery``.
     static func autoInjectedCJKFontMappings(
         preferredLanguages: [String] = Locale.preferredLanguages,
-        configPaths: [String] = loadedCJKScanPaths(),
+        configPaths: [String]? = nil,
         rangeCoverageProbe: ((String, String) -> Bool)? = nil
     ) -> [(String, String)]? {
-        guard var mappings = cjkFontMappings(preferredLanguages: preferredLanguages) else { return nil }
-
-        let summary = userFontConfigSummary(configPaths: configPaths)
-        if summary.containsCodepointMap || summary.hasExplicitFontFamilyFallbackChain {
-            return nil
-        }
-
-        guard let configuredFontFamily = summary.effectiveFontFamilies.first else {
-            return mappings
-        }
-
-        if let rangeCoverageProbe {
-            mappings.removeAll { range, _ in
-                rangeCoverageProbe(configuredFontFamily, range)
-            }
-        } else if let configuredFont = configuredCTFont(named: configuredFontFamily) {
-            mappings.removeAll { range, _ in
-                fontContainsGlyphs(configuredFont, forRange: range)
-            }
-        }
-
-        return mappings.isEmpty ? nil : mappings
+        configDiscovery.autoInjectedCJKFontMappings(
+            preferredLanguages: preferredLanguages,
+            configPaths: configPaths,
+            rangeCoverageProbe: rangeCoverageProbe
+        )
     }
 
-    /// Checks whether the user's Ghostty config files already contain
-    /// a `font-codepoint-map` entry covering CJK ranges. Also checks
-    /// application-support config paths that cmux may load at runtime.
+    /// Whether the user's Ghostty config files already contain a CJK
+    /// `font-codepoint-map` entry. Forwards to ``GhosttyConfigDiscovery``.
     static func userConfigContainsCJKCodepointMap(
-        configPaths: [String] = loadedGhosttyConfigScanPaths()
+        configPaths: [String]? = nil
     ) -> Bool {
-        userFontConfigSummary(configPaths: configPaths).containsCodepointMap
+        configDiscovery.userConfigContainsCJKCodepointMap(configPaths: configPaths)
     }
 
     static func userConfigHasExplicitFontFamilyFallbackChain(
-        configPaths: [String] = loadedGhosttyConfigScanPaths()
+        configPaths: [String]? = nil
     ) -> Bool {
-        userFontConfigSummary(configPaths: configPaths).hasExplicitFontFamilyFallbackChain
+        configDiscovery.userConfigHasExplicitFontFamilyFallbackChain(configPaths: configPaths)
     }
 
     static func shouldInjectCJKFontFallback(
         preferredLanguages: [String] = Locale.preferredLanguages,
-        configPaths: [String] = loadedCJKScanPaths(),
+        configPaths: [String]? = nil,
         rangeCoverageProbe: ((String, String) -> Bool)? = nil
     ) -> Bool {
-        autoInjectedCJKFontMappings(
+        configDiscovery.shouldInjectCJKFontFallback(
             preferredLanguages: preferredLanguages,
             configPaths: configPaths,
             rangeCoverageProbe: rangeCoverageProbe
-        ) != nil
+        )
     }
 
     static func shouldApplyManagedDefaultAppearance(
-        configPaths: [String] = loadedGhosttyConfigScanPaths()
+        configPaths: [String]? = nil
     ) -> Bool {
-        GhosttyConfig.shouldApplyManagedDefaultAppearance(configPaths: configPaths)
+        configDiscovery.shouldApplyManagedDefaultAppearance(configPaths: configPaths)
     }
 
     static func conditionalThemeOverrideConfigContents(
         preferredColorScheme: GhosttyConfig.ColorSchemePreference,
-        configPaths: [String] = loadedGhosttyConfigScanPaths()
+        configPaths: [String]? = nil
     ) -> String? {
-        let summary = GhosttyConfig.userAppearanceConfigSummary(configPaths: configPaths)
-        guard let rawThemeValue = summary.lastThemeDirective else { return nil }
-
-        // Inject a resolved plain theme whenever the requested appearance side is
-        // explicitly named via ghostty's conditional `light:...`/`dark:...`
-        // syntax, even when both sides resolve to the same theme. `cmux themes
-        // set` always encodes the selection with this syntax (a single theme
-        // becomes `light:X,dark:X`), and ghostty mis-applies the conditional form
-        // — the background lands but the foreground/palette stay at the default
-        // white colors, producing the white-on-light terminals reported in
-        // https://github.com/manaflow-ai/cmux/issues/3459. Only override sides the
-        // value explicitly specifies: a one-sided `light:X` must not force the
-        // light theme onto dark appearances (which would clobber the inherited or
-        // default dark theme). Plain (non-conditional) theme values are applied
-        // correctly by ghostty, so they need no override.
-        guard let explicitTheme = GhosttyConfig.explicitConditionalThemeName(
-            from: rawThemeValue,
-            preferredColorScheme: preferredColorScheme
-        ) else {
-            return nil
-        }
-
-        let resolvedTheme = explicitTheme.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !resolvedTheme.isEmpty,
-              resolvedTheme.rangeOfCharacter(from: .newlines) == nil else {
-            return nil
-        }
-
-        return "theme = \(resolvedTheme)"
+        configDiscovery.conditionalThemeOverrideConfigContents(
+            preferredColorScheme: preferredColorScheme,
+            configPaths: configPaths
+        )
     }
 
-    /// Resolve auto-injected CJK families through the regular-weight descriptor
-    /// path first so locale-sensitive families such as Hiragino Sans don't fall
-    /// back to ultra-light faces like W0 when Ghostty later matches by name.
+    /// Resolves auto-injected CJK families through the regular-weight descriptor
+    /// path. Forwards to ``GhosttyConfigDiscovery``.
     static func resolvedInjectedCJKFontName(
         named name: String,
         size: CGFloat = 12
     ) -> String {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return name }
-        guard let regularWeightFont = discoveredCTFont(named: trimmed, size: size, weightTrait: 0.0) else {
-            return trimmed
-        }
-
-        let candidateNames = [
-            CTFontCopyName(regularWeightFont, kCTFontFullNameKey) as String?,
-            CTFontCopyName(regularWeightFont, kCTFontPostScriptNameKey) as String?,
-        ].compactMap { $0 }
-        let expectedFullName = CTFontCopyFullName(regularWeightFont) as String
-        let expectedPostScriptName = CTFontCopyPostScriptName(regularWeightFont) as String
-
-        for candidate in candidateNames {
-            guard let verifiedFont = discoveredCTFont(named: candidate, size: size) else { continue }
-            let verifiedNames = [
-                CTFontCopyName(verifiedFont, kCTFontFamilyNameKey) as String?,
-                CTFontCopyName(verifiedFont, kCTFontFullNameKey) as String?,
-                CTFontCopyName(verifiedFont, kCTFontPostScriptNameKey) as String?,
-            ].compactMap { $0 }
-            let matchesRegularWeightFace = verifiedNames.contains {
-                normalizedFontName($0) == normalizedFontName(expectedFullName) ||
-                normalizedFontName($0) == normalizedFontName(expectedPostScriptName)
-            }
-            if matchesRegularWeightFace {
-                return candidate
-            }
-        }
-
-        return trimmed
+        configDiscovery.resolvedInjectedCJKFontName(named: name, size: size)
     }
 
-    private static func configuredCTFont(
-        named name: String,
-        size: CGFloat = 12
-    ) -> CTFont? {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        let font = CTFontCreateWithName(trimmed as CFString, size, nil)
-        let normalizedRequestedName = normalizedFontName(trimmed)
-        let resolvedNames = [
-            kCTFontFamilyNameKey,
-            kCTFontFullNameKey,
-            kCTFontPostScriptNameKey,
-        ].compactMap { CTFontCopyName(font, $0) as String? }
-
-        guard resolvedNames.contains(where: { normalizedFontName($0) == normalizedRequestedName }) else {
-            return nil
-        }
-
-        return font
-    }
-
-    /// Mirror Ghostty's family-name CoreText discovery path so injected
-    /// `font-codepoint-map` values are validated against the same lookup mode.
+    /// Mirror Ghostty's family-name CoreText discovery path. Forwards to
+    /// ``GhosttyConfigDiscovery``.
     static func discoveredCTFont(
         named name: String,
         size: CGFloat = 12,
         weightTrait: CGFloat? = nil
     ) -> CTFont? {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        var attributes: [CFString: Any] = [
-            kCTFontFamilyNameAttribute: trimmed,
-            kCTFontSizeAttribute: size,
-        ]
-        if let weightTrait {
-            attributes[kCTFontTraitsAttribute] = [
-                kCTFontWeightTrait: weightTrait,
-            ] as CFDictionary
-        }
-
-        let descriptor = CTFontDescriptorCreateWithAttributes(attributes as CFDictionary)
-        let collection = CTFontCollectionCreateWithFontDescriptors([descriptor] as CFArray, nil)
-        guard let match = (CTFontCollectionCreateMatchingFontDescriptors(collection) as? [CTFontDescriptor])?.first else {
-            return nil
-        }
-        return CTFontCreateWithFontDescriptor(match, size, nil)
+        configDiscovery.discoveredFont(named: name, size: size, weightTrait: weightTrait)
     }
 
-    private static func fontContainsGlyphs(
-        _ font: CTFont,
-        forRange range: String
-    ) -> Bool {
-        guard let characters = cjkCoverageSampleCharactersByRange[range] else {
-            return false
-        }
-
-        var glyphs = Array(repeating: CGGlyph(), count: characters.count)
-        let hasGlyphs = CTFontGetGlyphsForCharacters(font, characters, &glyphs, characters.count)
-        return hasGlyphs && !glyphs.contains(0)
-    }
-
-    private static func normalizedFontName(_ name: String) -> String {
-        name
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: \.isWhitespace)
-            .joined(separator: " ")
-            .folding(options: [.diacriticInsensitive, .widthInsensitive], locale: Locale(identifier: "en_US_POSIX"))
-            .lowercased()
-    }
-
-    private static func userFontConfigSummary(
-        configPaths: [String] = loadedCJKScanPaths()
-    ) -> UserFontConfigSummary {
-        var summary = UserFontConfigSummary()
-        var recursiveConfigPaths: [String] = []
-
-        for path in configPaths.map({ NSString(string: $0).expandingTildeInPath }) {
-            scanFontConfigFile(
-                atPath: path,
-                summary: &summary,
-                recursiveConfigPaths: &recursiveConfigPaths
-            )
-        }
-
-        var loadedRecursivePaths = Set<String>()
-        while !recursiveConfigPaths.isEmpty {
-            let path = recursiveConfigPaths.removeFirst()
-            let resolved = (path as NSString).standardizingPath
-            guard !loadedRecursivePaths.contains(resolved) else { continue }
-            loadedRecursivePaths.insert(resolved)
-
-            scanFontConfigFile(
-                atPath: path,
-                summary: &summary,
-                recursiveConfigPaths: &recursiveConfigPaths
-            )
-        }
-
-        return summary
-    }
-
-    /// Returns the top-level Ghostty config paths cmux may load before
-    /// recursive `config-file` processing.
+    /// Returns the top-level Ghostty config paths cmux may load before recursive
+    /// `config-file` processing. Forwards to ``GhosttyConfigDiscovery``.
     static func loadedGhosttyConfigScanPaths(
         currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = FileManager.default.urls(
@@ -1690,48 +1431,10 @@ class GhosttyApp {
             in: .userDomainMask
         ).first
     ) -> [String] {
-        var paths = [
-            "~/.config/ghostty/config",
-            "~/.config/ghostty/config.ghostty",
-        ]
-
-        guard let appSupportDirectory else { return paths }
-
-        let ghosttyDir = appSupportDirectory.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
-        let nativeLegacyConfig = ghosttyDir.appendingPathComponent("config", isDirectory: false)
-        let nativeConfig = ghosttyDir.appendingPathComponent("config.ghostty", isDirectory: false)
-        paths.append(nativeConfig.path)
-        if shouldIncludeLegacyGhosttyConfigInScanPaths(
-            newConfigFileSize: configFileSize(at: nativeConfig),
-            legacyConfigFileSize: configFileSize(at: nativeLegacyConfig)
-        ) {
-            paths.append(nativeLegacyConfig.path)
-        }
-
-        guard let bundleId = currentBundleIdentifier,
-              !bundleId.isEmpty else { return paths }
-
-        let appSupportConfigURLs = cmuxAppSupportConfigURLs(
-            currentBundleIdentifier: bundleId,
+        configDiscovery.loadedGhosttyConfigScanPaths(
+            currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupportDirectory
         )
-        paths.append(contentsOf: appSupportConfigURLs.map(\.path))
-
-        let releaseDir = appSupportDirectory.appendingPathComponent(releaseBundleIdentifier, isDirectory: true)
-        let releaseLegacyConfig = releaseDir.appendingPathComponent("config", isDirectory: false)
-        let releaseConfig = releaseDir.appendingPathComponent("config.ghostty", isDirectory: false)
-
-        let releaseConfigSize = configFileSize(at: releaseConfig)
-        let releaseLegacyConfigSize = configFileSize(at: releaseLegacyConfig)
-
-        if shouldIncludeLegacyGhosttyConfigInScanPaths(
-            newConfigFileSize: releaseConfigSize,
-            legacyConfigFileSize: releaseLegacyConfigSize
-        ), !paths.contains(releaseLegacyConfig.path) {
-            paths.append(releaseLegacyConfig.path)
-        }
-
-        return paths
     }
 
     static func loadedCJKScanPaths(
@@ -1741,127 +1444,30 @@ class GhosttyApp {
             in: .userDomainMask
         ).first
     ) -> [String] {
-        loadedGhosttyConfigScanPaths(
+        configDiscovery.loadedCJKScanPaths(
             currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupportDirectory
         )
-    }
-
-    private static func configFileSize(at url: URL) -> Int? {
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? NSNumber else { return nil }
-        return size.intValue
-    }
-
-    /// Scans a single config file for font settings relevant to cmux's
-    /// injected CJK fallback and updates the pending recursive config-file
-    /// queue using Ghostty's repeatable path semantics.
-    private static func scanFontConfigFile(
-        atPath path: String,
-        summary: inout UserFontConfigSummary,
-        recursiveConfigPaths: inout [String]
-    ) {
-        let resolved = (path as NSString).standardizingPath
-        guard let contents = try? String(contentsOfFile: resolved, encoding: .utf8) else {
-            return
-        }
-        let parentDir = (resolved as NSString).deletingLastPathComponent
-
-        for line in contents.components(separatedBy: .newlines) {
-            guard let entry = parsedConfigEntry(from: line) else { continue }
-
-            switch entry.key {
-            case "font-codepoint-map":
-                guard let value = entry.value else { continue }
-                summary.applyFontCodepointMap(value)
-            case "font-family":
-                guard let value = entry.value else { continue }
-                summary.recordFontFamily(value)
-            case "config-file":
-                guard let value = entry.value else { continue }
-                applyConfigFileDirective(
-                    value,
-                    valueWasQuoted: entry.valueWasQuoted,
-                    parentDir: parentDir,
-                    recursiveConfigPaths: &recursiveConfigPaths
-                )
-            default:
-                continue
-            }
-        }
-    }
-
-    private static func parsedConfigEntry(
-        from rawLine: String
-    ) -> (key: String, value: String?, valueWasQuoted: Bool)? {
-        var trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("\u{FEFF}") {
-            trimmed.removeFirst()
-        }
-        if trimmed.isEmpty || trimmed.hasPrefix("#") { return nil }
-
-        guard let separatorIndex = trimmed.firstIndex(of: "=") else {
-            return (trimmed.trimmingCharacters(in: .whitespacesAndNewlines), nil, false)
-        }
-
-        let key = trimmed[..<separatorIndex].trimmingCharacters(in: .whitespacesAndNewlines)
-        var value = trimmed[trimmed.index(after: separatorIndex)...]
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let valueWasQuoted = value.count >= 2 && value.hasPrefix("\"") && value.hasSuffix("\"")
-
-        if valueWasQuoted {
-            value.removeFirst()
-            value.removeLast()
-        }
-
-        return (String(key), String(value), valueWasQuoted)
-    }
-
-    private static func applyConfigFileDirective(
-        _ value: String,
-        valueWasQuoted: Bool,
-        parentDir: String,
-        recursiveConfigPaths: inout [String]
-    ) {
-        if value.isEmpty {
-            recursiveConfigPaths.removeAll()
-            return
-        }
-
-        var includePath = value
-        if !valueWasQuoted, includePath.hasPrefix("?") {
-            includePath.removeFirst()
-            if includePath.count >= 2,
-               includePath.hasPrefix("\""),
-               includePath.hasSuffix("\"") {
-                includePath.removeFirst()
-                includePath.removeLast()
-            }
-        }
-        guard !includePath.isEmpty else { return }
-
-        let expanded = NSString(string: includePath).expandingTildeInPath
-        let absolute = (expanded as NSString).isAbsolutePath
-            ? expanded
-            : (parentDir as NSString).appendingPathComponent(expanded)
-        recursiveConfigPaths.append(absolute)
     }
 
     static func shouldLoadLegacyGhosttyConfig(
         newConfigFileSize: Int?,
         legacyConfigFileSize: Int?
     ) -> Bool {
-        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
-        return newConfigFileSize == 0
+        GhosttyConfigDiscovery.shouldLoadLegacyGhosttyConfig(
+            newConfigFileSize: newConfigFileSize,
+            legacyConfigFileSize: legacyConfigFileSize
+        )
     }
 
     static func shouldIncludeLegacyGhosttyConfigInScanPaths(
         newConfigFileSize: Int?,
         legacyConfigFileSize: Int?
     ) -> Bool {
-        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
-        guard let newConfigFileSize else { return true }
-        return newConfigFileSize == 0
+        GhosttyConfigDiscovery.shouldIncludeLegacyGhosttyConfigInScanPaths(
+            newConfigFileSize: newConfigFileSize,
+            legacyConfigFileSize: legacyConfigFileSize
+        )
     }
 
     static func shouldIgnoreNativeLegacyBaselineForUnparsedAppearance(
@@ -1870,17 +1476,9 @@ class GhosttyApp {
             in: .userDomainMask
         ).first
     ) -> Bool {
-        guard let appSupportDirectory else { return false }
-        let ghosttyDir = appSupportDirectory.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
-        let nativeLegacyConfig = ghosttyDir.appendingPathComponent("config", isDirectory: false)
-        let nativeConfig = ghosttyDir.appendingPathComponent("config.ghostty", isDirectory: false)
-        guard let legacyConfigSize = configFileSize(at: nativeLegacyConfig), legacyConfigSize > 0 else {
-            return false
-        }
-        guard let nativeConfigSize = configFileSize(at: nativeConfig), nativeConfigSize > 0 else {
-            return false
-        }
-        return true
+        configDiscovery.shouldIgnoreNativeLegacyBaselineForUnparsedAppearance(
+            appSupportDirectory: appSupportDirectory
+        )
     }
 
     static func cmuxAppSupportConfigURLs(
@@ -1888,7 +1486,7 @@ class GhosttyApp {
         appSupportDirectory: URL,
         fileManager: FileManager = .default
     ) -> [URL] {
-        CmuxGhosttyConfigPathResolver().loadConfigURLs(
+        configDiscovery.cmuxAppSupportConfigURLs(
             currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupportDirectory,
             fileManager: fileManager

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		5E2701040000000000000004 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 5E2701040000000000000002 /* CmuxFoundation */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
 		CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
+		C750310000000000000000A3 /* CmuxGhosttyConfigLoader in Frameworks */ = {isa = PBXBuildFile; productRef = C750310000000000000000A2 /* CmuxGhosttyConfigLoader */; };
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
@@ -1783,6 +1784,7 @@
 				CFF11E0000000000000000A3 /* CmuxFileOpen in Frameworks */,
 				C8000313C8000313C8000313 /* CmuxFileWatch in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
+				C750310000000000000000A3 /* CmuxGhosttyConfigLoader in Frameworks */,
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
 				C19C5E0300000000000000A3 /* CmuxIPCService in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
@@ -2856,6 +2858,7 @@
 				CC0DE20000000000000000A2 /* CmuxRemoteWorkspace */,
 				CC0DE30000000000000000A2 /* CmuxRemoteSession */,
 				C750300000000000000000A2 /* CmuxTerminalEngine */,
+				C750310000000000000000A2 /* CmuxGhosttyConfigLoader */,
 				C750400000000000000000A2 /* CmuxTerminalServices */,
 				A8BD195031FC4B82B4354297 /* StackAuth */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
@@ -3042,6 +3045,7 @@
 				C9A2D00000000000000000D1 /* XCLocalSwiftPackageReference "CmuxFeedbackUI" */,
 				C750200000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminalCore" */,
 				C750300000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminalEngine" */,
+				C750310000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGhosttyConfigLoader" */,
 				C750400000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminalServices" */,
 				C750400000000000000000D1 /* XCLocalSwiftPackageReference "CmuxWorkspaceWindow" */,
 				C750500000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminal" */,
@@ -4607,6 +4611,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxTerminalEngine;
 		};
+		C750310000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGhosttyConfigLoader" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxGhosttyConfigLoader;
+		};
 		C750400000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminalServices" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxTerminalServices;
@@ -4918,6 +4926,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C750300000000000000000A1 /* XCLocalSwiftPackageReference "CmuxTerminalEngine" */;
 			productName = CmuxTerminalEngine;
+		};
+		C750310000000000000000A2 /* CmuxGhosttyConfigLoader */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C750310000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGhosttyConfigLoader" */;
+			productName = CmuxGhosttyConfigLoader;
 		};
 		C750400000000000000000A2 /* CmuxTerminalServices */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Pulls the pure Ghostty config-file discovery + scanning domain out of `GhosttyApp` (inside the ~12k-line `Sources/GhosttyTerminalView.swift` god file) into a new leaf package `CmuxGhosttyConfigLoader`, as a constructor-injected value type `GhosttyConfigDiscovery`.

## What moved
Now a real type with inverted seams instead of statics welded onto `GhosttyApp`:
- CJK font fallback: `cjkFontMappings`, `autoInjectedCJKFontMappings`, `shouldInjectCJKFontFallback`, `resolvedInjectedCJKFontName`, glyph-coverage probing.
- User font-config scanning: `userFontConfigSummary`, `config-file` include following, `parsedConfigEntry` / `applyConfigFileDirective`, `UserFontConfigSummary`.
- Scan-path resolution: `loadedGhosttyConfigScanPaths` / `loadedCJKScanPaths`, `cmuxAppSupportConfigURLs`.
- Legacy-config decisions: `shouldLoadLegacyGhosttyConfig`, `shouldIncludeLegacyGhosttyConfigInScanPaths`, `shouldIgnoreNativeLegacyBaselineForUnparsedAppearance`.
- Conditional-theme override + managed-default-appearance decisions.

## Seams (inverted, constructor-injected; defaults reproduce prior behavior)
- `GhosttyConfigFileReading` (default `FileManagerGhosttyConfigFileReader`) inverts every config file size/contents read that used `FileManager.default` / `String(contentsOfFile:)`.
- `GhosttyFontProbing` (default `CoreTextGhosttyFontProbe`) inverts the CoreText `CTFont` family-name discovery and glyph-coverage probing.
- `CmuxGhosttyConfigPathResolver` (from `CmuxFoundation`) injected for app-support URL resolution.

One major public type per file; `///` DocC on every public symbol; no caseless-enum namespace, no free functions, no `lint:allow`.

## Byte-identical
Every directive key, scan-path ordering, legacy-fallback size rule, `config-file` include semantics, CJK range set, and theme-override text is preserved exactly. The C-API config-load instance methods (`loadDefaultConfigFilesWithLegacyFallback`, `loadCJKFontFallbackIfNeeded`, `reloadConfiguration`, `synchronizeThemeWithAppearance`) stay in the app target and now call the new type to decide *what* to load while still issuing the `ghostty_config_load_*` calls themselves. The former `GhosttyApp` statics remain as thin one-line forwards, so all call sites (including `cmuxTests`) are unchanged.

Left in the app target on purpose: everything that mutates `ghostty_config_t`, `GhosttyApp` instance state, or reaches `AppDelegate.shared` / `NotificationCenter` — not pure, not part of this clean subset.

The seam is a synchronous value type (not an actor) because discovery runs inside the synchronous launch-path config-load sequence; an async actor would reorder the C-API calls. Principled over the actor shape the audit suggested.

## Tests
17 behavior unit tests with in-memory fakes for both seams (CJK mapping, font-config scanning incl. `config-file` includes, legacy-config rules, scan-path composition, theme override).

## Stats / wiring
- Giant `GhosttyTerminalView.swift` shrinks 12093 → 11691 lines (−402); `.github/swift-file-length-budget.tsv` reconciled.
- Wired into `cmux.xcodeproj` (6 pbxproj entries) + app-target dependency.

NOTE: full app build is validated by GitHub CI; local app `xcodebuild` was skipped intentionally (parallel refactor agents). The new package builds and tests pass locally, and `scripts/lint-ios-package-conventions.sh` is clean with zero new `lint:allow`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144071&installation_id=133855650&pr_number=6177&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6177&signature=b9df0ebfea101fa57c06822c11f59c24771a0cd209c68898ebdabd176a9fa3ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted Ghostty config discovery/scanning into a new leaf package `CmuxGhosttyConfigLoader` with `GhosttyConfigDiscovery`, reducing `GhosttyTerminalView.swift` by 402 lines and keeping behavior identical. Improves testability and isolates pure logic from app state.

- **Refactors**
  - Moved: CJK font fallback, user font-config scanning (with includes), scan-path resolution, legacy-config decisions, and theme override/managed default appearance into `GhosttyConfigDiscovery`.
  - Added seams: `GhosttyConfigFileReading` (default `FileManagerGhosttyConfigFileReader`), `GhosttyFontProbing` (default `CoreTextGhosttyFontProbe`); injects `CmuxGhosttyConfigPathResolver`.
  - App’s C-API config-loaders remain and now delegate to the new type while performing `ghostty_config_*` calls.
  - Preserves behavior: same scan-path ordering, legacy size rule, include semantics, CJK ranges, and theme override text.
  - Added 17 unit tests with in-memory fakes and small C stubs; wired `CmuxGhosttyConfigLoader` into `cmux.xcodeproj`.

<sup>Written for commit b56a7bb7b4ae80162dbe8f345336fcf6a18da0bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

