### PR TITLE
CI: deterministic required iOS build gate (prevent iOS compile breaks on main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,12 +1314,32 @@ jobs:
           key: spm-ios-${{ hashFiles('ios/cmuxPackage/Package.resolved') }}
           restore-keys: spm-ios-
 
+      - name: Pick simulator
+        run: |
+          set -euo pipefail
+          # Resolve a concrete available iPhone simulator UDID, exactly like the
+          # ios-simulator job. A concrete destination is what reliably compiles the
+          # app for the simulator; a generic 'platform=iOS Simulator' destination
+          # did not. No simulator is booted, build-for-testing only compiles.
+          python3 - <<'PY' > /tmp/iosbuild-sim.env
+          import json, subprocess
+          data = json.loads(subprocess.check_output(["xcrun", "simctl", "list", "devices", "available", "-j"]))
+          devices = [d for runtime in data.get("devices", {}).values() for d in runtime if d.get("isAvailable", True)]
+          preferred = ["iPhone 17", "iPhone 16"]
+          selected = next((d for name in preferred for d in devices if d.get("name") == name), None)
+          selected = selected or next(d for d in devices if d.get("name", "").startswith("iPhone"))
+          print(f"SIMULATOR_ID={selected['udid']}")
+          print(f"SIMULATOR_NAME={selected['name']}")
+          PY
+          cat /tmp/iosbuild-sim.env
+          cat /tmp/iosbuild-sim.env >> "$GITHUB_ENV"
+
       - name: Resolve packages
         run: |
           set -euo pipefail
           xcodebuild -workspace ios/cmux.xcworkspace \
             -scheme cmux-ios \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -derivedDataPath /tmp/cmux-ios-build \
             -clonedSourcePackagesDirPath .spm-cache-ios \
             -resolvePackageDependencies
@@ -1327,17 +1347,16 @@ jobs:
       - name: Build iOS app for simulator (compile only, no tests, no boot)
         run: |
           set -euo pipefail
-          # Compile the iOS app (and all its package dependencies, incl. the
+          # Compile the iOS app and its package dependencies (incl. the
           # CmuxMobile* packages where the actor-isolation break lived) for a
-          # GENERIC simulator destination: nothing is booted, no virtual display,
-          # no tests run, so the result is deterministic. Plain `build` (not
-          # build-for-testing) keeps the gate to a pure app compile, which is the
-          # break class we are gating; the ios-simulator job still builds+runs
-          # the test targets on iOS PRs.
+          # concrete iOS Simulator. build-for-testing compiles the app + test
+          # targets WITHOUT booting a simulator or running tests, mirroring the
+          # ios-simulator job's build phase, so it is deterministic and catches
+          # the Swift compile breaks the macOS jobs miss.
           xcodebuild -workspace ios/cmux.xcworkspace \
             -scheme cmux-ios \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
             -derivedDataPath /tmp/cmux-ios-build \
             -clonedSourcePackagesDirPath .spm-cache-ios \
             CODE_SIGNING_ALLOWED=NO \
-            build
+            build-for-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1306,7 +1306,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .spm-cache-ios
-          key: spm-ios-${{ hashFiles('ios/cmux-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          key: spm-ios-${{ hashFiles('ios/cmuxPackage/Package.resolved') }}
           restore-keys: spm-ios-
 
       - name: Resolve packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1262,7 +1262,12 @@ jobs:
     # simulator WITHOUT running tests or booting a simulator, so it is
     # deterministic (no virtual display, no sim boot) and safe to require.
     # It runs on every PR and on push to main; make it a required status check.
-    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    # Use GitHub-hosted macos-26 (NOT the warp/self-hosted MACOS_RUNNER_26 label
+    # the macOS app jobs use): ensure-ghosttykit.sh calls sudo during
+    # provisioning, which has no passwordless/tty path on the self-hosted fleet.
+    # The proven iOS jobs (ios-simulator, mobile-core-package in test-ios.yml)
+    # run on hosted macos-26 for the same reason.
+    runs-on: macos-26
     timeout-minutes: 35
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1327,15 +1327,17 @@ jobs:
       - name: Build iOS app for simulator (compile only, no tests, no boot)
         run: |
           set -euo pipefail
-          # build-for-testing compiles the app and the test targets for the
-          # simulator using a GENERIC destination, so nothing is booted and the
-          # result is deterministic. This catches the Swift compile breaks
-          # (actor isolation, missing await, etc.) that only manifest in the iOS
-          # build and are invisible to the macOS unit-test job.
+          # Compile the iOS app (and all its package dependencies, incl. the
+          # CmuxMobile* packages where the actor-isolation break lived) for a
+          # GENERIC simulator destination: nothing is booted, no virtual display,
+          # no tests run, so the result is deterministic. Plain `build` (not
+          # build-for-testing) keeps the gate to a pure app compile, which is the
+          # break class we are gating; the ios-simulator job still builds+runs
+          # the test targets on iOS PRs.
           xcodebuild -workspace ios/cmux.xcworkspace \
             -scheme cmux-ios \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath /tmp/cmux-ios-build \
             -clonedSourcePackagesDirPath .spm-cache-ios \
             CODE_SIGNING_ALLOWED=NO \
-            build-for-testing
+            build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1251,3 +1251,92 @@ jobs:
             kill "$VDISPLAY_PERSISTENT_PID" >/dev/null 2>&1 || true
           fi
           rm -f /tmp/cmux-vdisplay-persistent.ready /tmp/cmux-vdisplay-persistent.id /tmp/cmux-vdisplay-persistent.log
+
+  ios-build:
+    # Deterministic iOS compile gate. The iOS app and the iOS-only CmuxMobile*
+    # packages are otherwise compiled ONLY in the non-required, flaky
+    # ios-simulator job (test-ios.yml), so an iOS-only compile break can merge
+    # green even though every required check passed. That is exactly how the
+    # @MainActor/nonisolated break in the composer image-decode path
+    # (TerminalComposerView) reached main. This job compiles the iOS app for the
+    # simulator WITHOUT running tests or booting a simulator, so it is
+    # deterministic (no virtual display, no sim boot) and safe to require.
+    # It runs on every PR and on push to main; make it a required status check.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort | tail -n 1 || true)"
+            if [ -n "$XCODE_APP" ]; then
+              XCODE_DIR="$XCODE_APP/Contents/Developer"
+            else
+              echo "No Xcode.app found under /Applications" >&2
+              exit 1
+            fi
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+
+      - name: Capture Ghostty revision
+        id: ghostty-revision
+        run: |
+          echo "sha=$(git -C ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache GhosttyKit.xcframework
+        id: cache-ghosttykit-ios
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: GhosttyKit.xcframework
+          key: ghosttykit-${{ steps.ghostty-revision.outputs.sha }}
+
+      - name: Provision GhosttyKit
+        if: steps.cache-ghosttykit-ios.outputs.cache-hit != 'true'
+        run: |
+          # The iOS app links GhosttyKit (incl. its iOS + iOS-simulator slices)
+          # via a local-path binaryTarget, so it must exist before resolve.
+          ./scripts/install-zig-ci.sh
+          ./scripts/ensure-ghosttykit.sh
+
+      - name: Cache Swift packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache-ios
+          key: spm-ios-${{ hashFiles('ios/cmux-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-ios-
+
+      - name: Resolve packages
+        run: |
+          set -euo pipefail
+          xcodebuild -workspace ios/cmux.xcworkspace \
+            -scheme cmux-ios \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath /tmp/cmux-ios-build \
+            -clonedSourcePackagesDirPath .spm-cache-ios \
+            -resolvePackageDependencies
+
+      - name: Build iOS app for simulator (compile only, no tests, no boot)
+        run: |
+          set -euo pipefail
+          # build-for-testing compiles the app and the test targets for the
+          # simulator using a GENERIC destination, so nothing is booted and the
+          # result is deterministic. This catches the Swift compile breaks
+          # (actor isolation, missing await, etc.) that only manifest in the iOS
+          # build and are invisible to the macOS unit-test job.
+          xcodebuild -workspace ios/cmux.xcworkspace \
+            -scheme cmux-ios \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath /tmp/cmux-ios-build \
+            -clonedSourcePackagesDirPath .spm-cache-ios \
+            CODE_SIGNING_ALLOWED=NO \
+            build-for-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1288,23 +1288,17 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
-      - name: Capture Ghostty revision
-        id: ghostty-revision
-        run: |
-          echo "sha=$(git -C ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache GhosttyKit.xcframework
-        id: cache-ghosttykit-ios
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: GhosttyKit.xcframework
-          key: ghosttykit-${{ steps.ghostty-revision.outputs.sha }}
-
       - name: Provision GhosttyKit
-        if: steps.cache-ghosttykit-ios.outputs.cache-hit != 'true'
         run: |
           # The iOS app links GhosttyKit (incl. its iOS + iOS-simulator slices)
           # via a local-path binaryTarget, so it must exist before resolve.
+          # Mirror the ios-simulator job exactly: ensure-ghosttykit.sh manages
+          # its own $HOME/.cache/cmux/ghosttykit cache and writes the framework
+          # where the iOS workspace expects it. Do NOT add an actions/cache step
+          # keyed on repo-root GhosttyKit.xcframework here: ensure-ghosttykit.sh
+          # does not populate that path, and the shared ghosttykit-<sha> key is
+          # owned by the macOS jobs that use download-prebuilt (a real dir), so
+          # caching a symlink/absent path from this job would poison that key.
           ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -18,25 +18,6 @@ on:
       - "scripts/lint-ios-package-conventions.sh"
       - "scripts/lint-namespace-types-baseline.txt"
       - ".github/workflows/test-ios.yml"
-  # Re-run on push to main so an iOS break that slips past PR checks is detected
-  # on main immediately, instead of only surfacing on the next iOS PR. The
-  # deterministic compile gate lives in ci.yml (ios-build); this is detection.
-  push:
-    branches:
-      - main
-    paths:
-      - "ios/**"
-      - "Packages/CMUXAuthCore/**"
-      - "Packages/CMUXMobileCore/**"
-      - "Packages/CmuxAuthRuntime/**"
-      - "Packages/CmuxMobile*/**"
-      - "Packages/CMUXMobile*/**"
-      - "Sources/Mobile/**"
-      - "vendor/stack-auth-swift-sdk-prerelease/**"
-      - "Packages/**"
-      - "scripts/lint-ios-package-conventions.sh"
-      - "scripts/lint-namespace-types-baseline.txt"
-      - ".github/workflows/test-ios.yml"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -18,6 +18,25 @@ on:
       - "scripts/lint-ios-package-conventions.sh"
       - "scripts/lint-namespace-types-baseline.txt"
       - ".github/workflows/test-ios.yml"
+  # Re-run on push to main so an iOS break that slips past PR checks is detected
+  # on main immediately, instead of only surfacing on the next iOS PR. The
+  # deterministic compile gate lives in ci.yml (ios-build); this is detection.
+  push:
+    branches:
+      - main
+    paths:
+      - "ios/**"
+      - "Packages/CMUXAuthCore/**"
+      - "Packages/CMUXMobileCore/**"
+      - "Packages/CmuxAuthRuntime/**"
+      - "Packages/CmuxMobile*/**"
+      - "Packages/CMUXMobile*/**"
+      - "Sources/Mobile/**"
+      - "vendor/stack-auth-swift-sdk-prerelease/**"
+      - "Packages/**"
+      - "scripts/lint-ios-package-conventions.sh"
+      - "scripts/lint-namespace-types-baseline.txt"
+      - ".github/workflows/test-ios.yml"
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Why
The iOS app + iOS-only `CmuxMobile*` packages are compiled **only** in the non-required, flaky `ios-simulator` job (`test-ios.yml`). So an iOS-only Swift compile break merges green while every *required* check passes. That is exactly how the `@MainActor`/`nonisolated` break in the composer image-decode path (`TerminalComposerView.boundedSendPayload`) reached main via https://github.com/manaflow-ai/cmux/pull/6102 and broke main CI (fix: https://github.com/manaflow-ai/cmux/pull/6198).

## What
- New `ios-build` job in **ci.yml** (runs on every PR + push to main, no path filter → always reports → safe to require). It compiles the `cmux-ios` scheme for a **generic iOS Simulator** destination with `build-for-testing`: no simulator boot, no virtual display, no test execution. Pure compilation is deterministic, so it can be a required check without the flakiness that kept `ios-simulator` non-required.
- `test-ios.yml` also re-runs on push to main (iOS paths) for post-merge detection.

## Follow-up (manual, intentionally not in this PR)
After this merges and `ios-build` is observed running green on a few PRs, add `ios-build` to the `main` branch ruleset's **required status checks**. (Adding a required check that isn't yet on main would block all PRs, so it must land first.)

This would have hard-blocked #6102 and today's break with zero added flakiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784161403&installation_id=133855650&pr_number=6202&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6202&signature=6cfb3a29b9a11d8c438d402b6d2c575aedf0421be458df91f8a1ab0c48c5db34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow addition with no application or runtime behavior changes; main risk is job duration or hosted macOS/Xcode availability, not product code.
> 
> **Overview**
> Adds a new **`ios-build`** job to **`ci.yml`** so iOS-only Swift compile failures are caught on every PR and push to **`main`**, not only in the optional **`ios-simulator`** workflow.
> 
> The job runs on **GitHub-hosted `macos-26`**, provisions **GhosttyKit** via **`ensure-ghosttykit.sh`** (with an explicit note **not** to cache repo-root **`GhosttyKit.xcframework`** in a way that could poison macOS cache keys), caches SwiftPM under **`.spm-cache-ios`**, picks a concrete iPhone simulator UDID, then **`resolvePackageDependencies`** and **`build-for-testing`** for **`cmux-ios`** with **`CODE_SIGNING_ALLOWED=NO`**—compile only, no simulator boot and no test execution.
> 
> Intended follow-up (outside this diff): mark **`ios-build`** as a required branch protection check once it is green on **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6c927c9965aff7a200b07e9c583f6b413d41cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic iOS compile gate in CI to block iOS-only Swift compile breaks from merging. It runs on every PR and on pushes to `main`; the flaky push-triggered `test-ios` run is removed.

- **New Features**
  - New `ios-build` job in `ci.yml` compiles `cmux-ios` for a concrete iOS Simulator UDID (picked via `simctl`) using `build-for-testing` (compile only; no sim boot or tests).
  - Runs on GitHub‑hosted `macos-26` to support `sudo` during `GhosttyKit` provisioning.
  - Always provisions `GhosttyKit` via `ensure-ghosttykit.sh`; caches SwiftPM in `.spm-cache-ios` keyed by `ios/cmuxPackage/Package.resolved` (no `actions/cache` for `GhosttyKit.xcframework`).

- **Migration**
  - After merge, mark `ios-build` as a required status check once stable.

<sup>Written for commit ac6c927c9965aff7a200b07e9c583f6b413d41cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI job that performs deterministic iOS Simulator compile-only validation on macOS, without running tests or launching a simulator.
  * Resolves iOS Swift package dependencies during the workflow and caches build artifacts to improve repeat run times.
  * Automatically selects a suitable Xcode environment and provisions the required build tooling before compiling the iOS app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->