### PR TITLE
CI: drop ios-testflight push trigger (fix cancelled-run red on main)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,22 +1,17 @@
 name: iOS TestFlight (beta)
 
 on:
-  # Publish to the beta lane on every iOS-affecting merge to main, so testers get
-  # changes immediately instead of waiting for the nightly. Path-filtered to the
-  # inputs that actually change the iOS app (the iOS target, the linked Swift
-  # packages, and GhosttyKit); macOS-only Sources/ changes don't rebuild the iOS
-  # app, so they don't trigger an upload. Push runs always build (the SHA gate is
-  # schedule-only); each merge is a new commit, so there's no duplicate upload.
-  push:
-    branches: [main]
-    paths:
-      - "ios/**"
-      - "Packages/**"
-      - "ghostty"
-      - "scripts/ensure-ghosttykit.sh"
-      - "scripts/install-zig-ci.sh"
-      - "scripts/ghosttykit-checksums.txt"
-      - ".github/workflows/ios-testflight.yml"
+  # No push trigger. A TestFlight upload is a release action: you only ever want
+  # the LATEST main state in beta, exactly once per change, never one upload per
+  # commit. Triggering on every iOS-affecting push forced a concurrency group to
+  # dedup concurrent uploads, and GitHub cancels the superseded *pending* runs in
+  # that group during merge bursts; those cancelled runs surface as red checks on
+  # the intermediate main commits, making main look like CI is failing. The
+  # schedule below already SHA-compares HEAD to the last uploaded commit (the
+  # `decide` job), which is the correct primitive for a beta lane: it uploads the
+  # current main only when it has actually advanced, and skips (green) otherwise.
+  # For an immediate beta, use workflow_dispatch; intentional cuts go through the
+  # release flow. See nightly.yml for the rolling dogfood lane.
   workflow_dispatch:
     inputs:
       build_number:


### PR DESCRIPTION
## Problem
`main` shows red from the **iOS TestFlight (beta)** workflow: its jobs land as `cancelled` on intermediate main commits during merge bursts (e.g. two iOS merges close together). Isolated pushes upload fine; bursts don't.

## Root cause
A TestFlight upload is a release action, so the workflow needs a concurrency group to avoid N concurrent uploads. With `push: [main]` + `concurrency (cancel-in-progress: false)`, GitHub cancels the **superseded pending** runs in the group when newer commits queue. Those cancelled runs surface as red checks on the superseded commits → main looks like CI is failing. It is not a build failure, and ios-testflight is not a required check.

## Fix (first principles)
You only ever want the *latest* main in beta, exactly once per change. The `decide` job already does exactly that for the schedule lane: it SHA-compares HEAD to the last uploaded commit and uploads only when main advanced (skips green otherwise, retries an un-uploaded commit). So:
- Remove `push: [main]` (the sole source of the cancellation red).
- Keep `workflow_dispatch` (immediate on-demand beta) and the decide-gated `schedule`.
- Intentional cuts still go through the release flow; `nightly.yml` remains the rolling dogfood lane.

No required checks change. Eliminates the red without losing beta coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784170831&installation_id=133855650&pr_number=6214&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6214&signature=45199c3545d56d600c8a7210023744a245bda19d64fb573b6b19fbe92a35cc29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger-only change; no app, signing, or upload job logic is modified.
> 
> **Overview**
> Stops **iOS TestFlight (beta)** from running on every iOS-related push to `main`, which was queuing multiple runs under the workflow concurrency group and leaving **cancelled** checks on intermediate commits during merge bursts.
> 
> Beta uploads now rely on the existing **schedule** (with the `decide` job’s SHA gate so only new `main` HEAD ships) and **workflow_dispatch** for on-demand cuts; release and `nightly.yml` dogfood are unchanged. Inline comments in `ios-testflight.yml` document why push was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae2a18cffbd36da4607612d0e7b465d87b3f895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the push trigger from the iOS TestFlight (beta) workflow to stop cancelled runs marking main as red during merge bursts. Beta uploads now run via the scheduled SHA-gated decide job or manual dispatch.

- **Bug Fixes**
  - Schedule uses the existing `decide` job to upload only when main advances (SHA compare); skipped runs are green and missed uploads retry.
  - Keep `workflow_dispatch` for on-demand beta; release flow and `nightly.yml` unchanged.
  - No required checks change.

<sup>Written for commit 9ae2a18cffbd36da4607612d0e7b465d87b3f895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS TestFlight deployment configuration to remove automatic push-based triggers. TestFlight builds will now be deployed only through scheduled releases and manual deployment requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->