### PR TITLE
Fix Claude Teams forks after /new

### DIFF
--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -232,6 +232,16 @@ extension CMUXCLI {
         return wrapperPath
     }
 
+    func claudeTeamsProviderLaunchPath(claudeExecutablePath: String) -> String {
+        guard let wrapperPath = bundledClaudeWrapperExecutablePath() else {
+            return claudeExecutablePath
+        }
+        setenv("CMUX_CUSTOM_CLAUDE_PATH", claudeExecutablePath, 1)
+        setenv("CMUX_CLAUDE_WRAPPER_PRESERVE_AGENT_LAUNCH", "1", 1)
+        setenv("CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS", "1", 1)
+        return wrapperPath
+    }
+
     private func isCmuxAppBundleResourceBinDirectory(_ path: String) -> Bool {
         cmuxAppBundleResourceBinComponentIndex(path).map { index in
             URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.pathComponents.count == index + 4

--- a/CLI/CMUXCLI+ExecutableResolution.swift
+++ b/CLI/CMUXCLI+ExecutableResolution.swift
@@ -219,6 +219,19 @@ extension CMUXCLI {
         return directory
     }
 
+    func bundledClaudeWrapperExecutablePath() -> String? {
+        guard let directory = bundledProviderBinDirectory() else {
+            return nil
+        }
+        let wrapperPath = URL(fileURLWithPath: directory, isDirectory: true)
+            .appendingPathComponent("cmux-claude-wrapper", isDirectory: false)
+            .path
+        guard FileManager.default.isExecutableFile(atPath: wrapperPath) else {
+            return nil
+        }
+        return wrapperPath
+    }
+
     private func isCmuxAppBundleResourceBinDirectory(_ path: String) -> Bool {
         cmuxAppBundleResourceBinComponentIndex(path).map { index in
             URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.pathComponents.count == index + 4

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19578,13 +19578,8 @@ struct CMUXCLI {
             focusedContext: focusedContext
         )
 
-        let launchPath = bundledClaudeWrapperExecutablePath() ?? claudeExecutablePath
+        let launchPath = claudeTeamsProviderLaunchPath(claudeExecutablePath: claudeExecutablePath)
         let launchArguments = claudeTeamsLaunchArguments(commandArgs: commandArgs)
-        if launchPath != claudeExecutablePath {
-            setenv("CMUX_CUSTOM_CLAUDE_PATH", claudeExecutablePath, 1)
-            setenv("CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS", "1", 1)
-            setenv("CMUX_CLAUDE_WRAPPER_ASSUME_SOCKET_AVAILABLE", "1", 1)
-        }
         exportAgentLaunchCommandEnvironment(
             launcher: "claudeTeams",
             executablePath: executablePath,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19578,8 +19578,13 @@ struct CMUXCLI {
             focusedContext: focusedContext
         )
 
-        let launchPath = claudeExecutablePath
+        let launchPath = bundledClaudeWrapperExecutablePath() ?? claudeExecutablePath
         let launchArguments = claudeTeamsLaunchArguments(commandArgs: commandArgs)
+        if launchPath != claudeExecutablePath {
+            setenv("CMUX_CUSTOM_CLAUDE_PATH", claudeExecutablePath, 1)
+            setenv("CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS", "1", 1)
+            setenv("CMUX_CLAUDE_WRAPPER_ASSUME_SOCKET_AVAILABLE", "1", 1)
+        }
         exportAgentLaunchCommandEnvironment(
             launcher: "claudeTeams",
             executablePath: executablePath,

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -228,7 +228,7 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     exec "$REAL_CLAUDE" "$@"
 fi
 
-if [[ "$IN_CMUX" == "0" ]] || { [[ "${CMUX_CLAUDE_WRAPPER_ASSUME_SOCKET_AVAILABLE:-}" != "1" ]] && ! cmux_socket_available; }; then
+if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
     # In cmux-launched shells, preserve old behavior and always clear nested
     # Claude session markers, even when we must pass through due to stale socket.
     if [[ "$IN_CMUX" == "1" ]]; then
@@ -473,10 +473,12 @@ done
 # the actual claude process PID, which hooks use for stale-session detection.
 export CMUX_CLAUDE_PID=$$
 export CMUX_CLAUDE_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
-export CMUX_AGENT_LAUNCH_KIND="claude"
-export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
-export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
-export CMUX_AGENT_LAUNCH_CWD="$PWD"
+if [[ "${CMUX_CLAUDE_WRAPPER_PRESERVE_AGENT_LAUNCH:-}" != "1" || -z "${CMUX_AGENT_LAUNCH_KIND:-}" || -z "${CMUX_AGENT_LAUNCH_EXECUTABLE:-}" || -z "${CMUX_AGENT_LAUNCH_ARGV_B64:-}" ]]; then
+    export CMUX_AGENT_LAUNCH_KIND="claude"
+    export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
+    export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
+    export CMUX_AGENT_LAUNCH_CWD="$PWD"
+fi
 if [[ "${CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS:-}" != "1" ]] && GUARD_PATH="$(ensure_node_options_restore_module)"; then
     if [[ ${NODE_OPTIONS+x} ]]; then
         export CMUX_ORIGINAL_NODE_OPTIONS_PRESENT=1

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -358,7 +358,7 @@ claude_option_consumes_value() {
         --input-format|--json-schema|--max-budget-usd|--mcp-config|\
         --model|-m|-n|--name|--output-format|--permission-mode|--plugin-dir|\
         --plugin-url|--remote-control-session-name-prefix|--setting-sources|\
-        --settings|--system-prompt|--tools)
+        --settings|--system-prompt|--teammate-mode|--tools)
             return 0
             ;;
     esac

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -228,7 +228,7 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     exec "$REAL_CLAUDE" "$@"
 fi
 
-if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
+if [[ "$IN_CMUX" == "0" ]] || { [[ "${CMUX_CLAUDE_WRAPPER_ASSUME_SOCKET_AVAILABLE:-}" != "1" ]] && ! cmux_socket_available; }; then
     # In cmux-launched shells, preserve old behavior and always clear nested
     # Claude session markers, even when we must pass through due to stale socket.
     if [[ "$IN_CMUX" == "1" ]]; then
@@ -477,7 +477,7 @@ export CMUX_AGENT_LAUNCH_KIND="claude"
 export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_CLAUDE"
 export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
 export CMUX_AGENT_LAUNCH_CWD="$PWD"
-if GUARD_PATH="$(ensure_node_options_restore_module)"; then
+if [[ "${CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS:-}" != "1" ]] && GUARD_PATH="$(ensure_node_options_restore_module)"; then
     if [[ ${NODE_OPTIONS+x} ]]; then
         export CMUX_ORIGINAL_NODE_OPTIONS_PRESENT=1
         export CMUX_ORIGINAL_NODE_OPTIONS="$(normalize_node_options_for_restore "$NODE_OPTIONS")"

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -208,6 +208,11 @@ if [[ -n "$CMUX_SURFACE_ID" ]]; then
 fi
 
 exec_real_claude_passthrough() {
+    if [[ "${CMUX_ORIGINAL_NODE_OPTIONS_PRESENT:-}" == "1" ]]; then
+        export NODE_OPTIONS="${CMUX_ORIGINAL_NODE_OPTIONS:-}"
+    elif [[ "${CMUX_ORIGINAL_NODE_OPTIONS_PRESENT:-}" == "0" ]]; then
+        unset NODE_OPTIONS
+    fi
     if [[ "$IN_CMUX" == "1" ]]; then
         local cmux_key
         for cmux_key in "${!CMUX_@}"; do

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -46,6 +46,7 @@ def run_wrapper(
     node_options: str | None = None,
     tmpdir: str | None = None,
     hooks_disabled: bool = False,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -188,6 +189,8 @@ exit 0
             env["TMPDIR"] = tmpdir
         if node_options is not None:
             env["NODE_OPTIONS"] = node_options
+        if extra_env is not None:
+            env.update(extra_env)
 
         try:
             proc = subprocess.run(
@@ -587,6 +590,26 @@ def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> 
     argv = decode_nul_argv(launch_argv_b64)
     expect(len(argv) == 1, f"plain claude: expected only executable in encoded launch argv, got {argv}", failures)
     expect(argv[0].endswith("/real-bin/claude"), f"plain claude: expected real claude executable, got {argv}", failures)
+
+
+def test_preserve_agent_launch_keeps_launcher_metadata(failures: list[str]) -> None:
+    encoded_teams_argv = base64.b64encode(b"/tmp/cmux\0claude-teams\0--teammate-mode\0auto").decode("ascii")
+    code, _, _, stderr, _, _, _, _, _, launch_argv_b64 = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+        extra_env={
+            "CMUX_CLAUDE_WRAPPER_PRESERVE_AGENT_LAUNCH": "1",
+            "CMUX_AGENT_LAUNCH_KIND": "claudeTeams",
+            "CMUX_AGENT_LAUNCH_EXECUTABLE": "/tmp/cmux",
+            "CMUX_AGENT_LAUNCH_ARGV_B64": encoded_teams_argv,
+        },
+    )
+    expect(code == 0, f"preserve launch metadata: wrapper exited {code}: {stderr}", failures)
+    expect(
+        launch_argv_b64 == encoded_teams_argv,
+        f"preserve launch metadata: expected existing launch argv, got {launch_argv_b64!r}",
+        failures,
+    )
 
 
 def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> None:
@@ -1167,6 +1190,7 @@ def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
+    test_preserve_agent_launch_keeps_launcher_metadata(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)
     test_agents_subcommand_removes_cmux_terminal_fingerprint(failures)

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -9,6 +9,8 @@ import os
 import json
 import subprocess
 import tempfile
+import socket
+import threading
 from pathlib import Path
 
 from claude_teams_test_utils import resolve_cmux_cli
@@ -23,6 +25,54 @@ def read_text(path: Path) -> str:
     if not path.exists():
         return ""
     return path.read_text(encoding="utf-8").strip()
+
+
+def start_ping_socket(path: str) -> tuple[threading.Event, threading.Thread]:
+    stop = threading.Event()
+    ready = threading.Event()
+
+    def run() -> None:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(path)
+            server.listen()
+            server.settimeout(0.05)
+            ready.set()
+            while not stop.is_set():
+                try:
+                    conn, _ = server.accept()
+                except socket.timeout:
+                    continue
+                with conn:
+                    conn.settimeout(0.5)
+                    pending = b""
+                    try:
+                        while not stop.is_set():
+                            chunk = conn.recv(4096)
+                            if not chunk:
+                                break
+                            pending += chunk
+                            while b"\n" in pending:
+                                line, pending = pending.split(b"\n", 1)
+                                response = b"PONG\n" if line == b"ping" else b"OK\n"
+                                conn.sendall(response)
+                    except socket.timeout:
+                        pass
+                    except OSError:
+                        pass
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    if not ready.wait(timeout=2):
+        raise RuntimeError("timed out starting fake cmux socket")
+    return stop, thread
 
 
 def run_claude_teams(
@@ -49,6 +99,7 @@ def run_claude_teams(
         node_options_log = tmp / "node-options.log"
         runtime_node_options_log = tmp / "runtime-node-options.log"
         child_node_options_log = tmp / "child-node-options.log"
+        launch_kind_log = tmp / "launch-kind.log"
         fake_home = tmp / "home"
         fake_home.mkdir(parents=True, exist_ok=True)
 
@@ -67,6 +118,7 @@ printf '%s\\n' "${TERM_PROGRAM-__UNSET__}" > "$FAKE_TERM_PROGRAM_LOG"
 printf '%s\\n' "${CMUX_SOCKET_PATH-__UNSET__}" > "$FAKE_SOCKET_PATH_LOG"
 printf '%s\\n' "${CMUX_SOCKET_PASSWORD-__UNSET__}" > "$FAKE_SOCKET_PASSWORD_LOG"
 printf '%s\\n' "${NODE_OPTIONS-__UNSET__}" > "$FAKE_NODE_OPTIONS_LOG"
+printf '%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}" > "$FAKE_LAUNCH_KIND_LOG"
 exec node "$FAKE_REAL_NODE_SCRIPT" "$@"
 """,
         )
@@ -119,6 +171,7 @@ fs.writeFileSync(
         env["FAKE_SOCKET_PATH_LOG"] = str(socket_path_log)
         env["FAKE_SOCKET_PASSWORD_LOG"] = str(socket_password_log)
         env["FAKE_NODE_OPTIONS_LOG"] = str(node_options_log)
+        env["FAKE_LAUNCH_KIND_LOG"] = str(launch_kind_log)
         env["FAKE_RUNTIME_NODE_OPTIONS_LOG"] = str(runtime_node_options_log)
         env["FAKE_CHILD_NODE_OPTIONS_LOG"] = str(child_node_options_log)
         env["FAKE_REAL_NODE_SCRIPT"] = str(real_bin / "claude-real.js")
@@ -133,22 +186,27 @@ fs.writeFileSync(
             env["TMPDIR"] = tmpdir
         explicit_socket_path = str(tmp / "explicit-cmux.sock")
         explicit_socket_password = "topsecret"
+        socket_stop, socket_thread = start_ping_socket(explicit_socket_path)
 
-        proc = subprocess.run(
-            [
-                cli_path,
-                "--socket",
-                explicit_socket_path,
-                "--password",
-                explicit_socket_password,
-                "claude-teams",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=30,
-        )
+        try:
+            proc = subprocess.run(
+                [
+                    cli_path,
+                    "--socket",
+                    explicit_socket_path,
+                    "--password",
+                    explicit_socket_password,
+                    "claude-teams",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+                timeout=30,
+            )
+        finally:
+            socket_stop.set()
+            socket_thread.join(timeout=1)
 
         if proc.returncode != 0:
             return proc, "", "", ""
@@ -183,6 +241,11 @@ fs.writeFileSync(
 
         if not os.path.exists(cmux_bin_value):
             print(f"FAIL: CMUX_CLAUDE_TEAMS_CMUX_BIN does not exist: {cmux_bin_value!r}")
+            raise SystemExit(1)
+
+        launch_kind_value = read_text(launch_kind_log)
+        if launch_kind_value != "claudeTeams":
+            print(f"FAIL: expected claudeTeams launch metadata, got {launch_kind_value!r}")
             raise SystemExit(1)
 
         expected_wrapper_hooks = Path(cli_path).with_name("cmux-claude-wrapper").exists()

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -6,6 +6,7 @@ Regression test: `cmux claude-teams` injects the tmux-style auto-mode env.
 from __future__ import annotations
 
 import os
+import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -125,6 +126,8 @@ fs.writeFileSync(
         env["TMUX_PANE"] = "%999"
         env["TERM"] = "xterm-256color"
         env["TERM_PROGRAM"] = "__HOST_TERM_PROGRAM__"
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_WORKSPACE_ID"] = "workspace:test"
         env["NODE_OPTIONS"] = node_options
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
@@ -139,7 +142,6 @@ fs.writeFileSync(
                 "--password",
                 explicit_socket_password,
                 "claude-teams",
-                "--version",
             ],
             capture_output=True,
             text=True,
@@ -183,13 +185,35 @@ fs.writeFileSync(
             print(f"FAIL: CMUX_CLAUDE_TEAMS_CMUX_BIN does not exist: {cmux_bin_value!r}")
             raise SystemExit(1)
 
+        expected_wrapper_hooks = Path(cli_path).with_name("cmux-claude-wrapper").exists()
         argv_lines = argv_log.read_text(encoding="utf-8").splitlines()
-        if argv_lines[:2] != ["--teammate-mode", "auto"]:
-            print(f"FAIL: expected launcher to prepend --teammate-mode auto, got {argv_lines!r}")
+        original_arg_start = 0
+        if "--settings" in argv_lines:
+            settings_index = argv_lines.index("--settings")
+            if settings_index + 1 >= len(argv_lines):
+                print(f"FAIL: expected --settings to have a JSON value, got {argv_lines!r}")
+                raise SystemExit(1)
+            try:
+                settings = json.loads(argv_lines[settings_index + 1])
+            except json.JSONDecodeError as exc:
+                print(f"FAIL: expected --settings JSON, got {argv_lines[settings_index + 1]!r}: {exc}")
+                raise SystemExit(1)
+            hooks = settings.get("hooks", {})
+            if "SessionStart" not in hooks or "UserPromptSubmit" not in hooks:
+                print(f"FAIL: expected claude-teams wrapper to inject session hooks, got {hooks.keys()!r}")
+                raise SystemExit(1)
+            original_arg_start = settings_index + 2
+        elif expected_wrapper_hooks:
+            print(f"FAIL: expected bundled claude-teams launch to inject hook settings, got {argv_lines!r}")
             raise SystemExit(1)
+        if "--session-id" in argv_lines:
+            session_index = argv_lines.index("--session-id")
+            if session_index + 2 > original_arg_start:
+                original_arg_start = session_index + 2
 
-        if "--version" not in argv_lines:
-            print(f"FAIL: expected launcher to preserve user args, got {argv_lines!r}")
+        original_argv = argv_lines[original_arg_start:]
+        if original_argv[:2] != ["--teammate-mode", "auto"]:
+            print(f"FAIL: expected launcher to prepend --teammate-mode auto, got {argv_lines!r}")
             raise SystemExit(1)
 
         tmux_env_value = read_text(tmux_env_log)
@@ -243,7 +267,7 @@ def main() -> int:
         "--trace-warnings",
     )
     if proc.returncode != 0:
-        print("FAIL: `cmux claude-teams --version` exited non-zero")
+        print("FAIL: `cmux claude-teams` exited non-zero")
         print(f"exit={proc.returncode}")
         print(f"stdout={proc.stdout.strip()}")
         print(f"stderr={proc.stderr.strip()}")
@@ -284,7 +308,7 @@ def main() -> int:
         "--max-old-space-size 2048 --trace-warnings",
     )
     if proc.returncode != 0:
-        print("FAIL: `cmux claude-teams --version` with existing heap flag exited non-zero")
+        print("FAIL: `cmux claude-teams` with existing heap flag exited non-zero")
         print(f"exit={proc.returncode}")
         print(f"stdout={proc.stdout.strip()}")
         print(f"stderr={proc.stderr.strip()}")
@@ -329,7 +353,7 @@ def main() -> int:
             tmpdir=str(bad_tmpdir),
         )
     if proc.returncode != 0:
-        print("FAIL: `cmux claude-teams --version` should still succeed when TMPDIR is unusable")
+        print("FAIL: `cmux claude-teams` should still succeed when TMPDIR is unusable")
         print(f"exit={proc.returncode}")
         print(f"stdout={proc.stdout.strip()}")
         print(f"stderr={proc.stderr.strip()}")

--- a/tests/test_cli_claude_teams_help_passthrough.py
+++ b/tests/test_cli_claude_teams_help_passthrough.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Regression test: `cmux claude-teams --help` passes through to Claude.
+Regression test: `cmux claude-teams --version` passes through to Claude.
 """
 
 from __future__ import annotations
@@ -46,9 +46,11 @@ printf '%s\\n' "$@" > "$FAKE_ARGV_LOG"
         env["HOME"] = str(home)
         env["PATH"] = f"{real_bin}:/usr/bin:/bin"
         env["FAKE_ARGV_LOG"] = str(argv_log)
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_WORKSPACE_ID"] = "workspace:test"
 
         proc = subprocess.run(
-            [cli_path, "claude-teams", "--help"],
+            [cli_path, "claude-teams", "--version"],
             capture_output=True,
             text=True,
             check=False,
@@ -57,28 +59,32 @@ printf '%s\\n' "$@" > "$FAKE_ARGV_LOG"
         )
 
         if proc.returncode != 0:
-            print("FAIL: `cmux claude-teams --help` exited non-zero")
+            print("FAIL: `cmux claude-teams --version` exited non-zero")
             print(f"exit={proc.returncode}")
             print(f"stdout={proc.stdout.strip()}")
             print(f"stderr={proc.stderr.strip()}")
             return 1
 
         if not argv_log.exists():
-            print("FAIL: launcher intercepted --help instead of invoking Claude")
+            print("FAIL: launcher intercepted --version instead of invoking Claude")
             print(f"stdout={proc.stdout.strip()}")
             print(f"stderr={proc.stderr.strip()}")
             return 1
 
         argv_lines = argv_log.read_text(encoding="utf-8").splitlines()
+        if "--settings" in argv_lines or "--session-id" in argv_lines:
+            print(f"FAIL: expected --version to bypass hook injection, got {argv_lines!r}")
+            return 1
+
         if argv_lines[:2] != ["--teammate-mode", "auto"]:
             print(f"FAIL: expected launcher to prepend --teammate-mode auto, got {argv_lines!r}")
             return 1
 
-        if "--help" not in argv_lines:
-            print(f"FAIL: expected --help to reach Claude, got {argv_lines!r}")
+        if "--version" not in argv_lines:
+            print(f"FAIL: expected --version to reach Claude, got {argv_lines!r}")
             return 1
 
-    print("PASS: cmux claude-teams forwards --help to Claude")
+    print("PASS: cmux claude-teams forwards --version to Claude")
     return 0
 
 

--- a/tests/test_cli_claude_teams_help_passthrough.py
+++ b/tests/test_cli_claude_teams_help_passthrough.py
@@ -33,21 +33,37 @@ def main() -> int:
         real_bin.mkdir(parents=True, exist_ok=True)
 
         argv_log = tmp / "argv.log"
+        node_options_log = tmp / "node-options.log"
 
         make_executable(
             real_bin / "claude",
             """#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$@" > "$FAKE_ARGV_LOG"
+exec node "$FAKE_REAL_NODE_SCRIPT" "$@"
+""",
+        )
+        make_executable(
+            real_bin / "claude-real.js",
+            """#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(process.env.FAKE_ARGV_LOG, `${process.argv.slice(2).join("\\n")}\\n`, "utf8");
+fs.writeFileSync(
+  process.env.FAKE_NODE_OPTIONS_LOG,
+  `${process.env.NODE_OPTIONS ?? "__UNSET__"}\\n`,
+  "utf8",
+);
 """,
         )
 
         env = os.environ.copy()
         env["HOME"] = str(home)
-        env["PATH"] = f"{real_bin}:/usr/bin:/bin"
+        env["PATH"] = f"{real_bin}:{env.get('PATH', '/usr/bin:/bin')}"
         env["FAKE_ARGV_LOG"] = str(argv_log)
+        env["FAKE_NODE_OPTIONS_LOG"] = str(node_options_log)
+        env["FAKE_REAL_NODE_SCRIPT"] = str(real_bin / "claude-real.js")
         env["CMUX_SURFACE_ID"] = "surface:test"
         env["CMUX_WORKSPACE_ID"] = "workspace:test"
+        env["NODE_OPTIONS"] = "--trace-warnings"
 
         proc = subprocess.run(
             [cli_path, "claude-teams", "--version"],
@@ -82,6 +98,11 @@ printf '%s\\n' "$@" > "$FAKE_ARGV_LOG"
 
         if "--version" not in argv_lines:
             print(f"FAIL: expected --version to reach Claude, got {argv_lines!r}")
+            return 1
+
+        node_options_value = node_options_log.read_text(encoding="utf-8").strip()
+        if node_options_value != "--trace-warnings":
+            print(f"FAIL: expected --version passthrough to restore NODE_OPTIONS, got {node_options_value!r}")
             return 1
 
     print("PASS: cmux claude-teams forwards --version to Claude")


### PR DESCRIPTION
## Summary
- route `cmux claude-teams` through the bundled Claude wrapper so Claude hooks are injected
- let the Teams launcher reuse its prepared socket and NODE_OPTIONS environment without double wrapper setup
- tighten the Teams env regression so bundled launches must include `SessionStart` and `UserPromptSubmit` hooks

## Hook evidence
With wrapper instrumentation, typing `/new` in Claude Code produced `SessionEnd:clear` followed by `SessionStart:clear` and a new Claude session id. The tagged preflight also showed `cmux claude-teams` invoking fake Claude with `--session-id`, hook `--settings`, and `--teammate-mode auto`.

## Verification
- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-clnew-build build`
- `CMUX_CLI_BIN="/tmp/cmux-clnew-build/Build/Products/Debug/cmux DEV.app/Contents/Resources/bin/cmux" python3 tests/test_cli_claude_teams_env.py`
- `CMUX_CLI_BIN="/tmp/cmux-clnew-build/Build/Products/Debug/cmux DEV.app/Contents/Resources/bin/cmux" python3 tests/test_cli_claude_teams_existing_shim.py`
- `python3 tests/test_claude_wrapper_hooks.py`
- `./scripts/reload-cloud.sh --tag clnew`
- tagged preflight via `CMUX_TAG=clnew scripts/cmux-debug-cli.sh read-screen --workspace workspace:2 --lines 80`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784153718&installation_id=133855650&pr_number=6192&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6192&signature=4df471b04e3d7255e80ba0a2e53c1055946ef6c3e67f52dee0c9dc067002ced5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Claude Teams process launch path and wrapper env semantics; mistakes could break Teams sessions, hook metadata, or Node startup, but scope is limited to the Teams/wrapper integration with expanded regression tests.
> 
> **Overview**
> **`cmux claude-teams` now execs the bundled `cmux-claude-wrapper` when present** instead of the real Claude binary directly, so interactive Teams sessions get the same `--session-id` / `--settings` hook injection as normal terminal `claude` (fixing broken forks after `/new`).
> 
> The Teams launcher sets `CMUX_CUSTOM_CLAUDE_PATH` to the resolved Claude, plus `CMUX_CLAUDE_WRAPPER_PRESERVE_AGENT_LAUNCH=1` and `CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS=1` so the wrapper does not overwrite `CMUX_AGENT_LAUNCH_*` metadata or double-apply the Node `NODE_OPTIONS` preload the launcher already configured.
> 
> **Wrapper behavior changes:** optional preservation of pre-set agent-launch env; conditional skip of `NODE_OPTIONS` injection; `--teammate-mode` treated as value-taking; passthrough restores original `NODE_OPTIONS` via `CMUX_ORIGINAL_NODE_OPTIONS_*`.
> 
> **Tests** add a live-socket harness for Teams env regression (hook settings must include `SessionStart` / `UserPromptSubmit`, launch kind `claudeTeams`), wrapper metadata preservation, and switch passthrough coverage from `--help` to `--version` (no hooks on version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa77219287e9626f599ea84966ee85bcc79f87f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `cmux claude-teams` through the bundled `cmux-claude-wrapper` to inject session hooks and stop session forks after `/new`. Reuses the prepared socket, preserves launcher metadata, and restores original `NODE_OPTIONS` on passthrough; user args and `--version` still bypass hooks.

- **Bug Fixes**
  - Launch `claude-teams` via the wrapper when bundled; inject `--settings` with `SessionStart` and `UserPromptSubmit`.
  - Set `CMUX_CUSTOM_CLAUDE_PATH`, `CMUX_CLAUDE_WRAPPER_PRESERVE_AGENT_LAUNCH=1`, and `CMUX_CLAUDE_WRAPPER_SKIP_NODE_OPTIONS=1` so the wrapper uses the real Claude, keeps `CMUX_AGENT_LAUNCH_*`, and skips its Node preload.
  - Restore passthrough `NODE_OPTIONS` (keep or unset) so `--version` and similar flags don’t lose Node settings; passthrough still has no hooks or `--session-id`.
  - Treat `--teammate-mode` as a value-taking option in the wrapper.

<sup>Written for commit ffa77219287e9626f599ea84966ee85bcc79f87f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Claude Teams launch now prefers a bundled wrapper executable when available, improving setup and environment integration.
  * When the bundled wrapper is used, launch environment wiring is enhanced for Teams flows (including optional preservation of launcher metadata).

* **Bug Fixes**
  * Improved wrapper argument handling so `--teammate-mode` consumes a following value.
  * Refined wrapper environment behavior, including conditional agent-launch initialization and more reliable `NODE_OPTIONS` preservation/restoration.

* **Tests**
  * Expanded Claude Teams environment injection/regression coverage (socket harness) with stronger argv/settings/hook validation.
  * Added coverage for preserving launcher metadata and updated `--version` passthrough behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->