### PR TITLE
Fix main package-conventions-lint: scope ComposerDictationTextMerge onto String

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -15,7 +15,7 @@ import Speech
 ///
 /// Text behavior: ``start(existingText:onText:)`` captures the composer's current
 /// text as the base and, for every partial result, calls `onText` with
-/// base + transcript (see ``ComposerDictationTextMerge``) so dictation appends to
+/// base + transcript (see ``Swift/String/mergingDictation(transcript:)``) so dictation appends to
 /// whatever the user already typed and never clobbers it.
 ///
 /// Concurrency: the type is `@MainActor`, so all published state and the `onText`
@@ -306,10 +306,7 @@ final class ComposerDictationController {
             Task { @MainActor in
                 guard let self else { return }
                 if let transcript {
-                    self.onText?(ComposerDictationTextMerge.merged(
-                        base: self.baseText,
-                        transcript: transcript
-                    ))
+                    self.onText?(self.baseText.mergingDictation(transcript: transcript))
                 }
                 // A final result or an error (end-of-stream, recognition failure)
                 // settles the session so the mic does not stay hot. If a graceful

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -67,8 +67,9 @@ enum ComposerDictationState: Equatable {
 /// composer always reads `base` + the latest transcript and never accumulates
 /// stale partials. The base is preserved verbatim so text the user typed before
 /// starting is never clobbered.
-enum ComposerDictationTextMerge {
-    /// Combine the captured base text with the current transcript.
+extension String {
+    /// Combine this captured base text (the composer text at dictation start)
+    /// with the current transcript.
     ///
     /// - A trailing run of whitespace on the base is preserved (the user may
     ///   have typed "hello " and the dictation continues the sentence).
@@ -79,11 +80,10 @@ enum ComposerDictationTextMerge {
     ///   empty); leading whitespace in the transcript is trimmed so the join is
     ///   not doubled.
     ///
-    /// - Parameters:
-    ///   - base: The composer text captured when dictation started.
-    ///   - transcript: The latest (partial or final) recognized transcript.
+    /// - Parameter transcript: The latest (partial or final) recognized transcript.
     /// - Returns: The text to write back into the composer.
-    static func merged(base: String, transcript: String) -> String {
+    func mergingDictation(transcript: String) -> String {
+        let base = self
         let trimmedTranscript = transcript.drop(while: { $0.isWhitespace })
         if trimmedTranscript.isEmpty {
             return base

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -8,45 +8,45 @@ import Testing
     // MARK: - Text merge
 
     @Test func mergeAppendsTranscriptToEmptyBase() {
-        #expect(ComposerDictationTextMerge.merged(base: "", transcript: "hello world") == "hello world")
+        #expect("".mergingDictation(transcript: "hello world") == "hello world")
     }
 
     @Test func mergeInsertsSeparatingSpaceAfterNonWhitespaceBase() {
-        #expect(ComposerDictationTextMerge.merged(base: "hello", transcript: "world") == "hello world")
+        #expect("hello".mergingDictation(transcript: "world") == "hello world")
     }
 
     @Test func mergePreservesTrailingWhitespaceWithoutDoubling() {
         // Base already ends in a space; do not add a second one.
-        #expect(ComposerDictationTextMerge.merged(base: "hello ", transcript: "world") == "hello world")
+        #expect("hello ".mergingDictation(transcript: "world") == "hello world")
     }
 
     @Test func mergeTrimsLeadingTranscriptWhitespace() {
-        #expect(ComposerDictationTextMerge.merged(base: "hello", transcript: "   world") == "hello world")
+        #expect("hello".mergingDictation(transcript: "   world") == "hello world")
     }
 
     @Test func mergeEmptyTranscriptKeepsBaseUnchanged() {
         // A partial may briefly be empty; the user's pre-typed text must survive.
-        #expect(ComposerDictationTextMerge.merged(base: "draft ", transcript: "") == "draft ")
-        #expect(ComposerDictationTextMerge.merged(base: "draft", transcript: "   ") == "draft")
+        #expect("draft ".mergingDictation(transcript: "") == "draft ")
+        #expect("draft".mergingDictation(transcript: "   ") == "draft")
     }
 
     @Test func mergePreservesBaseVerbatim() {
         // The base is appended to, never rewritten: punctuation and casing stay.
         let base = "TODO: ship it,"
-        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "then rest") == "TODO: ship it, then rest")
+        #expect(base.mergingDictation(transcript: "then rest") == "TODO: ship it, then rest")
     }
 
     @Test func mergeIsIdempotentAcrossGrowingPartials() {
         // Successive partials always replace the tail, so the base is never
         // duplicated as the transcript grows.
         let base = "note: "
-        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy") == "note: buy")
-        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy milk") == "note: buy milk")
-        #expect(ComposerDictationTextMerge.merged(base: base, transcript: "buy milk today") == "note: buy milk today")
+        #expect(base.mergingDictation(transcript: "buy") == "note: buy")
+        #expect(base.mergingDictation(transcript: "buy milk") == "note: buy milk")
+        #expect(base.mergingDictation(transcript: "buy milk today") == "note: buy milk today")
     }
 
     @Test func mergeEmptyBaseEmptyTranscriptIsEmpty() {
-        #expect(ComposerDictationTextMerge.merged(base: "", transcript: "") == "")
+        #expect("".mergingDictation(transcript: "") == "")
     }
 
     // MARK: - State machine


### PR DESCRIPTION
`package-conventions-lint` is RED on `origin/main` (and therefore on every PR branched off it) because `Packages/CmuxMobileShellUI/.../ComposerDictationTextMerge.swift` is a caseless namespace-enum landed by #6197 without a `lint:allow` marker.

Fix it properly per the convention: scope the pure merge onto the type it operates on/produces — `String.mergingDictation(transcript:)` with `base = self`. Behavior byte-identical; updated the 1 controller call site, 11 test call sites, and the DocC reference. `lint-ios-package-conventions.sh` now prints OK.

Unblocks the in-flight refactor PRs whose required `package-conventions-lint` was failing on this inherited breakage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784177958&installation_id=133855650&pr_number=6237&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6237&signature=19f90f5778880051b862de84012fcc4457bc7466deaf078ca23c87be44e58e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `package-conventions-lint` on main by updating the dictation text merge to follow package conventions. Behavior is unchanged and in-flight PRs are unblocked.

- **Refactors**
  - Replace `ComposerDictationTextMerge.merged(base:transcript:)` with `String.mergingDictation(transcript:)`; remove the caseless namespace enum.
  - Update 1 controller call site, 11 tests, and DocC; `lint-ios-package-conventions.sh` now passes.

<sup>Written for commit 7a2b9c6747990b40cf6ff26199bbf2231c408b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

