### PR TITLE
iOS composer: on-device voice dictation

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -212,4 +212,4 @@
 503	Sources/Settings/ConfigSource.swift
 502	Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 502	Sources/CmuxEventPublishing.swift
-797	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+799	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -212,4 +212,4 @@
 503	Sources/Settings/ConfigSource.swift
 502	Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 502	Sources/CmuxEventPublishing.swift
-799	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+802	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -212,4 +212,4 @@
 503	Sources/Settings/ConfigSource.swift
 502	Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 502	Sources/CmuxEventPublishing.swift
-810	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+825	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -212,4 +212,4 @@
 503	Sources/Settings/ConfigSource.swift
 502	Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 502	Sources/CmuxEventPublishing.swift
-744	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+797	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -212,4 +212,4 @@
 503	Sources/Settings/ConfigSource.swift
 502	Packages/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 502	Sources/CmuxEventPublishing.swift
-802	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+810	Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import AVFoundation
 import Foundation
+import Observation
 import Speech
 
 /// On-device voice dictation for the composer text field.
@@ -23,10 +24,11 @@ import Speech
 /// back to the main actor before touching any state, and captures `self` weakly
 /// to avoid a retain cycle through the recognition task.
 @MainActor
-final class ComposerDictationController: ObservableObject {
+@Observable
+final class ComposerDictationController {
     /// The current point in the dictation state machine. Drives the mic button's
     /// enabled/listening presentation.
-    @Published private(set) var state: ComposerDictationState = .idle
+    private(set) var state: ComposerDictationState = .idle
 
     /// The recognizer for the user's locale. `nil` when the locale is
     /// unsupported, which is surfaced as ``ComposerDictationState/unavailable``.
@@ -66,7 +68,13 @@ final class ComposerDictationController: ObservableObject {
     /// user can toggle it off.
     var isAvailable: Bool { state != .unavailable }
 
-    /// Toggle dictation: start if idle, stop if already listening.
+    /// Toggle dictation: start if idle, stop if already listening, or cancel a
+    /// pending start if authorization is still resolving.
+    ///
+    /// A second tap while in ``ComposerDictationState/requestingPermission`` aborts
+    /// the pending start: the state returns to idle so the permission-completion
+    /// callback (which guards on `requestingPermission`) does not start the engine.
+    /// A later tap can then start dictation normally.
     ///
     /// - Parameters:
     ///   - existingText: The composer's current text, captured as the merge base.
@@ -75,9 +83,21 @@ final class ComposerDictationController: ObservableObject {
     func toggle(existingText: String, onText: @escaping (String) -> Void) {
         if state.isListening {
             stop()
+        } else if state.canCancelPendingStart {
+            cancelPendingStart()
         } else {
             start(existingText: existingText, onText: onText)
         }
+    }
+
+    /// Abort a start whose authorization has not resolved yet. Drops the captured
+    /// callback and returns to idle without touching the engine (none is running),
+    /// so the in-flight permission callback sees a non-`requestingPermission` state
+    /// and refuses to start. Safe to call only from `requestingPermission`.
+    private func cancelPendingStart() {
+        onText = nil
+        baseText = ""
+        state = .idle
     }
 
     /// Begin dictation: resolve authorization, then start the engine and stream
@@ -94,6 +114,11 @@ final class ComposerDictationController: ObservableObject {
         state = .requestingPermission
         requestAuthorization { [weak self] granted in
             guard let self else { return }
+            // A second tap may have cancelled (or otherwise moved on) while
+            // authorization resolved; if so this start is stale. Do nothing, so a
+            // cancel during the permission flow neither starts the engine nor
+            // overwrites the user's idle state with `unavailable`.
+            guard self.state == .requestingPermission else { return }
             guard granted else {
                 // Denied or restricted: a terminal rest state that disables the
                 // mic. The captured callback is dropped.
@@ -101,8 +126,6 @@ final class ComposerDictationController: ObservableObject {
                 self.state = .unavailable
                 return
             }
-            // A second tap (stop) may have landed while authorization resolved.
-            guard self.state == .requestingPermission else { return }
             self.beginRecognition()
         }
     }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -49,10 +49,21 @@ final class ComposerDictationController {
     /// so partials append rather than overwrite.
     private var baseText: String = ""
 
-    /// The callback that writes merged text back into the composer. Held only
-    /// while listening; cleared on teardown so a late callback cannot mutate the
+    /// The callback that writes merged text back into the composer. Held while
+    /// listening AND through a graceful stop (so the final result can refine the
+    /// committed text); cleared on cleanup so a late callback cannot mutate the
     /// store after the user left.
     private var onText: ((String) -> Void)?
+
+    /// Pending watchdog that force-finishes a graceful stop if the recognition
+    /// task never delivers a final result. Cancelled when the final result (or an
+    /// error) lands first, or when a hard cancel supersedes the graceful stop.
+    private var finalizeTimeout: Task<Void, Never>?
+
+    /// How long a graceful stop waits for the recognition task's final result
+    /// before force-finishing cleanup, so the controller cannot hang in
+    /// `.stopping` if no final result ever arrives.
+    private static let finalizeTimeoutSeconds: Double = 2.5
 
     init() {
         self.recognizer = SFSpeechRecognizer()
@@ -82,6 +93,8 @@ final class ComposerDictationController {
     ///     every partial and the final result.
     func toggle(existingText: String, onText: @escaping (String) -> Void) {
         if state.isListening {
+            // The visible Stop button: finalize gracefully so the last spoken
+            // words are not dropped.
             stop()
         } else if state.canCancelPendingStart {
             cancelPendingStart()
@@ -130,15 +143,53 @@ final class ComposerDictationController {
         }
     }
 
-    /// Stop dictation and tear everything down: cancel the task, end the request,
-    /// remove the audio tap, stop the engine, and deactivate the audio session.
-    /// Idempotent and safe to call from any teardown point (second tap, send,
-    /// focus loss, `onDisappear`, terminal switch).
+    /// Gracefully stop dictation, finalizing the transcript before cleanup. Used
+    /// for the visible Stop button, the stop right before send, and field focus
+    /// loss: the user intends to keep what they said.
+    ///
+    /// Flushes buffered audio (`endAudio()`) and stops the engine, but does NOT
+    /// cancel the recognition task or drop `onText`. The state moves to
+    /// `.stopping` and the in-flight task is left to deliver its final result,
+    /// which `onText` applies to the composer (refining the last partial) before
+    /// cleanup runs in `finishGraceful()`. A watchdog force-finishes if no final
+    /// result arrives, so the controller cannot hang in `.stopping`.
+    ///
+    /// The latest partial is already committed to the composer (every partial
+    /// wrote through `onText` while listening), so the user's words are preserved
+    /// even if the final result is only a refinement or never arrives.
     func stop() {
-        if state == .listening { state = .stopping }
+        // Only a live listening session can be finalized. From any other state a
+        // graceful stop is a no-op except for clearing a stuck-open mic: fall back
+        // to a hard cancel so callers (focus loss, send) always settle the state.
+        guard state == .listening else {
+            cancel()
+            return
+        }
+        state = .stopping
+        // Flush buffered audio so a late FINAL result can include the tail, then
+        // stop capturing. The task and `onText` stay alive to receive that result.
+        request?.endAudio()
+        stopEngineAndSession()
+        // Watchdog: if no final result (or error) lands, force cleanup so the
+        // controller returns to idle instead of hanging in `.stopping`.
+        finalizeTimeout?.cancel()
+        finalizeTimeout = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.finalizeTimeoutSeconds * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.finishGraceful()
+        }
+    }
+
+    /// Hard-cancel dictation and tear everything down immediately: cancel the
+    /// task, end the request, remove the audio tap, stop the engine, deactivate
+    /// the session, and drop the callback. Used when the user navigates away
+    /// (`onDisappear`, terminal switch) where losing the unrecognized tail is
+    /// acceptable. Idempotent and safe to call from any state.
+    func cancel() {
+        if state == .listening || state == .stopping { state = .stopping }
         teardown()
-        // Preserve a terminal `unavailable`; otherwise return to idle. A stop from
-        // an already-idle state is a harmless no-op (teardown is all nil-checks).
+        // Preserve a terminal `unavailable`; otherwise return to idle. A cancel
+        // from an already-idle state is a harmless no-op (teardown is nil-checks).
         if state != .unavailable {
             state = .idle
         }
@@ -247,9 +298,16 @@ final class ComposerDictationController {
                     ))
                 }
                 // A final result or an error (end-of-stream, recognition failure)
-                // tears down so the mic does not stay hot.
+                // settles the session so the mic does not stay hot. If a graceful
+                // stop is already in flight (`.stopping`), this is the awaited
+                // final result: apply it (done above) and finish cleanup. While
+                // still listening, the stream ended on its own; cancel to idle.
                 if isFinal || failed {
-                    self.stop()
+                    if self.state == .stopping {
+                        self.finishGraceful()
+                    } else {
+                        self.cancel()
+                    }
                 }
             }
         }
@@ -265,14 +323,29 @@ final class ComposerDictationController {
         state = .unavailable
     }
 
-    /// Cancel the recognition task, end and drop the request, remove the audio
-    /// tap, stop the engine, deactivate the audio session, and clear the
-    /// callback. Safe to call repeatedly; every reference is nil-checked.
-    private func teardown() {
+    /// Finish a graceful stop after the recognition task delivered its final
+    /// result (or the watchdog fired): drop the task/request and callback, and
+    /// return to idle. The engine and session are already stopped by `stop()`.
+    /// A no-op once the controller has left `.stopping` (final result and
+    /// watchdog can race; whichever lands first wins, the other is ignored).
+    private func finishGraceful() {
+        guard state == .stopping else { return }
+        finalizeTimeout?.cancel()
+        finalizeTimeout = nil
+        // The task already finalized; cancelling a finished task is a no-op, and
+        // it guarantees no late callback survives if the watchdog won the race.
         task?.cancel()
         task = nil
-        request?.endAudio()
         request = nil
+        onText = nil
+        baseText = ""
+        state = .idle
+    }
+
+    /// Stop the audio engine, remove the input tap, and deactivate the audio
+    /// session. Shared by the graceful stop (which keeps the recognition task and
+    /// callback alive) and the hard `teardown()`. Safe to call repeatedly.
+    private func stopEngineAndSession() {
         if audioEngine.isRunning {
             audioEngine.stop()
         }
@@ -280,11 +353,24 @@ final class ComposerDictationController {
         // failed start that installed the tap before `start()` threw does not
         // leak it onto the input node.
         audioEngine.inputNode.removeTap(onBus: 0)
-        onText = nil
-        baseText = ""
         // Deactivate the audio session so other audio (and the system) reclaim it.
         // Failure here is non-fatal: the engine is already stopped.
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    /// Cancel the recognition task, end and drop the request, remove the audio
+    /// tap, stop the engine, deactivate the audio session, and clear the
+    /// callback. Safe to call repeatedly; every reference is nil-checked.
+    private func teardown() {
+        finalizeTimeout?.cancel()
+        finalizeTimeout = nil
+        task?.cancel()
+        task = nil
+        request?.endAudio()
+        request = nil
+        stopEngineAndSession()
+        onText = nil
+        baseText = ""
     }
 }
 #endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -1,0 +1,267 @@
+#if os(iOS)
+import AVFoundation
+import Foundation
+import Speech
+
+/// On-device voice dictation for the composer text field.
+///
+/// Wraps `SFSpeechRecognizer` + `SFSpeechAudioBufferRecognitionRequest` driven by
+/// an `AVAudioEngine` tap, exposing a thin start/stop surface and a published
+/// state machine (see ``ComposerDictationState``) so the SwiftUI view stays
+/// declarative. On-device recognition is preferred when supported
+/// (`requiresOnDeviceRecognition = true`) for privacy and offline use, falling
+/// back to server recognition only when the device cannot recognize locally.
+///
+/// Text behavior: ``start(existingText:onText:)`` captures the composer's current
+/// text as the base and, for every partial result, calls `onText` with
+/// base + transcript (see ``ComposerDictationTextMerge``) so dictation appends to
+/// whatever the user already typed and never clobbers it.
+///
+/// Concurrency: the type is `@MainActor`, so all published state and the `onText`
+/// callback mutate the store on the main actor. Speech / AVFoundation deliver
+/// their recognition callbacks on an arbitrary queue, so the result handler hops
+/// back to the main actor before touching any state, and captures `self` weakly
+/// to avoid a retain cycle through the recognition task.
+@MainActor
+final class ComposerDictationController: ObservableObject {
+    /// The current point in the dictation state machine. Drives the mic button's
+    /// enabled/listening presentation.
+    @Published private(set) var state: ComposerDictationState = .idle
+
+    /// The recognizer for the user's locale. `nil` when the locale is
+    /// unsupported, which is surfaced as ``ComposerDictationState/unavailable``.
+    private let recognizer: SFSpeechRecognizer?
+
+    /// The audio engine capturing microphone buffers. Built lazily on first
+    /// start and reused; its input-node tap is installed on start and removed on
+    /// every teardown.
+    private let audioEngine = AVAudioEngine()
+
+    /// The in-flight recognition request, fed audio buffers from the engine tap.
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+
+    /// The in-flight recognition task. Cancelled and cleared on every teardown.
+    private var task: SFSpeechRecognitionTask?
+
+    /// The composer text captured when dictation started, used as the merge base
+    /// so partials append rather than overwrite.
+    private var baseText: String = ""
+
+    /// The callback that writes merged text back into the composer. Held only
+    /// while listening; cleared on teardown so a late callback cannot mutate the
+    /// store after the user left.
+    private var onText: ((String) -> Void)?
+
+    init() {
+        self.recognizer = SFSpeechRecognizer()
+        // A nil recognizer (unsupported locale) is terminal: the mic is disabled.
+        if recognizer == nil {
+            state = .unavailable
+        }
+    }
+
+    /// Whether the mic button should be shown enabled. False only when the
+    /// recognizer is permanently unavailable (unsupported locale, denied, or
+    /// restricted); a transient busy state still leaves the button enabled so the
+    /// user can toggle it off.
+    var isAvailable: Bool { state != .unavailable }
+
+    /// Toggle dictation: start if idle, stop if already listening.
+    ///
+    /// - Parameters:
+    ///   - existingText: The composer's current text, captured as the merge base.
+    ///   - onText: Receives merged text (base + transcript) on the main actor for
+    ///     every partial and the final result.
+    func toggle(existingText: String, onText: @escaping (String) -> Void) {
+        if state.isListening {
+            stop()
+        } else {
+            start(existingText: existingText, onText: onText)
+        }
+    }
+
+    /// Begin dictation: resolve authorization, then start the engine and stream
+    /// partial transcriptions through `onText`. A no-op unless the state machine
+    /// allows a start (idle and available).
+    func start(existingText: String, onText: @escaping (String) -> Void) {
+        guard state.canStart else { return }
+        guard recognizer != nil else {
+            state = .unavailable
+            return
+        }
+        baseText = existingText
+        self.onText = onText
+        state = .requestingPermission
+        requestAuthorization { [weak self] granted in
+            guard let self else { return }
+            guard granted else {
+                // Denied or restricted: a terminal rest state that disables the
+                // mic. The captured callback is dropped.
+                self.onText = nil
+                self.state = .unavailable
+                return
+            }
+            // A second tap (stop) may have landed while authorization resolved.
+            guard self.state == .requestingPermission else { return }
+            self.beginRecognition()
+        }
+    }
+
+    /// Stop dictation and tear everything down: cancel the task, end the request,
+    /// remove the audio tap, stop the engine, and deactivate the audio session.
+    /// Idempotent and safe to call from any teardown point (second tap, send,
+    /// focus loss, `onDisappear`, terminal switch).
+    func stop() {
+        if state == .listening { state = .stopping }
+        teardown()
+        // Preserve a terminal `unavailable`; otherwise return to idle. A stop from
+        // an already-idle state is a harmless no-op (teardown is all nil-checks).
+        if state != .unavailable {
+            state = .idle
+        }
+    }
+
+    // MARK: - Authorization
+
+    /// Resolve both speech-recognition and microphone authorization, calling back
+    /// on the main actor with whether BOTH were granted.
+    private func requestAuthorization(_ completion: @escaping @MainActor (Bool) -> Void) {
+        SFSpeechRecognizer.requestAuthorization { speechStatus in
+            // The Speech callback arrives off the main actor; hop back before
+            // touching any state or the microphone request.
+            Task { @MainActor in
+                guard speechStatus == .authorized else {
+                    completion(false)
+                    return
+                }
+                Self.requestMicrophonePermission { micGranted in
+                    completion(micGranted)
+                }
+            }
+        }
+    }
+
+    /// Request microphone permission, bridging the iOS 17+ API to its
+    /// pre-17 fallback. Calls back on the main actor.
+    private static func requestMicrophonePermission(_ completion: @escaping @MainActor (Bool) -> Void) {
+        if #available(iOS 17.0, *) {
+            AVAudioApplication.requestRecordPermission { granted in
+                Task { @MainActor in completion(granted) }
+            }
+        } else {
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                Task { @MainActor in completion(granted) }
+            }
+        }
+    }
+
+    // MARK: - Recognition
+
+    /// Configure the audio session, install the engine tap, and start the
+    /// recognition task. On any setup failure this tears down and lands in
+    /// `unavailable` so the mic does not appear hot after a failed start.
+    private func beginRecognition() {
+        guard let recognizer, recognizer.isAvailable else {
+            failStart()
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Prefer on-device recognition for privacy and offline use; fall back to
+        // server recognition only when the device cannot recognize locally.
+        if recognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+        self.request = request
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            failStart()
+            return
+        }
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        // A zero-channel format means there is no usable input route; bail rather
+        // than crash installing a tap with an invalid format.
+        guard format.channelCount > 0 else {
+            failStart()
+            return
+        }
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak request] buffer, _ in
+            // The tap fires on a realtime audio thread. `append` is thread-safe on
+            // the request; do not touch main-actor state here.
+            request?.append(buffer)
+        }
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+        } catch {
+            failStart()
+            return
+        }
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            // The recognition callback arrives on an arbitrary queue with
+            // non-Sendable reference types (`SFSpeechRecognitionResult`, `Error`).
+            // Extract only Sendable value snapshots HERE, then hop to the main
+            // actor with those, so no non-Sendable reference crosses the actor
+            // boundary. `self` is weak so the task does not retain the controller.
+            let transcript = result?.bestTranscription.formattedString
+            let isFinal = result?.isFinal ?? false
+            let failed = error != nil
+            Task { @MainActor in
+                guard let self else { return }
+                if let transcript {
+                    self.onText?(ComposerDictationTextMerge.merged(
+                        base: self.baseText,
+                        transcript: transcript
+                    ))
+                }
+                // A final result or an error (end-of-stream, recognition failure)
+                // tears down so the mic does not stay hot.
+                if isFinal || failed {
+                    self.stop()
+                }
+            }
+        }
+
+        state = .listening
+    }
+
+    /// Tear down after a setup failure and disable the mic. Distinct from a clean
+    /// stop because a failed start indicates the recognizer cannot be used right
+    /// now (no input route, session error, recognizer offline).
+    private func failStart() {
+        teardown()
+        state = .unavailable
+    }
+
+    /// Cancel the recognition task, end and drop the request, remove the audio
+    /// tap, stop the engine, deactivate the audio session, and clear the
+    /// callback. Safe to call repeatedly; every reference is nil-checked.
+    private func teardown() {
+        task?.cancel()
+        task = nil
+        request?.endAudio()
+        request = nil
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        // The tap must be removed whether or not the engine was running, so a
+        // failed start that installed the tap before `start()` threw does not
+        // leak it onto the input node.
+        audioEngine.inputNode.removeTap(onBus: 0)
+        onText = nil
+        baseText = ""
+        // Deactivate the audio session so other audio (and the system) reclaim it.
+        // Failure here is non-fatal: the engine is already stopped.
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+#endif

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -251,8 +251,13 @@ final class ComposerDictationController {
 
         do {
             let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
-            try session.setActive(true, options: .notifyOthersOnDeactivation)
+            // Record-only category for speech-to-text. `.duckOthers` is NOT valid
+            // for `.record` (only Ambient/PlayAndRecord/Playback/MultiRoute), and
+            // `.notifyOthersOnDeactivation` is only valid on deactivation, so both
+            // are omitted here; passing them throws on OSes that enforce the
+            // documented restrictions and would permanently disable the mic.
+            try session.setCategory(.record, mode: .measurement)
+            try session.setActive(true)
         } catch {
             failStart()
             return

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -79,6 +79,15 @@ final class ComposerDictationController {
     /// user can toggle it off.
     var isAvailable: Bool { state != .unavailable }
 
+    /// Whether dictation currently owns the composer text, so the field must be
+    /// locked (non-editable) until dictation settles to idle. True while
+    /// `.listening` (partials streaming in) and `.stopping` (final result
+    /// pending); see ``ComposerDictationState/locksComposerField``. The view binds
+    /// the field's `.disabled(...)` to this so a user edit made mid-dictation can
+    /// never be clobbered by a later partial/final callback. The mic toggle and
+    /// send remain usable while locked.
+    var locksComposerField: Bool { state.locksComposerField }
+
     /// Toggle dictation: start if idle, stop if already listening, or cancel a
     /// pending start if authorization is still resolving.
     ///

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -26,6 +26,15 @@ enum ComposerDictationState: Equatable {
     /// Whether the engine is actively capturing audio (drives the listening UI).
     var isListening: Bool { self == .listening }
 
+    /// Whether dictation owns the composer text and the field must be locked
+    /// (non-editable). True while ``listening`` (partials are streaming in) and
+    /// while ``stopping`` (the final result is still pending). Locking the field
+    /// across both states is what guarantees a user edit cannot be silently
+    /// discarded by a later partial/final callback: the user simply cannot type
+    /// until dictation fully settles to ``idle``. The mic toggle and send stay
+    /// live, and send hard-cancels dictation back to ``idle``, re-enabling editing.
+    var locksComposerField: Bool { self == .listening || self == .stopping }
+
     /// Whether a tap should be accepted to start dictation. Rejected while a
     /// request is in flight, while already listening, while stopping, or when the
     /// recognizer is unavailable.

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -30,6 +30,12 @@ enum ComposerDictationState: Equatable {
     /// request is in flight, while already listening, while stopping, or when the
     /// recognizer is unavailable.
     var canStart: Bool { self == .idle }
+
+    /// Whether a tap should cancel a start whose authorization is still resolving.
+    /// True only in ``requestingPermission``: a second tap there aborts the pending
+    /// start and returns to idle so recognition never begins, rather than being
+    /// ignored and letting the mic come on anyway when permission later resolves.
+    var canCancelPendingStart: Bool { self == .requestingPermission }
 }
 
 /// Pure text-merge for live dictation, factored out so it is host-testable

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// The dictation controller's state machine, factored out of the iOS-only
+/// controller so the pure transitions are host-testable without the Speech /
+/// AVFoundation frameworks.
+///
+/// Flow: `idle` -> `requestingPermission` (first tap, while authorization is
+/// resolved) -> `listening` (engine running, partials streaming) -> `stopping`
+/// (tearing down the engine/task) -> `idle`. A denied or unavailable recognizer
+/// lands in `unavailable`, a terminal rest state that disables the mic button.
+enum ComposerDictationState: Equatable {
+    /// Not listening; the mic button offers to start.
+    case idle
+    /// A tap was received and authorization is being resolved before the engine
+    /// can start. Transient; the button shows the request is in flight.
+    case requestingPermission
+    /// The audio engine is running and partial transcriptions are streaming into
+    /// the composer text.
+    case listening
+    /// Teardown is in progress (engine stopping, task cancelling). Transient.
+    case stopping
+    /// Speech recognition is unavailable on this device, or permission was denied
+    /// or restricted. The mic button is disabled in this state.
+    case unavailable
+
+    /// Whether the engine is actively capturing audio (drives the listening UI).
+    var isListening: Bool { self == .listening }
+
+    /// Whether a tap should be accepted to start dictation. Rejected while a
+    /// request is in flight, while already listening, while stopping, or when the
+    /// recognizer is unavailable.
+    var canStart: Bool { self == .idle }
+}
+
+/// Pure text-merge for live dictation, factored out so it is host-testable
+/// without Speech / AVFoundation.
+///
+/// At start the controller captures the composer's existing text as the
+/// `base`. Every partial transcription then replaces the live tail, so the
+/// composer always reads `base` + the latest transcript and never accumulates
+/// stale partials. The base is preserved verbatim so text the user typed before
+/// starting is never clobbered.
+enum ComposerDictationTextMerge {
+    /// Combine the captured base text with the current transcript.
+    ///
+    /// - A trailing run of whitespace on the base is preserved (the user may
+    ///   have typed "hello " and the dictation continues the sentence).
+    /// - When the base ends in a non-whitespace character and the transcript is
+    ///   non-empty, a single separating space is inserted so words do not run
+    ///   together ("hello" + "world" -> "hello world").
+    /// - An empty transcript yields the base unchanged (a partial may briefly be
+    ///   empty); leading whitespace in the transcript is trimmed so the join is
+    ///   not doubled.
+    ///
+    /// - Parameters:
+    ///   - base: The composer text captured when dictation started.
+    ///   - transcript: The latest (partial or final) recognized transcript.
+    /// - Returns: The text to write back into the composer.
+    static func merged(base: String, transcript: String) -> String {
+        let trimmedTranscript = transcript.drop(while: { $0.isWhitespace })
+        if trimmedTranscript.isEmpty {
+            return base
+        }
+        if base.isEmpty {
+            return String(trimmedTranscript)
+        }
+        if let last = base.last, last.isWhitespace {
+            return base + trimmedTranscript
+        }
+        return base + " " + trimmedTranscript
+    }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -36,6 +36,18 @@ enum ComposerDictationState: Equatable {
     /// start and returns to idle so recognition never begins, rather than being
     /// ignored and letting the mic come on anyway when permission later resolves.
     var canCancelPendingStart: Bool { self == .requestingPermission }
+
+    /// Whether a graceful stop can finalize from this state. True only while
+    /// ``listening``: a graceful stop flushes buffered audio and waits for the
+    /// recognition task's final result. From any other state there is no live
+    /// session to finalize, so the controller hard-cancels instead.
+    var canFinalize: Bool { self == .listening }
+
+    /// Whether the controller is mid-teardown, waiting for the recognition task's
+    /// final result before returning to idle. The mic is no longer capturing but
+    /// the session has not fully settled. Distinguishes a graceful stop's transient
+    /// wait from both the active ``listening`` state and the resting ``idle``.
+    var isStopping: Bool { self == .stopping }
 }
 
 /// Pure text-merge for live dictation, factored out so it is host-testable

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -65,8 +65,10 @@ struct TerminalComposerView: View {
     @State private var stagingTask = StagingTaskBox()
     /// On-device voice dictation for the field. Owned here so its lifecycle is
     /// the composer's: it is torn down on send, focus loss, `onDisappear`, and a
-    /// terminal switch so the mic never stays hot after the user leaves.
-    @StateObject private var dictation = ComposerDictationController()
+    /// terminal switch so the mic never stays hot after the user leaves. An
+    /// `@Observable` reference type is held with `@State`; SwiftUI tracks the
+    /// `state` it reads (mic button enabled/listening) automatically.
+    @State private var dictation = ComposerDictationController()
 
     init(store: CMUXMobileShellStore, terminalID: String, requestHeightRemeasure: @escaping () -> Void) {
         self.store = store

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -188,8 +188,9 @@ struct TerminalComposerView: View {
             // composer the user has already left. Without this, a switch right
             // after a big pick leaves the encode running unobserved.
             stagingTask.task?.cancel()
-            // Never leave the mic hot after the composer leaves the screen.
-            dictation.stop()
+            // Never leave the mic hot after the composer leaves the screen; the
+            // user navigated away, so hard-cancel (losing the tail is fine).
+            dictation.cancel()
         }
         .onChange(of: terminalID) { _, _ in
             // Defense in depth: if SwiftUI ever reuses this view's identity across
@@ -198,8 +199,8 @@ struct TerminalComposerView: View {
             // encode does not stage onto, or burn CPU for, the new terminal.
             stagingTask.task?.cancel()
             // A terminal switch must stop dictation so the live transcript does not
-            // bleed into the incoming terminal's draft.
-            dictation.stop()
+            // bleed into the incoming terminal's draft. Hard-cancel, not finalize.
+            dictation.cancel()
         }
         .onChange(of: isFieldFocused) { _, focused in
             // Mirror the field's focus into the store so a terminal switch knows
@@ -207,7 +208,8 @@ struct TerminalComposerView: View {
             // on the incoming composer) or merely looking at the default-open
             // field (keyboard stays down).
             store.composerFieldFocusChanged(focused)
-            // The field losing focus stops dictation cleanly (the user moved on).
+            // The field losing focus stops dictation gracefully (the user moved on
+            // but keeps the draft, so the last words are finalized into it).
             if !focused {
                 dictation.stop()
             }
@@ -420,8 +422,9 @@ struct TerminalComposerView: View {
     private func send() {
         // Allowed with empty text as long as an attachment is staged.
         guard canSend else { return }
-        // Stop dictation before sending so the final transcript is committed and
-        // the mic does not keep capturing into a now-empty field.
+        // Stop dictation gracefully before sending. Every partial already wrote
+        // into `terminalInputText`, so the latest spoken words are committed and
+        // read by `submitComposer()` below.
         dictation.stop()
         isFieldFocused = true
         Task { @MainActor in

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -63,6 +63,10 @@ struct TerminalComposerView: View {
     /// lifecycle moves on. Held as `@State` so it survives this value type's
     /// frequent re-creation.
     @State private var stagingTask = StagingTaskBox()
+    /// On-device voice dictation for the field. Owned here so its lifecycle is
+    /// the composer's: it is torn down on send, focus loss, `onDisappear`, and a
+    /// terminal switch so the mic never stays hot after the user leaves.
+    @StateObject private var dictation = ComposerDictationController()
 
     init(store: CMUXMobileShellStore, terminalID: String, requestHeightRemeasure: @escaping () -> Void) {
         self.store = store
@@ -182,6 +186,8 @@ struct TerminalComposerView: View {
             // composer the user has already left. Without this, a switch right
             // after a big pick leaves the encode running unobserved.
             stagingTask.task?.cancel()
+            // Never leave the mic hot after the composer leaves the screen.
+            dictation.stop()
         }
         .onChange(of: terminalID) { _, _ in
             // Defense in depth: if SwiftUI ever reuses this view's identity across
@@ -189,6 +195,9 @@ struct TerminalComposerView: View {
             // changing must also cancel the prior terminal's in-flight batch so its
             // encode does not stage onto, or burn CPU for, the new terminal.
             stagingTask.task?.cancel()
+            // A terminal switch must stop dictation so the live transcript does not
+            // bleed into the incoming terminal's draft.
+            dictation.stop()
         }
         .onChange(of: isFieldFocused) { _, focused in
             // Mirror the field's focus into the store so a terminal switch knows
@@ -196,6 +205,10 @@ struct TerminalComposerView: View {
             // on the incoming composer) or merely looking at the default-open
             // field (keyboard stays down).
             store.composerFieldFocusChanged(focused)
+            // The field losing focus stops dictation cleanly (the user moved on).
+            if !focused {
+                dictation.stop()
+            }
             // COMPOSER: a focus-lost while the flag stayed presented and the
             // view stayed mounted, yet the field reads empty, isolates the
             // residual TextField/@FocusState render-blank case.
@@ -261,6 +274,8 @@ struct TerminalComposerView: View {
                 .mobileGlassCircle()
                 .accessibilityIdentifier("MobileComposerAttach")
                 .accessibilityLabel(L10n.string("mobile.composer.attach", defaultValue: "Attach Photo"))
+
+                micButton
 
                 // The field and its send button share ONE rounded glass container —
                 // iMessage's layout, where the circular up-arrow lives INSIDE the
@@ -336,6 +351,41 @@ struct TerminalComposerView: View {
         }
     }
 
+    /// Mic button for on-device voice dictation, beside the attach button on the
+    /// leading side. Tapping toggles dictation; while listening it shows a filled,
+    /// tinted mic. Disabled when the recognizer is unavailable or permission was
+    /// denied so the user is never left tapping a dead control.
+    private var micButton: some View {
+        let listening = dictation.state.isListening
+        return Button {
+            toggleDictation()
+        } label: {
+            Image(systemName: listening ? "mic.fill" : "mic")
+                .font(.system(size: 15, weight: .semibold))
+                .frame(width: controlHeight, height: controlHeight)
+                .symbolEffect(.pulse, isActive: listening)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(listening ? AnyShapeStyle(Color.red) : AnyShapeStyle(TerminalPalette.foreground.opacity(0.7)))
+        .mobileGlassCircle()
+        .disabled(!dictation.isAvailable)
+        .accessibilityIdentifier("MobileComposerMic")
+        .accessibilityLabel(
+            listening
+                ? L10n.string("mobile.composer.mic.stop", defaultValue: "Stop Dictation")
+                : L10n.string("mobile.composer.mic.start", defaultValue: "Dictate Message")
+        )
+    }
+
+    /// Toggle voice dictation. On start the current text is captured as the merge
+    /// base and partial transcriptions are written back into `terminalInputText`
+    /// (base + transcript) so dictation appends to whatever was already typed.
+    private func toggleDictation() {
+        dictation.toggle(existingText: store.terminalInputText) { merged in
+            store.terminalInputText = merged
+        }
+    }
+
     /// Horizontal, removable thumbnail chips for the staged attachments. Each
     /// chip shows the picked image with an x to remove it.
     private var attachmentChipRow: some View {
@@ -368,6 +418,9 @@ struct TerminalComposerView: View {
     private func send() {
         // Allowed with empty text as long as an attachment is staged.
         guard canSend else { return }
+        // Stop dictation before sending so the final transcript is committed and
+        // the mic does not keep capturing into a now-empty field.
+        dictation.stop()
         isFieldFocused = true
         Task { @MainActor in
             // Sends staged images first (in order), then the text. Acknowledged

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -422,10 +422,18 @@ struct TerminalComposerView: View {
     private func send() {
         // Allowed with empty text as long as an attachment is staged.
         guard canSend else { return }
-        // Stop dictation gracefully before sending. Every partial already wrote
-        // into `terminalInputText`, so the latest spoken words are committed and
-        // read by `submitComposer()` below.
-        dictation.stop()
+        // Hard-cancel dictation before sending, NOT the graceful async stop. Every
+        // partial already wrote into `terminalInputText`, so the field holds the
+        // latest spoken words at send time. `cancel()` immediately tears down the
+        // recognition task and drops `onText`, so (a) `submitComposer()`'s
+        // synchronous snapshot of `terminalInputText` captures exactly the current
+        // field text, and (b) no late final result can fire `onText` back into the
+        // field that send is about to clear. A graceful `stop()` would let a late
+        // final result land after the snapshot, dropping the finalized tail from
+        // the sent message and re-polluting the just-cleared draft. `cancel()` on
+        // an idle controller is a no-op, so a send without active dictation is
+        // unchanged.
+        dictation.cancel()
         isFieldFocused = true
         Task { @MainActor in
             // Sends staged images first (in order), then the text. Acknowledged

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -209,8 +209,13 @@ struct TerminalComposerView: View {
             // field (keyboard stays down).
             store.composerFieldFocusChanged(focused)
             // The field losing focus stops dictation gracefully (the user moved on
-            // but keeps the draft, so the last words are finalized into it).
-            if !focused {
+            // but keeps the draft, so the last words are finalized into it). Skip
+            // this when dictation itself owns the field: locking it (.disabled
+            // while listening/stopping) makes SwiftUI resign first responder, and
+            // that lock-driven focus loss must NOT stop the dictation it just
+            // started. Only a focus loss while the field is NOT locked is the user
+            // moving on, and only that should finalize.
+            if !focused, !dictation.locksComposerField {
                 dictation.stop()
             }
             // COMPOSER: a focus-lost while the flag stayed presented and the
@@ -303,6 +308,16 @@ struct TerminalComposerView: View {
                     .textInputAutocapitalization(.sentences)
                     .autocorrectionDisabled(false)
                     .focused($isFieldFocused)
+                    // Lock the field while dictation owns the text (`.listening`
+                    // or `.stopping`). Every recognition callback rewrites the
+                    // field as base + transcript, so an edit the user made
+                    // mid-dictation would be silently discarded by the next
+                    // partial/final. Disabling input until dictation settles to
+                    // idle makes that edit impossible rather than letting it be
+                    // clobbered. The field stays visible showing the live
+                    // transcript; the mic toggle and send stay live (send
+                    // hard-cancels dictation -> idle, re-enabling the field).
+                    .disabled(dictation.locksComposerField)
                     .foregroundStyle(TerminalPalette.foreground)
                     // 6pt container padding + 3pt here keeps the text's 9pt inset
                     // from the round-7 layout, and bottom-aligns the single-line text

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import CmuxMobileShellUI
+
+/// Host-testable coverage for the dictation text-merge and the state machine's
+/// pure transitions. The Speech / AVFoundation engine wiring is iOS-only and not
+/// host-compilable, so it is exercised only on device / simulator.
+@Suite struct ComposerDictationTests {
+    // MARK: - Text merge
+
+    @Test func mergeAppendsTranscriptToEmptyBase() {
+        #expect(ComposerDictationTextMerge.merged(base: "", transcript: "hello world") == "hello world")
+    }
+
+    @Test func mergeInsertsSeparatingSpaceAfterNonWhitespaceBase() {
+        #expect(ComposerDictationTextMerge.merged(base: "hello", transcript: "world") == "hello world")
+    }
+
+    @Test func mergePreservesTrailingWhitespaceWithoutDoubling() {
+        // Base already ends in a space; do not add a second one.
+        #expect(ComposerDictationTextMerge.merged(base: "hello ", transcript: "world") == "hello world")
+    }
+
+    @Test func mergeTrimsLeadingTranscriptWhitespace() {
+        #expect(ComposerDictationTextMerge.merged(base: "hello", transcript: "   world") == "hello world")
+    }
+
+    @Test func mergeEmptyTranscriptKeepsBaseUnchanged() {
+        // A partial may briefly be empty; the user's pre-typed text must survive.
+        #expect(ComposerDictationTextMerge.merged(base: "draft ", transcript: "") == "draft ")
+        #expect(ComposerDictationTextMerge.merged(base: "draft", transcript: "   ") == "draft")
+    }
+
+    @Test func mergePreservesBaseVerbatim() {
+        // The base is appended to, never rewritten: punctuation and casing stay.
+        let base = "TODO: ship it,"
+        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "then rest") == "TODO: ship it, then rest")
+    }
+
+    @Test func mergeIsIdempotentAcrossGrowingPartials() {
+        // Successive partials always replace the tail, so the base is never
+        // duplicated as the transcript grows.
+        let base = "note: "
+        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy") == "note: buy")
+        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy milk") == "note: buy milk")
+        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy milk today") == "note: buy milk today")
+    }
+
+    @Test func mergeEmptyBaseEmptyTranscriptIsEmpty() {
+        #expect(ComposerDictationTextMerge.merged(base: "", transcript: "") == "")
+    }
+
+    // MARK: - State machine
+
+    @Test func idleCanStartAndIsNotListening() {
+        let state = ComposerDictationState.idle
+        #expect(state.canStart)
+        #expect(!state.isListening)
+    }
+
+    @Test func listeningIsListeningButCannotStart() {
+        let state = ComposerDictationState.listening
+        #expect(state.isListening)
+        #expect(!state.canStart)
+    }
+
+    @Test func transientStatesRejectStart() {
+        #expect(!ComposerDictationState.requestingPermission.canStart)
+        #expect(!ComposerDictationState.stopping.canStart)
+    }
+
+    @Test func unavailableRejectsStartAndIsNotListening() {
+        let state = ComposerDictationState.unavailable
+        #expect(!state.canStart)
+        #expect(!state.isListening)
+    }
+}

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -73,4 +73,28 @@ import Testing
         #expect(!state.canStart)
         #expect(!state.isListening)
     }
+
+    @Test func onlyRequestingPermissionCanCancelPendingStart() {
+        // A second tap while authorization is resolving cancels the pending start;
+        // every other state ignores cancellation (it has nothing to abort).
+        #expect(ComposerDictationState.requestingPermission.canCancelPendingStart)
+        #expect(!ComposerDictationState.idle.canCancelPendingStart)
+        #expect(!ComposerDictationState.listening.canCancelPendingStart)
+        #expect(!ComposerDictationState.stopping.canCancelPendingStart)
+        #expect(!ComposerDictationState.unavailable.canCancelPendingStart)
+    }
+
+    @Test func cancelAndStartAreMutuallyExclusivePerState() {
+        // A tap resolves to exactly one of start / cancel / neither, never both, so
+        // toggle's branching is unambiguous in every state.
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .stopping,
+            .unavailable,
+        ] {
+            #expect(!(state.canStart && state.canCancelPendingStart))
+        }
+    }
 }

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -97,4 +97,62 @@ import Testing
             #expect(!(state.canStart && state.canCancelPendingStart))
         }
     }
+
+    // MARK: - Graceful stop vs hard cancel
+
+    @Test func onlyListeningCanFinalizeGracefully() {
+        // A graceful stop finalizes only a live session; from any other state the
+        // controller hard-cancels instead, so there is no live task to await.
+        #expect(ComposerDictationState.listening.canFinalize)
+        #expect(!ComposerDictationState.idle.canFinalize)
+        #expect(!ComposerDictationState.requestingPermission.canFinalize)
+        #expect(!ComposerDictationState.stopping.canFinalize)
+        #expect(!ComposerDictationState.unavailable.canFinalize)
+    }
+
+    @Test func stoppingIsTheOnlyFinalizingWaitState() {
+        // `.stopping` marks the transient wait for the final result; it is neither
+        // capturing (`isListening`) nor accepting a new start (`canStart`).
+        #expect(ComposerDictationState.stopping.isStopping)
+        #expect(!ComposerDictationState.stopping.isListening)
+        #expect(!ComposerDictationState.stopping.canStart)
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .unavailable,
+        ] {
+            #expect(!state.isStopping)
+        }
+    }
+
+    @Test func finalizeAndStartAreMutuallyExclusivePerState() {
+        // A state is never both ready to start a fresh session and ready to
+        // finalize a live one, so the graceful-stop and start paths never collide.
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .stopping,
+            .unavailable,
+        ] {
+            #expect(!(state.canStart && state.canFinalize))
+        }
+    }
+
+    @Test func gracefulStopFinalizesOnlyFromListening() {
+        // Mirrors the controller's `stop()` branch: a graceful stop finalizes from
+        // `.listening` and otherwise falls back to a hard cancel (which finalizes
+        // from no state). The two paths partition the states with no overlap.
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .stopping,
+            .unavailable,
+        ] {
+            let takesGracefulPath = state.canFinalize
+            #expect(takesGracefulPath == (state == .listening))
+        }
+    }
 }

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -140,6 +140,58 @@ import Testing
         }
     }
 
+    // MARK: - Field lock (dictation owns the text)
+
+    @Test func dictationLocksFieldWhileListeningAndStopping() {
+        // While dictation owns the composer text the field must be locked so a
+        // user edit cannot be silently clobbered by the next partial/final
+        // callback. Both the live capture and the finalize-wait own the text.
+        #expect(ComposerDictationState.listening.locksComposerField)
+        #expect(ComposerDictationState.stopping.locksComposerField)
+    }
+
+    @Test func dictationLeavesFieldEditableWhenNotActive() {
+        // Idle (no session), requestingPermission (engine not started, the field
+        // still holds only what the user typed), and unavailable all leave the
+        // field editable: no callback will overwrite the user's text.
+        #expect(!ComposerDictationState.idle.locksComposerField)
+        #expect(!ComposerDictationState.requestingPermission.locksComposerField)
+        #expect(!ComposerDictationState.unavailable.locksComposerField)
+    }
+
+    @Test func fieldLockMatchesEngineOwnership() {
+        // The lock holds for exactly the states where a recognition callback can
+        // rewrite the field (listening streams partials, stopping awaits the
+        // final), and for no other state.
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .stopping,
+            .unavailable,
+        ] {
+            let ownsText = state == .listening || state == .stopping
+            #expect(state.locksComposerField == ownsText)
+        }
+    }
+
+    @Test func canStartImpliesFieldUnlocked() {
+        // A startable state is never a locked state: the user can always edit a
+        // field from which dictation can be (re)started, and dictation only locks
+        // once it actually owns the text.
+        for state in [
+            ComposerDictationState.idle,
+            .requestingPermission,
+            .listening,
+            .stopping,
+            .unavailable,
+        ] {
+            if state.canStart {
+                #expect(!state.locksComposerField)
+            }
+        }
+    }
+
     @Test func gracefulStopFinalizesOnlyFromListening() {
         // Mirrors the controller's `stop()` branch: a graceful stop finalizes from
         // `.listening` and otherwise falls back to a hard cancel (which finalizes

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -55,8 +55,12 @@
 	<string>Scan cmux pairing QR codes from your Mac terminal.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Connect to your Mac on the local network for cmux mobile pairing and terminal sync.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Record audio to transcribe your voice into the message box.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Attach photos to send to your terminal agent.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Transcribe your speech into the message box.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<!-- The in-app browser (WKWebView) loads pages the user navigates to,

--- a/ios/cmux/Resources/InfoPlist.xcstrings
+++ b/ios/cmux/Resources/InfoPlist.xcstrings
@@ -35,6 +35,23 @@
         }
       }
     },
+    "NSMicrophoneUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record audio to transcribe your voice into the message box."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声をメッセージ欄に文字起こしするため、音声を録音します。"
+          }
+        }
+      }
+    },
     "NSPhotoLibraryUsageDescription" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -48,6 +65,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ターミナルのエージェントに送信する写真を添付します。"
+          }
+        }
+      }
+    },
+    "NSSpeechRecognitionUsageDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transcribe your speech into the message box."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声をメッセージ欄に文字起こしします。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -766,6 +766,40 @@
         }
       }
     },
+    "mobile.composer.mic.start": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start dictation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声入力を開始"
+          }
+        }
+      }
+    },
+    "mobile.composer.mic.stop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop dictation"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声入力を停止"
+          }
+        }
+      }
+    },
     "mobile.composer.placeholder": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## What

Adds a microphone button to the iOS composer that does on-device voice dictation. Tap the mic, speak, and the transcription fills the composer text field live. Tap again (or tap send, or leave the field) to stop. The text is then sent as a normal message. This dictates INTO the textbox; it does not send audio.

## How to use

A mic button (`MobileComposerMic`) sits beside the paperclip attach button. Tap to start; it turns into a pulsing red `mic.fill` while listening. As you speak, partial transcriptions stream into the field, appended after whatever you already typed. Tap the mic again, tap send, move focus off the field, switch terminals, or leave the composer to stop.

## Permissions

- `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` added to `ios/Config/Info.plist`.
- Both keys added to `ios/cmux/Resources/InfoPlist.xcstrings` with English and Japanese values (minimal textual insertion, file stays valid JSON).
- Authorization: `SFSpeechRecognizer.requestAuthorization` plus microphone permission (`AVAudioApplication.requestRecordPermission` on iOS 17+, `AVAudioSession.requestRecordPermission` fallback). Denied/restricted/unsupported lands in a terminal `unavailable` state that disables the button. No crash.

## On-device vs server recognition

Prefers on-device recognition for privacy and offline use: sets `requiresOnDeviceRecognition = true` when `supportsOnDeviceRecognition`, falling back to server recognition only when the device cannot recognize locally.

## Design

`ComposerDictationController` is an `@MainActor` `ObservableObject` wrapping `SFSpeechRecognizer` + `SFSpeechAudioBufferRecognitionRequest` driven by an `AVAudioEngine` tap. State machine: `idle -> requestingPermission -> listening -> stopping -> idle`, with a terminal `unavailable`. The SwiftUI view stays thin (a `@StateObject` and a toggle).

Text merge: on start the controller captures the composer's current text as the base. Every partial replaces the live tail, so the field always reads base + transcript and the pre-typed text is never clobbered. A single separating space is inserted between a non-whitespace base and the transcript; existing trailing whitespace is preserved (no doubling). Factored into a pure `ComposerDictationTextMerge` for host testing.

## Lifecycle / teardown guarantees

`stop()` is idempotent and tears down fully: cancels the recognition task, ends and drops the request, removes the audio tap (`removeTap(onBus:)`), stops the engine, deactivates the audio session, and clears the callback. It is called from: a second mic tap, send, field focus loss, the view's `.onDisappear`, and `.onChange(of: terminalID)`. A failed start (no input route, session error, recognizer offline) tears down and disables the mic rather than leaving it hot.

## Swift 6 concurrency

The recognition result handler extracts only Sendable value snapshots (the transcript `String` and `isFinal`/error `Bool`s) before hopping to the main actor, so no non-Sendable reference (`SFSpeechRecognitionResult`, `Error`) crosses the actor boundary. The result closure captures `self` weakly (no retain cycle through the task). The realtime audio-tap closure only appends buffers to the request and touches no main-actor state.

## Tests

`ComposerDictationTests` covers the text-merge (empty base, separating space, trailing-whitespace preservation, leading-transcript trim, empty/growing partials, verbatim base) and the state machine's pure `canStart`/`isListening` transitions. The Speech/AVFoundation engine wiring is iOS-only and exercised by the simulator build, not host-compilable here (the package depends on the iOS-only GhosttyKit binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784158373&installation_id=133855650&pr_number=6197&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6197&signature=3dab3559c0bc13fd7c0b053592edc4dd003c65393568635eaff108938c28df20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches microphone/speech permissions and real-time audio session teardown; send uses hard-cancel to avoid late recognition callbacks mutating the draft after submit.
> 
> **Overview**
> Adds **on-device voice dictation** to the iOS message composer: a mic control beside attach streams live transcription into the draft (text only, not audio).
> 
> New **`ComposerDictationController`** (Speech + `AVAudioEngine`) and host-testable **`ComposerDictationState`** / **`ComposerDictationTextMerge`** handle permissions, prefer on-device recognition, merge partials as base + transcript without clobbering existing text, and distinguish **graceful stop** (finalize + 2.5s watchdog) from **hard cancel** (send, disappear, terminal switch).
> 
> **`TerminalComposerView`** wires the mic UI, disables the field while dictation owns the text, ignores focus-loss from that lock, and tears down dictation on lifecycle events. iOS adds microphone and speech recognition usage strings (EN/JA) plus localized mic accessibility labels; **`ComposerDictationTests`** covers merge and state rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5674550963362e4502f41325e3e844e149b5ffbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds on-device voice dictation to the iOS composer. Tap the mic to speak and see live transcription; send hard‑cancels to prevent late results from changing what gets sent.

- **New Features**
  - Mic button `MobileComposerMic` beside attach; pulsing red `mic.fill` while listening.
  - Streams partials via base+transcript merge; locks the field while listening/stopping to avoid clobbering edits.
  - Start/stop: second tap cancels pending permission; graceful stop on mic tap and focus loss; hard-cancel on send, terminal switch, and composer disappear.
  - Prefers on-device recognition with server fallback; `@MainActor` `@Observable` controller with clean teardown and an “unavailable” state; adds `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` (EN/JA) and localized “Start dictation”/“Stop dictation”; tests cover merge/state/lock.

- **Bug Fixes**
  - Split graceful stop vs hard cancel with a 2.5s watchdog; ignore lock-driven focus loss so dictation doesn’t auto-stop after starting.
  - Fixed `AVAudioSession` start: use `.record` + `.measurement` without invalid options to prevent start failures.

<sup>Written for commit 5674550963362e4502f41325e3e844e149b5ffbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS-only voice dictation for the message composer, including on-device transcription when available.
  * Added a microphone button to start/stop dictation with pulsing “listening” feedback, plus an unavailable/disabled state.
  * Automatically merges partial and final transcripts into the draft with consistent spacing.
* **Behavior & UX**
  * Dictation stops gracefully when finalizing, and is hard-cancelled when the composer view changes, loses focus, or before sending.
* **Permissions & Localization**
  * Added microphone and speech-recognition permission prompts and localized “Start dictation” / “Stop dictation” labels.
* **Tests**
  * Added host-test coverage for dictation state transitions and transcript/base merge rules (including graceful vs hard cancel).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->