### PR TITLE
CI: set up Node in nightly + release jobs (fix npm not found turning main red)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -142,6 +142,17 @@ jobs:
           set -euo pipefail
           ./scripts/select-nightly-xcodes.sh
 
+      # Provide node/npm explicitly. The build/sign/notarize job can land on a
+      # self-hosted macOS runner (the iOS-CI minis match the same label) that has
+      # no npm on PATH, so `npm install --global create-dmg` failed with
+      # "npm: command not found" and turned nightly red. setup-node makes the job
+      # self-sufficient on any runner instead of assuming a preinstalled npm.
+      - name: Set up Node
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
       - name: Install build deps
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,15 @@ jobs:
           xcodebuild -version
           xcrun --sdk macosx --show-sdk-path
 
+      # Same self-sufficiency as nightly: a self-hosted macOS runner may lack npm
+      # on PATH, which breaks the pinned create-dmg install below. setup-node
+      # guarantees node/npm regardless of which runner picks up the job.
+      - name: Set up Node
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
       - name: Install build deps
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |


### PR DESCRIPTION
## Why
`build-sign-notarize-nightly` is red on main (and has been across recent commits: fce15242a, #6199's 723329f98, #6102's 50ae24698). The job lands on a self-hosted macOS runner (the iOS-CI minis match the same `MACOS_RUNNER_15`/warp label) that has no `npm` on PATH, so the pinned `npm install --global create-dmg@${CREATE_DMG_VERSION}` fails with `npm: command not found` (exit 127).

No workflow used `setup-node`; runners were assumed to ship npm.

## Fix
Add a pinned `actions/setup-node@v6.4.0` (node 20) before `Install build deps` in both `nightly.yml` and `release.yml`, so the job is self-sufficient regardless of which runner picks it up. The `create-dmg` install stays pinned to `CREATE_DMG_VERSION=8.0.0`; `tests/test_ci_create_dmg_pinned.sh` still passes.

Workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784163716&installation_id=133855650&pr_number=6206&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6206&signature=e1e9bc4f256a6013375849ef6a14caeadbbfe4e9e5fc7529e76cebea21d932e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only CI change; no application, signing, or release artifact logic is modified beyond ensuring npm is available for the existing create-dmg install.
> 
> **Overview**
> Fixes **nightly** and **release** macOS jobs failing on self-hosted runners where `npm` is not on PATH, which broke the existing pinned `npm install --global create-dmg@${CREATE_DMG_VERSION}` step with `npm: command not found`.
> 
> Adds a **Set up Node** step (`actions/setup-node@v6.4.0`, Node 20) immediately before **Install build deps** in `nightly.yml` and `release.yml`, using the same `if` guards as the surrounding build steps. The `create-dmg` version pin and install command are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c72d8f4baab1f10b95e6d80f723eeaa991a0a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up Node in nightly and release build jobs to fix “npm: command not found” on self-hosted macOS runners. This makes the `create-dmg` install reliable and keeps CI green.

- **Bug Fixes**
  - Added `actions/setup-node@v6.4.0` (Node 20) before “Install build deps” in `nightly.yml` and `release.yml`.
  - Ensures `npm` is available on all runners; `create-dmg` stays pinned at `8.0.0`.

<sup>Written for commit 21c72d8f4baab1f10b95e6d80f723eeaa991a0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build and release workflows to ensure Node.js is properly installed on self-hosted runners before proceeding with build steps, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->