### PR TITLE
Extract Ghostty trigger decoding + config-store reload from AppDelegate into CmuxGhosttyShortcutDecoding

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,7 +2,7 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34202	CLI/cmux.swift
-17778	Sources/AppDelegate.swift
+17729	Sources/AppDelegate.swift
 16674	Sources/ContentView.swift
 14785	Sources/TerminalController.swift
 13358	Sources/Panels/BrowserPanel.swift

--- a/Packages/CmuxGhosttyShortcutDecoding/Package.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxGhosttyShortcutDecoding",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxGhosttyShortcutDecoding",
+            targets: ["CmuxGhosttyShortcutDecoding"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxGhosttyShortcutDecoding",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxGhosttyShortcutDecodingTests",
+            dependencies: ["CmuxGhosttyShortcutDecoding"]
+        ),
+    ]
+)

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/CmuxConfigStoreReloadCoordinator.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/CmuxConfigStoreReloadCoordinator.swift
@@ -1,0 +1,54 @@
+public import Observation
+
+/// Orchestrates reloading every per-window cmux configuration store and refreshing
+/// window titles, as the app delegate's `reloadCmuxConfigStores(source:)` did.
+///
+/// Owned by the app delegate and given a weak reference to it through
+/// `CmuxConfigStoreReloadEnvironment`, so the delegate retaining the coordinator
+/// does not create a retain cycle. The coordinator does no I/O itself; it sequences
+/// the stores' own `loadAll()` and the environment's title refresh, deduping shared
+/// stores by object identity exactly as before.
+@MainActor
+@Observable
+public final class CmuxConfigStoreReloadCoordinator {
+    private weak var environment: (any CmuxConfigStoreReloadEnvironment)?
+    private let onReload: (@MainActor (_ source: String, _ storeCount: Int) -> Void)?
+
+    /// Creates a coordinator.
+    /// - Parameters:
+    ///   - environment: The source of per-window stores and the title refresher.
+    ///     Held weakly because the environment (the app delegate) owns this
+    ///     coordinator.
+    ///   - onReload: An optional hook invoked after each reload with the reload
+    ///     source and the number of distinct stores reloaded. The app target wires
+    ///     this to its debug log; tests use it to observe behavior.
+    public init(
+        environment: any CmuxConfigStoreReloadEnvironment,
+        onReload: (@MainActor (_ source: String, _ storeCount: Int) -> Void)? = nil
+    ) {
+        self.environment = environment
+        self.onReload = onReload
+    }
+
+    /// Reloads every distinct per-window configuration store, then refreshes window
+    /// titles, then reports the reload through `onReload`.
+    ///
+    /// Distinct stores are determined by object identity so a store shared across
+    /// windows reloads once, preserving the original iteration-and-dedupe order.
+    /// - Parameter source: A short tag describing what triggered the reload.
+    public func reload(source: String) {
+        guard let environment else {
+            onReload?(source, 0)
+            return
+        }
+
+        var seenStores = Set<ObjectIdentifier>()
+        for store in environment.reloadableConfigStores {
+            let identifier = ObjectIdentifier(store)
+            guard seenStores.insert(identifier).inserted else { continue }
+            store.loadAll()
+        }
+        environment.refreshWindowTitlesAfterConfigReload()
+        onReload?(source, seenStores.count)
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/CmuxConfigStoreReloading.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/CmuxConfigStoreReloading.swift
@@ -1,0 +1,30 @@
+/// A per-window cmux configuration store that can re-read its backing file.
+///
+/// The app target's `CmuxConfigStore` conforms to this so
+/// `CmuxConfigStoreReloadCoordinator` can drive reloads without depending on the
+/// concrete app type. It is `AnyObject` so the coordinator can dedupe stores shared
+/// across windows by object identity, matching the original
+/// `Set<ObjectIdentifier>` logic.
+@MainActor
+public protocol CmuxConfigStoreReloading: AnyObject {
+    /// Re-reads the configuration from its backing source.
+    func loadAll()
+}
+
+/// Supplies the live set of per-window configuration stores and refreshes window
+/// chrome after a reload.
+///
+/// The app target's delegate conforms to this, exposing its `mainWindowContexts`
+/// stores and its `refreshWindowTitlesAcrossMainWindows()` behavior behind a
+/// read-only seam so the coordinator never reaches into window or context state.
+@MainActor
+public protocol CmuxConfigStoreReloadEnvironment: AnyObject {
+    /// The configuration stores across all open main windows, in iteration order.
+    ///
+    /// May contain the same store more than once when windows share a store; the
+    /// coordinator dedupes by object identity.
+    var reloadableConfigStores: [any CmuxConfigStoreReloading] { get }
+
+    /// Refreshes window titles across all main windows after stores reload.
+    func refreshWindowTitlesAfterConfigReload()
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyModifierMask.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyModifierMask.swift
@@ -1,0 +1,39 @@
+/// The raw Ghostty modifier bitmask carried by a key trigger.
+///
+/// Wraps the `UInt32` value of `ghostty_input_trigger_s.mods.rawValue` and exposes
+/// the four modifiers cmux maps onto a stored shortcut. The bit positions are the
+/// Ghostty ABI constants (`GHOSTTY_MODS_*`), fixed in `ghostty/include/ghostty.h`.
+public struct GhosttyModifierMask: Sendable, Equatable, Hashable {
+    /// `GHOSTTY_MODS_SHIFT` (`1 << 0`).
+    public static let shiftBit: UInt32 = 1 << 0
+    /// `GHOSTTY_MODS_CTRL` (`1 << 1`).
+    public static let controlBit: UInt32 = 1 << 1
+    /// `GHOSTTY_MODS_ALT` (`1 << 2`).
+    public static let optionBit: UInt32 = 1 << 2
+    /// `GHOSTTY_MODS_SUPER` (`1 << 3`).
+    public static let commandBit: UInt32 = 1 << 3
+
+    /// The raw Ghostty modifier bitmask.
+    public var rawValue: UInt32
+
+    /// Creates a modifier mask from a raw Ghostty bitmask.
+    /// - Parameter rawValue: The value of `ghostty_input_trigger_s.mods.rawValue`.
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    /// Whether the Command (`super`) modifier is set.
+    public var command: Bool { (rawValue & Self.commandBit) != 0 }
+    /// Whether the Shift modifier is set.
+    public var shift: Bool { (rawValue & Self.shiftBit) != 0 }
+    /// Whether the Option (`alt`) modifier is set.
+    public var option: Bool { (rawValue & Self.optionBit) != 0 }
+    /// Whether the Control modifier is set.
+    public var control: Bool { (rawValue & Self.controlBit) != 0 }
+
+    /// Whether none of the four mapped modifiers are set.
+    ///
+    /// Used to reject bogus empty triggers, matching the original
+    /// `!command && !shift && !option && !control` check.
+    public var isEmpty: Bool { !command && !shift && !option && !control }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerInput.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerInput.swift
@@ -1,0 +1,38 @@
+/// A Sendable description of a Ghostty key trigger, decoupled from GhosttyKit's C
+/// `ghostty_input_trigger_s` struct.
+///
+/// The app target reads the raw C trigger returned by `ghostty_config_trigger` and
+/// packs the parts cmux cares about into this value at the call seam, so
+/// `GhosttyTriggerShortcutDecoder` can decode it with no GhosttyKit dependency.
+public struct GhosttyTriggerInput: Sendable, Equatable, Hashable {
+    /// The kind of trigger Ghostty resolved the binding to.
+    public enum Tag: Sendable, Equatable, Hashable {
+        /// A trigger keyed by a physical key (`GHOSTTY_TRIGGER_PHYSICAL`).
+        ///
+        /// The associated value is `nil` when the physical key is one cmux does not
+        /// render as a shortcut, matching the original switch's `default` branch.
+        case physical(GhosttyTriggerPhysicalKey?)
+        /// A trigger keyed by a Unicode scalar (`GHOSTTY_TRIGGER_UNICODE`).
+        ///
+        /// The associated value is `nil` when the raw codepoint is not a valid
+        /// Unicode scalar, matching the original `UnicodeScalar(...)` guard.
+        case unicode(Unicode.Scalar?)
+        /// A catch-all trigger (`GHOSTTY_TRIGGER_CATCH_ALL`), which never yields a
+        /// shortcut.
+        case catchAll
+    }
+
+    /// The resolved trigger tag and its key payload.
+    public var tag: Tag
+    /// The raw Ghostty modifier bitmask (`ghostty_input_trigger_s.mods.rawValue`).
+    public var modifiers: GhosttyModifierMask
+
+    /// Creates a trigger input from a tag and a raw Ghostty modifier bitmask.
+    /// - Parameters:
+    ///   - tag: The resolved trigger tag and key payload.
+    ///   - modifiers: The raw Ghostty modifier bitmask carried by the trigger.
+    public init(tag: Tag, modifiers: GhosttyModifierMask) {
+        self.tag = tag
+        self.modifiers = modifiers
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerPhysicalKey.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerPhysicalKey.swift
@@ -1,0 +1,174 @@
+/// A physical keyboard key that Ghostty can bind a trigger to, restricted to the
+/// keys cmux maps to a menu-style shortcut glyph.
+///
+/// The app target translates Ghostty's C `GHOSTTY_KEY_*` enum into one of these
+/// cases at the call seam, so the decoding logic and its glyph table live in this
+/// package without importing GhosttyKit. Any Ghostty physical key cmux does not
+/// turn into a shortcut (modifiers, function keys, numpad keys, and so on) maps to
+/// `nil` at the seam rather than to a case here, mirroring the original `default`
+/// branch that returned no shortcut.
+public enum GhosttyTriggerPhysicalKey: String, Sendable, Equatable, Hashable, CaseIterable {
+    /// The left arrow key, rendered as `←`.
+    case arrowLeft
+    /// The right arrow key, rendered as `→`.
+    case arrowRight
+    /// The up arrow key, rendered as `↑`.
+    case arrowUp
+    /// The down arrow key, rendered as `↓`.
+    case arrowDown
+    /// The `A` letter key.
+    case a
+    /// The `B` letter key.
+    case b
+    /// The `C` letter key.
+    case c
+    /// The `D` letter key.
+    case d
+    /// The `E` letter key.
+    case e
+    /// The `F` letter key.
+    case f
+    /// The `G` letter key.
+    case g
+    /// The `H` letter key.
+    case h
+    /// The `I` letter key.
+    case i
+    /// The `J` letter key.
+    case j
+    /// The `K` letter key.
+    case k
+    /// The `L` letter key.
+    case l
+    /// The `M` letter key.
+    case m
+    /// The `N` letter key.
+    case n
+    /// The `O` letter key.
+    case o
+    /// The `P` letter key.
+    case p
+    /// The `Q` letter key.
+    case q
+    /// The `R` letter key.
+    case r
+    /// The `S` letter key.
+    case s
+    /// The `T` letter key.
+    case t
+    /// The `U` letter key.
+    case u
+    /// The `V` letter key.
+    case v
+    /// The `W` letter key.
+    case w
+    /// The `X` letter key.
+    case x
+    /// The `Y` letter key.
+    case y
+    /// The `Z` letter key.
+    case z
+    /// The `0` digit key.
+    case digit0
+    /// The `1` digit key.
+    case digit1
+    /// The `2` digit key.
+    case digit2
+    /// The `3` digit key.
+    case digit3
+    /// The `4` digit key.
+    case digit4
+    /// The `5` digit key.
+    case digit5
+    /// The `6` digit key.
+    case digit6
+    /// The `7` digit key.
+    case digit7
+    /// The `8` digit key.
+    case digit8
+    /// The `9` digit key.
+    case digit9
+    /// The left bracket key, rendered as `[`.
+    case bracketLeft
+    /// The right bracket key, rendered as `]`.
+    case bracketRight
+    /// The minus key, rendered as `-`.
+    case minus
+    /// The equal key, rendered as `=`.
+    case equal
+    /// The comma key, rendered as `,`.
+    case comma
+    /// The period key, rendered as `.`.
+    case period
+    /// The slash key, rendered as `/`.
+    case slash
+    /// The semicolon key, rendered as `;`.
+    case semicolon
+    /// The quote key, rendered as `'`.
+    case quote
+    /// The backquote key, rendered as `` ` ``.
+    case backquote
+    /// The backslash key, rendered as `\`.
+    case backslash
+
+    /// The menu-style glyph cmux renders for this physical key.
+    ///
+    /// These glyphs are byte-identical to the literals the original
+    /// `storedShortcutFromGhosttyTrigger` switch produced for each `GHOSTTY_KEY_*`
+    /// case.
+    public var glyph: String {
+        switch self {
+        case .arrowLeft: return "←"
+        case .arrowRight: return "→"
+        case .arrowUp: return "↑"
+        case .arrowDown: return "↓"
+        case .a: return "a"
+        case .b: return "b"
+        case .c: return "c"
+        case .d: return "d"
+        case .e: return "e"
+        case .f: return "f"
+        case .g: return "g"
+        case .h: return "h"
+        case .i: return "i"
+        case .j: return "j"
+        case .k: return "k"
+        case .l: return "l"
+        case .m: return "m"
+        case .n: return "n"
+        case .o: return "o"
+        case .p: return "p"
+        case .q: return "q"
+        case .r: return "r"
+        case .s: return "s"
+        case .t: return "t"
+        case .u: return "u"
+        case .v: return "v"
+        case .w: return "w"
+        case .x: return "x"
+        case .y: return "y"
+        case .z: return "z"
+        case .digit0: return "0"
+        case .digit1: return "1"
+        case .digit2: return "2"
+        case .digit3: return "3"
+        case .digit4: return "4"
+        case .digit5: return "5"
+        case .digit6: return "6"
+        case .digit7: return "7"
+        case .digit8: return "8"
+        case .digit9: return "9"
+        case .bracketLeft: return "["
+        case .bracketRight: return "]"
+        case .minus: return "-"
+        case .equal: return "="
+        case .comma: return ","
+        case .period: return "."
+        case .slash: return "/"
+        case .semicolon: return ";"
+        case .quote: return "'"
+        case .backquote: return "`"
+        case .backslash: return "\\"
+        }
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerShortcut.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerShortcut.swift
@@ -1,0 +1,33 @@
+/// A keyboard shortcut decoded from a Ghostty key trigger.
+///
+/// Carries exactly the fields the app target feeds into its `StoredShortcut`
+/// initializer from the Ghostty goto-split path: a lowercased key string and the
+/// four modifier flags. The app maps this value onto its own `StoredShortcut` at
+/// the call seam.
+public struct GhosttyTriggerShortcut: Sendable, Equatable, Hashable {
+    /// The key glyph or lowercased character for the shortcut.
+    public var key: String
+    /// Whether the Command modifier is part of the shortcut.
+    public var command: Bool
+    /// Whether the Shift modifier is part of the shortcut.
+    public var shift: Bool
+    /// Whether the Option modifier is part of the shortcut.
+    public var option: Bool
+    /// Whether the Control modifier is part of the shortcut.
+    public var control: Bool
+
+    /// Creates a decoded shortcut.
+    /// - Parameters:
+    ///   - key: The key glyph or lowercased character.
+    ///   - command: Whether Command is held.
+    ///   - shift: Whether Shift is held.
+    ///   - option: Whether Option is held.
+    ///   - control: Whether Control is held.
+    public init(key: String, command: Bool, shift: Bool, option: Bool, control: Bool) {
+        self.key = key
+        self.command = command
+        self.shift = shift
+        self.option = option
+        self.control = control
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerShortcutDecoder.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Sources/CmuxGhosttyShortcutDecoding/GhosttyTriggerShortcutDecoder.swift
@@ -1,0 +1,55 @@
+/// Decodes a Ghostty key trigger into the shortcut cmux stores for its goto-split
+/// menu syncing.
+///
+/// This owns the byte-identical logic that used to live in
+/// `AppDelegate.storedShortcutFromGhosttyTrigger`: choose the key glyph from the
+/// trigger tag, reject catch-all and unmapped keys, lowercase a Unicode-scalar key,
+/// and reject bogus triggers that carry no key or no modifier. The app target
+/// supplies a `GhosttyTriggerInput` (already lifted off the C `ghostty_input_trigger_s`)
+/// and maps the returned value onto its own `StoredShortcut`.
+public struct GhosttyTriggerShortcutDecoder: Sendable {
+    /// Creates a decoder. The decoder is stateless; the type exists so the logic is
+    /// owned by a value rather than a free function.
+    public init() {}
+
+    /// Decodes a trigger into a stored shortcut, or `nil` when the trigger cannot be
+    /// mapped to one.
+    ///
+    /// Returns `nil` for a catch-all trigger, an unmapped physical key, an invalid
+    /// Unicode scalar, an empty key, or a trigger with no Command/Shift/Option/Control
+    /// modifier set, exactly as the original implementation did.
+    /// - Parameter input: The lifted Ghostty trigger.
+    /// - Returns: The decoded shortcut, or `nil`.
+    public func decode(_ input: GhosttyTriggerInput) -> GhosttyTriggerShortcut? {
+        let key: String
+        switch input.tag {
+        case let .physical(physicalKey):
+            guard let physicalKey else { return nil }
+            key = physicalKey.glyph
+        case let .unicode(scalar):
+            guard let scalar else { return nil }
+            key = String(Character(scalar)).lowercased()
+        case .catchAll:
+            return nil
+        }
+
+        let modifiers = input.modifiers
+        let command = modifiers.command
+        let shift = modifiers.shift
+        let option = modifiers.option
+        let control = modifiers.control
+
+        // Ignore bogus empty triggers.
+        if key.isEmpty || modifiers.isEmpty {
+            return nil
+        }
+
+        return GhosttyTriggerShortcut(
+            key: key,
+            command: command,
+            shift: shift,
+            option: option,
+            control: control
+        )
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Tests/CmuxGhosttyShortcutDecodingTests/CmuxConfigStoreReloadCoordinatorTests.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Tests/CmuxGhosttyShortcutDecodingTests/CmuxConfigStoreReloadCoordinatorTests.swift
@@ -1,0 +1,70 @@
+import Testing
+@testable import CmuxGhosttyShortcutDecoding
+
+@MainActor
+private final class FakeConfigStore: CmuxConfigStoreReloading {
+    private(set) var loadAllCount = 0
+    func loadAll() { loadAllCount += 1 }
+}
+
+@MainActor
+private final class FakeEnvironment: CmuxConfigStoreReloadEnvironment {
+    var stores: [FakeConfigStore]
+    private(set) var titleRefreshCount = 0
+
+    init(stores: [FakeConfigStore]) { self.stores = stores }
+
+    var reloadableConfigStores: [any CmuxConfigStoreReloading] { stores }
+    func refreshWindowTitlesAfterConfigReload() { titleRefreshCount += 1 }
+}
+
+@MainActor
+@Suite struct CmuxConfigStoreReloadCoordinatorTests {
+    @Test func reloadsEachDistinctStoreOnceAndRefreshesTitles() {
+        let storeA = FakeConfigStore()
+        let storeB = FakeConfigStore()
+        // storeA appears twice to simulate windows sharing a store.
+        let env = FakeEnvironment(stores: [storeA, storeB, storeA])
+
+        var reportedSource: String?
+        var reportedCount: Int?
+        let coordinator = CmuxConfigStoreReloadCoordinator(environment: env) { source, count in
+            reportedSource = source
+            reportedCount = count
+        }
+
+        coordinator.reload(source: "test.source")
+
+        #expect(storeA.loadAllCount == 1)
+        #expect(storeB.loadAllCount == 1)
+        #expect(env.titleRefreshCount == 1)
+        #expect(reportedSource == "test.source")
+        #expect(reportedCount == 2)
+    }
+
+    @Test func reloadWithNoStoresStillRefreshesTitles() {
+        let env = FakeEnvironment(stores: [])
+        var reportedCount: Int?
+        let coordinator = CmuxConfigStoreReloadCoordinator(environment: env) { _, count in
+            reportedCount = count
+        }
+
+        coordinator.reload(source: "empty")
+
+        #expect(env.titleRefreshCount == 1)
+        #expect(reportedCount == 0)
+    }
+
+    @Test func reloadAfterEnvironmentDeallocatedReportsZero() {
+        var env: FakeEnvironment? = FakeEnvironment(stores: [FakeConfigStore()])
+        var reportedCount: Int?
+        let coordinator = CmuxConfigStoreReloadCoordinator(environment: env!) { _, count in
+            reportedCount = count
+        }
+        env = nil
+
+        coordinator.reload(source: "after-dealloc")
+
+        #expect(reportedCount == 0)
+    }
+}

--- a/Packages/CmuxGhosttyShortcutDecoding/Tests/CmuxGhosttyShortcutDecodingTests/GhosttyTriggerShortcutDecoderTests.swift
+++ b/Packages/CmuxGhosttyShortcutDecoding/Tests/CmuxGhosttyShortcutDecodingTests/GhosttyTriggerShortcutDecoderTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import CmuxGhosttyShortcutDecoding
+
+@Suite struct GhosttyTriggerShortcutDecoderTests {
+    private let decoder = GhosttyTriggerShortcutDecoder()
+    private let command = GhosttyModifierMask(rawValue: GhosttyModifierMask.commandBit)
+
+    @Test func physicalArrowKeysMapToArrowGlyphs() {
+        let left = decoder.decode(
+            GhosttyTriggerInput(tag: .physical(.arrowLeft), modifiers: command)
+        )
+        #expect(left == GhosttyTriggerShortcut(key: "←", command: true, shift: false, option: false, control: false))
+
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.arrowRight), modifiers: command))?.key == "→")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.arrowUp), modifiers: command))?.key == "↑")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.arrowDown), modifiers: command))?.key == "↓")
+    }
+
+    @Test func physicalLetterAndPunctuationGlyphs() {
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.k), modifiers: command))?.key == "k")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.digit7), modifiers: command))?.key == "7")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.bracketLeft), modifiers: command))?.key == "[")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.backslash), modifiers: command))?.key == "\\")
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.backquote), modifiers: command))?.key == "`")
+    }
+
+    @Test func allModifierBitsAreDecoded() {
+        let allMods = GhosttyModifierMask(
+            rawValue: GhosttyModifierMask.commandBit
+                | GhosttyModifierMask.shiftBit
+                | GhosttyModifierMask.optionBit
+                | GhosttyModifierMask.controlBit
+        )
+        let result = decoder.decode(GhosttyTriggerInput(tag: .physical(.a), modifiers: allMods))
+        #expect(result == GhosttyTriggerShortcut(key: "a", command: true, shift: true, option: true, control: true))
+    }
+
+    @Test func unmappedPhysicalKeyReturnsNil() {
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(nil), modifiers: command)) == nil)
+    }
+
+    @Test func catchAllReturnsNil() {
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .catchAll, modifiers: command)) == nil)
+    }
+
+    @Test func unicodeScalarIsLowercased() {
+        let scalar = Unicode.Scalar("K")
+        let result = decoder.decode(GhosttyTriggerInput(tag: .unicode(scalar), modifiers: command))
+        #expect(result?.key == "k")
+    }
+
+    @Test func invalidUnicodeScalarReturnsNil() {
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .unicode(nil), modifiers: command)) == nil)
+    }
+
+    @Test func triggerWithNoModifiersReturnsNil() {
+        let none = GhosttyModifierMask(rawValue: 0)
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.a), modifiers: none)) == nil)
+    }
+
+    @Test func capsAndNumLockOnlyAreTreatedAsEmpty() {
+        // GHOSTTY_MODS_CAPS (1 << 4) and GHOSTTY_MODS_NUM (1 << 5) are not mapped
+        // modifiers, so a trigger carrying only those is rejected as empty.
+        let capsAndNum = GhosttyModifierMask(rawValue: (1 << 4) | (1 << 5))
+        #expect(capsAndNum.isEmpty)
+        #expect(decoder.decode(GhosttyTriggerInput(tag: .physical(.a), modifiers: capsAndNum)) == nil)
+    }
+
+    @Test func everyPhysicalKeyGlyphIsNonEmpty() {
+        for key in GhosttyTriggerPhysicalKey.allCases {
+            #expect(!key.glyph.isEmpty)
+            let result = decoder.decode(GhosttyTriggerInput(tag: .physical(key), modifiers: command))
+            #expect(result?.key == key.glyph)
+        }
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -28,6 +28,7 @@ import Combine
 import ObjectiveC.runtime
 import Darwin
 import CmuxFoundation
+import CmuxGhosttyShortcutDecoding
 import CmuxSession
 import CmuxTerminal
 
@@ -504,7 +505,7 @@ final class CmuxMainThreadTurnProfiler {
 #endif
 
 @MainActor
-final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate, NSMenuItemValidation, NSMenuDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate, NSMenuItemValidation, NSMenuDelegate, CmuxConfigStoreReloadEnvironment {
     nonisolated(unsafe) static var shared: AppDelegate?
     /// Stateless control-socket syscall layer (CmuxControlSocket); composition-root owned.
     nonisolated let socketTransport = SocketTransport()
@@ -747,6 +748,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var menuBarVisibilityObserver: NSObjectProtocol?
     private var mobileHostSettingsObserver: NSObjectProtocol?
     private var reloadConfigurationMenuItemRefreshScheduled = false
+    /// Orchestrates per-window cmux config-store reloads + window-title refresh.
+    /// Holds `self` weakly through the environment seam to avoid a retain cycle.
+    private lazy var configStoreReloadCoordinator: CmuxConfigStoreReloadCoordinator = {
+        CmuxConfigStoreReloadCoordinator(environment: self) { source, storeCount in
+#if DEBUG
+            cmuxDebugLog("cmuxConfig.reload source=\(source) stores=\(storeCount)")
+#endif
+        }
+    }()
     private var splitButtonTooltipRefreshScheduled = false
     private var didScheduleGhosttyCrashBreadcrumbCheck = false
     private var ghosttyCrashBreadcrumbTask: Task<Void, Never>?
@@ -12093,17 +12103,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func reloadCmuxConfigStores(source: String) {
-        var seenStores = Set<ObjectIdentifier>()
-        for context in mainWindowContexts.values {
-            guard let store = context.cmuxConfigStore else { continue }
-            let identifier = ObjectIdentifier(store)
-            guard seenStores.insert(identifier).inserted else { continue }
-            store.loadAll()
-        }
+        configStoreReloadCoordinator.reload(source: source)
+    }
+
+    var reloadableConfigStores: [any CmuxConfigStoreReloading] {
+        mainWindowContexts.values.compactMap { $0.cmuxConfigStore }
+    }
+
+    func refreshWindowTitlesAfterConfigReload() {
         refreshWindowTitlesAcrossMainWindows()
-#if DEBUG
-        cmuxDebugLog("cmuxConfig.reload source=\(source) stores=\(seenStores.count)")
-#endif
     }
 
     private func refreshGhosttyGotoSplitShortcuts() {
@@ -12130,90 +12138,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func storedShortcutFromGhosttyTrigger(_ trigger: ghostty_input_trigger_s) -> StoredShortcut? {
-        let key: String
+        let tag: GhosttyTriggerInput.Tag
         switch trigger.tag {
         case GHOSTTY_TRIGGER_PHYSICAL:
-            switch trigger.key.physical {
-            case GHOSTTY_KEY_ARROW_LEFT:
-                key = "←"
-            case GHOSTTY_KEY_ARROW_RIGHT:
-                key = "→"
-            case GHOSTTY_KEY_ARROW_UP:
-                key = "↑"
-            case GHOSTTY_KEY_ARROW_DOWN:
-                key = "↓"
-            case GHOSTTY_KEY_A: key = "a"
-            case GHOSTTY_KEY_B: key = "b"
-            case GHOSTTY_KEY_C: key = "c"
-            case GHOSTTY_KEY_D: key = "d"
-            case GHOSTTY_KEY_E: key = "e"
-            case GHOSTTY_KEY_F: key = "f"
-            case GHOSTTY_KEY_G: key = "g"
-            case GHOSTTY_KEY_H: key = "h"
-            case GHOSTTY_KEY_I: key = "i"
-            case GHOSTTY_KEY_J: key = "j"
-            case GHOSTTY_KEY_K: key = "k"
-            case GHOSTTY_KEY_L: key = "l"
-            case GHOSTTY_KEY_M: key = "m"
-            case GHOSTTY_KEY_N: key = "n"
-            case GHOSTTY_KEY_O: key = "o"
-            case GHOSTTY_KEY_P: key = "p"
-            case GHOSTTY_KEY_Q: key = "q"
-            case GHOSTTY_KEY_R: key = "r"
-            case GHOSTTY_KEY_S: key = "s"
-            case GHOSTTY_KEY_T: key = "t"
-            case GHOSTTY_KEY_U: key = "u"
-            case GHOSTTY_KEY_V: key = "v"
-            case GHOSTTY_KEY_W: key = "w"
-            case GHOSTTY_KEY_X: key = "x"
-            case GHOSTTY_KEY_Y: key = "y"
-            case GHOSTTY_KEY_Z: key = "z"
-            case GHOSTTY_KEY_DIGIT_0: key = "0"
-            case GHOSTTY_KEY_DIGIT_1: key = "1"
-            case GHOSTTY_KEY_DIGIT_2: key = "2"
-            case GHOSTTY_KEY_DIGIT_3: key = "3"
-            case GHOSTTY_KEY_DIGIT_4: key = "4"
-            case GHOSTTY_KEY_DIGIT_5: key = "5"
-            case GHOSTTY_KEY_DIGIT_6: key = "6"
-            case GHOSTTY_KEY_DIGIT_7: key = "7"
-            case GHOSTTY_KEY_DIGIT_8: key = "8"
-            case GHOSTTY_KEY_DIGIT_9: key = "9"
-            case GHOSTTY_KEY_BRACKET_LEFT: key = "["
-            case GHOSTTY_KEY_BRACKET_RIGHT: key = "]"
-            case GHOSTTY_KEY_MINUS: key = "-"
-            case GHOSTTY_KEY_EQUAL: key = "="
-            case GHOSTTY_KEY_COMMA: key = ","
-            case GHOSTTY_KEY_PERIOD: key = "."
-            case GHOSTTY_KEY_SLASH: key = "/"
-            case GHOSTTY_KEY_SEMICOLON: key = ";"
-            case GHOSTTY_KEY_QUOTE: key = "'"
-            case GHOSTTY_KEY_BACKQUOTE: key = "`"
-            case GHOSTTY_KEY_BACKSLASH: key = "\\"
-            default:
-                return nil
-            }
+            tag = .physical(GhosttyTriggerPhysicalKey(ghosttyPhysicalKey: trigger.key.physical))
         case GHOSTTY_TRIGGER_UNICODE:
-            guard let scalar = UnicodeScalar(trigger.key.unicode) else { return nil }
-            key = String(Character(scalar)).lowercased()
+            tag = .unicode(UnicodeScalar(trigger.key.unicode))
         case GHOSTTY_TRIGGER_CATCH_ALL:
-            return nil
+            tag = .catchAll
         default:
             return nil
         }
 
-        let mods = trigger.mods.rawValue
-        let command = (mods & GHOSTTY_MODS_SUPER.rawValue) != 0
-        let shift = (mods & GHOSTTY_MODS_SHIFT.rawValue) != 0
-        let option = (mods & GHOSTTY_MODS_ALT.rawValue) != 0
-        let control = (mods & GHOSTTY_MODS_CTRL.rawValue) != 0
-
-        // Ignore bogus empty triggers.
-        if key.isEmpty || (!command && !shift && !option && !control) {
-            return nil
-        }
-
-        return StoredShortcut(key: key, command: command, shift: shift, option: option, control: control)
+        let input = GhosttyTriggerInput(
+            tag: tag,
+            modifiers: GhosttyModifierMask(rawValue: trigger.mods.rawValue)
+        )
+        guard let shortcut = Self.ghosttyTriggerShortcutDecoder.decode(input) else { return nil }
+        return StoredShortcut(
+            key: shortcut.key,
+            command: shortcut.command,
+            shift: shortcut.shift,
+            option: shortcut.option,
+            control: shortcut.control
+        )
     }
+
+    private static let ghosttyTriggerShortcutDecoder = GhosttyTriggerShortcutDecoder()
 
     private func handleQuitShortcutWarning() -> Bool {
         if !QuitConfirmationStore(defaults: .standard).shouldShowConfirmation(

--- a/Sources/CmuxConfigStore+ConfigStoreReloading.swift
+++ b/Sources/CmuxConfigStore+ConfigStoreReloading.swift
@@ -1,0 +1,6 @@
+import CmuxGhosttyShortcutDecoding
+
+/// Lets `CmuxConfigStoreReloadCoordinator` drive per-window config reloads through a
+/// protocol seam. `CmuxConfigStore`'s existing `loadAll()` already satisfies the
+/// requirement, so this conformance is empty.
+extension CmuxConfigStore: CmuxConfigStoreReloading {}

--- a/Sources/GhosttyTriggerPhysicalKey+GhosttyKit.swift
+++ b/Sources/GhosttyTriggerPhysicalKey+GhosttyKit.swift
@@ -1,0 +1,67 @@
+import CmuxGhosttyShortcutDecoding
+
+extension GhosttyTriggerPhysicalKey {
+    /// Maps a GhosttyKit C physical key (`ghostty_input_key_e`) onto the package's
+    /// shortcut-key token.
+    ///
+    /// This is the GhosttyKit-boundary translation kept in the app target (where the
+    /// C symbols are visible); the glyphs and decode rules live in
+    /// `CmuxGhosttyShortcutDecoding`. Returns `nil` for any key cmux does not render
+    /// as a goto-split shortcut, matching the original switch's `default` branch.
+    init?(ghosttyPhysicalKey physical: ghostty_input_key_e) {
+        switch physical {
+        case GHOSTTY_KEY_ARROW_LEFT: self = .arrowLeft
+        case GHOSTTY_KEY_ARROW_RIGHT: self = .arrowRight
+        case GHOSTTY_KEY_ARROW_UP: self = .arrowUp
+        case GHOSTTY_KEY_ARROW_DOWN: self = .arrowDown
+        case GHOSTTY_KEY_A: self = .a
+        case GHOSTTY_KEY_B: self = .b
+        case GHOSTTY_KEY_C: self = .c
+        case GHOSTTY_KEY_D: self = .d
+        case GHOSTTY_KEY_E: self = .e
+        case GHOSTTY_KEY_F: self = .f
+        case GHOSTTY_KEY_G: self = .g
+        case GHOSTTY_KEY_H: self = .h
+        case GHOSTTY_KEY_I: self = .i
+        case GHOSTTY_KEY_J: self = .j
+        case GHOSTTY_KEY_K: self = .k
+        case GHOSTTY_KEY_L: self = .l
+        case GHOSTTY_KEY_M: self = .m
+        case GHOSTTY_KEY_N: self = .n
+        case GHOSTTY_KEY_O: self = .o
+        case GHOSTTY_KEY_P: self = .p
+        case GHOSTTY_KEY_Q: self = .q
+        case GHOSTTY_KEY_R: self = .r
+        case GHOSTTY_KEY_S: self = .s
+        case GHOSTTY_KEY_T: self = .t
+        case GHOSTTY_KEY_U: self = .u
+        case GHOSTTY_KEY_V: self = .v
+        case GHOSTTY_KEY_W: self = .w
+        case GHOSTTY_KEY_X: self = .x
+        case GHOSTTY_KEY_Y: self = .y
+        case GHOSTTY_KEY_Z: self = .z
+        case GHOSTTY_KEY_DIGIT_0: self = .digit0
+        case GHOSTTY_KEY_DIGIT_1: self = .digit1
+        case GHOSTTY_KEY_DIGIT_2: self = .digit2
+        case GHOSTTY_KEY_DIGIT_3: self = .digit3
+        case GHOSTTY_KEY_DIGIT_4: self = .digit4
+        case GHOSTTY_KEY_DIGIT_5: self = .digit5
+        case GHOSTTY_KEY_DIGIT_6: self = .digit6
+        case GHOSTTY_KEY_DIGIT_7: self = .digit7
+        case GHOSTTY_KEY_DIGIT_8: self = .digit8
+        case GHOSTTY_KEY_DIGIT_9: self = .digit9
+        case GHOSTTY_KEY_BRACKET_LEFT: self = .bracketLeft
+        case GHOSTTY_KEY_BRACKET_RIGHT: self = .bracketRight
+        case GHOSTTY_KEY_MINUS: self = .minus
+        case GHOSTTY_KEY_EQUAL: self = .equal
+        case GHOSTTY_KEY_COMMA: self = .comma
+        case GHOSTTY_KEY_PERIOD: self = .period
+        case GHOSTTY_KEY_SLASH: self = .slash
+        case GHOSTTY_KEY_SEMICOLON: self = .semicolon
+        case GHOSTTY_KEY_QUOTE: self = .quote
+        case GHOSTTY_KEY_BACKQUOTE: self = .backquote
+        case GHOSTTY_KEY_BACKSLASH: self = .backslash
+        default: return nil
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		C0DEF0A40000000000000001 /* CmuxConfigContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A40000000000000002 /* CmuxConfigContextMenuTests.swift */; };
 		A5001652 /* CmuxConfigExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001653 /* CmuxConfigExecutor.swift */; };
 		E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */; };
+		C5D0DEC0CF00000000000A1 /* CmuxConfigStore+ConfigStoreReloading.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D0DEC0CF00000000000B1 /* CmuxConfigStore+ConfigStoreReloading.swift */; };
 		C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
 		C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A10000000000000002 /* CmuxConfigUI.swift */; };
 		C750100000000000000000A3 /* CmuxControlSocket in Frameworks */ = {isa = PBXBuildFile; productRef = C750100000000000000000A2 /* CmuxControlSocket */; };
@@ -230,6 +231,7 @@
 		5E2701040000000000000004 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 5E2701040000000000000002 /* CmuxFoundation */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
 		CF00F00000000000000000A4 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
+		C5D0DEC00000000000000003 /* CmuxGhosttyShortcutDecoding in Frameworks */ = {isa = PBXBuildFile; productRef = C5D0DEC00000000000000002 /* CmuxGhosttyShortcutDecoding */; };
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
@@ -444,6 +446,7 @@
 		D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */; };
 		D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */; };
 		D3284101A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3284102A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift */; };
+		C5D0DEC0F11E0000000000A1 /* GhosttyTriggerPhysicalKey+GhosttyKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D0DEC0F11E0000000000B1 /* GhosttyTriggerPhysicalKey+GhosttyKit.swift */; };
 		3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */; };
 		3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */; };
 		3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */; };
@@ -1144,6 +1147,7 @@
 		C0DEF0A40000000000000002 /* CmuxConfigContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigContextMenuTests.swift; sourceTree = "<group>"; };
 		A5001653 /* CmuxConfigExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigExecutor.swift; sourceTree = "<group>"; };
 		E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigNamedColorTests.swift; sourceTree = "<group>"; };
+		C5D0DEC0CF00000000000B1 /* CmuxConfigStore+ConfigStoreReloading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxConfigStore+ConfigStoreReloading.swift"; sourceTree = "<group>"; };
 		C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
 		C0DEF0A10000000000000002 /* CmuxConfigUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigUI.swift; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA5 /* CmuxDockTilePlugin.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CmuxDockTilePlugin.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1322,6 +1326,7 @@
 		D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalViewSupport.swift; sourceTree = "<group>"; };
 		D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalViewVisibilityPolicyTests.swift; sourceTree = "<group>"; };
 		D3284102A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTextInputSupport.swift; sourceTree = "<group>"; };
+		C5D0DEC0F11E0000000000B1 /* GhosttyTriggerPhysicalKey+GhosttyKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyTriggerPhysicalKey+GhosttyKit.swift"; sourceTree = "<group>"; };
 		3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchCoordinator.swift; sourceTree = "<group>"; };
 		3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchDocuments.swift; sourceTree = "<group>"; };
 		3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPanelCaptureManager.swift; sourceTree = "<group>"; };
@@ -1783,6 +1788,7 @@
 				CFF11E0000000000000000A3 /* CmuxFileOpen in Frameworks */,
 				C8000313C8000313C8000313 /* CmuxFileWatch in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
+				C5D0DEC00000000000000003 /* CmuxGhosttyShortcutDecoding in Frameworks */,
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
 				C19C5E0300000000000000A3 /* CmuxIPCService in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
@@ -2199,6 +2205,8 @@
 				B35750000000000000000001 /* VaultAgentRegistry.swift */,
 				D3284102A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift */,
 				77F5AB36771F1414A95E3330 /* GhosttyKeyModifiers.swift */,
+				C5D0DEC0F11E0000000000B1 /* GhosttyTriggerPhysicalKey+GhosttyKit.swift */,
+				C5D0DEC0CF00000000000B1 /* CmuxConfigStore+ConfigStoreReloading.swift */,
 				D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
 				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
 				D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
@@ -3037,6 +3045,7 @@
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
 				C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */,
+				C5D0DEC00000000000000001 /* XCLocalSwiftPackageReference "CmuxGhosttyShortcutDecoding" */,
 				C9A2B00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxAppKitSupportUI" */,
 				C9A2C00000000000000000C1 /* XCLocalSwiftPackageReference "CmuxFeedback" */,
 				C9A2D00000000000000000D1 /* XCLocalSwiftPackageReference "CmuxFeedbackUI" */,
@@ -3314,6 +3323,7 @@
 				A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */,
 				A5001650 /* CmuxConfig.swift in Sources */,
 				A5001652 /* CmuxConfigExecutor.swift in Sources */,
+				C5D0DEC0CF00000000000A1 /* CmuxConfigStore+ConfigStoreReloading.swift in Sources */,
 				C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */,
 				E7E000000000000000000005 /* CmuxEventBus.swift in Sources */,
 				E7E00000000000000000000D /* CmuxEventLogWriter.swift in Sources */,
@@ -3428,6 +3438,7 @@
 				A5001005 /* GhosttyTerminalView.swift in Sources */,
 				D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */,
 				D3284101A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift in Sources */,
+				C5D0DEC0F11E0000000000A1 /* GhosttyTriggerPhysicalKey+GhosttyKit.swift in Sources */,
 					3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */,
 				3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */,
 				3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
@@ -4587,6 +4598,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxControlSocket;
 		};
+		C5D0DEC00000000000000001 /* XCLocalSwiftPackageReference "CmuxGhosttyShortcutDecoding" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxGhosttyShortcutDecoding;
+		};
 		C9A2B00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxAppKitSupportUI" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxAppKitSupportUI;
@@ -4863,6 +4878,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */;
 			productName = CmuxControlSocket;
+		};
+		C5D0DEC00000000000000002 /* CmuxGhosttyShortcutDecoding */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5D0DEC00000000000000001 /* XCLocalSwiftPackageReference "CmuxGhosttyShortcutDecoding" */;
+			productName = CmuxGhosttyShortcutDecoding;
 		};
 		C9A2B00000000000000000B2 /* CmuxAppKitSupportUI */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
Pulls the byte-identical, cleanly-separable pieces of AppDelegate's configuration-reload domain into a new leaf package, `CmuxGhosttyShortcutDecoding` (no dependencies).

## What moved
- The ~85-line ghostty-trigger → shortcut decode logic from `storedShortcutFromGhosttyTrigger` becomes a tested value-object decoder: `GhosttyTriggerShortcutDecoder` over `GhosttyTriggerInput` / `GhosttyTriggerPhysicalKey` / `GhosttyModifierMask`, producing `GhosttyTriggerShortcut`. The glyph table (←/→/↑/↓, letters, digits, punctuation), catch-all rejection, unicode-scalar lowercasing, and the "bogus empty trigger" rule now live in the package.
- `reloadCmuxConfigStores` becomes `CmuxConfigStoreReloadCoordinator` (`@MainActor @Observable`), which sequences per-window store `loadAll()` (deduped by object identity) and the window-title refresh through injected seams.

## Seams (constructor-injected, no god-type reach in the package)
- `CmuxConfigStoreReloading`: `CmuxConfigStore` conforms via an empty extension (its existing `loadAll()` satisfies it).
- `CmuxConfigStoreReloadEnvironment`: `AppDelegate` conforms, exposing its `mainWindowContexts` stores and `refreshWindowTitlesAcrossMainWindows()` behind a read-only seam. The coordinator holds the environment **weakly** (AppDelegate owns the coordinator), so no retain cycle.

## Byte-identical notes
- `storedShortcutFromGhosttyTrigger` is now a thin adapter: lift the C `ghostty_input_trigger_s` into `GhosttyTriggerInput`, decode, map back onto the app-target `StoredShortcut`. The GhosttyKit-boundary key translation lives in a new app-target file (`GhosttyTriggerPhysicalKey+GhosttyKit.swift`) as a failable init, so `AppDelegate.swift` shrinks instead of growing.
- `reloadCmuxConfigStores` forwards to the coordinator: same iteration/dedupe order, same title refresh, same `#if DEBUG cmuxDebugLog("cmuxConfig.reload source=... stores=...")` via the coordinator's `onReload` hook.

## Left in the app target (intentional)
Menu-item wiring (`menuNeedsUpdate`, `configureReloadConfigurationMenuItem`) and the quit-warning / goto-split stored-property reads were not extracted: they are bound to `NSMenu`/`NSApp.mainMenu`, the app-target `KeyboardShortcutSettings`, and the keystroke-critical `handleCustomShortcut` path, so a byte-identical thin forward is not sound without dragging AppKit/GhosttyKit into a package. The largest clean subset (the decode logic + config-store reload orchestration) was extracted instead.

## Tests
13 behavior tests with fakes for the seams: decoder glyphs/mods/rejections over every physical key; coordinator dedupe/refresh/report and weak-environment teardown. `swift build` + `swift test` green in the package.

## Stats
- Package wired into `cmux.xcodeproj` (6 pbxproj entries mirroring `CmuxControlSocket`).
- `AppDelegate.swift` budget ratcheted 17778 → 17729.

NOTE: full app build + cmux test targets are validated by GitHub CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784144671&installation_id=133855650&pr_number=6183&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6183&signature=5ee7c3c21f8fa6f739de1539cfdc2556df2e8b9c0a47e30b799af0781bae8cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts Ghostty trigger-to-shortcut decoding and config-store reload orchestration out of AppDelegate into a new leaf package, `CmuxGhosttyShortcutDecoding`, keeping behavior byte-identical while adding focused tests and simplifying app wiring.

- **Refactors**
  - Introduced `GhosttyTriggerShortcutDecoder` over `GhosttyTriggerInput`/`GhosttyTriggerPhysicalKey`/`GhosttyModifierMask`, producing `GhosttyTriggerShortcut` with the same glyph table, unicode lowercasing, catch-all rejection, and empty-trigger rule.
  - Added `CmuxConfigStoreReloadCoordinator` (`@MainActor @Observable`) to dedupe `loadAll()` across windows and refresh titles via injected seams: `CmuxConfigStoreReloading` and `CmuxConfigStoreReloadEnvironment` (held weakly, `onReload` for debug).
  - App wiring: `AppDelegate` now lifts `ghostty_input_trigger_s` into `GhosttyTriggerInput`, decodes, and maps to `StoredShortcut`; reloads forward to the coordinator. Bridge added in `GhosttyTriggerPhysicalKey+GhosttyKit.swift`; `CmuxConfigStore` conforms to `CmuxConfigStoreReloading`.
  - Tests: 13 behavior tests cover decoder glyphs/mods/rejections and coordinator dedupe/refresh/teardown.

<sup>Written for commit 73aebaa6b4d5a533516397e558fdc7d56cca82ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

