### PR TITLE
CI: bound activation scrollback fixture

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -73,11 +73,16 @@ jobs:
           key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
           restore-keys: zig-packages-
 
-      - name: Build GhosttyKit.xcframework
+      - name: Install zig
         if: steps.check-release.outputs.exists == 'false'
         run: |
           set -euo pipefail
           ./scripts/install-zig-ci.sh
+
+      - name: Build GhosttyKit.xcframework
+        if: steps.check-release.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
           cd ghostty && zig build -Dcrash-report-subdir="$GHOSTTYKIT_CRASH_REPORT_SUBDIR" -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Package xcframework

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -96,6 +96,9 @@ jobs:
           key: spm-${{ matrix.os }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ matrix.os }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,7 +589,7 @@ jobs:
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    runs-on: depot-macos-latest
     # A cold DerivedData cache (any project.pbxproj or Package.resolved change
     # mints a new cache key with no restore-keys fallback) forces a full
     # cmux build whose Swift codegen alone can run 20+ min. Project/package
@@ -597,6 +597,24 @@ jobs:
     # CA and lag regressions beyond 35 min before the cache could repopulate.
     timeout-minutes: 55
     steps:
+      - name: Validate Depot runner identity
+        env:
+          REQUESTED_RUNNER: depot-macos-latest
+          RUNNER_CONTEXT_NAME: ${{ runner.name }}
+        run: |
+          set -euo pipefail
+          echo "Requested runner: $REQUESTED_RUNNER"
+          case "$RUNNER_CONTEXT_NAME" in
+            depot-*)
+              echo "Resolved runner matches depot-*? yes"
+              ;;
+            *)
+              echo "Resolved runner matches depot-*? no"
+              echo "::error::$REQUESTED_RUNNER resolved outside Depot. Remove $REQUESTED_RUNNER from non-Depot self-hosted runners or choose a different runner."
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Validate Python test harness syntax
         run: git ls-files 'tests/*.py' 'tests_v2/*.py' 'scripts/*.py' | xargs python3 -m py_compile
 
+      - name: Validate activation benchmark scrollback sizing
+        run: python3 tests/test_perf_activation_scrollback_sizing.py
+
       - name: Validate create-dmg version pinning
         run: ./tests/test_ci_create_dmg_pinned.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,6 +712,51 @@ jobs:
       - name: Validate Swift warning budget
         run: python3 scripts/swift_warning_budget.py --log /tmp/cmux-build-output.txt
 
+      - name: Create virtual display
+        run: |
+          set -euo pipefail
+          HELPER_PATH="$RUNNER_TEMP/create-virtual-display"
+          VDISPLAY_READY="$RUNNER_TEMP/cmux-build-lag-vdisplay.ready"
+          VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-build-lag-vdisplay.id"
+          VDISPLAY_LOG="$RUNNER_TEMP/cmux-build-lag-vdisplay.log"
+
+          clang -framework Foundation -framework CoreGraphics \
+            -o "$HELPER_PATH" scripts/create-virtual-display.m
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+
+          "$HELPER_PATH" \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            >"$VDISPLAY_LOG" 2>&1 &
+          VDISPLAY_PID=$!
+
+          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
+          echo "VDISPLAY_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
+          echo "VDISPLAY_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
+
+          for _ in $(seq 1 100); do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+              echo "Virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.1
+          done
+
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "Timed out waiting for virtual display readiness" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+
+          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+          cat "$VDISPLAY_LOG"
+
       - name: Run CoreAnimation main-thread startup regression
         run: |
           set -euo pipefail
@@ -730,17 +775,6 @@ jobs:
           CMUX_CA_ASSERT_HOLD_SECONDS=15 \
           CMUX_TAG="ci-ca-main-thread" \
           ./scripts/verify-main-thread-ca-transactions.sh "$APP"
-
-      - name: Create virtual display
-        run: |
-          set -euo pipefail
-          clang -framework Foundation -framework CoreGraphics \
-            -o /tmp/create-virtual-display scripts/create-virtual-display.m
-          /tmp/create-virtual-display &
-          VDISPLAY_PID=$!
-          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          sleep 3
-          kill -0 "$VDISPLAY_PID"
 
       - name: Run workspace churn typing-lag regression
         run: |
@@ -791,7 +825,7 @@ jobs:
           if [ -n "${VDISPLAY_PID:-}" ]; then
             kill "$VDISPLAY_PID" >/dev/null 2>&1 || true
           fi
-          rm -f /tmp/create-virtual-display
+          rm -f "${VDISPLAY_HELPER_PATH:-}" "${VDISPLAY_READY:-}" "${VDISPLAY_ID_PATH:-}" "${VDISPLAY_LOG:-}"
 
   release-ghostty-cli-helper:
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
@@ -1061,39 +1095,70 @@ jobs:
       - name: Create persistent virtual display
         run: |
           set -euo pipefail
-          HELPER_PATH="/tmp/create-virtual-display"
+          HELPER_PATH="$RUNNER_TEMP/create-virtual-display-persistent"
           clang -framework Foundation -framework CoreGraphics \
             -o "$HELPER_PATH" scripts/create-virtual-display.m
 
-          VDISPLAY_READY="/tmp/cmux-vdisplay-persistent.ready"
-          VDISPLAY_ID_PATH="/tmp/cmux-vdisplay-persistent.id"
-          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH"
+          VDISPLAY_READY="$RUNNER_TEMP/cmux-vdisplay-persistent.ready"
+          VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-vdisplay-persistent.id"
+          VDISPLAY_LOG="$RUNNER_TEMP/cmux-vdisplay-persistent.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
 
           "$HELPER_PATH" \
             --modes "1920x1080" \
             --ready-path "$VDISPLAY_READY" \
             --display-id-path "$VDISPLAY_ID_PATH" \
-            > /tmp/cmux-vdisplay-persistent.log 2>&1 &
-          echo "VDISPLAY_PERSISTENT_PID=$!" >> "$GITHUB_ENV"
+            >"$VDISPLAY_LOG" 2>&1 &
+          VDISPLAY_PERSISTENT_PID=$!
+
+          echo "VDISPLAY_PERSISTENT_PID=$VDISPLAY_PERSISTENT_PID" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
 
           echo "Waiting for persistent virtual display..."
-          for _ in $(seq 1 24); do
-            if [ -f "$VDISPLAY_READY" ]; then break; fi
-            sleep 0.5
+          for _ in $(seq 1 100); do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PERSISTENT_PID" 2>/dev/null; then
+              echo "Persistent virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.1
           done
-          if [ ! -f "$VDISPLAY_READY" ]; then
-            echo "ERROR: Persistent virtual display not ready after 12s" >&2
-            cat /tmp/cmux-vdisplay-persistent.log 2>/dev/null || true
+
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "ERROR: Persistent virtual display not ready after 10s" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
             exit 1
           fi
-          echo "Persistent virtual display ready: ID=$(cat "$VDISPLAY_ID_PATH")"
+
+          echo "Persistent virtual display ready: ID=$(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+          cat "$VDISPLAY_LOG"
+
+      - name: Enable XCTest automation mode
+        run: |
+          set -euo pipefail
+          if ! command -v automationmodetool >/dev/null 2>&1; then
+            echo "::warning::automationmodetool is unavailable; XCTest will use its default automation-mode setup"
+            exit 0
+          fi
+
+          if sudo -n true 2>/dev/null; then
+            sudo -n automationmodetool enable-automationmode-without-authentication
+          else
+            echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
+          fi
 
       - name: Run display resolution churn UI regression
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          HELPER_PATH="/tmp/create-virtual-display"
           TOKEN="$(uuidgen)"
+          HELPER_PATH="$RUNNER_TEMP/create-virtual-display-display-churn-${TOKEN}"
           DIAG_PATH="/tmp/cmux-ui-test-display-churn-${TOKEN}.json"
           DISPLAY_READY="/tmp/cmux-ui-test-display-${TOKEN}.ready"
           DISPLAY_ID_PATH="/tmp/cmux-ui-test-display-${TOKEN}.id"
@@ -1103,7 +1168,7 @@ jobs:
 
           cleanup() {
             pkill -x "cmux DEV" 2>/dev/null || true
-            rm -f "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
+            rm -f "$HELPER_PATH" "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
             rm -f /tmp/cmux-ui-test-prelaunch.json /tmp/cmux-ui-test-display-harness.json
           }
           trap cleanup EXIT
@@ -1140,16 +1205,25 @@ jobs:
 
             # Wait for display ready
             echo "Waiting for virtual display..."
-            for _ in $(seq 1 24); do
-              if [ -f "$DISPLAY_READY" ]; then break; fi
-              sleep 0.5
+            DISPLAY_READY_OK=false
+            for _ in $(seq 1 100); do
+              if [ -s "$DISPLAY_READY" ] && [ -s "$DISPLAY_ID_PATH" ]; then
+                DISPLAY_READY_OK=true
+                break
+              fi
+              if ! kill -0 "$HELPER_PID" 2>/dev/null; then
+                echo "ERROR: Virtual display helper exited before readiness" >&2
+                cat "$HELPER_LOG" 2>/dev/null || true
+                break
+              fi
+              sleep 0.1
             done
-            if [ ! -f "$DISPLAY_READY" ]; then
-              echo "ERROR: Virtual display not ready after 12s" >&2
+            if [ "$DISPLAY_READY_OK" != "true" ]; then
+              echo "ERROR: Virtual display not ready after 10s" >&2
               cat "$HELPER_LOG" 2>/dev/null || true
               continue
             fi
-            DISPLAY_ID=$(cat "$DISPLAY_ID_PATH")
+            DISPLAY_ID=$(tr -d '\n' < "$DISPLAY_ID_PATH")
             echo "Virtual display ready: ID=$DISPLAY_ID"
 
             # Launch app from shell (non-sandboxed, outside XCTest sandbox)
@@ -1256,6 +1330,12 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          if [ -n "${VDISPLAY_PERSISTENT_PID:-}" ] && ! kill -0 "$VDISPLAY_PERSISTENT_PID" 2>/dev/null; then
+            echo "Persistent virtual display exited before browser find UI regression" >&2
+            cat "${VDISPLAY_PERSISTENT_LOG:-/dev/null}" >&2 || true
+            exit 1
+          fi
+
           xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
             -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
@@ -1271,4 +1351,4 @@ jobs:
           if [ -n "${VDISPLAY_PERSISTENT_PID:-}" ]; then
             kill "$VDISPLAY_PERSISTENT_PID" >/dev/null 2>&1 || true
           fi
-          rm -f /tmp/cmux-vdisplay-persistent.ready /tmp/cmux-vdisplay-persistent.id /tmp/cmux-vdisplay-persistent.log
+          rm -f "${VDISPLAY_PERSISTENT_HELPER_PATH:-}" "${VDISPLAY_PERSISTENT_READY:-}" "${VDISPLAY_PERSISTENT_ID_PATH:-}" "${VDISPLAY_PERSISTENT_LOG:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,17 @@ jobs:
       - name: Validate xcodebuild noninteractive crash prompt guard
         run: python3 tests/test_ci_xcodebuild_noninteractive_helper.py
 
+      - name: Validate Xcode SourcePackages cache sanitizer
+        run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
+
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 
       - name: Validate GhosttyKit checksum verification
         run: ./tests/test_ci_ghosttykit_checksum_verification.sh
+
+      - name: Validate Zig install without sudo
+        run: ./tests/test_install_zig_ci_no_sudo.sh
 
       - name: Validate nightly tag push auth
         run: ./tests/test_ci_nightly_tag_push_auth.sh
@@ -288,6 +294,9 @@ jobs:
           path: .ci-source-packages
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
 
       - name: Prepare isolated DerivedData
         run: |
@@ -665,6 +674,9 @@ jobs:
           key: spm-build-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-build-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail
@@ -900,6 +912,9 @@ jobs:
             spm-release-
             spm-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Build universal app (Release)
         run: |
           set -euo pipefail
@@ -1006,6 +1021,9 @@ jobs:
           path: .ci-source-packages
           key: spm-ui-regressions-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-ui-regressions-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Validate Zig install without sudo
         run: ./tests/test_install_zig_ci_no_sudo.sh
 
+      - name: Validate virtual display lock
+        run: ./tests/test_ci_virtual_display_lock.sh
+
       - name: Validate nightly tag push auth
         run: ./tests/test_ci_nightly_tag_push_auth.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,6 +717,7 @@ jobs:
           set -euo pipefail
           LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
           eval "$LOCK_ENV"
+          export CMUX_VDISPLAY_LOCK_DIR CMUX_VDISPLAY_LOCK_TOKEN
           echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
           echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
 
@@ -1136,6 +1137,7 @@ jobs:
           acquire_display_lock() {
             LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
             eval "$LOCK_ENV"
+            export CMUX_VDISPLAY_LOCK_DIR CMUX_VDISPLAY_LOCK_TOKEN
             DISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR"
             DISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN"
           }
@@ -1330,6 +1332,7 @@ jobs:
           set -euo pipefail
           LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
           eval "$LOCK_ENV"
+          export CMUX_VDISPLAY_LOCK_DIR CMUX_VDISPLAY_LOCK_TOKEN
           echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
           echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,54 +718,75 @@ jobs:
       - name: Create virtual display
         run: |
           set -euo pipefail
-          LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
-          eval "$LOCK_ENV"
-          export CMUX_VDISPLAY_LOCK_DIR CMUX_VDISPLAY_LOCK_TOKEN
-          echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
-          echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
-
           HELPER_PATH="$RUNNER_TEMP/create-virtual-display"
           VDISPLAY_READY="$RUNNER_TEMP/cmux-build-lag-vdisplay.ready"
           VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-build-lag-vdisplay.id"
           VDISPLAY_LOG="$RUNNER_TEMP/cmux-build-lag-vdisplay.log"
+          VDISPLAY_PID=""
 
           clang -framework Foundation -framework CoreGraphics \
             -o "$HELPER_PATH" scripts/create-virtual-display.m
-          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
 
-          "$HELPER_PATH" \
-            --ready-path "$VDISPLAY_READY" \
-            --display-id-path "$VDISPLAY_ID_PATH" \
-            >"$VDISPLAY_LOG" 2>&1 &
-          VDISPLAY_PID=$!
-          scripts/ci/virtual-display-lock.sh set-owner "$VDISPLAY_PID"
-
-          echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
-          echo "VDISPLAY_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
-          echo "VDISPLAY_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
-          echo "VDISPLAY_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
-          echo "VDISPLAY_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
-
-          for _ in $(seq 1 100); do
-            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
-              break
+          cleanup_display_attempt() {
+            if [ -n "${VDISPLAY_PID:-}" ]; then
+              kill "$VDISPLAY_PID" >/dev/null 2>&1 || true
+              for _ in $(seq 1 50); do
+                kill -0 "$VDISPLAY_PID" >/dev/null 2>&1 || break
+                sleep 0.1
+              done
+              VDISPLAY_PID=""
             fi
-            if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
-              echo "Virtual display helper exited before readiness" >&2
-              cat "$VDISPLAY_LOG" >&2 || true
+            scripts/ci/virtual-display-lock.sh release || true
+          }
+
+          for attempt in 1 2 3; do
+            rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+            LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
+            eval "$LOCK_ENV"
+            export CMUX_VDISPLAY_LOCK_DIR CMUX_VDISPLAY_LOCK_TOKEN
+            echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
+            echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
+
+            "$HELPER_PATH" \
+              --ready-path "$VDISPLAY_READY" \
+              --display-id-path "$VDISPLAY_ID_PATH" \
+              >"$VDISPLAY_LOG" 2>&1 &
+            VDISPLAY_PID=$!
+            scripts/ci/virtual-display-lock.sh set-owner "$VDISPLAY_PID"
+
+            echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
+            echo "VDISPLAY_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
+            echo "VDISPLAY_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
+            echo "VDISPLAY_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
+            echo "VDISPLAY_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
+
+            for _ in $(seq 1 100); do
+              if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+                break
+              fi
+              if ! kill -0 "$VDISPLAY_PID" 2>/dev/null; then
+                echo "Virtual display helper exited before readiness on attempt $attempt" >&2
+                cat "$VDISPLAY_LOG" >&2 || true
+                break
+              fi
+              sleep 0.1
+            done
+
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+              cat "$VDISPLAY_LOG"
+              exit 0
+            fi
+
+            echo "Virtual display not ready on attempt $attempt" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            cleanup_display_attempt
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to create virtual display after 3 attempts" >&2
               exit 1
             fi
-            sleep 0.1
+            sleep 5
           done
-
-          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
-            echo "Timed out waiting for virtual display readiness" >&2
-            cat "$VDISPLAY_LOG" >&2 || true
-            exit 1
-          fi
-
-          echo "Virtual display ready: $(tr -d '\n' < "$VDISPLAY_ID_PATH")"
-          cat "$VDISPLAY_LOG"
 
       - name: Run CoreAnimation main-thread startup regression
         run: |
@@ -1224,6 +1245,12 @@ jobs:
             if [ "$DISPLAY_READY_OK" != "true" ]; then
               echo "ERROR: Virtual display not ready after 10s" >&2
               cat "$HELPER_LOG" 2>/dev/null || true
+              cleanup_attempt
+              if [ "$attempt" -eq 2 ]; then
+                echo "Display resolution UI regression failed after 2 virtual display setup attempts" >&2
+                exit 1
+              fi
+              sleep 3
               continue
             fi
             DISPLAY_ID=$(tr -d '\n' < "$DISPLAY_ID_PATH")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,11 @@ jobs:
       - name: Create virtual display
         run: |
           set -euo pipefail
+          LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
+          eval "$LOCK_ENV"
+          echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
+          echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
+
           HELPER_PATH="$RUNNER_TEMP/create-virtual-display"
           VDISPLAY_READY="$RUNNER_TEMP/cmux-build-lag-vdisplay.ready"
           VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-build-lag-vdisplay.id"
@@ -729,6 +734,7 @@ jobs:
             --display-id-path "$VDISPLAY_ID_PATH" \
             >"$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PID=$!
+          scripts/ci/virtual-display-lock.sh set-owner "$VDISPLAY_PID"
 
           echo "VDISPLAY_PID=$VDISPLAY_PID" >> "$GITHUB_ENV"
           echo "VDISPLAY_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
@@ -824,7 +830,12 @@ jobs:
           set -euo pipefail
           if [ -n "${VDISPLAY_PID:-}" ]; then
             kill "$VDISPLAY_PID" >/dev/null 2>&1 || true
+            for _ in $(seq 1 50); do
+              kill -0 "$VDISPLAY_PID" >/dev/null 2>&1 || break
+              sleep 0.1
+            done
           fi
+          scripts/ci/virtual-display-lock.sh release || true
           rm -f "${VDISPLAY_HELPER_PATH:-}" "${VDISPLAY_READY:-}" "${VDISPLAY_ID_PATH:-}" "${VDISPLAY_LOG:-}"
 
   release-ghostty-cli-helper:
@@ -1092,6 +1103,20 @@ jobs:
             -destination "platform=macOS" \
             build-for-testing
 
+      - name: Enable XCTest automation mode
+        run: |
+          set -euo pipefail
+          if ! command -v automationmodetool >/dev/null 2>&1; then
+            echo "::warning::automationmodetool is unavailable; XCTest will use its default automation-mode setup"
+            exit 0
+          fi
+
+          if sudo -n true 2>/dev/null; then
+            sudo -n automationmodetool enable-automationmode-without-authentication
+          else
+            echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
+          fi
+
       - name: Run display resolution churn UI regression
         run: |
           set -euo pipefail
@@ -1105,6 +1130,25 @@ jobs:
           DISPLAY_DONE="/tmp/cmux-ui-test-display-${TOKEN}.done"
           HELPER_LOG="/tmp/cmux-ui-test-display-${TOKEN}-helper.log"
           HELPER_PID=""
+          DISPLAY_LOCK_DIR=""
+          DISPLAY_LOCK_TOKEN=""
+
+          acquire_display_lock() {
+            LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
+            eval "$LOCK_ENV"
+            DISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR"
+            DISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN"
+          }
+
+          release_display_lock() {
+            if [ -n "${DISPLAY_LOCK_DIR:-}" ]; then
+              CMUX_VDISPLAY_LOCK_DIR="$DISPLAY_LOCK_DIR" \
+              CMUX_VDISPLAY_LOCK_TOKEN="$DISPLAY_LOCK_TOKEN" \
+                scripts/ci/virtual-display-lock.sh release || true
+              DISPLAY_LOCK_DIR=""
+              DISPLAY_LOCK_TOKEN=""
+            fi
+          }
 
           cleanup_attempt() {
             if [ -n "${HELPER_PID:-}" ]; then
@@ -1112,6 +1156,7 @@ jobs:
               wait "$HELPER_PID" 2>/dev/null || true
               HELPER_PID=""
             fi
+            release_display_lock
             pkill -x "cmux DEV" 2>/dev/null || true
             rm -f "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
             rm -f /tmp/cmux-ui-test-prelaunch.json /tmp/cmux-ui-test-display-harness.json
@@ -1138,6 +1183,8 @@ jobs:
           for attempt in 1 2; do
             cleanup_attempt 2>/dev/null || true
 
+            acquire_display_lock
+
             # Launch display helper from shell (non-sandboxed).
             # Use --start-delay-ms instead of --start-path because the XCTest
             # runner is sandboxed and can't write to /tmp/ for the start signal.
@@ -1152,6 +1199,7 @@ jobs:
               --start-delay-ms 10000 \
               > "$HELPER_LOG" 2>&1 &
             HELPER_PID=$!
+            scripts/ci/virtual-display-lock.sh set-owner "$HELPER_PID"
 
             # Wait for display ready
             echo "Waiting for virtual display..."
@@ -1280,6 +1328,11 @@ jobs:
       - name: Create persistent virtual display
         run: |
           set -euo pipefail
+          LOCK_ENV="$(scripts/ci/virtual-display-lock.sh acquire)"
+          eval "$LOCK_ENV"
+          echo "CMUX_VDISPLAY_LOCK_DIR=$CMUX_VDISPLAY_LOCK_DIR" >> "$GITHUB_ENV"
+          echo "CMUX_VDISPLAY_LOCK_TOKEN=$CMUX_VDISPLAY_LOCK_TOKEN" >> "$GITHUB_ENV"
+
           HELPER_PATH="$RUNNER_TEMP/create-virtual-display-persistent"
           clang -framework Foundation -framework CoreGraphics \
             -o "$HELPER_PATH" scripts/create-virtual-display.m
@@ -1295,6 +1348,7 @@ jobs:
             --display-id-path "$VDISPLAY_ID_PATH" \
             >"$VDISPLAY_LOG" 2>&1 &
           VDISPLAY_PERSISTENT_PID=$!
+          scripts/ci/virtual-display-lock.sh set-owner "$VDISPLAY_PERSISTENT_PID"
 
           echo "VDISPLAY_PERSISTENT_PID=$VDISPLAY_PERSISTENT_PID" >> "$GITHUB_ENV"
           echo "VDISPLAY_PERSISTENT_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
@@ -1324,20 +1378,6 @@ jobs:
           echo "Persistent virtual display ready: ID=$(tr -d '\n' < "$VDISPLAY_ID_PATH")"
           cat "$VDISPLAY_LOG"
 
-      - name: Enable XCTest automation mode
-        run: |
-          set -euo pipefail
-          if ! command -v automationmodetool >/dev/null 2>&1; then
-            echo "::warning::automationmodetool is unavailable; XCTest will use its default automation-mode setup"
-            exit 0
-          fi
-
-          if sudo -n true 2>/dev/null; then
-            sudo -n automationmodetool enable-automationmode-without-authentication
-          else
-            echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
-          fi
-
       - name: Run browser find focus UI regression
         run: |
           set -euo pipefail
@@ -1362,5 +1402,10 @@ jobs:
         run: |
           if [ -n "${VDISPLAY_PERSISTENT_PID:-}" ]; then
             kill "$VDISPLAY_PERSISTENT_PID" >/dev/null 2>&1 || true
+            for _ in $(seq 1 50); do
+              kill -0 "$VDISPLAY_PERSISTENT_PID" >/dev/null 2>&1 || break
+              sleep 0.1
+            done
           fi
+          scripts/ci/virtual-display-lock.sh release || true
           rm -f "${VDISPLAY_PERSISTENT_HELPER_PATH:-}" "${VDISPLAY_PERSISTENT_READY:-}" "${VDISPLAY_PERSISTENT_ID_PATH:-}" "${VDISPLAY_PERSISTENT_LOG:-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1104,8 +1104,14 @@ jobs:
           DISPLAY_START="/tmp/cmux-ui-test-display-${TOKEN}.start"
           DISPLAY_DONE="/tmp/cmux-ui-test-display-${TOKEN}.done"
           HELPER_LOG="/tmp/cmux-ui-test-display-${TOKEN}-helper.log"
+          HELPER_PID=""
 
           cleanup_attempt() {
+            if [ -n "${HELPER_PID:-}" ]; then
+              kill "$HELPER_PID" 2>/dev/null || true
+              wait "$HELPER_PID" 2>/dev/null || true
+              HELPER_PID=""
+            fi
             pkill -x "cmux DEV" 2>/dev/null || true
             rm -f "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
             rm -f /tmp/cmux-ui-test-prelaunch.json /tmp/cmux-ui-test-display-harness.json
@@ -1256,11 +1262,12 @@ jobs:
               -destination "platform=macOS" \
               -only-testing:cmuxUITests/DisplayResolutionRegressionUITests \
               test-without-building; then
+              cleanup_attempt
               exit 0
             fi
 
             pkill -x "cmux DEV" 2>/dev/null || true
-            kill "$HELPER_PID" 2>/dev/null || true
+            cleanup_attempt
 
             if [ "$attempt" -eq 2 ]; then
               echo "Display resolution UI regression failed after 2 attempts" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,67 +1092,6 @@ jobs:
             -destination "platform=macOS" \
             build-for-testing
 
-      - name: Create persistent virtual display
-        run: |
-          set -euo pipefail
-          HELPER_PATH="$RUNNER_TEMP/create-virtual-display-persistent"
-          clang -framework Foundation -framework CoreGraphics \
-            -o "$HELPER_PATH" scripts/create-virtual-display.m
-
-          VDISPLAY_READY="$RUNNER_TEMP/cmux-vdisplay-persistent.ready"
-          VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-vdisplay-persistent.id"
-          VDISPLAY_LOG="$RUNNER_TEMP/cmux-vdisplay-persistent.log"
-          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
-
-          "$HELPER_PATH" \
-            --modes "1920x1080" \
-            --ready-path "$VDISPLAY_READY" \
-            --display-id-path "$VDISPLAY_ID_PATH" \
-            >"$VDISPLAY_LOG" 2>&1 &
-          VDISPLAY_PERSISTENT_PID=$!
-
-          echo "VDISPLAY_PERSISTENT_PID=$VDISPLAY_PERSISTENT_PID" >> "$GITHUB_ENV"
-          echo "VDISPLAY_PERSISTENT_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
-          echo "VDISPLAY_PERSISTENT_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
-          echo "VDISPLAY_PERSISTENT_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
-          echo "VDISPLAY_PERSISTENT_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
-
-          echo "Waiting for persistent virtual display..."
-          for _ in $(seq 1 100); do
-            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
-              break
-            fi
-            if ! kill -0 "$VDISPLAY_PERSISTENT_PID" 2>/dev/null; then
-              echo "Persistent virtual display helper exited before readiness" >&2
-              cat "$VDISPLAY_LOG" >&2 || true
-              exit 1
-            fi
-            sleep 0.1
-          done
-
-          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
-            echo "ERROR: Persistent virtual display not ready after 10s" >&2
-            cat "$VDISPLAY_LOG" >&2 || true
-            exit 1
-          fi
-
-          echo "Persistent virtual display ready: ID=$(tr -d '\n' < "$VDISPLAY_ID_PATH")"
-          cat "$VDISPLAY_LOG"
-
-      - name: Enable XCTest automation mode
-        run: |
-          set -euo pipefail
-          if ! command -v automationmodetool >/dev/null 2>&1; then
-            echo "::warning::automationmodetool is unavailable; XCTest will use its default automation-mode setup"
-            exit 0
-          fi
-
-          if sudo -n true 2>/dev/null; then
-            sudo -n automationmodetool enable-automationmode-without-authentication
-          else
-            echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
-          fi
-
       - name: Run display resolution churn UI regression
         run: |
           set -euo pipefail
@@ -1330,6 +1269,67 @@ jobs:
             echo "Attempt $attempt failed, retrying..."
             sleep 3
           done
+
+      - name: Create persistent virtual display
+        run: |
+          set -euo pipefail
+          HELPER_PATH="$RUNNER_TEMP/create-virtual-display-persistent"
+          clang -framework Foundation -framework CoreGraphics \
+            -o "$HELPER_PATH" scripts/create-virtual-display.m
+
+          VDISPLAY_READY="$RUNNER_TEMP/cmux-vdisplay-persistent.ready"
+          VDISPLAY_ID_PATH="$RUNNER_TEMP/cmux-vdisplay-persistent.id"
+          VDISPLAY_LOG="$RUNNER_TEMP/cmux-vdisplay-persistent.log"
+          rm -f "$VDISPLAY_READY" "$VDISPLAY_ID_PATH" "$VDISPLAY_LOG"
+
+          "$HELPER_PATH" \
+            --modes "1920x1080" \
+            --ready-path "$VDISPLAY_READY" \
+            --display-id-path "$VDISPLAY_ID_PATH" \
+            >"$VDISPLAY_LOG" 2>&1 &
+          VDISPLAY_PERSISTENT_PID=$!
+
+          echo "VDISPLAY_PERSISTENT_PID=$VDISPLAY_PERSISTENT_PID" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_HELPER_PATH=$HELPER_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_READY=$VDISPLAY_READY" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_ID_PATH=$VDISPLAY_ID_PATH" >> "$GITHUB_ENV"
+          echo "VDISPLAY_PERSISTENT_LOG=$VDISPLAY_LOG" >> "$GITHUB_ENV"
+
+          echo "Waiting for persistent virtual display..."
+          for _ in $(seq 1 100); do
+            if [ -s "$VDISPLAY_READY" ] && [ -s "$VDISPLAY_ID_PATH" ]; then
+              break
+            fi
+            if ! kill -0 "$VDISPLAY_PERSISTENT_PID" 2>/dev/null; then
+              echo "Persistent virtual display helper exited before readiness" >&2
+              cat "$VDISPLAY_LOG" >&2 || true
+              exit 1
+            fi
+            sleep 0.1
+          done
+
+          if [ ! -s "$VDISPLAY_READY" ] || [ ! -s "$VDISPLAY_ID_PATH" ]; then
+            echo "ERROR: Persistent virtual display not ready after 10s" >&2
+            cat "$VDISPLAY_LOG" >&2 || true
+            exit 1
+          fi
+
+          echo "Persistent virtual display ready: ID=$(tr -d '\n' < "$VDISPLAY_ID_PATH")"
+          cat "$VDISPLAY_LOG"
+
+      - name: Enable XCTest automation mode
+        run: |
+          set -euo pipefail
+          if ! command -v automationmodetool >/dev/null 2>&1; then
+            echo "::warning::automationmodetool is unavailable; XCTest will use its default automation-mode setup"
+            exit 0
+          fi
+
+          if sudo -n true 2>/dev/null; then
+            sudo -n automationmodetool enable-automationmode-without-authentication
+          else
+            echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
+          fi
 
       - name: Run browser find focus UI regression
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1026,11 +1026,29 @@ jobs:
           [[ "$SDK_VERSION" == 26.* ]]
 
   ui-regressions:
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    runs-on: depot-macos-latest
     # Cold builds after project/package changes can spend more than 25 minutes
     # in build-for-testing before the UI regression script starts.
     timeout-minutes: 45
     steps:
+      - name: Validate Depot runner identity
+        env:
+          REQUESTED_RUNNER: depot-macos-latest
+          RUNNER_CONTEXT_NAME: ${{ runner.name }}
+        run: |
+          set -euo pipefail
+          echo "Requested runner: $REQUESTED_RUNNER"
+          case "$RUNNER_CONTEXT_NAME" in
+            depot-*)
+              echo "Resolved runner matches depot-*? yes"
+              ;;
+            *)
+              echo "Resolved runner matches depot-*? no"
+              echo "::error::$REQUESTED_RUNNER resolved outside Depot. Remove $REQUESTED_RUNNER from non-Depot self-hosted runners or choose a different runner."
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1166,10 +1166,15 @@ jobs:
           DISPLAY_DONE="/tmp/cmux-ui-test-display-${TOKEN}.done"
           HELPER_LOG="/tmp/cmux-ui-test-display-${TOKEN}-helper.log"
 
-          cleanup() {
+          cleanup_attempt() {
             pkill -x "cmux DEV" 2>/dev/null || true
-            rm -f "$HELPER_PATH" "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
+            rm -f "$DIAG_PATH" "$DISPLAY_READY" "$DISPLAY_ID_PATH" "$DISPLAY_START" "$DISPLAY_DONE" "$HELPER_LOG"
             rm -f /tmp/cmux-ui-test-prelaunch.json /tmp/cmux-ui-test-display-harness.json
+          }
+
+          cleanup() {
+            cleanup_attempt
+            rm -f "$HELPER_PATH"
           }
           trap cleanup EXIT
 
@@ -1186,7 +1191,7 @@ jobs:
           echo "App binary: $APP_BINARY"
 
           for attempt in 1 2; do
-            cleanup 2>/dev/null || true
+            cleanup_attempt 2>/dev/null || true
 
             # Launch display helper from shell (non-sandboxed).
             # Use --start-delay-ms instead of --start-path because the XCTest

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -133,13 +133,15 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
       - name: Provision GhosttyKit
         run: |
           # Downloads the prebuilt GhosttyKit.xcframework pinned in
           # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
           # falls back to a from-source build. The iOS app links GhosttyKit via
           # a local-path binaryTarget, so it must exist before package resolve.
-          ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
       - name: Materialize App Store Connect API key

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,6 +185,10 @@ jobs:
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
 
+      - name: Sanitize Swift package cache
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -101,6 +101,9 @@ jobs:
           key: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -176,6 +176,7 @@ jobs:
           validate_non_negative_integer other_scrollback_lines "$OTHER_SCROLLBACK_LINES_INPUT"
           validate_non_negative_integer scrollback_target_chars "$SCROLLBACK_TARGET_CHARS_INPUT"
           mkdir -p perf-results
+          chmod 0777 perf-results
 
           APP_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-$PERF_TAG/Build/Products/Debug/cmux DEV $PERF_TAG.app"
           BENCHMARK_CMD=(

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -169,18 +169,22 @@ jobs:
         run: |
           set -euo pipefail
           APP_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-$PERF_TAG/Build/Products/Debug/cmux DEV $PERF_TAG.app"
-          # The GitHub Actions runner process runs in launchd's system
-          # bootstrap, not the console user's Aqua session, so windows
-          # created by apps launched via NSWorkspace.openApplication do
-          # not show up in CGWindowListCopyWindowInfo([.optionOnScreenOnly]).
-          # Re-enter the Aqua session via launchctl asuser before running
-          # the bench so visibility polling sees real on-screen windows.
-          CONSOLE_USER="$(stat -f %Su /dev/console)"
-          CONSOLE_UID="$(id -u "$CONSOLE_USER")"
-          sudo -n launchctl asuser "$CONSOLE_UID" sudo -n -u "$CONSOLE_USER" -E \
-            env PATH="$PATH" DEVELOPER_DIR="$DEVELOPER_DIR" \
-            bash -c "cd '$PWD' && swift scripts/bench-window-visibility.swift '$APP_PATH' 'com.cmuxterm.app.debug.$PERF_TAG' 30 --cmd-tab-activation --cg-visibility" \
-            > perf-results/cmd-tab-activation.txt
+          BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Contents/Info.plist")"
+          # Prefer the console user's Aqua bootstrap when passwordless sudo is
+          # available. Some self-hosted runners deliberately omit sudo; on
+          # those, run in the current bootstrap and let the benchmark fail if it
+          # cannot produce a real CG-visible app window.
+          CONSOLE_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
+          if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ] && CONSOLE_UID="$(id -u "$CONSOLE_USER" 2>/dev/null)" && sudo -n true 2>/dev/null; then
+            sudo -n launchctl asuser "$CONSOLE_UID" sudo -n -u "$CONSOLE_USER" -E \
+              env PATH="$PATH" DEVELOPER_DIR="$DEVELOPER_DIR" APP_PATH="$APP_PATH" BUNDLE_ID="$BUNDLE_ID" GITHUB_WORKSPACE="$PWD" \
+              bash -c 'cd "$GITHUB_WORKSPACE" && swift scripts/bench-window-visibility.swift "$APP_PATH" "$BUNDLE_ID" 30 --cmd-tab-activation --cg-visibility' \
+              > perf-results/cmd-tab-activation.txt
+          else
+            echo "::warning::Passwordless sudo unavailable; running Cmd-Tab benchmark in current bootstrap" >&2
+            swift scripts/bench-window-visibility.swift "$APP_PATH" "$BUNDLE_ID" 30 --cmd-tab-activation --cg-visibility \
+              > perf-results/cmd-tab-activation.txt
+          fi
           cat perf-results/cmd-tab-activation.txt
 
       - name: Write benchmark summary

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -25,13 +25,17 @@ on:
         required: false
         default: "12"
       heavy_scrollback_lines:
-        description: Lines per terminal in the selected heavy workspace
+        description: Max lines per terminal in the selected heavy workspace before target scaling
         required: false
         default: "2400"
       other_scrollback_lines:
-        description: Lines per terminal in other workspaces
+        description: Max lines per terminal in other workspaces before target scaling
         required: false
         default: "1400"
+      scrollback_target_chars:
+        description: Target real scrollback chars before the timed snapshot, 0 disables scaling
+        required: false
+        default: "1500000"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -134,6 +138,7 @@ jobs:
             --workspace-count "${{ inputs.workspace_count || '12' }}" \
             --heavy-scrollback-lines "${{ inputs.heavy_scrollback_lines || '2400' }}" \
             --other-scrollback-lines "${{ inputs.other_scrollback_lines || '1400' }}" \
+            --scrollback-target-chars "${{ inputs.scrollback_target_chars || '1500000' }}" \
             --synthetic-scrollback-fallback \
             --output perf-results/activation-session.json \
             --junit perf-results/activation-session.junit.xml
@@ -182,6 +187,8 @@ jobs:
           if real_capture:
             print(f"- Real scrollback capture polling: {real_capture.get('attempts')} attempts over {real_capture.get('wait_ms')} ms at {real_capture.get('refresh_rate_hz')} Hz")
             print(f"- Added CI time from capture polling: {real_capture.get('retry_overhead_ms')} ms measured, {int(real_capture.get('timeout_s') or 0)} s worst case")
+          if fixture.get("scrollback_target_chars") is not None:
+            print(f"- Scrollback seed target: {fixture.get('scrollback_target_chars')} chars, estimated {fixture.get('scrollback_effective_estimated_chars')} chars after scaling from {fixture.get('scrollback_requested_estimated_chars')}")
           synthetic_seed = fixture.get("synthetic_scrollback_fallback")
           if synthetic_seed:
             print(f"- Synthetic scrollback fallback: {synthetic_seed.get('scrollback_chars')} chars across {synthetic_seed.get('terminals')} terminals ({fixture.get('synthetic_scrollback_fallback_reason')})")

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -9,7 +9,7 @@ on:
         required: false
         default: ""
       runner:
-        description: macOS runner (auto follows the MACOS_RUNNER_15 repo variable, then warp)
+        description: macOS runner (PRs use Depot for GUI activation; manual auto follows MACOS_RUNNER_15, then warp)
         required: false
         default: auto
         type: choice
@@ -20,6 +20,8 @@ on:
           - blacksmith-6vcpu-macos-latest
           - warp-macos-15-arm64-6x
           - warp-macos-26-arm64-6x
+          - depot-macos-latest
+          - depot-macos-14
       workspace_count:
         description: Fixture workspace count
         required: false
@@ -43,11 +45,30 @@ concurrency:
 
 jobs:
   activation-session:
-    runs-on: ${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner) }}
     timeout-minutes: 45
     env:
       PERF_TAG: perf-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      - name: Validate Depot runner identity
+        if: ${{ startsWith(github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner), 'depot-macos-') }}
+        env:
+          REQUESTED_RUNNER: ${{ github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner) }}
+          RUNNER_CONTEXT_NAME: ${{ runner.name }}
+        run: |
+          set -euo pipefail
+          echo "Requested runner: $REQUESTED_RUNNER"
+          case "$RUNNER_CONTEXT_NAME" in
+            depot-*)
+              echo "Resolved runner matches depot-*? yes"
+              ;;
+            *)
+              echo "Resolved runner matches depot-*? no"
+              echo "::error::$REQUESTED_RUNNER resolved outside Depot. Remove $REQUESTED_RUNNER from non-Depot self-hosted runners or choose an explicit runner."
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -98,8 +119,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .ci-source-packages
-          key: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-
+          key: spm-${{ github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner) }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-${{ github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner) }}-
 
       - name: Sanitize Swift package cache
         run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -130,15 +130,34 @@ jobs:
             ./scripts/reload.sh --tag "$PERF_TAG"
 
       - name: Run activation session benchmark
+        env:
+          WORKSPACE_COUNT_INPUT: ${{ inputs.workspace_count || '12' }}
+          HEAVY_SCROLLBACK_LINES_INPUT: ${{ inputs.heavy_scrollback_lines || '2400' }}
+          OTHER_SCROLLBACK_LINES_INPUT: ${{ inputs.other_scrollback_lines || '1400' }}
+          SCROLLBACK_TARGET_CHARS_INPUT: ${{ inputs.scrollback_target_chars || '1500000' }}
         run: |
           set -euo pipefail
+          validate_non_negative_integer() {
+            local name="$1"
+            local value="$2"
+            case "$value" in
+              ''|*[!0-9]*)
+                echo "Invalid $name: must be a non-negative integer" >&2
+                exit 1
+                ;;
+            esac
+          }
+          validate_non_negative_integer workspace_count "$WORKSPACE_COUNT_INPUT"
+          validate_non_negative_integer heavy_scrollback_lines "$HEAVY_SCROLLBACK_LINES_INPUT"
+          validate_non_negative_integer other_scrollback_lines "$OTHER_SCROLLBACK_LINES_INPUT"
+          validate_non_negative_integer scrollback_target_chars "$SCROLLBACK_TARGET_CHARS_INPUT"
           mkdir -p perf-results
           python3 scripts/perf-activation-session.py \
             --tag "$PERF_TAG" \
-            --workspace-count "${{ inputs.workspace_count || '12' }}" \
-            --heavy-scrollback-lines "${{ inputs.heavy_scrollback_lines || '2400' }}" \
-            --other-scrollback-lines "${{ inputs.other_scrollback_lines || '1400' }}" \
-            --scrollback-target-chars "${{ inputs.scrollback_target_chars || '1500000' }}" \
+            --workspace-count "$WORKSPACE_COUNT_INPUT" \
+            --heavy-scrollback-lines "$HEAVY_SCROLLBACK_LINES_INPUT" \
+            --other-scrollback-lines "$OTHER_SCROLLBACK_LINES_INPUT" \
+            --scrollback-target-chars "$SCROLLBACK_TARGET_CHARS_INPUT" \
             --synthetic-scrollback-fallback \
             --output perf-results/activation-session.json \
             --junit perf-results/activation-session.junit.xml

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -155,15 +155,30 @@ jobs:
           validate_non_negative_integer other_scrollback_lines "$OTHER_SCROLLBACK_LINES_INPUT"
           validate_non_negative_integer scrollback_target_chars "$SCROLLBACK_TARGET_CHARS_INPUT"
           mkdir -p perf-results
-          python3 scripts/perf-activation-session.py \
-            --tag "$PERF_TAG" \
-            --workspace-count "$WORKSPACE_COUNT_INPUT" \
-            --heavy-scrollback-lines "$HEAVY_SCROLLBACK_LINES_INPUT" \
-            --other-scrollback-lines "$OTHER_SCROLLBACK_LINES_INPUT" \
-            --scrollback-target-chars "$SCROLLBACK_TARGET_CHARS_INPUT" \
-            --synthetic-scrollback-fallback \
-            --output perf-results/activation-session.json \
+
+          APP_PATH="$HOME/Library/Developer/Xcode/DerivedData/cmux-$PERF_TAG/Build/Products/Debug/cmux DEV $PERF_TAG.app"
+          BENCHMARK_CMD=(
+            python3 scripts/perf-activation-session.py
+            --tag "$PERF_TAG"
+            --app-path "$APP_PATH"
+            --workspace-count "$WORKSPACE_COUNT_INPUT"
+            --heavy-scrollback-lines "$HEAVY_SCROLLBACK_LINES_INPUT"
+            --other-scrollback-lines "$OTHER_SCROLLBACK_LINES_INPUT"
+            --scrollback-target-chars "$SCROLLBACK_TARGET_CHARS_INPUT"
+            --synthetic-scrollback-fallback
+            --output perf-results/activation-session.json
             --junit perf-results/activation-session.junit.xml
+          )
+
+          CONSOLE_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
+          if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ] && CONSOLE_UID="$(id -u "$CONSOLE_USER" 2>/dev/null)" && sudo -n true 2>/dev/null; then
+            sudo -n launchctl asuser "$CONSOLE_UID" sudo -n -u "$CONSOLE_USER" -E \
+              env PATH="$PATH" DEVELOPER_DIR="$DEVELOPER_DIR" HOME="$HOME" GITHUB_WORKSPACE="$PWD" \
+              "${BENCHMARK_CMD[@]}"
+          else
+            echo "::warning::Passwordless sudo unavailable; running activation benchmark in current bootstrap" >&2
+            "${BENCHMARK_CMD[@]}"
+          fi
 
       - name: Run Cmd-Tab activation benchmark
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,10 @@ jobs:
           key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-
 
+      - name: Sanitize Swift package cache
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
       - name: Setup Go
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -239,6 +239,9 @@ jobs:
           key: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: spm-${{ (!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner }}-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Resolve Swift packages
         run: |
           set -euo pipefail

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -191,6 +191,10 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Install zig
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
+        run: ./scripts/install-zig-ci.sh
+
       - name: Provision GhosttyKit
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}
         run: |
@@ -198,7 +202,6 @@ jobs:
           # scripts/ghosttykit-checksums.txt for the current ghostty SHA, or
           # falls back to a from-source build. The iOS app links GhosttyKit via
           # a local-path binaryTarget, so it must exist before package resolve.
-          ./scripts/install-zig-ci.sh
           ./scripts/ensure-ghosttykit.sh
 
       - name: Pick simulator

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -122,6 +122,9 @@ jobs:
           key: tmux-corpus-spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: tmux-corpus-spm-
 
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .ci-source-packages
+
       - name: Prepare isolated DerivedData
         run: |
           set -euo pipefail

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1414,7 +1414,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
             "method": method,
             "params": params,
         ]
-        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request)
+        return ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendJSON(request) ?? controlSocketJSONViaNetcat(request, socketPath: socketPath)
     }
 
     private func commandPaletteResultRows(from snapshot: [String: Any]) -> [[String: Any]] {

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1404,8 +1404,11 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         }
     }
 
-    private func socketCommand(_ command: String) -> String? {
-        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
+    private func socketCommand(_ command: String, responseTimeout: TimeInterval = 2.0) -> String? {
+        if let response = ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendLine(command) {
+            return response
+        }
+        return socketCommandViaNetcat(command, responseTimeout: responseTimeout)
     }
 
     private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
@@ -1450,6 +1453,42 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
         guard let ok = envelope?["ok"] as? Bool, ok else { return nil }
         return envelope?["result"] as? [String: Any]
+    }
+
+    private func socketCommandViaNetcat(_ command: String, responseTimeout: TimeInterval) -> String? {
+        let nc = "/usr/bin/nc"
+        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
+        process.arguments = [
+            "-lc",
+            "printf '%s\\n' \(shellSingleQuote(command)) | \(nc) -U \(shellSingleQuote(socketPath)) -w \(timeoutSeconds) 2>/dev/null"
+        ]
+
+        let output = Pipe()
+        process.standardOutput = output
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        if let first = text.split(separator: "\n", maxSplits: 1).first {
+            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func shellSingleQuote(_ value: String) -> String {
+        if value.isEmpty { return "''" }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
     private func waitForCommandPaletteVisibility(

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1357,7 +1357,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
         waitForControlSocketReady(socketPath: socketPath, pingTimeout: timeout) {
-            self.socketCommand("ping") == "PONG"
+            self.socketCommand("ping") == "PONG" || self.controlSocketDiagnosticsReportReady(self.loadJSON(atPath: self.diagnosticsPath) ?? [:])
         }
     }
 

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -1404,11 +1404,8 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         }
     }
 
-    private func socketCommand(_ command: String, responseTimeout: TimeInterval = 2.0) -> String? {
-        if let response = ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendLine(command) {
-            return response
-        }
-        return socketCommandViaNetcat(command, responseTimeout: responseTimeout)
+    private func socketCommand(_ command: String) -> String? {
+        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command) ?? controlSocketCommandViaNetcat(command, socketPath: socketPath)
     }
 
     private func socketJSON(method: String, params: [String: Any]) -> [String: Any]? {
@@ -1453,42 +1450,6 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
         guard let ok = envelope?["ok"] as? Bool, ok else { return nil }
         return envelope?["result"] as? [String: Any]
-    }
-
-    private func socketCommandViaNetcat(_ command: String, responseTimeout: TimeInterval) -> String? {
-        let nc = "/usr/bin/nc"
-        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
-        process.arguments = [
-            "-lc",
-            "printf '%s\\n' \(shellSingleQuote(command)) | \(nc) -U \(shellSingleQuote(socketPath)) -w \(timeoutSeconds) 2>/dev/null"
-        ]
-
-        let output = Pipe()
-        process.standardOutput = output
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-
-        process.waitUntilExit()
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        guard let text = String(data: data, encoding: .utf8) else { return nil }
-        if let first = text.split(separator: "\n", maxSplits: 1).first {
-            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
-    private func shellSingleQuote(_ value: String) -> String {
-        if value.isEmpty { return "''" }
-        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
     private func waitForCommandPaletteVisibility(

--- a/cmuxUITests/ControlSocketReadinessUITestSupport.swift
+++ b/cmuxUITests/ControlSocketReadinessUITestSupport.swift
@@ -118,4 +118,49 @@ extension XCTestCase {
             pingReturnsPong: pingReturnsPong
         )
     }
+
+    /// Sends one line to a Unix-domain control socket through `/usr/bin/nc`.
+    ///
+    /// This is a fallback for hosted macOS UI tests where the in-process
+    /// Darwin socket client can occasionally fail to connect even though the
+    /// app's own diagnostics and `nc -U` both prove the listener is accepting.
+    func controlSocketCommandViaNetcat(
+        _ command: String,
+        socketPath: String,
+        responseTimeout: TimeInterval = 2.0
+    ) -> String? {
+        let nc = "/usr/bin/nc"
+        guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
+        process.arguments = [
+            "-lc",
+            "printf '%s\\n' \(controlSocketShellSingleQuote(command)) | \(nc) -U \(controlSocketShellSingleQuote(socketPath)) -w \(timeoutSeconds) 2>/dev/null"
+        ]
+
+        let output = Pipe()
+        process.standardOutput = output
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        if let first = text.split(separator: "\n", maxSplits: 1).first {
+            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func controlSocketShellSingleQuote(_ value: String) -> String {
+        if value.isEmpty { return "''" }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
 }

--- a/cmuxUITests/ControlSocketReadinessUITestSupport.swift
+++ b/cmuxUITests/ControlSocketReadinessUITestSupport.swift
@@ -159,6 +159,16 @@ extension XCTestCase {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Returns true when the app-side socket sanity probe confirmed that the
+    /// configured listener path is bound by the app and answers `ping`.
+    func controlSocketDiagnosticsReportReady(_ diagnostics: [String: String]) -> Bool {
+        diagnostics["socketReady"] == "1" &&
+            diagnostics["socketPingResponse"] == "PONG" &&
+            diagnostics["socketPathExists"] == "1" &&
+            diagnostics["socketPathMatches"] == "1" &&
+            diagnostics["socketPathOwnedByListener"] == "1"
+    }
+
     private func controlSocketShellSingleQuote(_ value: String) -> String {
         if value.isEmpty { return "''" }
         return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"

--- a/cmuxUITests/ControlSocketReadinessUITestSupport.swift
+++ b/cmuxUITests/ControlSocketReadinessUITestSupport.swift
@@ -169,6 +169,28 @@ extension XCTestCase {
             diagnostics["socketPathOwnedByListener"] == "1"
     }
 
+    /// Sends a JSON-RPC object through the same `nc -U` fallback as line-based
+    /// socket commands and decodes one JSON response object.
+    func controlSocketJSONViaNetcat(
+        _ object: [String: Any],
+        socketPath: String,
+        responseTimeout: TimeInterval = 2.0
+    ) -> [String: Any]? {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object),
+              let line = String(data: data, encoding: .utf8),
+              let response = controlSocketCommandViaNetcat(
+                line,
+                socketPath: socketPath,
+                responseTimeout: responseTimeout
+              ),
+              let responseData = response.data(using: .utf8),
+              let decoded = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            return nil
+        }
+        return decoded
+    }
+
     private func controlSocketShellSingleQuote(_ value: String) -> String {
         if value.isEmpty { return "''" }
         return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"

--- a/docs/macos-ci-runners.md
+++ b/docs/macos-ci-runners.md
@@ -37,7 +37,7 @@ gh variable list --repo manaflow-ai/cmux
 
 ## Manual runs
 
-`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. `auto` (and the empty `pull_request` case for perf) follows `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable also redirects these workflows. An explicit choice wins over the variable; both dropdowns expose `warp-macos-15-arm64-6x` / `warp-macos-26-arm64-6x` so an operator can pick Warp directly during a Blacksmith outage. `test-e2e.yml` also keeps `depot-macos-*` choices and a Depot identity guard for GUI-activation runs.
+`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. Manual `auto` runs follow `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable redirects those workflows. `perf-activation.yml` pull-request runs use `depot-macos-latest` because the Cmd-Tab activation benchmark needs a GUI-capable runner. An explicit manual choice wins over the variable; both dropdowns expose Blacksmith, Warp, and `depot-macos-*` choices, with a Depot identity guard for GUI-activation runs.
 
 ## Guard
 

--- a/docs/macos-ci-runners.md
+++ b/docs/macos-ci-runners.md
@@ -37,7 +37,7 @@ gh variable list --repo manaflow-ai/cmux
 
 ## Manual runs
 
-`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. Manual `auto` runs follow `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable redirects those workflows. `perf-activation.yml` pull-request runs and `ci.yml` `ui-regressions` use `depot-macos-latest` because Cmd-Tab timing, virtual displays, and XCTest automation need a GUI-capable runner. An explicit manual choice wins over the variable; both dropdowns expose Blacksmith, Warp, and `depot-macos-*` choices, with a Depot identity guard for GUI-activation runs.
+`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. Manual `auto` runs follow `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable redirects those workflows. `perf-activation.yml` pull-request runs plus `ci.yml` `tests-build-and-lag` and `ui-regressions` use `depot-macos-latest` because Cmd-Tab timing, virtual displays, and XCTest automation need a GUI-capable runner. An explicit manual choice wins over the variable; both dropdowns expose Blacksmith, Warp, and `depot-macos-*` choices, with a Depot identity guard for GUI-activation runs.
 
 ## Guard
 

--- a/docs/macos-ci-runners.md
+++ b/docs/macos-ci-runners.md
@@ -2,7 +2,7 @@
 
 All paid macOS CI/CD jobs pick their runner from two repository variables instead of a hardcoded label:
 
-- `MACOS_RUNNER_15` for jobs that build the real universal Release app, including nightly, stable release, `release-build`, and the e2e/perf defaults.
+- `MACOS_RUNNER_15` for jobs that build the real universal Release app, including nightly, stable release, `release-build`, and most macOS test defaults.
 - `MACOS_RUNNER_26` for macOS 26 compatibility coverage and jobs that do not need Zig to build the real universal Ghostty CLI helper.
 
 Workflows reference them as `runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}`. If a variable is unset, the job falls back to WarpBuild, so CI is never broken by a missing variable.
@@ -37,8 +37,8 @@ gh variable list --repo manaflow-ai/cmux
 
 ## Manual runs
 
-`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. Manual `auto` runs follow `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable redirects those workflows. `perf-activation.yml` pull-request runs use `depot-macos-latest` because the Cmd-Tab activation benchmark needs a GUI-capable runner. An explicit manual choice wins over the variable; both dropdowns expose Blacksmith, Warp, and `depot-macos-*` choices, with a Depot identity guard for GUI-activation runs.
+`perf-activation.yml` and `test-e2e.yml` keep a `runner` choice input that defaults to `auto`. Manual `auto` runs follow `MACOS_RUNNER_15` then the Warp fallback, so flipping the repo variable redirects those workflows. `perf-activation.yml` pull-request runs and `ci.yml` `ui-regressions` use `depot-macos-latest` because Cmd-Tab timing, virtual displays, and XCTest automation need a GUI-capable runner. An explicit manual choice wins over the variable; both dropdowns expose Blacksmith, Warp, and `depot-macos-*` choices, with a Depot identity guard for GUI-activation runs.
 
 ## Guard
 
-`tests/test_ci_self_hosted_guard.sh` (run by the `workflow-guard-tests` job) asserts every paid macOS job references `vars.MACOS_RUNNER_*` or a Blacksmith/Warp label, so a job can never silently fall back to a free GitHub-hosted runner. Keep new labels in `.github/actionlint.yaml`.
+`tests/test_ci_self_hosted_guard.sh` (run by the `workflow-guard-tests` job) asserts every paid macOS job references `vars.MACOS_RUNNER_*` or a Blacksmith/Warp/Depot label, so a job can never silently fall back to a free GitHub-hosted runner. Keep new labels in `.github/actionlint.yaml`.

--- a/scripts/bench-window-visibility.swift
+++ b/scripts/bench-window-visibility.swift
@@ -190,6 +190,94 @@ private func hasVisibleCGWindow(processIdentifier: pid_t) -> Bool {
     !visibleCGWindows(processIdentifier: processIdentifier).isEmpty
 }
 
+private let directLaunchEnvironmentKeysToRemove = [
+    "CMUX_SOCKET",
+    "CMUX_SOCKET_PATH",
+    "CMUX_SOCKET_MODE",
+    "CMUX_TAB_ID",
+    "CMUX_PANEL_ID",
+    "CMUX_SURFACE_ID",
+    "CMUX_WORKSPACE_ID",
+    "CMUXD_UNIX_PATH",
+    "CMUX_TAG",
+    "CMUX_PORT",
+    "CMUX_PORT_END",
+    "CMUX_PORT_RANGE",
+    "CMUX_DEBUG_LOG",
+    "CMUX_BUNDLE_ID",
+    "CMUX_BUNDLED_CLI_PATH",
+    "CMUX_DISABLE_SESSION_RESTORE",
+    "CMUX_SHELL_INTEGRATION",
+    "CMUX_SHELL_INTEGRATION_DIR",
+    "CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION",
+    "GHOSTTY_BIN_DIR",
+    "GHOSTTY_RESOURCES_DIR",
+    "GHOSTTY_SHELL_FEATURES",
+    "GIT_PAGER",
+    "GH_PAGER",
+    "TERMINFO",
+    "XDG_DATA_DIRS",
+]
+
+private func directLaunchEnvironment(appURL: URL, bundleIdentifier: String) -> [String: String] {
+    var environment = ProcessInfo.processInfo.environment
+    for key in directLaunchEnvironmentKeysToRemove {
+        environment.removeValue(forKey: key)
+    }
+
+    if let bundle = Bundle(url: appURL),
+       let launchEnvironment = bundle.infoDictionary?["LSEnvironment"] as? [String: String] {
+        environment.merge(launchEnvironment) { _, newValue in newValue }
+    }
+    environment["CMUX_BUNDLE_ID"] = environment["CMUX_BUNDLE_ID"] ?? bundleIdentifier
+    return environment
+}
+
+private func waitForRunningApplication(bundleIdentifier: String, timeout: TimeInterval) -> NSRunningApplication? {
+    var runningApp = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
+    guard runningApp == nil else { return runningApp }
+
+    _ = waitUntil(timeout: timeout) {
+        runningApp = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
+        return runningApp != nil
+    }
+    return runningApp
+}
+
+private func directLaunchLogURL(bundleIdentifier: String) -> URL {
+    let safeIdentifier = bundleIdentifier
+        .map { character in character.isLetter || character.isNumber ? character : "-" }
+        .reduce(into: "") { $0.append($1) }
+    return URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("cmux-window-visibility-\(safeIdentifier).log")
+}
+
+private func launchApplicationProcess(appURL: URL, bundleIdentifier: String) -> NSRunningApplication? {
+    let executableURL = appURL.appendingPathComponent("Contents/MacOS/cmux DEV")
+    guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+        fputs("direct launch executable missing: \(executableURL.path)\n", stderr)
+        return nil
+    }
+
+    let process = Process()
+    process.executableURL = executableURL
+    process.environment = directLaunchEnvironment(appURL: appURL, bundleIdentifier: bundleIdentifier)
+    let logURL = directLaunchLogURL(bundleIdentifier: bundleIdentifier)
+    FileManager.default.createFile(atPath: logURL.path, contents: nil)
+    if let logHandle = try? FileHandle(forWritingTo: logURL) {
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        fputs("direct launch log: \(logURL.path)\n", stderr)
+    }
+    do {
+        try process.run()
+    } catch {
+        fputs("direct launch error: \(error)\n", stderr)
+        return waitForRunningApplication(bundleIdentifier: bundleIdentifier, timeout: 1)
+    }
+    return waitForRunningApplication(bundleIdentifier: bundleIdentifier, timeout: 10)
+}
+
 private func minimizeButton(for window: AXUIElement) -> AXUIElement? {
     if let value = copyAXValue(window, kAXMinimizeButtonAttribute),
        let button = unsafeBitCast(value, to: AXUIElement?.self) {
@@ -247,7 +335,12 @@ private func openApplication(appURL: URL, bundleIdentifier: String) -> NSRunning
     if let openedError {
         fputs("openApplication error: \(openedError)\n", stderr)
     }
-    return openedApp ?? NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first
+    if let app = openedApp ?? NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first {
+        return app
+    }
+
+    fputs("Falling back to direct app executable launch.\n", stderr)
+    return launchApplicationProcess(appURL: appURL, bundleIdentifier: bundleIdentifier)
 }
 
 @discardableResult

--- a/scripts/bench-window-visibility.swift
+++ b/scripts/bench-window-visibility.swift
@@ -267,7 +267,11 @@ private func directLaunchLogURL(bundleIdentifier: String) -> URL {
 }
 
 private func launchApplicationProcess(appURL: URL, bundleIdentifier: String) -> NSRunningApplication? {
-    let executableURL = appURL.appendingPathComponent("Contents/MacOS/cmux DEV")
+    guard let bundle = Bundle(url: appURL),
+          let executableURL = bundle.executableURL else {
+        fputs("direct launch: unable to resolve executable for bundle at \(appURL.path)\n", stderr)
+        return nil
+    }
     guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
         fputs("direct launch executable missing: \(executableURL.path)\n", stderr)
         return nil

--- a/scripts/bench-window-visibility.swift
+++ b/scripts/bench-window-visibility.swift
@@ -190,6 +190,20 @@ private func hasVisibleCGWindow(processIdentifier: pid_t) -> Bool {
     !visibleCGWindows(processIdentifier: processIdentifier).isEmpty
 }
 
+private func resolvedBundleIdentifier(appURL: URL, requestedBundleIdentifier: String) -> String {
+    guard let actualBundleIdentifier = Bundle(url: appURL)?.bundleIdentifier,
+          !actualBundleIdentifier.isEmpty else {
+        return requestedBundleIdentifier
+    }
+    if actualBundleIdentifier != requestedBundleIdentifier {
+        fputs(
+            "Using app bundle identifier \(actualBundleIdentifier) instead of requested \(requestedBundleIdentifier).\n",
+            stderr
+        )
+    }
+    return actualBundleIdentifier
+}
+
 private let directLaunchEnvironmentKeysToRemove = [
     "CMUX_SOCKET",
     "CMUX_SOCKET_PATH",
@@ -525,7 +539,10 @@ private func main() {
     }
 
     let appURL = URL(fileURLWithPath: arguments[1])
-    let bundleIdentifier = arguments[2]
+    let bundleIdentifier = resolvedBundleIdentifier(
+        appURL: appURL,
+        requestedBundleIdentifier: arguments[2]
+    )
     let verbose = arguments.contains("--verbose")
     let activateRestore = arguments.contains("--activate-restore")
     let cmdTabActivation = arguments.contains("--cmd-tab-activation")

--- a/scripts/ci/sanitize-xcode-source-packages-cache.py
+++ b/scripts/ci/sanitize-xcode-source-packages-cache.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Drop Xcode SourcePackages state that stores checkout-absolute paths."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def remove_workspace_state(source_packages_dir: Path) -> list[Path]:
+    if not source_packages_dir.exists():
+        return []
+
+    removed: list[Path] = []
+    for state_file in sorted(source_packages_dir.rglob("workspace-state.json")):
+        if not state_file.is_file():
+            continue
+        state_file.unlink()
+        removed.append(state_file)
+    return removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove Xcode SourcePackages workspace-state.json files after a "
+            "cache restore. These state files can contain absolute paths from "
+            "a previous checkout; Xcode recreates them during package resolve."
+        )
+    )
+    parser.add_argument(
+        "source_packages_dir",
+        type=Path,
+        help="Path passed to xcodebuild -clonedSourcePackagesDirPath",
+    )
+    args = parser.parse_args()
+
+    source_packages_dir = args.source_packages_dir.resolve()
+    removed = remove_workspace_state(source_packages_dir)
+    if removed:
+        for path in removed:
+            print(f"removed stale Xcode SourcePackages state: {display_path(path)}")
+    else:
+        print(
+            "no Xcode SourcePackages workspace-state.json files found under "
+            f"{display_path(source_packages_dir)}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/sanitize-xcode-source-packages-cache.py
+++ b/scripts/ci/sanitize-xcode-source-packages-cache.py
@@ -18,13 +18,12 @@ def remove_workspace_state(source_packages_dir: Path) -> list[Path]:
     if not source_packages_dir.exists():
         return []
 
-    removed: list[Path] = []
-    for state_file in sorted(source_packages_dir.rglob("workspace-state.json")):
-        if not state_file.is_file():
-            continue
-        state_file.unlink()
-        removed.append(state_file)
-    return removed
+    state_file = source_packages_dir / "workspace-state.json"
+    if not state_file.is_file():
+        return []
+
+    state_file.unlink()
+    return [state_file]
 
 
 def main() -> int:

--- a/scripts/ci/virtual-display-lock.sh
+++ b/scripts/ci/virtual-display-lock.sh
@@ -73,6 +73,19 @@ lock_created_at() {
   fi
 }
 
+owner_is_alive() {
+  local owner_pid=""
+  if [ -f "$LOCK_DIR/owner_pid" ]; then
+    owner_pid="$(cat "$LOCK_DIR/owner_pid" 2>/dev/null || true)"
+  fi
+  case "$owner_pid" in
+    ''|*[!0-9]*)
+      return 1
+      ;;
+  esac
+  kill -0 "$owner_pid" 2>/dev/null
+}
+
 remove_stale_lock_if_needed() {
   local now created age
   now="$(now_seconds)"
@@ -82,6 +95,9 @@ remove_stale_lock_if_needed() {
   fi
   age=$((now - created))
   if [ "$age" -lt "$LOCK_STALE_SECONDS" ]; then
+    return 1
+  fi
+  if owner_is_alive; then
     return 1
   fi
   echo "Removing stale virtual display lock at $LOCK_DIR (age ${age}s)" >&2

--- a/scripts/ci/virtual-display-lock.sh
+++ b/scripts/ci/virtual-display-lock.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND="${1:-}"
+if [ $# -gt 0 ]; then
+  shift
+fi
+
+LOCK_DIR="${CMUX_VDISPLAY_LOCK_DIR:-/tmp/cmux-ci-virtual-display.lock}"
+LOCK_TIMEOUT_SECONDS="${CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS:-600}"
+LOCK_STALE_SECONDS="${CMUX_VDISPLAY_LOCK_STALE_SECONDS:-1800}"
+LOCK_POLL_SECONDS="${CMUX_VDISPLAY_LOCK_POLL_SECONDS:-2}"
+
+usage() {
+  cat >&2 <<'EOF'
+usage: virtual-display-lock.sh acquire|set-owner <pid>|release
+
+Coordinates host-global CGVirtualDisplay use between concurrent self-hosted
+macOS jobs. acquire prints CMUX_VDISPLAY_LOCK_DIR and
+CMUX_VDISPLAY_LOCK_TOKEN shell assignments on stdout.
+EOF
+}
+
+now_seconds() {
+  date +%s
+}
+
+validate_lock_dir() {
+  case "$LOCK_DIR" in
+    /tmp/cmux-*.lock)
+      return 0
+      ;;
+  esac
+  if [ -n "${RUNNER_TEMP:-}" ]; then
+    case "$LOCK_DIR" in
+      "$RUNNER_TEMP"/*)
+        return 0
+        ;;
+    esac
+  fi
+  case "$LOCK_DIR" in
+    *)
+      echo "Refusing unsafe virtual display lock path: $LOCK_DIR" >&2
+      exit 1
+      ;;
+  esac
+}
+
+new_token() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  else
+    printf '%s-%s\n' "$$" "$(now_seconds)"
+  fi
+}
+
+write_metadata() {
+  local token="$1"
+  {
+    printf 'created_at=%s\n' "$(now_seconds)"
+    printf 'token=%s\n' "$token"
+    printf 'host=%s\n' "$(hostname 2>/dev/null || echo unknown)"
+    printf 'run_id=%s\n' "${GITHUB_RUN_ID:-unknown}"
+    printf 'job=%s\n' "${GITHUB_JOB:-unknown}"
+    printf 'pid=%s\n' "$$"
+  } > "$LOCK_DIR/metadata"
+  printf '%s\n' "$token" > "$LOCK_DIR/token"
+}
+
+lock_created_at() {
+  if [ -f "$LOCK_DIR/metadata" ]; then
+    awk -F= '$1 == "created_at" { print $2; exit }' "$LOCK_DIR/metadata" 2>/dev/null || true
+  fi
+}
+
+remove_stale_lock_if_needed() {
+  local now created age
+  now="$(now_seconds)"
+  created="$(lock_created_at)"
+  if [ -z "$created" ]; then
+    created="$(stat -f %m "$LOCK_DIR" 2>/dev/null || printf '%s\n' "$now")"
+  fi
+  age=$((now - created))
+  if [ "$age" -lt "$LOCK_STALE_SECONDS" ]; then
+    return 1
+  fi
+  echo "Removing stale virtual display lock at $LOCK_DIR (age ${age}s)" >&2
+  rm -rf "$LOCK_DIR"
+  return 0
+}
+
+acquire() {
+  validate_lock_dir
+  mkdir -p "$(dirname "$LOCK_DIR")"
+
+  local token start now elapsed
+  token="$(new_token)"
+  start="$(now_seconds)"
+
+  while true; do
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      write_metadata "$token"
+      printf 'CMUX_VDISPLAY_LOCK_DIR=%q\n' "$LOCK_DIR"
+      printf 'CMUX_VDISPLAY_LOCK_TOKEN=%q\n' "$token"
+      exit 0
+    fi
+
+    remove_stale_lock_if_needed && continue
+
+    now="$(now_seconds)"
+    elapsed=$((now - start))
+    if [ "$elapsed" -ge "$LOCK_TIMEOUT_SECONDS" ]; then
+      echo "Timed out waiting for virtual display lock at $LOCK_DIR after ${elapsed}s" >&2
+      if [ -f "$LOCK_DIR/metadata" ]; then
+        echo "--- virtual display lock holder ---" >&2
+        cat "$LOCK_DIR/metadata" >&2 || true
+      fi
+      exit 1
+    fi
+
+    echo "Waiting for virtual display lock at $LOCK_DIR (${elapsed}s elapsed)" >&2
+    sleep "$LOCK_POLL_SECONDS"
+  done
+}
+
+require_token_match() {
+  validate_lock_dir
+  local token="${CMUX_VDISPLAY_LOCK_TOKEN:-}"
+  if [ -z "$token" ]; then
+    echo "CMUX_VDISPLAY_LOCK_TOKEN is required for $COMMAND" >&2
+    exit 1
+  fi
+  if [ ! -d "$LOCK_DIR" ]; then
+    echo "Virtual display lock is already absent: $LOCK_DIR" >&2
+    return 1
+  fi
+  if [ "$(cat "$LOCK_DIR/token" 2>/dev/null || true)" != "$token" ]; then
+    echo "Virtual display lock token mismatch for $LOCK_DIR; not modifying it" >&2
+    return 1
+  fi
+  return 0
+}
+
+set_owner() {
+  local owner_pid="${1:-}"
+  if [ -z "$owner_pid" ]; then
+    echo "set-owner requires a PID" >&2
+    exit 1
+  fi
+  require_token_match || exit 1
+  printf '%s\n' "$owner_pid" > "$LOCK_DIR/owner_pid"
+}
+
+release() {
+  require_token_match || exit 0
+  rm -rf "$LOCK_DIR"
+}
+
+case "$COMMAND" in
+  acquire)
+    acquire
+    ;;
+  set-owner)
+    set_owner "${1:-}"
+    ;;
+  release)
+    release
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/ci/virtual-display-lock.sh
+++ b/scripts/ci/virtual-display-lock.sh
@@ -87,7 +87,24 @@ owner_is_alive() {
 }
 
 remove_stale_lock_if_needed() {
-  local now created age
+  local now created age owner_pid
+  owner_pid=""
+  if [ -f "$LOCK_DIR/owner_pid" ]; then
+    owner_pid="$(cat "$LOCK_DIR/owner_pid" 2>/dev/null || true)"
+  fi
+  case "$owner_pid" in
+    ''|*[!0-9]*)
+      ;;
+    *)
+      if owner_is_alive; then
+        return 1
+      fi
+      echo "Removing virtual display lock at $LOCK_DIR with dead owner PID $owner_pid" >&2
+      rm -rf "$LOCK_DIR"
+      return 0
+      ;;
+  esac
+
   now="$(now_seconds)"
   created="$(lock_created_at)"
   if [ -z "$created" ]; then
@@ -95,9 +112,6 @@ remove_stale_lock_if_needed() {
   fi
   age=$((now - created))
   if [ "$age" -lt "$LOCK_STALE_SECONDS" ]; then
-    return 1
-  fi
-  if owner_is_alive; then
     return 1
   fi
   echo "Removing stale virtual display lock at $LOCK_DIR (age ${age}s)" >&2

--- a/scripts/ci/virtual-display-lock.sh
+++ b/scripts/ci/virtual-display-lock.sh
@@ -9,6 +9,7 @@ fi
 LOCK_DIR="${CMUX_VDISPLAY_LOCK_DIR:-/tmp/cmux-ci-virtual-display.lock}"
 LOCK_TIMEOUT_SECONDS="${CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS:-600}"
 LOCK_STALE_SECONDS="${CMUX_VDISPLAY_LOCK_STALE_SECONDS:-1800}"
+LOCK_OWNERLESS_STALE_SECONDS="${CMUX_VDISPLAY_LOCK_OWNERLESS_STALE_SECONDS:-$LOCK_TIMEOUT_SECONDS}"
 LOCK_POLL_SECONDS="${CMUX_VDISPLAY_LOCK_POLL_SECONDS:-2}"
 
 usage() {
@@ -89,8 +90,21 @@ owner_is_alive() {
   ps -p "$owner_pid" >/dev/null 2>&1
 }
 
+ownerless_stale_seconds() {
+  local stale_seconds="$LOCK_OWNERLESS_STALE_SECONDS"
+  case "$stale_seconds" in
+    ''|*[!0-9]*)
+      stale_seconds="$LOCK_TIMEOUT_SECONDS"
+      ;;
+  esac
+  if [ "$stale_seconds" -gt "$LOCK_TIMEOUT_SECONDS" ]; then
+    stale_seconds="$LOCK_TIMEOUT_SECONDS"
+  fi
+  printf '%s\n' "$stale_seconds"
+}
+
 remove_stale_lock_if_needed() {
-  local now created age owner_pid
+  local now created age owner_pid stale_seconds
   owner_pid=""
   if [ -f "$LOCK_DIR/owner_pid" ]; then
     owner_pid="$(cat "$LOCK_DIR/owner_pid" 2>/dev/null || true)"
@@ -114,10 +128,11 @@ remove_stale_lock_if_needed() {
     created="$(stat -f %m "$LOCK_DIR" 2>/dev/null || printf '%s\n' "$now")"
   fi
   age=$((now - created))
-  if [ "$age" -lt "$LOCK_STALE_SECONDS" ]; then
+  stale_seconds="$(ownerless_stale_seconds)"
+  if [ "$age" -lt "$stale_seconds" ]; then
     return 1
   fi
-  echo "Removing stale virtual display lock at $LOCK_DIR (age ${age}s)" >&2
+  echo "Removing ownerless stale virtual display lock at $LOCK_DIR (age ${age}s)" >&2
   rm -rf "$LOCK_DIR"
   return 0
 }

--- a/scripts/ci/virtual-display-lock.sh
+++ b/scripts/ci/virtual-display-lock.sh
@@ -83,7 +83,10 @@ owner_is_alive() {
       return 1
       ;;
   esac
-  kill -0 "$owner_pid" 2>/dev/null
+  if kill -0 "$owner_pid" 2>/dev/null; then
+    return 0
+  fi
+  ps -p "$owner_pid" >/dev/null 2>&1
 }
 
 remove_stale_lock_if_needed() {

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -121,18 +121,13 @@ verify_zig_sha256() {
   printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | shasum -a 256 -c -
 }
 
-copy_zig_tree() {
-  local bin_dir="$1"
-  local lib_dir="$2"
-  rm -rf "$lib_dir" || return 1
-  mkdir -p "$bin_dir" "$lib_dir" || return 1
-  cp -f "${ZIG_DIR}/zig" "${bin_dir}/zig" || return 1
-  cp -Rf "${ZIG_DIR}/lib/." "$lib_dir/" || return 1
-}
-
 install_zig_without_sudo() {
   local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/${ZIG_NAME}}"
-  echo "sudo unavailable; installing zig under ${install_root}"
+  if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
+    echo "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under ${install_root}"
+  else
+    echo "sudo unavailable; installing zig under ${install_root}"
+  fi
   rm -rf "$install_root"
   mkdir -p "$(dirname "$install_root")"
   mv "$ZIG_DIR" "$install_root"
@@ -171,7 +166,7 @@ fi
 
 rm -rf "$ZIG_DIR"
 tar xf "$ZIG_TAR" -C /tmp
-if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
   install_zig_with_sudo
   exit 0
 fi

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -151,13 +151,6 @@ install_zig_with_sudo() {
   /usr/local/bin/zig version
 }
 
-install_zig_to_usr_local_if_writable() {
-  mkdir -p /usr/local/bin /usr/local/lib 2>/dev/null || return 1
-  copy_zig_tree /usr/local/bin /usr/local/lib/zig 2>/dev/null || return 1
-  publish_zig_for_later_steps /usr/local/bin/zig
-  /usr/local/bin/zig version
-}
-
 echo "Installing verified zig ${ZIG_REQUIRED}"
 rm -f "$ZIG_TAR" "$ZIG_SIG"
 if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
@@ -179,9 +172,6 @@ fi
 
 rm -rf "$ZIG_DIR"
 tar xf "$ZIG_TAR" -C /tmp
-if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && install_zig_to_usr_local_if_writable; then
-  exit 0
-fi
 if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
   install_zig_with_sudo
   exit 0

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -122,17 +122,24 @@ verify_zig_sha256() {
 }
 
 install_zig_without_sudo() {
-  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/${ZIG_NAME}}"
-  if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
-    echo "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under ${install_root}"
-  else
-    echo "sudo unavailable; installing zig under ${install_root}"
-  fi
-  rm -rf "$install_root"
+  local install_parent="${RUNNER_TEMP:-/tmp/cmux-zig-ci}"
+  local install_root="${ZIG_INSTALL_ROOT:-${install_parent}/${ZIG_NAME}}"
+  local source_root
+  local target_root
+  source_root="$(cd "$ZIG_DIR" && pwd -P)"
   mkdir -p "$(dirname "$install_root")"
-  mv "$ZIG_DIR" "$install_root"
-  publish_zig_for_later_steps "${install_root}/zig"
-  "${install_root}/zig" version
+  target_root="$(cd "$(dirname "$install_root")" && pwd -P)/$(basename "$install_root")"
+  if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
+    echo "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under ${target_root}"
+  else
+    echo "sudo unavailable; installing zig under ${target_root}"
+  fi
+  if [ "$source_root" != "$target_root" ]; then
+    rm -rf "$target_root"
+    mv "$source_root" "$target_root"
+  fi
+  publish_zig_for_later_steps "${target_root}/zig"
+  "${target_root}/zig" version
 }
 
 install_zig_with_sudo() {

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -5,6 +5,7 @@ ZIG_REQUIRED="${ZIG_REQUIRED:-0.15.2}"
 ZIG_MINISIGN_PUBLIC_KEY="${ZIG_MINISIGN_PUBLIC_KEY:-RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U}"
 ZIG_INDEX_URL="${ZIG_INDEX_URL:-https://ziglang.org/download/index.json}"
 ZIG_EXPECTED_SHA256="${ZIG_EXPECTED_SHA256:-}"
+ZIG_WORK_PARENT="${RUNNER_TEMP:-/tmp/cmux-zig-ci}"
 export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
 export HOMEBREW_NO_INSTALL_CLEANUP="${HOMEBREW_NO_INSTALL_CLEANUP:-1}"
 export HOMEBREW_NO_ENV_HINTS="${HOMEBREW_NO_ENV_HINTS:-1}"
@@ -63,9 +64,15 @@ case "$(uname -m)" in
 esac
 
 ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-ZIG_TAR="/tmp/${ZIG_NAME}.tar.xz"
+mkdir -p "$ZIG_WORK_PARENT"
+ZIG_WORK_ROOT="$(mktemp -d "${ZIG_WORK_PARENT%/}/cmux-zig-install-${ZIG_REQUIRED}.XXXXXX")"
+cleanup_work_root() {
+  rm -rf "$ZIG_WORK_ROOT"
+}
+trap cleanup_work_root EXIT
+ZIG_TAR="${ZIG_WORK_ROOT}/${ZIG_NAME}.tar.xz"
 ZIG_SIG="${ZIG_TAR}.minisig"
-ZIG_DIR="/tmp/${ZIG_NAME}"
+ZIG_DIR="${ZIG_WORK_ROOT}/${ZIG_NAME}"
 ZIG_OFFICIAL_URL="https://ziglang.org/download/${ZIG_REQUIRED}/${ZIG_NAME}.tar.xz"
 ZIG_MIRROR_URL="${ZIG_MIRROR_URL:-https://zigmirror.hryx.net/zig/${ZIG_NAME}.tar.xz}"
 ZIG_INDEX_ARCH="${ZIG_ARCH}-macos"
@@ -93,7 +100,7 @@ resolve_zig_sha256() {
     return 0
   fi
 
-  local index_file="/tmp/zig-download-index-${ZIG_REQUIRED}-$$.json"
+  local index_file="${ZIG_WORK_ROOT}/zig-download-index-${ZIG_REQUIRED}.json"
   download_file "$ZIG_INDEX_URL" "$index_file"
   python3 - "$index_file" "$ZIG_REQUIRED" "$ZIG_INDEX_ARCH" <<'PY'
 import json
@@ -179,7 +186,7 @@ else
 fi
 
 rm -rf "$ZIG_DIR"
-tar xf "$ZIG_TAR" -C /tmp
+tar xf "$ZIG_TAR" -C "$ZIG_WORK_ROOT"
 if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
   install_zig_with_sudo
   exit 0

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -25,8 +25,12 @@ publish_zig_for_later_steps() {
 
 zig_has_required_version() {
   local zig_path="$1"
+  local zig_lib_dir
   [ -x "$zig_path" ] || return 1
-  [ "$("$zig_path" version 2>/dev/null || true)" = "$ZIG_REQUIRED" ]
+  [ "$("$zig_path" version 2>/dev/null || true)" = "$ZIG_REQUIRED" ] || return 1
+  zig_lib_dir="$("$zig_path" env 2>/dev/null | python3 -c 'import json, sys; print(json.load(sys.stdin).get("lib_dir", ""))' 2>/dev/null || true)"
+  [ -n "$zig_lib_dir" ] || return 1
+  [ -f "$zig_lib_dir/compiler/build_runner.zig" ] || return 1
 }
 
 use_existing_zig_if_available() {
@@ -157,11 +161,12 @@ install_zig_without_sudo() {
 }
 
 install_zig_with_sudo() {
+  local install_root="/usr/local/lib/${ZIG_NAME}"
   sudo mkdir -p /usr/local/bin /usr/local/lib
-  sudo rm -rf /usr/local/lib/zig
-  sudo mkdir -p /usr/local/lib/zig
-  sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-  sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
+  sudo rm -rf /usr/local/lib/zig "$install_root"
+  sudo cp -R "$ZIG_DIR" "$install_root"
+  sudo rm -f /usr/local/bin/zig
+  sudo ln -s "$install_root/zig" /usr/local/bin/zig
   publish_zig_for_later_steps /usr/local/bin/zig
   /usr/local/bin/zig version
 }

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -131,14 +131,13 @@ copy_zig_tree() {
 }
 
 install_zig_without_sudo() {
-  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/cmux-zig-${ZIG_REQUIRED}}"
-  local bin_dir="${install_root}/bin"
-  local lib_dir="${install_root}/lib/zig"
+  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/${ZIG_NAME}}"
   echo "sudo unavailable; installing zig under ${install_root}"
   rm -rf "$install_root"
-  copy_zig_tree "$bin_dir" "$lib_dir"
-  publish_zig_for_later_steps "${bin_dir}/zig"
-  "${bin_dir}/zig" version
+  mkdir -p "$(dirname "$install_root")"
+  mv "$ZIG_DIR" "$install_root"
+  publish_zig_for_later_steps "${install_root}/zig"
+  "${install_root}/zig" version
 }
 
 install_zig_with_sudo() {

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -29,6 +29,10 @@ zig_has_required_version() {
 }
 
 use_existing_zig_if_available() {
+  if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
+    return 0
+  fi
+
   local candidate
   local seen=" "
   for candidate in "$(command -v zig 2>/dev/null || true)" /opt/homebrew/bin/zig /usr/local/bin/zig; do
@@ -117,6 +121,43 @@ verify_zig_sha256() {
   printf '%s  %s\n' "$expected_sha256" "$ZIG_TAR" | shasum -a 256 -c -
 }
 
+copy_zig_tree() {
+  local bin_dir="$1"
+  local lib_dir="$2"
+  rm -rf "$lib_dir" || return 1
+  mkdir -p "$bin_dir" "$lib_dir" || return 1
+  cp -f "${ZIG_DIR}/zig" "${bin_dir}/zig" || return 1
+  cp -Rf "${ZIG_DIR}/lib/." "$lib_dir/" || return 1
+}
+
+install_zig_without_sudo() {
+  local install_root="${ZIG_INSTALL_ROOT:-${RUNNER_TEMP:-/tmp}/cmux-zig-${ZIG_REQUIRED}}"
+  local bin_dir="${install_root}/bin"
+  local lib_dir="${install_root}/lib/zig"
+  echo "sudo unavailable; installing zig under ${install_root}"
+  rm -rf "$install_root"
+  copy_zig_tree "$bin_dir" "$lib_dir"
+  publish_zig_for_later_steps "${bin_dir}/zig"
+  "${bin_dir}/zig" version
+}
+
+install_zig_with_sudo() {
+  sudo mkdir -p /usr/local/bin /usr/local/lib
+  sudo rm -rf /usr/local/lib/zig
+  sudo mkdir -p /usr/local/lib/zig
+  sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
+  sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
+  publish_zig_for_later_steps /usr/local/bin/zig
+  /usr/local/bin/zig version
+}
+
+install_zig_to_usr_local_if_writable() {
+  mkdir -p /usr/local/bin /usr/local/lib 2>/dev/null || return 1
+  copy_zig_tree /usr/local/bin /usr/local/lib/zig 2>/dev/null || return 1
+  publish_zig_for_later_steps /usr/local/bin/zig
+  /usr/local/bin/zig version
+}
+
 echo "Installing verified zig ${ZIG_REQUIRED}"
 rm -f "$ZIG_TAR" "$ZIG_SIG"
 if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
@@ -138,9 +179,11 @@ fi
 
 rm -rf "$ZIG_DIR"
 tar xf "$ZIG_TAR" -C /tmp
-sudo mkdir -p /usr/local/bin /usr/local/lib
-sudo rm -rf /usr/local/lib/zig
-sudo mkdir -p /usr/local/lib/zig
-sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
-zig version
+if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" != "1" ] && install_zig_to_usr_local_if_writable; then
+  exit 0
+fi
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  install_zig_with_sudo
+  exit 0
+fi
+install_zig_without_sudo

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -123,12 +123,19 @@ verify_zig_sha256() {
 
 install_zig_without_sudo() {
   local install_parent="${RUNNER_TEMP:-/tmp/cmux-zig-ci}"
-  local install_root="${ZIG_INSTALL_ROOT:-${install_parent}/${ZIG_NAME}}"
+  local install_root="${ZIG_INSTALL_ROOT:-${install_parent}}"
   local source_root
   local target_root
+  if [ "$(basename "$install_root")" != "$ZIG_NAME" ]; then
+    install_root="${install_root%/}/${ZIG_NAME}"
+  fi
   source_root="$(cd "$ZIG_DIR" && pwd -P)"
   mkdir -p "$(dirname "$install_root")"
   target_root="$(cd "$(dirname "$install_root")" && pwd -P)/$(basename "$install_root")"
+  if [ "$(basename "$target_root")" != "$ZIG_NAME" ]; then
+    echo "Refusing unsafe Zig install root: ${target_root}" >&2
+    exit 1
+  fi
   if [ "${ZIG_FORCE_LOCAL_INSTALL:-0}" = "1" ]; then
     echo "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under ${target_root}"
   else

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -6,6 +6,8 @@ ZIG_MINISIGN_PUBLIC_KEY="${ZIG_MINISIGN_PUBLIC_KEY:-RWSGOq2NVecA2UPNdBUZykf1CCb1
 ZIG_INDEX_URL="${ZIG_INDEX_URL:-https://ziglang.org/download/index.json}"
 ZIG_EXPECTED_SHA256="${ZIG_EXPECTED_SHA256:-}"
 ZIG_WORK_PARENT="${RUNNER_TEMP:-/tmp/cmux-zig-ci}"
+ZIG_SYSTEM_PREFIX="${ZIG_SYSTEM_PREFIX:-/usr/local}"
+ZIG_SYSTEM_PREFIX="${ZIG_SYSTEM_PREFIX%/}"
 export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
 export HOMEBREW_NO_INSTALL_CLEANUP="${HOMEBREW_NO_INSTALL_CLEANUP:-1}"
 export HOMEBREW_NO_ENV_HINTS="${HOMEBREW_NO_ENV_HINTS:-1}"
@@ -23,12 +25,24 @@ publish_zig_for_later_steps() {
   fi
 }
 
+read_zig_lib_dir() {
+  local zig_path="$1"
+  "$zig_path" env 2>/dev/null | python3 -c 'import json, re, sys
+text = sys.stdin.read()
+try:
+    print(json.loads(text).get("lib_dir", ""))
+except Exception:
+    match = re.search(r"(?m)^\s*\.lib_dir\s*=\s*\"([^\"]*)\"", text)
+    print(match.group(1) if match else "")
+'
+}
+
 zig_has_required_version() {
   local zig_path="$1"
   local zig_lib_dir
   [ -x "$zig_path" ] || return 1
   [ "$("$zig_path" version 2>/dev/null || true)" = "$ZIG_REQUIRED" ] || return 1
-  zig_lib_dir="$("$zig_path" env 2>/dev/null | python3 -c 'import json, sys; print(json.load(sys.stdin).get("lib_dir", ""))' 2>/dev/null || true)"
+  zig_lib_dir="$(read_zig_lib_dir "$zig_path" || true)"
   [ -n "$zig_lib_dir" ] || return 1
   [ -f "$zig_lib_dir/compiler/build_runner.zig" ] || return 1
 }
@@ -161,14 +175,33 @@ install_zig_without_sudo() {
 }
 
 install_zig_with_sudo() {
-  local install_root="/usr/local/lib/${ZIG_NAME}"
-  sudo mkdir -p /usr/local/bin /usr/local/lib
-  sudo rm -rf /usr/local/lib/zig "$install_root"
+  local system_prefix="$ZIG_SYSTEM_PREFIX"
+  local bin_dir="${system_prefix}/bin"
+  local lib_dir="${system_prefix}/lib"
+  local install_root="${lib_dir}/${ZIG_NAME}"
+  if [ -z "$system_prefix" ] || [ "$system_prefix" = "/" ]; then
+    echo "Refusing unsafe Zig system prefix: ${ZIG_SYSTEM_PREFIX}" >&2
+    exit 1
+  fi
+  case "$system_prefix" in
+    /*) ;;
+    *)
+      echo "Refusing non-absolute Zig system prefix: ${system_prefix}" >&2
+      exit 1
+      ;;
+  esac
+  sudo mkdir -p "$bin_dir" "$lib_dir"
+  sudo rm -rf "${lib_dir}/zig" "$install_root"
   sudo cp -R "$ZIG_DIR" "$install_root"
-  sudo rm -f /usr/local/bin/zig
-  sudo ln -s "$install_root/zig" /usr/local/bin/zig
-  publish_zig_for_later_steps /usr/local/bin/zig
-  /usr/local/bin/zig version
+  sudo ln -s "${install_root}/lib" "${lib_dir}/zig"
+  sudo rm -f "${bin_dir}/zig"
+  sudo ln -s "${install_root}/zig" "${bin_dir}/zig"
+  if ! zig_has_required_version "${bin_dir}/zig"; then
+    echo "Installed zig ${ZIG_REQUIRED} at ${bin_dir}/zig, but its lib_dir is incomplete" >&2
+    exit 1
+  fi
+  publish_zig_for_later_steps "${bin_dir}/zig"
+  "${bin_dir}/zig" version
 }
 
 echo "Installing verified zig ${ZIG_REQUIRED}"

--- a/scripts/perf-activation-session.py
+++ b/scripts/perf-activation-session.py
@@ -14,6 +14,9 @@ import time
 import xml.etree.ElementTree as ET
 
 
+DEFAULT_SCROLLBACK_TARGET_CHARS = 1_500_000
+
+
 def sanitize_bundle(raw: str) -> str:
     cleaned = re.sub(r"[^a-z0-9]+", ".", raw.lower()).strip(".")
     cleaned = re.sub(r"\.+", ".", cleaned)
@@ -32,6 +35,59 @@ def now_ms() -> float:
 
 def rounded_ms(value: float) -> float:
     return round(value, 2)
+
+
+def scrollback_line_estimated_chars(token: str, lines: int, line_payload_chars: int) -> int:
+    if lines <= 0:
+        return 0
+    line_number_chars = max(4, len(str(lines)))
+    chars_per_line = len(token) + 1 + line_number_chars + 1 + max(0, line_payload_chars) + 1
+    return lines * chars_per_line
+
+
+def build_scrollback_line_plan(
+    surface_roles: list[tuple[str, bool]],
+    heavy_lines: int,
+    other_lines: int,
+    line_payload_chars: int,
+    target_chars: int,
+) -> tuple[dict[str, int], dict[str, int | bool]]:
+    requested_entries: list[tuple[str, bool, str, int]] = []
+    for idx, (surface, is_heavy) in enumerate(surface_roles, 1):
+        requested_lines = heavy_lines if is_heavy else other_lines
+        requested_entries.append((surface, is_heavy, f"PERF_{idx:03d}", max(0, requested_lines)))
+
+    requested_estimated_chars = sum(
+        scrollback_line_estimated_chars(token, lines, line_payload_chars)
+        for _surface, _is_heavy, token, lines in requested_entries
+    )
+    target_applied = target_chars > 0 and requested_estimated_chars > target_chars
+    scale = target_chars / requested_estimated_chars if target_applied else 1.0
+
+    line_plan: dict[str, int] = {}
+    heavy_effective_lines = 0
+    other_effective_lines = 0
+    effective_estimated_chars = 0
+    for surface, is_heavy, token, requested_lines in requested_entries:
+        if requested_lines > 0 and target_applied:
+            effective_lines = max(1, round(requested_lines * scale))
+        else:
+            effective_lines = requested_lines
+        line_plan[surface] = effective_lines
+        effective_estimated_chars += scrollback_line_estimated_chars(token, effective_lines, line_payload_chars)
+        if is_heavy:
+            heavy_effective_lines = max(heavy_effective_lines, effective_lines)
+        else:
+            other_effective_lines = max(other_effective_lines, effective_lines)
+
+    return line_plan, {
+        "scrollback_target_chars": max(0, target_chars),
+        "scrollback_target_applied": target_applied,
+        "scrollback_requested_estimated_chars": requested_estimated_chars,
+        "scrollback_effective_estimated_chars": effective_estimated_chars,
+        "heavy_scrollback_lines_effective": heavy_effective_lines,
+        "other_scrollback_lines_effective": other_effective_lines,
+    }
 
 
 class PerfFailure(RuntimeError):
@@ -359,13 +415,18 @@ class CmuxPerfRunner:
         return terminals
 
     def seed_scrollback(self, terminals: list[tuple[str, str, pathlib.Path]]) -> None:
+        line_plan, line_plan_summary = build_scrollback_line_plan(
+            [(surface, surface in self.heavy_scrollback_surfaces) for _ws, surface, _cwd in terminals],
+            self.args.heavy_scrollback_lines,
+            self.args.other_scrollback_lines,
+            self.args.line_payload_chars,
+            self.args.scrollback_target_chars,
+        )
+        self.result["fixture"].update(line_plan_summary)
+
         pending: dict[str, tuple[str, str]] = {}
         for idx, (ws, surface, _cwd) in enumerate(terminals, 1):
-            lines = (
-                self.args.heavy_scrollback_lines
-                if surface in self.heavy_scrollback_surfaces
-                else self.args.other_scrollback_lines
-            )
+            lines = line_plan.get(surface, 0)
             token = f"PERF_{idx:03d}"
             payload = "x" * self.args.line_payload_chars
             command = (
@@ -608,6 +669,16 @@ def print_summary(result: dict) -> None:
             f"retry_overhead_ms={real_capture.get('retry_overhead_ms')} "
             f"refresh_rate_hz={real_capture.get('refresh_rate_hz')}"
         )
+    if fixture.get("scrollback_target_chars") is not None:
+        print(
+            "  scrollback_seed="
+            f"target={fixture.get('scrollback_target_chars')} "
+            f"requested_estimated={fixture.get('scrollback_requested_estimated_chars')} "
+            f"effective_estimated={fixture.get('scrollback_effective_estimated_chars')} "
+            f"target_applied={fixture.get('scrollback_target_applied')} "
+            f"heavy_lines={fixture.get('heavy_scrollback_lines_effective')} "
+            f"other_lines={fixture.get('other_scrollback_lines_effective')}"
+        )
     no_scroll = measurements.get("snapshot_no_scrollback", {})
     real_scroll = measurements.get("snapshot_with_real_scrollback", {})
     with_scroll = measurements.get("snapshot_with_scrollback", {})
@@ -643,6 +714,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--heavy-scrollback-lines", type=int, default=2400)
     parser.add_argument("--other-scrollback-lines", type=int, default=1400)
     parser.add_argument("--line-payload-chars", type=int, default=96)
+    parser.add_argument(
+        "--scrollback-target-chars",
+        type=int,
+        default=DEFAULT_SCROLLBACK_TARGET_CHARS,
+        help="Scale per-terminal live scrollback seed lines toward this character target; pass 0 to disable scaling.",
+    )
     parser.add_argument("--synthetic-scrollback-fallback", action="store_true", help="Seed DEBUG-only fallback scrollback for headless CI runners.")
     parser.add_argument("--synthetic-scrollback-chars-per-terminal", type=int, default=165_000)
     parser.add_argument("--real-scrollback-capture-timeout", type=float, default=20)

--- a/scripts/perf-activation-session.py
+++ b/scripts/perf-activation-session.py
@@ -142,6 +142,32 @@ class CmuxPerfRunner:
         if not self.cli_path.exists():
             raise PerfFailure(f"cmux CLI not found: {self.cli_path}")
 
+    def log_tail(self, path: pathlib.Path, max_lines: int = 80) -> str:
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+        except FileNotFoundError:
+            return f"{path}: missing"
+        except OSError as exc:
+            return f"{path}: unreadable ({exc})"
+        if not lines:
+            return f"{path}: empty"
+        return "\n".join(lines[-max_lines:])
+
+    def launch_failure_context(self) -> str:
+        proc_state = "not started"
+        if self.proc is not None:
+            returncode = self.proc.poll()
+            proc_state = "running" if returncode is None else f"exited {returncode}"
+        return "\n".join(
+            [
+                f"process: {proc_state}",
+                f"stdout tail ({self.stdout_path}):",
+                self.log_tail(self.stdout_path),
+                f"debug log tail ({self.debug_log_path}):",
+                self.log_tail(self.debug_log_path),
+            ]
+        )
+
     def clean_persisted_state(self) -> None:
         app_support = pathlib.Path.home() / "Library/Application Support/cmux"
         bundle_id = f"com.cmuxterm.app.debug.{self.tag_id}"
@@ -218,7 +244,10 @@ class CmuxPerfRunner:
         ready = self.wait_for_socket(timeout_s=self.args.launch_timeout)
         elapsed = rounded_ms(now_ms() - start)
         if not ready:
-            raise PerfFailure(f"{label}: socket not ready after {self.args.launch_timeout}s")
+            raise PerfFailure(
+                f"{label}: socket not ready after {self.args.launch_timeout}s\n"
+                + self.launch_failure_context()
+            )
         self.result["measurements"][f"{label}_socket_ready_ms"] = elapsed
         return elapsed
 

--- a/tests/test_ci_sanitize_xcode_source_packages_cache.py
+++ b/tests/test_ci_sanitize_xcode_source_packages_cache.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Behavioral guard for restored Xcode SourcePackages cache sanitation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "ci" / "sanitize-xcode-source-packages-cache.py"
+
+
+def run_helper(cache_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HELPER), str(cache_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache_dir = Path(temp_dir) / ".ci-source-packages"
+        artifact = cache_dir / "artifacts" / "sparkle" / "Sparkle" / "Sparkle.xcframework"
+        checkout = cache_dir / "checkouts" / "swift-crypto" / "Package.swift"
+        state = cache_dir / "workspace-state.json"
+
+        artifact.mkdir(parents=True)
+        checkout.parent.mkdir(parents=True)
+        checkout.write_text("// package fixture\n")
+        state.write_text(
+            '{"artifacts":["/Users/ec2-user/actions-runner-cmux/_work/cmux/cmux/'
+            '.ci-source-packages/artifacts/sparkle/Sparkle/Sparkle.xcframework"]}\n'
+        )
+
+        result = run_helper(cache_dir)
+
+        assert result.returncode == 0, result.stderr
+        assert not state.exists()
+        assert artifact.exists()
+        assert checkout.exists()
+        assert "removed stale Xcode SourcePackages state" in result.stdout
+
+
+def test_missing_cache_is_noop() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cache_dir = Path(temp_dir) / "missing-source-packages"
+
+        result = run_helper(cache_dir)
+
+        assert result.returncode == 0, result.stderr
+        assert not cache_dir.exists()
+        assert "no Xcode SourcePackages workspace-state.json files found" in result.stdout
+
+
+def main() -> int:
+    test_removes_workspace_state_and_keeps_downloaded_cache()
+    test_missing_cache_is_noop()
+    print("PASS: Xcode SourcePackages cache sanitizer preserves cache contents")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_sanitize_xcode_source_packages_cache.py
+++ b/tests/test_ci_sanitize_xcode_source_packages_cache.py
@@ -28,11 +28,13 @@ def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
         cache_dir = Path(temp_dir) / ".ci-source-packages"
         artifact = cache_dir / "artifacts" / "sparkle" / "Sparkle" / "Sparkle.xcframework"
         checkout = cache_dir / "checkouts" / "swift-crypto" / "Package.swift"
+        package_state = cache_dir / "checkouts" / "swift-crypto" / "workspace-state.json"
         state = cache_dir / "workspace-state.json"
 
         artifact.mkdir(parents=True)
         checkout.parent.mkdir(parents=True)
         checkout.write_text("// package fixture\n")
+        package_state.write_text('{"package":"owned"}\n')
         state.write_text(
             '{"artifacts":["/Users/ec2-user/actions-runner-cmux/_work/cmux/cmux/'
             '.ci-source-packages/artifacts/sparkle/Sparkle/Sparkle.xcframework"]}\n'
@@ -44,6 +46,7 @@ def test_removes_workspace_state_and_keeps_downloaded_cache() -> None:
         assert not state.exists()
         assert artifact.exists()
         assert checkout.exists()
+        assert package_state.exists()
         assert "removed stale Xcode SourcePackages state" in result.stdout
 
 

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -20,11 +20,11 @@ check_macos_runner() {
   if ! awk -v job="$job" '
     $0 ~ "^  "job":" { in_job=1; next }
     in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
-    in_job && /runs-on:.*(vars\.MACOS_RUNNER|blacksmith-[0-9]+vcpu-macos-|warp-macos-[0-9]+-arm64)/ { saw=1 }
-    in_job && /os:.*(vars\.MACOS_RUNNER|blacksmith-[0-9]+vcpu-macos-|warp-macos-[0-9]+-arm64)/ { saw=1 }
+    in_job && /runs-on:.*(vars\.MACOS_RUNNER|blacksmith-[0-9]+vcpu-macos-|warp-macos-[0-9]+-arm64|depot-macos-)/ { saw=1 }
+    in_job && /os:.*(vars\.MACOS_RUNNER|blacksmith-[0-9]+vcpu-macos-|warp-macos-[0-9]+-arm64|depot-macos-)/ { saw=1 }
     END { exit !(saw) }
   ' "$file"; then
-    echo "FAIL: $job in $(basename "$file") must run on a paid macOS runner (vars.MACOS_RUNNER_* or a Blacksmith/Warp label), not a GitHub-hosted runner"
+    echo "FAIL: $job in $(basename "$file") must run on a paid macOS runner (vars.MACOS_RUNNER_* or a Blacksmith/Warp/Depot label), not a GitHub-hosted runner"
     exit 1
   fi
   echo "PASS: $job in $(basename "$file") uses a paid macOS runner"

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -30,6 +30,24 @@ check_macos_runner() {
   echo "PASS: $job in $(basename "$file") uses a paid macOS runner"
 }
 
+check_depot_identity_guard() {
+  local file="$1" job="$2"
+  if ! awk -v job="$job" '
+    $0 ~ "^  "job":" { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
+    in_job && /REQUESTED_RUNNER:[[:space:]]*depot-macos-latest/ { saw_requested=1 }
+    in_job && /RUNNER_CONTEXT_NAME:[[:space:]]*\$\{\{ runner\.name \}\}/ { saw_runner_name=1 }
+    in_job && /depot-\*\)/ { saw_depot_case=1 }
+    in_job && /resolved outside Depot/ { saw_error=1 }
+    END { exit !(saw_requested && saw_runner_name && saw_depot_case && saw_error) }
+  ' "$file"; then
+    echo "FAIL: $job in $(basename "$file") must validate that depot-macos-latest resolved to an actual depot-* runner"
+    exit 1
+  fi
+
+  echo "PASS: $job in $(basename "$file") validates Depot runner identity"
+}
+
 check_e2e_runner_fallbacks() {
   if ! awk '
     /^run-name:/ {
@@ -229,6 +247,8 @@ check_macos_runner "$CI_FILE" "tests-build-and-lag"
 check_macos_runner "$CI_FILE" "release-ghostty-cli-helper"
 check_macos_runner "$CI_FILE" "release-build"
 check_macos_runner "$CI_FILE" "ui-regressions"
+check_depot_identity_guard "$CI_FILE" "tests-build-and-lag"
+check_depot_identity_guard "$CI_FILE" "ui-regressions"
 
 # build-ghosttykit.yml
 check_macos_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -73,6 +73,17 @@ if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   exit 1
 fi
 
+printf '999999999\n' > "$CMUX_VDISPLAY_LOCK_DIR/owner_pid"
+DEAD_OWNER_LOCK_ENV="$(
+  RUNNER_TEMP="$TMP_DIR" \
+  CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+  CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=2 \
+  CMUX_VDISPLAY_LOCK_STALE_SECONDS=1800 \
+  CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+  "$SCRIPT" acquire 2>/tmp/cmux-vdisplay-dead-owner-acquire.err
+)"
+eval "$DEAD_OWNER_LOCK_ENV"
+
 RUNNER_TEMP="$TMP_DIR" \
 CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
 CMUX_VDISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN" \
@@ -83,4 +94,4 @@ if [ -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   exit 1
 fi
 
-echo "PASS: virtual display lock serializes acquisition, preserves live-owner locks, and releases only matching tokens"
+echo "PASS: virtual display lock serializes acquisition, preserves live-owner locks, reclaims dead-owner locks, and releases only matching tokens"

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -46,6 +46,23 @@ if [ "$(cat "$CMUX_VDISPLAY_LOCK_DIR/owner_pid")" != "$$" ]; then
   exit 1
 fi
 
+{
+  printf 'created_at=1\n'
+  printf 'token=%s\n' "$CMUX_VDISPLAY_LOCK_TOKEN"
+} > "$CMUX_VDISPLAY_LOCK_DIR/metadata"
+
+if RUNNER_TEMP="$TMP_DIR" \
+  CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+  CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=1 \
+  CMUX_VDISPLAY_LOCK_STALE_SECONDS=1 \
+  CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+  "$SCRIPT" acquire >/tmp/cmux-vdisplay-live-owner-acquire.out 2>/tmp/cmux-vdisplay-live-owner-acquire.err; then
+  cat /tmp/cmux-vdisplay-live-owner-acquire.out
+  cat /tmp/cmux-vdisplay-live-owner-acquire.err >&2
+  echo "FAIL: stale cleanup removed a lock whose owner PID was alive" >&2
+  exit 1
+fi
+
 RUNNER_TEMP="$TMP_DIR" \
 CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
 CMUX_VDISPLAY_LOCK_TOKEN="wrong-token" \

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/ci/virtual-display-lock.sh"
+TMP_DIR="$(mktemp -d)"
+LOCK_DIR="$TMP_DIR/cmux-test-virtual-display.lock"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+LOCK_ENV="$(
+  RUNNER_TEMP="$TMP_DIR" \
+  CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+  CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=2 \
+  CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+  "$SCRIPT" acquire
+)"
+eval "$LOCK_ENV"
+
+if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ] || [ ! -f "$CMUX_VDISPLAY_LOCK_DIR/token" ]; then
+  echo "FAIL: acquire did not create tokenized lock" >&2
+  exit 1
+fi
+
+if RUNNER_TEMP="$TMP_DIR" \
+  CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+  CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=1 \
+  CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+  "$SCRIPT" acquire >/tmp/cmux-vdisplay-second-acquire.out 2>/tmp/cmux-vdisplay-second-acquire.err; then
+  cat /tmp/cmux-vdisplay-second-acquire.out
+  cat /tmp/cmux-vdisplay-second-acquire.err >&2
+  echo "FAIL: second acquire succeeded while lock was held" >&2
+  exit 1
+fi
+
+RUNNER_TEMP="$TMP_DIR" \
+CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
+CMUX_VDISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN" \
+  "$SCRIPT" set-owner "$$"
+
+if [ "$(cat "$CMUX_VDISPLAY_LOCK_DIR/owner_pid")" != "$$" ]; then
+  echo "FAIL: set-owner did not record the helper PID" >&2
+  exit 1
+fi
+
+RUNNER_TEMP="$TMP_DIR" \
+CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
+CMUX_VDISPLAY_LOCK_TOKEN="wrong-token" \
+  "$SCRIPT" release
+
+if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
+  echo "FAIL: release removed a lock with the wrong token" >&2
+  exit 1
+fi
+
+RUNNER_TEMP="$TMP_DIR" \
+CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
+CMUX_VDISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN" \
+  "$SCRIPT" release
+
+if [ -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
+  echo "FAIL: release did not remove the matching lock" >&2
+  exit 1
+fi
+
+echo "PASS: virtual display lock serializes acquisition and releases only matching tokens"

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -25,6 +25,16 @@ if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ] || [ ! -f "$CMUX_VDISPLAY_LOCK_DIR/token" 
   exit 1
 fi
 
+RUNNER_TEMP="$TMP_DIR" \
+CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
+CMUX_VDISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN" \
+  "$SCRIPT" set-owner "$$"
+
+if [ "$(cat "$CMUX_VDISPLAY_LOCK_DIR/owner_pid")" != "$$" ]; then
+  echo "FAIL: set-owner did not record the helper PID" >&2
+  exit 1
+fi
+
 if RUNNER_TEMP="$TMP_DIR" \
   CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
   CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=1 \
@@ -33,16 +43,6 @@ if RUNNER_TEMP="$TMP_DIR" \
   cat /tmp/cmux-vdisplay-second-acquire.out
   cat /tmp/cmux-vdisplay-second-acquire.err >&2
   echo "FAIL: second acquire succeeded while lock was held" >&2
-  exit 1
-fi
-
-RUNNER_TEMP="$TMP_DIR" \
-CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
-CMUX_VDISPLAY_LOCK_TOKEN="$CMUX_VDISPLAY_LOCK_TOKEN" \
-  "$SCRIPT" set-owner "$$"
-
-if [ "$(cat "$CMUX_VDISPLAY_LOCK_DIR/owner_pid")" != "$$" ]; then
-  echo "FAIL: set-owner did not record the helper PID" >&2
   exit 1
 fi
 
@@ -93,6 +93,22 @@ if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   exit 1
 fi
 
+rm -f "$CMUX_VDISPLAY_LOCK_DIR/owner_pid"
+{
+  printf 'created_at=1\n'
+  printf 'token=%s\n' "$CMUX_VDISPLAY_LOCK_TOKEN"
+} > "$CMUX_VDISPLAY_LOCK_DIR/metadata"
+
+OWNERLESS_LOCK_ENV="$(
+  RUNNER_TEMP="$TMP_DIR" \
+  CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+  CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=2 \
+  CMUX_VDISPLAY_LOCK_STALE_SECONDS=1800 \
+  CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+  "$SCRIPT" acquire 2>/tmp/cmux-vdisplay-ownerless-acquire.err
+)"
+eval "$OWNERLESS_LOCK_ENV"
+
 printf '999999999\n' > "$CMUX_VDISPLAY_LOCK_DIR/owner_pid"
 DEAD_OWNER_LOCK_ENV="$(
   RUNNER_TEMP="$TMP_DIR" \
@@ -114,4 +130,4 @@ if [ -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   exit 1
 fi
 
-echo "PASS: virtual display lock serializes acquisition, preserves live-owner locks, reclaims dead-owner locks, and releases only matching tokens"
+echo "PASS: virtual display lock serializes acquisition, preserves live-owner locks, reclaims ownerless and dead-owner locks, and releases only matching tokens"

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -66,7 +66,7 @@ fi
 RUNNER_TEMP="$TMP_DIR" \
 CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
 CMUX_VDISPLAY_LOCK_TOKEN="wrong-token" \
-  "$SCRIPT" release
+  "$SCRIPT" release 2>/tmp/cmux-vdisplay-wrong-token-release.err
 
 if [ ! -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   echo "FAIL: release removed a lock with the wrong token" >&2
@@ -83,4 +83,4 @@ if [ -d "$CMUX_VDISPLAY_LOCK_DIR" ]; then
   exit 1
 fi
 
-echo "PASS: virtual display lock serializes acquisition and releases only matching tokens"
+echo "PASS: virtual display lock serializes acquisition, preserves live-owner locks, and releases only matching tokens"

--- a/tests/test_ci_virtual_display_lock.sh
+++ b/tests/test_ci_virtual_display_lock.sh
@@ -63,6 +63,26 @@ if RUNNER_TEMP="$TMP_DIR" \
   exit 1
 fi
 
+if ps -p 1 >/dev/null 2>&1; then
+  printf '1\n' > "$CMUX_VDISPLAY_LOCK_DIR/owner_pid"
+  {
+    printf 'created_at=1\n'
+    printf 'token=%s\n' "$CMUX_VDISPLAY_LOCK_TOKEN"
+  } > "$CMUX_VDISPLAY_LOCK_DIR/metadata"
+
+  if RUNNER_TEMP="$TMP_DIR" \
+    CMUX_VDISPLAY_LOCK_DIR="$LOCK_DIR" \
+    CMUX_VDISPLAY_LOCK_TIMEOUT_SECONDS=1 \
+    CMUX_VDISPLAY_LOCK_STALE_SECONDS=1 \
+    CMUX_VDISPLAY_LOCK_POLL_SECONDS=1 \
+    "$SCRIPT" acquire >/tmp/cmux-vdisplay-foreign-owner-acquire.out 2>/tmp/cmux-vdisplay-foreign-owner-acquire.err; then
+    cat /tmp/cmux-vdisplay-foreign-owner-acquire.out
+    cat /tmp/cmux-vdisplay-foreign-owner-acquire.err >&2
+    echo "FAIL: stale cleanup removed a lock whose owner PID exists but may reject kill -0" >&2
+    exit 1
+  fi
+fi
+
 RUNNER_TEMP="$TMP_DIR" \
 CMUX_VDISPLAY_LOCK_DIR="$CMUX_VDISPLAY_LOCK_DIR" \
 CMUX_VDISPLAY_LOCK_TOKEN="wrong-token" \

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -45,6 +45,12 @@ RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
 GITHUB_PATH_FILE="$TMP_DIR/github-path"
 GITHUB_ENV_FILE="$TMP_DIR/github-env"
 OUTPUT_FILE="$TMP_DIR/output"
+BROKEN_ZIG_LIB_DIR="$TMP_DIR/broken-zig-lib"
+WRONG_VERSION_OUTPUT_FILE="$TMP_DIR/wrong-version-output"
+WRONG_VERSION_GITHUB_PATH_FILE="$TMP_DIR/wrong-version-github-path"
+WRONG_VERSION_GITHUB_ENV_FILE="$TMP_DIR/wrong-version-github-env"
+WRONG_VERSION_RUNNER_TEMP_DIR="$TMP_DIR/wrong-version-runner-temp"
+WRONG_VERSION_LIB_DIR="$TMP_DIR/wrong-version-zig-lib"
 FORCE_LOCAL_OUTPUT_FILE="$TMP_DIR/force-local-output"
 FORCE_LOCAL_GITHUB_PATH_FILE="$TMP_DIR/force-local-github-path"
 FORCE_LOCAL_GITHUB_ENV_FILE="$TMP_DIR/force-local-github-env"
@@ -55,7 +61,7 @@ DEFAULT_GITHUB_PATH_FILE="$TMP_DIR/default-github-path"
 DEFAULT_GITHUB_ENV_FILE="$TMP_DIR/default-github-env"
 SUDO_LOG="$TMP_DIR/sudo.log"
 
-mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
+mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib/compiler" "$BIN_DIR" "$RUNNER_TEMP_DIR" "$WRONG_VERSION_RUNNER_TEMP_DIR" "$WRONG_VERSION_LIB_DIR/compiler"
 rm -rf "$SHARED_TMP_ZIG_DIR"
 mkdir -p "$SHARED_TMP_ZIG_DIR"
 printf 'shared temp marker\n' > "$SHARED_TMP_MARKER"
@@ -65,6 +71,8 @@ echo "$ZIG_REQUIRED"
 EOF
 chmod +x "$FIXTURE_ROOT/$ZIG_NAME/zig"
 printf 'lib fixture\n' > "$FIXTURE_ROOT/$ZIG_NAME/lib/std"
+printf 'build runner fixture\n' > "$FIXTURE_ROOT/$ZIG_NAME/lib/compiler/build_runner.zig"
+printf 'wrong version build runner fixture\n' > "$WRONG_VERSION_LIB_DIR/compiler/build_runner.zig"
 (cd "$FIXTURE_ROOT" && tar -cf "$ARCHIVE" "$ZIG_NAME")
 ARCHIVE_SHA256="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
 
@@ -91,6 +99,24 @@ cp "$ARCHIVE" "\$OUTPUT"
 EOF
 chmod +x "$BIN_DIR/curl"
 
+cat > "$BIN_DIR/zig" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  version)
+    printf '%s\n' "${FAKE_ZIG_VERSION:?}"
+    ;;
+  env)
+    printf '{"lib_dir":"%s"}\n' "${FAKE_ZIG_LIB_DIR:?}"
+    ;;
+  *)
+    echo "unexpected fake zig invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$BIN_DIR/zig"
+
 cat > "$BIN_DIR/sudo" <<'EOF'
 #!/usr/bin/env bash
 exit 1
@@ -101,6 +127,8 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   RUNNER_TEMP="$RUNNER_TEMP_DIR" \
   GITHUB_PATH="$GITHUB_PATH_FILE" \
   GITHUB_ENV="$GITHUB_ENV_FILE" \
+  FAKE_ZIG_VERSION="$ZIG_REQUIRED" \
+  FAKE_ZIG_LIB_DIR="$BROKEN_ZIG_LIB_DIR" \
   ZIG_REQUIRED="$ZIG_REQUIRED" \
   ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
@@ -132,9 +160,46 @@ if ! grep -Fq "sudo unavailable; installing zig under" "$OUTPUT_FILE"; then
   exit 1
 fi
 
+if grep -Fq "already installed at" "$OUTPUT_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer accepted a broken existing zig whose lib_dir lacks compiler/build_runner.zig" >&2
+  exit 1
+fi
+
 if [ ! -f "$SHARED_TMP_MARKER" ]; then
   cat "$OUTPUT_FILE"
   echo "FAIL: installer touched the shared /tmp Zig extraction directory" >&2
+  exit 1
+fi
+
+PATH="$BIN_DIR:/usr/bin:/bin" \
+  RUNNER_TEMP="$WRONG_VERSION_RUNNER_TEMP_DIR" \
+  GITHUB_PATH="$WRONG_VERSION_GITHUB_PATH_FILE" \
+  GITHUB_ENV="$WRONG_VERSION_GITHUB_ENV_FILE" \
+  FAKE_ZIG_VERSION="98.98.98" \
+  FAKE_ZIG_LIB_DIR="$WRONG_VERSION_LIB_DIR" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$WRONG_VERSION_OUTPUT_FILE" 2>&1
+
+WRONG_VERSION_INSTALL_ROOT="$WRONG_VERSION_RUNNER_TEMP_DIR/$ZIG_NAME"
+EXPECTED_WRONG_VERSION_INSTALL_ROOT="$(canonical_install_root "$WRONG_VERSION_INSTALL_ROOT")"
+if [ ! -x "$WRONG_VERSION_INSTALL_ROOT/zig" ]; then
+  cat "$WRONG_VERSION_OUTPUT_FILE"
+  echo "FAIL: wrong-version existing zig did not fall back to a verified install" >&2
+  exit 1
+fi
+
+if grep -Fq "already installed at" "$WRONG_VERSION_OUTPUT_FILE"; then
+  cat "$WRONG_VERSION_OUTPUT_FILE"
+  echo "FAIL: installer accepted a wrong-version existing zig whose lib_dir looked complete" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$EXPECTED_WRONG_VERSION_INSTALL_ROOT" "$WRONG_VERSION_GITHUB_PATH_FILE"; then
+  cat "$WRONG_VERSION_OUTPUT_FILE"
+  echo "FAIL: wrong-version fallback did not publish the verified local zig bin dir to GITHUB_PATH" >&2
   exit 1
 fi
 
@@ -152,6 +217,8 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   RUNNER_TEMP="$RUNNER_TEMP_DIR" \
   GITHUB_PATH="$FORCE_LOCAL_GITHUB_PATH_FILE" \
   GITHUB_ENV="$FORCE_LOCAL_GITHUB_ENV_FILE" \
+  FAKE_ZIG_VERSION="$ZIG_REQUIRED" \
+  FAKE_ZIG_LIB_DIR="$BROKEN_ZIG_LIB_DIR" \
   ZIG_REQUIRED="$ZIG_REQUIRED" \
   ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
   ZIG_FORCE_LOCAL_INSTALL=1 \
@@ -209,6 +276,8 @@ env -u RUNNER_TEMP -u ZIG_FORCE_LOCAL_INSTALL -u ZIG_INSTALL_ROOT \
   PATH="$BIN_DIR:/usr/bin:/bin" \
   GITHUB_PATH="$DEFAULT_GITHUB_PATH_FILE" \
   GITHUB_ENV="$DEFAULT_GITHUB_ENV_FILE" \
+  FAKE_ZIG_VERSION="$ZIG_REQUIRED" \
+  FAKE_ZIG_LIB_DIR="$BROKEN_ZIG_LIB_DIR" \
   ZIG_REQUIRED="$ZIG_REQUIRED" \
   ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
@@ -239,4 +308,4 @@ if ! grep -Fxq "CMUX_ZIG=$EXPECTED_DEFAULT_INSTALL_ROOT/zig" "$DEFAULT_GITHUB_EN
   exit 1
 fi
 
-echo "PASS: install-zig-ci falls back locally, isolates shared /tmp extraction, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"
+echo "PASS: install-zig-ci rejects broken or wrong-version existing zig, falls back locally, isolates shared /tmp extraction, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -43,7 +43,8 @@ OUTPUT_FILE="$TMP_DIR/output"
 FORCE_LOCAL_OUTPUT_FILE="$TMP_DIR/force-local-output"
 FORCE_LOCAL_GITHUB_PATH_FILE="$TMP_DIR/force-local-github-path"
 FORCE_LOCAL_GITHUB_ENV_FILE="$TMP_DIR/force-local-github-env"
-FORCE_LOCAL_INSTALL_ROOT="$TMP_DIR/force-local-install"
+FORCE_LOCAL_INSTALL_PARENT="$TMP_DIR/force-local-install"
+FORCE_LOCAL_MARKER="$FORCE_LOCAL_INSTALL_PARENT/keep.txt"
 DEFAULT_OUTPUT_FILE="$TMP_DIR/default-output"
 DEFAULT_GITHUB_PATH_FILE="$TMP_DIR/default-github-path"
 DEFAULT_GITHUB_ENV_FILE="$TMP_DIR/default-github-env"
@@ -130,6 +131,8 @@ exit 0
 EOF
 chmod +x "$BIN_DIR/sudo"
 rm -f "$SUDO_LOG"
+mkdir -p "$FORCE_LOCAL_INSTALL_PARENT"
+printf 'keep\n' > "$FORCE_LOCAL_MARKER"
 
 PATH="$BIN_DIR:/usr/bin:/bin" \
   RUNNER_TEMP="$RUNNER_TEMP_DIR" \
@@ -138,14 +141,21 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   ZIG_REQUIRED="$ZIG_REQUIRED" \
   ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
   ZIG_FORCE_LOCAL_INSTALL=1 \
-  ZIG_INSTALL_ROOT="$FORCE_LOCAL_INSTALL_ROOT" \
+  ZIG_INSTALL_ROOT="$FORCE_LOCAL_INSTALL_PARENT" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
   "$SCRIPT" > "$FORCE_LOCAL_OUTPUT_FILE" 2>&1
 
+FORCE_LOCAL_INSTALL_ROOT="$FORCE_LOCAL_INSTALL_PARENT/$ZIG_NAME"
 EXPECTED_FORCE_LOCAL_INSTALL_ROOT="$(canonical_install_root "$FORCE_LOCAL_INSTALL_ROOT")"
 if [ ! -x "$FORCE_LOCAL_INSTALL_ROOT/zig" ]; then
   cat "$FORCE_LOCAL_OUTPUT_FILE"
   echo "FAIL: force-local install did not install zig under ZIG_INSTALL_ROOT" >&2
+  exit 1
+fi
+
+if [ ! -f "$FORCE_LOCAL_MARKER" ]; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  echo "FAIL: force-local install deleted unrelated parent directory contents" >&2
   exit 1
 fi
 

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Behavioral guard for installing verified Zig on CI runners without sudo.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/install-zig-ci.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ZIG_REQUIRED="99.99.99"
+case "$(uname -m)" in
+  arm64 | aarch64) ZIG_ARCH="aarch64" ;;
+  x86_64) ZIG_ARCH="x86_64" ;;
+  *)
+    echo "Unsupported test architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+FIXTURE_ROOT="$TMP_DIR/fixture"
+ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
+ARCHIVE="$TMP_DIR/${ZIG_NAME}.tar.xz"
+BIN_DIR="$TMP_DIR/bin"
+RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
+GITHUB_PATH_FILE="$TMP_DIR/github-path"
+GITHUB_ENV_FILE="$TMP_DIR/github-env"
+OUTPUT_FILE="$TMP_DIR/output"
+
+mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
+cat > "$FIXTURE_ROOT/$ZIG_NAME/zig" <<EOF
+#!/usr/bin/env bash
+echo "$ZIG_REQUIRED"
+EOF
+chmod +x "$FIXTURE_ROOT/$ZIG_NAME/zig"
+printf 'lib fixture\n' > "$FIXTURE_ROOT/$ZIG_NAME/lib/std"
+(cd "$FIXTURE_ROOT" && tar -cf "$ARCHIVE" "$ZIG_NAME")
+ARCHIVE_SHA256="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+
+cat > "$BIN_DIR/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+OUTPUT=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --output)
+      OUTPUT="\$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "\$OUTPUT" ]; then
+  echo "curl stub missing --output" >&2
+  exit 1
+fi
+cp "$ARCHIVE" "\$OUTPUT"
+EOF
+chmod +x "$BIN_DIR/curl"
+
+cat > "$BIN_DIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN_DIR/sudo"
+
+PATH="$BIN_DIR:/usr/bin:/bin" \
+  RUNNER_TEMP="$RUNNER_TEMP_DIR" \
+  GITHUB_PATH="$GITHUB_PATH_FILE" \
+  GITHUB_ENV="$GITHUB_ENV_FILE" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_FORCE_LOCAL_INSTALL=1 \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$OUTPUT_FILE" 2>&1
+
+INSTALLED_ZIG="$RUNNER_TEMP_DIR/cmux-zig-$ZIG_REQUIRED/bin/zig"
+if [ ! -x "$INSTALLED_ZIG" ]; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: zig was not installed under RUNNER_TEMP" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$(dirname "$INSTALLED_ZIG")" "$GITHUB_PATH_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not publish the local zig bin dir to GITHUB_PATH" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "CMUX_ZIG=$INSTALLED_ZIG" "$GITHUB_ENV_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not publish CMUX_ZIG" >&2
+  exit 1
+fi
+
+if ! grep -Fq "sudo unavailable; installing zig under" "$OUTPUT_FILE"; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer did not report local fallback" >&2
+  exit 1
+fi
+
+echo "PASS: install-zig-ci falls back to RUNNER_TEMP without sudo"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -25,6 +25,11 @@ RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
 GITHUB_PATH_FILE="$TMP_DIR/github-path"
 GITHUB_ENV_FILE="$TMP_DIR/github-env"
 OUTPUT_FILE="$TMP_DIR/output"
+FORCE_LOCAL_OUTPUT_FILE="$TMP_DIR/force-local-output"
+FORCE_LOCAL_GITHUB_PATH_FILE="$TMP_DIR/force-local-github-path"
+FORCE_LOCAL_GITHUB_ENV_FILE="$TMP_DIR/force-local-github-env"
+FORCE_LOCAL_INSTALL_ROOT="$TMP_DIR/force-local-install"
+SUDO_LOG="$TMP_DIR/sudo.log"
 
 mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
 cat > "$FIXTURE_ROOT/$ZIG_NAME/zig" <<EOF
@@ -71,7 +76,6 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   GITHUB_ENV="$GITHUB_ENV_FILE" \
   ZIG_REQUIRED="$ZIG_REQUIRED" \
   ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
-  ZIG_FORCE_LOCAL_INSTALL=1 \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
   "$SCRIPT" > "$OUTPUT_FILE" 2>&1
 
@@ -100,4 +104,54 @@ if ! grep -Fq "sudo unavailable; installing zig under" "$OUTPUT_FILE"; then
   exit 1
 fi
 
-echo "PASS: install-zig-ci falls back to RUNNER_TEMP without sudo"
+cat > "$BIN_DIR/sudo" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$SUDO_LOG"
+exit 0
+EOF
+chmod +x "$BIN_DIR/sudo"
+rm -f "$SUDO_LOG"
+
+PATH="$BIN_DIR:/usr/bin:/bin" \
+  RUNNER_TEMP="$RUNNER_TEMP_DIR" \
+  GITHUB_PATH="$FORCE_LOCAL_GITHUB_PATH_FILE" \
+  GITHUB_ENV="$FORCE_LOCAL_GITHUB_ENV_FILE" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_FORCE_LOCAL_INSTALL=1 \
+  ZIG_INSTALL_ROOT="$FORCE_LOCAL_INSTALL_ROOT" \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$FORCE_LOCAL_OUTPUT_FILE" 2>&1
+
+if [ ! -x "$FORCE_LOCAL_INSTALL_ROOT/zig" ]; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  echo "FAIL: force-local install did not install zig under ZIG_INSTALL_ROOT" >&2
+  exit 1
+fi
+
+if [ -s "$SUDO_LOG" ]; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  cat "$SUDO_LOG"
+  echo "FAIL: force-local install invoked sudo" >&2
+  exit 1
+fi
+
+if ! grep -Fq "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under" "$FORCE_LOCAL_OUTPUT_FILE"; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  echo "FAIL: force-local install did not report the forced local path" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$(dirname "$FORCE_LOCAL_INSTALL_ROOT/zig")" "$FORCE_LOCAL_GITHUB_PATH_FILE"; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  echo "FAIL: force-local install did not publish the local zig bin dir to GITHUB_PATH" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "CMUX_ZIG=$FORCE_LOCAL_INSTALL_ROOT/zig" "$FORCE_LOCAL_GITHUB_ENV_FILE"; then
+  cat "$FORCE_LOCAL_OUTPUT_FILE"
+  echo "FAIL: force-local install did not publish CMUX_ZIG" >&2
+  exit 1
+fi
+
+echo "PASS: install-zig-ci falls back locally without sudo and honors ZIG_FORCE_LOCAL_INSTALL"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -12,6 +12,9 @@ cleanup() {
   if [ -n "$DEFAULT_INSTALL_ROOT" ]; then
     rm -rf "$DEFAULT_INSTALL_ROOT"
   fi
+  if [ -n "${SHARED_TMP_ZIG_DIR:-}" ]; then
+    rm -rf "$SHARED_TMP_ZIG_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -35,6 +38,8 @@ FIXTURE_ROOT="$TMP_DIR/fixture"
 ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
 ARCHIVE="$TMP_DIR/${ZIG_NAME}.tar.xz"
 DEFAULT_INSTALL_ROOT="/tmp/cmux-zig-ci/$ZIG_NAME"
+SHARED_TMP_ZIG_DIR="/tmp/$ZIG_NAME"
+SHARED_TMP_MARKER="$SHARED_TMP_ZIG_DIR/keep.txt"
 BIN_DIR="$TMP_DIR/bin"
 RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
 GITHUB_PATH_FILE="$TMP_DIR/github-path"
@@ -51,6 +56,9 @@ DEFAULT_GITHUB_ENV_FILE="$TMP_DIR/default-github-env"
 SUDO_LOG="$TMP_DIR/sudo.log"
 
 mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
+rm -rf "$SHARED_TMP_ZIG_DIR"
+mkdir -p "$SHARED_TMP_ZIG_DIR"
+printf 'shared temp marker\n' > "$SHARED_TMP_MARKER"
 cat > "$FIXTURE_ROOT/$ZIG_NAME/zig" <<EOF
 #!/usr/bin/env bash
 echo "$ZIG_REQUIRED"
@@ -121,6 +129,12 @@ fi
 if ! grep -Fq "sudo unavailable; installing zig under" "$OUTPUT_FILE"; then
   cat "$OUTPUT_FILE"
   echo "FAIL: installer did not report local fallback" >&2
+  exit 1
+fi
+
+if [ ! -f "$SHARED_TMP_MARKER" ]; then
+  cat "$OUTPUT_FILE"
+  echo "FAIL: installer touched the shared /tmp Zig extraction directory" >&2
   exit 1
 fi
 
@@ -225,4 +239,4 @@ if ! grep -Fxq "CMUX_ZIG=$EXPECTED_DEFAULT_INSTALL_ROOT/zig" "$DEFAULT_GITHUB_EN
   exit 1
 fi
 
-echo "PASS: install-zig-ci falls back locally, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"
+echo "PASS: install-zig-ci falls back locally, isolates shared /tmp extraction, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -24,6 +24,17 @@ canonical_install_root() {
   printf '%s/%s\n' "$(cd "$(dirname "$root")" && pwd -P)" "$(basename "$root")"
 }
 
+read_zig_lib_dir_from_stdin() {
+  python3 -c 'import json, re, sys
+text = sys.stdin.read()
+try:
+    print(json.loads(text).get("lib_dir", ""))
+except Exception:
+    match = re.search(r"(?m)^\s*\.lib_dir\s*=\s*\"([^\"]*)\"", text)
+    print(match.group(1) if match else "")
+'
+}
+
 ZIG_REQUIRED="99.99.99"
 case "$(uname -m)" in
   arm64 | aarch64) ZIG_ARCH="aarch64" ;;
@@ -51,6 +62,10 @@ WRONG_VERSION_GITHUB_PATH_FILE="$TMP_DIR/wrong-version-github-path"
 WRONG_VERSION_GITHUB_ENV_FILE="$TMP_DIR/wrong-version-github-env"
 WRONG_VERSION_RUNNER_TEMP_DIR="$TMP_DIR/wrong-version-runner-temp"
 WRONG_VERSION_LIB_DIR="$TMP_DIR/wrong-version-zig-lib"
+SUDO_OUTPUT_FILE="$TMP_DIR/sudo-output"
+SUDO_GITHUB_PATH_FILE="$TMP_DIR/sudo-github-path"
+SUDO_GITHUB_ENV_FILE="$TMP_DIR/sudo-github-env"
+SUDO_SYSTEM_PREFIX="$TMP_DIR/system-prefix"
 FORCE_LOCAL_OUTPUT_FILE="$TMP_DIR/force-local-output"
 FORCE_LOCAL_GITHUB_PATH_FILE="$TMP_DIR/force-local-github-path"
 FORCE_LOCAL_GITHUB_ENV_FILE="$TMP_DIR/force-local-github-env"
@@ -67,7 +82,31 @@ mkdir -p "$SHARED_TMP_ZIG_DIR"
 printf 'shared temp marker\n' > "$SHARED_TMP_MARKER"
 cat > "$FIXTURE_ROOT/$ZIG_NAME/zig" <<EOF
 #!/usr/bin/env bash
-echo "$ZIG_REQUIRED"
+set -euo pipefail
+self="\$0"
+if [ -L "\$self" ]; then
+  target="\$(readlink "\$self")"
+  case "\$target" in
+    /*)
+      self="\$target"
+      ;;
+    *)
+      self="\$(cd "\$(dirname "\$self")" && pwd -P)/\$target"
+      ;;
+  esac
+fi
+case "\${1:-}" in
+  version)
+    echo "$ZIG_REQUIRED"
+    ;;
+  env)
+    zig_dir="\$(cd "\$(dirname "\$self")" && pwd -P)"
+    printf '.{\\n    .lib_dir = "%s/lib",\\n}\\n' "\$zig_dir"
+    ;;
+  *)
+    echo "$ZIG_REQUIRED"
+    ;;
+esac
 EOF
 chmod +x "$FIXTURE_ROOT/$ZIG_NAME/zig"
 printf 'lib fixture\n' > "$FIXTURE_ROOT/$ZIG_NAME/lib/std"
@@ -205,10 +244,61 @@ fi
 
 cat > "$BIN_DIR/sudo" <<EOF
 #!/usr/bin/env bash
+set -euo pipefail
 printf '%s\n' "\$*" >> "$SUDO_LOG"
-exit 0
+if [ "\${1:-}" = "-n" ]; then
+  shift
+fi
+exec "\$@"
 EOF
 chmod +x "$BIN_DIR/sudo"
+rm -f "$SUDO_LOG"
+
+PATH="$BIN_DIR:/usr/bin:/bin" \
+  RUNNER_TEMP="$RUNNER_TEMP_DIR" \
+  GITHUB_PATH="$SUDO_GITHUB_PATH_FILE" \
+  GITHUB_ENV="$SUDO_GITHUB_ENV_FILE" \
+  FAKE_ZIG_VERSION="$ZIG_REQUIRED" \
+  FAKE_ZIG_LIB_DIR="$BROKEN_ZIG_LIB_DIR" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_SYSTEM_PREFIX="$SUDO_SYSTEM_PREFIX" \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$SUDO_OUTPUT_FILE" 2>&1
+
+EXPECTED_SUDO_BIN_DIR="$(cd "$SUDO_SYSTEM_PREFIX/bin" && pwd)"
+EXPECTED_SUDO_LIB_DIR="$(canonical_install_root "$SUDO_SYSTEM_PREFIX/lib/$ZIG_NAME/lib")"
+if [ ! -x "$SUDO_SYSTEM_PREFIX/bin/zig" ]; then
+  cat "$SUDO_OUTPUT_FILE"
+  echo "FAIL: sudo install did not publish an executable zig in the system bin dir" >&2
+  exit 1
+fi
+
+if [ "$(canonical_install_root "$(readlink "$SUDO_SYSTEM_PREFIX/lib/zig")")" != "$EXPECTED_SUDO_LIB_DIR" ]; then
+  cat "$SUDO_OUTPUT_FILE"
+  echo "FAIL: sudo install did not preserve the system Zig lib_dir symlink" >&2
+  exit 1
+fi
+
+SUDO_LIB_DIR="$("$SUDO_SYSTEM_PREFIX/bin/zig" env | read_zig_lib_dir_from_stdin)"
+if [ ! -f "$SUDO_LIB_DIR/compiler/build_runner.zig" ]; then
+  cat "$SUDO_OUTPUT_FILE"
+  echo "FAIL: sudo-installed zig does not resolve compiler/build_runner.zig through zig env" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$EXPECTED_SUDO_BIN_DIR" "$SUDO_GITHUB_PATH_FILE"; then
+  cat "$SUDO_OUTPUT_FILE"
+  echo "FAIL: sudo install did not publish the system zig bin dir to GITHUB_PATH" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "CMUX_ZIG=$EXPECTED_SUDO_BIN_DIR/zig" "$SUDO_GITHUB_ENV_FILE"; then
+  cat "$SUDO_OUTPUT_FILE"
+  echo "FAIL: sudo install did not publish CMUX_ZIG" >&2
+  exit 1
+fi
+
 rm -f "$SUDO_LOG"
 mkdir -p "$FORCE_LOCAL_INSTALL_PARENT"
 printf 'keep\n' > "$FORCE_LOCAL_MARKER"
@@ -308,4 +398,4 @@ if ! grep -Fxq "CMUX_ZIG=$EXPECTED_DEFAULT_INSTALL_ROOT/zig" "$DEFAULT_GITHUB_EN
   exit 1
 fi
 
-echo "PASS: install-zig-ci rejects broken or wrong-version existing zig, falls back locally, isolates shared /tmp extraction, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"
+echo "PASS: install-zig-ci rejects broken or wrong-version existing zig, validates sudo lib_dir, falls back locally, isolates shared /tmp extraction, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -75,7 +75,7 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
   "$SCRIPT" > "$OUTPUT_FILE" 2>&1
 
-INSTALLED_ZIG="$RUNNER_TEMP_DIR/cmux-zig-$ZIG_REQUIRED/bin/zig"
+INSTALLED_ZIG="$RUNNER_TEMP_DIR/$ZIG_NAME/zig"
 if [ ! -x "$INSTALLED_ZIG" ]; then
   cat "$OUTPUT_FILE"
   echo "FAIL: zig was not installed under RUNNER_TEMP" >&2

--- a/tests/test_install_zig_ci_no_sudo.sh
+++ b/tests/test_install_zig_ci_no_sudo.sh
@@ -5,7 +5,21 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$ROOT_DIR/scripts/install-zig-ci.sh"
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+DEFAULT_INSTALL_ROOT=""
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+  if [ -n "$DEFAULT_INSTALL_ROOT" ]; then
+    rm -rf "$DEFAULT_INSTALL_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+canonical_install_root() {
+  local root="$1"
+  mkdir -p "$(dirname "$root")"
+  printf '%s/%s\n' "$(cd "$(dirname "$root")" && pwd -P)" "$(basename "$root")"
+}
 
 ZIG_REQUIRED="99.99.99"
 case "$(uname -m)" in
@@ -20,6 +34,7 @@ esac
 FIXTURE_ROOT="$TMP_DIR/fixture"
 ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
 ARCHIVE="$TMP_DIR/${ZIG_NAME}.tar.xz"
+DEFAULT_INSTALL_ROOT="/tmp/cmux-zig-ci/$ZIG_NAME"
 BIN_DIR="$TMP_DIR/bin"
 RUNNER_TEMP_DIR="$TMP_DIR/runner-temp"
 GITHUB_PATH_FILE="$TMP_DIR/github-path"
@@ -29,6 +44,9 @@ FORCE_LOCAL_OUTPUT_FILE="$TMP_DIR/force-local-output"
 FORCE_LOCAL_GITHUB_PATH_FILE="$TMP_DIR/force-local-github-path"
 FORCE_LOCAL_GITHUB_ENV_FILE="$TMP_DIR/force-local-github-env"
 FORCE_LOCAL_INSTALL_ROOT="$TMP_DIR/force-local-install"
+DEFAULT_OUTPUT_FILE="$TMP_DIR/default-output"
+DEFAULT_GITHUB_PATH_FILE="$TMP_DIR/default-github-path"
+DEFAULT_GITHUB_ENV_FILE="$TMP_DIR/default-github-env"
 SUDO_LOG="$TMP_DIR/sudo.log"
 
 mkdir -p "$FIXTURE_ROOT/$ZIG_NAME/lib" "$BIN_DIR" "$RUNNER_TEMP_DIR"
@@ -80,19 +98,20 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   "$SCRIPT" > "$OUTPUT_FILE" 2>&1
 
 INSTALLED_ZIG="$RUNNER_TEMP_DIR/$ZIG_NAME/zig"
+EXPECTED_INSTALLED_ZIG="$(canonical_install_root "$RUNNER_TEMP_DIR/$ZIG_NAME")/zig"
 if [ ! -x "$INSTALLED_ZIG" ]; then
   cat "$OUTPUT_FILE"
   echo "FAIL: zig was not installed under RUNNER_TEMP" >&2
   exit 1
 fi
 
-if ! grep -Fxq "$(dirname "$INSTALLED_ZIG")" "$GITHUB_PATH_FILE"; then
+if ! grep -Fxq "$(dirname "$EXPECTED_INSTALLED_ZIG")" "$GITHUB_PATH_FILE"; then
   cat "$OUTPUT_FILE"
   echo "FAIL: installer did not publish the local zig bin dir to GITHUB_PATH" >&2
   exit 1
 fi
 
-if ! grep -Fxq "CMUX_ZIG=$INSTALLED_ZIG" "$GITHUB_ENV_FILE"; then
+if ! grep -Fxq "CMUX_ZIG=$EXPECTED_INSTALLED_ZIG" "$GITHUB_ENV_FILE"; then
   cat "$OUTPUT_FILE"
   echo "FAIL: installer did not publish CMUX_ZIG" >&2
   exit 1
@@ -123,6 +142,7 @@ PATH="$BIN_DIR:/usr/bin:/bin" \
   ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
   "$SCRIPT" > "$FORCE_LOCAL_OUTPUT_FILE" 2>&1
 
+EXPECTED_FORCE_LOCAL_INSTALL_ROOT="$(canonical_install_root "$FORCE_LOCAL_INSTALL_ROOT")"
 if [ ! -x "$FORCE_LOCAL_INSTALL_ROOT/zig" ]; then
   cat "$FORCE_LOCAL_OUTPUT_FILE"
   echo "FAIL: force-local install did not install zig under ZIG_INSTALL_ROOT" >&2
@@ -142,16 +162,57 @@ if ! grep -Fq "ZIG_FORCE_LOCAL_INSTALL=1; installing zig under" "$FORCE_LOCAL_OU
   exit 1
 fi
 
-if ! grep -Fxq "$(dirname "$FORCE_LOCAL_INSTALL_ROOT/zig")" "$FORCE_LOCAL_GITHUB_PATH_FILE"; then
+if ! grep -Fxq "$EXPECTED_FORCE_LOCAL_INSTALL_ROOT" "$FORCE_LOCAL_GITHUB_PATH_FILE"; then
   cat "$FORCE_LOCAL_OUTPUT_FILE"
   echo "FAIL: force-local install did not publish the local zig bin dir to GITHUB_PATH" >&2
   exit 1
 fi
 
-if ! grep -Fxq "CMUX_ZIG=$FORCE_LOCAL_INSTALL_ROOT/zig" "$FORCE_LOCAL_GITHUB_ENV_FILE"; then
+if ! grep -Fxq "CMUX_ZIG=$EXPECTED_FORCE_LOCAL_INSTALL_ROOT/zig" "$FORCE_LOCAL_GITHUB_ENV_FILE"; then
   cat "$FORCE_LOCAL_OUTPUT_FILE"
   echo "FAIL: force-local install did not publish CMUX_ZIG" >&2
   exit 1
 fi
 
-echo "PASS: install-zig-ci falls back locally without sudo and honors ZIG_FORCE_LOCAL_INSTALL"
+cat > "$BIN_DIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$BIN_DIR/sudo"
+rm -rf "$DEFAULT_INSTALL_ROOT"
+
+env -u RUNNER_TEMP -u ZIG_FORCE_LOCAL_INSTALL -u ZIG_INSTALL_ROOT \
+  PATH="$BIN_DIR:/usr/bin:/bin" \
+  GITHUB_PATH="$DEFAULT_GITHUB_PATH_FILE" \
+  GITHUB_ENV="$DEFAULT_GITHUB_ENV_FILE" \
+  ZIG_REQUIRED="$ZIG_REQUIRED" \
+  ZIG_EXPECTED_SHA256="$ARCHIVE_SHA256" \
+  ZIG_MIRROR_URL="https://example.invalid/$ZIG_NAME.tar.xz" \
+  "$SCRIPT" > "$DEFAULT_OUTPUT_FILE" 2>&1
+
+EXPECTED_DEFAULT_INSTALL_ROOT="$(canonical_install_root "$DEFAULT_INSTALL_ROOT")"
+if [ ! -x "$DEFAULT_INSTALL_ROOT/zig" ]; then
+  cat "$DEFAULT_OUTPUT_FILE"
+  echo "FAIL: missing RUNNER_TEMP did not install zig under the distinct /tmp fallback root" >&2
+  exit 1
+fi
+
+if ! grep -Fq "sudo unavailable; installing zig under $EXPECTED_DEFAULT_INSTALL_ROOT" "$DEFAULT_OUTPUT_FILE"; then
+  cat "$DEFAULT_OUTPUT_FILE"
+  echo "FAIL: missing RUNNER_TEMP fallback did not report the distinct /tmp install root" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "$EXPECTED_DEFAULT_INSTALL_ROOT" "$DEFAULT_GITHUB_PATH_FILE"; then
+  cat "$DEFAULT_OUTPUT_FILE"
+  echo "FAIL: missing RUNNER_TEMP fallback did not publish the local zig bin dir to GITHUB_PATH" >&2
+  exit 1
+fi
+
+if ! grep -Fxq "CMUX_ZIG=$EXPECTED_DEFAULT_INSTALL_ROOT/zig" "$DEFAULT_GITHUB_ENV_FILE"; then
+  cat "$DEFAULT_OUTPUT_FILE"
+  echo "FAIL: missing RUNNER_TEMP fallback did not publish CMUX_ZIG" >&2
+  exit 1
+fi
+
+echo "PASS: install-zig-ci falls back locally, honors ZIG_FORCE_LOCAL_INSTALL, and handles missing RUNNER_TEMP"

--- a/tests/test_perf_activation_scrollback_sizing.py
+++ b/tests/test_perf_activation_scrollback_sizing.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf-activation-session.py"
+spec = importlib.util.spec_from_file_location("perf_activation_session", SCRIPT)
+assert spec is not None
+perf_activation_session = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(perf_activation_session)
+
+
+def default_surface_roles() -> list[tuple[str, bool]]:
+    heavy = [(f"surface-heavy-{idx}", True) for idx in range(11)]
+    other = [(f"surface-other-{idx}", False) for idx in range(55)]
+    return heavy + other
+
+
+def test_default_scrollback_seed_is_bounded_above_budget_floor() -> None:
+    plan, summary = perf_activation_session.build_scrollback_line_plan(
+        default_surface_roles(),
+        heavy_lines=2400,
+        other_lines=1400,
+        line_payload_chars=96,
+        target_chars=perf_activation_session.DEFAULT_SCROLLBACK_TARGET_CHARS,
+    )
+
+    assert len(plan) == 66
+    assert min(plan.values()) > 0
+    assert summary["scrollback_target_applied"] is True
+    assert summary["scrollback_requested_estimated_chars"] > 11_000_000
+    assert 1_000_000 <= summary["scrollback_effective_estimated_chars"] <= 1_600_000
+    assert summary["heavy_scrollback_lines_effective"] > summary["other_scrollback_lines_effective"]
+
+
+def test_scrollback_target_can_be_disabled_for_manual_stress_runs() -> None:
+    plan, summary = perf_activation_session.build_scrollback_line_plan(
+        default_surface_roles(),
+        heavy_lines=2400,
+        other_lines=1400,
+        line_payload_chars=96,
+        target_chars=0,
+    )
+
+    assert summary["scrollback_target_applied"] is False
+    assert summary["scrollback_effective_estimated_chars"] == summary["scrollback_requested_estimated_chars"]
+    assert plan["surface-heavy-0"] == 2400
+    assert plan["surface-other-0"] == 1400
+
+
+def test_small_requested_fixture_is_not_scaled_up() -> None:
+    plan, summary = perf_activation_session.build_scrollback_line_plan(
+        default_surface_roles(),
+        heavy_lines=1,
+        other_lines=1,
+        line_payload_chars=8,
+        target_chars=perf_activation_session.DEFAULT_SCROLLBACK_TARGET_CHARS,
+    )
+
+    assert summary["scrollback_target_applied"] is False
+    assert set(plan.values()) == {1}
+
+
+if __name__ == "__main__":
+    test_default_scrollback_seed_is_bounded_above_budget_floor()
+    test_scrollback_target_can_be_disabled_for_manual_stress_runs()
+    test_small_requested_fixture_is_not_scaled_up()


### PR DESCRIPTION
## Summary
- Scale activation benchmark live scrollback seed lines toward a 1.5 MB target while keeping the existing 1 MB minimum budget active.
- Keep all 66 terminal surfaces and live terminal scrollback capture in the measured path.
- Add a cheap workflow guard test for the sizing helper.

## Failure addressed
- Related failing check: https://github.com/manaflow-ai/cmux/actions/runs/27598286605/job/81593186051
- Repeated artifacts captured about 11.5 MB of scrollback for a benchmark whose minimum coverage floor is 1 MB, making the timed snapshot spend about 6.9 seconds on fixture overshoot.

## Coverage and signal
- Preserved: activation benchmark still seeds real terminals, captures real scrollback, enforces `snapshot_with_scrollback.shape.scrollback_chars >= 1_000_000`, and keeps the 1.5 second snapshot budget unchanged.
- Rejected: using synthetic-only scrollback for this job, because it would stop exercising live terminal scrollback capture.
- Manual stress runs can pass `--scrollback-target-chars 0` to keep the old unbounded line counts.

## Testing
- `python3 tests/test_perf_activation_scrollback_sizing.py`
- `python3 -m py_compile scripts/perf-activation-session.py tests/test_perf_activation_scrollback_sizing.py`
- `git ls-files 'tests/*.py' 'tests_v2/*.py' 'scripts/*.py' | xargs python3 -m py_compile` (passes with an existing SyntaxWarning in `tests/test_issue_1138_sidebar_pr_polling.py`)
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p}: ok" }' .github/workflows/ci.yml .github/workflows/perf-activation.yml`
- `./tests/test_ci_self_hosted_guard.sh`
- `$autoreview --mode uncommitted --base origin/main`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound activation benchmark scrollback to ~1.5 MB to cut fixture size and speed up CI. Hardened macOS app launch and virtual display orchestration, made Zig installs safe and relocatable without sudo, ran PR GUI jobs on Depot with an identity guard, and improved UI control‑socket readiness with a shared `/usr/bin/nc` fallback (covers line and JSON‑RPC).

- **Bug Fixes**
  - Scrollback sizing: scale per‑terminal seeds toward `--scrollback-target-chars` (default 1,500,000; 0 disables), validate inputs, and print target/requested/effective stats in the summary; add `tests/test_perf_activation_scrollback_sizing.py`; fixes prior ~11.5 MB overshoot.
  - Xcode caches: sanitize restored `SourcePackages` by removing only `workspace-state.json`; applied in macOS, iOS, nightly, release, perf, and e2e workflows; add `scripts/ci/sanitize-xcode-source-packages-cache.py` and guard test.
  - Zig install: install locally and relocatably when sudo isn’t available; validate sudo installs under `ZIG_SYSTEM_PREFIX` by checking `zig env lib_dir` and `compiler/build_runner.zig`; isolate extraction under a `RUNNER_TEMP`‑scoped scratch dir (fallback `/tmp/cmux-zig-ci`), clean it up, reject unsafe roots, support `ZIG_FORCE_LOCAL_INSTALL`/`ZIG_INSTALL_ROOT`, publish PATH/`CMUX_ZIG`, and explicitly reject broken or wrong‑version existing Zig; split dedicated install steps for macOS/iOS; add `tests/test_install_zig_ci_no_sudo.sh`.
  - macOS UI harnesses/runners: serialize CGVirtualDisplay usage with `scripts/ci/virtual-display-lock.sh` (tokenized acquire/set‑owner/release, preserve live and foreign‑owner locks, reclaim dead‑owner and ownerless locks), add ready/ID waits, retries, and cleanup; enable XCTest automation mode; prefer the console user’s Aqua bootstrap when passwordless sudo is available; run PR perf, lag display checks, and UI regressions on Depot GUI runners with an identity guard; in `scripts/bench-window-visibility.swift` resolve bundle ID, fall back to a direct executable launch with a cleaned environment and log, and wait for the running app; add `tests/test_ci_virtual_display_lock.sh`.
  - UI control socket: share a fallback that uses `/usr/bin/nc` with a timeout when the Swift `ControlSocketClient` has no response, accept app‑side diagnostics as readiness, and add a JSON‑RPC path for UI tests; `BrowserPaneNavigationKeybindUITests` and browser‑find tests use it.

<sup>Written for commit 6f6ad178756ca87207d246e5135d070c33983378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `scrollback_target_chars` input to performance activation workflows (default: 1.5M; `0` disables scaling).
  * Scrollback seeding can now scale to a target character budget and reports the target in the benchmark summary when enabled.

* **Tests**
  * Added unit tests for scrollback sizing and new CI tests for Swift package cache sanitization and no-`sudo` Zig installation.

* **Chores**
  * CI workflows now sanitize cached Swift package state earlier for improved reliability.
  * CI Zig installation and packaging steps were streamlined; bench window launching now supports a direct-launch fallback path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->