### PR TITLE
ci(ios): run iOS macOS jobs on our self-hosted mini fleet

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -195,6 +195,16 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Install zig
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
+        run: |
+          # Own step (not folded into Provision GhosttyKit): install-zig-ci.sh
+          # publishes zig onto GITHUB_PATH, which only takes effect in the NEXT
+          # step. Running it in the same step as ensure-ghosttykit.sh means a
+          # freshly-downloaded zig isn't on PATH yet on runners that lack a
+          # pre-installed zig, so the GhosttyKit source-build fallback fails.
+          ./scripts/install-zig-ci.sh
+
       - name: Provision GhosttyKit
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
         run: |
@@ -202,20 +212,42 @@ jobs:
           # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
           # falls back to a from-source build. The iOS app links GhosttyKit via
           # a local-path binaryTarget, so it must exist before package resolve.
-          ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
       - name: Ensure iOS simulator runtime
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
+        env:
+          DEVICE_FAMILY: ${{ matrix.family }}
         run: |
-          # GitHub-hosted macOS images ship the iOS simulator runtime; the
-          # self-hosted mini fleet may not, in which case the next step's
-          # `simctl list devices available` returns nothing. Download it once
-          # (idempotent, cached after first run) so the job is runner-agnostic.
-          if ! xcrun simctl list devices available 2>/dev/null | grep -qiE "iPhone|iPad"; then
-            echo "No iOS simulator runtime found; downloading (one-time, ~8GB)..."
-            xcodebuild -downloadPlatform iOS
+          # GitHub-hosted macOS images ship a usable iOS runtime + the standard
+          # simulator device set; the self-hosted mini fleet may have neither,
+          # in which case the next "Pick simulator" step finds no available
+          # device and fails. Make the runner self-healing without depending on
+          # `-downloadPlatform` exit status (it exits non-zero with "Duplicate"
+          # when the runtime image is already cached).
+          set -uo pipefail
+          NEEDLE=$([ "$DEVICE_FAMILY" = ipad ] && echo iPad || echo iPhone)
+          # 1. Ensure an iOS runtime is registered. Only download when none is
+          #    listed; tolerate the "Duplicate"/already-cached non-zero exit.
+          if ! xcrun simctl list runtimes 2>/dev/null | grep -qE "iOS [0-9].*com\.apple\.CoreSimulator\.SimRuntime\.iOS"; then
+            echo "No iOS runtime registered; downloading (one-time, ~8GB)..."
+            xcodebuild -downloadPlatform iOS 2>&1 | tail -8 || true
           fi
+          # 2. Ensure at least one device of this family is available. Creating
+          #    one device makes Xcode populate the full standard set, which the
+          #    "Pick simulator" step prefers from. Resolve the device type and a
+          #    Ready iOS runtime at runtime so this stays Xcode-version-agnostic.
+          if ! xcrun simctl list devices available 2>/dev/null | grep -qi "$NEEDLE"; then
+            RT=$(xcrun simctl list runtimes 2>/dev/null | grep -E "iOS [0-9]" | grep -oE "com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+" | tail -1)
+            DT=$(xcrun simctl list devicetypes 2>/dev/null | grep -E "^$NEEDLE " | grep -oE "com\.apple\.CoreSimulator\.SimDeviceType\.[A-Za-z0-9-]+" | head -1)
+            if [ -n "$RT" ] && [ -n "$DT" ]; then
+              echo "Creating $NEEDLE device ($DT on $RT) to populate the device set..."
+              xcrun simctl create "ci-$NEEDLE" "$DT" "$RT" || true
+            else
+              echo "WARN: could not resolve runtime ($RT) or device type ($DT)" >&2
+            fi
+          fi
+          xcrun simctl list devices available 2>/dev/null | grep -iE "iPhone|iPad" | head -5 || true
 
       - name: Pick simulator
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -71,7 +71,7 @@ jobs:
           fi
           BASE_MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           git diff --name-only "$BASE_MERGE_BASE" "$HEAD_SHA" > /tmp/changed-files.txt
-          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Packages/CmuxSyncStore/|Sources/Mobile/|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$)' /tmp/changed-files.txt; then
+          if grep -Eq '^(ios/|Packages/CMUXAuthCore/|Packages/CMUXMobileCore/|Packages/CmuxAuthRuntime/|Packages/CmuxMobile[^/]*/|Packages/CMUXMobile[^/]*/|Packages/CmuxSyncStore/|Sources/Mobile/|vendor/stack-auth-swift-sdk-prerelease/|scripts/lint-ios-package-conventions\.sh$|\.github/workflows/test-ios\.yml$)' /tmp/changed-files.txt; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "No iOS-owned files changed; skipping iOS tests."
@@ -113,7 +113,9 @@ jobs:
   mobile-core-package:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
-    runs-on: macos-26
+    # Self-hosted macOS-26 fleet (cmux Mac minis) via the MACOS_RUNNER_26 repo
+    # variable; falls back to GitHub-hosted macos-26 when the variable is unset.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'macos-26' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -153,7 +155,9 @@ jobs:
   ios-simulator:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}
-    runs-on: macos-26
+    # Self-hosted macOS-26 fleet (cmux Mac minis) via the MACOS_RUNNER_26 repo
+    # variable; falls back to GitHub-hosted macos-26 when the variable is unset.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'macos-26' }}
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -200,6 +204,18 @@ jobs:
           # a local-path binaryTarget, so it must exist before package resolve.
           ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
+
+      - name: Ensure iOS simulator runtime
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
+        run: |
+          # GitHub-hosted macOS images ship the iOS simulator runtime; the
+          # self-hosted mini fleet may not, in which case the next step's
+          # `simctl list devices available` returns nothing. Download it once
+          # (idempotent, cached after first run) so the job is runner-agnostic.
+          if ! xcrun simctl list devices available 2>/dev/null | grep -qiE "iPhone|iPad"; then
+            echo "No iOS simulator runtime found; downloading (one-time, ~8GB)..."
+            xcodebuild -downloadPlatform iOS
+          fi
 
       - name: Pick simulator
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}


### PR DESCRIPTION
Routes `test-ios.yml`'s `mobile-core-package` + `ios-simulator` jobs to our macОS-26 cmux Mac mini fleet (via `MACOS_RUNNER_26`) instead of GitHub-hosted `macos-26`, so all macОS CI runs on our own cluster. Falls back to hosted when the var is unset.

- Adds an **Ensure iOS simulator runtime** step (self-hosted minis may lack the simulator that hosted images ship with).
- Treats a change to this workflow as an iOS change so this PR exercises the rerouted jobs.

Follow-up: `ios-testflight.yml` (only runs on main, so not PR-validatable) to be rerouted separately after a real TestFlight run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784161536&installation_id=133855650&pr_number=6204&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6204&signature=ea3e274d0756d776dbccfa78a794f7e888f63f639546a61e2a39b8019b14849f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shifts iOS simulator and package tests onto self-hosted infrastructure with one-time runtime downloads and runner-specific behavior; misconfiguration could block PR iOS gates until fallback or fleet is fixed.
> 
> **Overview**
> **`mobile-core-package`** and **`ios-simulator`** now use **`${{ vars.MACOS_RUNNER_26 || 'macos-26' }}`** so iOS macOS work runs on the cmux Mac mini fleet when the repo variable is set, with GitHub-hosted **`macos-26`** as fallback.
> 
> For self-hosted runners that may lack simulators, **`ios-simulator`** adds **Ensure iOS simulator runtime** (download iOS platform when no runtime is registered, create a family device if none are available) and splits **Install zig** into its own step so **`GITHUB_PATH`** is visible before **Provision GhosttyKit**.
> 
> PR change detection now treats edits to **`.github/workflows/test-ios.yml`** as iOS-owned so workflow-only PRs still run the rerouted jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11748b7fdad1e34abc919ddd3fef66e7c9b9238f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves iOS macOS CI to our self-hosted macOS-26 Mac mini fleet via `MACOS_RUNNER_26`, with a fallback to GitHub `macos-26`. Improves simulator reliability and GhosttyKit setup so jobs run the same on both runners.

- **Refactors**
  - `mobile-core-package` and `ios-simulator` now run on `${{ vars.MACOS_RUNNER_26 || 'macos-26' }}`; changes to `.github/workflows/test-ios.yml` now trigger these jobs in PRs.
  - Added a self-healing “Ensure iOS simulator runtime” step: only downloads when no runtime is registered and creates one `iPhone`/`iPad` device to populate the set, so “Pick simulator” always finds a device.
  - Split `Install zig` into its own step so `GITHUB_PATH` applies before `ensure-ghosttykit.sh`, fixing zig-not-found failures on fresh runners.

<sup>Written for commit 11748b7fdad1e34abc919ddd3fef66e7c9b9238f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved iOS CI/CD pipeline configuration with more accurate detection of iOS-related package directory changes.
  * Updated macOS runner selection to use a configured runner version when available.
  * Enhanced iOS simulator setup by proactively verifying required iOS runtimes and downloading/creating them as needed before running simulator-based jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->