### PR TITLE
Extract browser profile management into CmuxBrowserProfiles package

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17778	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
-13358	Sources/Panels/BrowserPanel.swift
+13247	Sources/Panels/BrowserPanel.swift
 12361	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Packages/CmuxBrowserProfiles/Package.swift
+++ b/Packages/CmuxBrowserProfiles/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserProfiles",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserProfiles",
+            targets: ["CmuxBrowserProfiles"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserProfiles",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxBrowserProfilesTests",
+            dependencies: ["CmuxBrowserProfiles"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Repository/BrowserProfileRepository.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Repository/BrowserProfileRepository.swift
@@ -1,0 +1,304 @@
+public import Foundation
+import Observation
+
+/// Durable source of truth for browser profiles.
+///
+/// Owns the persisted profile list, the last-used profile selection, and the
+/// per-profile `WKWebsiteDataStore` / history-store caches. Backed by
+/// `UserDefaults` and the injected ``BrowserProfileHistoryProviding``,
+/// ``BrowserProfileWebsiteDataStoreProviding``, and ``BrowserProfileFileRemoving``
+/// seams so the WebKit, filesystem, and bundle dependencies stay in the app
+/// target. The app's `BrowserProfileStore` is a thin `ObservableObject` facade
+/// over this repository.
+///
+/// `@MainActor` because it seeds synchronously in `init` and is consumed by the
+/// main-thread facade and views; mirrors the original `@MainActor` store exactly.
+@MainActor
+@Observable
+public final class BrowserProfileRepository {
+    /// `UserDefaults` key for the encoded profile list.
+    public static let profilesDefaultsKey = "browserProfiles.v1"
+    /// `UserDefaults` key for the last-used profile id string.
+    public static let lastUsedProfileDefaultsKey = "browserProfiles.lastUsed"
+    /// Stable identifier of the immovable built-in default profile.
+    public static let builtInDefaultProfileID = UUID(uuidString: "52B43C05-4A1D-45D3-8FD5-9EF94952E445")!
+
+    /// The current profile list, default first then alphabetical by display name.
+    public private(set) var profiles: [BrowserProfileDefinition] = []
+    /// The last-used profile id; defaults to the built-in default.
+    public private(set) var lastUsedProfileID: UUID = builtInDefaultProfileID
+
+    private let defaults: UserDefaults
+    private let historyProvider: any BrowserProfileHistoryProviding
+    private let websiteDataStoreProvider: any BrowserProfileWebsiteDataStoreProviding
+    private let fileRemover: any BrowserProfileFileRemoving
+    private let bundleIdentifier: String
+    private let defaultProfileDisplayName: String
+
+    private var dataStores: [UUID: AnyObject] = [:]
+    private var historyStores: [UUID: any BrowserProfileHistoryStore] = [:]
+
+    /// Creates the repository and synchronously loads persisted state.
+    /// - Parameters:
+    ///   - defaults: Backing `UserDefaults`.
+    ///   - historyProvider: Seam producing per-profile and shared history stores.
+    ///   - websiteDataStoreProvider: Seam producing and wiping `WKWebsiteDataStore` handles.
+    ///   - fileRemover: Seam deleting profile-owned files.
+    ///   - bundleIdentifier: The running app's bundle identifier (falls back to `"cmux"` upstream).
+    ///   - defaultProfileDisplayName: Localized display name for the built-in default profile.
+    public init(
+        defaults: UserDefaults,
+        historyProvider: any BrowserProfileHistoryProviding,
+        websiteDataStoreProvider: any BrowserProfileWebsiteDataStoreProviding,
+        fileRemover: any BrowserProfileFileRemoving,
+        bundleIdentifier: String,
+        defaultProfileDisplayName: String
+    ) {
+        self.defaults = defaults
+        self.historyProvider = historyProvider
+        self.websiteDataStoreProvider = websiteDataStoreProvider
+        self.fileRemover = fileRemover
+        self.bundleIdentifier = bundleIdentifier
+        self.defaultProfileDisplayName = defaultProfileDisplayName
+        load()
+    }
+
+    /// Stable identifier of the immovable built-in default profile.
+    public var builtInDefaultProfileID: UUID {
+        Self.builtInDefaultProfileID
+    }
+
+    /// The last-used profile id if it still exists, else the built-in default.
+    public var effectiveLastUsedProfileID: UUID {
+        profileDefinition(id: lastUsedProfileID) != nil ? lastUsedProfileID : Self.builtInDefaultProfileID
+    }
+
+    /// Looks up a profile by id.
+    /// - Parameter id: The profile id.
+    /// - Returns: The matching definition, or `nil`.
+    public func profileDefinition(id: UUID) -> BrowserProfileDefinition? {
+        profiles.first(where: { $0.id == id })
+    }
+
+    /// Display name for a profile id, falling back to the default profile name.
+    /// - Parameter id: The profile id.
+    /// - Returns: The profile's display name, or the default name when unknown.
+    public func displayName(for id: UUID) -> String {
+        profileDefinition(id: id)?.displayName ?? defaultProfileDisplayName
+    }
+
+    /// Creates a new non-default profile, persists, and marks it used.
+    /// - Parameter rawName: The requested name; trimmed of surrounding whitespace.
+    /// - Returns: The created profile, or `nil` when the trimmed name is empty.
+    public func createProfile(named rawName: String) -> BrowserProfileDefinition? {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return nil }
+        let profile = BrowserProfileDefinition(
+            id: UUID(),
+            displayName: name,
+            createdAt: Date(),
+            isBuiltInDefault: false
+        )
+        profiles.append(profile)
+        profiles.sort {
+            if $0.isBuiltInDefault != $1.isBuiltInDefault {
+                return $0.isBuiltInDefault && !$1.isBuiltInDefault
+            }
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+        persist()
+        noteUsed(profile.id)
+        return profile
+    }
+
+    /// Renames a non-default profile and persists.
+    /// - Parameters:
+    ///   - id: The profile id.
+    ///   - rawName: The new name; trimmed of surrounding whitespace.
+    /// - Returns: `true` on success; `false` for an empty name, unknown id, or the built-in default.
+    public func renameProfile(id: UUID, to rawName: String) -> Bool {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty,
+              let index = profiles.firstIndex(where: { $0.id == id }),
+              !profiles[index].isBuiltInDefault else {
+            return false
+        }
+        profiles[index].displayName = name
+        profiles.sort {
+            if $0.isBuiltInDefault != $1.isBuiltInDefault {
+                return $0.isBuiltInDefault && !$1.isBuiltInDefault
+            }
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+        persist()
+        return true
+    }
+
+    /// Whether a profile can be renamed (i.e. exists and is not the built-in default).
+    /// - Parameter id: The profile id.
+    /// - Returns: `true` when renaming is allowed.
+    public func canRenameProfile(id: UUID) -> Bool {
+        guard let profile = profileDefinition(id: id) else { return false }
+        return !profile.isBuiltInDefault
+    }
+
+    /// Deletes a non-default profile, tears down its stores, and removes its history directory.
+    /// - Parameter id: The profile id.
+    /// - Returns: The removed profile, or `nil` for an unknown id or the built-in default.
+    public func deleteProfile(id: UUID) -> BrowserProfileDefinition? {
+        guard let index = profiles.firstIndex(where: { $0.id == id }),
+              !profiles[index].isBuiltInDefault else {
+            return nil
+        }
+        let removed = profiles.remove(at: index)
+        let historyDirectoryURL = historyFileURL(for: id)?.deletingLastPathComponent()
+        historyStores[id]?.cancelPendingSaves()
+        dataStores.removeValue(forKey: id)
+        historyStores.removeValue(forKey: id)
+        if lastUsedProfileID == id {
+            lastUsedProfileID = Self.builtInDefaultProfileID
+            defaults.set(lastUsedProfileID.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
+        }
+        persist()
+        if let historyDirectoryURL {
+            let remover = fileRemover
+            Task.detached(priority: .utility) {
+                await remover.removeItemIfExists(at: historyDirectoryURL)
+            }
+        }
+        return removed
+    }
+
+    /// Wipes one profile's website data and history.
+    /// - Parameter id: The profile id.
+    /// - Returns: A ``BrowserProfileClearOutcome`` describing what was cleared, or `nil` for an unknown id.
+    public func clearProfileData(id: UUID) async -> BrowserProfileClearOutcome? {
+        guard let profile = profileDefinition(id: id) else { return nil }
+        let store = websiteDataStore(for: id)
+        let historyURL = historyFileURL(for: id)
+        historyStore(for: id).clearHistoryWithoutLoadingPersistedFile()
+        let dataTypes = websiteDataStoreProvider.allWebsiteDataTypes
+        await websiteDataStoreProvider.removeAllData(ofTypes: dataTypes, from: store)
+        if let historyURL {
+            await fileRemover.removeItemIfExists(at: historyURL)
+        }
+        return BrowserProfileClearOutcome(
+            profile: profile,
+            clearedWebsiteDataTypes: dataTypes.sorted(),
+            clearedHistory: true
+        )
+    }
+
+    /// Records a profile as last-used and persists the selection.
+    /// - Parameter id: The profile id; ignored when unknown.
+    public func noteUsed(_ id: UUID) {
+        guard profileDefinition(id: id) != nil else { return }
+        if lastUsedProfileID != id {
+            lastUsedProfileID = id
+            defaults.set(id.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
+        }
+    }
+
+    /// Returns the cached `WKWebsiteDataStore` handle for a profile, creating it on first use.
+    /// - Parameter profileID: The profile id.
+    /// - Returns: An opaque `WKWebsiteDataStore` handle (the default store for the built-in default profile).
+    public func websiteDataStore(for profileID: UUID) -> AnyObject {
+        if profileID == Self.builtInDefaultProfileID {
+            return websiteDataStoreProvider.defaultWebsiteDataStore
+        }
+        if let existing = dataStores[profileID] {
+            return existing
+        }
+        let store = websiteDataStoreProvider.makeWebsiteDataStore(forProfileID: profileID)
+        dataStores[profileID] = store
+        return store
+    }
+
+    /// Returns the cached history store for a profile, creating it on first use.
+    /// - Parameter profileID: The profile id.
+    /// - Returns: The shared history store for the built-in default, else a file-backed per-profile store.
+    public func historyStore(for profileID: UUID) -> any BrowserProfileHistoryStore {
+        if profileID == Self.builtInDefaultProfileID {
+            return historyProvider.sharedHistoryStore
+        }
+        if let existing = historyStores[profileID] {
+            return existing
+        }
+        let store = historyProvider.makeHistoryStore(fileURL: historyFileURL(for: profileID))
+        historyStores[profileID] = store
+        return store
+    }
+
+    /// The history file URL for a profile.
+    /// - Parameter profileID: The profile id.
+    /// - Returns: The built-in default's shared file for the default profile, else a per-profile
+    ///   `…/<namespace>/browser_profiles/<uuid>/browser_history.json` URL, or `nil` if unresolvable.
+    public func historyFileURL(for profileID: UUID) -> URL? {
+        if profileID == Self.builtInDefaultProfileID {
+            return historyProvider.defaultHistoryFileURLForCurrentBundle()
+        }
+
+        let fm = FileManager.default
+        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        let namespace = historyProvider.normalizedBrowserHistoryNamespace(forBundleIdentifier: bundleIdentifier)
+        let profilesDir = appSupport
+            .appendingPathComponent(namespace, isDirectory: true)
+            .appendingPathComponent("browser_profiles", isDirectory: true)
+            .appendingPathComponent(profileID.uuidString.lowercased(), isDirectory: true)
+        return profilesDir.appendingPathComponent("browser_history.json", isDirectory: false)
+    }
+
+    /// Flushes pending saves on the shared default history store and every cached per-profile store.
+    public func flushPendingSaves() {
+        historyProvider.flushSharedHistoryPendingSaves()
+        for store in historyStores.values {
+            store.flushPendingSaves()
+        }
+    }
+
+    private func load() {
+        let builtInDefaultProfile = BrowserProfileDefinition(
+            id: Self.builtInDefaultProfileID,
+            displayName: defaultProfileDisplayName,
+            createdAt: Date(timeIntervalSince1970: 0),
+            isBuiltInDefault: true
+        )
+
+        if let data = defaults.data(forKey: Self.profilesDefaultsKey),
+           let decoded = try? JSONDecoder().decode([BrowserProfileDefinition].self, from: data),
+           !decoded.isEmpty {
+            var resolvedProfiles = decoded.filter { $0.id != Self.builtInDefaultProfileID }
+            resolvedProfiles.append(builtInDefaultProfile)
+            profiles = sortedProfiles(resolvedProfiles)
+        } else {
+            profiles = [builtInDefaultProfile]
+            persist()
+        }
+
+        if let rawLastUsed = defaults.string(forKey: Self.lastUsedProfileDefaultsKey),
+           let parsed = UUID(uuidString: rawLastUsed),
+           profileDefinition(id: parsed) != nil {
+            lastUsedProfileID = parsed
+        } else {
+            lastUsedProfileID = Self.builtInDefaultProfileID
+            defaults.set(lastUsedProfileID.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
+        }
+    }
+
+    private func persist() {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(profiles) else { return }
+        defaults.set(data, forKey: Self.profilesDefaultsKey)
+    }
+
+    private func sortedProfiles(_ profiles: [BrowserProfileDefinition]) -> [BrowserProfileDefinition] {
+        profiles.sorted {
+            if $0.isBuiltInDefault != $1.isBuiltInDefault {
+                return $0.isBuiltInDefault && !$1.isBuiltInDefault
+            }
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileFileRemoving.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileFileRemoving.swift
@@ -1,0 +1,12 @@
+public import Foundation
+
+/// Removes profile-owned files and directories from disk.
+///
+/// Inverts the repository's dependency on `FileManager.default`. The concrete
+/// conformer in the app target deletes via a detached utility-priority task,
+/// matching the original best-effort, ignore-errors behavior.
+public protocol BrowserProfileFileRemoving: Sendable {
+    /// Removes the item at the given URL if present, ignoring any error.
+    /// - Parameter url: The file or directory to remove.
+    func removeItemIfExists(at url: URL) async
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileHistoryProviding.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileHistoryProviding.swift
@@ -1,0 +1,27 @@
+public import Foundation
+
+/// Provides per-profile history stores and the locations of their backing files.
+///
+/// Inverts the repository's dependency on `BrowserHistoryStore`. The concrete
+/// conformer in the app target maps the built-in default profile to the shared
+/// history store and constructs a file-backed store for every other profile.
+@MainActor
+public protocol BrowserProfileHistoryProviding: AnyObject {
+    /// The shared history store used by the built-in default profile.
+    var sharedHistoryStore: any BrowserProfileHistoryStore { get }
+
+    /// Builds a file-backed history store for a non-default profile.
+    /// - Parameter fileURL: The profile's history file location, or `nil` to use the store's own default.
+    func makeHistoryStore(fileURL: URL?) -> any BrowserProfileHistoryStore
+
+    /// The history file URL for the built-in default profile, if resolvable.
+    func defaultHistoryFileURLForCurrentBundle() -> URL?
+
+    /// Maps a bundle identifier to the namespace segment used in history paths.
+    /// - Parameter bundleIdentifier: The running app's bundle identifier.
+    /// - Returns: The normalized namespace folder name.
+    func normalizedBrowserHistoryNamespace(forBundleIdentifier bundleIdentifier: String) -> String
+
+    /// Flushes pending saves on the shared default history store.
+    func flushSharedHistoryPendingSaves()
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileHistoryStore.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileHistoryStore.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A per-profile browsing-history store handle, as seen by profile management.
+///
+/// The concrete conformer in the app target wraps `BrowserHistoryStore`. The
+/// repository only needs the lifecycle operations it invokes during delete and
+/// clear; navigation and query APIs stay out of this seam.
+@MainActor
+public protocol BrowserProfileHistoryStore: AnyObject {
+    /// Clears in-memory history entries without first reading the persisted file.
+    func clearHistoryWithoutLoadingPersistedFile()
+    /// Cancels any debounced pending saves for this profile's history file.
+    func cancelPendingSaves()
+    /// Flushes any pending saves for this profile's history file synchronously.
+    func flushPendingSaves()
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileWebsiteDataStoreProviding.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Seams/BrowserProfileWebsiteDataStoreProviding.swift
@@ -1,0 +1,27 @@
+public import Foundation
+
+/// Provides and wipes per-profile `WKWebsiteDataStore` instances.
+///
+/// Inverts the repository's dependency on WebKit. The concrete conformer in the
+/// app target maps the built-in default profile to `WKWebsiteDataStore.default()`
+/// and constructs `WKWebsiteDataStore(forIdentifier:)` for every other profile,
+/// returning each as an opaque `AnyObject` handle the repository caches by id.
+@MainActor
+public protocol BrowserProfileWebsiteDataStoreProviding: AnyObject {
+    /// The data store handle for the built-in default profile (`WKWebsiteDataStore.default()`).
+    var defaultWebsiteDataStore: AnyObject { get }
+
+    /// Builds an isolated data store handle for a non-default profile.
+    /// - Parameter profileID: The profile's identifier, used as the store identifier.
+    /// - Returns: An opaque `WKWebsiteDataStore` handle.
+    func makeWebsiteDataStore(forProfileID profileID: UUID) -> AnyObject
+
+    /// The sorted set of all website-data-type identifiers (`WKWebsiteDataStore.allWebsiteDataTypes()`).
+    var allWebsiteDataTypes: [String] { get }
+
+    /// Removes all of the given website data types from a data store handle.
+    /// - Parameters:
+    ///   - dataTypes: The website-data-type identifiers to remove.
+    ///   - store: The opaque data store handle obtained from this provider.
+    func removeAllData(ofTypes dataTypes: [String], from store: AnyObject) async
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Values/BrowserProfileClearOutcome.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Values/BrowserProfileClearOutcome.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Result of wiping one profile's website data and history.
+///
+/// Produced by ``BrowserProfileRepository/clearProfileData(id:)`` and surfaced to
+/// the automation socket via ``socketPayload``.
+public struct BrowserProfileClearOutcome: Sendable {
+    /// The profile whose data was cleared.
+    public let profile: BrowserProfileDefinition
+    /// Sorted list of `WKWebsiteDataStore` data-type identifiers that were removed.
+    public let clearedWebsiteDataTypes: [String]
+    /// Whether the profile's browsing history was cleared.
+    public let clearedHistory: Bool
+
+    /// Creates a clear outcome.
+    /// - Parameters:
+    ///   - profile: The profile whose data was cleared.
+    ///   - clearedWebsiteDataTypes: Sorted website-data-type identifiers that were removed.
+    ///   - clearedHistory: Whether history was cleared.
+    public init(profile: BrowserProfileDefinition, clearedWebsiteDataTypes: [String], clearedHistory: Bool) {
+        self.profile = profile
+        self.clearedWebsiteDataTypes = clearedWebsiteDataTypes
+        self.clearedHistory = clearedHistory
+    }
+
+    /// JSON-shaped dictionary for the browser automation socket reply.
+    public var socketPayload: [String: Any] {
+        [
+            "id": profile.id.uuidString,
+            "name": profile.displayName,
+            "slug": profile.slug,
+            "built_in_default": profile.isBuiltInDefault,
+            "cleared_website_data_types": clearedWebsiteDataTypes,
+            "cleared_history": clearedHistory,
+        ]
+    }
+}

--- a/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Values/BrowserProfileDefinition.swift
+++ b/Packages/CmuxBrowserProfiles/Sources/CmuxBrowserProfiles/Values/BrowserProfileDefinition.swift
@@ -1,0 +1,49 @@
+public import Foundation
+
+/// Persisted metadata describing one browser profile.
+///
+/// A profile owns an isolated `WKWebsiteDataStore` and an isolated history file,
+/// keyed by ``id``. Exactly one profile is the built-in default
+/// (``isBuiltInDefault`` is `true`), which maps to the shared/default backing
+/// stores rather than per-profile ones.
+public struct BrowserProfileDefinition: Codable, Hashable, Identifiable, Sendable {
+    /// Stable identifier used as the key for the profile's data and history stores.
+    public let id: UUID
+    /// Human-readable profile name shown in the UI.
+    public var displayName: String
+    /// Creation timestamp; the built-in default uses the Unix epoch so it sorts deterministically.
+    public let createdAt: Date
+    /// Whether this is the immovable built-in default profile.
+    public let isBuiltInDefault: Bool
+
+    /// Creates a profile definition.
+    /// - Parameters:
+    ///   - id: Stable identifier for the profile's stores.
+    ///   - displayName: Human-readable name.
+    ///   - createdAt: Creation timestamp.
+    ///   - isBuiltInDefault: Whether this is the built-in default profile.
+    public init(id: UUID, displayName: String, createdAt: Date, isBuiltInDefault: Bool) {
+        self.id = id
+        self.displayName = displayName
+        self.createdAt = createdAt
+        self.isBuiltInDefault = isBuiltInDefault
+    }
+
+    /// URL/socket-safe identifier derived from ``displayName``.
+    ///
+    /// The built-in default always slugs to `"default"`. Other profiles lowercase
+    /// the name, collapse runs of non-alphanumerics to `-`, trim leading/trailing
+    /// `-`, and fall back to the lowercased UUID string when the result is empty.
+    public var slug: String {
+        if isBuiltInDefault {
+            return "default"
+        }
+
+        let normalized = displayName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return normalized.isEmpty ? id.uuidString.lowercased() : normalized
+    }
+}

--- a/Packages/CmuxBrowserProfiles/Tests/CmuxBrowserProfilesTests/BrowserProfileRepositoryTests.swift
+++ b/Packages/CmuxBrowserProfiles/Tests/CmuxBrowserProfilesTests/BrowserProfileRepositoryTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import Testing
+@testable import CmuxBrowserProfiles
+
+@MainActor
+private final class FakeHistoryStore: BrowserProfileHistoryStore {
+    var clearedWithoutLoading = false
+    var canceled = false
+    var flushed = false
+    func clearHistoryWithoutLoadingPersistedFile() { clearedWithoutLoading = true }
+    func cancelPendingSaves() { canceled = true }
+    func flushPendingSaves() { flushed = true }
+}
+
+@MainActor
+private final class FakeHistoryProvider: BrowserProfileHistoryProviding {
+    let shared = FakeHistoryStore()
+    private(set) var made: [FakeHistoryStore] = []
+    var madeFileURLs: [URL?] = []
+    var sharedFlushed = false
+    var defaultURL: URL? = URL(fileURLWithPath: "/tmp/cmux-test-default/browser_history.json")
+
+    var sharedHistoryStore: any BrowserProfileHistoryStore { shared }
+
+    func makeHistoryStore(fileURL: URL?) -> any BrowserProfileHistoryStore {
+        madeFileURLs.append(fileURL)
+        let store = FakeHistoryStore()
+        made.append(store)
+        return store
+    }
+
+    func defaultHistoryFileURLForCurrentBundle() -> URL? { defaultURL }
+
+    func normalizedBrowserHistoryNamespace(forBundleIdentifier bundleIdentifier: String) -> String {
+        "ns-\(bundleIdentifier)"
+    }
+
+    func flushSharedHistoryPendingSaves() { sharedFlushed = true }
+}
+
+@MainActor
+private final class FakeDataStore: NSObject {}
+
+@MainActor
+private final class FakeWebsiteDataStoreProvider: BrowserProfileWebsiteDataStoreProviding {
+    let defaultStore = FakeDataStore()
+    private(set) var madeCount = 0
+    private(set) var removedFromStores: [ObjectIdentifier] = []
+    var types = ["WKCookies", "WKLocalStorage"]
+
+    var defaultWebsiteDataStore: AnyObject { defaultStore }
+
+    func makeWebsiteDataStore(forProfileID profileID: UUID) -> AnyObject {
+        madeCount += 1
+        return FakeDataStore()
+    }
+
+    var allWebsiteDataTypes: [String] { types }
+
+    func removeAllData(ofTypes dataTypes: [String], from store: AnyObject) async {
+        removedFromStores.append(ObjectIdentifier(store))
+    }
+}
+
+private actor FakeFileRemover: BrowserProfileFileRemoving {
+    private(set) var removed: [URL] = []
+    func removeItemIfExists(at url: URL) async { removed.append(url) }
+    func removedURLs() -> [URL] { removed }
+}
+
+@MainActor
+private func makeRepository(
+    suiteName: String = "cmux.browserprofiles.test.\(UUID().uuidString)",
+    history: FakeHistoryProvider = FakeHistoryProvider(),
+    data: FakeWebsiteDataStoreProvider = FakeWebsiteDataStoreProvider(),
+    files: FakeFileRemover = FakeFileRemover(),
+    bundleIdentifier: String = "ai.manaflow.cmux.test"
+) -> (BrowserProfileRepository, UserDefaults) {
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    let repo = BrowserProfileRepository(
+        defaults: defaults,
+        historyProvider: history,
+        websiteDataStoreProvider: data,
+        fileRemover: files,
+        bundleIdentifier: bundleIdentifier,
+        defaultProfileDisplayName: "Default"
+    )
+    return (repo, defaults)
+}
+
+@Suite @MainActor
+struct BrowserProfileRepositoryTests {
+    @Test func freshLoadSeedsBuiltInDefault() {
+        let (repo, defaults) = makeRepository()
+        #expect(repo.profiles.count == 1)
+        #expect(repo.profiles.first?.isBuiltInDefault == true)
+        #expect(repo.profiles.first?.id == BrowserProfileRepository.builtInDefaultProfileID)
+        #expect(repo.lastUsedProfileID == BrowserProfileRepository.builtInDefaultProfileID)
+        // Persisted on first load.
+        #expect(defaults.data(forKey: BrowserProfileRepository.profilesDefaultsKey) != nil)
+        #expect(defaults.string(forKey: BrowserProfileRepository.lastUsedProfileDefaultsKey)
+                == BrowserProfileRepository.builtInDefaultProfileID.uuidString)
+    }
+
+    @Test func createTrimsSortsPersistsAndMarksUsed() {
+        let (repo, defaults) = makeRepository()
+        let created = repo.createProfile(named: "  Work  ")
+        #expect(created?.displayName == "Work")
+        #expect(repo.lastUsedProfileID == created?.id)
+        // Default sorts before the new profile.
+        #expect(repo.profiles.first?.isBuiltInDefault == true)
+        #expect(repo.profiles.last?.displayName == "Work")
+        // Persisted.
+        let raw = defaults.data(forKey: BrowserProfileRepository.profilesDefaultsKey)!
+        let decoded = try! JSONDecoder().decode([BrowserProfileDefinition].self, from: raw)
+        #expect(decoded.contains { $0.displayName == "Work" })
+    }
+
+    @Test func createRejectsEmptyName() {
+        let (repo, _) = makeRepository()
+        #expect(repo.createProfile(named: "   ") == nil)
+        #expect(repo.profiles.count == 1)
+    }
+
+    @Test func alphabeticalSortAfterDefault() {
+        let (repo, _) = makeRepository()
+        _ = repo.createProfile(named: "Zeta")
+        _ = repo.createProfile(named: "alpha")
+        #expect(repo.profiles.map(\.displayName) == ["Default", "alpha", "Zeta"])
+    }
+
+    @Test func renameNonDefaultAndRejectDefault() {
+        let (repo, _) = makeRepository()
+        let p = repo.createProfile(named: "Old")!
+        #expect(repo.renameProfile(id: p.id, to: " New ") == true)
+        #expect(repo.profileDefinition(id: p.id)?.displayName == "New")
+        #expect(repo.renameProfile(id: p.id, to: "  ") == false)
+        #expect(repo.renameProfile(id: BrowserProfileRepository.builtInDefaultProfileID, to: "X") == false)
+    }
+
+    @Test func canRenameRules() {
+        let (repo, _) = makeRepository()
+        let p = repo.createProfile(named: "X")!
+        #expect(repo.canRenameProfile(id: p.id) == true)
+        #expect(repo.canRenameProfile(id: BrowserProfileRepository.builtInDefaultProfileID) == false)
+        #expect(repo.canRenameProfile(id: UUID()) == false)
+    }
+
+    @Test func deleteResetsLastUsedAndCancelsHistory() {
+        let history = FakeHistoryProvider()
+        let (repo, _) = makeRepository(history: history)
+        let p = repo.createProfile(named: "Temp")!
+        // Materialize the history store so delete cancels it.
+        _ = repo.historyStore(for: p.id)
+        #expect(repo.lastUsedProfileID == p.id)
+        let removed = repo.deleteProfile(id: p.id)
+        #expect(removed?.id == p.id)
+        #expect(repo.lastUsedProfileID == BrowserProfileRepository.builtInDefaultProfileID)
+        #expect(history.made.first?.canceled == true)
+        #expect(repo.profileDefinition(id: p.id) == nil)
+    }
+
+    @Test func deleteRejectsDefaultAndUnknown() {
+        let (repo, _) = makeRepository()
+        #expect(repo.deleteProfile(id: BrowserProfileRepository.builtInDefaultProfileID) == nil)
+        #expect(repo.deleteProfile(id: UUID()) == nil)
+    }
+
+    @Test func websiteDataStoreCachesAndDefaultMapsToDefault() {
+        let data = FakeWebsiteDataStoreProvider()
+        let (repo, _) = makeRepository(data: data)
+        let p = repo.createProfile(named: "P")!
+        let first = repo.websiteDataStore(for: p.id)
+        let second = repo.websiteDataStore(for: p.id)
+        #expect(ObjectIdentifier(first) == ObjectIdentifier(second))
+        #expect(data.madeCount == 1)
+        let def = repo.websiteDataStore(for: BrowserProfileRepository.builtInDefaultProfileID)
+        #expect(ObjectIdentifier(def) == ObjectIdentifier(data.defaultStore))
+    }
+
+    @Test func historyStoreCachesAndDefaultMapsToShared() {
+        let history = FakeHistoryProvider()
+        let (repo, _) = makeRepository(history: history)
+        let p = repo.createProfile(named: "P")!
+        let a = repo.historyStore(for: p.id)
+        let b = repo.historyStore(for: p.id)
+        #expect(ObjectIdentifier(a) == ObjectIdentifier(b))
+        #expect(history.made.count == 1)
+        let def = repo.historyStore(for: BrowserProfileRepository.builtInDefaultProfileID)
+        #expect(ObjectIdentifier(def) == ObjectIdentifier(history.shared))
+    }
+
+    @Test func historyFileURLDefaultAndPerProfileShape() {
+        let history = FakeHistoryProvider()
+        let (repo, _) = makeRepository(history: history, bundleIdentifier: "ai.manaflow.cmux.test")
+        #expect(repo.historyFileURL(for: BrowserProfileRepository.builtInDefaultProfileID) == history.defaultURL)
+        let p = repo.createProfile(named: "P")!
+        let url = repo.historyFileURL(for: p.id)!
+        #expect(url.lastPathComponent == "browser_history.json")
+        #expect(url.path.contains("ns-ai.manaflow.cmux.test"))
+        #expect(url.path.contains("browser_profiles"))
+        #expect(url.path.contains(p.id.uuidString.lowercased()))
+    }
+
+    @Test func clearProfileDataWipesAndReports() async {
+        let history = FakeHistoryProvider()
+        let data = FakeWebsiteDataStoreProvider()
+        data.types = ["WKZeta", "WKAlpha"]
+        let (repo, _) = makeRepository(history: history, data: data)
+        let p = repo.createProfile(named: "P")!
+        let outcome = await repo.clearProfileData(id: p.id)
+        #expect(outcome?.profile.id == p.id)
+        #expect(outcome?.clearedHistory == true)
+        #expect(outcome?.clearedWebsiteDataTypes == ["WKAlpha", "WKZeta"]) // sorted
+        #expect(history.made.first?.clearedWithoutLoading == true)
+        #expect(data.removedFromStores.count == 1)
+    }
+
+    @Test func clearProfileDataUnknownReturnsNil() async {
+        let (repo, _) = makeRepository()
+        let outcome = await repo.clearProfileData(id: UUID())
+        #expect(outcome == nil)
+    }
+
+    @Test func noteUsedIgnoresUnknownAndPersists() {
+        let (repo, defaults) = makeRepository()
+        repo.noteUsed(UUID())
+        #expect(repo.lastUsedProfileID == BrowserProfileRepository.builtInDefaultProfileID)
+        let p = repo.createProfile(named: "P")!
+        repo.noteUsed(p.id)
+        #expect(repo.lastUsedProfileID == p.id)
+        #expect(defaults.string(forKey: BrowserProfileRepository.lastUsedProfileDefaultsKey) == p.id.uuidString)
+    }
+
+    @Test func effectiveLastUsedFallsBackWhenMissing() {
+        let (_, defaults) = makeRepository()
+        // Force lastUsed to a stale id via persistence, then reload.
+        let stale = UUID()
+        defaults.set(stale.uuidString, forKey: BrowserProfileRepository.lastUsedProfileDefaultsKey)
+        let reloaded = BrowserProfileRepository(
+            defaults: defaults,
+            historyProvider: FakeHistoryProvider(),
+            websiteDataStoreProvider: FakeWebsiteDataStoreProvider(),
+            fileRemover: FakeFileRemover(),
+            bundleIdentifier: "x",
+            defaultProfileDisplayName: "Default"
+        )
+        #expect(reloaded.lastUsedProfileID == BrowserProfileRepository.builtInDefaultProfileID)
+        #expect(reloaded.effectiveLastUsedProfileID == BrowserProfileRepository.builtInDefaultProfileID)
+    }
+
+    @Test func loadDedupesPersistedBuiltInDefault() {
+        let suite = "cmux.browserprofiles.test.dedup.\(UUID().uuidString)"
+        let (repo, defaults) = makeRepository(suiteName: suite)
+        _ = repo.createProfile(named: "Keep")
+        // Inject a duplicate built-in default into persisted data.
+        let dupe = BrowserProfileDefinition(
+            id: BrowserProfileRepository.builtInDefaultProfileID,
+            displayName: "Bogus",
+            createdAt: Date(),
+            isBuiltInDefault: true
+        )
+        var stored = repo.profiles
+        stored.append(dupe)
+        defaults.set(try! JSONEncoder().encode(stored), forKey: BrowserProfileRepository.profilesDefaultsKey)
+        let reloaded = BrowserProfileRepository(
+            defaults: defaults,
+            historyProvider: FakeHistoryProvider(),
+            websiteDataStoreProvider: FakeWebsiteDataStoreProvider(),
+            fileRemover: FakeFileRemover(),
+            bundleIdentifier: "x",
+            defaultProfileDisplayName: "Default"
+        )
+        let defaults0 = reloaded.profiles.filter { $0.isBuiltInDefault }
+        #expect(defaults0.count == 1)
+        #expect(defaults0.first?.displayName == "Default") // canonical, not "Bogus"
+    }
+
+    @Test func flushPendingSavesFlushesSharedAndCached() {
+        let history = FakeHistoryProvider()
+        let (repo, _) = makeRepository(history: history)
+        let p = repo.createProfile(named: "P")!
+        _ = repo.historyStore(for: p.id)
+        repo.flushPendingSaves()
+        #expect(history.sharedFlushed == true)
+        #expect(history.made.first?.flushed == true)
+    }
+
+    @Test func slugRules() {
+        let def = BrowserProfileDefinition(id: UUID(), displayName: "x", createdAt: Date(), isBuiltInDefault: true)
+        #expect(def.slug == "default")
+        let named = BrowserProfileDefinition(id: UUID(), displayName: "  My Work! ", createdAt: Date(), isBuiltInDefault: false)
+        #expect(named.slug == "my-work")
+        let id = UUID()
+        let empty = BrowserProfileDefinition(id: id, displayName: "!!!", createdAt: Date(), isBuiltInDefault: false)
+        #expect(empty.slug == id.uuidString.lowercased())
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6,6 +6,7 @@ import WebKit
 import AppKit
 import Bonsplit
 import CmuxBrowserPanel
+import CmuxBrowserProfiles
 import CmuxTerminalCore
 import Network
 import CFNetwork
@@ -285,40 +286,67 @@ enum BrowserImportHintSettings {
     }
 }
 
-struct BrowserProfileDefinition: Codable, Hashable, Identifiable, Sendable {
-    let id: UUID
-    var displayName: String
-    let createdAt: Date
-    let isBuiltInDefault: Bool
+// `BrowserProfileDefinition` and `BrowserProfileClearOutcome` now live in the
+// `CmuxBrowserProfiles` package (imported above); the call sites reference them
+// unqualified through that import.
 
-    var slug: String {
-        if isBuiltInDefault {
-            return "default"
-        }
+// Adapts `BrowserHistoryStore` to the `CmuxBrowserProfiles` history seams so the
+// profile repository can manage per-profile history stores without depending on
+// the app-target `BrowserHistoryStore` type.
+extension BrowserHistoryStore: BrowserProfileHistoryStore {}
 
-        let normalized = displayName
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-            .replacingOccurrences(of: "[^a-z0-9]+", with: "-", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
-        return normalized.isEmpty ? id.uuidString.lowercased() : normalized
+@MainActor
+private final class BrowserProfileHistoryAdapter: BrowserProfileHistoryProviding {
+    var sharedHistoryStore: any BrowserProfileHistoryStore { BrowserHistoryStore.shared }
+
+    func makeHistoryStore(fileURL: URL?) -> any BrowserProfileHistoryStore {
+        BrowserHistoryStore(fileURL: fileURL)
+    }
+
+    func defaultHistoryFileURLForCurrentBundle() -> URL? {
+        BrowserHistoryStore.defaultHistoryFileURLForCurrentBundle()
+    }
+
+    func normalizedBrowserHistoryNamespace(forBundleIdentifier bundleIdentifier: String) -> String {
+        BrowserHistoryStore.normalizedBrowserHistoryNamespaceForBundleIdentifier(bundleIdentifier)
+    }
+
+    func flushSharedHistoryPendingSaves() {
+        BrowserHistoryStore.shared.flushPendingSaves()
     }
 }
 
-struct BrowserProfileClearOutcome: Sendable {
-    let profile: BrowserProfileDefinition
-    let clearedWebsiteDataTypes: [String]
-    let clearedHistory: Bool
+// Adapts WebKit's `WKWebsiteDataStore` to the `CmuxBrowserProfiles` data-store
+// seam, mapping the built-in default profile to the default store and bridging
+// the legacy completion-handler wipe to `async`/`await` at this one boundary.
+@MainActor
+private final class BrowserProfileWebsiteDataStoreAdapter: BrowserProfileWebsiteDataStoreProviding {
+    var defaultWebsiteDataStore: AnyObject { WKWebsiteDataStore.default() }
 
-    var socketPayload: [String: Any] {
-        [
-            "id": profile.id.uuidString,
-            "name": profile.displayName,
-            "slug": profile.slug,
-            "built_in_default": profile.isBuiltInDefault,
-            "cleared_website_data_types": clearedWebsiteDataTypes,
-            "cleared_history": clearedHistory,
-        ]
+    func makeWebsiteDataStore(forProfileID profileID: UUID) -> AnyObject {
+        WKWebsiteDataStore(forIdentifier: profileID)
+    }
+
+    var allWebsiteDataTypes: [String] { Array(WKWebsiteDataStore.allWebsiteDataTypes()) }
+
+    func removeAllData(ofTypes dataTypes: [String], from store: AnyObject) async {
+        guard let store = store as? WKWebsiteDataStore else { return }
+        let types = Set(dataTypes)
+        await withCheckedContinuation { continuation in
+            store.removeData(ofTypes: types, modifiedSince: .distantPast) {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+// Removes profile-owned files via a detached utility task, matching the original
+// best-effort, ignore-errors deletion behavior.
+private struct BrowserProfileFileRemover: BrowserProfileFileRemoving {
+    func removeItemIfExists(at url: URL) async {
+        await Task.detached(priority: .utility) {
+            try? FileManager.default.removeItem(at: url)
+        }.value
     }
 }
 
@@ -326,232 +354,93 @@ struct BrowserProfileClearOutcome: Sendable {
 final class BrowserProfileStore: ObservableObject {
     static let shared = BrowserProfileStore()
 
-    private static let profilesDefaultsKey = "browserProfiles.v1"
-    private static let lastUsedProfileDefaultsKey = "browserProfiles.lastUsed"
-    private static let builtInDefaultProfileID = UUID(uuidString: "52B43C05-4A1D-45D3-8FD5-9EF94952E445")!
-
     @Published private(set) var profiles: [BrowserProfileDefinition] = []
-    @Published private(set) var lastUsedProfileID: UUID = builtInDefaultProfileID
+    @Published private(set) var lastUsedProfileID: UUID = BrowserProfileRepository.builtInDefaultProfileID
 
-    private let defaults: UserDefaults
-    private var dataStores: [UUID: WKWebsiteDataStore] = [:]
-    private var historyStores: [UUID: BrowserHistoryStore] = [:]
+    private let repository: BrowserProfileRepository
 
     init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
-        load()
+        repository = BrowserProfileRepository(
+            defaults: defaults,
+            historyProvider: BrowserProfileHistoryAdapter(),
+            websiteDataStoreProvider: BrowserProfileWebsiteDataStoreAdapter(),
+            fileRemover: BrowserProfileFileRemover(),
+            bundleIdentifier: Bundle.main.bundleIdentifier ?? "cmux",
+            defaultProfileDisplayName: String(localized: "browser.profile.default", defaultValue: "Default")
+        )
+        mirrorPublishedState()
+    }
+
+    private func mirrorPublishedState() {
+        profiles = repository.profiles
+        lastUsedProfileID = repository.lastUsedProfileID
     }
 
     var builtInDefaultProfileID: UUID {
-        Self.builtInDefaultProfileID
+        repository.builtInDefaultProfileID
     }
 
     var effectiveLastUsedProfileID: UUID {
-        profileDefinition(id: lastUsedProfileID) != nil ? lastUsedProfileID : Self.builtInDefaultProfileID
+        repository.effectiveLastUsedProfileID
     }
 
     func profileDefinition(id: UUID) -> BrowserProfileDefinition? {
-        profiles.first(where: { $0.id == id })
+        repository.profileDefinition(id: id)
     }
 
     func displayName(for id: UUID) -> String {
-        profileDefinition(id: id)?.displayName
-        ?? String(localized: "browser.profile.default", defaultValue: "Default")
+        repository.displayName(for: id)
     }
 
     func createProfile(named rawName: String) -> BrowserProfileDefinition? {
-        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else { return nil }
-        let profile = BrowserProfileDefinition(
-            id: UUID(),
-            displayName: name,
-            createdAt: Date(),
-            isBuiltInDefault: false
-        )
-        profiles.append(profile)
-        profiles.sort {
-            if $0.isBuiltInDefault != $1.isBuiltInDefault {
-                return $0.isBuiltInDefault && !$1.isBuiltInDefault
-            }
-            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-        }
-        persist()
-        noteUsed(profile.id)
-        return profile
+        let result = repository.createProfile(named: rawName)
+        mirrorPublishedState()
+        return result
     }
 
     func renameProfile(id: UUID, to rawName: String) -> Bool {
-        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty,
-              let index = profiles.firstIndex(where: { $0.id == id }),
-              !profiles[index].isBuiltInDefault else {
-            return false
-        }
-        profiles[index].displayName = name
-        profiles.sort {
-            if $0.isBuiltInDefault != $1.isBuiltInDefault {
-                return $0.isBuiltInDefault && !$1.isBuiltInDefault
-            }
-            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-        }
-        persist()
-        return true
+        let result = repository.renameProfile(id: id, to: rawName)
+        mirrorPublishedState()
+        return result
     }
 
     func canRenameProfile(id: UUID) -> Bool {
-        guard let profile = profileDefinition(id: id) else { return false }
-        return !profile.isBuiltInDefault
+        repository.canRenameProfile(id: id)
     }
 
     func deleteProfile(id: UUID) -> BrowserProfileDefinition? {
-        guard let index = profiles.firstIndex(where: { $0.id == id }),
-              !profiles[index].isBuiltInDefault else {
-            return nil
-        }
-        let removed = profiles.remove(at: index)
-        let historyDirectoryURL = historyFileURL(for: id)?.deletingLastPathComponent()
-        historyStores[id]?.cancelPendingSaves()
-        dataStores.removeValue(forKey: id)
-        historyStores.removeValue(forKey: id)
-        if lastUsedProfileID == id {
-            lastUsedProfileID = Self.builtInDefaultProfileID
-            defaults.set(lastUsedProfileID.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
-        }
-        persist()
-        if let historyDirectoryURL {
-            Task.detached(priority: .utility) {
-                try? FileManager.default.removeItem(at: historyDirectoryURL)
-            }
-        }
-        return removed
+        let result = repository.deleteProfile(id: id)
+        mirrorPublishedState()
+        return result
     }
 
     func clearProfileData(id: UUID) async -> BrowserProfileClearOutcome? {
-        guard let profile = profileDefinition(id: id) else { return nil }
-        let store = websiteDataStore(for: id)
-        let historyURL = historyFileURL(for: id)
-        historyStore(for: id).clearHistoryWithoutLoadingPersistedFile()
-        let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
-        await withCheckedContinuation { continuation in
-            store.removeData(ofTypes: dataTypes, modifiedSince: .distantPast) {
-                continuation.resume()
-            }
-        }
-        if let historyURL {
-            await Self.removeItemIfExists(at: historyURL)
-        }
-        return BrowserProfileClearOutcome(
-            profile: profile,
-            clearedWebsiteDataTypes: Array(dataTypes).sorted(),
-            clearedHistory: true
-        )
-    }
-
-    @Sendable private nonisolated static func removeItemIfExists(at url: URL) async {
-        await Task.detached(priority: .utility) {
-            try? FileManager.default.removeItem(at: url)
-        }.value
+        let result = await repository.clearProfileData(id: id)
+        mirrorPublishedState()
+        return result
     }
 
     func noteUsed(_ id: UUID) {
-        guard profileDefinition(id: id) != nil else { return }
-        if lastUsedProfileID != id {
-            lastUsedProfileID = id
-            defaults.set(id.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
-        }
+        repository.noteUsed(id)
+        mirrorPublishedState()
     }
 
     func websiteDataStore(for profileID: UUID) -> WKWebsiteDataStore {
-        if profileID == Self.builtInDefaultProfileID {
-            return .default()
-        }
-        if let existing = dataStores[profileID] {
-            return existing
-        }
-        let store = WKWebsiteDataStore(forIdentifier: profileID)
-        dataStores[profileID] = store
-        return store
+        // Safe force-cast: the adapter only ever vends `WKWebsiteDataStore` handles.
+        repository.websiteDataStore(for: profileID) as! WKWebsiteDataStore
     }
 
     func historyStore(for profileID: UUID) -> BrowserHistoryStore {
-        if profileID == Self.builtInDefaultProfileID {
-            return .shared
-        }
-        if let existing = historyStores[profileID] {
-            return existing
-        }
-        let store = BrowserHistoryStore(fileURL: historyFileURL(for: profileID))
-        historyStores[profileID] = store
-        return store
+        // Safe force-cast: the adapter only ever vends `BrowserHistoryStore` handles.
+        repository.historyStore(for: profileID) as! BrowserHistoryStore
     }
 
     func historyFileURL(for profileID: UUID) -> URL? {
-        if profileID == Self.builtInDefaultProfileID {
-            return BrowserHistoryStore.defaultHistoryFileURLForCurrentBundle()
-        }
-
-        let fm = FileManager.default
-        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-        let bundleId = Bundle.main.bundleIdentifier ?? "cmux"
-        let namespace = BrowserHistoryStore.normalizedBrowserHistoryNamespaceForBundleIdentifier(bundleId)
-        let profilesDir = appSupport
-            .appendingPathComponent(namespace, isDirectory: true)
-            .appendingPathComponent("browser_profiles", isDirectory: true)
-            .appendingPathComponent(profileID.uuidString.lowercased(), isDirectory: true)
-        return profilesDir.appendingPathComponent("browser_history.json", isDirectory: false)
+        repository.historyFileURL(for: profileID)
     }
 
     func flushPendingSaves() {
-        BrowserHistoryStore.shared.flushPendingSaves()
-        for store in historyStores.values {
-            store.flushPendingSaves()
-        }
-    }
-
-    private func load() {
-        let builtInDefaultProfile = BrowserProfileDefinition(
-            id: Self.builtInDefaultProfileID,
-            displayName: String(localized: "browser.profile.default", defaultValue: "Default"),
-            createdAt: Date(timeIntervalSince1970: 0),
-            isBuiltInDefault: true
-        )
-
-        if let data = defaults.data(forKey: Self.profilesDefaultsKey),
-           let decoded = try? JSONDecoder().decode([BrowserProfileDefinition].self, from: data),
-           !decoded.isEmpty {
-            var resolvedProfiles = decoded.filter { $0.id != Self.builtInDefaultProfileID }
-            resolvedProfiles.append(builtInDefaultProfile)
-            profiles = sortedProfiles(resolvedProfiles)
-        } else {
-            profiles = [builtInDefaultProfile]
-            persist()
-        }
-
-        if let rawLastUsed = defaults.string(forKey: Self.lastUsedProfileDefaultsKey),
-           let parsed = UUID(uuidString: rawLastUsed),
-           profileDefinition(id: parsed) != nil {
-            lastUsedProfileID = parsed
-        } else {
-            lastUsedProfileID = Self.builtInDefaultProfileID
-            defaults.set(lastUsedProfileID.uuidString, forKey: Self.lastUsedProfileDefaultsKey)
-        }
-    }
-
-    private func persist() {
-        let encoder = JSONEncoder()
-        guard let data = try? encoder.encode(profiles) else { return }
-        defaults.set(data, forKey: Self.profilesDefaultsKey)
-    }
-
-    private func sortedProfiles(_ profiles: [BrowserProfileDefinition]) -> [BrowserProfileDefinition] {
-        profiles.sorted {
-            if $0.isBuiltInDefault != $1.isBuiltInDefault {
-                return $0.isBuiltInDefault && !$1.isBuiltInDefault
-            }
-            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
-        }
+        repository.flushPendingSaves()
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 53750002A0B1C2D3E4F50002 /* CmuxAuthRuntime */; };
 		E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000C2 /* CmuxBrowser */; };
 		5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */ = {isa = PBXBuildFile; productRef = 5E55100000000000000000B2 /* CmuxBrowserPanel */; };
+		5E5510000000000000000BF3 /* CmuxBrowserProfiles in Frameworks */ = {isa = PBXBuildFile; productRef = 5E5510000000000000000BF2 /* CmuxBrowserProfiles */; };
 		CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */ = {isa = PBXBuildFile; productRef = CA52A005CA52A005CA52A005 /* CmuxCanvas */; };
 		CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */ = {isa = PBXBuildFile; productRef = CA53A005CA53A005CA53A005 /* CmuxCanvasUI */; };
@@ -1769,6 +1770,7 @@
 				53750003A0B1C2D3E4F50003 /* CmuxAuthRuntime in Frameworks */,
 				E3B7A30000000000000000C3 /* CmuxBrowser in Frameworks */,
 				5E55100000000000000000B3 /* CmuxBrowserPanel in Frameworks */,
+				5E5510000000000000000BF3 /* CmuxBrowserProfiles in Frameworks */,
 				CA52A003CA52A003CA52A003 /* CmuxCanvas in Frameworks */,
 				CA53A003CA53A003CA53A003 /* CmuxCanvasUI in Frameworks */,
 				5E55500000000000000000E3 /* CmuxCommandPalette in Frameworks */,
@@ -2829,6 +2831,7 @@
 				C19C5E0200000000000000A2 /* CmuxIPCService */,
 				5E55100000000000000000A2 /* CmuxSession */,
 				5E55100000000000000000B2 /* CmuxBrowserPanel */,
+				5E5510000000000000000BF2 /* CmuxBrowserProfiles */,
 				5E55200000000000000000B2 /* CmuxWindowing */,
 				5E55300000000000000000C2 /* CmuxCommandPaletteUI */,
 				5E55500000000000000000E2 /* CmuxCommandPalette */,
@@ -3022,6 +3025,7 @@
 				C19C5E0100000000000000A1 /* XCLocalSwiftPackageReference "CmuxIPCService" */,
 				5E55100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSession" */,
 				5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */,
+				5E5510000000000000000BF1 /* XCLocalSwiftPackageReference "CmuxBrowserProfiles" */,
 				5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */,
 				5E55300000000000000000C1 /* XCLocalSwiftPackageReference "CmuxCommandPaletteUI" */,
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
@@ -4527,6 +4531,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxBrowserPanel;
 		};
+		5E5510000000000000000BF1 /* XCLocalSwiftPackageReference "CmuxBrowserProfiles" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxBrowserProfiles;
+		};
 		5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWindowing;
@@ -4893,6 +4901,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5E55100000000000000000B1 /* XCLocalSwiftPackageReference "CmuxBrowserPanel" */;
 			productName = CmuxBrowserPanel;
+		};
+		5E5510000000000000000BF2 /* CmuxBrowserProfiles */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5E5510000000000000000BF1 /* XCLocalSwiftPackageReference "CmuxBrowserProfiles" */;
+			productName = CmuxBrowserProfiles;
 		};
 		5E55200000000000000000B2 /* CmuxWindowing */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the browser profile lifecycle and data-management domain out of the ~13k-line `Sources/Panels/BrowserPanel.swift` god file into a new `Packages/CmuxBrowserProfiles` package, following the modular-refactor conventions.

## What moved
- `BrowserProfileDefinition` (Sendable value type, slug derivation)
- `BrowserProfileClearOutcome` (Sendable value type, `socketPayload`)
- A new `@MainActor @Observable BrowserProfileRepository` owning all profile state and logic: `createProfile` / `renameProfile` / `canRenameProfile` / `deleteProfile` / `clearProfileData`, `noteUsed`, the per-profile `WKWebsiteDataStore` and history-store caches, `historyFileURL(for:)`, `flushPendingSaves`, `load`/`persist`, last-used tracking, and the built-in default profile.

## Seams (constructor-injected; concrete conformers stay in the app target)
- `BrowserProfileHistoryProviding` + `BrowserProfileHistoryStore` invert the `BrowserHistoryStore` dependency (shared + per-profile stores, default history file URL, namespace mapping, shared flush).
- `BrowserProfileWebsiteDataStoreProviding` inverts WebKit: `WKWebsiteDataStore.default()` / `WKWebsiteDataStore(forIdentifier:)`, `allWebsiteDataTypes`, and an async data-removal call that bridges the legacy completion handler at one boundary.
- `BrowserProfileFileRemoving` inverts `FileManager.default` deletion (detached utility task, ignore-errors).
- `UserDefaults`, the bundle identifier, and the localized default profile name are injected into the repository `init`.

The app target keeps a thin `BrowserProfileStore` `ObservableObject` facade that owns the repository, mirrors `profiles` / `lastUsedProfileID` into its `@Published` properties after each mutation (preserving the existing `@ObservedObject` view reactivity in `BrowserPanelView`), and forwards every method one-to-one. The concrete adapters (`BrowserProfileHistoryAdapter`, `BrowserProfileWebsiteDataStoreAdapter`, `BrowserProfileFileRemover`) live in the app target. All call sites (`Workspace`, `AppDelegate`, `TerminalController`, `BrowserAutomation`, `BrowserPanelView`) are unchanged.

## Byte-identical
Same Defaults keys (`browserProfiles.v1`, `browserProfiles.lastUsed`), same built-in default UUID, same JSON encode/decode, same default-first-then-alphabetical sort, same data-types `Set` passed to `removeData(ofTypes:)` and the same sorted array reported in the outcome, same per-profile history paths (`<namespace>/browser_profiles/<uuid>/browser_history.json`), and the same detached-task deletion semantics.

## Tests
`CmuxBrowserProfilesTests` adds 18 Swift Testing cases with fakes for every seam: load/seed, CRUD, trimming, sorting, last-used fallback, dedup of a persisted duplicate built-in default, store caching (default mapping vs per-profile), history-URL shape, clear-data wipe + outcome reporting, and slug rules. `swift build` and `swift test` pass in the package; package-conventions lint prints OK with zero new `lint:allow`.

Shrinks `BrowserPanel.swift` by ~111 lines (budget reconciled). Wired into `cmux.xcodeproj` via the 6 standard pbxproj entries as an app-target dependency.

NOTE: app build validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144096&installation_id=133855650&pr_number=6178&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6178&signature=dcc1989640cef1198621520c7a0bd2879edaaabbf3164d95eb0565512ec1b183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted browser profile lifecycle and data management into a new `CmuxBrowserProfiles` package with a `BrowserProfileRepository`. Behavior is unchanged; `BrowserPanel.swift` shrinks by ~111 lines and all call sites remain the same.

- **Refactors**
  - Added `CmuxBrowserProfiles` and moved `BrowserProfileDefinition` and `BrowserProfileClearOutcome`.
  - Introduced `@MainActor @Observable` `BrowserProfileRepository` for profiles, last-used, persistence, store caches, clear/delete.
  - Added seams: `BrowserProfileHistoryProviding`, `BrowserProfileWebsiteDataStoreProviding`, `BrowserProfileFileRemoving` (adapters live in the app target).
  - Kept `BrowserProfileStore` as a thin facade to preserve `@Published` view reactivity.
  - Preserved behavior: same defaults keys/UUID/sort, same history paths, same website-data types cleared, same deletion semantics; project wired to include the package.

- **Tests**
  - Added `CmuxBrowserProfilesTests` (18 cases) covering load/seed, CRUD, sorting, last-used fallback, duplicate-default dedup, store caching, history URL shape, and clear-data outcome.

<sup>Written for commit 3c181bb2a9a9461e0e90ecbecfc69f9075167b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

