### PR TITLE
Fix iOS composer compile break (nonisolated image helpers)

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -344,7 +344,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Per-image encoded-bytes cap. An add whose single image exceeds this is
     /// rejected outright (the view bounds the encode below this, but the store
     /// re-enforces it as the single source of truth).
-    public static let maxPendingAttachmentImageBytes = 8 * 1024 * 1024
+    // nonisolated so the composer's off-main (nonisolated) image-encode path can
+    // read the authoritative per-image cap; it is an immutable Sendable literal.
+    public nonisolated static let maxPendingAttachmentImageBytes = 8 * 1024 * 1024
     /// GLOBAL encoded-bytes budget summed across EVERY terminal's staged set, not
     /// just the target's. The per-terminal cap bounds one draft, but each live
     /// terminal carries its own per-terminal budget, so staging photos across many

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -542,7 +542,7 @@ struct TerminalComposerView: View {
     /// 3. Progressively smaller dimensions as a last resort.
     /// Returns the encoded bytes + a lowercase format hint, or `nil` if the source
     /// is undecodable. The cap is also re-enforced authoritatively in the store.
-    private static func boundedSendPayload(from source: CGImageSource) -> (data: Data, format: String)? {
+    private nonisolated static func boundedSendPayload(from source: CGImageSource) -> (data: Data, format: String)? {
         // PNG at the bounded send size: lossless, and for a typical screenshot it
         // lands well under the cap.
         if let png = downsampledImageData(
@@ -599,7 +599,7 @@ struct TerminalComposerView: View {
     ///   - maxPixelSize: The longest-edge cap, in pixels, for the downsample.
     ///   - type: The destination UTType identifier (`"public.png"`/`"public.jpeg"`).
     ///   - jpegQuality: The JPEG compression quality (0...1); `nil` for PNG.
-    private static func downsampledImageData(
+    private nonisolated static func downsampledImageData(
         from source: CGImageSource,
         maxPixelSize: Int,
         type: String,

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -114,7 +114,7 @@ struct TerminalComposerView: View {
     /// clipboard paste path and keep the bounded encode under ~8 MB. The store
     /// re-enforces this as the authoritative per-image cap; this constant only
     /// bounds the encode loop below it.
-    private static let maxImageBytes = CMUXMobileShellStore.maxPendingAttachmentImageBytes
+    private nonisolated static let maxImageBytes = CMUXMobileShellStore.maxPendingAttachmentImageBytes
 
     /// Cap how many images one message may carry, mirrored from the store so the
     /// picker's `maxSelectionCount` matches the store's authoritative count cap.
@@ -137,14 +137,14 @@ struct TerminalComposerView: View {
 
     /// Max pixel dimension of the cached chip thumbnail. The chip renders at 56pt;
     /// 3x covers Retina without holding the full-resolution image.
-    private static let thumbnailMaxPixelSize = 168
+    private nonisolated static let thumbnailMaxPixelSize = 168
 
     /// Max pixel dimension of the SEND payload. ImageIO downsamples the picked
     /// item to fit this longest edge before re-encoding, so a panorama or a
     /// 48-megapixel HEIC never materializes as a full-resolution raster. 2048 px
     /// keeps screenshot text legible for an agent while bounding the bytes well
     /// under the per-image cap.
-    private static let sendMaxPixelSize = 2048
+    private nonisolated static let sendMaxPixelSize = 2048
 
     var body: some View {
         composerSurface


### PR DESCRIPTION
main's iOS build is currently broken. `TerminalComposerView: View` is implicitly `@MainActor`, so its static `boundedSendPayload` / `downsampledImageData` are main-actor-isolated, but the `nonisolated` `prepare(url:)` calls them synchronously off-actor inside a background `TaskGroup`. ios-simulator fails to compile:

```
TerminalComposerView.swift:516: error: main actor-isolated static method 'boundedSendPayload(from:)' cannot be called from outside of the actor
TerminalComposerView.swift:520: error: expression is 'async' but is not marked with 'await'
```

These are pure ImageIO functions with no main-actor state (the doc comment already says the decode must not run on the main actor), so both are marked `nonisolated`. The size constants they read are `static let` Sendable Ints, already nonisolated-accessible; `PreparedAttachment` is a `Sendable` nested struct (no inherited isolation).

Landed on main via https://github.com/manaflow-ai/cmux/pull/6102 because `ios-simulator` is not a required check (iOS CI false-green). Unblocks the in-flight iOS PRs (#6038, #6044, #6096, #6119) which all merged main and inherited the break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784160177&installation_id=133855650&pr_number=6198&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6198&signature=1ed6a337fef397cca8f9074c41cbbd9fc11eb2ce123c486b9ba8b7f36f09e14e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolation annotations only; image encode logic and store caps are unchanged.
> 
> **Overview**
> Fixes the **iOS simulator compile failure** where background image staging called main-actor-isolated static helpers on `TerminalComposerView`.
> 
> `prepare(url:)` already runs ImageIO in a background `TaskGroup`; **`boundedSendPayload`** and **`downsampledImageData`** are now **`nonisolated`** so they can be invoked from that path without crossing the main actor. Related size constants (`maxImageBytes`, `sendMaxPixelSize`, `thumbnailMaxPixelSize`) and **`CMUXMobileShellStore.maxPendingAttachmentImageBytes`** are also marked **`nonisolated`** so the off-main encode path can read the same caps. No change to attachment limits or encoding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffadba7bd02cec3595ff08a638cf49aca41c2d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix iOS build by marking `TerminalComposerView` image helpers and size-cap constants as `nonisolated` so background calls from `prepare(url:)` compile under Swift 6. Keeps ImageIO work off the main thread and removes the main-actor isolation error in the iOS simulator.

- **Bug Fixes**
  - Marked `boundedSendPayload` and `downsampledImageData` in `TerminalComposerView` as `nonisolated`.
  - Marked `maxImageBytes`, `thumbnailMaxPixelSize`, `sendMaxPixelSize`, and the store’s `maxPendingAttachmentImageBytes` as `nonisolated` for off-actor reads.
  - No behavioral changes; isolation-only update.

<sup>Written for commit ffadba7bd02cec3595ff08a638cf49aca41c2d30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated terminal composer image-encoding helpers to use nonisolated static declarations, improving correctness/performance in off-main encoding paths.
  * Marked the exported pending-attachment image size limit as `nonisolated` for safe reads from the composer image-encoding workflow.
  * No changes to image size limits, encoding results, or other user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->