### PR TITLE
Fix closed Settings window reappearing

### DIFF
--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -16,6 +16,7 @@ struct SettingsWindowPresenter {
         var pendingNavigationTarget: SettingsNavigationTarget?
         var pendingContentNavigationTarget: SettingsNavigationTarget?
         var shouldOpenWhenConfigured = false
+        var shouldFocusWhenConfigured = false
     }
 
     private let state: State
@@ -51,7 +52,10 @@ struct SettingsWindowPresenter {
     }
 
     func configure(window: NSWindow) {
-        let shouldFocusAfterConfiguration = state.settingsWindow !== window
+        let shouldFocusAfterConfiguration = state.settingsWindow !== window && state.shouldFocusWhenConfigured
+        if shouldFocusAfterConfiguration {
+            state.shouldFocusWhenConfigured = false
+        }
         state.settingsWindow = window
         window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
         window.isReleasedWhenClosed = false
@@ -109,14 +113,17 @@ struct SettingsWindowPresenter {
         }
 
         if let openWindowOverride {
+            state.shouldFocusWhenConfigured = true
             openWindowOverride()
             return
         }
 
         guard let openWindow = state.openWindow else {
             state.shouldOpenWhenConfigured = true
+            state.shouldFocusWhenConfigured = true
             return
         }
+        state.shouldFocusWhenConfigured = true
         openWindow()
     }
 
@@ -145,7 +152,7 @@ struct SettingsWindowPresenter {
     }
 
     func refocusIfVisible() {
-        guard let window = existingWindow() else { return }
+        guard let window = visibleExistingWindow() else { return }
         focus(window)
     }
 
@@ -163,6 +170,19 @@ struct SettingsWindowPresenter {
         }
         return NSApp.windows.first {
             $0.identifier?.rawValue == Self.windowIdentifier
+        }
+    }
+
+    private func visibleExistingWindow() -> NSWindow? {
+        if let settingsWindow = state.settingsWindow,
+           settingsWindow.isVisible,
+           !settingsWindow.isMiniaturized {
+            return settingsWindow
+        }
+        return NSApp.windows.first {
+            $0.identifier?.rawValue == Self.windowIdentifier &&
+            $0.isVisible &&
+            !$0.isMiniaturized
         }
     }
 

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -50,12 +50,28 @@ final class SettingsWindowPresenterTests: XCTestCase {
             settingsWindow.close()
         }
 
+        presenter.show(openWindowOverride: {})
         presenter.configure(window: settingsWindow)
         await Task.yield()
         presenter.configure(window: settingsWindow)
         await Task.yield()
 
         XCTAssertEqual(settingsWindow.makeKeyAndOrderFrontCallCount, 1)
+    }
+
+    func testConfigureWindowWithoutOpenRequestDoesNotFocus() async {
+        let presenter = SettingsWindowPresenter()
+        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        defer {
+            settingsWindow.orderOut(nil)
+            settingsWindow.close()
+        }
+
+        presenter.configure(window: settingsWindow)
+        await Task.yield()
+
+        XCTAssertEqual(settingsWindow.makeKeyAndOrderFrontCallCount, 0)
+        XCTAssertFalse(settingsWindow.isVisible)
     }
 
     func testShowPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async {
@@ -90,6 +106,7 @@ final class SettingsWindowPresenterTests: XCTestCase {
         weak var weakSettingsWindow = settingsWindow
         var didOpen = false
 
+        presenter.show(openWindowOverride: {})
         presenter.configure(window: settingsWindow!)
         await Task.yield()
         settingsWindow?.orderOut(nil)

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -109,6 +109,28 @@ final class SettingsWindowPresenterTests: XCTestCase {
         weakSettingsWindow?.close()
     }
 
+    func testRefocusIfVisibleDoesNotReopenClosedSettingsWindow() async {
+        let presenter = SettingsWindowPresenter()
+        let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
+        defer {
+            settingsWindow.orderOut(nil)
+            settingsWindow.close()
+        }
+
+        presenter.show(openWindowOverride: {})
+        presenter.configure(window: settingsWindow)
+        await Task.yield()
+        XCTAssertEqual(settingsWindow.makeKeyAndOrderFrontCallCount, 1)
+
+        settingsWindow.orderOut(nil)
+        XCTAssertFalse(settingsWindow.isVisible)
+
+        presenter.refocusIfVisible()
+
+        XCTAssertEqual(settingsWindow.makeKeyAndOrderFrontCallCount, 1)
+        XCTAssertFalse(settingsWindow.isVisible)
+    }
+
     // Settings is a top-level *peer* window, not a child of the main window.
     // A child window (`addChildWindow`) is pinned above its parent forever and
     // can never recede when the user clicks the main window — that is the


### PR DESCRIPTION
## Summary
- keep hidden retained Settings windows available for explicit reopen, but exclude them from passive refocus
- only focus newly configured Settings windows when an explicit open request is pending
- add regression coverage for closed Settings staying closed after refocus

## Tests
- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-setwin -only-testing:cmuxTests/SettingsWindowPresenterTests

## Dogfood
Tagged build: http://127.0.0.1:17320/setwin

Open Settings, close it, then keep using the app or activate it again. Settings should stay closed until explicitly opened again.

No localization changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784153904&installation_id=133855650&pr_number=6193&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6193&signature=2d067e233fdd9adac2d4927c05bc7471ad67efaf05fa2c613a780f13f201c6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS window presentation logic with targeted unit tests; no auth, data, or network impact.
> 
> **Overview**
> Fixes Settings popping back after the user closed it while still allowing an explicit **Open Settings** to reuse the hidden SwiftUI window.
> 
> **Passive refocus** (`refocusIfVisible`) now only targets a **visible, non-miniaturized** settings window via `visibleExistingWindow()`, so ordered-out (closed) windows are ignored. **Explicit open** (`show`) still finds the retained hidden window through `existingWindow()` and can front it again.
> 
> **Configure-time focus** is gated on `shouldFocusWhenConfigured`, set when `show` triggers an open path; SwiftUI calling `configure(window:)` without a pending open no longer calls `makeKeyAndOrderFront`. Unit tests cover configure-without-open, refocus-after-close, and updated reopen scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f6f0e1abc4e019d05f1ed02b3e66c1533df559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings window reappearing after it’s been closed. Closed or minimized Settings no longer reopen on app refocus, and the window only focuses when an explicit open is requested.

- **Bug Fixes**
  - Added `shouldFocusWhenConfigured` to only focus after an explicit show request.
  - Refocus now targets only visible, non-minimized Settings windows, ignoring closed ones; added tests for these cases.

<sup>Written for commit 68f6f0e1abc4e019d05f1ed02b3e66c1533df559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved settings window focus behavior when opening or configuring the window.
  * Fixed settings window from inappropriately reopening after being closed or minimized.

* **Tests**
  * Added test coverage for settings window configuration and focus scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->