### PR TITLE
[codex] Avoid SF Symbols in layout toolbar toggle

### DIFF
--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -211,11 +211,11 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             segmented.segmentCount = 2
             segmented.controlSize = .small
             segmented.setImage(
-                NSImage(systemSymbolName: "rectangle.split.2x1", accessibilityDescription: nil),
+                LayoutModeToolbarImages.splits,
                 forSegment: LayoutModeSegment.splits.rawValue
             )
             segmented.setImage(
-                NSImage(systemSymbolName: "square.on.square.dashed", accessibilityDescription: nil),
+                LayoutModeToolbarImages.canvas,
                 forSegment: LayoutModeSegment.canvas.rawValue
             )
             segmented.setToolTip(
@@ -260,4 +260,57 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
         }
     }
 
+}
+
+@MainActor
+private enum LayoutModeToolbarImages {
+    static let splits = makeImage { rect in
+        let outer = NSBezierPath(roundedRect: rect, xRadius: 2.5, yRadius: 2.5)
+        outer.lineWidth = 1.4
+        outer.stroke()
+
+        let divider = NSBezierPath()
+        divider.move(to: NSPoint(x: rect.midX, y: rect.minY + 1.0))
+        divider.line(to: NSPoint(x: rect.midX, y: rect.maxY - 1.0))
+        divider.lineWidth = 1.2
+        divider.stroke()
+    }
+
+    static let canvas = makeImage { rect in
+        let backRect = NSRect(
+            x: rect.minX + 1.0,
+            y: rect.minY + 1.0,
+            width: rect.width - 5.0,
+            height: rect.height - 5.0
+        )
+        let frontRect = NSRect(
+            x: rect.minX + 5.0,
+            y: rect.minY + 5.0,
+            width: rect.width - 5.0,
+            height: rect.height - 5.0
+        )
+
+        let back = NSBezierPath(roundedRect: backRect, xRadius: 2.0, yRadius: 2.0)
+        back.lineWidth = 1.2
+        back.stroke()
+
+        let front = NSBezierPath(roundedRect: frontRect, xRadius: 2.0, yRadius: 2.0)
+        front.lineWidth = 1.4
+        front.stroke()
+    }
+
+    private static func makeImage(draw: @escaping (NSRect) -> Void) -> NSImage {
+        let size = NSSize(width: 16, height: 16)
+        let image = NSImage(size: size, flipped: false) { bounds in
+            // macOS 27 betas can throw while CoreUI rasterizes named SF Symbol
+            // glyphs inside titlebar toolbar controls. These local template
+            // images keep the toolbar off that code path.
+            NSGraphicsContext.current?.shouldAntialias = true
+            NSColor.black.setStroke()
+            draw(bounds.insetBy(dx: 1.5, dy: 1.5))
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the layout-mode toolbar segmented-control SF Symbols with local AppKit-drawn template images.
- Keep the existing toolbar behavior, labels, and tooltips unchanged.

## Why
The macOS 27 beta crash report points at CoreUI/SF Symbol glyph rasterization while rendering the titlebar toolbar. The layout toggle was using `rectangle.split.2x1` and `square.on.square.dashed` inside the main `NSToolbar`, so this moves that control off the named-vector-glyph path.

## Validation
- `git diff --check`
- `PATH="$HOME/.cache/cmux/tools/zig-aarch64-macos-0.15.2:$PATH" CMUX_ZIG="$HOME/.cache/cmux/tools/zig-aarch64-macos-0.15.2/zig" CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag toolbar-symbol-crash --launch`
- Opened the tagged dev app via LaunchServices and confirmed it remained running without a new `cmux` crash report in `~/Library/Logs/DiagnosticReports`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784175176&installation_id=133855650&pr_number=6229&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6229&signature=a931ed89b2e3c1783ef249b4d6aae35f6e800faff17daaf63935a337abf3d78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced SF Symbol icons in the layout-mode toolbar toggle with locally drawn AppKit template images to prevent a macOS 27 beta crash in CoreUI glyph rasterization. Toolbar behavior, labels, and tooltips are unchanged.

- **Bug Fixes**
  - Swapped `rectangle.split.2x1` and `square.on.square.dashed` for `LayoutModeToolbarImages.splits` and `.canvas` drawn with AppKit.
  - Keeps the titlebar toolbar off the SF Symbol rasterization code path on macOS 27 betas.

<sup>Written for commit 0f991ef8392ef9d14ae1b2711429ecbd6c58a1db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

