### PR TITLE
CI: remove unused cache and deflake display setup

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -73,11 +73,16 @@ jobs:
           key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
           restore-keys: zig-packages-
 
-      - name: Build GhosttyKit.xcframework
+      - name: Install zig
         if: steps.check-release.outputs.exists == 'false'
         run: |
           set -euo pipefail
           ./scripts/install-zig-ci.sh
+
+      - name: Build GhosttyKit.xcframework
+        if: steps.check-release.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
           cd ghostty && zig build -Dcrash-report-subdir="$GHOSTTYKIT_CRASH_REPORT_SUBDIR" -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Package xcframework

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -170,10 +170,34 @@ jobs:
           echo ""
           clang -framework Foundation -framework CoreGraphics \
             -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
+          VDISPLAY_READY="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.ready"
+          VDISPLAY_ID_PATH="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.id"
+          VDISPLAY_LOG="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+          /tmp/create-virtual-display \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            > "$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PID=$!
           echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
+          for _ in {1..24}; do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+              echo "Virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "Timed out waiting for virtual display readiness" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+          cat "$VDISPLAY_LOG"
+          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
           echo "=== Display after ==="
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(no display info)"
 

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -96,6 +96,9 @@ jobs:
           key: spm-${{ matrix.os }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ matrix.os }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,17 @@ jobs:
       - name: Validate xcodebuild noninteractive crash prompt guard
         run: python3 tests/test_ci_xcodebuild_noninteractive_helper.py
 
+      - name: Validate Xcode SourcePackages cache sanitizer
+        run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
+
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 
       - name: Validate GhosttyKit checksum verification
         run: ./tests/test_ci_ghosttykit_checksum_verification.sh
+
+      - name: Validate Zig install without sudo
+        run: ./tests/test_install_zig_ci_no_sudo.sh
 
       - name: Validate nightly tag push auth
         run: ./tests/test_ci_nightly_tag_push_auth.sh
@@ -285,6 +291,9 @@ jobs:
           path: .ci-source-packages
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
 
       - name: Prepare isolated DerivedData
         run: |
@@ -654,6 +663,9 @@ jobs:
           key: spm-build-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-build-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail
@@ -912,6 +924,9 @@ jobs:
             spm-release-
             spm-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Build universal app (Release)
         run: |
           set -euo pipefail
@@ -1018,6 +1033,9 @@ jobs:
           path: .ci-source-packages
           key: spm-ui-regressions-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-ui-regressions-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,11 +713,34 @@ jobs:
           set -euo pipefail
           clang -framework Foundation -framework CoreGraphics \
             -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
+          VDISPLAY_READY="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.ready"
+          VDISPLAY_ID_PATH="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.id"
+          VDISPLAY_LOG="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+          /tmp/create-virtual-display \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            > "$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PID=$!
           echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
-          kill -0 "$VDISPLAY_PID"
+          for _ in {1..24}; do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+              echo "Virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "Timed out waiting for virtual display readiness" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+          cat "$VDISPLAY_LOG"
+          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
 
       - name: Run workspace churn typing-lag regression
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,11 +575,9 @@ jobs:
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
-    # A cold DerivedData cache (any project.pbxproj or Package.resolved change
-    # mints a new cache key with no restore-keys fallback) forces a full
-    # cmux build whose Swift codegen alone can run 20+ min. Project/package
-    # changes from the sidebar extension kit pushed this full build plus the
-    # CA and lag regressions beyond 35 min before the cache could repopulate.
+    # This job uses isolated DerivedData under RUNNER_TEMP, so it deliberately
+    # avoids restoring the shared ~/Library DerivedData cache. Cold full builds
+    # can still run 20+ min before the CA and lag regressions execute.
     timeout-minutes: 55
     steps:
       - name: Checkout
@@ -648,12 +646,6 @@ jobs:
           path: ~/.cache/zig
           key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
           restore-keys: zig-packages-
-
-      - name: Cache DerivedData
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/Library/Developer/Xcode/DerivedData/cmux-*
-          key: deriveddata-build-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('cmux.xcodeproj/project.pbxproj') }}-${{ steps.ghostty-revision.outputs.sha }}
 
       - name: Cache Swift packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -133,13 +133,15 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
       - name: Provision GhosttyKit
         run: |
           # Downloads the prebuilt GhosttyKit.xcframework pinned in
           # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
           # falls back to a from-source build. The iOS app links GhosttyKit via
           # a local-path binaryTarget, so it must exist before package resolve.
-          ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
       - name: Materialize App Store Connect API key

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,6 +185,10 @@ jobs:
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
 
+      - name: Sanitize Swift package cache
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -97,6 +97,9 @@ jobs:
           key: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,10 @@ jobs:
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
 
+      - name: Sanitize Swift package cache
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Setup Go
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -105,10 +105,34 @@ jobs:
           echo ""
           clang -framework Foundation -framework CoreGraphics \
             -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
+          VDISPLAY_READY="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.ready"
+          VDISPLAY_ID_PATH="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.id"
+          VDISPLAY_LOG="${RUNNER_TEMP:-/tmp}/cmux-virtual-display.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+          /tmp/create-virtual-display \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            > "$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PID=$!
           echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
+          for _ in {1..24}; do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+              echo "Virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.5
+          done
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "Timed out waiting for virtual display readiness" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+          cat "$VDISPLAY_LOG"
+          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
           echo "=== Display after ==="
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(none)"
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -239,6 +239,9 @@ jobs:
           key: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -191,6 +191,10 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Install zig
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
+        run: ./scripts/install-zig-ci.sh
+
       - name: Provision GhosttyKit
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
         run: |
@@ -198,7 +202,6 @@ jobs:
           # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
           # falls back to a from-source build. The iOS app links GhosttyKit via
           # a local-path binaryTarget, so it must exist before package resolve.
-          ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
       - name: Pick simulator

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -122,6 +122,9 @@ jobs:
           key: tmux-corpus-spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: tmux-corpus-spm-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Prepare isolated DerivedData
         run: |
           set -euo pipefail

--- a/scripts/ci/sanitize-xcode-source-packages-cache.py
+++ b/scripts/ci/sanitize-xcode-source-packages-cache.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Drop Xcode SourcePackages state that stores checkout-absolute paths."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def remove_workspace_state(source_packages_dir: Path) -> list[Path]:
+    if not source_packages_dir.exists():
+        return []
+
+    removed: list[Path] = []
+    for state_file in sorted(source_packages_dir.rglob("workspace-state.json")):
+        if not state_file.is_file():
+            continue
+        state_file.unlink()
+        removed.append(state_file)
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove Xcode SourcePackages workspace-state.json files after a "
+            "cache restore. These state files can contain absolute paths from "
+            "a previous checkout; Xcode recreates them during package resolve."
+        )
+    )
+    parser.add_argument(
+        "source_packages_dir",
+        type=Path,
+        help="Path passed to xcodebuild -clonedSourcePackagesDirPath",
+    )
+    args = parser.parse_args()
+
+    source_packages_dir = args.source_packages_dir.resolve()
+    removed = remove_workspace_state(source_packages_dir)
+    if removed:
+        for path in removed:
+            print(f"removed stale Xcode SourcePackages state: {display_path(path)}")
+    else:
+        print(
+            "no Xcode SourcePackages workspace-state.json files found under "
+            f"{display_path(source_packages_dir)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/sanitize-xcode-source-packages-cache.py
+++ b/scripts/ci/sanitize-xcode-source-packages-cache.py
@@ -18,13 +18,12 @@ def remove_workspace_state(source_packages_dir: Path) -> list[Path]:
     if not source_packages_dir.exists():
         return []
 
-    removed: list[Path] = []
-    for state_file in sorted(source_packages_dir.rglob("workspace-state.json")):
-        if not state_file.is_file():
-            continue
-        state_file.unlink()
-        removed.append(state_file)
-    return removed
+    state_file = source_packages_dir / "workspace-state.json"
+    if not state_file.is_file():
+        return []
+
+    state_file.unlink()
+    return [state_file]
 
 
 def main() -> int:

--- a/scripts/create-virtual-display.m
+++ b/scripts/create-virtual-display.m
@@ -168,6 +168,12 @@ int main(int argc, const char *argv[]) {
         useconds_t intervalMicros = (useconds_t)(MAX(1, intervalMs) * 1000);
         NSString *startDelayArgument = argumentValue(arguments, @"--start-delay-ms");
         NSInteger startDelayMs = startDelayArgument.length > 0 ? startDelayArgument.integerValue : 0;
+        NSString *createAttemptsArgument = argumentValue(arguments, @"--create-attempts");
+        NSInteger createAttempts = createAttemptsArgument.length > 0 ? createAttemptsArgument.integerValue : 3;
+        createAttempts = MAX(1, createAttempts);
+        NSString *createRetryDelayArgument = argumentValue(arguments, @"--create-retry-delay-ms");
+        NSInteger createRetryDelayMs = createRetryDelayArgument.length > 0 ? createRetryDelayArgument.integerValue : 500;
+        useconds_t createRetryDelayMicros = (useconds_t)(MAX(0, createRetryDelayMs) * 1000);
 
         unsigned int width = 0;
         unsigned int height = 0;
@@ -205,10 +211,21 @@ int main(int argc, const char *argv[]) {
         descriptor.serialNum = 0x0001;
         descriptor.queue = dispatch_get_main_queue();
 
-        // Create virtual display
-        CGVirtualDisplay *display = [[CGVirtualDisplay alloc] initWithDescriptor:descriptor];
+        // Create virtual display. CI runners can occasionally reject the first
+        // request while the WindowServer display state is still settling.
+        CGVirtualDisplay *display = nil;
+        for (NSInteger attempt = 1; attempt <= createAttempts; attempt += 1) {
+            display = [[CGVirtualDisplay alloc] initWithDescriptor:descriptor];
+            if (display) { break; }
+            if (attempt < createAttempts) {
+                fprintf(stderr, "WARN: Failed to create CGVirtualDisplay (attempt %ld/%ld), retrying\n", (long)attempt, (long)createAttempts);
+                if (createRetryDelayMicros > 0) {
+                    usleep(createRetryDelayMicros);
+                }
+            }
+        }
         if (!display) {
-            fprintf(stderr, "ERROR: Failed to create CGVirtualDisplay\n");
+            fprintf(stderr, "ERROR: Failed to create CGVirtualDisplay after %ld attempt(s)\n", (long)createAttempts);
             return 1;
         }
 

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -151,13 +151,6 @@ install_zig_with_sudo() {
   /usr/local/bin/zig version
 }
 
-install_zig_to_usr_local_if_writable() {
-  mkdir -p /usr/local/bin /usr/local/lib 2>/dev/null || return 1
-  copy_zig_tree /usr/local/bin /usr/local/lib/zig 2>/dev/null || return 1
-  publish_zig_for_later_steps /usr/local/bin/zig
-  /usr/local/bin/zig version
-}
-
 echo "Installing verified zig ${ZIG_REQUIRED}"
 rm -f "$ZIG_TAR" "$ZIG_SIG"
 if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
@@ -179,9 +172,6 @@ fi
 
 rm -rf "$ZIG_DIR"
 tar xf "$ZIG_TAR" -C /tmp
-if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && install_zig_to_usr_local_if_writable; then
-  exit 0
-fi
 if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
   install_zig_with_sudo
   exit 0

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -131,14 +131,13 @@ copy_zig_tree() {
 }
 
 install_zig_without_sudo() {
-  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/cmux-zig-${ZIG_REQUIRED}}"
-  local bin_dir="${install_root}/bin"
-  local lib_dir="${install_root}/lib/zig"
+  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/${ZIG_NAME}}"
   echo "sudo unavailable; installing zig under ${install_root}"
   rm -rf "$install_root"
-  copy_zig_tree "$bin_dir" "$lib_dir"
-  publish_zig_for_later_steps "${bin_dir}/zig"
-  "${bin_dir}/zig" version
+  mkdir -p "$(dirname "$install_root")"
+  mv "$ZIG_DIR" "$install_root"
+  publish_zig_for_later_steps "${install_root}/zig"
+  "${install_root}/zig" version
 }
 
 install_zig_with_sudo() {

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -29,6 +29,10 @@ zig_has_required_version() {
 }
 
 use_existing_zig_if_available() {
+  if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
+    return 0
+  fi
+
   local candidate
   local seen=" "
   for candidate in "$(command -v zig 2>/dev/null || true)" /opt/homebrew/bin/zig /usr/local/bin/zig; do
@@ -117,6 +121,43 @@ verify_zig_sha256() {
   printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | shasum -a 256 -c -
 }
 
+copy_zig_tree() {
+  local bin_dir="$1"
+  local lib_dir="$2"
+  rm -rf "$lib_dir" || return 1
+  mkdir -p "$bin_dir" "$lib_dir" || return 1
+  cp -f "${ZIG_DIR}/zig" "${bin_dir}/zig" || return 1
+  cp -Rf "${ZIG_DIR}/lib/." "$lib_dir/" || return 1
+}
+
+install_zig_without_sudo() {
+  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/cmux-zig-${ZIG_REQUIRED}}"
+  local bin_dir="${install_root}/bin"
+  local lib_dir="${install_root}/lib/zig"
+  echo "sudo unavailable; installing zig under ${install_root}"
+  rm -rf "$install_root"
+  copy_zig_tree "$bin_dir" "$lib_dir"
+  publish_zig_for_later_steps "${bin_dir}/zig"
+  "${bin_dir}/zig" version
+}
+
+install_zig_with_sudo() {
+  sudo mkdir -p /usr/local/bin /usr/local/lib
+  sudo rm -rf /usr/local/lib/zig
+  sudo mkdir -p /usr/local/lib/zig
+  sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
+  sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
+  publish_zig_for_later_steps /usr/local/bin/zig
+  /usr/local/bin/zig version
+}
+
+install_zig_to_usr_local_if_writable() {
+  mkdir -p /usr/local/bin /usr/local/lib 2>/dev/null || return 1
+  copy_zig_tree /usr/local/bin /usr/local/lib/zig 2>/dev/null || return 1
+  publish_zig_for_later_steps /usr/local/bin/zig
+  /usr/local/bin/zig version
+}
+
 echo "Installing verified zig ${ZIG_REQUIRED}"
 rm -f "$ZIG_TAR" "$ZIG_SIG"
 if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
@@ -138,9 +179,11 @@ fi
 
 rm -rf "$ZIG_DIR"
 tar xf "$ZIG_TAR" -C /tmp
-sudo mkdir -p /usr/local/bin /usr/local/lib
-sudo rm -rf /usr/local/lib/zig
-sudo mkdir -p /usr/local/lib/zig
-sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
-zig version
+if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && install_zig_to_usr_local_if_writable; then
+  exit 0
+fi
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  install_zig_with_sudo
+  exit 0
+fi
+install_zig_without_sudo

--- a/tests/test_ci_sanitize_xcode_source_packages_cache.py
+++ b/tests/test_ci_sanitize_xcode_source_packages_cache.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Behavioral guard for restored Xcode SourcePackages cache sanitation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "ci" / "sanitize-xcode-source-packages-cache.py"
+
+
+def run_helper(cache_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HELPER), str(cache_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache_dir = Path(temp_dir) / ".ci-source-packages"
+        artifact = cache_dir / "artifacts" / "sparkle" / "Sparkle" / "Sparkle.xcframework"
+        checkout = cache_dir / "checkouts" / "swift-crypto" / "Package.swift"
+        state = cache_dir / "workspace-state.json"
+
+        artifact.mkdir(parents=True)
+        checkout.parent.mkdir(parents=True)
+        checkout.write_text("// package fixture\n")
+        state.write_text(
+            '{"artifacts":["/Users/ec2-user/actions-runner-cmux/_work/cmux/cmux/'
+            '.ci-source-packages/artifacts/sparkle/Sparkle/Sparkle.xcframework"]}\n'
+        )
+
+        result = run_helper(cache_dir)
+
+        assert result.returncode == 0, result.stderr
+        assert not state.exists()
+        assert artifact.exists()
+        assert checkout.exists()
+        assert "removed stale Xcode SourcePackages state" in result.stdout
+
+
+def test_missing_cache_is_noop() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache_dir = Path(temp_dir) / "missing-source-packages"
+
+        result = run_helper(cache_dir)
+
+        assert result.returncode == 0, result.stderr
+        assert not cache_dir.exists()
+        assert "no Xcode SourcePackages workspace-state.json files found" in result.stdout
+
+
+def main() -> int:
+    test_removes_workspace_state_and_keeps_downloaded_cache()
+    test_missing_cache_is_noop()
+    print("PASS: Xcode SourcePackages cache sanitizer preserves cache contents")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_sanitize_xcode_source_packages_cache.py
+++ b/tests/test_ci_sanitize_xcode_source_packages_cache.py
@@ -28,11 +28,13 @@ def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
         cache_dir = Path(temp_dir) / ".ci-source-packages"
         artifact = cache_dir / "artifacts" / "sparkle" / "Sparkle" / "Sparkle.xcframework"
         checkout = cache_dir / "checkouts" / "swift-crypto" / "Package.swift"
+        package_state = cache_dir / "checkouts" / "swift-crypto" / "workspace-state.json"
         state = cache_dir / "workspace-state.json"
 
         artifact.mkdir(parents=True)
         checkout.parent.mkdir(parents=True)
         checkout.write_text("// package fixture\n")
+        package_state.write_text('{"package":"owned"}\n')
         state.write_text(
             '{"artifacts":["/Users/ec2-user/actions-runner-cmux/_work/cmux/cmux/'
             '.ci-source-packages/artifacts/sparkle/Sparkle/Sparkle.xcframework"]}\n'
@@ -44,6 +46,7 @@ def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
         assert not state.exists()
         assert artifact.exists()
         assert checkout.exists()
+        assert package_state.exists()
         assert "removed stale Xcode SourcePackages state" in result.stdout
 
 

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Behavioral guard for installing verified Zig on CI runners without sudo.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/install-zig-ci.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ZIG_REQUIRED="99.99.99"
+case "$(uname -m)" in
+  arm64 | aarch64) ZIG_ARCH="aarch64" ;;
+  x86_64) ZIG_ARCH="x86_64" ;;
+  *)
+    echo "Unsupported test architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+FIXTURE_ROOT="$TMP_DIR/fixture"
+ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
+ARCHIVE="$TMP_DIR/${ZIG_NAME}.tar.xz"
+BIN_DIR="$TMP_DIR/bin"
+RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
+GITHUB_PATH_FILE="$TMP_DIR/github-path"
+GITHUB_ENV_FILE="$TMP_DIR/github-env"
+OUTPUT_FILE="$TMP_DIR/output"
+
+mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
+cat > "$FIXTURE_ROOT/$ZIG_NAME/zig" <<EOF
+#!/usr/bin/env bash
+echo "$ZIG_REQUIRED"
+EOF
+chmod +x "$FIXTURE_ROOT/$ZIG_NAME/zig"
+printf 'lib fixture\n' > "$FIXTURE_ROOT/$ZIG_NAME/lib/std"
+(cd "$FIXTURE_ROOT" && tar -cf "$ARCHIVE" "$ZIG_NAME")
+ARCHIVE_SHA256="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+
+cat > "$BIN_DIR/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+OUTPUT=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --output)
+      OUTPUT="\$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "\$OUTPUT" ]; then
+  echo "curl stub missing --output" >&2
+  exit 1
+fi
+cp "$ARCHIVE" "\$OUTPUT"
+EOF
+chmod +x "$BIN_DIR/curl"
+
+cat > "$BIN_DIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN_DIR/sudo"
+
+PATH="$BIN_DIR:/usr/bin:/bin" \
+  RUNNER_TEMP="$RUNNER_TEMP_DIR" \
+  GITHUB_PATH="$GITHUB_PATH_FILE" \
+  GITHUB_ENV="$GITHUB_ENV_FILE" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_FORCE_LOCAL_INSTALL=1 \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$OUTPUT_FILE" 2>&1
+
+INSTALLED_ZIG="$RUNNER_TEMP_DIR/cmux-zig-$ZIG_REQUIRED/bin/zig"
+if [ ! -x "$INSTALLED_ZIG" ]; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: zig was not installed under RUNNER_TEMP" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$(dirname "$INSTALLED_ZIG")" "$GITHUB_PATH_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not publish the local zig bin dir to GITHUB_PATH" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "CMUX_ZIG=$INSTALLED_ZIG" "$GITHUB_ENV_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not publish CMUX_ZIG" >&2
+  exit 1
+fi
+
+if ! grep -Fq "sudo unavailable; installing zig under" "$OUTPUT_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not report local fallback" >&2
+  exit 1
+fi
+
+echo "PASS: install-zig-ci falls back to RUNNER_TEMP without sudo"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -75,7 +75,7 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
   "$SCRIPT" > "$OUTPUT_FILE" 2>&1
 
-INSTALLED_ZIG="$RUNNER_TEMP_DIR/cmux-zig-$ZIG_REQUIRED/bin/zig"
+INSTALLED_ZIG="$RUNNER_TEMP_DIR/$ZIG_NAME/zig"
 if [ ! -x "$INSTALLED_ZIG" ]; then
   cat "$OUTPUT_FILE"
   echo "FAIL: zig was not installed under RUNNER_TEMP" >&2


### PR DESCRIPTION
## Summary
- Remove the unused `tests-build-and-lag` DerivedData cache restore for `~/Library/Developer/Xcode/DerivedData/cmux-*`; the job builds from isolated `$RUNNER_TEMP` DerivedData, so the restored 4.3 GB cache was not consumed.
- Replace fixed virtual-display startup sleeps with ready-file waits in CI workflows that still used `sleep 3`.
- Add bounded retries inside `scripts/create-virtual-display.m` for transient `CGVirtualDisplay` creation failures.

## Testing
- `./tests/test_ci_self_hosted_guard.sh`
- `./tests/test_ci_unit_test_spm_retry.sh`
- `./tests/test_ci_scheme_testaction_debug.sh`
- Full local `workflow-guard-tests` command set from `.github/workflows/ci.yml`
- `clang -framework Foundation -framework CoreGraphics -o /tmp/create-virtual-display-check scripts/create-virtual-display.m`
- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/ci-macos-compat.yml .github/workflows/test-depot.yml].each { |path| YAML.load_file(path); puts "yaml ok #{path}" }'`\n- `git diff origin/main --check`\n- `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main`\n\n## CI waste sources\n- Related failed cache-restore job: https://github.com/manaflow-ai/cmux/actions/runs/27586029868/job/81556454232\n- Related virtual display setup failure: https://github.com/manaflow-ai/cmux/actions/runs/27594353093/job/81581450399\n\n## Coverage\n- Build, warning-budget, CoreAnimation, lag regression, UI regression, GhosttyKit, Zig, and SwiftPM gates remain active.\n- No tests, assertions, jobs, or required checks are skipped or hidden.\n\n## Issues\n- Related: no tracked issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI stability by sanitizing cached Xcode Swift Package Manager source state before resolving packages (across multiple build/test workflows).
  * Reworked virtual display startup to use temp-scoped readiness/id/log files with polling, timeouts, and clearer diagnostics (instead of a fixed delay).
  * Enhanced CI Zig installation to support local-only installs and more reliable fallback when elevated privileges aren’t available.
* **Tests**
  * Added CI behavioral tests for the cache sanitization helper.
  * Added an integration test validating Zig installation without `sudo`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->