### PR TITLE
Fix iOS scrollback replay ordering after attach

### DIFF
--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -1,6 +1,14 @@
 import CMUXMobileCore
+internal import CmuxMobileDiagnostics
+import CmuxMobileRPC
 import CmuxMobileShellModel
 public import Foundation
+internal import OSLog
+
+nonisolated private let terminalOutputLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "mobile-shell"
+)
 
 extension MobileShellComposite {
     /// Yield a raw PTY byte chunk to the surface stream, if one is attached.
@@ -19,6 +27,141 @@ extension MobileShellComposite {
             ),
             surfaceID: surfaceID
         )
+    }
+
+    func deliverAuthoritativeTerminalRenderGrid(
+        _ renderGrid: MobileTerminalRenderGridFrame,
+        expectedSurfaceID: String? = nil,
+        source: String
+    ) {
+        guard expectedSurfaceID == nil || renderGrid.surfaceID == expectedSurfaceID,
+              hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
+            return
+        }
+        if terminalReplayIDsInFlightBySurfaceID[renderGrid.surfaceID] != nil {
+            bufferTerminalRenderGridFrameDuringReplay(renderGrid, source: source)
+            return
+        }
+        if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[renderGrid.surfaceID],
+           deliveredSeq > renderGrid.stateSeq {
+            MobileDebugLog.anchormux(
+                "sync.render_grid_stale source=\(source) surface=\(renderGrid.surfaceID) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
+            )
+            return
+        }
+        if terminalRenderGridContinuityGapSurfaceIDs.contains(renderGrid.surfaceID) {
+            guard renderGrid.full else {
+                MobileDebugLog.anchormux(
+                    "sync.render_grid_gap_drop_delta source=\(source) surface=\(renderGrid.surfaceID) seq=\(renderGrid.stateSeq)"
+                )
+                requestTerminalReplay(surfaceID: renderGrid.surfaceID)
+                return
+            }
+            terminalRenderGridContinuityGapSurfaceIDs.remove(renderGrid.surfaceID)
+            MobileDebugLog.anchormux(
+                "sync.render_grid_gap_full_frame source=\(source) surface=\(renderGrid.surfaceID) seq=\(renderGrid.stateSeq)"
+            )
+        }
+        markTerminalBytesDelivered(surfaceID: renderGrid.surfaceID, endSeq: renderGrid.stateSeq)
+        deliverTerminalRenderGrid(renderGrid, surfaceID: renderGrid.surfaceID)
+    }
+
+    private func bufferTerminalRenderGridFrameDuringReplay(
+        _ renderGrid: MobileTerminalRenderGridFrame,
+        source: String
+    ) {
+        let surfaceID = renderGrid.surfaceID
+        var frames = terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] ?? []
+        if frames.count >= Self.maxRenderGridFramesBufferedDuringReplay {
+            frames.removeFirst()
+            terminalRenderGridReplayBufferDroppedSurfaceIDs.insert(surfaceID)
+            MobileDebugLog.anchormux("sync.render_grid_replay_buffer_drop_oldest source=\(source) surface=\(surfaceID)")
+            terminalOutputLog.warning("render-grid replay buffer dropped oldest frame source=\(source, privacy: .public) surface=\(surfaceID, privacy: .public)")
+        }
+        frames.append(renderGrid)
+        terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] = frames
+        MobileDebugLog.anchormux("sync.render_grid_buffered_during_replay source=\(source) surface=\(surfaceID) seq=\(renderGrid.stateSeq)")
+    }
+
+    func flushTerminalRenderGridFramesBufferedDuringReplay(
+        surfaceID: String,
+        replaySeq: UInt64?
+    ) {
+        let droppedFrames = terminalRenderGridReplayBufferDroppedSurfaceIDs.remove(surfaceID) != nil
+        let frames = terminalRenderGridFramesBufferedDuringReplayBySurfaceID.removeValue(forKey: surfaceID) ?? []
+        if droppedFrames {
+            guard !frames.isEmpty else { return }
+            terminalRenderGridContinuityGapSurfaceIDs.insert(surfaceID)
+            MobileDebugLog.anchormux("sync.render_grid_replay_buffer_overflow_discard surface=\(surfaceID) frames=\(frames.count)")
+            terminalOutputLog.info("discarded overflowed render-grid replay buffer surface=\(surfaceID, privacy: .public) frames=\(frames.count, privacy: .public)")
+            requestTerminalReplay(surfaceID: surfaceID)
+            return
+        }
+        guard hasTerminalOutputSink(surfaceID: surfaceID) else { return }
+        for frame in frames where replaySeq.map({ frame.stateSeq > $0 }) ?? true {
+            deliverAuthoritativeTerminalRenderGrid(frame, expectedSurfaceID: surfaceID, source: "buffered_replay")
+        }
+    }
+
+    @discardableResult
+    func discardTerminalRenderGridFramesBufferedDuringReplay(surfaceID: String) -> Int {
+        terminalRenderGridReplayBufferDroppedSurfaceIDs.remove(surfaceID)
+        let frames = terminalRenderGridFramesBufferedDuringReplayBySurfaceID.removeValue(forKey: surfaceID) ?? []
+        guard !frames.isEmpty else { return 0 }
+        MobileDebugLog.anchormux("sync.render_grid_replay_buffer_discard surface=\(surfaceID) frames=\(frames.count)")
+        terminalOutputLog.info("discarded render-grid replay buffer surface=\(surfaceID, privacy: .public) frames=\(frames.count, privacy: .public)")
+        return frames.count
+    }
+
+    func markTerminalRenderGridContinuityGapAfterReplayFailure(
+        surfaceID: String,
+        discardedFrameCount: Int
+    ) {
+        guard hasTerminalOutputSink(surfaceID: surfaceID) else { return }
+        let hasNoSafeBase = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] == nil
+        let alreadyGap = terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID)
+        guard hasNoSafeBase || discardedFrameCount > 0 || alreadyGap else { return }
+        terminalRenderGridContinuityGapSurfaceIDs.insert(surfaceID)
+        MobileDebugLog.anchormux(
+            "sync.render_grid_gap_after_failed_replay surface=\(surfaceID) discarded=\(discardedFrameCount) noBase=\(hasNoSafeBase)"
+        )
+    }
+
+    func recoverOrDiscardTerminalRenderGridFramesBufferedDuringReplayFailure(
+        surfaceID: String
+    ) -> (recovered: Bool, discardedFrameCount: Int) {
+        let droppedFrames = terminalRenderGridReplayBufferDroppedSurfaceIDs.remove(surfaceID) != nil
+        let frames = terminalRenderGridFramesBufferedDuringReplayBySurfaceID.removeValue(forKey: surfaceID) ?? []
+        guard !frames.isEmpty else { return (false, 0) }
+        guard hasTerminalOutputSink(surfaceID: surfaceID) else {
+            MobileDebugLog.anchormux("sync.render_grid_replay_buffer_discard surface=\(surfaceID) frames=\(frames.count)")
+            terminalOutputLog.info("discarded render-grid replay buffer surface=\(surfaceID, privacy: .public) frames=\(frames.count, privacy: .public)")
+            return (false, frames.count)
+        }
+        guard let fullFrameIndex = frames.lastIndex(where: { $0.full }) else {
+            MobileDebugLog.anchormux("sync.render_grid_replay_buffer_discard surface=\(surfaceID) frames=\(frames.count)")
+            terminalOutputLog.info("discarded render-grid replay buffer surface=\(surfaceID, privacy: .public) frames=\(frames.count, privacy: .public)")
+            return (false, frames.count)
+        }
+
+        let discardedBeforeFull = frames.distance(from: frames.startIndex, to: fullFrameIndex)
+        let framesToRecover = frames[fullFrameIndex...]
+        MobileDebugLog.anchormux(
+            "sync.render_grid_replay_buffer_recover_full surface=\(surfaceID) recovered=\(framesToRecover.count) discarded=\(discardedBeforeFull) dropped=\(droppedFrames)"
+        )
+        terminalOutputLog.info(
+            "recovered render-grid replay buffer from full frame surface=\(surfaceID, privacy: .public) recovered=\(framesToRecover.count, privacy: .public) discarded=\(discardedBeforeFull, privacy: .public) dropped=\(droppedFrames, privacy: .public)"
+        )
+        for frame in framesToRecover {
+            deliverAuthoritativeTerminalRenderGrid(frame, expectedSurfaceID: surfaceID, source: "failed_replay_buffer")
+        }
+        return (true, discardedBeforeFull)
+    }
+
+    static func terminalSnapshotReplacementBytes(_ snapshotBytes: Data) -> Data {
+        var bytes = Data("\u{1B}c\u{1B}[H\u{1B}[2J\u{1B}[3J".utf8)
+        bytes.append(snapshotBytes)
+        return bytes
     }
 
     private func deliverTerminalOutput(_ delivery: TerminalOutputDelivery, surfaceID: String) {
@@ -47,4 +190,270 @@ extension MobileShellComposite {
         }
         continuation.yield(MobileTerminalOutputChunk(data: next.bytes, streamToken: streamToken))
     }
+
+    /// Cold-attach/self-heal replay. Prefer the Mac's bounded render-grid
+    /// snapshot, replacing the local iOS terminal state before live bytes
+    /// resume. The VT snapshot and raw byte ring remain fallbacks, but neither
+    /// is the target architecture: a byte tail is not a complete screen state
+    /// for TUIs, and a VT export is still a replay stream rather than state.
+    func requestTerminalReplay(surfaceID: String) {
+        guard let client = remoteClient else {
+            #if DEBUG
+            terminalOutputLog.error("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=no_remote_client")
+            #endif
+            return
+        }
+        guard let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+            #if DEBUG
+            terminalOutputLog.error("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=workspace_not_found")
+            #endif
+            return
+        }
+        guard terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil else {
+            #if DEBUG
+            terminalOutputLog.info("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=in_flight")
+            #endif
+            return
+        }
+        let request: Data
+        do {
+            request = try MobileCoreRPCClient.requestData(
+                method: "mobile.terminal.replay",
+                params: [
+                    "workspace_id": workspaceID.rawValue,
+                    "surface_id": surfaceID,
+                ]
+            )
+        } catch {
+            terminalOutputLog.error("CMUX_REPLAY encode failed surface=\(surfaceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            return
+        }
+        let replayID = UUID()
+        terminalReplayIDsInFlightBySurfaceID[surfaceID] = replayID
+        Task.detached(priority: .userInitiated) { [weak self, client, request, replayID, surfaceID] in
+            do {
+                let data = try await client.sendRequest(request)
+                await self?.applyTerminalReplayResponse(
+                    surfaceID: surfaceID,
+                    replayID: replayID,
+                    client: client,
+                    data: data
+                )
+            } catch {
+                await self?.failTerminalReplayRequest(
+                    surfaceID: surfaceID,
+                    replayID: replayID,
+                    client: client,
+                    error: error
+                )
+            }
+        }
+    }
+
+    private func applyTerminalReplayResponse(
+        surfaceID: String,
+        replayID: UUID,
+        client: MobileCoreRPCClient,
+        data: Data
+    ) {
+        do {
+            let payload = try MobileTerminalReplayResponse.decode(data)
+            applyTerminalReplayPayload(
+                surfaceID: surfaceID,
+                replayID: replayID,
+                clientIsCurrent: remoteClient === client,
+                payload: payload
+            )
+        } catch {
+            terminalOutputLog.error("CMUX_REPLAY decode failed surface=\(surfaceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            finishTerminalReplayRequest(
+                surfaceID: surfaceID,
+                replayID: replayID,
+                replayDidApply: false,
+                replaySeqForFlush: nil
+            )
+        }
+    }
+
+    private func applyTerminalReplayPayload(
+        surfaceID: String,
+        replayID: UUID,
+        clientIsCurrent: Bool,
+        payload: MobileTerminalReplayResponse
+    ) {
+        var replaySeqForFlush: UInt64?
+        var replayDidApply = false
+        defer {
+            finishTerminalReplayRequest(
+                surfaceID: surfaceID,
+                replayID: replayID,
+                replayDidApply: replayDidApply,
+                replaySeqForFlush: replaySeqForFlush
+            )
+        }
+        do {
+            guard terminalReplayIDsInFlightBySurfaceID[surfaceID] == replayID else {
+                return
+            }
+            guard clientIsCurrent else { return }
+            let bytes = payload.dataBase64.flatMap { Data(base64Encoded: $0) }
+            let snapshotBytes = payload.snapshotBase64.flatMap { Data(base64Encoded: $0) }
+            let decodedRenderGrid = payload.renderGrid
+            let renderGrid = decodedRenderGrid?.surfaceID == surfaceID ? decodedRenderGrid : nil
+            let replaySeq = renderGrid?.stateSeq ?? payload.sequence
+            replaySeqForFlush = replaySeq
+            #if DEBUG
+            let seq = replaySeq ?? 0
+            let cols = payload.columns ?? -1
+            let rows = payload.rows ?? -1
+            terminalOutputLog.info("CMUX_REPLAY response surface=\(surfaceID, privacy: .public) byteCount=\(bytes?.count ?? -1, privacy: .public) snapshotBytes=\(snapshotBytes?.count ?? -1, privacy: .public) renderGrid=\(renderGrid != nil, privacy: .public) seq=\(seq, privacy: .public) macGrid=\(cols, privacy: .public)x\(rows, privacy: .public) hasSink=\(self.hasTerminalOutputSink(surfaceID: surfaceID), privacy: .public)")
+            #endif
+            if let replaySeq,
+               let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceID],
+               deliveredSeq > replaySeq {
+                MobileDebugLog.anchormux("CMUX_REPLAY stale surface=\(surfaceID) delivered=\(deliveredSeq) replay=\(replaySeq)")
+                return
+            }
+            let hasReplayPayload = renderGrid != nil
+                || snapshotBytes?.isEmpty == false
+                || bytes?.isEmpty == false
+            guard hasReplayPayload else {
+                MobileDebugLog.anchormux("CMUX_REPLAY empty surface=\(surfaceID)")
+                return
+            }
+            replayDidApply = true
+            let deliverBytes: Data?
+            if let renderGrid {
+                deliverBytes = nil
+                MobileDebugLog.anchormux("CMUX_REPLAY render_grid surface=\(surfaceID) spans=\(renderGrid.rowSpans.count) seq=\(renderGrid.stateSeq)")
+            } else if let snapshotBytes, !snapshotBytes.isEmpty {
+                deliverBytes = Self.terminalSnapshotReplacementBytes(snapshotBytes)
+                MobileDebugLog.anchormux("CMUX_REPLAY snapshot surface=\(surfaceID) bytes=\(snapshotBytes.count) seq=\(replaySeq ?? 0)")
+            } else {
+                deliverBytes = bytes
+                MobileDebugLog.anchormux("CMUX_REPLAY raw_tail surface=\(surfaceID) bytes=\(bytes?.count ?? -1) seq=\(replaySeq ?? 0)")
+            }
+            if let replaySeq {
+                markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replaySeq)
+            }
+            if renderGrid != nil || snapshotBytes?.isEmpty == false {
+                terminalRenderGridContinuityGapSurfaceIDs.remove(surfaceID)
+            }
+            if let renderGrid {
+                deliverTerminalRenderGrid(renderGrid, surfaceID: surfaceID)
+                return
+            }
+            guard let deliverBytes, !deliverBytes.isEmpty else {
+                return
+            }
+            deliverTerminalBytes(deliverBytes, surfaceID: surfaceID)
+        }
+    }
+
+    private func failTerminalReplayRequest(
+        surfaceID: String,
+        replayID: UUID,
+        client: MobileCoreRPCClient,
+        error: any Error
+    ) {
+        terminalOutputLog.error("CMUX_REPLAY failed surface=\(surfaceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
+        finishTerminalReplayRequest(
+            surfaceID: surfaceID,
+            replayID: replayID,
+            replayDidApply: false,
+            replaySeqForFlush: nil
+        )
+        // The replay request is the view-only/foreground-resume path. A
+        // definitive auth failure here (after the RPC layer's
+        // force-refresh-and-retry already gave up) must drive the re-auth
+        // prompt instead of silently leaving a stale frame.
+        guard remoteClient === client else { return }
+        _ = disconnectForAuthorizationFailureIfNeeded(error)
+    }
+
+    private func finishTerminalReplayRequest(
+        surfaceID: String,
+        replayID: UUID,
+        replayDidApply: Bool,
+        replaySeqForFlush: UInt64?
+    ) {
+        guard terminalReplayIDsInFlightBySurfaceID[surfaceID] == replayID else {
+            return
+        }
+        terminalReplayIDsInFlightBySurfaceID.removeValue(forKey: surfaceID)
+        if replayDidApply {
+            flushTerminalRenderGridFramesBufferedDuringReplay(
+                surfaceID: surfaceID,
+                replaySeq: replaySeqForFlush
+            )
+        } else {
+            let recovery = recoverOrDiscardTerminalRenderGridFramesBufferedDuringReplayFailure(
+                surfaceID: surfaceID
+            )
+            guard !recovery.recovered else { return }
+            markTerminalRenderGridContinuityGapAfterReplayFailure(
+                surfaceID: surfaceID,
+                discardedFrameCount: recovery.discardedFrameCount
+            )
+        }
+    }
+
+    #if DEBUG
+    @discardableResult
+    func debugMarkTerminalReplayInFlightForTesting(surfaceID: String) -> UUID {
+        let replayID = UUID()
+        terminalReplayIDsInFlightBySurfaceID[surfaceID] = replayID
+        return replayID
+    }
+
+    func debugCancelTerminalReplayForTesting(surfaceID: String) {
+        terminalReplayIDsInFlightBySurfaceID.removeValue(forKey: surfaceID)
+        discardTerminalRenderGridFramesBufferedDuringReplay(surfaceID: surfaceID)
+    }
+
+    func debugFailTerminalReplayForTesting(surfaceID: String, replayID: UUID? = nil) {
+        if let replayID, terminalReplayIDsInFlightBySurfaceID[surfaceID] != replayID {
+            return
+        }
+        terminalReplayIDsInFlightBySurfaceID.removeValue(forKey: surfaceID)
+        let recovery = recoverOrDiscardTerminalRenderGridFramesBufferedDuringReplayFailure(surfaceID: surfaceID)
+        guard !recovery.recovered else { return }
+        markTerminalRenderGridContinuityGapAfterReplayFailure(
+            surfaceID: surfaceID,
+            discardedFrameCount: recovery.discardedFrameCount
+        )
+    }
+
+    func debugApplyTerminalReplayResponseForTesting(
+        surfaceID: String,
+        replayID: UUID,
+        data: Data
+    ) throws {
+        let payload = try MobileTerminalReplayResponse.decode(data)
+        applyTerminalReplayPayload(
+            surfaceID: surfaceID,
+            replayID: replayID,
+            clientIsCurrent: true,
+            payload: payload
+        )
+    }
+
+    func debugFinishTerminalReplayForTesting(
+        surfaceID: String,
+        replayID: UUID? = nil,
+        replayFrame: MobileTerminalRenderGridFrame
+    ) {
+        if let replayID, terminalReplayIDsInFlightBySurfaceID[surfaceID] != replayID {
+            return
+        }
+        terminalReplayIDsInFlightBySurfaceID.removeValue(forKey: surfaceID)
+        terminalRenderGridContinuityGapSurfaceIDs.remove(surfaceID)
+        markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replayFrame.stateSeq)
+        deliverTerminalRenderGrid(replayFrame, surfaceID: surfaceID)
+        flushTerminalRenderGridFramesBufferedDuringReplay(
+            surfaceID: surfaceID,
+            replaySeq: replayFrame.stateSeq
+        )
+    }
+    #endif
 }

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -79,6 +79,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// reschedule per received event (an actively-streaming connection just keeps
     /// failing the silence check because `lastTerminalEventAt` stays fresh).
     private static let renderGridLivenessCheckInterval: TimeInterval = 2.5
+    static let maxRenderGridFramesBufferedDuringReplay = 128
 
     public private(set) var isSignedIn: Bool {
         didSet {
@@ -588,9 +589,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var connectionGeneration: UUID
     private var connectionAttemptGeneration: UUID
     private var reportedViewportSizesByTerminalKey: [MobileTerminalViewportKey: MobileTerminalViewportSize]
-    private var deliveredTerminalByteEndSeqBySurfaceID: [String: UInt64]
-    private var pendingTerminalByteEndSeqBySurfaceID: [String: UInt64]
-    private var terminalReplaySurfaceIDsInFlight: Set<String>
+    var deliveredTerminalByteEndSeqBySurfaceID: [String: UInt64]
+    var pendingTerminalByteEndSeqBySurfaceID: [String: UInt64]
+    var terminalReplayIDsInFlightBySurfaceID: [String: UUID]
+    var terminalRenderGridFramesBufferedDuringReplayBySurfaceID: [String: [MobileTerminalRenderGridFrame]]
+    var terminalRenderGridReplayBufferDroppedSurfaceIDs: Set<String>
+    var terminalRenderGridContinuityGapSurfaceIDs: Set<String>
     private var terminalOutputTransport: TerminalOutputTransport
     var terminalByteContinuationsBySurfaceID: [String: AsyncStream<MobileTerminalOutputChunk>.Continuation]
     var terminalOutputStreamTokensBySurfaceID: [String: UUID]
@@ -719,7 +723,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.reportedViewportSizesByTerminalKey = [:]
         self.deliveredTerminalByteEndSeqBySurfaceID = [:]
         self.pendingTerminalByteEndSeqBySurfaceID = [:]
-        self.terminalReplaySurfaceIDsInFlight = []
+        self.terminalReplayIDsInFlightBySurfaceID = [:]
+        self.terminalRenderGridFramesBufferedDuringReplayBySurfaceID = [:]
+        self.terminalRenderGridReplayBufferDroppedSurfaceIDs = []
+        self.terminalRenderGridContinuityGapSurfaceIDs = []
         self.terminalOutputTransport = .rawBytes
         self.terminalByteContinuationsBySurfaceID = [:]
         self.terminalOutputStreamTokensBySurfaceID = [:]
@@ -3553,7 +3560,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func resetTerminalOutputTracking() {
         deliveredTerminalByteEndSeqBySurfaceID = [:]
         pendingTerminalByteEndSeqBySurfaceID = [:]
-        terminalReplaySurfaceIDsInFlight = []
+        terminalReplayIDsInFlightBySurfaceID = [:]
+        terminalRenderGridFramesBufferedDuringReplayBySurfaceID = [:]
+        terminalRenderGridReplayBufferDroppedSurfaceIDs = []
+        terminalRenderGridContinuityGapSurfaceIDs = []
         terminalOutputQueuesBySurfaceID = [:]
         terminalOutputStreamTokensBySurfaceID = terminalOutputStreamTokensBySurfaceID.mapValues { _ in UUID() }
         terminalScrollQueueTokensBySurfaceID = [:]
@@ -4884,7 +4894,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
     }
 
-    private func markTerminalBytesDelivered(surfaceID: String, endSeq: UInt64) {
+    func markTerminalBytesDelivered(surfaceID: String, endSeq: UInt64) {
         let current = deliveredTerminalByteEndSeqBySurfaceID[surfaceID] ?? 0
         deliveredTerminalByteEndSeqBySurfaceID[surfaceID] = max(current, endSeq)
         if let pendingSeq = pendingTerminalByteEndSeqBySurfaceID[surfaceID],
@@ -4894,34 +4904,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    func deliverAuthoritativeTerminalRenderGrid(
-        _ renderGrid: MobileTerminalRenderGridFrame,
-        expectedSurfaceID: String? = nil,
-        source: String
-    ) {
-        guard expectedSurfaceID == nil || renderGrid.surfaceID == expectedSurfaceID,
-              hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
-            return
-        }
-        if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[renderGrid.surfaceID],
-           deliveredSeq > renderGrid.stateSeq {
-            MobileDebugLog.anchormux(
-                "sync.render_grid_stale source=\(source) surface=\(renderGrid.surfaceID) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
-            )
-            return
-        }
-        markTerminalBytesDelivered(surfaceID: renderGrid.surfaceID, endSeq: renderGrid.stateSeq)
-        deliverTerminalRenderGrid(renderGrid, surfaceID: renderGrid.surfaceID)
-    }
-
-    private static func terminalSnapshotReplacementBytes(_ snapshotBytes: Data) -> Data {
-        var bytes = Data("\u{1B}c\u{1B}[H\u{1B}[2J\u{1B}[3J".utf8)
-        bytes.append(snapshotBytes)
-        return bytes
-    }
-
     /// Whether a surface currently has an attached output stream consumer.
-    private func hasTerminalOutputSink(surfaceID: String) -> Bool {
+    func hasTerminalOutputSink(surfaceID: String) -> Bool {
         terminalByteContinuationsBySurfaceID[surfaceID] != nil
     }
 
@@ -4949,6 +4933,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalScrollbackPrefetchStatesBySurfaceID.removeValue(forKey: surfaceID)
         deliveredTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
         pendingTerminalByteEndSeqBySurfaceID.removeValue(forKey: surfaceID)
+        terminalReplayIDsInFlightBySurfaceID.removeValue(forKey: surfaceID)
+        terminalRenderGridFramesBufferedDuringReplayBySurfaceID.removeValue(forKey: surfaceID)
+        terminalRenderGridReplayBufferDroppedSurfaceIDs.remove(surfaceID)
+        terminalRenderGridContinuityGapSurfaceIDs.remove(surfaceID)
         // Tell the Mac this device is no longer viewing the surface so it stops
         // pinning the shared grid to our viewport and clears the macOS border.
         clearTerminalViewport(surfaceID: surfaceID)
@@ -5034,96 +5022,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    /// Cold-attach/self-heal replay. Prefer the Mac's bounded render-grid
-    /// snapshot, replacing the local iOS terminal state before live bytes
-    /// resume. The VT snapshot and raw byte ring remain fallbacks, but neither
-    /// is the target architecture: a byte tail is not a complete screen state
-    /// for TUIs, and a VT export is still a replay stream rather than state.
-    private func requestTerminalReplay(surfaceID: String) {
-        guard let client = remoteClient else {
-            #if DEBUG
-            mobileShellLog.error("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=no_remote_client")
-            #endif
-            return
-        }
-        guard let workspaceID = workspaceID(forTerminalID: surfaceID) else {
-            #if DEBUG
-            mobileShellLog.error("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=workspace_not_found")
-            #endif
-            return
-        }
-        guard !terminalReplaySurfaceIDsInFlight.contains(surfaceID) else {
-            #if DEBUG
-            mobileShellLog.info("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=in_flight")
-            #endif
-            return
-        }
-        terminalReplaySurfaceIDsInFlight.insert(surfaceID)
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer { self.terminalReplaySurfaceIDsInFlight.remove(surfaceID) }
-            do {
-                let request = try MobileCoreRPCClient.requestData(
-                    method: "mobile.terminal.replay",
-                    params: [
-                        "workspace_id": workspaceID.rawValue,
-                        "surface_id": surfaceID,
-                    ]
-                )
-                let data = try await client.sendRequest(request)
-                guard self.remoteClient === client else { return }
-                let payload = try? MobileTerminalReplayResponse.decode(data)
-                let bytes = payload?.dataBase64.flatMap { Data(base64Encoded: $0) }
-                let snapshotBytes = payload?.snapshotBase64.flatMap { Data(base64Encoded: $0) }
-                let decodedRenderGrid = payload?.renderGrid
-                let renderGrid = decodedRenderGrid?.surfaceID == surfaceID ? decodedRenderGrid : nil
-                let replaySeq = renderGrid?.stateSeq ?? payload?.sequence
-                #if DEBUG
-                let seq = replaySeq ?? 0
-                let cols = payload?.columns ?? -1
-                let rows = payload?.rows ?? -1
-                mobileShellLog.info("CMUX_REPLAY response surface=\(surfaceID, privacy: .public) byteCount=\(bytes?.count ?? -1, privacy: .public) snapshotBytes=\(snapshotBytes?.count ?? -1, privacy: .public) renderGrid=\(renderGrid != nil, privacy: .public) seq=\(seq, privacy: .public) macGrid=\(cols, privacy: .public)x\(rows, privacy: .public) hasSink=\(self.hasTerminalOutputSink(surfaceID: surfaceID), privacy: .public)")
-                #endif
-                if let replaySeq,
-                   let deliveredSeq = self.deliveredTerminalByteEndSeqBySurfaceID[surfaceID],
-                   deliveredSeq > replaySeq {
-                    MobileDebugLog.anchormux("CMUX_REPLAY stale surface=\(surfaceID) delivered=\(deliveredSeq) replay=\(replaySeq)")
-                    return
-                }
-                let deliverBytes: Data?
-                if let renderGrid {
-                    deliverBytes = nil
-                    MobileDebugLog.anchormux("CMUX_REPLAY render_grid surface=\(surfaceID) spans=\(renderGrid.rowSpans.count) seq=\(renderGrid.stateSeq)")
-                } else if let snapshotBytes, !snapshotBytes.isEmpty {
-                    deliverBytes = Self.terminalSnapshotReplacementBytes(snapshotBytes)
-                    MobileDebugLog.anchormux("CMUX_REPLAY snapshot surface=\(surfaceID) bytes=\(snapshotBytes.count) seq=\(replaySeq ?? 0)")
-                } else {
-                    deliverBytes = bytes
-                    MobileDebugLog.anchormux("CMUX_REPLAY raw_tail surface=\(surfaceID) bytes=\(bytes?.count ?? -1) seq=\(replaySeq ?? 0)")
-                }
-                if let replaySeq {
-                    self.markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replaySeq)
-                }
-                if let renderGrid {
-                    self.deliverTerminalRenderGrid(renderGrid, surfaceID: surfaceID)
-                    return
-                }
-                guard let deliverBytes, !deliverBytes.isEmpty else {
-                    return
-                }
-                self.deliverTerminalBytes(deliverBytes, surfaceID: surfaceID)
-            } catch {
-                mobileShellLog.error("CMUX_REPLAY failed surface=\(surfaceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
-                // The replay request is the view-only/foreground-resume path. A
-                // definitive auth failure here (after the RPC layer's
-                // force-refresh-and-retry already gave up) must drive the re-auth
-                // prompt instead of silently leaving a stale frame.
-                guard self.remoteClient === client else { return }
-                _ = self.disconnectForAuthorizationFailureIfNeeded(error)
-            }
-        }
-    }
-
     private func handleTerminalRenderGridEvent(_ event: MobileEventEnvelope) {
         guard let json = event.payloadJSON else {
             return
@@ -5140,21 +5038,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         #endif
         deliverAuthoritativeTerminalRenderGrid(renderGrid, source: "event")
     }
-
-    #if DEBUG
-    func debugMarkTerminalReplayInFlightForTesting(surfaceID: String) {
-        terminalReplaySurfaceIDsInFlight.insert(surfaceID)
-    }
-
-    func debugFinishTerminalReplayForTesting(
-        surfaceID: String,
-        replayFrame: MobileTerminalRenderGridFrame
-    ) {
-        terminalReplaySurfaceIDsInFlight.remove(surfaceID)
-        markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replayFrame.stateSeq)
-        deliverTerminalRenderGrid(replayFrame, surfaceID: surfaceID)
-    }
-    #endif
 
     private func handleNotificationDismissedEvent(_ event: MobileEventEnvelope) async {
         guard

--- a/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5141,6 +5141,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         deliverAuthoritativeTerminalRenderGrid(renderGrid, source: "event")
     }
 
+    #if DEBUG
+    func debugMarkTerminalReplayInFlightForTesting(surfaceID: String) {
+        terminalReplaySurfaceIDsInFlight.insert(surfaceID)
+    }
+
+    func debugFinishTerminalReplayForTesting(
+        surfaceID: String,
+        replayFrame: MobileTerminalRenderGridFrame
+    ) {
+        terminalReplaySurfaceIDsInFlight.remove(surfaceID)
+        markTerminalBytesDelivered(surfaceID: surfaceID, endSeq: replayFrame.stateSeq)
+        deliverTerminalRenderGrid(replayFrame, surfaceID: surfaceID)
+    }
+    #endif
+
     private func handleNotificationDismissedEvent(_ event: MobileEventEnvelope) async {
         guard
             let json = event.payloadJSON,

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -101,6 +101,221 @@ import Testing
     #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
 }
 
+@MainActor
+@Test func staleReplayFinishCannotFlushNewReplayBuffer() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    let staleReplayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let staleLiveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 2,
+        columns: 16,
+        rows: 2,
+        text: "stale\nlive",
+        full: false,
+        changedRows: [0, 1]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(staleLiveFrame, source: "event")
+    store.debugCancelTerminalReplayForTesting(surfaceID: surfaceID)
+
+    let currentReplayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let currentLiveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 4,
+        columns: 16,
+        rows: 2,
+        text: "current\nlive",
+        full: false,
+        changedRows: [0, 1]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(currentLiveFrame, source: "event")
+
+    let staleReplayFrame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 1,
+        columns: 16,
+        rows: 2,
+        rowSpans: [
+            .init(row: 0, column: 0, text: "old-vp0"),
+            .init(row: 1, column: 0, text: "old-vp1"),
+        ],
+        scrollbackRows: 1,
+        scrollbackSpans: [
+            .init(row: 0, column: 0, text: "old-scroll"),
+        ]
+    )
+    store.debugFinishTerminalReplayForTesting(
+        surfaceID: surfaceID,
+        replayID: staleReplayID,
+        replayFrame: staleReplayFrame
+    )
+
+    #expect(
+        store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true,
+        "a stale replay must not clear the newer replay barrier or deliver old scrollback"
+    )
+
+    let currentReplayFrame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 3,
+        columns: 16,
+        rows: 2,
+        rowSpans: [
+            .init(row: 0, column: 0, text: "new-vp0"),
+            .init(row: 1, column: 0, text: "new-vp1"),
+        ],
+        scrollbackRows: 1,
+        scrollbackSpans: [
+            .init(row: 0, column: 0, text: "new-scroll"),
+        ]
+    )
+    store.debugFinishTerminalReplayForTesting(
+        surfaceID: surfaceID,
+        replayID: currentReplayID,
+        replayFrame: currentReplayFrame
+    )
+
+    let queueAfterReplay = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplay.isIdle == false)
+    #expect(queueAfterReplay.pendingCount == 1)
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+
+    let queueAfterReplayAck = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplayAck.isIdle == false)
+    #expect(queueAfterReplayAck.pendingCount == 0)
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+}
+
+@MainActor
+@Test func failedReplayDropsBufferedLiveRenderGrid() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    let replayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let liveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 2,
+        columns: 16,
+        rows: 2,
+        text: "live\nviewport",
+        full: false,
+        changedRows: [0, 1]
+    )
+
+    store.deliverAuthoritativeTerminalRenderGrid(liveFrame, source: "event")
+    store.debugFailTerminalReplayForTesting(surfaceID: surfaceID, replayID: replayID)
+
+    #expect(
+        store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true,
+        "a failed replay must not flush live render-grid frames before scrollback has been seeded"
+    )
+    #expect(store.terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] == nil)
+}
+
+@MainActor
+@Test func replayOverflowRequiresFullFrameBeforeLiveDeltasResume() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let liveFrameCount = MobileShellComposite.maxRenderGridFramesBufferedDuringReplay + 2
+    for index in 0..<liveFrameCount {
+        let frame = try MobileTerminalRenderGridFrame.fromPlainRows(
+            surfaceID: surfaceID,
+            stateSeq: UInt64(index + 2),
+            columns: 16,
+            rows: 2,
+            text: "live \(index)\nviewport",
+            full: false,
+            changedRows: [0, 1]
+        )
+        store.deliverAuthoritativeTerminalRenderGrid(frame, source: "event")
+    }
+
+    let replayFrame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 1,
+        columns: 16,
+        rows: 2,
+        rowSpans: [
+            .init(row: 0, column: 0, text: "replay-vp0"),
+            .init(row: 1, column: 0, text: "replay-vp1"),
+        ],
+        scrollbackRows: 1,
+        scrollbackSpans: [
+            .init(row: 0, column: 0, text: "replay-scroll"),
+        ]
+    )
+    store.debugFinishTerminalReplayForTesting(surfaceID: surfaceID, replayFrame: replayFrame)
+
+    let queueAfterReplay = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplay.isIdle == false)
+    #expect(
+        queueAfterReplay.pendingCount == 0,
+        "overflow drops part of a render-grid delta chain, so the retained live tail must be discarded instead of replayed on top of a gap"
+    )
+    #expect(store.terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+
+    let queueAfterReplayAck = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplayAck.isIdle == true)
+    #expect(queueAfterReplayAck.pendingCount == 0)
+
+    let partialAfterGap = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: UInt64(liveFrameCount + 2),
+        columns: 16,
+        rows: 2,
+        text: "partial after gap\nviewport",
+        full: false,
+        changedRows: [0]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(partialAfterGap, source: "event")
+    #expect(
+        store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true,
+        "a partial delta after an overflow gap must not apply until a full frame or replay restores continuity"
+    )
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let fullAfterGap = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: UInt64(liveFrameCount + 3),
+        columns: 16,
+        rows: 2,
+        text: "full after gap\nviewport",
+        full: true
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(fullAfterGap, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == false)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID) == false)
+}
+
 @Test func terminalOutputQueueCoalescesReplaceableViewportFramesBehindBackpressure() {
     var queue = TerminalOutputDeliveryQueue()
     let inFlight = TerminalOutputDelivery(bytes: Data("in-flight".utf8), replaceable: false)

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileShellModel
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -39,6 +40,65 @@ import Testing
     store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: currentChunk.streamToken)
     let secondChunk = try #require(await currentIterator.next())
     #expect(String(decoding: secondChunk.data, as: UTF8.self) == "new-second")
+}
+
+@MainActor
+@Test func liveRenderGridWaitsBehindInFlightReplay() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let liveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 2,
+        columns: 16,
+        rows: 2,
+        text: "live\nviewport",
+        full: false,
+        changedRows: [0, 1]
+    )
+
+    store.deliverAuthoritativeTerminalRenderGrid(liveFrame, source: "event")
+
+    #expect(
+        store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true,
+        "live deltas must wait behind the cold replay so scrollback is seeded before the viewport starts updating"
+    )
+
+    let replayFrame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 1,
+        columns: 16,
+        rows: 2,
+        rowSpans: [
+            .init(row: 0, column: 0, text: "vp0"),
+            .init(row: 1, column: 0, text: "vp1"),
+        ],
+        scrollbackRows: 2,
+        scrollbackSpans: [
+            .init(row: 0, column: 0, text: "old0"),
+            .init(row: 1, column: 0, text: "old1"),
+        ]
+    )
+    store.debugFinishTerminalReplayForTesting(surfaceID: surfaceID, replayFrame: replayFrame)
+
+    let queueAfterReplay = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplay.isIdle == false, "the replay should be the in-flight delivery")
+    #expect(queueAfterReplay.pendingCount == 1, "the live frame should be queued behind the replay")
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+
+    let queueAfterReplayAck = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterReplayAck.isIdle == false, "acking the replay should advance the buffered live frame")
+    #expect(queueAfterReplayAck.pendingCount == 0)
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
 }
 
 @Test func terminalOutputQueueCoalescesReplaceableViewportFramesBehindBackpressure() {

--- a/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRenderGridReplayContinuityTests.swift
+++ b/Packages/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRenderGridReplayContinuityTests.swift
@@ -1,0 +1,238 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func failedReplayLeavesContinuityGapUntilFullRenderGrid() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    let replayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let liveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 2,
+        columns: 16,
+        rows: 2,
+        text: "live\nviewport",
+        full: false,
+        changedRows: [0, 1]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(liveFrame, source: "event")
+    store.debugFailTerminalReplayForTesting(surfaceID: surfaceID, replayID: replayID)
+
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let partialAfterFailure = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 3,
+        columns: 16,
+        rows: 2,
+        text: "partial after failure\nviewport",
+        full: false,
+        changedRows: [0]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(partialAfterFailure, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let fullAfterFailure = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 4,
+        columns: 16,
+        rows: 2,
+        text: "full after failure\nviewport",
+        full: true
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(fullAfterFailure, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == false)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID) == false)
+}
+
+@MainActor
+@Test func sequenceOnlyReplayLeavesContinuityGapUntilFullRenderGrid() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    let replayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let liveFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 6,
+        columns: 16,
+        rows: 2,
+        text: "live\nviewport",
+        full: false,
+        changedRows: [0, 1]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(liveFrame, source: "event")
+
+    try store.debugApplyTerminalReplayResponseForTesting(
+        surfaceID: surfaceID,
+        replayID: replayID,
+        data: Data(#"{"seq":5}"#.utf8)
+    )
+
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.deliveredTerminalByteEndSeqBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let partialAfterSequenceOnly = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 7,
+        columns: 16,
+        rows: 2,
+        text: "partial after sequence-only\nviewport",
+        full: false,
+        changedRows: [0]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(partialAfterSequenceOnly, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let fullAfterSequenceOnly = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 8,
+        columns: 16,
+        rows: 2,
+        text: "full after sequence-only\nviewport",
+        full: true
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(fullAfterSequenceOnly, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == false)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID) == false)
+}
+
+@MainActor
+@Test func failedReplayRecoversFromBufferedFullRenderGrid() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    let replayID = store.debugMarkTerminalReplayInFlightForTesting(surfaceID: surfaceID)
+    let partialBeforeFull = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 6,
+        columns: 16,
+        rows: 2,
+        text: "partial before full\nviewport",
+        full: false,
+        changedRows: [0]
+    )
+    let fullFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 7,
+        columns: 16,
+        rows: 2,
+        text: "buffered full\nviewport",
+        full: true
+    )
+    let partialAfterFull = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 8,
+        columns: 16,
+        rows: 2,
+        text: "partial after full\nviewport",
+        full: false,
+        changedRows: [1]
+    )
+
+    store.deliverAuthoritativeTerminalRenderGrid(partialBeforeFull, source: "event")
+    store.deliverAuthoritativeTerminalRenderGrid(fullFrame, source: "event")
+    store.deliverAuthoritativeTerminalRenderGrid(partialAfterFull, source: "event")
+    store.debugFailTerminalReplayForTesting(surfaceID: surfaceID, replayID: replayID)
+
+    let queueAfterRecovery = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterRecovery.isIdle == false)
+    #expect(queueAfterRecovery.pendingCount == 1)
+    #expect(store.deliveredTerminalByteEndSeqBySurfaceID[surfaceID] == 8)
+    #expect(store.terminalReplayIDsInFlightBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridFramesBufferedDuringReplayBySurfaceID[surfaceID] == nil)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID) == false)
+
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+    let queueAfterFullAck = try #require(store.terminalOutputQueuesBySurfaceID[surfaceID])
+    #expect(queueAfterFullAck.isIdle == false)
+    #expect(queueAfterFullAck.pendingCount == 0)
+
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: streamToken)
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+}
+
+@MainActor
+@Test func staleFullRenderGridDoesNotClearContinuityGap() async throws {
+    let store = MobileShellComposite.preview()
+    let surfaceID = "terminal"
+    let streamToken = UUID()
+    let stream = AsyncStream<MobileTerminalOutputChunk> { continuation in
+        store.terminalByteContinuationsBySurfaceID[surfaceID] = continuation
+        store.terminalOutputStreamTokensBySurfaceID[surfaceID] = streamToken
+        store.terminalOutputQueuesBySurfaceID[surfaceID] = TerminalOutputDeliveryQueue()
+    }
+    _ = stream
+
+    store.deliveredTerminalByteEndSeqBySurfaceID[surfaceID] = 10
+    store.terminalRenderGridContinuityGapSurfaceIDs.insert(surfaceID)
+
+    let staleFullFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 9,
+        columns: 16,
+        rows: 2,
+        text: "stale full\nviewport",
+        full: true
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(staleFullFrame, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let partialAfterStaleFull = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 11,
+        columns: 16,
+        rows: 2,
+        text: "partial after stale full\nviewport",
+        full: false,
+        changedRows: [0]
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(partialAfterStaleFull, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == true)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID))
+
+    let freshFullFrame = try MobileTerminalRenderGridFrame.fromPlainRows(
+        surfaceID: surfaceID,
+        stateSeq: 12,
+        columns: 16,
+        rows: 2,
+        text: "fresh full\nviewport",
+        full: true
+    )
+    store.deliverAuthoritativeTerminalRenderGrid(freshFullFrame, source: "event")
+    #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.isIdle == false)
+    #expect(store.terminalRenderGridContinuityGapSurfaceIDs.contains(surfaceID) == false)
+}


### PR DESCRIPTION
Summary
- Fixes https://github.com/manaflow-ai/cmux/issues/5376 by making cold terminal replay an ordering barrier for live render-grid frames.
- Buffers live render-grid deltas while a replay is in flight, then flushes only frames newer than the replay snapshot.
- Adds a per-surface replay owner token so a stale replay response cannot apply old scrollback or clear/flush a newer replay after quick leave/re-enter navigation.
- Bounds replay-time buffering at 128 frames with a liveness-first tail strategy: on overflow it drops the oldest buffered delta, retains the newest tail, and flushes that tail after replay instead of starting an unbounded replay loop.
- Moves replay-delivery helpers into `MobileShellComposite+TerminalOutputDelivery.swift` so `MobileShellComposite.swift` stays under the CI file-length budget.

Red test
- c3abd7a1c6 adds `liveRenderGridWaitsBehindInFlightReplay`; before the fix it failed because live render-grid delivery made the output queue non-idle before replay seeded scrollback.

Green fix
- 4f7c8712f4 adds the ordering barrier, stale-replay owner token, bounded replay tail buffer, and focused regression tests for replay ordering, stale replay completion, and overflow tail flushing.

Verification
- `swift test --package-path Packages/CmuxMobileShell --filter liveRenderGridWaitsBehindInFlightReplay` passed.
- `swift test --package-path Packages/CmuxMobileShell --filter staleReplayFinishCannotFlushNewReplayBuffer` passed.
- `swift test --package-path Packages/CmuxMobileShell --filter TerminalOutputDeliveryQueueTests` passed, 11 tests.
- `swift test --package-path Packages/CMUXMobileCore --filter MobileTerminalRenderGridTests` passed, 16 tests.
- `git diff --check` passed.
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv` passed.
- Localization audit found no new user-facing strings in the changed files.

Reloads
- macOS tagged reload `rgrid` passed from clean HEAD. Dev web origin printed `http://localhost:9710`.
- iOS simulator reload `rgrid` passed on iPhone 17, bundle `dev.cmux.ios.rgrid`, with `CMUX_GIT_SHA=4f7c8712f4`.
- Simulator app container verified with `xcrun simctl get_app_container C9D82663-886D-4EBD-92A0-96CF38A42FF3 dev.cmux.ios.rgrid app`.
- Simulator launch screenshot: `/Users/abdulazizalbahar/Dev/Manaflow/cmuxterm-hq/cmux-assets/issue-5376-ios-scrollback-after-attach/ios-simulator/20260615-220129/rgrid-launch.png` | TLDR: tagged iOS app launches to the cmux sign-in screen.

Proof blockers
- Cloud before/after video proof is blocked: `provision-gh-macos-vm.sh` timed out waiting for Tailscale device `cmux-loader-27594287976`, run https://github.com/manaflow-ai/cmux-loader/actions/runs/27594287976.
- API-backed sign-in/pairing dogfood is blocked locally: `~/.secrets/cmuxterm-dev.env` has dogfood email/password but is missing `STACK_SECRET_SERVER_KEY`, `NEXT_PUBLIC_STACK_PROJECT_ID`, and `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`; Next.js exits during `next.config.ts` validation before `/`, `/handler/sign-in`, and `/handler/after-sign-in` can be warmed.
- Physical iPhone reload is unavailable per task instructions.

Existing unrelated failure
- `swift test --package-path Packages/CmuxMobileShell --filter MobileShellRenderGridLivenessTests` was already failing on `origin/main` before this change because scripted connect does not succeed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal replay and delivery handling, including replay-aware render-grid ordering with bounded per-surface buffering and recovery modes.

* **Bug Fixes**
  * Prevented stale/out-of-order render-grid frames from advancing delivery while a cold replay is in-flight.
  * Added continuity-gap detection/clearing and correct behavior on replay cancellation, failure, overflow, and subsequent full-frame recovery.

* **Tests**
  * Added async tests covering terminal replay lifecycle, buffered delivery gating, overflow behavior, and continuity-gap transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->