### PR TITLE
Allow sidebar to expand to persisted width cap

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13582,39 +13582,39 @@ struct TabItemView: View, Equatable {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .top, spacing: 8) {
-                if unreadCount > 0 {
-                    ZStack {
-                        Circle()
-                            .fill(activeUnreadBadgeFillColor)
-                        Text("\(unreadCount)")
-                            .font(.system(size: scaledFontSize(9), weight: .semibold))
-                            .foregroundColor(activeUnreadBadgeTextColor)
+            ZStack(alignment: .topTrailing) {
+                HStack(alignment: .top, spacing: 8) {
+                    if unreadCount > 0 {
+                        ZStack {
+                            Circle()
+                                .fill(activeUnreadBadgeFillColor)
+                            Text("\(unreadCount)")
+                                .font(.system(size: scaledFontSize(9), weight: .semibold))
+                                .foregroundColor(activeUnreadBadgeTextColor)
+                        }
+                        .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
                     }
-                    .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
+
+                    if workspaceSnapshot.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: scaledFontSize(9), weight: .semibold))
+                            .foregroundColor(activeSecondaryColor(0.8))
+                            .safeHelp(protectedWorkspaceTooltip)
+                    }
+
+                    Text(displayedTitle)
+                        .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
+                        .foregroundColor(activePrimaryTextColor)
+                        .lineLimit(titleLineLimit)
+                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .layoutPriority(1)
                 }
+                .padding(.trailing, canCloseWorkspace ? scaledCloseButtonWidth + 8 : 0)
 
-                if workspaceSnapshot.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.system(size: scaledFontSize(9), weight: .semibold))
-                        .foregroundColor(activeSecondaryColor(0.8))
-                        .safeHelp(protectedWorkspaceTooltip)
-                }
-
-                Text(displayedTitle)
-                    .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
-                    .foregroundColor(activePrimaryTextColor)
-                    .lineLimit(titleLineLimit)
-                    .truncationMode(.tail)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .layoutPriority(1)
-
-                // The close button is a sibling that always reserves its width
-                // when the workspace is closable, so the title wraps/truncates
-                // before this corner instead of flowing under the hover x. Its
-                // visibility toggles via opacity so hover never re-lays-out the
-                // row. (Matches the group-header plus-button pattern.)
+                // Reserve the close affordance with fixed trailing padding so
+                // hover visibility never changes the title's proposed width.
                 if canCloseWorkspace {
                     Button(action: {
                         #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13611,10 +13611,10 @@ struct TabItemView: View, Equatable {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .layoutPriority(1)
                 }
-                .padding(.trailing, canCloseWorkspace ? scaledCloseButtonWidth + 8 : 0)
+                .padding(.trailing, canCloseWorkspace ? scaledCloseButtonWidth : 0)
 
-                // Reserve the close affordance with fixed trailing padding so
-                // hover visibility never changes the title's proposed width.
+                // Reserve only the close affordance itself so hover visibility
+                // never changes layout, while titles still use the row width.
                 if canCloseWorkspace {
                     Button(action: {
                         #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13582,57 +13582,45 @@ struct TabItemView: View, Equatable {
         )
 
         VStack(alignment: .leading, spacing: 4) {
-            ZStack(alignment: .topTrailing) {
-                HStack(alignment: .top, spacing: 8) {
-                    if unreadCount > 0 {
-                        ZStack {
-                            Circle()
-                                .fill(activeUnreadBadgeFillColor)
-                            Text("\(unreadCount)")
-                                .font(.system(size: scaledFontSize(9), weight: .semibold))
-                                .foregroundColor(activeUnreadBadgeTextColor)
-                        }
-                        .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
-                    }
-
-                    if workspaceSnapshot.isPinned {
-                        Image(systemName: "pin.fill")
+            HStack(alignment: .top, spacing: 8) {
+                if unreadCount > 0 {
+                    ZStack {
+                        Circle()
+                            .fill(activeUnreadBadgeFillColor)
+                        Text("\(unreadCount)")
                             .font(.system(size: scaledFontSize(9), weight: .semibold))
-                            .foregroundColor(activeSecondaryColor(0.8))
-                            .safeHelp(protectedWorkspaceTooltip)
+                            .foregroundColor(activeUnreadBadgeTextColor)
                     }
-
-                    Text(displayedTitle)
-                        .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
-                        .foregroundColor(activePrimaryTextColor)
-                        .lineLimit(titleLineLimit)
-                        .truncationMode(.tail)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .layoutPriority(1)
+                    .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
                 }
-                .padding(.trailing, canCloseWorkspace ? scaledCloseButtonWidth : 0)
 
-                // Reserve only the close affordance itself so hover visibility
-                // never changes layout, while titles still use the row width.
+                if workspaceSnapshot.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: scaledFontSize(9), weight: .semibold))
+                        .foregroundColor(activeSecondaryColor(0.8))
+                        .safeHelp(protectedWorkspaceTooltip)
+                }
+
+                Text(displayedTitle)
+                    .font(.system(size: scaledFontSize(12.5), weight: titleFontWeight))
+                    .foregroundColor(activePrimaryTextColor)
+                    .lineLimit(titleLineLimit)
+                    .truncationMode(.tail)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.trailing, canCloseWorkspace ? scaledCloseButtonWidth : 0)
+            // Keep the close button outside HStack width negotiation so
+            // wrapped titles receive a concrete row width.
+            .overlay(alignment: .topTrailing) {
                 if canCloseWorkspace {
-                    Button(action: {
-                        #if DEBUG
-                        cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
-                        #endif
-                        tabManager.closeWorkspaceWithConfirmation(tab)
-                    }) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: scaledFontSize(9), weight: .medium))
-                            .foregroundColor(activeSecondaryColor(0.7))
-                            .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .safeHelp(closeButtonTooltip)
-                    .opacity(showCloseButton ? 1 : 0)
-                    .allowsHitTesting(showCloseButton)
-                    .accessibilityHidden(!showCloseButton)
+                    closeWorkspaceButton(
+                        tooltip: closeButtonTooltip,
+                        width: scaledCloseButtonWidth,
+                        hitSize: scaledCloseButtonHitSize
+                    )
                 }
             }
 
@@ -14011,6 +13999,30 @@ struct TabItemView: View, Equatable {
                     flushDeferredWorkspaceObservationInvalidation()
                 }
         }
+    }
+
+    private func closeWorkspaceButton(
+        tooltip: String,
+        width: CGFloat,
+        hitSize: CGFloat
+    ) -> some View {
+        Button(action: {
+            #if DEBUG
+            cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=button")
+            #endif
+            tabManager.closeWorkspaceWithConfirmation(tab)
+        }) {
+            Image(systemName: "xmark")
+                .font(.system(size: scaledFontSize(9), weight: .medium))
+                .foregroundColor(activeSecondaryColor(0.7))
+                .frame(width: width, height: hitSize, alignment: .center)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .safeHelp(tooltip)
+        .opacity(showCloseButton ? 1 : 0)
+        .allowsHitTesting(showCloseButton)
+        .accessibilityHidden(!showCloseButton)
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1253,7 +1253,7 @@ struct ContentView: View {
     nonisolated private static let commandPaletteCommandsPrefix = ">"
     private static let commandPaletteVisiblePreviewResultLimit = 48
     private static let commandPaletteVisiblePreviewCandidateLimit = 128
-    private static let maximumSidebarWidthRatio: CGFloat = 1.0 / 3.0
+    private static let minimumContentWidthWithSidebar: CGFloat = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
     private static let minimumRightSidebarWidth: CGFloat = CGFloat(RightSidebarWidthSettings.minimumWidth)
     private static let maximumRightSidebarWidth: CGFloat = CGFloat(RightSidebarWidthSettings.builtInMaximumWidth)
     private static let minimumTerminalWidthWithRightSidebar: CGFloat = 360
@@ -1322,13 +1322,32 @@ struct ContentView: View {
             ?? NSApp.keyWindow?.contentView?.bounds.width
             ?? NSApp.keyWindow?.contentLayoutRect.width
         if let resolvedAvailableWidth, resolvedAvailableWidth > 0 {
-            return max(minimumSidebarWidth, resolvedAvailableWidth * Self.maximumSidebarWidthRatio)
+            return Self.maximumSidebarWidth(
+                availableWidth: resolvedAvailableWidth,
+                minimumWidth: minimumSidebarWidth
+            )
         }
 
         let fallbackScreenWidth = NSApp.keyWindow?.screen?.frame.width
             ?? NSScreen.main?.frame.width
             ?? 1920
-        return max(minimumSidebarWidth, fallbackScreenWidth * Self.maximumSidebarWidthRatio)
+        return Self.maximumSidebarWidth(
+            availableWidth: fallbackScreenWidth,
+            minimumWidth: minimumSidebarWidth
+        )
+    }
+
+    static func maximumSidebarWidth(
+        availableWidth: CGFloat,
+        minimumWidth: CGFloat = CGFloat(SessionPersistencePolicy.defaultMinimumSidebarWidth)
+    ) -> CGFloat {
+        guard availableWidth.isFinite, availableWidth > 0 else {
+            return max(minimumWidth, CGFloat(SessionPersistencePolicy.maximumSidebarWidth))
+        }
+        let maximumPersistedWidth = CGFloat(SessionPersistencePolicy.maximumSidebarWidth)
+        let contentPreservingCap = availableWidth - Self.minimumContentWidthWithSidebar
+        let maximumWidth = min(maximumPersistedWidth, contentPreservingCap)
+        return max(minimumWidth, maximumWidth)
     }
 
     static func clampedSidebarWidth(

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -51,6 +51,22 @@ final class SidebarWidthPolicyTests: XCTestCase {
         )
     }
 
+    func testContentViewMaximumSidebarWidthAllowsPersistedMaximumOnWideWindows() {
+        XCTAssertEqual(
+            ContentView.maximumSidebarWidth(availableWidth: 1_400),
+            CGFloat(SessionPersistencePolicy.maximumSidebarWidth),
+            accuracy: 0.001
+        )
+    }
+
+    func testContentViewMaximumSidebarWidthLeavesContentWidthOnNarrowWindows() {
+        XCTAssertEqual(
+            ContentView.maximumSidebarWidth(availableWidth: 700),
+            400,
+            accuracy: 0.001
+        )
+    }
+
     func testSessionPersistenceReadsConfiguredMinimumSidebarWidth() {
         let suiteName = "SidebarWidthPolicyTests.minimumSidebarWidth.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
Summary:
- Replace the left sidebar one-third-of-window cap with the existing persisted 600px product cap.
- Keep a minimum content-width reserve on narrow windows.
- Add focused sidebar width policy regression coverage.

Tests:
- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-sidebar-width -only-testing:cmuxTests/SidebarWidthPolicyTests

Dogfood:
- Built tagged app via ./scripts/reload-cloud.sh --tag swidth.
- Launched cmux DEV swidth, created long workspace titles, widened the left sidebar with Computer Use, and confirmed the sidebar rows rendered with more text width.

Localization:
- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784185594&installation_id=133855650&pr_number=6240&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6240&signature=5842a42e9e4b1da43dd7cc83cef2f3e73b7c6b9a3bed525de08a2e55cf119fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout and resize math in ContentView with new unit tests; no auth, data, or API changes.
> 
> **Overview**
> **Left sidebar resizing** no longer caps width at one-third of the window. Maximum width is now the persisted **600px** product limit, and on narrow windows it is further limited so the main content keeps at least `SessionPersistencePolicy.minimumWindowWidth`.
> 
> **Workspace sidebar rows** move the close control into a trailing **overlay** (with trailing padding reserved) and extract `closeWorkspaceButton`, so long titles get a stable row width and hover visibility does not fight layout.
> 
> **Tests** add `ContentView.maximumSidebarWidth` coverage for wide vs narrow available widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4eca5416b0d9cf2f9899f3f5bbd260e660a2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the left sidebar expand to the persisted max width (600px) instead of the one‑third window cap, while preserving a minimum main-content width on narrow windows. Restored stable title wrapping by overlaying the close button with fixed trailing padding (no hover reflow), and added regression tests for both wide and narrow window cases.

<sup>Written for commit 3b4eca5416b0d9cf2f9899f3f5bbd260e660a2c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved left sidebar resizing by enforcing a content-preserving minimum width, ensuring the sidebar never caps in a way that overly squeezes the main content on smaller windows.
  * Updated workspace row header layout so the close control no longer impacts title sizing during hover-driven visibility changes.
* **Tests**
  * Added sidebar width policy test coverage for both wide and narrow window sizes to verify persisted maximums and constrained resizing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->