### PR TITLE
Normalize browser navigation icon sizing

### DIFF
--- a/Sources/Panels/BrowserChromeMetrics.swift
+++ b/Sources/Panels/BrowserChromeMetrics.swift
@@ -1,12 +1,50 @@
 import CoreGraphics
 
+enum BrowserNavigationToolbarIcon: CaseIterable, Equatable {
+    case back
+    case forward
+    case reload
+    case stop
+
+    var symbolName: String {
+        switch self {
+        case .back: return "chevron.left"
+        case .forward: return "chevron.right"
+        case .reload: return "arrow.clockwise"
+        case .stop: return "xmark"
+        }
+    }
+
+    /// SF Symbol intrinsic sizes at the legacy 12pt medium-weight browser
+    /// navigation size. The toolbar uses the largest measured edge across all
+    /// variants so the reload button does not resize when it flips to stop and
+    /// the back/forward buttons share that same optical box.
+    var measuredReferenceSize: CGSize {
+        switch self {
+        case .back, .forward:
+            CGSize(width: 9, height: 13)
+        case .reload:
+            CGSize(width: 13, height: 15)
+        case .stop:
+            CGSize(width: 13, height: 12)
+        }
+    }
+
+    var measuredReferenceMaxEdge: CGFloat {
+        max(measuredReferenceSize.width, measuredReferenceSize.height)
+    }
+
+    static func reloadOrStop(isLoading: Bool) -> BrowserNavigationToolbarIcon {
+        isLoading ? .stop : .reload
+    }
+}
+
 /// Derives the browser top-chrome sizes (omnibar text, navigation glyphs,
 /// toolbar icon buttons) from the user's tab bar font size so the whole top
 /// chrome — tabs plus the browser toolbar — renders at one consistent scale.
 ///
-/// Every size is a pure multiple of a legacy base constant. At
-/// ``referenceFontSize`` the scale is exactly `1`, so the chrome is
-/// byte-identical to the previously hardcoded layout; larger or smaller tab bar
+/// Every size is a pure multiple of a reference base constant. At
+/// ``referenceFontSize`` the scale is exactly `1`; larger or smaller tab bar
 /// font sizes scale the chrome proportionally. The derived scale is clamped to
 /// ``minimumScale``...``maximumScale`` so a malformed config value can never
 /// blow the toolbar up or collapse it.
@@ -42,8 +80,10 @@ struct BrowserChromeMetrics: Equatable {
     /// Height of the omnibar text field so taller text is not clipped. Base `18`.
     var omnibarFieldHeight: CGFloat { scaled(18) }
 
-    /// Point size for the back/forward/reload navigation glyphs. Base `12`.
-    var navigationIconFontSize: CGFloat { scaled(12) }
+    /// Square raster size for every back/forward/reload/stop navigation glyph.
+    /// Base `15`, the largest measured intrinsic edge among the four symbols at
+    /// the legacy 12pt medium-weight setting.
+    var navigationIconRasterSize: CGFloat { scaled(Self.navigationIconReferenceRasterSize) }
 
     /// Point size for the HTTPS lock badge in the omnibar. Base `10`.
     var secureBadgeFontSize: CGFloat { scaled(10) }
@@ -57,6 +97,16 @@ struct BrowserChromeMetrics: Equatable {
 
     /// Square hit target of the back/forward/reload buttons. Base `26`.
     var buttonHitSize: CGFloat { scaled(26) }
+
+    func navigationIconRasterSize(for _: BrowserNavigationToolbarIcon) -> CGFloat {
+        return navigationIconRasterSize
+    }
+
+    private static var navigationIconReferenceRasterSize: CGFloat {
+        BrowserNavigationToolbarIcon.allCases
+            .map(\.measuredReferenceMaxEdge)
+            .max() ?? 12
+    }
 
     private func scaled(_ base: CGFloat) -> CGFloat { base * scale }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1310,8 +1310,9 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goBack()
             }) {
-                Image(systemName: "chevron.left")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                let icon = BrowserNavigationToolbarIcon.back
+                Image(systemName: icon.symbolName)
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconRasterSize(for: icon), weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1326,8 +1327,9 @@ struct BrowserPanelView: View {
                 #endif
                 panel.goForward()
             }) {
-                Image(systemName: "chevron.right")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                let icon = BrowserNavigationToolbarIcon.forward
+                Image(systemName: icon.symbolName)
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconRasterSize(for: icon), weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }
@@ -1337,8 +1339,9 @@ struct BrowserPanelView: View {
             .safeHelp(String(localized: "browser.goForward", defaultValue: "Go Forward"))
 
             Button(action: handleReloadOrStopButtonAction) {
-                Image(systemName: panel.isLoading ? "xmark" : "arrow.clockwise")
-                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconFontSize, weight: .medium)
+                let icon = BrowserNavigationToolbarIcon.reloadOrStop(isLoading: panel.isLoading)
+                Image(systemName: icon.symbolName)
+                    .cmuxSymbolRasterSize(chromeMetrics.navigationIconRasterSize(for: icon), weight: .medium)
                     .frame(width: addressBarButtonHitSize, height: addressBarButtonHitSize, alignment: .center)
                     .contentShape(Rectangle())
             }

--- a/cmuxTests/BrowserChromeMetricsTests.swift
+++ b/cmuxTests/BrowserChromeMetricsTests.swift
@@ -8,29 +8,30 @@ import Testing
 #endif
 
 @Suite struct BrowserChromeMetricsTests {
-    /// The legacy hardcoded chrome sizes the layout must reproduce exactly at the
-    /// default tab bar font size, so default appearance stays byte-identical.
-    private static let legacy = (
+    /// The default chrome sizes at the reference tab bar font size. Most values
+    /// preserve the legacy hardcoded layout; the navigation raster is normalized
+    /// from measured SF Symbol bounds so all browser nav variants share one box.
+    private static let reference = (
         omnibarFontSize: CGFloat(12),
         omnibarFieldHeight: CGFloat(18),
-        navigationIconFontSize: CGFloat(12),
+        navigationIconRasterSize: CGFloat(15),
         secureBadgeFontSize: CGFloat(10),
         accessoryIconFontSize: CGFloat(11),
         buttonIconSize: CGFloat(22),
         buttonHitSize: CGFloat(26)
     )
 
-    @Test func defaultFontSizeReproducesLegacySizesByteIdentical() {
+    @Test func defaultFontSizeUsesReferenceSizes() {
         let metrics = BrowserChromeMetrics(tabBarFontSize: BrowserChromeMetrics.referenceFontSize)
 
         #expect(metrics.scale == 1)
-        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize)
-        #expect(metrics.omnibarFieldHeight == Self.legacy.omnibarFieldHeight)
-        #expect(metrics.navigationIconFontSize == Self.legacy.navigationIconFontSize)
-        #expect(metrics.secureBadgeFontSize == Self.legacy.secureBadgeFontSize)
-        #expect(metrics.accessoryIconFontSize == Self.legacy.accessoryIconFontSize)
-        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize)
-        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize)
+        #expect(metrics.omnibarFontSize == Self.reference.omnibarFontSize)
+        #expect(metrics.omnibarFieldHeight == Self.reference.omnibarFieldHeight)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize)
+        #expect(metrics.secureBadgeFontSize == Self.reference.secureBadgeFontSize)
+        #expect(metrics.accessoryIconFontSize == Self.reference.accessoryIconFontSize)
+        #expect(metrics.buttonIconSize == Self.reference.buttonIconSize)
+        #expect(metrics.buttonHitSize == Self.reference.buttonHitSize)
     }
 
     @Test func referenceFontSizeMatchesShippedDefault() {
@@ -46,10 +47,11 @@ import Testing
 
         #expect(metrics.scale > 1)
         #expect(metrics.scale == expectedScale)
-        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * expectedScale)
-        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize * expectedScale)
-        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize * expectedScale)
-        #expect(metrics.accessoryIconFontSize == Self.legacy.accessoryIconFontSize * expectedScale)
+        #expect(metrics.omnibarFontSize == Self.reference.omnibarFontSize * expectedScale)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize * expectedScale)
+        #expect(metrics.buttonIconSize == Self.reference.buttonIconSize * expectedScale)
+        #expect(metrics.buttonHitSize == Self.reference.buttonHitSize * expectedScale)
+        #expect(metrics.accessoryIconFontSize == Self.reference.accessoryIconFontSize * expectedScale)
     }
 
     @Test func smallerFontScalesEverySizeDownProportionally() {
@@ -59,26 +61,53 @@ import Testing
 
         #expect(metrics.scale < 1)
         #expect(metrics.scale == expectedScale)
-        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * expectedScale)
-        #expect(metrics.buttonHitSize == Self.legacy.buttonHitSize * expectedScale)
+        #expect(metrics.omnibarFontSize == Self.reference.omnibarFontSize * expectedScale)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize * expectedScale)
+        #expect(metrics.buttonHitSize == Self.reference.buttonHitSize * expectedScale)
     }
 
     @Test func absurdlyLargeFontClampsToMaximumScale() {
         let metrics = BrowserChromeMetrics(tabBarFontSize: 10_000)
         #expect(metrics.scale == BrowserChromeMetrics.maximumScale)
-        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize * BrowserChromeMetrics.maximumScale)
+        #expect(metrics.buttonIconSize == Self.reference.buttonIconSize * BrowserChromeMetrics.maximumScale)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize * BrowserChromeMetrics.maximumScale)
     }
 
     @Test func nearZeroFontClampsToMinimumScale() {
         let metrics = BrowserChromeMetrics(tabBarFontSize: 0.001)
         #expect(metrics.scale == BrowserChromeMetrics.minimumScale)
-        #expect(metrics.omnibarFontSize == Self.legacy.omnibarFontSize * BrowserChromeMetrics.minimumScale)
+        #expect(metrics.omnibarFontSize == Self.reference.omnibarFontSize * BrowserChromeMetrics.minimumScale)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize * BrowserChromeMetrics.minimumScale)
     }
 
     @Test(arguments: [CGFloat(0), CGFloat(-5), CGFloat.nan, CGFloat.infinity, -CGFloat.infinity])
     func nonPositiveOrNonFiniteFontFallsBackToNeutralScale(_ value: CGFloat) {
         let metrics = BrowserChromeMetrics(tabBarFontSize: value)
         #expect(metrics.scale == 1)
-        #expect(metrics.buttonIconSize == Self.legacy.buttonIconSize)
+        #expect(metrics.buttonIconSize == Self.reference.buttonIconSize)
+        #expect(metrics.navigationIconRasterSize == Self.reference.navigationIconRasterSize)
+    }
+
+    @Test func navigationIconReferenceSizesMatchMeasuredSymbolBounds() {
+        #expect(BrowserNavigationToolbarIcon.back.symbolName == "chevron.left")
+        #expect(BrowserNavigationToolbarIcon.back.measuredReferenceSize == CGSize(width: 9, height: 13))
+        #expect(BrowserNavigationToolbarIcon.forward.symbolName == "chevron.right")
+        #expect(BrowserNavigationToolbarIcon.forward.measuredReferenceSize == CGSize(width: 9, height: 13))
+        #expect(BrowserNavigationToolbarIcon.reload.symbolName == "arrow.clockwise")
+        #expect(BrowserNavigationToolbarIcon.reload.measuredReferenceSize == CGSize(width: 13, height: 15))
+        #expect(BrowserNavigationToolbarIcon.stop.symbolName == "xmark")
+        #expect(BrowserNavigationToolbarIcon.stop.measuredReferenceSize == CGSize(width: 13, height: 12))
+    }
+
+    @Test func navigationIconVariantsUseOneScaledRasterSize() {
+        let metrics = BrowserChromeMetrics(tabBarFontSize: BrowserChromeMetrics.referenceFontSize + 2)
+        let sizes = BrowserNavigationToolbarIcon.allCases.map {
+            metrics.navigationIconRasterSize(for: $0)
+        }
+
+        #expect(Set(sizes).count == 1)
+        #expect(sizes.first == metrics.navigationIconRasterSize)
+        #expect(BrowserNavigationToolbarIcon.reloadOrStop(isLoading: false) == .reload)
+        #expect(BrowserNavigationToolbarIcon.reloadOrStop(isLoading: true) == .stop)
     }
 }


### PR DESCRIPTION
## Summary
- Define measured browser navigation icon variants for back, forward, reload, and stop.
- Derive one shared navigation raster size from the largest measured SF Symbol edge and scale it from the user tab bar font size.
- Route the toolbar buttons through the shared variant sizing path.

## Testing
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-btnsz test -only-testing:cmuxTests/BrowserChromeMetricsTests` passed, 9 Swift Testing tests.\n- `./scripts/reload-cloud.sh --tag btnsz` passed.\n- Launched tagged app, opened browser surface, verified back/forward/reload toolbar.\n- Navigated to a deliberately hanging local URL and verified reload flipped to the stop xmark toolbar variant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784166429&installation_id=133855650&pr_number=6208&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6208&signature=072532b90c3178662927fc6d979246058642e0ca2b56630bf199a2b4fe25980b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized browser chrome layout and metrics only; minor default-scale visual tweak (nav raster 12→15) with no auth, data, or networking impact.
> 
> **Overview**
> Browser back, forward, reload, and stop controls now share one **scaled raster size** derived from measured SF Symbol bounds, so the reload/stop toggle and chevrons no longer shift layout.
> 
> A new `BrowserNavigationToolbarIcon` type centralizes symbol names, per-variant reference measurements, and `reloadOrStop(isLoading:)`. `BrowserChromeMetrics` drops `navigationIconFontSize` in favor of `navigationIconRasterSize` (reference base **15**, the max intrinsic edge across the four glyphs) plus `navigationIconRasterSize(for:)`. The address bar button bar routes all three nav buttons through that path with `cmuxSymbolRasterSize`.
> 
> Tests rename the legacy fixture to **reference** sizes, expect **15** for navigation raster at scale 1, and add coverage for measured bounds and a single raster size across variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa5bf0f7dc4f7064b99c74c43fe812d531bc7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized browser navigation icon sizing so back, forward, reload, and stop share one consistent raster size. Prevents size jumps when reload switches to stop and keeps the toolbar scale aligned with the tab bar font size.

- **Bug Fixes**
  - Added BrowserNavigationToolbarIcon with measured SF Symbol bounds and a single shared raster size (derived from the largest edge, scaled from the tab bar font).
  - Replaced navigationIconFontSize with navigationIconRasterSize and routed toolbar buttons through the shared sizing path.
  - Expanded tests to cover reference sizes, scaling/clamping, measured symbol bounds, and variant consistency.

<sup>Written for commit ffa5bf0f7dc4f7064b99c74c43fe812d531bc7a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for navigation icon handling (back, forward, reload, stop) to provide better consistency and maintainability in sizing and symbol management across the browser toolbar.

* **Tests**
  * Updated test coverage to validate navigation icon sizing and variants against reference metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->