### PR TITLE
iOS: fix Swift 6 actor-isolation compile error in composer image encode path

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -344,7 +344,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Per-image encoded-bytes cap. An add whose single image exceeds this is
     /// rejected outright (the view bounds the encode below this, but the store
     /// re-enforces it as the single source of truth).
-    public static let maxPendingAttachmentImageBytes = 8 * 1024 * 1024
+    public nonisolated static let maxPendingAttachmentImageBytes = 8 * 1024 * 1024
     /// GLOBAL encoded-bytes budget summed across EVERY terminal's staged set, not
     /// just the target's. The per-terminal cap bounds one draft, but each live
     /// terminal carries its own per-terminal budget, so staging photos across many

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -114,7 +114,7 @@ struct TerminalComposerView: View {
     /// clipboard paste path and keep the bounded encode under ~8 MB. The store
     /// re-enforces this as the authoritative per-image cap; this constant only
     /// bounds the encode loop below it.
-    private static let maxImageBytes = CMUXMobileShellStore.maxPendingAttachmentImageBytes
+    private nonisolated static let maxImageBytes = CMUXMobileShellStore.maxPendingAttachmentImageBytes
 
     /// Cap how many images one message may carry, mirrored from the store so the
     /// picker's `maxSelectionCount` matches the store's authoritative count cap.
@@ -137,14 +137,14 @@ struct TerminalComposerView: View {
 
     /// Max pixel dimension of the cached chip thumbnail. The chip renders at 56pt;
     /// 3x covers Retina without holding the full-resolution image.
-    private static let thumbnailMaxPixelSize = 168
+    private nonisolated static let thumbnailMaxPixelSize = 168
 
     /// Max pixel dimension of the SEND payload. ImageIO downsamples the picked
     /// item to fit this longest edge before re-encoding, so a panorama or a
     /// 48-megapixel HEIC never materializes as a full-resolution raster. 2048 px
     /// keeps screenshot text legible for an agent while bounding the bytes well
     /// under the per-image cap.
-    private static let sendMaxPixelSize = 2048
+    private nonisolated static let sendMaxPixelSize = 2048
 
     var body: some View {
         composerSurface
@@ -542,7 +542,7 @@ struct TerminalComposerView: View {
     /// 3. Progressively smaller dimensions as a last resort.
     /// Returns the encoded bytes + a lowercase format hint, or `nil` if the source
     /// is undecodable. The cap is also re-enforced authoritatively in the store.
-    private static func boundedSendPayload(from source: CGImageSource) -> (data: Data, format: String)? {
+    private nonisolated static func boundedSendPayload(from source: CGImageSource) -> (data: Data, format: String)? {
         // PNG at the bounded send size: lossless, and for a typical screenshot it
         // lands well under the cap.
         if let png = downsampledImageData(
@@ -599,7 +599,7 @@ struct TerminalComposerView: View {
     ///   - maxPixelSize: The longest-edge cap, in pixels, for the downsample.
     ///   - type: The destination UTType identifier (`"public.png"`/`"public.jpeg"`).
     ///   - jpegQuality: The JPEG compression quality (0...1); `nil` for PNG.
-    private static func downsampledImageData(
+    private nonisolated static func downsampledImageData(
         from source: CGImageSource,
         maxPixelSize: Int,
         type: String,


### PR DESCRIPTION
The Release/archive build (Swift 6 language mode) fails to compile `TerminalComposerView`: the `nonisolated` detached `prepare()` task calls `boundedSendPayload` / `downsampledImageData` and reads `maxImageBytes` / `thumbnailMaxPixelSize` / `sendMaxPixelSize`, all of which inherited the View's `@MainActor` isolation and so are inaccessible from the nonisolated context.

Fix: mark those two pure ImageIO helpers and the three constants `nonisolated`, plus the store constant `maxPendingAttachmentImageBytes` they mirror. Pure functions over `CGImageSource`/`Data` and immutable `Int` constants, so `nonisolated` is correct.

Regression came in with #6102; the ios-simulator CI checks timed out (saturated fleet) rather than reporting the compile failure, so it was not caught before merge. The archive/TestFlight build surfaced it. Verified locally with a Swift 6 iOS simulator build (BUILD SUCCEEDED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784160324&installation_id=133855650&pr_number=6199&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6199&signature=7cf3769545decc17f22a2e03bdc0f94b68d1be9d1ac37ef648eb4192c48edcfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolation-only annotations on pure ImageIO helpers and immutable constants; no runtime or attachment-limit behavior change.
> 
> **Overview**
> **Swift 6 compile fix** for the terminal composer’s off-main image encode path: `prepare(url:)` already runs ImageIO in a background child task, but `boundedSendPayload`, `downsampledImageData`, and related static caps still inherited `@MainActor` isolation from `TerminalComposerView`, so Release/archive builds failed when those symbols were used from that `nonisolated` context.
> 
> The change adds `nonisolated` to those two static helpers, the view’s `maxImageBytes` / `thumbnailMaxPixelSize` / `sendMaxPixelSize` mirrors, and `CMUXMobileShellStore.maxPendingAttachmentImageBytes`. Behavior and attachment limits are unchanged—only actor isolation annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d237a0f0e8fc136a8a29a91a532a853dc0ff5da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Swift 6 actor-isolation compile error in the iOS composer image encode path by marking pure helpers and related constants as nonisolated. Restores successful Release/TestFlight builds.

- **Bug Fixes**
  - Marked `boundedSendPayload` and `downsampledImageData` as `nonisolated`.
  - Marked constants `maxImageBytes`, `thumbnailMaxPixelSize`, `sendMaxPixelSize`, and the store’s `maxPendingAttachmentImageBytes` as `nonisolated` so the detached `prepare()` task can access them from a nonisolated context.

<sup>Written for commit 8d237a0f0e8fc136a8a29a91a532a853dc0ff5da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal concurrency declarations for improved code stability and performance characteristics in image processing and attachment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->