### PR TITLE
iOS Devices sheet: add + remove devices

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryRefreshing.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryRefreshing.swift
@@ -34,6 +34,17 @@ public protocol DeviceRegistryRefreshing: Sendable {
     /// after the token/scope changed must NOT keep the previous scope's
     /// team-device data visible.
     func listDevices() async -> DeviceRegistryListOutcome
+
+    /// Remove the caller's registration for the given device from the team-scoped
+    /// registry (`DELETE /api/devices`), the same server path `cmux remotes remove`
+    /// uses. Scoped server-side to the caller's own row, so a co-member cannot
+    /// remove another member's registered Mac.
+    ///
+    /// - Returns: `true` when the server confirmed a row was deleted, `false`
+    ///   otherwise (no such device, not owned by the caller, or the request
+    ///   failed). Best-effort: a transient failure returns `false` rather than
+    ///   throwing, so the caller can still drop the local pairing.
+    func removeDevice(deviceID: String) async -> Bool
 }
 
 /// The outcome of a device-list registry read, distinguishing the cases that

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -190,7 +190,47 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
         return .ok(devices)
     }
 
+    public func removeDevice(deviceID: String) async -> Bool {
+        let trimmed = deviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let request = await makeRequest(
+                method: "DELETE",
+                path: "/api/devices",
+                body: ["deviceId": trimmed]
+              ) else {
+            return false
+        }
+        do {
+            let (responseData, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+                return false
+            }
+            // The server returns `{ ok, deleted }`; report whether a row was
+            // actually removed so the caller does not claim a registry removal
+            // that hit nothing (e.g. a device owned by another team member).
+            return Self.parseDeleteDeleted(in: responseData)
+        } catch {
+            deviceRegistryLog.debug("removeDevice request failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
     // MARK: - Parsing (pure, testable)
+
+    /// Decode the `DELETE /api/devices` response, returning whether the server
+    /// reported a row as deleted. A `deleted` count > 0 is a confirmed removal;
+    /// an absent/zero count (device not found or not owned by the caller) is
+    /// `false`. An undecodable body is treated as "not deleted" so a contract
+    /// glitch never reports a phantom removal.
+    static func parseDeleteDeleted(in data: Data) -> Bool {
+        struct DeleteResponse: Decodable {
+            let deleted: Int?
+        }
+        guard let decoded = try? JSONDecoder().decode(DeleteResponse.self, from: data) else {
+            return false
+        }
+        return (decoded.deleted ?? 0) > 0
+    }
 
     /// Decode the `/api/devices` list response into the full two-level device
     /// tree (devices → app instances), for the device tree UI. Returns `nil` only

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1923,6 +1923,63 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         await loadPairedMacs()
     }
 
+    /// Remove a device shown in the device tree, routing to the correct backing
+    /// store(s).
+    ///
+    /// The device tree's source is either the team-scoped registry
+    /// (``registryDevices``) or, when the registry is unreachable, the locally
+    /// paired Macs (``deviceTreeDevices``'s fallback). Removal mirrors that:
+    ///
+    /// - A **registry-backed** device (its id appears in ``registryDevices``) is
+    ///   removed from the registry via `DELETE /api/devices` (the same path
+    ///   `cmux remotes remove` uses), then the registry tree is reloaded so the
+    ///   row disappears. We still drop any matching local pairing so a forgotten
+    ///   registry device cannot silently auto-reconnect from the local store.
+    /// - A **local-only** device (registry empty / not present, known only as a
+    ///   paired Mac) is forgotten from the local paired-Mac store via
+    ///   ``forgetMac(macDeviceID:)``; there is no registry row to delete.
+    ///
+    /// Best-effort throughout: a registry-delete failure still removes the local
+    /// pairing so the user is not stuck with an undeletable row, and the tree
+    /// reload reflects the authoritative server state on the next refresh.
+    ///
+    /// - Parameter deviceID: The device's registry/cmux device id (the tree row id).
+    public func removeDevice(deviceID: String) async {
+        let isRegistryBacked = registryDevices.contains { $0.deviceId == deviceID }
+        // Always drop the local pairing for this device id (if any) so a removed
+        // device cannot reconnect from the local store. `forgetMac` also tears
+        // down the live connection when this is the active Mac and reloads the
+        // local paired list.
+        await forgetMac(macDeviceID: deviceID)
+        guard isRegistryBacked, let deviceRegistry else { return }
+        let deleted = await deviceRegistry.removeDevice(deviceID: deviceID)
+        if !deleted {
+            mobileShellLog.error(
+                "registry device remove did not delete a row device=\(deviceID, privacy: .public)"
+            )
+        }
+        // Reload from the authoritative registry regardless: a confirmed delete
+        // drops the row, and a no-op delete (already gone, or not owned) still
+        // reconciles the tree to the server's truth rather than leaving a stale row.
+        await loadRegistryDevices()
+    }
+
+    // MARK: - Add device request
+
+    /// A monotonically increasing token bumped by ``requestAddDevice()``. The root
+    /// view observes changes and presents the existing add-device (pairing) sheet,
+    /// so every entrypoint (disconnected shell button, device tree bottom button)
+    /// drives the one shared add-device flow rather than each owning its own sheet.
+    public private(set) var addDeviceRequest: Int = 0
+
+    /// Request the shared add-device flow. Bumps ``addDeviceRequest`` so the root
+    /// view presents the pairing sheet. Used by surfaces (like the device tree)
+    /// that are themselves presented as a sheet and so cannot own the pairing
+    /// sheet directly.
+    public func requestAddDevice() {
+        addDeviceRequest &+= 1
+    }
+
     static func firstReconnectHostPortRoute(
         _ routes: [CmxAttachRoute],
         supportedKinds: [CmxAttachTransportKind]

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceTreeRemoveDeviceTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceTreeRemoveDeviceTests.swift
@@ -1,0 +1,127 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``MobileShellComposite/removeDevice(deviceID:)`` routing:
+/// a registry-backed device must be deleted from the team-scoped registry AND
+/// dropped from the local paired-Mac store, while a device known only locally
+/// (registry empty, fallback tree) must be forgotten locally WITHOUT a registry
+/// `DELETE` call. This is the exact split the Devices sheet's remove affordance
+/// depends on, so it is covered at the store-behavior level rather than the UI.
+@MainActor
+@Suite struct DeviceTreeRemoveDeviceTests {
+    private static func makeStore(
+        pairedMacStore: any MobilePairedMacStoring,
+        registry: RecordingDeviceRegistry
+    ) -> MobileShellComposite {
+        MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedMacStore,
+            deviceRegistry: registry,
+            identityProvider: FixedIdentityProvider(userID: "user-1")
+        )
+    }
+
+    private static func temporaryStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("device-tree-remove-\(UUID().uuidString).sqlite3")
+    }
+
+    @Test func removingRegistryBackedDeviceDeletesRegistryRowAndLocalPairing() async throws {
+        let dbURL = Self.temporaryStoreURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let paired = try MobilePairedMacStore(databaseURL: dbURL)
+        // The device exists both in the local store and the registry tree.
+        try await paired.upsert(
+            macDeviceID: "dev-registry",
+            displayName: "Registry Mac",
+            routes: [],
+            markActive: false,
+            stackUserID: "user-1"
+        )
+        let registry = RecordingDeviceRegistry(initialDevices: [
+            RegistryDevice(
+                deviceId: "dev-registry",
+                platform: "mac",
+                displayName: "Registry Mac",
+                lastSeenAt: .distantPast,
+                instances: []
+            )
+        ])
+        let store = Self.makeStore(pairedMacStore: paired, registry: registry)
+        await store.loadPairedMacs()
+        await store.loadRegistryDevices()
+        #expect(store.registryDevices.contains { $0.deviceId == "dev-registry" })
+
+        await store.removeDevice(deviceID: "dev-registry")
+
+        // Registry-backed: the server DELETE ran for exactly this device id...
+        #expect(await registry.removedDeviceIDs == ["dev-registry"])
+        // ...the tree reload reflects the server having dropped the row...
+        #expect(store.registryDevices.contains { $0.deviceId == "dev-registry" } == false)
+        // ...and the local pairing was dropped so it cannot silently reconnect.
+        let remaining = try await paired.loadAll(stackUserID: "user-1")
+        #expect(remaining.contains { $0.macDeviceID == "dev-registry" } == false)
+    }
+
+    @Test func removingLocalOnlyDeviceForgetsLocallyWithoutRegistryDelete() async throws {
+        let dbURL = Self.temporaryStoreURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let paired = try MobilePairedMacStore(databaseURL: dbURL)
+        try await paired.upsert(
+            macDeviceID: "dev-local",
+            displayName: "Local Mac",
+            routes: [],
+            markActive: false,
+            stackUserID: "user-1"
+        )
+        // Registry returns no devices: the tree falls back to local paired Macs,
+        // so this device is local-only and must not trigger a registry DELETE.
+        let registry = RecordingDeviceRegistry(initialDevices: [])
+        let store = Self.makeStore(pairedMacStore: paired, registry: registry)
+        await store.loadPairedMacs()
+        await store.loadRegistryDevices()
+        #expect(store.registryDevices.isEmpty)
+
+        await store.removeDevice(deviceID: "dev-local")
+
+        // Local-only: no registry DELETE was attempted...
+        #expect(await registry.removedDeviceIDs.isEmpty)
+        // ...but the local pairing was forgotten.
+        let remaining = try await paired.loadAll(stackUserID: "user-1")
+        #expect(remaining.contains { $0.macDeviceID == "dev-local" } == false)
+    }
+}
+
+/// A stateful ``DeviceRegistryRefreshing`` test double. `listDevices` returns its
+/// current device set and `removeDevice` deletes from it (recording the call), so
+/// the store's `loadRegistryDevices()` reconcile after a remove sees the row gone
+/// exactly as it would against the real server.
+private actor RecordingDeviceRegistry: DeviceRegistryRefreshing {
+    private(set) var removedDeviceIDs: [String] = []
+    private var devices: [RegistryDevice]
+
+    init(initialDevices: [RegistryDevice]) {
+        self.devices = initialDevices
+    }
+
+    func freshRoutes(forMacDeviceID macDeviceID: String) async -> [CmxAttachRoute]? { nil }
+
+    func listDevices() async -> DeviceRegistryListOutcome { .ok(devices) }
+
+    func removeDevice(deviceID: String) async -> Bool {
+        removedDeviceIDs.append(deviceID)
+        let before = devices.count
+        devices.removeAll { $0.deviceId == deviceID }
+        return devices.count != before
+    }
+}
+
+private struct FixedIdentityProvider: MobileIdentityProviding {
+    let userID: String?
+    var currentUserID: String? { userID }
+    var currentUserEmail: String? { nil }
+}

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -152,6 +152,13 @@ struct CMUXMobileRootView: View {
                 clearAttachTicketAuthenticationIfNeeded()
             }
         }
+        // The shared add-device entrypoint. Surfaces presented as their own sheet
+        // (the device tree's bottom "Add device" button) cannot own the pairing
+        // sheet, so they bump `store.requestAddDevice()` and the root view turns
+        // that into `showAddDevice()`, the same flow the disconnected shell uses.
+        .onChange(of: store.addDeviceRequest) { _, _ in
+            showAddDevice()
+        }
     }
 
     @ViewBuilder

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeRows.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeRows.swift
@@ -17,6 +17,15 @@ enum DeviceTreePresence: Equatable {
     case offline(lastSeenAt: Date)
 }
 
+/// An immutable identifier + label for a device pending remove-confirmation.
+/// Captured out of the store so the confirmation alert holds values, not a
+/// store reference (snapshot-boundary rule).
+struct DeviceTreeRemovalTarget: Identifiable, Equatable {
+    let deviceId: String
+    let title: String
+    var id: String { deviceId }
+}
+
 /// Immutable per-device snapshot for the device (top-level) row.
 struct DeviceTreeDeviceSnapshot: Equatable {
     let deviceId: String
@@ -55,6 +64,10 @@ struct DeviceTreeDeviceRow: View {
     let device: DeviceTreeDeviceSnapshot
     let isExpanded: Bool
     let setExpanded: (Bool) -> Void
+    /// Ask to remove this device. The caller (the tree) raises a confirmation
+    /// before the destructive ``CMUXMobileShellStore/removeDevice(deviceID:)``
+    /// runs, so this closure only signals intent.
+    let requestRemove: () -> Void
 
     var body: some View {
         Button {
@@ -98,6 +111,27 @@ struct DeviceTreeDeviceRow: View {
                 ? L10n.string("mobile.deviceTree.collapseHint", defaultValue: "Collapse builds")
                 : L10n.string("mobile.deviceTree.expandHint", defaultValue: "Expand builds")
         )
+        // iOS-idiomatic destructive affordances, both routed through the same
+        // confirm-then-remove path: trailing swipe-to-delete and a long-press
+        // context menu. The list owns the confirmation alert.
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive, action: requestRemove) {
+                Label(
+                    L10n.string("mobile.deviceTree.remove", defaultValue: "Remove"),
+                    systemImage: "trash"
+                )
+            }
+            .accessibilityIdentifier("MobileDeviceTreeRemove-\(device.deviceId)")
+        }
+        .contextMenu {
+            Button(role: .destructive, action: requestRemove) {
+                Label(
+                    L10n.string("mobile.deviceTree.remove", defaultValue: "Remove"),
+                    systemImage: "trash"
+                )
+            }
+            .accessibilityIdentifier("MobileDeviceTreeRemoveMenu-\(device.deviceId)")
+        }
     }
 
     private var chevronSymbol: String {

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -42,6 +42,11 @@ struct DeviceTreeView: View {
         DeviceTreeExpansionStore(storage: expandedStorage)
     }
 
+    /// The device pending remove-confirmation, captured as a value snapshot (id +
+    /// title) so the confirmation alert never holds a store reference and the
+    /// `List` snapshot boundary stays intact.
+    @State private var pendingRemoval: DeviceTreeRemovalTarget?
+
     /// Devices the phone can attach to (mac/linux/windows hosts). The phone never
     /// controls itself, so an `ios` row is filtered out rather than shown as a
     /// tappable, dead host. Sourced from ``CMUXMobileShellStore/deviceTreeDevices``
@@ -85,8 +90,85 @@ struct DeviceTreeView: View {
                 await store.loadPairedMacs()
                 await store.loadRegistryDevices()
             }
+            // A full-width, bottom-anchored "Add device" button pinned below the
+            // list and above the home indicator. `safeAreaInset` keeps it visible
+            // while the list scrolls and respects the safe area automatically.
+            .safeAreaInset(edge: .bottom) {
+                addDeviceBar
+            }
+        }
+        .alert(
+            removalAlertTitle,
+            isPresented: removalAlertBinding,
+            presenting: pendingRemoval
+        ) { target in
+            Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
+                pendingRemoval = nil
+            }
+            Button(
+                L10n.string("mobile.deviceTree.removeConfirm", defaultValue: "Remove"),
+                role: .destructive
+            ) {
+                removeDevice(target)
+            }
+        } message: { target in
+            Text(removalAlertMessage(for: target))
         }
         .accessibilityIdentifier("MobileDeviceTree")
+    }
+
+    /// The bottom add-device button bar. Triggers the one shared add-device flow
+    /// through the store (`requestAddDevice`), which the root view turns into the
+    /// existing pairing sheet, then dismisses this sheet so the pairing sheet is
+    /// the only thing presented.
+    @ViewBuilder
+    private var addDeviceBar: some View {
+        Button {
+            store.requestAddDevice()
+            dismiss()
+        } label: {
+            Label(
+                L10n.string("mobile.addDevice.title", defaultValue: "Add device"),
+                systemImage: "plus"
+            )
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.bar)
+        .accessibilityIdentifier("MobileDeviceTreeAddDevice")
+    }
+
+    private var removalAlertBinding: Binding<Bool> {
+        Binding(
+            get: { pendingRemoval != nil },
+            set: { isPresented in
+                if !isPresented { pendingRemoval = nil }
+            }
+        )
+    }
+
+    private var removalAlertTitle: String {
+        L10n.string("mobile.deviceTree.removeTitle", defaultValue: "Remove Device?")
+    }
+
+    private func removalAlertMessage(for target: DeviceTreeRemovalTarget) -> String {
+        String(
+            format: L10n.string(
+                "mobile.deviceTree.removeMessageFormat",
+                defaultValue: "Remove \"%@\"? You can pair it again anytime."
+            ),
+            target.title
+        )
+    }
+
+    private func removeDevice(_ target: DeviceTreeRemovalTarget) {
+        pendingRemoval = nil
+        let store = store
+        Task { await store.removeDevice(deviceID: target.deviceId) }
     }
 
     @ViewBuilder
@@ -132,7 +214,13 @@ struct DeviceTreeView: View {
                     presence: presence
                 ),
                 isExpanded: expansion.isExpanded(deviceExpansionID(device)),
-                setExpanded: { expanded in setExpanded(deviceExpansionID(device), expanded) }
+                setExpanded: { expanded in setExpanded(deviceExpansionID(device), expanded) },
+                requestRemove: {
+                    pendingRemoval = DeviceTreeRemovalTarget(
+                        deviceId: device.deviceId,
+                        title: device.title
+                    )
+                }
             )
 
             if expansion.isExpanded(deviceExpansionID(device)) {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1106,6 +1106,74 @@
         }
       }
     },
+    "mobile.deviceTree.remove": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "mobile.deviceTree.removeConfirm": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "mobile.deviceTree.removeMessageFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove “%@”? You can pair it again anytime."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」を削除しますか？いつでも再度ペアリングできます。"
+          }
+        }
+      }
+    },
+    "mobile.deviceTree.removeTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove Device?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイスを削除しますか？"
+          }
+        }
+      }
+    },
     "mobile.deviceTree.title": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
The Devices sheet (top-left Devices button, `DeviceTreeView`) now lets the user add and remove devices.

**Remove.** Each device row gets iOS-idiomatic trailing swipe-to-delete plus a long-press context menu "Remove", both routed through one confirm-then-remove path. The list owns a confirmation alert built from a value-snapshot target, so no store reference crosses below the `List` boundary. Removal is store-routed by source:
- A registry-backed device (present in `registryDevices`) is deleted from the team-scoped registry via `DELETE /api/devices` (the same server path `cmux remotes remove` uses), then the tree reloads. The matching local pairing is also dropped so a forgotten device cannot silently auto-reconnect from the local store.
- A local-only device (registry empty/unreachable, fallback tree) is forgotten from the local paired-Mac store via `forgetMac`, with no registry `DELETE`.

**Add.** A full-width, bottom-anchored "Add device" button pinned via `safeAreaInset(edge: .bottom)`, respecting the safe area. It drives the one shared add-device flow: it bumps `store.requestAddDevice()`, the root view turns that into `showAddDevice()` (the existing pairing sheet), and dismisses the Devices sheet so only the pairing sheet is presented. No duplicated add-device logic.

**Plumbing.** New `DeviceRegistryRefreshing.removeDevice(deviceID:)` + `DeviceRegistryService` implementation (`DELETE /api/devices`, parses `{deleted}`). Store gains `removeDevice(deviceID:)` and the `requestAddDevice()` signal.

**Test.** Swift Testing behavior test covers the remove routing split: registry-backed removal hits the registry `DELETE` and drops the local pairing; local-only removal forgets locally with no registry call. Passing locally.

**Localization.** All new user-facing strings have en + ja entries in `ios/cmux/Resources/Localizable.xcstrings`.

Dogfood-gated UI change; do not merge before user dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784175656&installation_id=133855650&pr_number=6230&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6230&signature=ee76282d61fe004f019c2dd17ebf6e7a931ffb94ff9071dbef7fa9066cf1db6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 202deeaea70e29382576d9a730deacba6a2d9e1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds add/remove to the iOS Devices sheet. Users can swipe to delete with a confirm alert and use a bottom “Add device” button that opens the existing pairing flow. Dogfood-gated.

- New Features
  - Remove: trailing swipe-to-delete and long-press “Remove,” both with a single confirm-then-remove path owned by the list. Registry-backed devices call DELETE `/api/devices`, then reload; local-only devices are forgotten locally. Local pairing is always dropped.
  - Add: a bottom “Add device” bar pinned with `safeAreaInset`. It calls `store.requestAddDevice()`, the root presents the existing pairing sheet, and the Devices sheet dismisses.
  - Plumbing: `DeviceRegistryRefreshing.removeDevice(deviceID:)` with `DeviceRegistryService` DELETE implementation that parses `{deleted}`. Store adds `removeDevice(deviceID:)`, `requestAddDevice()`, and `addDeviceRequest` observed by the root view.
  - Tests/Localization: behavior tests cover registry vs local remove routing. New strings added in en + ja.

<sup>Written for commit 202deeaea70e29382576d9a730deacba6a2d9e1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now remove devices from the device list using swipe-to-delete or context menu options with confirmation.
  * Added an "Add device" button to the device tree view for convenient device pairing access.

* **Tests**
  * Added test coverage for device removal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->