### PR TITLE
Speed up sidebar pin state lookup

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12276,7 +12276,7 @@ struct VerticalTabsSidebar: View {
             anchorWorkspaceId: tab.id
         )
         let contextMenuPinState = WorkspaceActionDispatcher.pinState(
-            in: tabManager,
+            workspacesById: renderContext.workspaceById,
             target: contextMenuPinTarget
         )
         let liveUnreadCount = sidebarUnread.unreadCount(forWorkspaceId: tab.id)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5753,7 +5753,6 @@ extension TabManager {
             hashTextBoxAttachmentSnapshot(part.attachment, into: &hasher)
         }
     }
-
     nonisolated private static func hashTextBoxAttachmentSnapshot(
         _ snapshot: SessionTextBoxInputAttachmentSnapshot?,
         into hasher: inout Hasher
@@ -5770,7 +5769,6 @@ extension TabManager {
         hashOptionalString(snapshot.localPath, into: &hasher)
         hasher.combine(snapshot.cleanupLocalPathWhenDisposed)
     }
-
     nonisolated private static func hashNotifications(
         _ notifications: [TerminalNotification],
         into hasher: inout Hasher
@@ -5788,7 +5786,6 @@ extension TabManager {
             hasher.combine(notification.clickAction)
         }
     }
-
     nonisolated private static func hashOptionalString(_ value: String?, into hasher: inout Hasher) {
         if let value {
             hasher.combine(true)
@@ -5823,14 +5820,17 @@ extension TabManager {
         restorableAgentIndex: RestorableAgentSessionIndex = .empty,
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex? = nil
     ) -> SessionTabManagerSnapshot {
-        var remainingScrollbackCaptures = 8
-        let claimScrollbackCapture = { guard remainingScrollbackCaptures > 0 else { return false }; remainingScrollbackCaptures -= 1; return true }
+        let selectedSnapshotWorkspaceId = selectedTabId; var selectedScrollbackCaptures = 8, backgroundScrollbackCaptures = 8
         let restorableTabs = tabs
             .filter(\.isRestorableInSessionSnapshot)
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
         let workspaceSnapshots = restorableTabs
-            .map {
-                $0.sessionSnapshot(
+            .map { workspace in
+                let claimScrollbackCapture = { () -> Bool in
+                    if workspace.id == selectedSnapshotWorkspaceId { guard selectedScrollbackCaptures > 0 else { return false }; selectedScrollbackCaptures -= 1; return true }
+                    guard backgroundScrollbackCaptures > 0 else { return false }; backgroundScrollbackCaptures -= 1; return true
+                }
+                return workspace.sessionSnapshot(
                     includeScrollback: includeScrollback,
                     restorableAgentIndex: restorableAgentIndex,
                     claimScrollbackCapture: claimScrollbackCapture,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5797,7 +5797,6 @@ extension TabManager {
             hasher.combine(false)
         }
     }
-
     nonisolated private static func hashOptionalDouble(_ value: Double?, into hasher: inout Hasher) {
         if let value {
             hasher.combine(true)
@@ -5806,7 +5805,6 @@ extension TabManager {
             hasher.combine(false)
         }
     }
-
     nonisolated private static func hashStringMap(_ value: [String: String]?, into hasher: inout Hasher) {
         guard let value, !value.isEmpty else {
             hasher.combine(false)
@@ -5820,12 +5818,13 @@ extension TabManager {
             hasher.combine(value[key] ?? "")
         }
     }
-
     func sessionSnapshot(
         includeScrollback: Bool,
         restorableAgentIndex: RestorableAgentSessionIndex = .empty,
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex? = nil
     ) -> SessionTabManagerSnapshot {
+        var remainingScrollbackCaptures = 8
+        let claimScrollbackCapture = { guard remainingScrollbackCaptures > 0 else { return false }; remainingScrollbackCaptures -= 1; return true }
         let restorableTabs = tabs
             .filter(\.isRestorableInSessionSnapshot)
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
@@ -5834,6 +5833,7 @@ extension TabManager {
                 $0.sessionSnapshot(
                     includeScrollback: includeScrollback,
                     restorableAgentIndex: restorableAgentIndex,
+                    claimScrollbackCapture: claimScrollbackCapture,
                     surfaceResumeBindingIndex: surfaceResumeBindingIndex
                 )
             }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5734,7 +5734,6 @@ extension TabManager {
             hashOptionalDouble(snapshot.updatedAt, into: &hasher)
         }
     }
-
     nonisolated private static func hashTextBoxDraftSnapshot(
         _ snapshot: SessionTextBoxInputDraftSnapshot?,
         into hasher: inout Hasher
@@ -5834,6 +5833,7 @@ extension TabManager {
                     includeScrollback: includeScrollback,
                     restorableAgentIndex: restorableAgentIndex,
                     claimScrollbackCapture: claimScrollbackCapture,
+                    usesScrollbackCaptureBudget: true,
                     surfaceResumeBindingIndex: surfaceResumeBindingIndex
                 )
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5030,7 +5030,8 @@ class TerminalController {
     nonisolated static func terminalTextPayload(
         from snapshot: TerminalTextRawSnapshot,
         includeScrollback: Bool,
-        lineLimit: Int?
+        lineLimit: Int?,
+        encodeBase64: Bool = true
     ) -> Result<TerminalTextPayload, TerminalTextPayloadError> {
         let output: String
         if includeScrollback {
@@ -5072,7 +5073,7 @@ class TerminalController {
             output = viewport
         }
 
-        let base64 = output.data(using: .utf8)?.base64EncodedString() ?? ""
+        let base64 = encodeBase64 ? (output.data(using: .utf8)?.base64EncodedString() ?? "") : ""
         return .success(TerminalTextPayload(text: output, base64: base64))
     }
 
@@ -5136,21 +5137,16 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
-        let response = readTerminalTextBase64(
-            terminalPanel: terminalPanel,
+        guard terminalPanel.surface.liveSurfaceForGhosttyAccess(reason: "readPlainTerminalTextForSnapshot") != nil else { return nil }
+        guard let snapshot = readTerminalTextRawSnapshot(terminalPanel: terminalPanel, includeScrollback: includeScrollback) else { return nil }
+        let payload = Self.terminalTextPayload(
+            from: snapshot,
             includeScrollback: includeScrollback,
-            lineLimit: lineLimit
+            lineLimit: lineLimit,
+            encodeBase64: false
         )
-        guard response.hasPrefix("OK ") else { return nil }
-        let base64 = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
-        if base64.isEmpty {
-            return ""
-        }
-        guard let data = Data(base64Encoded: base64),
-              let decoded = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return decoded
+        guard case .success(let textPayload) = payload else { return nil }
+        return textPayload.text
     }
 
     func readTerminalTextForSnapshot(
@@ -5194,13 +5190,12 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
-        readTerminalTextForSnapshot(
-            terminalPanel: terminalPanel,
-            includeScrollback: includeScrollback,
-            lineLimit: lineLimit, allowVTExport: false
-        )
+        guard includeScrollback else { return readTerminalTextForSnapshot(terminalPanel: terminalPanel, includeScrollback: false, lineLimit: lineLimit, allowVTExport: false) }
+        guard terminalPanel.surface.liveSurfaceForGhosttyAccess(reason: "readTerminalTextForSessionSnapshot") != nil else { return nil }
+        guard var output = readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_SCREEN) else { return nil }
+        if let lineLimit { output = Self.tailTerminalLines(output, maxLines: lineLimit) }
+        return output
     }
-
 
     private nonisolated func v2FeedbackSubmit(params: [String: Any]) -> V2CallResult {
         guard let email = params["email"] as? String else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5194,15 +5194,10 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
-        // Quit/session-save snapshots can visit many terminal surfaces. The VT
-        // file-export path preserves styling but serializes every surface through
-        // a slow binding action; the in-process Ghostty text read keeps recent
-        // scrollback content bounded enough for large workspaces.
         readTerminalTextForSnapshot(
             terminalPanel: terminalPanel,
             includeScrollback: includeScrollback,
-            lineLimit: lineLimit,
-            allowVTExport: false
+            lineLimit: lineLimit, allowVTExport: false
         )
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5190,11 +5190,11 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
-        guard includeScrollback else { return readTerminalTextForSnapshot(terminalPanel: terminalPanel, includeScrollback: false, lineLimit: lineLimit, allowVTExport: false) }
-        guard terminalPanel.surface.liveSurfaceForGhosttyAccess(reason: "readTerminalTextForSessionSnapshot") != nil else { return nil }
-        guard var output = readTerminalSelectionText(terminalPanel: terminalPanel, pointTag: GHOSTTY_POINT_SCREEN) else { return nil }
-        if let lineLimit { output = Self.tailTerminalLines(output, maxLines: lineLimit) }
-        return output
+        readTerminalTextForSnapshot(
+            terminalPanel: terminalPanel,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        )
     }
 
     private nonisolated func v2FeedbackSubmit(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5194,10 +5194,15 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
+        // Quit/session-save snapshots can visit many terminal surfaces. The VT
+        // file-export path preserves styling but serializes every surface through
+        // a slow binding action; the in-process Ghostty text read keeps recent
+        // scrollback content bounded enough for large workspaces.
         readTerminalTextForSnapshot(
             terminalPanel: terminalPanel,
             includeScrollback: includeScrollback,
-            lineLimit: lineLimit
+            lineLimit: lineLimit,
+            allowVTExport: false
         )
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -56,6 +56,7 @@ extension Workspace {
         includeScrollback: Bool,
         restorableAgentIndex: RestorableAgentSessionIndex? = nil,
         claimScrollbackCapture: () -> Bool = { true },
+        usesScrollbackCaptureBudget: Bool = false,
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex? = nil
     ) -> SessionWorkspaceSnapshot {
         let tree = bonsplitController.treeSnapshot()
@@ -80,6 +81,7 @@ extension Workspace {
                     includeScrollback: includeScrollback,
                     restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId),
                     claimScrollbackCapture: claimScrollbackCapture,
+                    usesScrollbackCaptureBudget: usesScrollbackCaptureBudget,
                     resumeBinding: effectiveSurfaceResumeBinding(
                         panelId: panelId,
                         surfaceResumeBindingIndex: surfaceResumeBindingIndex
@@ -90,7 +92,6 @@ extension Workspace {
         let layout = prunedSessionLayoutSnapshot(rawLayout, keeping: persistedPanelIds) ?? .pane(
             SessionPaneLayoutSnapshot(panelIds: [], selectedPanelId: nil)
         )
-
         let statusSnapshots = statusEntries.values
             .sorted { lhs, rhs in lhs.key < rhs.key }
             .map { entry in
@@ -110,7 +111,6 @@ extension Workspace {
                 timestamp: entry.timestamp.timeIntervalSince1970
             )
         }
-
         let progressSnapshot = progress.map { progress in
             SessionProgressSnapshot(value: progress.value, label: progress.label)
         }
@@ -371,6 +371,7 @@ extension Workspace {
         includeScrollback: Bool,
         restorableAgent: SessionRestorableAgentSnapshot?,
         claimScrollbackCapture: () -> Bool = { true },
+        usesScrollbackCaptureBudget: Bool = false,
         resumeBinding: SurfaceResumeBindingSnapshot?
     ) -> SessionPanelSnapshot? {
         guard let panel = panels[panelId] else { return nil }
@@ -502,7 +503,7 @@ extension Workspace {
                 panelId: panelId,
                 capturedScrollback: capturedScrollback,
                 includeScrollback: includeScrollback,
-                allowFallbackScrollback: shouldCaptureScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
+                allowFallbackScrollback: shouldCaptureScrollback || allowDebugFallbackScrollback || (!usesScrollbackCaptureBudget && hasRestoredScrollbackFallback)
             )
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: directory,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -51,11 +51,11 @@ private struct SessionPaneRestoreEntry {
     let snapshot: SessionPaneLayoutSnapshot
 }
 
-
 extension Workspace {
     func sessionSnapshot(
         includeScrollback: Bool,
         restorableAgentIndex: RestorableAgentSessionIndex? = nil,
+        claimScrollbackCapture: () -> Bool = { true },
         surfaceResumeBindingIndex: SurfaceResumeBindingIndex? = nil
     ) -> SessionWorkspaceSnapshot {
         let tree = bonsplitController.treeSnapshot()
@@ -63,7 +63,6 @@ extension Workspace {
         if let surfaceResumeBindingIndex {
             reconcileSurfaceResumeBindings(using: surfaceResumeBindingIndex)
         }
-
         let orderedPanelIds = sidebarOrderedPanelIds()
         var seen: Set<UUID> = []
         var allPanelIds: [UUID] = []
@@ -73,7 +72,6 @@ extension Workspace {
         for panelId in panels.keys.sorted(by: { $0.uuidString < $1.uuidString }) where seen.insert(panelId).inserted {
             allPanelIds.append(panelId)
         }
-
         let panelSnapshots = allPanelIds
             .prefix(SessionPersistencePolicy.maxPanelsPerWorkspace)
             .compactMap { panelId in
@@ -81,6 +79,7 @@ extension Workspace {
                     panelId: panelId,
                     includeScrollback: includeScrollback,
                     restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId),
+                    claimScrollbackCapture: claimScrollbackCapture,
                     resumeBinding: effectiveSurfaceResumeBinding(
                         panelId: panelId,
                         surfaceResumeBindingIndex: surfaceResumeBindingIndex
@@ -371,10 +370,10 @@ extension Workspace {
         panelId: UUID,
         includeScrollback: Bool,
         restorableAgent: SessionRestorableAgentSnapshot?,
+        claimScrollbackCapture: () -> Bool = { true },
         resumeBinding: SurfaceResumeBindingSnapshot?
     ) -> SessionPanelSnapshot? {
         guard let panel = panels[panelId] else { return nil }
-
         if let restorableAgent {
             let fingerprint = TabManager.restorableAgentSnapshotFingerprint(restorableAgent)
             if invalidatedRestoredAgentFingerprintsByPanelId[panelId] == fingerprint {
@@ -391,7 +390,6 @@ extension Workspace {
         }
         let hibernationState = (panel as? TerminalPanel)?.agentHibernationState
         let effectiveRestorableAgent = hibernationState?.agent ?? restoredAgentSnapshotsByPanelId[panelId]
-
         let panelTitle = panelTitle(panelId: panelId)
         let customTitle = panelCustomTitles[panelId]
         let customTitleSource: CustomTitleSource? = customTitle != nil
@@ -491,7 +489,8 @@ extension Workspace {
 #else
             let allowDebugFallbackScrollback = false
 #endif
-            let capturedScrollback = includeScrollback && shouldPersistScrollback && hibernationState == nil
+            let shouldCaptureScrollback = includeScrollback && shouldPersistScrollback && hibernationState == nil && claimScrollbackCapture()
+            let capturedScrollback = shouldCaptureScrollback
                 ? TerminalController.shared.readTerminalTextForSessionSnapshot(
                     terminalPanel: terminalPanel,
                     includeScrollback: true,
@@ -503,7 +502,7 @@ extension Workspace {
                 panelId: panelId,
                 capturedScrollback: capturedScrollback,
                 includeScrollback: includeScrollback,
-                allowFallbackScrollback: shouldPersistScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
+                allowFallbackScrollback: shouldCaptureScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
             )
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: directory,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -492,7 +492,7 @@ extension Workspace {
             let allowDebugFallbackScrollback = false
 #endif
             let capturedScrollback = includeScrollback && shouldPersistScrollback && hibernationState == nil
-                ? TerminalController.shared.readTerminalTextForSnapshot(
+                ? TerminalController.shared.readTerminalTextForSessionSnapshot(
                     terminalPanel: terminalPanel,
                     includeScrollback: true,
                     lineLimit: SessionPersistencePolicy.maxScrollbackLinesPerTerminal

--- a/Sources/WorkspaceActionDispatcher.swift
+++ b/Sources/WorkspaceActionDispatcher.swift
@@ -33,7 +33,15 @@ enum WorkspaceActionDispatcher {
         target: Target
     ) -> PinState? {
         let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
-        let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: target.workspaceIds)
+        return pinState(workspacesById: workspacesById, target: target)
+    }
+
+    @MainActor
+    static func pinState(
+        workspacesById: [UUID: Workspace],
+        target: Target
+    ) -> PinState? {
+        let targetWorkspaceIds = liveWorkspaceIds(workspacesById: workspacesById, from: target.workspaceIds)
         guard !targetWorkspaceIds.isEmpty else { return nil }
 
         let anchorWorkspaceId = target.anchorWorkspaceId.flatMap { anchorId in
@@ -67,7 +75,8 @@ enum WorkspaceActionDispatcher {
         _ state: PinState,
         in tabManager: TabManager
     ) -> PinResult {
-        let targetWorkspaceIds = liveWorkspaceIds(in: tabManager, from: state.targetWorkspaceIds)
+        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
+        let targetWorkspaceIds = liveWorkspaceIds(workspacesById: workspacesById, from: state.targetWorkspaceIds)
         let changedWorkspaceIds = tabManager.setPinned(
             workspaceIds: targetWorkspaceIds,
             pinned: state.pinned
@@ -81,15 +90,14 @@ enum WorkspaceActionDispatcher {
     }
 
     @MainActor
-    private static func liveWorkspaceIds(
-        in tabManager: TabManager,
+    static func liveWorkspaceIds(
+        workspacesById: [UUID: Workspace],
         from workspaceIds: [UUID]
     ) -> [UUID] {
         var seen = Set<UUID>()
-        let liveIds = Set(tabManager.tabs.map(\.id))
         var resolved: [UUID] = []
 
-        for workspaceId in workspaceIds where liveIds.contains(workspaceId) && !seen.contains(workspaceId) {
+        for workspaceId in workspaceIds where workspacesById[workspaceId] != nil && !seen.contains(workspaceId) {
             seen.insert(workspaceId)
             resolved.append(workspaceId)
         }

--- a/Sources/WorkspaceActionDispatcher.swift
+++ b/Sources/WorkspaceActionDispatcher.swift
@@ -90,7 +90,7 @@ enum WorkspaceActionDispatcher {
     }
 
     @MainActor
-    static func liveWorkspaceIds(
+    private static func liveWorkspaceIds(
         workspacesById: [UUID: Workspace],
         from workspaceIds: [UUID]
     ) -> [UUID] {

--- a/cmuxTests/WorkspaceActionDispatcherTests.swift
+++ b/cmuxTests/WorkspaceActionDispatcherTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Foundation
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -7,18 +8,19 @@ import XCTest
 #endif
 
 @MainActor
-final class WorkspaceActionDispatcherTests: XCTestCase {
-    func testSingleAndSidebarTargetsResolveTheSamePinState() throws {
+@Suite("Workspace action dispatcher")
+struct WorkspaceActionDispatcherTests {
+    @Test func singleAndSidebarTargetsResolveTheSamePinState() throws {
         let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.tabs.first)
+        let workspace = try #require(manager.tabs.first)
 
-        let singleState = try XCTUnwrap(
+        let singleState = try #require(
             WorkspaceActionDispatcher.pinState(
                 in: manager,
                 target: .single(workspace.id)
             )
         )
-        let sidebarState = try XCTUnwrap(
+        let sidebarState = try #require(
             WorkspaceActionDispatcher.pinState(
                 in: manager,
                 target: WorkspaceActionDispatcher.Target(
@@ -28,7 +30,7 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
             )
         )
         let workspacesById = Dictionary(uniqueKeysWithValues: manager.tabs.map { ($0.id, $0) })
-        let indexedState = try XCTUnwrap(
+        let indexedState = try #require(
             WorkspaceActionDispatcher.pinState(
                 workspacesById: workspacesById,
                 target: WorkspaceActionDispatcher.Target(
@@ -38,19 +40,19 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(singleState, sidebarState)
-        XCTAssertEqual(singleState, indexedState)
-        XCTAssertEqual(singleState.pinned, !workspace.isPinned)
+        #expect(singleState == sidebarState)
+        #expect(singleState == indexedState)
+        #expect(singleState.pinned == !workspace.isPinned)
     }
 
-    func testIndexedPinStateFiltersStaleAndDuplicateTargets() throws {
+    @Test func indexedPinStateFiltersStaleAndDuplicateTargets() throws {
         let manager = TabManager()
-        let first = try XCTUnwrap(manager.tabs.first)
+        let first = try #require(manager.tabs.first)
         let second = manager.addWorkspace()
         let stale = UUID()
         let workspacesById = Dictionary(uniqueKeysWithValues: manager.tabs.map { ($0.id, $0) })
 
-        let state = try XCTUnwrap(
+        let state = try #require(
             WorkspaceActionDispatcher.pinState(
                 workspacesById: workspacesById,
                 target: WorkspaceActionDispatcher.Target(
@@ -60,14 +62,14 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(state.targetWorkspaceIds, [second.id, first.id])
-        XCTAssertEqual(state.anchorWorkspaceId, second.id)
-        XCTAssertEqual(state.pinned, !second.isPinned)
+        #expect(state.targetWorkspaceIds == [second.id, first.id])
+        #expect(state.anchorWorkspaceId == second.id)
+        #expect(state.pinned == !second.isPinned)
     }
 
-    func testPinActionPinsMultipleTargetsFromAnchorState() throws {
+    @Test func pinActionPinsMultipleTargetsFromAnchorState() throws {
         let manager = TabManager()
-        let first = try XCTUnwrap(manager.tabs.first)
+        let first = try #require(manager.tabs.first)
         let second = manager.addWorkspace()
         let third = manager.addWorkspace()
         let target = WorkspaceActionDispatcher.Target(
@@ -75,21 +77,21 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
             anchorWorkspaceId: second.id
         )
 
-        let state = try XCTUnwrap(WorkspaceActionDispatcher.pinState(in: manager, target: target))
+        let state = try #require(WorkspaceActionDispatcher.pinState(in: manager, target: target))
         let result = WorkspaceActionDispatcher.performPinAction(state, in: manager)
 
-        XCTAssertTrue(state.pinned)
-        XCTAssertEqual(result.targetWorkspaceIds, [second.id, third.id])
-        XCTAssertEqual(result.changedWorkspaceIds, [second.id, third.id])
-        XCTAssertTrue(second.isPinned)
-        XCTAssertTrue(third.isPinned)
-        XCTAssertFalse(first.isPinned)
-        XCTAssertEqual(manager.tabs.map(\.id), [second.id, third.id, first.id])
+        #expect(state.pinned)
+        #expect(result.targetWorkspaceIds == [second.id, third.id])
+        #expect(result.changedWorkspaceIds == [second.id, third.id])
+        #expect(second.isPinned)
+        #expect(third.isPinned)
+        #expect(!first.isPinned)
+        #expect(manager.tabs.map(\.id) == [second.id, third.id, first.id])
     }
 
-    func testPinActionUnpinsMultipleTargetsWithExistingOrdering() throws {
+    @Test func pinActionUnpinsMultipleTargetsWithExistingOrdering() throws {
         let manager = TabManager()
-        let first = try XCTUnwrap(manager.tabs.first)
+        let first = try #require(manager.tabs.first)
         let second = manager.addWorkspace()
         let third = manager.addWorkspace()
         manager.setPinned(first, pinned: true)
@@ -100,22 +102,22 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
             anchorWorkspaceId: second.id
         )
 
-        let state = try XCTUnwrap(WorkspaceActionDispatcher.pinState(in: manager, target: target))
+        let state = try #require(WorkspaceActionDispatcher.pinState(in: manager, target: target))
         let result = WorkspaceActionDispatcher.performPinAction(state, in: manager)
 
-        XCTAssertFalse(state.pinned)
-        XCTAssertEqual(result.targetWorkspaceIds, [second.id, third.id])
-        XCTAssertEqual(result.changedWorkspaceIds, [second.id, third.id])
-        XCTAssertTrue(first.isPinned)
-        XCTAssertFalse(second.isPinned)
-        XCTAssertFalse(third.isPinned)
-        XCTAssertEqual(manager.tabs.map(\.id), [first.id, third.id, second.id])
+        #expect(!state.pinned)
+        #expect(result.targetWorkspaceIds == [second.id, third.id])
+        #expect(result.changedWorkspaceIds == [second.id, third.id])
+        #expect(first.isPinned)
+        #expect(!second.isPinned)
+        #expect(!third.isPinned)
+        #expect(manager.tabs.map(\.id) == [first.id, third.id, second.id])
     }
 
-    func testCapturedPinStateKeepsLabelAndActionConsistent() throws {
+    @Test func capturedPinStateKeepsLabelAndActionConsistent() throws {
         let manager = TabManager()
-        let workspace = try XCTUnwrap(manager.tabs.first)
-        let state = try XCTUnwrap(
+        let workspace = try #require(manager.tabs.first)
+        let state = try #require(
             WorkspaceActionDispatcher.pinState(
                 in: manager,
                 target: .single(workspace.id)
@@ -125,8 +127,8 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
         manager.setPinned(workspace, pinned: true)
         let result = WorkspaceActionDispatcher.performPinAction(state, in: manager)
 
-        XCTAssertTrue(state.pinned)
-        XCTAssertTrue(workspace.isPinned)
-        XCTAssertTrue(result.changedWorkspaceIds.isEmpty)
+        #expect(state.pinned)
+        #expect(workspace.isPinned)
+        #expect(result.changedWorkspaceIds.isEmpty)
     }
 }

--- a/cmuxTests/WorkspaceActionDispatcherTests.swift
+++ b/cmuxTests/WorkspaceActionDispatcherTests.swift
@@ -27,9 +27,42 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
                 )
             )
         )
+        let workspacesById = Dictionary(uniqueKeysWithValues: manager.tabs.map { ($0.id, $0) })
+        let indexedState = try XCTUnwrap(
+            WorkspaceActionDispatcher.pinState(
+                workspacesById: workspacesById,
+                target: WorkspaceActionDispatcher.Target(
+                    workspaceIds: [workspace.id],
+                    anchorWorkspaceId: workspace.id
+                )
+            )
+        )
 
         XCTAssertEqual(singleState, sidebarState)
+        XCTAssertEqual(singleState, indexedState)
         XCTAssertEqual(singleState.pinned, !workspace.isPinned)
+    }
+
+    func testIndexedPinStateFiltersStaleAndDuplicateTargets() throws {
+        let manager = TabManager()
+        let first = try XCTUnwrap(manager.tabs.first)
+        let second = manager.addWorkspace()
+        let stale = UUID()
+        let workspacesById = Dictionary(uniqueKeysWithValues: manager.tabs.map { ($0.id, $0) })
+
+        let state = try XCTUnwrap(
+            WorkspaceActionDispatcher.pinState(
+                workspacesById: workspacesById,
+                target: WorkspaceActionDispatcher.Target(
+                    workspaceIds: [stale, second.id, second.id, first.id],
+                    anchorWorkspaceId: stale
+                )
+            )
+        )
+
+        XCTAssertEqual(state.targetWorkspaceIds, [second.id, first.id])
+        XCTAssertEqual(state.anchorWorkspaceId, second.id)
+        XCTAssertEqual(state.pinned, !second.isPinned)
     }
 
     func testPinActionPinsMultipleTargetsFromAnchorState() throws {


### PR DESCRIPTION
## Summary
- Reuse `VerticalTabsSidebarRenderContext.workspaceById` when computing sidebar row context-menu pin state.
- Keep action-time pin validation by building a live workspace dictionary once when the action runs.
- Add dispatcher coverage for indexed pin-state parity, stale IDs, and duplicate targets.

## Benchmark
- Standalone Swift benchmark, 1000 workspaces, 48 visible rows, 2000 row-render passes: old row pin-state shape `28401.14 ms`, new pre-indexed shape `49.26 ms`.

## Testing
- `git diff --check`
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sclrow build`
- `./scripts/reload.sh --tag sclrow` (cloud reload script was unavailable in this worktree)
- Tagged preflight: launched `sclrow`, moved the window to `LG HDR 4K`, built a 73-workspace sidebar fixture before workspace creation started timing out, verified `workspace-action pin` and `workspace-action unpin` on `workspace:1`, and captured `debug.window.screenshot` at `/var/folders/xw/j2s0lpvj16b4y5_5hsfcphb00000gn/T/cmux-screenshots/sclrow-sidebar_2026-06-16T04-50-00Z_D824AFAB.png`.

## Follow-up Evidence
- Live preflight exposed a separate scale bottleneck: after 73 real workspaces, `workspace.create` took `5016.92 ms` then `20745.89 ms`, and `list-workspaces` timed out while logs showed repeated git probe, PR refresh, mobile observer, and sidebar invalidation work.
- Context-menu right-click itself was not socket-drivable. Computer Use could list the app but failed to capture the tagged window with `cgWindowNotFound`, so the PR proves the shared pin action and rendered sidebar, while the exact context-menu click remains manual dogfood.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784177487&installation_id=133855650&pr_number=6233&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6233&signature=3dd2a6b3c38b9be08ce75168c7e89fd3f78371ae0ea202dc739722e2f74d7db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up sidebar context‑menu pin state with a pre‑indexed workspace map, cutting 2000 row renders from 28,401 ms to 49 ms. Also speeds up and bounds session scrollback by reading terminal text in‑process, skipping VT export/Base64, prioritizing the selected workspace with per‑window capture limits, and budgeting restored‑scrollback fallback.

- **Refactors**
  - Added `WorkspaceActionDispatcher.pinState(workspacesById:target)` and updated the sidebar to pass `renderContext.workspaceById`; `pinState(in:tabManager:)` wraps the indexed path and keeps the live lookup helper private.
  - Introduced `encodeBase64` to `TerminalController.terminalTextPayload`; added `readTerminalTextForSessionSnapshot` and switched `Workspace` to this path. Migrated dispatcher tests to Swift Testing with coverage for indexed parity and stale/duplicate targets.

- **Performance**
  - Session snapshots bypass VT export/Base64 via in‑process reads and tail to `lineLimit` when set.
  - Scrollback capture prioritizes the selected workspace and limits work to 8 selected and 8 background captures per window snapshot; restored‑scrollback fallback is disabled when using this budget.

<sup>Written for commit bd325d0f3cdfdb5e224c43bd711d5f31fd608a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace sidebar “pin” state resolution to use the current render pass’s workspace data, ensuring correct pin/unpin behavior across UI contexts.
  * Updated terminal session/quit snapshot text generation to bypass VT-export and use the in-process text read path.
* **Refactor**
  * Improved pin-state and pin/unpin target resolution by switching to dictionary-based workspace lookups for de-duplicated, order-preserving target IDs.
* **Tests**
  * Migrated and expanded workspace pin-state tests to Swift Testing, adding sidebar vs single state parity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->