### PR TITLE
Extract tmux pane-overlay geometry into CmuxSplitPaneLayout package

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -96,8 +96,7 @@
 918	cmuxTests/WorkspaceGroupTests.swift
 905	Sources/CmuxSSHURLRequest.swift
 901	Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
-892	Sources/WorkspaceContentView.swift
-878	Sources/Panels/TerminalPanel.swift
+879	Sources/Panels/TerminalPanel.swift
 868	Sources/Panels/BrowserScreenshotSnapshotter.swift
 859	Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -106,6 +105,7 @@
 830	Sources/TaskManagerTypes.swift
 810	Packages/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
 787	Sources/ClosedItemHistory.swift
+782	Sources/WorkspaceContentView.swift
 779	cmuxUITests/BrowserOmnibarSuggestionsUITests.swift
 774	cmuxUITests/BrowserFixtureInteractionUITests.swift
 773	Sources/MainWindowFocusController.swift

--- a/Packages/CmuxSplitPaneLayout/Package.swift
+++ b/Packages/CmuxSplitPaneLayout/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxSplitPaneLayout",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxSplitPaneLayout",
+            targets: ["CmuxSplitPaneLayout"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../../vendor/bonsplit"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxSplitPaneLayout",
+            dependencies: [
+                .product(name: "Bonsplit", package: "bonsplit"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxSplitPaneLayoutTests",
+            dependencies: ["CmuxSplitPaneLayout"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxSplitPaneLayout/Sources/CmuxSplitPaneLayout/Geometry/TmuxPaneOverlayGeometry.swift
+++ b/Packages/CmuxSplitPaneLayout/Sources/CmuxSplitPaneLayout/Geometry/TmuxPaneOverlayGeometry.swift
@@ -1,0 +1,166 @@
+public import CoreGraphics
+public import Bonsplit
+
+/// Pure geometry for placing the tmux-style pane overlay (unread dots and the
+/// attention flash) over a Bonsplit split layout.
+///
+/// All inputs are Bonsplit value snapshots (`LayoutSnapshot`, `PaneID`) plus the
+/// titlebar-chrome inset to trim from the top of each pane; there is no
+/// dependency on the app's `Workspace`, AppKit windows, or notification state.
+/// The app layer resolves which panes are unread or flashing and then asks this
+/// type for the matching rectangles, keeping the placement math testable in
+/// isolation and identical across every call site.
+public struct TmuxPaneOverlayGeometry: Sendable, Equatable {
+    /// Height of the titlebar chrome trimmed off the top of each pane rect so the
+    /// overlay covers only the terminal content, not the tab strip.
+    public let topChromeHeight: CGFloat
+
+    /// Creates a geometry resolver.
+    /// - Parameter topChromeHeight: titlebar chrome height to trim from the top of
+    ///   each resolved pane rectangle.
+    public init(topChromeHeight: CGFloat) {
+        self.topChromeHeight = topChromeHeight
+    }
+
+    /// Whether a resolved pane rect is expressed in window-content coordinates
+    /// (container x-offset preserved) or workspace-local coordinates (container
+    /// origin removed on both axes).
+    public enum TrimMode: Sendable, Equatable {
+        /// Workspace-local coordinates: the container origin is subtracted on both
+        /// axes.
+        case workspaceLocal
+        /// Window-content coordinates: only the container y-offset is removed; the
+        /// x-offset is preserved so the rect aligns with the window's content view.
+        case windowContent
+    }
+
+    /// Trims the titlebar chrome inset off the top of `rect`.
+    /// - Parameter rect: the full pane rectangle.
+    /// - Returns: the pane rectangle with the top chrome removed, clamped so the
+    ///   height never drops below zero.
+    public func contentRect(_ rect: CGRect) -> CGRect {
+        let topInset = min(topChromeHeight, max(0, rect.height - 1))
+        return CGRect(
+            x: rect.origin.x,
+            y: rect.origin.y + topInset,
+            width: rect.width,
+            height: max(0, rect.height - topInset)
+        )
+    }
+
+    /// Resolves the content rectangle for a single pane in a layout snapshot.
+    /// - Parameters:
+    ///   - layoutSnapshot: the Bonsplit layout snapshot, if any.
+    ///   - paneId: the pane to resolve, if any.
+    ///   - includeContainerOffset: when `true` only the container y-offset is
+    ///     removed (window-content space); when `false` both axes are offset by the
+    ///     container origin (workspace-local space).
+    ///   - trimMode: which coordinate space the result is expressed in.
+    /// - Returns: the trimmed pane content rect, or `nil` when the snapshot or pane
+    ///   is missing.
+    public func paneRect(
+        layoutSnapshot: LayoutSnapshot?,
+        paneId: PaneID?,
+        includeContainerOffset: Bool,
+        trimMode: TrimMode
+    ) -> CGRect? {
+        guard let layoutSnapshot,
+              let paneId,
+              let paneRect = layoutSnapshot.panes
+                .first(where: { $0.paneId == paneId.id.uuidString })?
+                .frame
+                .cgRect else {
+            return nil
+        }
+
+        let rect: CGRect
+        if includeContainerOffset {
+            rect = paneRect.offsetBy(
+                dx: 0,
+                dy: -CGFloat(layoutSnapshot.containerFrame.y)
+            )
+        } else {
+            rect = paneRect.offsetBy(
+                dx: -CGFloat(layoutSnapshot.containerFrame.x),
+                dy: -CGFloat(layoutSnapshot.containerFrame.y)
+            )
+        }
+        _ = trimMode
+        return contentRect(rect)
+    }
+
+    /// Resolves a pane's overlay rect in workspace-local coordinates.
+    /// - Parameters:
+    ///   - layoutSnapshot: the Bonsplit layout snapshot, if any.
+    ///   - paneId: the pane to resolve, if any.
+    /// - Returns: the workspace-local content rect, or `nil` when unresolved.
+    public func overlayRect(
+        layoutSnapshot: LayoutSnapshot?,
+        paneId: PaneID?
+    ) -> CGRect? {
+        paneRect(
+            layoutSnapshot: layoutSnapshot,
+            paneId: paneId,
+            includeContainerOffset: false,
+            trimMode: .workspaceLocal
+        )
+    }
+
+    /// Resolves a pane's overlay rect in window-content coordinates.
+    /// - Parameters:
+    ///   - layoutSnapshot: the Bonsplit layout snapshot, if any.
+    ///   - paneId: the pane to resolve, if any.
+    /// - Returns: the window-content content rect, or `nil` when unresolved.
+    public func windowOverlayRect(
+        layoutSnapshot: LayoutSnapshot?,
+        paneId: PaneID?
+    ) -> CGRect? {
+        paneRect(
+            layoutSnapshot: layoutSnapshot,
+            paneId: paneId,
+            includeContainerOffset: true,
+            trimMode: .windowContent
+        )
+    }
+
+    /// Picks the snapshot with renderable geometry, preferring the live snapshot.
+    /// - Parameters:
+    ///   - cachedSnapshot: the previously cached snapshot, if any.
+    ///   - liveSnapshot: the freshly read live snapshot, if any.
+    /// - Returns: the live snapshot when it has renderable geometry, otherwise the
+    ///   cached snapshot when it does, otherwise whichever is non-nil.
+    public func effectiveSnapshot(
+        cachedSnapshot: LayoutSnapshot?,
+        liveSnapshot: LayoutSnapshot?
+    ) -> LayoutSnapshot? {
+        if let liveSnapshot,
+           Self.hasRenderableGeometry(liveSnapshot) {
+            return liveSnapshot
+        }
+        if let cachedSnapshot,
+           Self.hasRenderableGeometry(cachedSnapshot) {
+            return cachedSnapshot
+        }
+        return cachedSnapshot ?? liveSnapshot
+    }
+
+    /// Whether a snapshot has a non-degenerate container and at least one
+    /// non-degenerate pane.
+    /// - Parameter snapshot: the snapshot to inspect.
+    /// - Returns: `true` when the container and at least one pane exceed 1pt on
+    ///   both axes.
+    public static func hasRenderableGeometry(_ snapshot: LayoutSnapshot) -> Bool {
+        snapshot.containerFrame.width > 1 &&
+            snapshot.containerFrame.height > 1 &&
+            snapshot.panes.contains { pane in
+                pane.frame.width > 1 && pane.frame.height > 1
+            }
+    }
+}
+
+extension PixelRect {
+    /// This rectangle expressed as a `CGRect`.
+    public var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}

--- a/Packages/CmuxSplitPaneLayout/Sources/CmuxSplitPaneLayout/Values/TmuxPaneLayoutReport.swift
+++ b/Packages/CmuxSplitPaneLayout/Sources/CmuxSplitPaneLayout/Values/TmuxPaneLayoutReport.swift
@@ -1,0 +1,75 @@
+public import CoreGraphics
+
+/// A single pane reported by tmux in character-cell coordinates, used by the
+/// experimental tmux-active-pane overlay to position a highlight over the pane
+/// tmux considers active.
+public struct TmuxPaneLayoutPane: Codable, Equatable, Sendable {
+    /// tmux's identifier for the pane.
+    public let paneId: String
+    /// Left edge of the pane, in character cells from the surface origin.
+    public let left: Int
+    /// Top edge of the pane, in character cells from the surface origin.
+    public let top: Int
+    /// Pane width in character cells.
+    public let width: Int
+    /// Pane height in character cells.
+    public let height: Int
+    /// Whether tmux currently considers this pane the active one.
+    public let isActive: Bool
+
+    /// Creates a tmux pane layout entry.
+    /// - Parameters:
+    ///   - paneId: tmux's pane identifier.
+    ///   - left: left edge in character cells.
+    ///   - top: top edge in character cells.
+    ///   - width: width in character cells.
+    ///   - height: height in character cells.
+    ///   - isActive: whether tmux marks this pane active.
+    public init(paneId: String, left: Int, top: Int, width: Int, height: Int, isActive: Bool) {
+        self.paneId = paneId
+        self.left = left
+        self.top = top
+        self.width = width
+        self.height = height
+        self.isActive = isActive
+    }
+
+    /// The overlay rect for this pane within a terminal surface.
+    /// - Parameters:
+    ///   - surfaceFrame: the surface frame the pane lives in.
+    ///   - cellSize: the size of one character cell in points.
+    /// - Returns: the pane's pixel rect, or `nil` when the cell size or pane
+    ///   dimensions are degenerate.
+    public func overlayRect(surfaceFrame: CGRect, cellSize: CGSize) -> CGRect? {
+        guard cellSize.width > 0,
+              cellSize.height > 0,
+              width > 0,
+              height > 0 else {
+            return nil
+        }
+
+        return CGRect(
+            x: surfaceFrame.origin.x + (CGFloat(left) * cellSize.width),
+            y: surfaceFrame.origin.y + (CGFloat(top) * cellSize.height),
+            width: CGFloat(width) * cellSize.width,
+            height: CGFloat(height) * cellSize.height
+        )
+    }
+}
+
+/// A tmux pane layout report: the full set of panes tmux reported for a surface.
+public struct TmuxPaneLayoutReport: Codable, Equatable, Sendable {
+    /// All panes tmux reported, in tmux's order.
+    public let panes: [TmuxPaneLayoutPane]
+
+    /// Creates a layout report.
+    /// - Parameter panes: the reported panes.
+    public init(panes: [TmuxPaneLayoutPane]) {
+        self.panes = panes
+    }
+
+    /// The active pane, or the first pane when none is marked active.
+    public var activePane: TmuxPaneLayoutPane? {
+        panes.first(where: \.isActive) ?? panes.first
+    }
+}

--- a/Packages/CmuxSplitPaneLayout/Tests/CmuxSplitPaneLayoutTests/TmuxPaneOverlayGeometryTests.swift
+++ b/Packages/CmuxSplitPaneLayout/Tests/CmuxSplitPaneLayoutTests/TmuxPaneOverlayGeometryTests.swift
@@ -1,0 +1,148 @@
+import CoreGraphics
+import Foundation
+import Testing
+import Bonsplit
+@testable import CmuxSplitPaneLayout
+
+@Suite("TmuxPaneOverlayGeometry")
+struct TmuxPaneOverlayGeometryTests {
+    private func snapshot(
+        container: PixelRect,
+        panes: [(id: UUID, frame: PixelRect)]
+    ) -> LayoutSnapshot {
+        LayoutSnapshot(
+            containerFrame: container,
+            panes: panes.map {
+                PaneGeometry(
+                    paneId: $0.id.uuidString,
+                    frame: $0.frame,
+                    selectedTabId: nil,
+                    tabIds: []
+                )
+            },
+            focusedPaneId: nil,
+            timestamp: 0
+        )
+    }
+
+    @Test("content rect trims the top chrome and clamps height to zero")
+    func contentRectTrims() {
+        let geometry = TmuxPaneOverlayGeometry(topChromeHeight: 28)
+        let rect = geometry.contentRect(CGRect(x: 10, y: 20, width: 100, height: 200))
+        #expect(rect == CGRect(x: 10, y: 48, width: 100, height: 172))
+
+        // A pane shorter than the chrome height keeps at least 1pt of content.
+        let tiny = geometry.contentRect(CGRect(x: 0, y: 0, width: 50, height: 10))
+        #expect(tiny == CGRect(x: 0, y: 9, width: 50, height: 1))
+    }
+
+    @Test("workspace-local overlay rect offsets by both container axes")
+    func overlayRectWorkspaceLocal() {
+        let paneId = UUID()
+        let snap = snapshot(
+            container: PixelRect(x: 5, y: 7, width: 300, height: 400),
+            panes: [(paneId, PixelRect(x: 50, y: 100, width: 120, height: 240))]
+        )
+        let geometry = TmuxPaneOverlayGeometry(topChromeHeight: 28)
+        let rect = geometry.overlayRect(layoutSnapshot: snap, paneId: PaneID(id: paneId))
+        // offset: x -5, y -7; then top inset 28.
+        #expect(rect == CGRect(x: 45, y: 93 + 28, width: 120, height: 240 - 28))
+    }
+
+    @Test("window-content overlay rect preserves the container x-offset")
+    func windowOverlayRectKeepsX() {
+        let paneId = UUID()
+        let snap = snapshot(
+            container: PixelRect(x: 5, y: 7, width: 300, height: 400),
+            panes: [(paneId, PixelRect(x: 50, y: 100, width: 120, height: 240))]
+        )
+        let geometry = TmuxPaneOverlayGeometry(topChromeHeight: 28)
+        let rect = geometry.windowOverlayRect(layoutSnapshot: snap, paneId: PaneID(id: paneId))
+        // x is NOT offset; y offset by -7; top inset 28.
+        #expect(rect == CGRect(x: 50, y: 93 + 28, width: 120, height: 240 - 28))
+    }
+
+    @Test("missing snapshot or pane yields nil")
+    func missingYieldsNil() {
+        let geometry = TmuxPaneOverlayGeometry(topChromeHeight: 28)
+        #expect(geometry.overlayRect(layoutSnapshot: nil, paneId: PaneID()) == nil)
+        let snap = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 100, height: 100),
+            panes: []
+        )
+        #expect(geometry.overlayRect(layoutSnapshot: snap, paneId: PaneID()) == nil)
+        #expect(geometry.overlayRect(layoutSnapshot: snap, paneId: nil) == nil)
+    }
+
+    @Test("effective snapshot prefers a renderable live snapshot")
+    func effectiveSnapshotPrefersLive() {
+        let geometry = TmuxPaneOverlayGeometry(topChromeHeight: 0)
+        let renderable = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 100, height: 100),
+            panes: [(UUID(), PixelRect(x: 0, y: 0, width: 50, height: 50))]
+        )
+        let degenerate = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 0, height: 0),
+            panes: []
+        )
+        // Live renderable wins.
+        #expect(geometry.effectiveSnapshot(cachedSnapshot: degenerate, liveSnapshot: renderable) == renderable)
+        // Live degenerate falls back to renderable cache.
+        #expect(geometry.effectiveSnapshot(cachedSnapshot: renderable, liveSnapshot: degenerate) == renderable)
+        // Both degenerate: returns cached (non-nil) per the fallback order.
+        #expect(geometry.effectiveSnapshot(cachedSnapshot: degenerate, liveSnapshot: degenerate) == degenerate)
+        // Nil cache with degenerate live returns the degenerate live.
+        #expect(geometry.effectiveSnapshot(cachedSnapshot: nil, liveSnapshot: degenerate) == degenerate)
+    }
+
+    @Test("hasRenderableGeometry requires a non-degenerate container and pane")
+    func hasRenderableGeometry() {
+        let renderable = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 100, height: 100),
+            panes: [(UUID(), PixelRect(x: 0, y: 0, width: 50, height: 50))]
+        )
+        #expect(TmuxPaneOverlayGeometry.hasRenderableGeometry(renderable))
+
+        let tinyContainer = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 1, height: 1),
+            panes: [(UUID(), PixelRect(x: 0, y: 0, width: 50, height: 50))]
+        )
+        #expect(!TmuxPaneOverlayGeometry.hasRenderableGeometry(tinyContainer))
+
+        let tinyPanes = snapshot(
+            container: PixelRect(x: 0, y: 0, width: 100, height: 100),
+            panes: [(UUID(), PixelRect(x: 0, y: 0, width: 1, height: 1))]
+        )
+        #expect(!TmuxPaneOverlayGeometry.hasRenderableGeometry(tinyPanes))
+    }
+}
+
+@Suite("TmuxPaneLayoutReport")
+struct TmuxPaneLayoutReportTests {
+    @Test("activePane prefers the active pane, falls back to first")
+    func activePane() {
+        let a = TmuxPaneLayoutPane(paneId: "a", left: 0, top: 0, width: 10, height: 10, isActive: false)
+        let b = TmuxPaneLayoutPane(paneId: "b", left: 10, top: 0, width: 10, height: 10, isActive: true)
+        #expect(TmuxPaneLayoutReport(panes: [a, b]).activePane == b)
+        #expect(TmuxPaneLayoutReport(panes: [a]).activePane == a)
+        #expect(TmuxPaneLayoutReport(panes: []).activePane == nil)
+    }
+
+    @Test("overlayRect scales by cell size and offsets by surface origin")
+    func overlayRect() {
+        let pane = TmuxPaneLayoutPane(paneId: "a", left: 2, top: 3, width: 4, height: 5, isActive: true)
+        let rect = pane.overlayRect(
+            surfaceFrame: CGRect(x: 100, y: 200, width: 999, height: 999),
+            cellSize: CGSize(width: 8, height: 16)
+        )
+        #expect(rect == CGRect(x: 100 + 16, y: 200 + 48, width: 32, height: 80))
+    }
+
+    @Test("overlayRect returns nil for degenerate cell sizes or panes")
+    func overlayRectNil() {
+        let pane = TmuxPaneLayoutPane(paneId: "a", left: 0, top: 0, width: 4, height: 5, isActive: true)
+        #expect(pane.overlayRect(surfaceFrame: .zero, cellSize: CGSize(width: 0, height: 16)) == nil)
+        let zeroPane = TmuxPaneLayoutPane(paneId: "a", left: 0, top: 0, width: 0, height: 5, isActive: true)
+        #expect(zeroPane.overlayRect(surfaceFrame: .zero, cellSize: CGSize(width: 8, height: 16)) == nil)
+    }
+}

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -3,6 +3,7 @@ import CmuxTerminalCore
 import Combine
 import AppKit
 import Bonsplit
+import CmuxSplitPaneLayout
 import CmuxTerminal
 
 struct AgentHibernationPanelState {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -3,6 +3,7 @@ import Foundation
 import AppKit
 import CmuxFoundation
 import Bonsplit
+import CmuxSplitPaneLayout
 import CmuxTerminal
 
 enum TmuxOverlayExperimentTarget: String, CaseIterable, Codable, Sendable {
@@ -50,49 +51,6 @@ private enum WorkspaceTitlebarInteractionMetrics {
     // Keep in sync with the minimal-mode titlebar strip so the monitor only
     // covers titlebar chrome.
     static let minimalModeTopStripHeight: CGFloat = MinimalModeChromeMetrics.titlebarHeight
-}
-
-struct TmuxPaneLayoutPane: Codable, Equatable, Sendable {
-    let paneId: String
-    let left: Int
-    let top: Int
-    let width: Int
-    let height: Int
-    let isActive: Bool
-}
-
-struct TmuxPaneLayoutReport: Codable, Equatable, Sendable {
-    let panes: [TmuxPaneLayoutPane]
-
-    var activePane: TmuxPaneLayoutPane? {
-        panes.first(where: \.isActive) ?? panes.first
-    }
-}
-
-func tmuxActivePaneOverlayRect(
-    surfaceFrame: CGRect,
-    cellSize: CGSize,
-    pane: TmuxPaneLayoutPane
-) -> CGRect? {
-    guard cellSize.width > 0,
-          cellSize.height > 0,
-          pane.width > 0,
-          pane.height > 0 else {
-        return nil
-    }
-
-    return CGRect(
-        x: surfaceFrame.origin.x + (CGFloat(pane.left) * cellSize.width),
-        y: surfaceFrame.origin.y + (CGFloat(pane.top) * cellSize.height),
-        width: CGFloat(pane.width) * cellSize.width,
-        height: CGFloat(pane.height) * cellSize.height
-    )
-}
-
-private extension PixelRect {
-    var cgRect: CGRect {
-        CGRect(x: x, y: y, width: width, height: height)
-    }
 }
 
 struct TmuxWorkspacePaneOverlayRenderState: Equatable {
@@ -416,67 +374,18 @@ struct WorkspaceContentView: View {
         workspace.bonsplitController.zoomedPaneId.map { "zoom:\($0.id.uuidString)" } ?? "unzoomed"
     }
 
-    private static let tmuxWorkspacePaneTopChromeHeight: CGFloat = MinimalModeChromeMetrics.titlebarHeight
-
-    private enum TmuxWorkspacePaneOverlayTrimMode {
-        case workspaceLocal
-        case windowContent
-    }
-
-    private static func tmuxWorkspacePaneContentRect(
-        _ rect: CGRect,
-        trimMode: TmuxWorkspacePaneOverlayTrimMode
-    ) -> CGRect {
-        let topInset = min(tmuxWorkspacePaneTopChromeHeight, max(0, rect.height - 1))
-        switch trimMode {
-        case .workspaceLocal, .windowContent:
-            return CGRect(
-                x: rect.origin.x,
-                y: rect.origin.y + topInset,
-                width: rect.width,
-                height: max(0, rect.height - topInset)
-            )
-        }
-    }
-
-    private static func tmuxWorkspacePaneRect(
-        layoutSnapshot: LayoutSnapshot?,
-        paneId: PaneID?,
-        includeContainerOffset: Bool,
-        trimMode: TmuxWorkspacePaneOverlayTrimMode
-    ) -> CGRect? {
-        guard let layoutSnapshot,
-              let paneId,
-              let paneRect = layoutSnapshot.panes
-                .first(where: { $0.paneId == paneId.id.uuidString })?
-                .frame
-                .cgRect else {
-            return nil
-        }
-
-        let rect: CGRect
-        if includeContainerOffset {
-            rect = paneRect.offsetBy(
-                dx: 0,
-                dy: -CGFloat(layoutSnapshot.containerFrame.y)
-            )
-        } else {
-            rect = paneRect.offsetBy(
-                dx: -CGFloat(layoutSnapshot.containerFrame.x),
-                dy: -CGFloat(layoutSnapshot.containerFrame.y)
-            )
-        }
-        return tmuxWorkspacePaneContentRect(rect, trimMode: trimMode)
-    }
+    private static let tmuxPaneOverlayGeometry = TmuxPaneOverlayGeometry(
+        topChromeHeight: MinimalModeChromeMetrics.titlebarHeight
+    )
 
     private static func tmuxWorkspacePaneRects(
         workspace: Workspace,
         notificationStore: TerminalNotificationStore,
         layoutSnapshot: LayoutSnapshot?,
-        includeContainerOffset: Bool,
-        trimMode: TmuxWorkspacePaneOverlayTrimMode
+        includeContainerOffset: Bool
     ) -> [CGRect] {
         guard let layoutSnapshot else { return [] }
+        let geometry = tmuxPaneOverlayGeometry
         let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
         let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
 
@@ -512,7 +421,7 @@ struct WorkspaceContentView: View {
                     dy: -CGFloat(layoutSnapshot.containerFrame.y)
                 )
             }
-            return tmuxWorkspacePaneContentRect(rect, trimMode: trimMode)
+            return geometry.contentRect(rect)
         }
     }
 
@@ -520,11 +429,9 @@ struct WorkspaceContentView: View {
         layoutSnapshot: LayoutSnapshot?,
         paneId: PaneID?
     ) -> CGRect? {
-        tmuxWorkspacePaneRect(
+        tmuxPaneOverlayGeometry.overlayRect(
             layoutSnapshot: layoutSnapshot,
-            paneId: paneId,
-            includeContainerOffset: false,
-            trimMode: .workspaceLocal
+            paneId: paneId
         )
     }
 
@@ -532,11 +439,9 @@ struct WorkspaceContentView: View {
         layoutSnapshot: LayoutSnapshot?,
         paneId: PaneID?
     ) -> CGRect? {
-        tmuxWorkspacePaneRect(
+        tmuxPaneOverlayGeometry.windowOverlayRect(
             layoutSnapshot: layoutSnapshot,
-            paneId: paneId,
-            includeContainerOffset: true,
-            trimMode: .windowContent
+            paneId: paneId
         )
     }
 
@@ -544,15 +449,10 @@ struct WorkspaceContentView: View {
         cachedSnapshot: LayoutSnapshot?,
         liveSnapshot: LayoutSnapshot?
     ) -> LayoutSnapshot? {
-        if let liveSnapshot,
-           tmuxLayoutSnapshotHasRenderableGeometry(liveSnapshot) {
-            return liveSnapshot
-        }
-        if let cachedSnapshot,
-           tmuxLayoutSnapshotHasRenderableGeometry(cachedSnapshot) {
-            return cachedSnapshot
-        }
-        return cachedSnapshot ?? liveSnapshot
+        tmuxPaneOverlayGeometry.effectiveSnapshot(
+            cachedSnapshot: cachedSnapshot,
+            liveSnapshot: liveSnapshot
+        )
     }
 
     static func tmuxWorkspacePaneUnreadRects(
@@ -564,8 +464,7 @@ struct WorkspaceContentView: View {
             workspace: workspace,
             notificationStore: notificationStore,
             layoutSnapshot: layoutSnapshot,
-            includeContainerOffset: false,
-            trimMode: .workspaceLocal
+            includeContainerOffset: false
         )
     }
 
@@ -578,17 +477,8 @@ struct WorkspaceContentView: View {
             workspace: workspace,
             notificationStore: notificationStore,
             layoutSnapshot: layoutSnapshot,
-            includeContainerOffset: true,
-            trimMode: .windowContent
+            includeContainerOffset: true
         )
-    }
-
-    private static func tmuxLayoutSnapshotHasRenderableGeometry(_ snapshot: LayoutSnapshot) -> Bool {
-        snapshot.containerFrame.width > 1 &&
-            snapshot.containerFrame.height > 1 &&
-            snapshot.panes.contains { pane in
-                pane.frame.width > 1 && pane.frame.height > 1
-            }
     }
 
     private func flushDeferredThemeRefreshIfNeeded() {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		B900004CA1B2C3D4E5F60719 /* CmuxSocketControl in Frameworks */ = {isa = PBXBuildFile; productRef = A5354305A5354305A5354305 /* CmuxSocketControl */; };
 		E7E000000000000000000009 /* CmuxSocketEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000A /* CmuxSocketEventMapper.swift */; };
+		5917A1000000000000000003 /* CmuxSplitPaneLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 5917A1000000000000000002 /* CmuxSplitPaneLayout */; };
 		C3677002000000000000001 /* CmuxSSHURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677002000000000000002 /* CmuxSSHURLRequest.swift */; };
 		C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677001000000000000002 /* CmuxSSHURLRequestTests.swift */; };
 		C10D00030000000000000003 /* CmuxSurfaceTabBarBuiltInAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */; };
@@ -1803,6 +1804,7 @@
 				C0DE4A000000000000000001 /* CmuxSidebarProviderKit in Frameworks */,
 				C5A1FED200000000000000E5 /* CmuxSidebarRemoteRender in Frameworks */,
 				A5354303A5354303A5354303 /* CmuxSocketControl in Frameworks */,
+				5917A1000000000000000003 /* CmuxSplitPaneLayout in Frameworks */,
 				C5A1FED000000000000000C1 /* CmuxSwiftRender in Frameworks */,
 				C5A1FED100000000000000D1 /* CmuxSwiftRenderUI in Frameworks */,
 				C750500000000000000000A3 /* CmuxTerminal in Frameworks */,
@@ -2841,6 +2843,7 @@
 				E3B7A30000000000000000D2 /* CmuxNotifications */,
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
 				E3B7A30000000000000000F2 /* CmuxPanes */,
+				5917A1000000000000000002 /* CmuxSplitPaneLayout */,
 				E3B7A3000000000000000112 /* CmuxWorkspaceCore */,
 				E3B7A3000000000000000102 /* CmuxWorkspaces */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
@@ -3034,6 +3037,7 @@
 				E3B7A30000000000000000D1 /* XCLocalSwiftPackageReference "CmuxNotifications" */,
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
+				5917A1000000000000000001 /* XCLocalSwiftPackageReference "CmuxSplitPaneLayout" */,
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
 				C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */,
@@ -4575,6 +4579,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxPanes;
 		};
+		5917A1000000000000000001 /* XCLocalSwiftPackageReference "CmuxSplitPaneLayout" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxSplitPaneLayout;
+		};
 		E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaceCore;
@@ -4848,6 +4856,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */;
 			productName = CmuxPanes;
+		};
+		5917A1000000000000000002 /* CmuxSplitPaneLayout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5917A1000000000000000001 /* XCLocalSwiftPackageReference "CmuxSplitPaneLayout" */;
+			productName = CmuxSplitPaneLayout;
 		};
 		E3B7A3000000000000000112 /* CmuxWorkspaceCore */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Extracts the pure split-pane overlay geometry out of `WorkspaceContentView.swift` (and the dead free function in it) into a new leaf package, `CmuxSplitPaneLayout`, which depends only on Bonsplit + CoreGraphics.

## What moved

`Packages/CmuxSplitPaneLayout`:

- **`TmuxPaneOverlayGeometry`** (`Sendable` value type): resolves split-pane overlay rectangles from a Bonsplit `LayoutSnapshot`/`PaneID`. Holds the titlebar chrome inset as an injected init parameter. Public API: `contentRect`, `paneRect`, `overlayRect`, `windowOverlayRect`, `effectiveSnapshot`, `hasRenderableGeometry`. `PixelRect.cgRect` lives here as the single public conversion.
- **`TmuxPaneLayoutPane` / `TmuxPaneLayoutReport`** value types, plus the active-pane overlay rect. The old top-level free function `tmuxActivePaneOverlayRect` became `TmuxPaneLayoutPane.overlayRect`, removing one banned free function from the app target.

## Seams (dependency inversion)

The geometry type takes the chrome height (`MinimalModeChromeMetrics.titlebarHeight`) as an `init` parameter and touches no `Workspace`, `AppDelegate`, `NSWindow`, or notification state. The `Workspace`/notification-coupled unread-rect filters stay in the app target and forward their per-pane math through the package geometry, so every call site (`ContentView`, `WorkspaceContentView`, `TerminalPanel`) is unchanged apart from an added `import`.

## Byte-identical

The moved math is preserved exactly: same container-offset logic, same min/max chrome trim, same renderable-geometry thresholds (`> 1`), same effective-snapshot fallback order, same active-pane cell scaling. The app-side `WorkspaceContentView` statics are now thin one-line forwards. The original `contentRect` switch returned the same rect for both trim-mode cases, so dropping the enum changes nothing.

## Tests

9 Swift Testing cases in the package cover trim/clamp, both coordinate spaces, nil handling, snapshot fallback order, renderable thresholds, and active-pane scaling. `swift build` + `swift test` pass; `scripts/lint-ios-package-conventions.sh` prints OK with zero new `lint:allow`.

## Stats

~110 lines removed from `WorkspaceContentView.swift` (892 -> 782). File-length budget reconciled (`scripts/swift_file_length_budget.py --write-budget`).

NOTE: the full app build is validated by GitHub CI (not built locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144348&installation_id=133855650&pr_number=6181&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6181&signature=363555132dacf685e975a1fad19c139ef9c4c054b5d3097ef72713cb4c13b52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted tmux split‑pane overlay geometry into `CmuxSplitPaneLayout` to decouple layout math from app code with no behavior changes. This reduces `WorkspaceContentView.swift` by ~110 lines and adds focused tests.

- **Refactors**
  - Moved geometry to `TmuxPaneOverlayGeometry` in `CmuxSplitPaneLayout` with `contentRect`, `overlayRect`, `windowOverlayRect`, `effectiveSnapshot`, `hasRenderableGeometry`.
  - Replaced the free function with `TmuxPaneLayoutPane.overlayRect`; added `TmuxPaneLayoutReport`.
  - Updated call sites to import `CmuxSplitPaneLayout`; math is byte‑identical (same offsets, chrome trim, thresholds).

- **Dependencies**
  - Added local package `CmuxSplitPaneLayout` (depends on `Bonsplit` + `CoreGraphics`) and linked it in the Xcode project.

<sup>Written for commit f9dd84778a7f0c67c6bce3538566c9ef26321514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

