### PR TITLE
Polish canvas minimap interactions

### DIFF
--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapAutoHideScheduler.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapAutoHideScheduler.swift
@@ -6,6 +6,9 @@ final class CanvasMinimapAutoHideScheduler {
     private let delay: Duration
     private var deadline: Duration?
     private var task: Task<Void, Never>?
+    var hasPendingHide: Bool {
+        deadline != nil || task != nil
+    }
 
     init<C: Clock & Sendable>(clock: C, delay: Duration = .seconds(3)) where C.Duration == Duration {
         self.clock = CanvasMinimapAutoHideClock(clock)

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapView.swift
@@ -108,6 +108,12 @@ final class CanvasMinimapView: NSView {
         onScrollWheel?(event)
     }
 
+    func resetInteractionState() {
+        isPointerInside = false
+        isDragging = false
+        isInteractionActive = false
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         guard snapshot.shouldShow else { return }
         drawBackground()

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasMinimapView.swift
@@ -15,9 +15,22 @@ final class CanvasMinimapView: NSView {
     var onCenterChanged: ((CGPoint) -> Void)?
     var onCenterSettled: ((CGPoint) -> Void)?
     var onScrollWheel: ((NSEvent) -> Void)?
+    var onInteractionBegan: (() -> Void)?
+    var onInteractionEnded: (() -> Void)?
+    var accessibilityLabelText = "" {
+        didSet { setAccessibilityLabel(accessibilityLabelText) }
+    }
+    var accessibilityHelpText = "" {
+        didSet { setAccessibilityHelp(accessibilityHelpText) }
+    }
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { false }
+
+    private var trackingArea: NSTrackingArea?
+    private var isPointerInside = false
+    private var isDragging = false
+    private var isInteractionActive = false
 
     private var drawingRect: CGRect {
         bounds.insetBy(dx: 10, dy: 10)
@@ -30,6 +43,8 @@ final class CanvasMinimapView: NSView {
         layer?.shadowOpacity = 0.18
         layer?.shadowRadius = 10
         layer?.shadowOffset = CGSize(width: 0, height: -2)
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
     }
 
     @available(*, unavailable)
@@ -42,16 +57,51 @@ final class CanvasMinimapView: NSView {
         addCursorRect(bounds, cursor: .openHand)
     }
 
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        self.trackingArea = trackingArea
+        addTrackingArea(trackingArea)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        beginInteraction()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        endInteractionIfIdle()
+    }
+
     override func mouseDown(with event: NSEvent) {
-        recenter(at: convert(event.locationInWindow, from: nil), settled: false)
+        let point = convert(event.locationInWindow, from: nil)
+        isPointerInside = bounds.contains(point)
+        isDragging = true
+        beginInteraction()
+        recenter(at: point, settled: false)
     }
 
     override func mouseDragged(with event: NSEvent) {
-        recenter(at: convert(event.locationInWindow, from: nil), settled: false)
+        let point = convert(event.locationInWindow, from: nil)
+        isPointerInside = bounds.contains(point)
+        recenter(at: point, settled: false)
     }
 
     override func mouseUp(with event: NSEvent) {
-        recenter(at: convert(event.locationInWindow, from: nil), settled: true)
+        let point = convert(event.locationInWindow, from: nil)
+        isPointerInside = bounds.contains(point)
+        isDragging = false
+        recenter(at: point, settled: true)
+        endInteractionIfIdle()
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -77,6 +127,23 @@ final class CanvasMinimapView: NSView {
         } else {
             onCenterChanged?(center)
         }
+    }
+
+    private func beginInteraction() {
+        guard !isInteractionActive else { return }
+        isInteractionActive = true
+        onInteractionBegan?()
+    }
+
+    private func endInteractionIfIdle() {
+        guard !isPointerInside, !isDragging else { return }
+        endInteraction()
+    }
+
+    private func endInteraction() {
+        guard isInteractionActive else { return }
+        isInteractionActive = false
+        onInteractionEnded?()
     }
 
     private func drawBackground() {

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Initialization.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Initialization.swift
@@ -5,12 +5,16 @@ extension CanvasRootView {
     public convenience init(
         model: CanvasModel,
         commandScrollHintText: String,
+        minimapAccessibilityLabel: String = "",
+        minimapAccessibilityHelp: String = "",
         callbacks: CanvasHostCallbacks,
         themeProvider: @escaping () -> CanvasTheme
     ) {
         self.init(
             model: model,
             commandScrollHintText: commandScrollHintText,
+            minimapAccessibilityLabel: minimapAccessibilityLabel,
+            minimapAccessibilityHelp: minimapAccessibilityHelp,
             callbacks: callbacks,
             themeProvider: themeProvider,
             minimapClock: ContinuousClock()

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
@@ -53,6 +53,7 @@ extension CanvasRootView {
 
     func resetMinimapVisibility() {
         isMinimapInteractionActive = false
+        minimapView.resetInteractionState()
         minimapAutoHideScheduler.cancel()
         minimapView.alphaValue = 0
         minimapView.isHidden = true

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
@@ -44,12 +44,15 @@ extension CanvasRootView {
         minimapView.snapshot = snapshot
         if !snapshot.shouldShow {
             resetMinimapVisibility()
+        } else if isMinimapInteractionActive {
+            holdMinimapVisible()
         } else if reveal {
             showMinimapTemporarily()
         }
     }
 
     func resetMinimapVisibility() {
+        isMinimapInteractionActive = false
         minimapAutoHideScheduler.cancel()
         minimapView.alphaValue = 0
         minimapView.isHidden = true
@@ -60,12 +63,14 @@ extension CanvasRootView {
             resetMinimapVisibility()
             return
         }
+        isMinimapInteractionActive = true
         minimapAutoHideScheduler.cancel()
         minimapView.isHidden = false
         minimapView.alphaValue = Self.minimapVisibleAlpha
     }
 
     func releaseMinimapAfterInteraction() {
+        isMinimapInteractionActive = false
         guard minimapView.snapshot.shouldShow else {
             resetMinimapVisibility()
             return
@@ -95,6 +100,10 @@ extension CanvasRootView {
 
     private func hideMinimap(animated: Bool) {
         minimapAutoHideScheduler.cancel()
+        guard !isMinimapInteractionActive else {
+            holdMinimapVisible()
+            return
+        }
         guard !minimapView.isHidden || minimapView.alphaValue != 0 else { return }
         if animated {
             NSAnimationContext.runAnimationGroup({ context in

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
@@ -41,8 +41,29 @@ extension CanvasRootView {
         minimapView.isHidden = true
     }
 
+    func holdMinimapVisible() {
+        guard syncMinimapOverlayHost() else {
+            resetMinimapVisibility()
+            return
+        }
+        minimapAutoHideScheduler.cancel()
+        minimapView.isHidden = false
+        minimapView.alphaValue = Self.minimapVisibleAlpha
+    }
+
+    func releaseMinimapAfterInteraction() {
+        guard minimapView.snapshot.shouldShow else {
+            resetMinimapVisibility()
+            return
+        }
+        showMinimapTemporarily()
+    }
+
     private func showMinimapTemporarily() {
-        syncMinimapOverlayHost()
+        guard syncMinimapOverlayHost() else {
+            resetMinimapVisibility()
+            return
+        }
         let shouldAnimateIn = minimapView.isHidden || minimapView.alphaValue < Self.minimapVisibleAlpha
         minimapView.isHidden = false
         if shouldAnimateIn {

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Minimap.swift
@@ -4,6 +4,20 @@ extension CanvasRootView {
     private static let minimapVisibleAlpha: CGFloat = 0.92
     private static let minimapAutoHideDelay: Duration = .seconds(3)
 
+    func configureMinimap(accessibilityLabel: String, accessibilityHelp: String) {
+        minimapView.onCenterChanged = { [weak self] center in
+            self?.setViewport(center: center, magnification: nil, notifySettled: false)
+        }
+        minimapView.onCenterSettled = { [weak self] center in
+            self?.setViewport(center: center, magnification: nil, notifySettled: true)
+        }
+        minimapView.onScrollWheel = { [weak self] event in self?.scrollView.scrollWheel(with: event) }
+        minimapView.onInteractionBegan = { [weak self] in self?.holdMinimapVisible() }
+        minimapView.onInteractionEnded = { [weak self] in self?.releaseMinimapAfterInteraction() }
+        minimapView.accessibilityLabelText = accessibilityLabel
+        minimapView.accessibilityHelpText = accessibilityHelp
+    }
+
     func updateMinimap(reveal: Bool = false) {
         guard isWorkspaceVisible else {
             resetMinimapVisibility()

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+MinimapOverlay.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+MinimapOverlay.swift
@@ -3,9 +3,11 @@ import AppKit
 extension CanvasRootView {
     private static let minimapOverlaySize = CGSize(width: 168, height: 112)
     private static let minimapOverlayInset: CGFloat = 14
+    private static let minimapOverlayMinimumSize = CGSize(width: 96, height: 64)
 
-    func syncMinimapOverlayHost() {
-        guard let window, let container = window.contentView?.superview ?? window.contentView else { return }
+    @discardableResult
+    func syncMinimapOverlayHost() -> Bool {
+        let container = window?.contentView?.superview ?? window?.contentView ?? self
         if minimapView.superview !== container {
             minimapView.removeFromSuperview()
             minimapView.translatesAutoresizingMaskIntoConstraints = true
@@ -14,23 +16,50 @@ extension CanvasRootView {
         } else if container.subviews.last !== minimapView {
             container.addSubview(minimapView, positioned: .above, relativeTo: nil)
         }
-        positionMinimapOverlay(in: container)
+        return positionMinimapOverlay(in: container)
     }
 
     func detachMinimapOverlay() {
         minimapView.removeFromSuperview()
     }
 
-    private func positionMinimapOverlay(in container: NSView) {
+    @discardableResult
+    private func positionMinimapOverlay(in container: NSView) -> Bool {
         let rootRect = container.convert(bounds, from: self)
+        guard let frame = Self.minimapOverlayFrame(
+            rootRect: rootRect,
+            containerIsFlipped: container.isFlipped
+        ) else {
+            minimapView.frame = .zero
+            return false
+        }
+        minimapView.frame = frame
+        return true
+    }
+
+    static func minimapOverlayFrame(rootRect: CGRect, containerIsFlipped: Bool) -> CGRect? {
         let size = Self.minimapOverlaySize
         let inset = Self.minimapOverlayInset
-        let y = container.isFlipped ? rootRect.maxY - inset - size.height : rootRect.minY + inset
-        minimapView.frame = CGRect(
-            x: rootRect.maxX - inset - size.width,
+        let maxWidth = rootRect.width - inset * 2
+        let maxHeight = rootRect.height - inset * 2
+        guard maxWidth >= Self.minimapOverlayMinimumSize.width,
+              maxHeight >= Self.minimapOverlayMinimumSize.height else {
+            return nil
+        }
+
+        let resolvedSize = CGSize(
+            width: min(size.width, maxWidth),
+            height: min(size.height, maxHeight)
+        )
+        let x = rootRect.maxX - inset - resolvedSize.width
+        let y = containerIsFlipped
+            ? rootRect.maxY - inset - resolvedSize.height
+            : rootRect.minY + inset
+        return CGRect(
+            x: x,
             y: y,
-            width: size.width,
-            height: size.height
+            width: resolvedSize.width,
+            height: resolvedSize.height
         ).integral
     }
 }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
@@ -22,6 +22,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             model.bringToFront(panelId)
         }
         applyZOrder()
+        holdMinimapVisible()
         updateMinimap(reveal: true)
     }
 
@@ -89,10 +90,19 @@ extension CanvasRootView: CanvasPaneViewDelegate {
 
     func paneViewDidEndDrag(_ view: CanvasPaneView) {
         guidesView.setJoinHighlight(nil)
-        guard let session = dragSession,
-              let panelId = model.layout.selectedPanelId(in: session.paneID)?.rawValue else { return }
+        guard let session = dragSession else {
+            releaseMinimapAfterInteraction()
+            return
+        }
         dragSession = nil
+        defer {
+            releaseMinimapAfterInteraction()
+        }
         guidesView.setGuides([])
+        guard let panelId = model.layout.selectedPanelId(in: session.paneID)?.rawValue else {
+            updateMinimap(reveal: true)
+            return
+        }
 
         // Dropping a single-tab pane onto another pane's tab bar joins it as
         // a tab there (the canvas twin of bonsplit's tab drop).
@@ -148,6 +158,8 @@ extension CanvasRootView: CanvasPaneViewDelegate {
                     lastFrame: frame,
                     lastPoint: point
                 )
+                holdMinimapVisible()
+                updateMinimap(reveal: true)
             }
             return
         }
@@ -162,7 +174,6 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         reconcilePanes()
         applyZOrder()
         applyAllPaneFrames()
-        updateMinimap(reveal: true)
         guard let paneID = model.paneID(containing: panelId) else { return }
         dragSession = DragSession(
             paneID: paneID,
@@ -172,6 +183,8 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             lastFrame: frame,
             lastPoint: point
         )
+        holdMinimapVisible()
+        updateMinimap(reveal: true)
         callbacks.onFocusPanel(panelId)
         callbacks.onViewportGeometryChanged(window)
     }

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
@@ -22,6 +22,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             model.bringToFront(panelId)
         }
         applyZOrder()
+        updateMinimap(reveal: true)
     }
 
     func paneView(_ view: CanvasPaneView, draggedTo documentPoint: CGPoint, modifiers: NSEvent.ModifierFlags) {
@@ -65,7 +66,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         paneViews[session.paneID]?.frame = documentRect(fromCanvas: session.lastFrame)
         guidesView.setGuides(result.guides)
         updateJoinHighlight(for: session, at: documentPoint)
-        updateMinimap()
+        updateMinimap(reveal: true)
         callbacks.onViewportGeometryChanged(window)
     }
 
@@ -104,7 +105,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             recomputeDocumentGeometry()
             applyAllPaneFrames()
             updateLifecycle()
-            updateMinimap()
+            updateMinimap(reveal: true)
             callbacks.onLayoutChanged()
             callbacks.onFocusPanel(panelId)
             callbacks.onViewportGeometryChanged(window)
@@ -115,7 +116,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         recomputeDocumentGeometry()
         applyAllPaneFrames()
         updateLifecycle()
-        updateMinimap()
+        updateMinimap(reveal: true)
         callbacks.onLayoutChanged()
         callbacks.onViewportGeometryChanged(window)
     }
@@ -161,7 +162,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         reconcilePanes()
         applyZOrder()
         applyAllPaneFrames()
-        updateMinimap()
+        updateMinimap(reveal: true)
         guard let paneID = model.paneID(containing: panelId) else { return }
         dragSession = DragSession(
             paneID: paneID,

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -17,6 +17,9 @@ public final class CanvasRootView: NSView {
     let minimapAutoHideScheduler: CanvasMinimapAutoHideScheduler
     /// Pre-localized text for the Command+scroll discovery hint.
     let commandScrollHintText: String
+    /// Pre-localized accessibility label/help for the minimap.
+    let minimapAccessibilityLabel: String
+    let minimapAccessibilityHelp: String
     let scrollView: CanvasScrollView
     let documentView = CanvasDocumentView()
     let guidesView = CanvasGuidesView()
@@ -71,12 +74,16 @@ public final class CanvasRootView: NSView {
     init<C: Clock & Sendable>(
         model: CanvasModel,
         commandScrollHintText: String,
+        minimapAccessibilityLabel: String,
+        minimapAccessibilityHelp: String,
         callbacks: CanvasHostCallbacks,
         themeProvider: @escaping () -> CanvasTheme, minimapClock: C
     ) where C.Duration == Duration {
         self.model = model
         self.callbacks = callbacks
         self.commandScrollHintText = commandScrollHintText
+        self.minimapAccessibilityLabel = minimapAccessibilityLabel
+        self.minimapAccessibilityHelp = minimapAccessibilityHelp
         self.themeProvider = themeProvider
         self.minimapAutoHideScheduler = CanvasMinimapAutoHideScheduler(clock: minimapClock)
         self.scrollView = CanvasScrollView(documentView: documentView)
@@ -100,6 +107,10 @@ public final class CanvasRootView: NSView {
             self?.setViewport(center: center, magnification: nil, notifySettled: true)
         }
         minimapView.onScrollWheel = { [weak self] event in self?.scrollView.scrollWheel(with: event) }
+        minimapView.onInteractionBegan = { [weak self] in self?.holdMinimapVisible() }
+        minimapView.onInteractionEnded = { [weak self] in self?.releaseMinimapAfterInteraction() }
+        minimapView.accessibilityLabelText = minimapAccessibilityLabel
+        minimapView.accessibilityHelpText = minimapAccessibilityHelp
         resetMinimapVisibility()
 
         // Platform seam: clip-view bounds changes are how AppKit reports
@@ -196,6 +207,8 @@ public final class CanvasRootView: NSView {
         minimapView.onCenterChanged = nil
         minimapView.onCenterSettled = nil
         minimapView.onScrollWheel = nil
+        minimapView.onInteractionBegan = nil
+        minimapView.onInteractionEnded = nil
         removeCommandScrollMonitor()
         if model.viewport === self {
             model.viewport = nil

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -17,9 +17,6 @@ public final class CanvasRootView: NSView {
     let minimapAutoHideScheduler: CanvasMinimapAutoHideScheduler
     /// Pre-localized text for the Command+scroll discovery hint.
     let commandScrollHintText: String
-    /// Pre-localized accessibility label/help for the minimap.
-    let minimapAccessibilityLabel: String
-    let minimapAccessibilityHelp: String
     let scrollView: CanvasScrollView
     let documentView = CanvasDocumentView()
     let guidesView = CanvasGuidesView()
@@ -82,8 +79,6 @@ public final class CanvasRootView: NSView {
         self.model = model
         self.callbacks = callbacks
         self.commandScrollHintText = commandScrollHintText
-        self.minimapAccessibilityLabel = minimapAccessibilityLabel
-        self.minimapAccessibilityHelp = minimapAccessibilityHelp
         self.themeProvider = themeProvider
         self.minimapAutoHideScheduler = CanvasMinimapAutoHideScheduler(clock: minimapClock)
         self.scrollView = CanvasScrollView(documentView: documentView)
@@ -100,17 +95,7 @@ public final class CanvasRootView: NSView {
         ])
         guidesView.autoresizingMask = [.width, .height]
         documentView.addSubview(guidesView)
-        minimapView.onCenterChanged = { [weak self] center in
-            self?.setViewport(center: center, magnification: nil, notifySettled: false)
-        }
-        minimapView.onCenterSettled = { [weak self] center in
-            self?.setViewport(center: center, magnification: nil, notifySettled: true)
-        }
-        minimapView.onScrollWheel = { [weak self] event in self?.scrollView.scrollWheel(with: event) }
-        minimapView.onInteractionBegan = { [weak self] in self?.holdMinimapVisible() }
-        minimapView.onInteractionEnded = { [weak self] in self?.releaseMinimapAfterInteraction() }
-        minimapView.accessibilityLabelText = minimapAccessibilityLabel
-        minimapView.accessibilityHelpText = minimapAccessibilityHelp
+        configureMinimap(accessibilityLabel: minimapAccessibilityLabel, accessibilityHelp: minimapAccessibilityHelp)
         resetMinimapVisibility()
 
         // Platform seam: clip-view bounds changes are how AppKit reports

--- a/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -21,6 +21,7 @@ public final class CanvasRootView: NSView {
     let documentView = CanvasDocumentView()
     let guidesView = CanvasGuidesView()
     let minimapView = CanvasMinimapView()
+    var isMinimapInteractionActive = false
     var paneViews: [CanvasPaneID: CanvasPaneView] = [:]
     /// One mount per pane: its selected tab's content. Keyed by panel id.
     private var mounts: [UUID: any CanvasPaneContentMounting] = [:]

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -27,6 +27,36 @@ struct CanvasMinimapViewTests {
         #expect(root.minimapView.alphaValue > 0)
     }
 
+    @Test func minimapDragRecenterDoesNotScheduleAutoHideUntilRelease() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+        root.holdMinimapVisible()
+
+        root.minimapView.mouseDown(
+            with: mouseEvent(
+                type: .leftMouseDown,
+                location: minimapWindowPoint(root, CGPoint(x: 40, y: 40))
+            )
+        )
+
+        #expect(root.isMinimapInteractionActive)
+        #expect(!root.minimapAutoHideScheduler.hasPendingHide)
+
+        root.minimapView.mouseUp(
+            with: mouseEvent(
+                type: .leftMouseUp,
+                location: minimapWindowPoint(root, CGPoint(x: root.minimapView.bounds.maxX + 24, y: 40))
+            )
+        )
+
+        #expect(!root.isMinimapInteractionActive)
+        #expect(root.minimapAutoHideScheduler.hasPendingHide)
+    }
+
     @Test func overlayFrameShrinksInsideNarrowRoot() {
         let frame = CanvasRootView.minimapOverlayFrame(
             rootRect: CGRect(x: 0, y: 0, width: 150, height: 100),
@@ -133,6 +163,14 @@ struct CanvasMinimapViewTests {
     }
 
     private func makeRootWithMinimapContent(panelA: UUID, panelB: UUID) -> CanvasRootView {
+        makeRootWithMinimapContent(panelA: panelA, panelB: panelB, minimapClock: ContinuousClock())
+    }
+
+    private func makeRootWithMinimapContent<C: Clock & Sendable>(
+        panelA: UUID,
+        panelB: UUID,
+        minimapClock: C
+    ) -> CanvasRootView where C.Duration == Duration {
         let model = CanvasModel(metricsProvider: {
             CanvasMetrics(gap: 16, snapThreshold: 8, minPaneSize: CanvasSize(width: 120, height: 80))
         })
@@ -152,7 +190,8 @@ struct CanvasMinimapViewTests {
             ),
             themeProvider: {
                 CanvasTheme(canvasBackground: .windowBackgroundColor, paneBackground: .windowBackgroundColor)
-            }
+            },
+            minimapClock: minimapClock
         )
         root.frame = CGRect(x: 0, y: 0, width: 640, height: 360)
         root.layoutSubtreeIfNeeded()
@@ -176,6 +215,10 @@ struct CanvasMinimapViewTests {
             closeActionLabel: "",
             makeMount: { _ in TestMount() }
         )
+    }
+
+    private func minimapWindowPoint(_ root: CanvasRootView, _ point: CGPoint) -> CGPoint {
+        CGPoint(x: root.minimapView.frame.minX + point.x, y: root.minimapView.frame.minY + point.y)
     }
 
     private func mouseEvent(type: NSEvent.EventType, location: CGPoint) -> NSEvent {

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -191,9 +191,4 @@ struct CanvasMinimapViewTests {
             pressure: 1
         )!
     }
-
-    private final class TestMount: CanvasPaneContentMounting {
-        func setRendering(_ rendering: Bool) {}
-        func unmount() {}
-    }
 }

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -27,6 +27,29 @@ struct CanvasMinimapViewTests {
         #expect(root.minimapView.alphaValue > 0)
     }
 
+    @Test func paneDragKeepsMinimapPinnedUntilDrop() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+
+        root.resetMinimapVisibility()
+        let paneID = root.model.paneID(containing: panelA)!
+        let paneView = root.paneViews[paneID]!
+        root.paneView(paneView, mouseDownAt: CGPoint(x: 20, y: 10), region: .titleBar)
+        root.paneView(paneView, draggedTo: CGPoint(x: 64, y: 18), modifiers: [])
+
+        #expect(root.isMinimapInteractionActive)
+        #expect(!root.minimapAutoHideScheduler.hasPendingHide)
+
+        root.paneViewDidEndDrag(paneView)
+
+        #expect(!root.isMinimapInteractionActive)
+        #expect(root.minimapAutoHideScheduler.hasPendingHide)
+    }
+
     @Test func minimapDragRecenterDoesNotScheduleAutoHideUntilRelease() {
         let panelA = UUID()
         let panelB = UUID()

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -80,6 +80,37 @@ struct CanvasMinimapViewTests {
         #expect(root.minimapAutoHideScheduler.hasPendingHide)
     }
 
+    @Test func resetClearsMinimapViewInteractionStateBeforeNextDrag() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+        root.holdMinimapVisible()
+        root.minimapView.mouseEntered(
+            with: mouseEvent(
+                type: .mouseMoved,
+                location: minimapWindowPoint(root, CGPoint(x: 40, y: 40))
+            )
+        )
+
+        root.resetMinimapVisibility()
+        root.updateMinimap(reveal: true)
+
+        #expect(root.minimapAutoHideScheduler.hasPendingHide)
+
+        root.minimapView.mouseDown(
+            with: mouseEvent(
+                type: .leftMouseDown,
+                location: minimapWindowPoint(root, CGPoint(x: 44, y: 42))
+            )
+        )
+
+        #expect(root.isMinimapInteractionActive)
+        #expect(!root.minimapAutoHideScheduler.hasPendingHide)
+    }
+
     @Test func overlayFrameShrinksInsideNarrowRoot() {
         let frame = CanvasRootView.minimapOverlayFrame(
             rootRect: CGRect(x: 0, y: 0, width: 150, height: 100),

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -7,6 +7,103 @@ import CmuxCanvas
 @MainActor
 @Suite("CanvasMinimapView")
 struct CanvasMinimapViewTests {
+    @Test func paneDragRevealsMinimap() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+
+        root.resetMinimapVisibility()
+        #expect(root.minimapView.isHidden)
+
+        let paneID = root.model.paneID(containing: panelA)!
+        let paneView = root.paneViews[paneID]!
+        root.paneView(paneView, mouseDownAt: CGPoint(x: 20, y: 10), region: .titleBar)
+        root.paneView(paneView, draggedTo: CGPoint(x: 64, y: 18), modifiers: [])
+
+        #expect(!root.minimapView.isHidden)
+        #expect(root.minimapView.alphaValue > 0)
+    }
+
+    @Test func overlayFrameShrinksInsideNarrowRoot() {
+        let frame = CanvasRootView.minimapOverlayFrame(
+            rootRect: CGRect(x: 0, y: 0, width: 150, height: 100),
+            containerIsFlipped: true
+        )
+
+        #expect(frame == CGRect(x: 14, y: 14, width: 122, height: 72))
+    }
+
+    @Test func overlayFrameIsNilWhenRootCannotFitUsableMinimap() {
+        let frame = CanvasRootView.minimapOverlayFrame(
+            rootRect: CGRect(x: 0, y: 0, width: 110, height: 80),
+            containerIsFlipped: true
+        )
+
+        #expect(frame == nil)
+    }
+
+    @Test func hoverKeepsInteractionActiveAfterMouseUpInside() {
+        let view = CanvasMinimapView(frame: CGRect(x: 0, y: 0, width: 160, height: 120))
+        view.snapshot = CanvasMinimapSnapshot(
+            panes: [
+                CanvasMinimapPaneSnapshot(
+                    id: CanvasPaneID(rawValue: UUID()),
+                    frame: CGRect(x: 0, y: 0, width: 1_000, height: 800)
+                ),
+            ],
+            visibleRect: CGRect(x: 100, y: 100, width: 200, height: 160),
+            focusedPaneID: nil
+        )
+        var beganCount = 0
+        var endedCount = 0
+        view.onInteractionBegan = { beganCount += 1 }
+        view.onInteractionEnded = { endedCount += 1 }
+
+        view.mouseEntered(with: mouseEvent(type: .mouseMoved, location: CGPoint(x: 40, y: 40)))
+        view.mouseDown(with: mouseEvent(type: .leftMouseDown, location: CGPoint(x: 40, y: 40)))
+        view.mouseUp(with: mouseEvent(type: .leftMouseUp, location: CGPoint(x: 100, y: 70)))
+
+        #expect(beganCount == 1)
+        #expect(endedCount == 0)
+
+        view.mouseExited(with: mouseEvent(type: .mouseMoved, location: CGPoint(x: 180, y: 70)))
+
+        #expect(beganCount == 1)
+        #expect(endedCount == 1)
+    }
+
+    @Test func dragExitEndsInteractionOnlyAfterMouseUpOutside() {
+        let view = CanvasMinimapView(frame: CGRect(x: 0, y: 0, width: 160, height: 120))
+        view.snapshot = CanvasMinimapSnapshot(
+            panes: [
+                CanvasMinimapPaneSnapshot(
+                    id: CanvasPaneID(rawValue: UUID()),
+                    frame: CGRect(x: 0, y: 0, width: 1_000, height: 800)
+                ),
+            ],
+            visibleRect: CGRect(x: 100, y: 100, width: 200, height: 160),
+            focusedPaneID: nil
+        )
+        var beganCount = 0
+        var endedCount = 0
+        view.onInteractionBegan = { beganCount += 1 }
+        view.onInteractionEnded = { endedCount += 1 }
+
+        view.mouseDown(with: mouseEvent(type: .leftMouseDown, location: CGPoint(x: 40, y: 40)))
+        view.mouseExited(with: mouseEvent(type: .mouseMoved, location: CGPoint(x: 180, y: 70)))
+
+        #expect(beganCount == 1)
+        #expect(endedCount == 0)
+
+        view.mouseUp(with: mouseEvent(type: .leftMouseUp, location: CGPoint(x: 180, y: 70)))
+
+        #expect(beganCount == 1)
+        #expect(endedCount == 1)
+    }
+
     @Test func dragSettlesOnlyOnMouseUp() {
         let pane = CanvasMinimapPaneSnapshot(
             id: CanvasPaneID(rawValue: UUID()),
@@ -35,6 +132,52 @@ struct CanvasMinimapViewTests {
         #expect(settledCenters.count == 1)
     }
 
+    private func makeRootWithMinimapContent(panelA: UUID, panelB: UUID) -> CanvasRootView {
+        let model = CanvasModel(metricsProvider: {
+            CanvasMetrics(gap: 16, snapThreshold: 8, minPaneSize: CanvasSize(width: 120, height: 80))
+        })
+        model.restoreFrames([
+            (id: panelA, frame: CGRect(x: 0, y: 0, width: 300, height: 220)),
+            (id: panelB, frame: CGRect(x: 520, y: 0, width: 300, height: 220)),
+        ])
+        let root = CanvasRootView(
+            model: model,
+            commandScrollHintText: "",
+            minimapAccessibilityLabel: "Canvas minimap",
+            minimapAccessibilityHelp: "Click or drag to move the canvas viewport",
+            callbacks: CanvasHostCallbacks(
+                onFocusPanel: { _ in },
+                onClosePanel: { _ in },
+                onLayoutChanged: {}
+            ),
+            themeProvider: {
+                CanvasTheme(canvasBackground: .windowBackgroundColor, paneBackground: .windowBackgroundColor)
+            }
+        )
+        root.frame = CGRect(x: 0, y: 0, width: 640, height: 360)
+        root.layoutSubtreeIfNeeded()
+        root.sync(
+            descriptors: [
+                descriptor(id: panelA, title: "A", focused: true),
+                descriptor(id: panelB, title: "B", focused: false),
+            ],
+            focusedPanelId: panelA,
+            isWorkspaceVisible: true
+        )
+        root.layoutSubtreeIfNeeded()
+        return root
+    }
+
+    private func descriptor(id: UUID, title: String, focused: Bool) -> CanvasPaneDescriptor {
+        CanvasPaneDescriptor(
+            id: id,
+            tab: CanvasTabChrome(id: id, title: title, iconSystemName: nil),
+            isFocused: focused,
+            closeActionLabel: "",
+            makeMount: { _ in TestMount() }
+        )
+    }
+
     private func mouseEvent(type: NSEvent.EventType, location: CGPoint) -> NSEvent {
         NSEvent.mouseEvent(
             with: type,
@@ -47,5 +190,10 @@ struct CanvasMinimapViewTests {
             clickCount: 1,
             pressure: 1
         )!
+    }
+
+    private final class TestMount: CanvasPaneContentMounting {
+        func setRendering(_ rendering: Bool) {}
+        func unmount() {}
     }
 }

--- a/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/TestMount.swift
+++ b/Packages/CmuxCanvasUI/Tests/CmuxCanvasUITests/TestMount.swift
@@ -1,0 +1,6 @@
+@testable import CmuxCanvasUI
+
+final class TestMount: CanvasPaneContentMounting {
+    func setRendering(_ rendering: Bool) {}
+    func unmount() {}
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -67,7 +67,9 @@ enum ComposerDictationState: Equatable {
 /// composer always reads `base` + the latest transcript and never accumulates
 /// stale partials. The base is preserved verbatim so text the user typed before
 /// starting is never clobbered.
-enum ComposerDictationTextMerge {
+struct ComposerDictationTextMerge {
+    private init() {}
+
     /// Combine the captured base text with the current transcript.
     ///
     /// - A trailing run of whitespace on the base is preserved (the user may

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -130,6 +130,14 @@ private struct CanvasRootRepresentable: NSViewRepresentable {
                 localized: "canvas.commandScrollHint",
                 defaultValue: "Command+scroll pans the canvas from anywhere"
             ),
+            minimapAccessibilityLabel: String(
+                localized: "canvas.minimap.accessibilityLabel",
+                defaultValue: "Canvas minimap"
+            ),
+            minimapAccessibilityHelp: String(
+                localized: "canvas.minimap.accessibilityHelp",
+                defaultValue: "Click or drag to move the canvas viewport"
+            ),
             callbacks: CanvasHostCallbacks(
                 onFocusPanel: { [weak workspace] panelId in
                     guard let workspace else { return }


### PR DESCRIPTION
## Summary
- Reveal the canvas minimap while panes are moved, resized, joined, or otherwise repositioned, not only after viewport scroll.
- Keep the minimap visible while hovered or dragged, clamp the overlay in narrow canvas roots, and expose localized accessibility label/help text.
- Cover pane-drag reveal, hover/drag interaction state, and narrow-root overlay sizing in `CmuxCanvasUI` tests.

## Testing
- `swift test --package-path Packages/CmuxCanvasUI`
- `swift test --package-path Packages/CmuxCanvas`
- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- Localization audit: `canvas.minimap.accessibilityLabel` and `canvas.minimap.accessibilityHelp` include the same locale set as nearby canvas strings.
- Tagged reload: `./scripts/reload-cloud.sh --tag task-canvas-minimap-polish` fell back to local `./scripts/reload.sh --tag task-canvas-minimap-polish` and succeeded.
- Preflight: launched the tagged app, used View > Toggle Canvas Layout, View > Split Right, dragged a canvas pane, and confirmed the minimap remained visible with accessibility description `Canvas minimap`. Screenshot: `/tmp/cmux-canvas-preflight-D2.png`.

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/1221

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784173803&installation_id=133855650&pr_number=6220&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6220&signature=6faf4dc1ef943c01398fc2f72ab9eed4a29ad561cd447feaa37ddad211bb2611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the canvas minimap: it reveals during pane moves and stays visible while hovered or dragged, only auto-hiding after release or pointer exit. The overlay shrinks to fit (hidden below 96×64) and now includes localized accessibility label/help.

- **New Features**
  - Reveal during pane drag/resize/join via `updateMinimap(reveal: true)`; pin during minimap/pane hover/drag and auto-hide after release/exit.
  - Reset clears minimap interaction state to avoid stuck pinning.
  - Clamp/shrink overlay in narrow roots; hide if smaller than 96×64. Localized `minimapAccessibilityLabel`/`minimapAccessibilityHelp` wired in `WorkspaceCanvasHostView`.

- **Refactors**
  - Extract minimap setup into `configureMinimap`; add overlay frame helper and guard overlay host sync.
  - Move canvas UI test mount helper into `CmuxCanvasUI` tests as `TestMount`.

<sup>Written for commit b00089f21177c1a31a49d77bedc18d172e3c7c7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Minimap now remains visible while actively being used and resumes auto-hide after interaction concludes
  - Added accessibility labels and help text support for the minimap

* **Localization**
  - Extended localization coverage with minimap accessibility strings across supported languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->