### PR TITLE
Fix omo jsonc opencode config

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -21414,10 +21414,7 @@ struct CMUXCLI {
 
         var config: [String: Any]
         if let data = try? Data(contentsOf: userJsonURL) {
-            guard let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw CLIError(message: "Failed to parse \(userJsonURL.path). Fix the JSON syntax and retry.")
-            }
-            config = existing
+            config = try Self.parseOpenCodeConfig(data: data, sourcePath: userJsonURL.path)
         } else {
             config = [:]
         }
@@ -27503,6 +27500,26 @@ export default CMUXSessionRestore;
         try Self.openCodeSessionPluginSource.write(to: pluginURL, atomically: true, encoding: .utf8)
     }
 
+    /// Parses an opencode `opencode.json` config file's bytes into a dictionary.
+    ///
+    /// opencode treats `opencode.json` as JSONC (it tolerates `//` and `/* */`
+    /// comments and trailing commas), so cmux must decode it the same way before
+    /// layering plugins on top. Every cmux code path that reads the user's
+    /// `opencode.json` routes through this single helper so the JSONC handling and
+    /// the user-facing parse-error message stay consistent.
+    ///
+    /// - Parameters:
+    ///   - data: The raw bytes of the config file.
+    ///   - sourcePath: Filesystem path used in the thrown error message.
+    /// - Returns: The decoded top-level JSON object.
+    /// - Throws: ``CLIError`` when the bytes are not a valid JSON/JSONC object.
+    static func parseOpenCodeConfig(data: Data, sourcePath: String) throws -> [String: Any] {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CLIError(message: "Failed to parse \(sourcePath). Fix the JSON syntax and retry.")
+        }
+        return object
+    }
+
     private static func openCodePluginListContains(
         _ plugins: [Any],
         spec: String,
@@ -27643,8 +27660,7 @@ export default CMUXSessionRestore;
         let configURL = configDir.appendingPathComponent("opencode.json", isDirectory: false); let existingData = try? Data(contentsOf: configURL)
         var config: [String: Any]
         if let data = existingData {
-            guard let decoded = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw CLIError(message: "Failed to parse \(configURL.path). Fix the JSON syntax and retry.") }
-            config = decoded
+            config = try Self.parseOpenCodeConfig(data: data, sourcePath: configURL.path)
         } else {
             config = [:]
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27514,8 +27514,21 @@ export default CMUXSessionRestore;
     /// - Returns: The decoded top-level JSON object.
     /// - Throws: ``CLIError`` when the bytes are not a valid JSON/JSONC object.
     static func parseOpenCodeConfig(data: Data, sourcePath: String) throws -> [String: Any] {
-        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw CLIError(message: "Failed to parse \(sourcePath). Fix the JSON syntax and retry.")
+        let sanitized: Data
+        let configParseError = String.localizedStringWithFormat(
+          String(
+            localized: "cli.hooks.opencode.error.invalidJSON",
+            defaultValue: "Failed to parse %@. Fix the JSON syntax and retry."
+          ), sourcePath
+        )
+
+        do {
+            sanitized = try JSONCParser.preprocess(data: data)
+        } catch {
+            throw CLIError(message: configParseError)
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: sanitized) as? [String: Any] else {
+            throw CLIError(message: configParseError)
         }
         return object
     }
@@ -27656,19 +27669,73 @@ export default CMUXSessionRestore;
         }
     }
 
+    /// Compares two opencode `plugin` arrays for logical equality so a no-op
+    /// registration call does not rewrite (and reformat) the user's config.
+    ///
+    /// Raw-byte comparison is wrong here: the on-disk file may be JSONC, but the
+    /// re-serialized array is always strict JSON, so the two can never match even
+    /// when nothing changed. Comparing the decoded arrays avoids needlessly
+    /// stripping the user's comments on every hook install/uninstall.
+    static func openCodePluginListsEqual(_ lhs: [Any], _ rhs: [Any]) -> Bool {
+        guard
+            let lhsData = try? JSONSerialization.data(withJSONObject: lhs, options: [.sortedKeys]),
+            let rhsData = try? JSONSerialization.data(withJSONObject: rhs, options: [.sortedKeys])
+        else { return false }
+        return lhsData == rhsData
+    }
+
+    /// Serializes an opencode `plugin` array to pretty-printed JSON for embedding
+    /// as a property value via ``JSONCObjectEditor``.
+    static func openCodePluginListValueJSON(_ plugins: [Any]) -> String? {
+        guard
+            JSONSerialization.isValidJSONObject(plugins),
+            let data = try? JSONSerialization.data(withJSONObject: plugins, options: [.prettyPrinted]),
+            let string = String(data: data, encoding: .utf8)
+        else { return nil }
+        return string
+    }
+
     private func updateOpenCodePluginRegistration(configDir: URL, shouldInstall: Bool) throws -> Bool {
-        let configURL = configDir.appendingPathComponent("opencode.json", isDirectory: false); let existingData = try? Data(contentsOf: configURL)
+        let configURL = configDir.appendingPathComponent("opencode.json", isDirectory: false)
+        let existingData = try? Data(contentsOf: configURL)
         var config: [String: Any]
+        var sourceText: String?
+        var sourceEncoding: String.Encoding = .utf8
         if let data = existingData {
             config = try Self.parseOpenCodeConfig(data: data, sourcePath: configURL.path)
+            if let parsed = try? JSONCParser.source(data: data) {
+                sourceText = parsed.text
+                sourceEncoding = parsed.encoding
+            }
         } else {
             config = [:]
         }
-        var plugins = Self.openCodePluginListRemovingSessionPlugin((config["plugin"] as? [Any]) ?? [])
-        if shouldInstall, !Self.openCodePluginListContains(plugins, spec: Self.openCodeSessionPluginConfigSpec) { plugins.append(Self.openCodeSessionPluginConfigSpec) }
+        let originalPlugins = (config["plugin"] as? [Any]) ?? []
+        var plugins = Self.openCodePluginListRemovingSessionPlugin(originalPlugins)
+        if shouldInstall, !Self.openCodePluginListContains(plugins, spec: Self.openCodeSessionPluginConfigSpec) {
+            plugins.append(Self.openCodeSessionPluginConfigSpec)
+        }
+        // Logical no-op detection: if the plugin list already matches what we'd
+        // write, leave the file (and its comments) untouched.
+        if Self.openCodePluginListsEqual(originalPlugins, plugins) {
+            return false
+        }
         config["plugin"] = plugins
+
+        // Prefer a surgical, comment-preserving edit of the existing JSONC text so
+        // the user's `opencode.json` keeps its comments, trailing commas, and
+        // formatting. Fall back to a full re-serialization only when we have no
+        // existing source to edit or the edit cannot be applied.
+        if let sourceText,
+           let valueJSON = Self.openCodePluginListValueJSON(plugins),
+           let edited = JSONCObjectEditor.setRootProperty(key: "plugin", valueJSON: valueJSON, in: sourceText) {
+            try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+            let outputData = edited.data(using: sourceEncoding) ?? Data(edited.utf8)
+            try outputData.write(to: configURL, options: .atomic)
+            return true
+        }
+
         let output = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
-        if existingData == output { return false }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         try output.write(to: configURL, options: .atomic)
         return true

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27676,12 +27676,32 @@ export default CMUXSessionRestore;
     /// re-serialized array is always strict JSON, so the two can never match even
     /// when nothing changed. Comparing the decoded arrays avoids needlessly
     /// stripping the user's comments on every hook install/uninstall.
+    ///
+    /// The comparison is order-insensitive on purpose. Registration rebuilds the
+    /// list by removing the session plugin and re-appending it at the end, so an
+    /// already-registered config like `["cmux-session", "other"]` would otherwise
+    /// look "changed" (it re-serializes to `["other", "cmux-session"]`) and get
+    /// rewritten — needlessly reordering the user's plugins and stripping their
+    /// comments. `.sortedKeys` only sorts keys inside JSON objects, not array
+    /// element order, so we canonicalize each element and sort before comparing.
     static func openCodePluginListsEqual(_ lhs: [Any], _ rhs: [Any]) -> Bool {
-        guard
-            let lhsData = try? JSONSerialization.data(withJSONObject: lhs, options: [.sortedKeys]),
-            let rhsData = try? JSONSerialization.data(withJSONObject: rhs, options: [.sortedKeys])
-        else { return false }
-        return lhsData == rhsData
+        func canonicalized(_ plugins: [Any]) -> [String]? {
+            var encoded: [String] = []
+            encoded.reserveCapacity(plugins.count)
+            for element in plugins {
+                guard
+                    JSONSerialization.isValidJSONObject([element]),
+                    let data = try? JSONSerialization.data(withJSONObject: [element], options: [.sortedKeys]),
+                    let string = String(data: data, encoding: .utf8)
+                else { return nil }
+                encoded.append(string)
+            }
+            return encoded.sorted()
+        }
+        guard let lhsCanonical = canonicalized(lhs), let rhsCanonical = canonicalized(rhs) else {
+            return false
+        }
+        return lhsCanonical == rhsCanonical
     }
 
     /// Serializes an opencode `plugin` array to pretty-printed JSON for embedding

--- a/Sources/JSONCParser.swift
+++ b/Sources/JSONCParser.swift
@@ -231,6 +231,42 @@ enum JSONCParser {
 }
 
 enum JSONCObjectEditor {
+    /// Sets (replaces or inserts) a top-level property on the root JSON object
+    /// while preserving the rest of the document verbatim — including comments,
+    /// trailing commas, indentation, and newline style.
+    ///
+    /// Use this instead of re-serializing a decoded dictionary when the on-disk
+    /// file may be JSONC and the user's formatting/comments must survive the edit.
+    ///
+    /// - Parameters:
+    ///   - key: The top-level property key to set.
+    ///   - valueJSON: The replacement value, encoded as JSON (may be multi-line;
+    ///     it is re-indented to match the property's column).
+    ///   - source: The original document text.
+    /// - Returns: The edited document text, or `nil` when `source` is not a JSON
+    ///   object (so the caller can fall back to a full re-serialization).
+    static func setRootProperty(
+        key: String,
+        valueJSON: String,
+        in source: String
+    ) -> String? {
+        guard let root = rootObject(in: source) else { return nil }
+        let newline = preferredNewline(in: source)
+
+        if let property = root.property(named: key) {
+            let indent = indentationBeforeLine(containing: property.keyStart, in: source)
+            let replacement = withPreferredNewline(
+                valueJSONForProperty(valueJSON, propertyIndent: indent),
+                newline: newline
+            )
+            return replacing(source, from: property.valueStart, to: property.valueEnd, with: replacement)
+        }
+
+        let indent = propertyIndent(for: root, in: source)
+        let property = propertyText(key: key, valueJSON: valueJSON, indent: indent)
+        return inserting(property, into: root, in: source)
+    }
+
     static func setNestedObjectProperty(
         parentKey: String,
         childKey: String,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 		9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D6AE11906A4DF3BEB8CDFE /* OmnibarSubmitDecisionTests.swift */; };
+		5F974EF929C6A0731042168E /* OmoOpenCodeConfigJSONCParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCEDE8A1DC84219D8A06464 /* OmoOpenCodeConfigJSONCParsingTests.swift */; };
 		0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0F00550000000000000002 /* OmpSupportTests.swift */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
 		FEED0000000000000000F007 /* opencode-plugin.js in Resources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F006 /* opencode-plugin.js */; };
@@ -1465,6 +1466,7 @@
 		D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/NSWindow+CmuxPeerWindow.swift"; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		48D6AE11906A4DF3BEB8CDFE /* OmnibarSubmitDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarSubmitDecisionTests.swift; sourceTree = "<group>"; };
+		9FCEDE8A1DC84219D8A06464 /* OmoOpenCodeConfigJSONCParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmoOpenCodeConfigJSONCParsingTests.swift; sourceTree = "<group>"; };
 		0A0F00550000000000000002 /* OmpSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmpSupportTests.swift; sourceTree = "<group>"; };
 		D1BEF00001A1B2C3D4E5F719 /* open */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/open; sourceTree = SOURCE_ROOT; };
 		FEED0000000000000000F006 /* opencode-plugin.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "opencode-plugin.js"; sourceTree = "<group>"; };
@@ -2831,6 +2833,7 @@
 				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
 				86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */,
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
+				9FCEDE8A1DC84219D8A06464 /* OmoOpenCodeConfigJSONCParsingTests.swift */,
 				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
@@ -4131,6 +4134,7 @@
 				4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */,
 				4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
+				5F974EF929C6A0731042168E /* OmoOpenCodeConfigJSONCParsingTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,

--- a/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
+++ b/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for `cmux omo` (and the session-plugin registration path)
+/// failing to start when the user's `opencode.json` contains JSONC syntax.
+///
+/// opencode itself treats `opencode.json` as JSONC, so a leading `// ...` mode
+/// line, block comments, and trailing commas are all valid. Before the fix, cmux
+/// decoded the file with strict `JSONSerialization`, which rejects comments and
+/// aborts with "Failed to parse … Fix the JSON syntax and retry." See
+/// https://github.com/manaflow-ai/cmux for the omo config layering code.
+@Suite("omo opencode.json JSONC parsing")
+struct OmoOpenCodeConfigJSONCParsingTests {
+    /// The exact shape that broke `cmux omo`: a leading editor mode-line comment
+    /// on the very first byte of the file, ahead of the opening brace.
+    @Test
+    func parsesLeadingLineCommentBeforeOpeningBrace() throws {
+        let source = """
+        // be in -*- jsonc -*- mode
+        {
+          "$schema": "https://opencode.ai/config.json",
+          "model": "github-copilot/claude-opus-4.8"
+        }
+        """
+        let config = try CMUXCLI.parseOpenCodeConfig(
+            data: Data(source.utf8),
+            sourcePath: "/tmp/opencode.json"
+        )
+        #expect(config["model"] as? String == "github-copilot/claude-opus-4.8")
+        #expect(config["$schema"] as? String == "https://opencode.ai/config.json")
+    }
+
+    /// Line comments, block comments, and a trailing comma should all decode the
+    /// same way opencode reads them.
+    @Test
+    func parsesInlineBlockCommentsAndTrailingCommas() throws {
+        let source = """
+        {
+          // line comment
+          "model": "x", /* trailing block comment */
+          "permission": {
+            "external_directory": {
+              "~/foo/**": "allow",
+            },
+          },
+        }
+        """
+        let config = try CMUXCLI.parseOpenCodeConfig(
+            data: Data(source.utf8),
+            sourcePath: "/tmp/opencode.json"
+        )
+        #expect(config["model"] as? String == "x")
+        let permission = try #require(config["permission"] as? [String: Any])
+        let external = try #require(permission["external_directory"] as? [String: Any])
+        #expect(external["~/foo/**"] as? String == "allow")
+    }
+
+    /// Comment-free strict JSON must keep working unchanged.
+    @Test
+    func parsesPlainStrictJSON() throws {
+        let source = #"{"model":"y"}"#
+        let config = try CMUXCLI.parseOpenCodeConfig(
+            data: Data(source.utf8),
+            sourcePath: "/tmp/opencode.json"
+        )
+        #expect(config["model"] as? String == "y")
+    }
+
+    /// Genuinely malformed config must still surface the user-facing error so the
+    /// fix does not mask real syntax mistakes.
+    @Test
+    func throwsCLIErrorForMalformedConfig() {
+        let source = "{ not valid json"
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseOpenCodeConfig(
+                data: Data(source.utf8),
+                sourcePath: "/tmp/opencode.json"
+            )
+        }
+    }
+}

--- a/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
+++ b/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
@@ -113,7 +113,9 @@ struct OmoOpenCodePluginRegistrationTests {
         #expect(edited.contains("// be in -*- jsonc -*- mode"))
         #expect(edited.contains("// primary model"))
         #expect(edited.contains("\"plugin\""))
-        #expect(edited.contains("cmux-session"))
+        // The pre-existing model property (and its trailing comma) must survive
+        // the surgical insertion untouched.
+        #expect(edited.contains(#""model": "github-copilot/claude-opus-4.8","#))
 
         // The edited document must still decode (as JSONC) back to the expected shape.
         let config = try CMUXCLI.parseOpenCodeConfig(
@@ -121,8 +123,9 @@ struct OmoOpenCodePluginRegistrationTests {
             sourcePath: "/tmp/opencode.json"
         )
         #expect(config["model"] as? String == "github-copilot/claude-opus-4.8")
+        // Assert the exact plugin array so a duplicate or stray entry fails the test.
         let plugins = try #require(config["plugin"] as? [Any])
-        #expect(plugins.contains { $0 as? String == "cmux-session" })
+        #expect(plugins.compactMap { $0 as? String } == ["cmux-session"])
     }
 
     /// Replacing an existing `plugin` array must keep unrelated comments intact.
@@ -154,12 +157,25 @@ struct OmoOpenCodePluginRegistrationTests {
         #expect(config["model"] as? String == "x")
     }
 
-    /// The logical no-op comparison must treat reordering-free identical lists as
-    /// equal so an already-registered config is never rewritten.
+    /// The logical no-op comparison must treat identical lists as equal so an
+    /// already-registered config is never rewritten. It must also be
+    /// order-insensitive: registration re-appends the session plugin at the end,
+    /// so a config that already lists it earlier must still count as a no-op
+    /// instead of triggering a comment-stripping reorder rewrite.
     @Test
     func pluginListsEqualDetectsNoOp() {
         #expect(CMUXCLI.openCodePluginListsEqual(["cmux-session"], ["cmux-session"]))
         #expect(!CMUXCLI.openCodePluginListsEqual([], ["cmux-session"]))
         #expect(!CMUXCLI.openCodePluginListsEqual(["a"], ["a", "cmux-session"]))
+        // Order-insensitive: same membership, different order -> still equal.
+        #expect(CMUXCLI.openCodePluginListsEqual(
+            ["cmux-session", "other-plugin"],
+            ["other-plugin", "cmux-session"]
+        ))
+        // Different membership must not be masked by the order-insensitive compare.
+        #expect(!CMUXCLI.openCodePluginListsEqual(
+            ["cmux-session", "other-plugin"],
+            ["other-plugin", "third-plugin"]
+        ))
     }
 }

--- a/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
+++ b/cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift
@@ -85,3 +85,81 @@ struct OmoOpenCodeConfigJSONCParsingTests {
         }
     }
 }
+
+/// Regression coverage for the plugin-registration write path stripping JSONC
+/// comments out of the user's real `~/.config/opencode/opencode.json`.
+///
+/// opencode treats `opencode.json` as JSONC, so cmux must register its session
+/// plugin with a surgical, comment-preserving edit rather than re-serializing the
+/// decoded dictionary back to strict JSON. See
+/// https://github.com/manaflow-ai/cmux/pull/6187 for the original report.
+@Suite("opencode.json JSONC-preserving plugin registration")
+struct OmoOpenCodePluginRegistrationTests {
+    /// Inserting the `plugin` property into a JSONC document must keep the
+    /// surrounding comments and trailing commas intact.
+    @Test
+    func insertingPluginPreservesComments() throws {
+        let source = """
+        // be in -*- jsonc -*- mode
+        {
+          // primary model
+          "model": "github-copilot/claude-opus-4.8",
+        }
+        """
+        let valueJSON = try #require(CMUXCLI.openCodePluginListValueJSON(["cmux-session"]))
+        let edited = try #require(
+            JSONCObjectEditor.setRootProperty(key: "plugin", valueJSON: valueJSON, in: source)
+        )
+        #expect(edited.contains("// be in -*- jsonc -*- mode"))
+        #expect(edited.contains("// primary model"))
+        #expect(edited.contains("\"plugin\""))
+        #expect(edited.contains("cmux-session"))
+
+        // The edited document must still decode (as JSONC) back to the expected shape.
+        let config = try CMUXCLI.parseOpenCodeConfig(
+            data: Data(edited.utf8),
+            sourcePath: "/tmp/opencode.json"
+        )
+        #expect(config["model"] as? String == "github-copilot/claude-opus-4.8")
+        let plugins = try #require(config["plugin"] as? [Any])
+        #expect(plugins.contains { $0 as? String == "cmux-session" })
+    }
+
+    /// Replacing an existing `plugin` array must keep unrelated comments intact.
+    @Test
+    func replacingPluginPreservesComments() throws {
+        let source = """
+        {
+          // keep me
+          "plugin": [
+            "existing-plugin",
+          ],
+          "model": "x", /* inline */
+        }
+        """
+        let valueJSON = try #require(
+            CMUXCLI.openCodePluginListValueJSON(["existing-plugin", "cmux-session"])
+        )
+        let edited = try #require(
+            JSONCObjectEditor.setRootProperty(key: "plugin", valueJSON: valueJSON, in: source)
+        )
+        #expect(edited.contains("// keep me"))
+        #expect(edited.contains("/* inline */"))
+        let config = try CMUXCLI.parseOpenCodeConfig(
+            data: Data(edited.utf8),
+            sourcePath: "/tmp/opencode.json"
+        )
+        let plugins = try #require(config["plugin"] as? [Any])
+        #expect(plugins.compactMap { $0 as? String } == ["existing-plugin", "cmux-session"])
+        #expect(config["model"] as? String == "x")
+    }
+
+    /// The logical no-op comparison must treat reordering-free identical lists as
+    /// equal so an already-registered config is never rewritten.
+    @Test
+    func pluginListsEqualDetectsNoOp() {
+        #expect(CMUXCLI.openCodePluginListsEqual(["cmux-session"], ["cmux-session"]))
+        #expect(!CMUXCLI.openCodePluginListsEqual([], ["cmux-session"]))
+        #expect(!CMUXCLI.openCodePluginListsEqual(["a"], ["a", "cmux-session"]))
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** `cmux` now reads the user's `~/.config/opencode/opencode.json` as **JSONC** instead of strict JSON. Added a single shared helper `CMUXCLI.parseOpenCodeConfig(data:sourcePath:)` that runs the existing `JSONCParser.preprocess` (strips `//` and `/* */` comments and trailing commas) before `JSONSerialization`, and routed both code paths that read `opencode.json` through it: `omoEnsurePlugin` (the `cmux omo` path) and `updateOpenCodePluginRegistration` (session-plugin registration). The user-facing error message (`Failed to parse <path>. Fix the JSON syntax and retry.`) is preserved, so genuinely malformed configs still surface it.
- **Why?** `cmux omo` aborted with `Failed to parse <path>. Fix the JSON syntax and retry.` whenever `opencode.json` contained JSONC syntax — most commonly a leading editor mode line such as `// be in -*- jsonc -*- mode`. opencode itself treats `opencode.json` as JSONC, and cmux already uses `JSONCParser.preprocess` for its other config reads; `opencode.json` was the one path still doing a strict parse, so it failed on the very first byte. Both affected entrypoints shared the identical bug, so per the repo's shared-behavior policy they were fixed through one common path.

## Testing

- **Automated regression test (two-commit red/green):** added `cmuxTests/OmoOpenCodeConfigJSONCParsingTests.swift` (Swift Testing) covering the exact repro (leading `//` mode line), inline/block comments + trailing commas, plain strict JSON, and a malformed-config case that must still throw. Commit 1 adds the test against the still-strict helper (red); commit 2 makes the helper JSONC-aware (green). The test file is wired into `cmux.xcodeproj/project.pbxproj` (all four sections) and `./scripts/lint-pbxproj-test-wiring.sh` passes.
- **What I verified manually:**
  - Reproduced the failure on the released app: `cmux omo` → `Error: Failed to parse /Users/.../.config/opencode/opencode.json. Fix the JSON syntax and retry.`, and bisected it (via an isolated `HOME` copy) to the leading `//` comment — every comment form (`//`, `/* */`, line 1 or 2) triggered it; the comment-free file parsed.
  - **Could not run the real Xcode test target on my machine** (Command Line Tools only — no `Xcode.app`, GhosttyKit unbuilt — so `xcodebuild`/`cmux-unit` is unavailable). Instead I compiled the **real** `Sources/JSONCParser.swift` with a standalone `swiftc` harness using the exact test inputs and confirmed: the strict parse rejects the leading-comment repro (test is genuinely red without the fix), and the JSONC path parses leading comments, inline/block comments, trailing commas, and plain JSON while still throwing on malformed input. CI's `tests` job is the authoritative compile/run of the test target.

## Demo Video

Not applicable — this is a CLI startup/config-parsing fix with no UI surface. Behavior change is covered by the automated regression test and the manual repro above.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally *(repro + logic verified via swiftc harness against the real JSONCParser; the Xcode `cmux-unit` test target was NOT run locally — no Xcode.app on this machine — relying on CI)*
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed *(no docs/changelog change; release/changelog is handled via the repo's `/release` flow — flag if you want a CHANGELOG entry now)*
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent) *(do this after opening the PR)*
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784150540&installation_id=133855650&pr_number=6187&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6187&signature=561e955a57ae3306de26c792c4b8b5fbe2a6dbb28b3392059b5a42823620378d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
cmux now parses `~/.config/opencode/opencode.json` as JSONC and preserves comments/formatting when updating the `plugin` list, fixing `cmux omo` and session plugin registration failures and preventing comment stripping or plugin reordering.

- **Bug Fixes**
  - Both paths now use a shared `CMUXCLI.parseOpenCodeConfig(data:sourcePath:)` that runs `JSONCParser.preprocess` before `JSONSerialization`.
  - Plugin registration edits the existing JSONC text via `JSONCObjectEditor.setRootProperty`, keeping comments, trailing commas, and formatting; falls back to pretty JSON only if needed.
  - No-op writes are skipped using `CMUXCLI.openCodePluginListsEqual`, which now canonicalizes and compares plugin arrays order-insensitively to avoid needless rewrites and reordering.
  - Added `OmoOpenCodeConfigJSONCParsingTests` covering JSONC parsing, comment-preserving plugin updates, order-insensitive no-op detection, plain JSON, and malformed input.

<sup>Written for commit 3b08cafdfbaa2010a3c3208337f6e8645eb9a6a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced `opencode.json` handling with JSONC support (comments and trailing commas) and improved plugin registration updates.

* **Bug Fixes**
  * Reduced unnecessary rewrites via more reliable no-op detection.
  * Standardized configuration parse failures with clearer “Fix the JSON syntax and retry” guidance.

* **Tests**
  * Added unit coverage for JSONC parsing, comment-preserving plugin updates, and no-op detection.

* **Documentation**
  * Refined the user-facing configuration parse error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->