### PR TITLE
Extract workspace surface-list derivation into CmuxWorkspaceSurfaceList

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -6,7 +6,7 @@
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift
-12361	Sources/Workspace.swift
+12323	Sources/Workspace.swift
 12093	Sources/GhosttyTerminalView.swift
 12046	cmuxTests/AppDelegateShortcutRoutingTests.swift
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift

--- a/Packages/CmuxWorkspaceSurfaceList/Package.swift
+++ b/Packages/CmuxWorkspaceSurfaceList/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxWorkspaceSurfaceList",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxWorkspaceSurfaceList",
+            targets: ["CmuxWorkspaceSurfaceList"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxWorkspaceSurfaceList",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxWorkspaceSurfaceListTests",
+            dependencies: ["CmuxWorkspaceSurfaceList"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxWorkspaceSurfaceList/Sources/CmuxWorkspaceSurfaceList/WorkspaceSurfaceListModel.swift
+++ b/Packages/CmuxWorkspaceSurfaceList/Sources/CmuxWorkspaceSurfaceList/WorkspaceSurfaceListModel.swift
@@ -1,0 +1,156 @@
+public import Foundation
+public import Observation
+
+/// The per-workspace surface-list derivation model: turns the live bonsplit
+/// split tree and panel registry into the ordered panel-id lists the rest of
+/// the app navigates by, and owns the reorder-detection that bumps the
+/// workspace's pane-layout version.
+///
+/// This is the navigation-state half of what the legacy `Workspace` god object
+/// computed inline: `orderedPanelIds`, `focusedPanelId`,
+/// `representativePanelIdForWorkspaceManualUnread()`,
+/// `effectiveSelectedPanelId(inPane:)`, the `tabIdsToLeft/Right/CloseOthers`
+/// pane queries, and the `paneLayoutVersion` bump in the geometry-change
+/// handler. It owns no stored panel state itself; the registry and the
+/// `lastOrderedPanelIds`/`paneLayoutVersion` bookkeeping live in the
+/// workspace's `PaneTreeModel`, reached through ``WorkspaceSurfaceTreeReading``.
+///
+/// The owning `Workspace` composition root holds one instance, attaches itself
+/// as the tree-reading host (weak, to avoid a retain cycle), and forwards its
+/// legacy accessors here. Every derivation preserves the legacy ordering and
+/// fallback chains exactly.
+@MainActor
+@Observable
+public final class WorkspaceSurfaceListModel {
+    @ObservationIgnored
+    private weak var tree: (any WorkspaceSurfaceTreeReading)?
+
+    /// Creates a detached model; call ``attach(tree:)`` before any derivation.
+    public init() {}
+
+    /// Attaches the workspace-side tree-reading seam. Must be called before the
+    /// first derivation. Held weakly: the workspace owns this model, so a strong
+    /// back-reference would retain-cycle.
+    public func attach(tree: any WorkspaceSurfaceTreeReading) {
+        self.tree = tree
+    }
+
+    /// Panel ids in bonsplit's spatial order: bonsplit tab order across all
+    /// panes, deduplicated and filtered to panels that still exist, with any
+    /// panels missing from bonsplit appended in stable `uuidString` order so
+    /// the list never drops a panel (legacy `Workspace.orderedPanelIds`).
+    ///
+    /// This is the single source of truth for serializing panels (e.g. the
+    /// mobile terminal list) and for detecting reorders.
+    public var orderedPanelIds: [UUID] {
+        guard let tree else { return [] }
+        var result: [UUID] = []
+        var seen = Set<UUID>()
+        for surfaceId in tree.surfaceIdsInTabOrderAcrossAllPanes {
+            guard let panelId = tree.panelId(forSurfaceId: surfaceId), tree.panelExists(panelId) else { continue }
+            guard seen.insert(panelId).inserted else { continue }
+            result.append(panelId)
+        }
+        let orphans = tree.allPanelIds
+            .filter { !seen.contains($0) }
+            .sorted { $0.uuidString < $1.uuidString }
+        result.append(contentsOf: orphans)
+        return result
+    }
+
+    /// The focused pane's selected panel id, or `nil` when no pane is focused
+    /// or the selection resolves to no panel (legacy
+    /// `Workspace.focusedPanelId`).
+    public var focusedPanelId: UUID? {
+        guard let tree, let surfaceId = tree.focusedPaneSelectedSurfaceId else { return nil }
+        return tree.panelId(forSurfaceId: surfaceId)
+    }
+
+    /// The panel that owns the workspace-level manual-unread indicator: the
+    /// focused panel when it still exists, else the spatially-first selected
+    /// panel across panes, else the first sidebar-ordered panel (legacy
+    /// `Workspace.representativePanelIdForWorkspaceManualUnread()`).
+    public func representativePanelIdForWorkspaceManualUnread() -> UUID? {
+        guard let tree else { return nil }
+        if let focusedPanelId, tree.panelExists(focusedPanelId) {
+            return focusedPanelId
+        }
+
+        let selectedPanelsByPaneId = Dictionary(
+            uniqueKeysWithValues: tree.allPaneIds.compactMap { paneId -> (UUID, UUID)? in
+                guard let surfaceId = tree.selectedSurfaceId(inPaneId: paneId),
+                      let panelId = tree.panelId(forSurfaceId: surfaceId),
+                      tree.panelExists(panelId) else {
+                    return nil
+                }
+                return (paneId, panelId)
+            }
+        )
+
+        for paneId in tree.spatiallyOrderedPaneIds {
+            guard let panelId = selectedPanelsByPaneId[paneId] else { continue }
+            return panelId
+        }
+
+        return tree.firstSidebarOrderedPanelId
+    }
+
+    /// The selected panel id in the pane, or `nil` when the pane has no
+    /// selection or the selection resolves to no panel (legacy
+    /// `Workspace.effectiveSelectedPanelId(inPane:)`).
+    public func effectiveSelectedPanelId(inPaneId paneId: UUID) -> UUID? {
+        guard let tree else { return nil }
+        return tree.selectedSurfaceId(inPaneId: paneId).flatMap { tree.panelId(forSurfaceId: $0) }
+    }
+
+    /// Surface ids in tab order strictly before the anchor surface in its pane,
+    /// or `[]` when the anchor is not in the pane (legacy
+    /// `Workspace.tabIdsToLeft(of:inPane:)`).
+    public func surfaceIdsToLeft(of anchorSurfaceId: UUID, inPaneId paneId: UUID) -> [UUID] {
+        guard let tree else { return [] }
+        let surfaceIds = tree.surfaceIdsInTabOrder(inPaneId: paneId)
+        guard let index = surfaceIds.firstIndex(of: anchorSurfaceId) else { return [] }
+        return Array(surfaceIds.prefix(index))
+    }
+
+    /// Surface ids in tab order strictly after the anchor surface in its pane,
+    /// or `[]` when the anchor is absent or last (legacy
+    /// `Workspace.tabIdsToRight(of:inPane:)`).
+    public func surfaceIdsToRight(of anchorSurfaceId: UUID, inPaneId paneId: UUID) -> [UUID] {
+        guard let tree else { return [] }
+        let surfaceIds = tree.surfaceIdsInTabOrder(inPaneId: paneId)
+        guard let index = surfaceIds.firstIndex(of: anchorSurfaceId),
+              index + 1 < surfaceIds.count else { return [] }
+        return Array(surfaceIds.suffix(from: index + 1))
+    }
+
+    /// Every surface id in the pane except the anchor, in tab order (legacy
+    /// `Workspace.tabIdsToCloseOthers(of:inPane:)`).
+    public func surfaceIdsToCloseOthers(of anchorSurfaceId: UUID, inPaneId paneId: UUID) -> [UUID] {
+        guard let tree else { return [] }
+        return tree.surfaceIdsInTabOrder(inPaneId: paneId).filter { $0 != anchorSurfaceId }
+    }
+
+    /// Reconciles the reorder-detection bookkeeping after a geometry change.
+    ///
+    /// Every order/membership mutation (same-pane reorder, cross-pane move,
+    /// split, close) routes through the workspace's geometry-change handler. A
+    /// pure reorder mutates only bonsplit's internal state, which is not
+    /// observed, so observers would miss it. This bumps `paneLayoutVersion`
+    /// only when the ordered panel-id sequence actually changed, so divider
+    /// drags and selection-only events (also routed through that handler) do
+    /// not fire an app-wide change (legacy gate in
+    /// `Workspace.splitTabBar(_:didChangeGeometry:)`).
+    ///
+    /// Returns whether the layout version was bumped, for callers that want to
+    /// observe the decision in tests.
+    @discardableResult
+    public func registerGeometryChange() -> Bool {
+        guard let tree else { return false }
+        let currentOrder = orderedPanelIds
+        guard currentOrder != tree.lastOrderedPanelIds else { return false }
+        tree.lastOrderedPanelIds = currentOrder
+        tree.bumpPaneLayoutVersion()
+        return true
+    }
+}

--- a/Packages/CmuxWorkspaceSurfaceList/Sources/CmuxWorkspaceSurfaceList/WorkspaceSurfaceTreeReading.swift
+++ b/Packages/CmuxWorkspaceSurfaceList/Sources/CmuxWorkspaceSurfaceList/WorkspaceSurfaceTreeReading.swift
@@ -1,0 +1,86 @@
+public import Foundation
+
+/// The workspace-side seam the surface-list model reads through to derive its
+/// ordered panel lists and reorder-detection state.
+///
+/// **Why a synchronous read-only protocol and not value snapshots.** Every
+/// derivation (`orderedPanelIds`, `focusedPanelId`,
+/// `representativePanelId(forWorkspaceManualUnread:)`, the reorder bump) is one
+/// MainActor turn that must observe the live `BonsplitController` split tree and
+/// the live panel registry exactly as the legacy computed properties on
+/// `Workspace` did. The split tree, pane selection, and tab order are owned by
+/// `BonsplitController`; the panel registry, `lastOrderedPanelIds`, and
+/// `paneLayoutVersion` are owned by the workspace's `PaneTreeModel`. The model
+/// reads them through this seam so it never imports `Bonsplit` and stays a pure
+/// leaf, while the values it sees are always the authoritative current state.
+///
+/// All identifiers are surfaced as `UUID`/`UUID` arrays: bonsplit `TabID`/
+/// `PaneID` are 1:1 with `UUID`, so the seam erases the opaque bonsplit types at
+/// the boundary. Reads return `nil`/`[]` when a pane or surface is gone,
+/// mirroring the legacy optional-chained lookups.
+@MainActor
+public protocol WorkspaceSurfaceTreeReading: AnyObject {
+    // MARK: Bonsplit tree reads
+
+    /// Every surface (bonsplit `TabID.uuid`) across all panes in bonsplit's tab
+    /// order (legacy `bonsplitController.allTabIds`). Pane grouping is not
+    /// preserved here; this is the flat membership sequence used by
+    /// ``WorkspaceSurfaceListModel/orderedPanelIds``.
+    var surfaceIdsInTabOrderAcrossAllPanes: [UUID] { get }
+
+    /// The surface id of the selected tab in the currently focused pane, or
+    /// `nil` when no pane is focused or the focused pane has no selection
+    /// (legacy `bonsplitController.selectedTab(inPane: focusedPaneId)?.id`).
+    var focusedPaneSelectedSurfaceId: UUID? { get }
+
+    /// Every pane id (bonsplit `PaneID.id`), unordered (legacy
+    /// `bonsplitController.allPaneIds`).
+    var allPaneIds: [UUID] { get }
+
+    /// Pane ids in on-screen spatial order (depth-first over the split tree),
+    /// the legacy `bonsplitController.treeSnapshot().orderedPaneIds` mapped to
+    /// `UUID`. Used to resolve the representative panel deterministically.
+    var spatiallyOrderedPaneIds: [UUID] { get }
+
+    /// The selected tab's surface id in the pane, or `nil` when the pane has no
+    /// selection (legacy `bonsplitController.selectedTab(inPane:)?.id`).
+    func selectedSurfaceId(inPaneId paneId: UUID) -> UUID?
+
+    /// The pane's surface ids in tab order (legacy
+    /// `bonsplitController.tabs(inPane:)` mapped to `\.id`).
+    func surfaceIdsInTabOrder(inPaneId paneId: UUID) -> [UUID]
+
+    // MARK: Panel-registry reads
+
+    /// Resolves the owning panel id for a surface id, or `nil` when the surface
+    /// maps to no panel (legacy `Workspace.panelIdFromSurfaceId`).
+    func panelId(forSurfaceId surfaceId: UUID) -> UUID?
+
+    /// Whether a panel id currently exists in the workspace panel registry
+    /// (legacy `panels[panelId] != nil`).
+    func panelExists(_ panelId: UUID) -> Bool
+
+    /// All panel ids in the workspace registry, unordered (legacy
+    /// `panels.keys`). The model sorts these by `uuidString` for the stable
+    /// orphan/fallback tail, matching the legacy ordering.
+    var allPanelIds: [UUID] { get }
+
+    /// The first ordered panel id from the sidebar ordering, used only as the
+    /// last-resort representative fallback (legacy
+    /// `sidebarOrderedPanelIds().first`). Sidebar ordering depends on
+    /// directory/branch resolution owned by the workspace, so it stays
+    /// host-side.
+    var firstSidebarOrderedPanelId: UUID? { get }
+
+    // MARK: Reorder bookkeeping (PaneTreeModel-owned)
+
+    /// The spatially ordered panel ids captured at the last geometry
+    /// notification, used to gate reorder bumps (legacy
+    /// `Workspace.lastOrderedPanelIds`, owned by `PaneTreeModel`).
+    var lastOrderedPanelIds: [UUID] { get set }
+
+    /// Bumps the monotonic pane-layout version (legacy
+    /// `Workspace.paneLayoutVersion &+= 1`, owned by `PaneTreeModel`). Wrapping
+    /// add, matching the legacy `&+=`.
+    func bumpPaneLayoutVersion()
+}

--- a/Packages/CmuxWorkspaceSurfaceList/Tests/CmuxWorkspaceSurfaceListTests/WorkspaceSurfaceListModelTests.swift
+++ b/Packages/CmuxWorkspaceSurfaceList/Tests/CmuxWorkspaceSurfaceListTests/WorkspaceSurfaceListModelTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Testing
+
+@testable import CmuxWorkspaceSurfaceList
+
+/// In-memory fake of the workspace-side tree seam. Models a set of panes, each
+/// with an ordered list of surface ids and a selected index, plus a
+/// surface->panel mapping and a panel registry.
+@MainActor
+private final class FakeTree: WorkspaceSurfaceTreeReading {
+    struct Pane {
+        var id: UUID
+        var surfaceIds: [UUID]
+        var selectedIndex: Int?
+    }
+
+    var panes: [Pane] = []
+    var paneSpatialOrder: [UUID] = []
+    var focusedPaneId: UUID?
+    var surfaceToPanel: [UUID: UUID] = [:]
+    var registry: Set<UUID> = []
+    var firstSidebarOrderedPanelId: UUID?
+
+    var lastOrderedPanelIds: [UUID] = []
+    private(set) var bumpCount = 0
+    func bumpPaneLayoutVersion() { bumpCount &+= 1 }
+
+    var surfaceIdsInTabOrderAcrossAllPanes: [UUID] {
+        panes.flatMap(\.surfaceIds)
+    }
+
+    var focusedPaneSelectedSurfaceId: UUID? {
+        guard let focusedPaneId, let pane = panes.first(where: { $0.id == focusedPaneId }),
+              let index = pane.selectedIndex, pane.surfaceIds.indices.contains(index) else { return nil }
+        return pane.surfaceIds[index]
+    }
+
+    var allPaneIds: [UUID] { panes.map(\.id) }
+    var spatiallyOrderedPaneIds: [UUID] { paneSpatialOrder }
+
+    func selectedSurfaceId(inPaneId paneId: UUID) -> UUID? {
+        guard let pane = panes.first(where: { $0.id == paneId }),
+              let index = pane.selectedIndex, pane.surfaceIds.indices.contains(index) else { return nil }
+        return pane.surfaceIds[index]
+    }
+
+    func surfaceIdsInTabOrder(inPaneId paneId: UUID) -> [UUID] {
+        panes.first(where: { $0.id == paneId })?.surfaceIds ?? []
+    }
+
+    func panelId(forSurfaceId surfaceId: UUID) -> UUID? { surfaceToPanel[surfaceId] }
+    func panelExists(_ panelId: UUID) -> Bool { registry.contains(panelId) }
+    var allPanelIds: [UUID] { Array(registry) }
+}
+
+@MainActor
+@Suite struct WorkspaceSurfaceListModelTests {
+    private func make() -> (WorkspaceSurfaceListModel, FakeTree) {
+        let tree = FakeTree()
+        let model = WorkspaceSurfaceListModel()
+        model.attach(tree: tree)
+        return (model, tree)
+    }
+
+    @Test func orderedPanelIdsFollowsTabOrderThenAppendsOrphansSorted() {
+        let (model, tree) = make()
+        let s1 = UUID(), s2 = UUID()
+        let p1 = UUID(), p2 = UUID()
+        // Two orphan panels with deterministic uuidString order.
+        let orphanA = UUID(uuidString: "00000000-0000-0000-0000-0000000000AA")!
+        let orphanB = UUID(uuidString: "00000000-0000-0000-0000-0000000000BB")!
+        tree.panes = [.init(id: UUID(), surfaceIds: [s1, s2], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1, s2: p2]
+        tree.registry = [p1, p2, orphanA, orphanB]
+
+        #expect(model.orderedPanelIds == [p1, p2, orphanA, orphanB])
+    }
+
+    @Test func orderedPanelIdsDropsSurfacesWithoutLivePanels() {
+        let (model, tree) = make()
+        let s1 = UUID(), s2 = UUID()
+        let p1 = UUID(), p2 = UUID()
+        tree.panes = [.init(id: UUID(), surfaceIds: [s1, s2], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1, s2: p2]
+        tree.registry = [p1] // p2 not in registry
+
+        #expect(model.orderedPanelIds == [p1])
+    }
+
+    @Test func orderedPanelIdsDeduplicatesRepeatedSurfaces() {
+        let (model, tree) = make()
+        let s1 = UUID(), s2 = UUID()
+        let p1 = UUID()
+        tree.panes = [.init(id: UUID(), surfaceIds: [s1, s2], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1, s2: p1]
+        tree.registry = [p1]
+
+        #expect(model.orderedPanelIds == [p1])
+    }
+
+    @Test func focusedPanelIdResolvesThroughFocusedPaneSelection() {
+        let (model, tree) = make()
+        let pane = UUID(), s1 = UUID(), p1 = UUID()
+        tree.panes = [.init(id: pane, surfaceIds: [s1], selectedIndex: 0)]
+        tree.focusedPaneId = pane
+        tree.surfaceToPanel = [s1: p1]
+        tree.registry = [p1]
+
+        #expect(model.focusedPanelId == p1)
+    }
+
+    @Test func focusedPanelIdNilWhenNoPaneFocused() {
+        let (model, tree) = make()
+        let s1 = UUID(), p1 = UUID()
+        tree.panes = [.init(id: UUID(), surfaceIds: [s1], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1]
+        tree.registry = [p1]
+
+        #expect(model.focusedPanelId == nil)
+    }
+
+    @Test func representativePrefersFocusedWhenItExists() {
+        let (model, tree) = make()
+        let pane = UUID(), s1 = UUID(), p1 = UUID()
+        tree.panes = [.init(id: pane, surfaceIds: [s1], selectedIndex: 0)]
+        tree.focusedPaneId = pane
+        tree.surfaceToPanel = [s1: p1]
+        tree.registry = [p1]
+
+        #expect(model.representativePanelIdForWorkspaceManualUnread() == p1)
+    }
+
+    @Test func representativeFallsBackToSpatiallyFirstSelectedWhenNoFocus() {
+        let (model, tree) = make()
+        let paneA = UUID(), paneB = UUID()
+        let sA = UUID(), sB = UUID()
+        let pA = UUID(), pB = UUID()
+        tree.panes = [
+            .init(id: paneA, surfaceIds: [sA], selectedIndex: 0),
+            .init(id: paneB, surfaceIds: [sB], selectedIndex: 0),
+        ]
+        // Spatial order puts B before A.
+        tree.paneSpatialOrder = [paneB, paneA]
+        tree.surfaceToPanel = [sA: pA, sB: pB]
+        tree.registry = [pA, pB]
+
+        #expect(model.representativePanelIdForWorkspaceManualUnread() == pB)
+    }
+
+    @Test func representativeFallsBackToSidebarFirstWhenNoSelection() {
+        let (model, tree) = make()
+        let sidebarFirst = UUID()
+        tree.firstSidebarOrderedPanelId = sidebarFirst
+
+        #expect(model.representativePanelIdForWorkspaceManualUnread() == sidebarFirst)
+    }
+
+    @Test func effectiveSelectedPanelIdResolvesPerPane() {
+        let (model, tree) = make()
+        let pane = UUID(), s1 = UUID(), p1 = UUID()
+        tree.panes = [.init(id: pane, surfaceIds: [s1], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1]
+        tree.registry = [p1]
+
+        #expect(model.effectiveSelectedPanelId(inPaneId: pane) == p1)
+        #expect(model.effectiveSelectedPanelId(inPaneId: UUID()) == nil)
+    }
+
+    @Test func surfaceIdsLeftRightAndCloseOthers() {
+        let (model, tree) = make()
+        let pane = UUID()
+        let a = UUID(), b = UUID(), c = UUID()
+        tree.panes = [.init(id: pane, surfaceIds: [a, b, c], selectedIndex: 0)]
+
+        #expect(model.surfaceIdsToLeft(of: b, inPaneId: pane) == [a])
+        #expect(model.surfaceIdsToRight(of: b, inPaneId: pane) == [c])
+        #expect(model.surfaceIdsToCloseOthers(of: b, inPaneId: pane) == [a, c])
+        // Anchor absent.
+        #expect(model.surfaceIdsToLeft(of: UUID(), inPaneId: pane) == [])
+        // Last tab has nothing to the right.
+        #expect(model.surfaceIdsToRight(of: c, inPaneId: pane) == [])
+    }
+
+    @Test func registerGeometryChangeBumpsOnlyOnReorder() {
+        let (model, tree) = make()
+        let s1 = UUID(), s2 = UUID()
+        let p1 = UUID(), p2 = UUID()
+        let pane = UUID()
+        tree.panes = [.init(id: pane, surfaceIds: [s1, s2], selectedIndex: 0)]
+        tree.surfaceToPanel = [s1: p1, s2: p2]
+        tree.registry = [p1, p2]
+
+        // First call: order changed from empty -> bump.
+        #expect(model.registerGeometryChange() == true)
+        #expect(tree.bumpCount == 1)
+        #expect(tree.lastOrderedPanelIds == [p1, p2])
+
+        // No change -> no bump.
+        #expect(model.registerGeometryChange() == false)
+        #expect(tree.bumpCount == 1)
+
+        // Reorder -> bump.
+        tree.panes = [.init(id: pane, surfaceIds: [s2, s1], selectedIndex: 0)]
+        #expect(model.registerGeometryChange() == true)
+        #expect(tree.bumpCount == 2)
+        #expect(tree.lastOrderedPanelIds == [p2, p1])
+    }
+
+    @Test func detachedModelReturnsEmptyDefaults() {
+        let model = WorkspaceSurfaceListModel()
+        #expect(model.orderedPanelIds == [])
+        #expect(model.focusedPanelId == nil)
+        #expect(model.representativePanelIdForWorkspaceManualUnread() == nil)
+        #expect(model.registerGeometryChange() == false)
+    }
+}

--- a/Sources/Workspace+WorkspaceSurfaceTreeReading.swift
+++ b/Sources/Workspace+WorkspaceSurfaceTreeReading.swift
@@ -1,0 +1,65 @@
+import Bonsplit
+import CmuxPanes
+import CmuxWorkspaceSurfaceList
+import Foundation
+
+/// `Workspace` is the tree-reading host for its `WorkspaceSurfaceListModel`.
+/// Every member erases the opaque bonsplit `TabID`/`PaneID` types to `UUID` at
+/// the boundary and reads the live `BonsplitController` split tree and the
+/// `PaneTreeModel` panel registry, reproducing the legacy computed-property
+/// reads exactly. The model is held by `Workspace` and references this host
+/// weakly, so there is no retain cycle.
+extension Workspace: WorkspaceSurfaceTreeReading {
+    var surfaceIdsInTabOrderAcrossAllPanes: [UUID] {
+        bonsplitController.allTabIds.map(\.uuid)
+    }
+
+    var focusedPaneSelectedSurfaceId: UUID? {
+        guard let paneId = bonsplitController.focusedPaneId,
+              let tab = bonsplitController.selectedTab(inPane: paneId) else {
+            return nil
+        }
+        return tab.id.uuid
+    }
+
+    var allPaneIds: [UUID] {
+        bonsplitController.allPaneIds.map(\.id)
+    }
+
+    var spatiallyOrderedPaneIds: [UUID] {
+        bonsplitController.treeSnapshot().orderedPaneIds.compactMap(UUID.init(uuidString:))
+    }
+
+    func selectedSurfaceId(inPaneId paneId: UUID) -> UUID? {
+        bonsplitController.selectedTab(inPane: PaneID(id: paneId))?.id.uuid
+    }
+
+    func surfaceIdsInTabOrder(inPaneId paneId: UUID) -> [UUID] {
+        bonsplitController.tabs(inPane: PaneID(id: paneId)).map(\.id.uuid)
+    }
+
+    func panelId(forSurfaceId surfaceId: UUID) -> UUID? {
+        panelIdFromSurfaceId(TabID(uuid: surfaceId))
+    }
+
+    func panelExists(_ panelId: UUID) -> Bool {
+        panels[panelId] != nil
+    }
+
+    var allPanelIds: [UUID] {
+        Array(panels.keys)
+    }
+
+    var firstSidebarOrderedPanelId: UUID? {
+        sidebarOrderedPanelIds().first
+    }
+
+    var lastOrderedPanelIds: [UUID] {
+        get { paneTree.lastOrderedPanelIds }
+        set { paneTree.lastOrderedPanelIds = newValue }
+    }
+
+    func bumpPaneLayoutVersion() {
+        paneLayoutVersion &+= 1
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -16,6 +16,7 @@ import CmuxCanvasUI
 import CmuxPanes
 import CmuxSidebar
 import CmuxWorkspaceCore
+import CmuxWorkspaceSurfaceList
 import CmuxWorkspaces
 import CmuxNotifications
 import CmuxSocketControl
@@ -2587,6 +2588,13 @@ final class Workspace: Identifiable, ObservableObject {
     /// hooks via `PaneTreeHosting`.
     let paneTree = PaneTreeModel<any Panel>()
 
+    /// The surface-list derivation sub-model (CmuxWorkspaceSurfaceList): derives
+    /// the ordered panel-id lists, focused panel, representative panel, per-pane
+    /// selection, the `tabIdsTo*` pane queries, and the `paneLayoutVersion`
+    /// reorder bump. `Workspace` is its tree-reading host via
+    /// `WorkspaceSurfaceTreeReading`; the legacy accessors below forward here.
+    let surfaceList = WorkspaceSurfaceListModel()
+
     /// The surface-registry sub-model (CmuxWorkspaceCore): owns the
     /// per-surface registry annotations (tty names, shell-activity states)
     /// and the transient tab-selection/focus-reassert request state. The
@@ -2631,13 +2639,6 @@ final class Workspace: Identifiable, ObservableObject {
         set { paneTree.paneLayoutVersion = newValue }
     }
 
-    /// Snapshot of `orderedPanelIds` from the last geometry notification, used to
-    /// gate `paneLayoutVersion` bumps to genuine reorder events.
-    private var lastOrderedPanelIds: [UUID] {
-        get { paneTree.lastOrderedPanelIds }
-        set { paneTree.lastOrderedPanelIds = newValue }
-    }
-
     /// Subscriptions for panel updates (e.g., browser title changes)
     var panelSubscriptions: [UUID: AnyCancellable] = [:]
     private var agentSessionPanelCallbackIds: Set<UUID> = []
@@ -2666,13 +2667,10 @@ final class Workspace: Identifiable, ObservableObject {
     // Closing tabs mutates split layout immediately; terminal views handle their own AppKit
     // layout/size synchronization.
 
-    /// The currently focused pane's panel ID
+    /// The currently focused pane's panel ID. Forwards to
+    /// ``WorkspaceSurfaceListModel/focusedPanelId``.
     var focusedPanelId: UUID? {
-        guard let paneId = bonsplitController.focusedPaneId,
-              let tab = bonsplitController.selectedTab(inPane: paneId) else {
-            return nil
-        }
-        return panelIdFromSurfaceId(tab.id)
+        surfaceList.focusedPanelId
     }
 
     /// Panel ids in bonsplit's spatial order: depth-first over the split tree
@@ -2681,19 +2679,9 @@ final class Workspace: Identifiable, ObservableObject {
     /// the single source of truth for serializing panels (e.g. the mobile
     /// terminal list) and for detecting reorders. Any panels not currently in
     /// bonsplit are appended in a stable id order so the list never drops a panel.
+    /// Forwards to ``WorkspaceSurfaceListModel/orderedPanelIds``.
     var orderedPanelIds: [UUID] {
-        var result: [UUID] = []
-        var seen = Set<UUID>()
-        for tabId in bonsplitController.allTabIds {
-            guard let panelId = panelIdFromSurfaceId(tabId), panels[panelId] != nil else { continue }
-            guard seen.insert(panelId).inserted else { continue }
-            result.append(panelId)
-        }
-        let orphans = panels.keys
-            .filter { !seen.contains($0) }
-            .sorted { $0.uuidString < $1.uuidString }
-        result.append(contentsOf: orphans)
-        return result
+        surfaceList.orderedPanelIds
     }
 
     /// The currently focused terminal panel (if any)
@@ -2705,32 +2693,16 @@ final class Workspace: Identifiable, ObservableObject {
         return panel
     }
 
+    /// Forwards to
+    /// ``WorkspaceSurfaceListModel/representativePanelIdForWorkspaceManualUnread()``.
     func representativePanelIdForWorkspaceManualUnread() -> UUID? {
-        if let focusedPanelId, panels[focusedPanelId] != nil {
-            return focusedPanelId
-        }
-
-        let selectedPanelsByPaneId = Dictionary(
-            uniqueKeysWithValues: bonsplitController.allPaneIds.compactMap { paneId -> (String, UUID)? in
-                guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
-                      let panelId = panelIdFromSurfaceId(tabId),
-                      panels[panelId] != nil else {
-                    return nil
-                }
-                return (paneId.id.uuidString, panelId)
-            }
-        )
-
-        for paneId in bonsplitController.treeSnapshot().orderedPaneIds {
-            guard let panelId = selectedPanelsByPaneId[paneId] else { continue }
-            return panelId
-        }
-
-        return sidebarOrderedPanelIds().first
+        surfaceList.representativePanelIdForWorkspaceManualUnread()
     }
 
+    /// Forwards to
+    /// ``WorkspaceSurfaceListModel/effectiveSelectedPanelId(inPaneId:)``.
     func effectiveSelectedPanelId(inPane paneId: PaneID) -> UUID? {
-        bonsplitController.selectedTab(inPane: paneId).flatMap { panelIdFromSurfaceId($0.id) }
+        surfaceList.effectiveSelectedPanelId(inPaneId: paneId.id)
     }
 
     /// Published directory for each panel
@@ -3298,6 +3270,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
         self.bonsplitController = BonsplitController(configuration: config)
         paneTree.attach(host: self)
+        surfaceList.attach(tree: self)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()
 
         // Remove the default "Welcome" tab that bonsplit creates
@@ -10303,22 +10276,15 @@ final class Workspace: Identifiable, ObservableObject {
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) { closeTabsFromContextMenu(tabIds, skipPinned: skipPinned) }
 
     private func tabIdsToLeft(of anchorTabId: TabID, inPane paneId: PaneID) -> [TabID] {
-        let tabs = bonsplitController.tabs(inPane: paneId)
-        guard let index = tabs.firstIndex(where: { $0.id == anchorTabId }) else { return [] }
-        return Array(tabs.prefix(index).map(\.id))
+        surfaceList.surfaceIdsToLeft(of: anchorTabId.uuid, inPaneId: paneId.id).map { TabID(uuid: $0) }
     }
 
     private func tabIdsToRight(of anchorTabId: TabID, inPane paneId: PaneID) -> [TabID] {
-        let tabs = bonsplitController.tabs(inPane: paneId)
-        guard let index = tabs.firstIndex(where: { $0.id == anchorTabId }),
-              index + 1 < tabs.count else { return [] }
-        return Array(tabs.suffix(from: index + 1).map(\.id))
+        surfaceList.surfaceIdsToRight(of: anchorTabId.uuid, inPaneId: paneId.id).map { TabID(uuid: $0) }
     }
 
     private func tabIdsToCloseOthers(of anchorTabId: TabID, inPane paneId: PaneID) -> [TabID] {
-        bonsplitController.tabs(inPane: paneId)
-            .map(\.id)
-            .filter { $0 != anchorTabId }
+        surfaceList.surfaceIdsToCloseOthers(of: anchorTabId.uuid, inPaneId: paneId.id).map { TabID(uuid: $0) }
     }
 
     private func createTerminalToRight(of anchorTabId: TabID, inPane paneId: PaneID) {
@@ -12346,11 +12312,7 @@ extension Workspace: BonsplitDelegate {
         // would miss it. Bump `paneLayoutVersion` only when the ordered panel-id
         // sequence actually changed, so divider drags and selection-only events
         // (also routed here) do not fire `objectWillChange` app-wide.
-        let currentOrder = orderedPanelIds
-        if currentOrder != lastOrderedPanelIds {
-            lastOrderedPanelIds = currentOrder
-            paneLayoutVersion &+= 1
-        }
+        surfaceList.registerGeometryChange()
         scheduleTerminalGeometryReconcile()
         if !isDetachingCloseTransaction {
             scheduleFocusReconcile()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */; };
 		E3B7A30000000000000000E3 /* CmuxWorkspaceNavigation in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */; };
 		E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000102 /* CmuxWorkspaces */; };
+		E3B7A3000000000000000203 /* CmuxWorkspaceSurfaceList in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000202 /* CmuxWorkspaceSurfaceList */; };
 		C750400000000000000000D3 /* CmuxWorkspaceWindow in Frameworks */ = {isa = PBXBuildFile; productRef = C750400000000000000000D2 /* CmuxWorkspaceWindow */; };
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
@@ -838,6 +839,7 @@
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
+		E3B7A400000000000000020A /* Workspace+WorkspaceSurfaceTreeReading.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		7D77A0EBBE3D8E05CDC16229 /* WorkspaceActionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5CC15CEAA80B779ADEE78AA /* WorkspaceActionDispatcher.swift */; };
 		7F0A0E04A8CADC84BB4F1DF7 /* WorkspaceActionDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */; };
@@ -1705,6 +1707,7 @@
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
+		E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+WorkspaceSurfaceTreeReading.swift"; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		C5CC15CEAA80B779ADEE78AA /* WorkspaceActionDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceActionDispatcher.swift; sourceTree = "<group>"; };
 		EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceActionDispatcherTests.swift; sourceTree = "<group>"; };
@@ -1817,6 +1820,7 @@
 				E3B7A3000000000000000113 /* CmuxWorkspaceCore in Frameworks */,
 				E3B7A30000000000000000E3 /* CmuxWorkspaceNavigation in Frameworks */,
 				E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */,
+				E3B7A3000000000000000203 /* CmuxWorkspaceSurfaceList in Frameworks */,
 				C750400000000000000000D3 /* CmuxWorkspaceWindow in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
@@ -2161,6 +2165,7 @@
 				E3B7A4000000000000000008 /* WorkspaceIndicatorStyle+Display.swift */,
 				E3B7A400000000000000000A /* TabManager+NotificationDismissalHosting.swift */,
 				E3B7A400000000000000000C /* TabManager+FocusHistoryHosting.swift */,
+				E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */,
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
@@ -2840,6 +2845,7 @@
 				E3B7A30000000000000000C2 /* CmuxBrowser */,
 				E3B7A30000000000000000D2 /* CmuxNotifications */,
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
+				E3B7A3000000000000000202 /* CmuxWorkspaceSurfaceList */,
 				E3B7A30000000000000000F2 /* CmuxPanes */,
 				E3B7A3000000000000000112 /* CmuxWorkspaceCore */,
 				E3B7A3000000000000000102 /* CmuxWorkspaces */,
@@ -3033,6 +3039,7 @@
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
 				E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */,
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
+				E3B7A3000000000000000201 /* XCLocalSwiftPackageReference "CmuxWorkspaceSurfaceList" */,
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
@@ -3685,6 +3692,7 @@
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
+				E3B7A400000000000000020A /* Workspace+WorkspaceSurfaceTreeReading.swift in Sources */,
 				A5001406 /* Workspace.swift in Sources */,
 				7D77A0EBBE3D8E05CDC16229 /* WorkspaceActionDispatcher.swift in Sources */,
 				A11EAD000000000000000000 /* WorkspaceAppearanceResolution.swift in Sources */,
@@ -4571,6 +4579,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaceNavigation;
 		};
+		E3B7A3000000000000000201 /* XCLocalSwiftPackageReference "CmuxWorkspaceSurfaceList" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxWorkspaceSurfaceList;
+		};
 		E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxPanes;
@@ -4843,6 +4855,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */;
 			productName = CmuxWorkspaceNavigation;
+		};
+		E3B7A3000000000000000202 /* CmuxWorkspaceSurfaceList */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E3B7A3000000000000000201 /* XCLocalSwiftPackageReference "CmuxWorkspaceSurfaceList" */;
+			productName = CmuxWorkspaceSurfaceList;
 		};
 		E3B7A30000000000000000F2 /* CmuxPanes */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## What moved

Pulls the per-workspace navigation-state derivation out of the `Workspace` god file (`Sources/Workspace.swift`) into a new leaf package, `Packages/CmuxWorkspaceSurfaceList`, as a `@MainActor @Observable` `WorkspaceSurfaceListModel` with a constructor-injected protocol seam.

Domain moved from `Workspace` into `WorkspaceSurfaceListModel`:
- `orderedPanelIds` (bonsplit tab order, dedup, orphan-append in stable `uuidString` order)
- `focusedPanelId`
- `representativePanelIdForWorkspaceManualUnread()`
- `effectiveSelectedPanelId(inPane:)`
- `tabIdsToLeft` / `tabIdsToRight` / `tabIdsToCloseOthers` (the per-pane tab-slice queries)
- the `paneLayoutVersion` reorder-bump gate in `splitTabBar(_:didChangeGeometry:)` (now `registerGeometryChange()`)

## The seams

`WorkspaceSurfaceTreeReading` inverts every god-type reach (`BonsplitController` queries + the `PaneTreeModel` panel registry), erasing the opaque bonsplit `TabID`/`PaneID` to `UUID` at the boundary. The package therefore imports neither `Bonsplit` nor `CmuxPanes` and is a pure zero-dependency leaf, mirroring the existing `CmuxWorkspaceNavigation` package exactly (its `FocusHistoryModel` + `FocusHistoryHosting` pattern).

`Workspace` conforms to the seam in `Sources/Workspace+WorkspaceSurfaceTreeReading.swift` and owns the model, which references the host **weakly** to avoid a retain cycle. The moved `Workspace` bodies became one-line forwards, so every call site is unchanged.

## Byte-identical notes

Same ordering, same fallback chains, same `uuidString` orphan sort, same wrapping `&+=` bump, and the same `paneLayoutVersion` `willSet` bridge timing (the bump still routes through `Workspace.paneLayoutVersion` -> `PaneTreeModel`, preserving the legacy `@Published`-bridge re-emission). The representative-panel pane match now keys on `UUID` instead of `PaneID.id.uuidString` `String`, which is a lossless reencoding of the same `PaneID` identity (`PaneID.description == id.uuidString`).

## Tests

12 behavior tests in `CmuxWorkspaceSurfaceListTests` against an in-memory seam fake: ordering, dedup, orphan sort, focus resolution, the full representative fallback chain (focused -> spatially-first selected -> sidebar-first), per-pane selection, the three tab-slice queries, and reorder-bump gating (bump only on a genuine order change). `swift build` + `swift test` pass locally.

## Stats / verification

- Shrinks `Sources/Workspace.swift` by 38 lines; `.github/swift-file-length-budget.tsv` ratcheted down to match.
- `scripts/lint-ios-package-conventions.sh` prints OK with zero new `lint:allow`.
- pbxproj wired via the 6 package entries + 4 source-file entries, normalized with `scripts/normalize-pbxproj.py`, `plutil -lint` OK.
- NOTE: the full app build and test suite are validated by GitHub CI (not run locally per refactor protocol).

Do NOT merge: app/runtime refactor awaiting dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144241&installation_id=133855650&pr_number=6180&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6180&signature=ecfcdffae12072d4a8947f1105136d2f8220c2abee390d430e7803d2e9aaccc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the workspace surface-list/navigation logic into a new leaf package `CmuxWorkspaceSurfaceList` as `WorkspaceSurfaceListModel`, behind a read-only seam. Behavior is unchanged and call sites remain the same.

- **Refactors**
  - Added `WorkspaceSurfaceListModel` and `WorkspaceSurfaceTreeReading`; `Workspace` implements the seam and forwards to the model (held weakly).
  - Moved: `orderedPanelIds`, `focusedPanelId`, representative panel resolution, `effectiveSelectedPanelId(inPane:)`, tab-slice queries, and the `paneLayoutVersion` reorder bump.
  - The package depends on neither `Bonsplit` nor `CmuxPanes` (IDs are `UUID` at the boundary); mirrors `CmuxWorkspaceNavigation`’s pattern.
  - 12 tests added in `CmuxWorkspaceSurfaceListTests` covering ordering, focus, fallbacks, and reorder gating.

<sup>Written for commit 94c9255c6c2c1393f97c4e3db166e4686ed1354f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized workspace panel and tab ordering logic into a dedicated module with improved state management and navigation helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->