### PR TITLE
changelog: downplay freeform canvas (not production-ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to cmux are documented here.
 ## [0.64.16] - 2026-06-15
 
 ### Added
-- Freeform 2D canvas layout for workspace panes: arrange panes anywhere on a zoomable canvas ([#5987](https://github.com/manaflow-ai/cmux/pull/5987)) -- thanks @azooz2003-bit!
 - Opt-in AI auto-naming of workspaces and tabs from your agent conversations ([#5547](https://github.com/manaflow-ai/cmux/pull/5547)) -- thanks @mvanhorn!
 - Per-workspace environment variables inherited by every shell in the workspace ([#6116](https://github.com/manaflow-ai/cmux/pull/6116))
 - Configurable file explorer double-click action: preview, default editor, or preferred editor ([#5827](https://github.com/manaflow-ai/cmux/pull/5827))
@@ -17,11 +16,12 @@ All notable changes to cmux are documented here.
 - iOS (beta): workspace list with groups, unread dots, last-activity previews, and a shared Unread filter ([#5726](https://github.com/manaflow-ai/cmux/pull/5726))
 - iOS (beta): workspace row actions ([#6022](https://github.com/manaflow-ai/cmux/pull/6022)) -- thanks @azooz2003-bit!
 - iOS (beta): Shift key on the terminal keyboard toolbar ([#6104](https://github.com/manaflow-ai/cmux/pull/6104))
+- Experimental freeform 2D canvas layout for workspace panes, still in progress ([#5987](https://github.com/manaflow-ai/cmux/pull/5987)) -- thanks @azooz2003-bit!
 
 ### Changed
 - macos-option-as-alt now honors left and right Option independently, sending sided modifier bits to the terminal ([#6007](https://github.com/manaflow-ai/cmux/pull/6007)) -- thanks @1nto5, @ucan-lab, @MrSpock, @Sancerro, @dreasan, @alceal, @lejahmie, and @tofunori for the reports!
 - Gate remote SSH port scanning on the sidebar ports setting ([#6136](https://github.com/manaflow-ai/cmux/pull/6136)) -- thanks @Fail-Safe for the report!
-- Polish canvas minimap navigation ([#6105](https://github.com/manaflow-ai/cmux/pull/6105)) -- thanks @azooz2003-bit!
+- Polish the experimental canvas minimap navigation ([#6105](https://github.com/manaflow-ai/cmux/pull/6105)) -- thanks @azooz2003-bit!
 - Make Codex agent hooks fire-and-forget so they never block the session ([#6110](https://github.com/manaflow-ai/cmux/pull/6110))
 - Detect live claude/codex processes so hook-less agent sessions stay fork-able ([#6133](https://github.com/manaflow-ai/cmux/pull/6133))
 - Stagger restored terminal surface spawns to smooth session restore ([#6149](https://github.com/manaflow-ai/cmux/pull/6149))

--- a/web/app/[locale]/docs/changelog/changelog-media.ts
+++ b/web/app/[locale]/docs/changelog/changelog-media.ts
@@ -28,13 +28,8 @@ export interface VersionMedia {
 export const changelogMedia: Record<string, VersionMedia> = {
   "0.64.16": {
     title:
-      "Freeform 2D Canvas, AI Auto-Naming, Per-Workspace Env Vars, Left/Right Option as Alt",
+      "AI Auto-Naming, Per-Workspace Env Vars, Left/Right Option as Alt",
     features: [
-      {
-        title: "Freeform 2D Canvas Layout",
-        description:
-          "Arrange a workspace's panes anywhere on a zoomable 2D canvas instead of a fixed split grid, with a polished minimap for navigation.",
-      },
       {
         title: "AI Auto-Naming for Workspaces and Tabs",
         description:


### PR DESCRIPTION
Canvas is still experimental, so it should not be a headline feature of 0.64.16.

**Changed**
- Drop "Freeform 2D Canvas" from the 0.64.16 changelog-media `title` and remove its feature card (the bold highlight cards above the raw list on the docs changelog page were the most prominent surface).
- Move the canvas `Added` bullet in `CHANGELOG.md` to the bottom of the section and relabel it "Experimental freeform 2D canvas layout ... still in progress".
- Mark the canvas minimap `Changed` line as experimental.

No code/runtime behavior changes; docs/changelog copy only. The feature still ships in the build, it is just no longer presented as production-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784172957&installation_id=133855650&pr_number=6218&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6218&signature=12a56a62c373cd219dff9352895d7f4c8e2a74ff96fe5149db0f8d0c49d4d4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog copy only; no application code or configuration behavior is modified.
> 
> **Overview**
> Reframes **0.64.16** release notes so the freeform 2D canvas is no longer presented as a headline, production-ready feature.
> 
> In **`CHANGELOG.md`**, the canvas **Added** bullet moves to the bottom of the section and is relabeled **experimental … still in progress**. The canvas minimap **Changed** line is explicitly marked experimental.
> 
> On the docs changelog page, **`changelog-media.ts`** drops "Freeform 2D Canvas" from the version title and removes its feature highlight card; AI auto-naming, per-workspace env vars, and Option-as-alt remain the promoted highlights.
> 
> No runtime or product behavior changes—copy only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b5cdc2c470f25234043962f1e5663b31afa37f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downplay the freeform 2D canvas in the 0.64.16 changelog by removing it from the docs highlights/title and marking the canvas and minimap as experimental. The feature still ships, but its Added bullet is moved to the bottom and labeled “Experimental … still in progress”; no code/runtime changes.

<sup>Written for commit 93b5cdc2c470f25234043962f1e5663b31afa37f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to clarify that Freeform 2D Canvas layout is experimental and still in progress.
  * Refreshed featured highlights for the release to reflect current capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->