### PR TITLE
Fix `cmux ssh` to slash SSH aliases by uploading cmuxd-remote over ssh stdin

### DIFF
--- a/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
+++ b/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
@@ -179,8 +179,20 @@ public struct RemoteSessionProcessRunner: RemoteSessionProcessRunning {
         defer { operation?.clearCancellationHandler() }
 
         if let stdin, let pipe = process.standardInput as? Pipe {
-            pipe.fileHandleForWriting.write(stdin)
-            try? pipe.fileHandleForWriting.close()
+            // Write stdin on a background queue so a stalled peer (one that stops
+            // draining the pipe) cannot block past the timeout wait below. A
+            // synchronous write here would fill the pipe buffer and block before
+            // `exitSemaphore.wait(timeout:)` ever starts, so the request timeout
+            // would not bound the transfer. When the timeout/cancel path
+            // terminates the process, the read end closes and this write fails
+            // out; `F_SETNOSIGPIPE` turns that into an EPIPE throw instead of a
+            // process-killing SIGPIPE.
+            let writeHandle = pipe.fileHandleForWriting
+            _ = fcntl(writeHandle.fileDescriptor, F_SETNOSIGPIPE, 1)
+            DispatchQueue.global(qos: .utility).async {
+                try? writeHandle.write(contentsOf: stdin)
+                try? writeHandle.close()
+            }
         }
 
         func terminateProcessAndWait() {

--- a/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -320,26 +320,24 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        let scpSSHOptions = backgroundSSHOptions(configuration.sshOptions)
-        var scpArgs: [String] = ["-q"]
-        if !hasSSHOptionKey(scpSSHOptions, key: "StrictHostKeyChecking") {
-            scpArgs += ["-o", "StrictHostKeyChecking=accept-new"]
-        }
-        scpArgs += ["-o", "ControlMaster=no"]
-        if let port = configuration.port {
-            scpArgs += ["-P", String(port)]
-        }
-        if let identityFile = configuration.identityFile,
-           !identityFile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            scpArgs += ["-i", identityFile]
-        }
-        for option in scpSSHOptions {
-            scpArgs += ["-o", option]
-        }
-        scpArgs += [localBinary.path, "\(configuration.destination):\(remoteTempPath)"]
-        let scpResult = try scpExec(arguments: scpArgs, timeout: 45)
-        guard scpResult.status == 0 else {
-            let detail = Self.bestErrorLine(stderr: scpResult.stderr, stdout: scpResult.stdout) ?? "scp exited \(scpResult.status)"
+        // Upload over `ssh ... 'cat > <path>'` with the binary piped on stdin
+        // rather than scp. scp parses its remote operand as `host:path`, but
+        // when the SSH destination is an alias containing a slash (e.g.
+        // `prod/web`), the slash precedes the first colon and scp treats the
+        // whole operand as a local path, so the daemon never reaches the
+        // remote and bootstrap loops forever. ssh takes the destination as a
+        // plain argument, so slash aliases install correctly.
+        let localBinaryData = try Data(contentsOf: localBinary)
+        let uploadScript = "cat > \(remoteTempPath.shellSingleQuoted)"
+        let uploadCommand = "sh -c \(uploadScript.shellSingleQuoted)"
+        let uploadResult = try sshExec(
+            arguments: sshCommonArguments(batchMode: true) + [configuration.destination, uploadCommand],
+            stdin: localBinaryData,
+            timeout: 45
+        )
+        guard uploadResult.status == 0 else {
+            let detail = Self.bestErrorLine(stderr: uploadResult.stderr, stdout: uploadResult.stdout) ??
+                "ssh exited \(uploadResult.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
                 NSLocalizedDescriptionKey: "failed to upload cmuxd-remote: \(detail)",
             ])

--- a/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -327,11 +327,18 @@ extension RemoteSessionCoordinator {
         // whole operand as a local path, so the daemon never reaches the
         // remote and bootstrap loops forever. ssh takes the destination as a
         // plain argument, so slash aliases install correctly.
-        let localBinaryData = try Data(contentsOf: localBinary)
+        // `.alwaysMapped` keeps the (15–40 MB) binary memory-mapped so it pages
+        // in during the pipe write instead of being fully resident up front.
+        let localBinaryData = try Data(contentsOf: localBinary, options: .alwaysMapped)
         let uploadScript = "cat > \(remoteTempPath.shellSingleQuoted)"
         let uploadCommand = "sh -c \(uploadScript.shellSingleQuoted)"
+        // `-T` disables remote pty allocation. Without it, `RequestTTY force` in
+        // the user's ssh config would put this upload on a pty, whose line
+        // discipline rewrites CR/LF bytes and corrupts the binary (scp never used
+        // a pty). The other bootstrap commands transfer text, but this one is raw
+        // bytes, so the explicit `-T` matters here.
         let uploadResult = try sshExec(
-            arguments: sshCommonArguments(batchMode: true) + [configuration.destination, uploadCommand],
+            arguments: sshCommonArguments(batchMode: true) + ["-T", configuration.destination, uploadCommand],
             stdin: localBinaryData,
             timeout: 45
         )

--- a/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -43,6 +43,9 @@ struct RemoteDaemonUploadTests {
                 (request.arguments.last?.contains("cat >") ?? false)
         })
         #expect(uploadRequest.stdin == binaryData)
+        // `-T` disables pty allocation so a `RequestTTY force` config can't put
+        // the raw binary on a pty and corrupt it via CR/LF translation.
+        #expect(uploadRequest.arguments.contains("-T"))
         #expect(uploadRequest.arguments.contains("prod/web"))
         #expect(!uploadRequest.arguments.contains(where: { $0.hasPrefix("prod/web:") }))
         #expect(uploadRequest.arguments.last?.contains(

--- a/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
+++ b/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteDaemonUploadTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+import CmuxCore
+import CmuxRemoteDaemon
+import CmuxRemoteWorkspace
+@testable import CmuxRemoteSession
+
+@Suite("Remote daemon upload")
+struct RemoteDaemonUploadTests {
+    @Test("Slash SSH aliases upload the daemon over ssh stdin instead of scp host-path parsing")
+    func slashSSHAliasUploadsDaemonOverSSHStdin() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-remote-daemon-ssh-upload-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directoryURL) }
+
+        let localBinary = directoryURL.appendingPathComponent("cmuxd-remote", isDirectory: false)
+        let binaryData = Data([0x7f, 0x45, 0x4c, 0x46, 0x63, 0x6d, 0x75, 0x78])
+        try binaryData.write(to: localBinary)
+
+        let runner = RecordingDaemonUploadProcessRunner()
+        let coordinator = Self.makeCoordinator(destination: "prod/web", runner: runner)
+        defer { coordinator.stop() }
+        let location = try RemoteSessionCoordinator.remoteDaemonInstallLocation(
+            version: "0.64.16",
+            goOS: "linux",
+            goArch: "arm64",
+            homeDirectory: "/home/ubuntu"
+        )
+
+        try coordinator.queue.sync {
+            try coordinator.uploadRemoteDaemonBinaryLocked(localBinary: localBinary, location: location)
+        }
+
+        let requests = runner.requests
+        #expect(!requests.contains(where: { $0.executable == "/usr/bin/scp" }))
+
+        let uploadRequest = try #require(requests.first { request in
+            request.executable == "/usr/bin/ssh" &&
+                (request.arguments.last?.contains("cat >") ?? false)
+        })
+        #expect(uploadRequest.stdin == binaryData)
+        #expect(uploadRequest.arguments.contains("prod/web"))
+        #expect(!uploadRequest.arguments.contains(where: { $0.hasPrefix("prod/web:") }))
+        #expect(uploadRequest.arguments.last?.contains(
+            "/home/ubuntu/.cmux/bin/cmuxd-remote/0.64.16/linux-arm64/cmuxd-remote.tmp-"
+        ) == true)
+    }
+
+    private static func makeCoordinator(
+        destination: String,
+        runner: RecordingDaemonUploadProcessRunner
+    ) -> RemoteSessionCoordinator {
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: destination,
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: "ssh \(destination)",
+            preserveAfterTerminalExit: false,
+            persistentDaemonSlot: nil
+        )
+
+        return RemoteSessionCoordinator(
+            host: DaemonUploadNoopRemoteSessionHost(),
+            configuration: configuration,
+            proxyBroker: DaemonUploadUnusedRemoteProxyBroker(),
+            manifestRepository: RemoteDaemonManifestRepository(
+                homeDirectory: FileManager.default.temporaryDirectory
+            ),
+            processRunner: runner,
+            reachabilityProbe: DaemonUploadNoopReachabilityProbe(),
+            relayCommandRewriter: DaemonUploadPassthroughRelayCommandRewriter(),
+            buildInfo: DaemonUploadStubBuildInfo(),
+            daemonStrings: RemoteDaemonStrings(
+                missingPersistentPTYCapability: "",
+                missingRequiredFunctionality: ""
+            ),
+            strings: RemoteSessionStrings(
+                connectedVMNoProxyFormat: "%@",
+                suspendedDetailFormat: "%@"
+            )
+        )
+    }
+}
+
+private final class RecordingDaemonUploadProcessRunner: RemoteSessionProcessRunning, @unchecked Sendable {
+    // `run` is a synchronous protocol method; this lock only protects test observations.
+    private let lock = NSLock()
+    private var recordedRequests: [RemoteProcessRequest] = []
+
+    var requests: [RemoteProcessRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests
+    }
+
+    func run(
+        _ request: RemoteProcessRequest,
+        operation: (any RemoteTransferCancelling)?
+    ) throws -> RemoteCommandResult {
+        lock.lock()
+        recordedRequests.append(request)
+        lock.unlock()
+
+        if request.executable == "/usr/bin/scp" {
+            return RemoteCommandResult(status: 1, stdout: "", stderr: "scp should not be used for slash aliases")
+        }
+
+        return RemoteCommandResult(status: 0, stdout: "", stderr: "")
+    }
+}
+
+private struct DaemonUploadNoopRemoteSessionHost: RemoteSessionHosting {
+    func publishConnectionState(_ state: WorkspaceRemoteConnectionState, detail: String?) {}
+    func publishDaemonStatus(_ status: WorkspaceRemoteDaemonStatus) {}
+    func publishProxyEndpoint(_ endpoint: BrowserProxyEndpoint?) {}
+    func publishPortsSnapshot(detectedByPanel: [UUID: [Int]], detected: [Int]) {}
+    func publishHeartbeat(count: Int, lastSeenAt: Date?) {}
+    func publishBootstrapRemoteTTY(_ ttyName: String) {}
+}
+
+private final class DaemonUploadUnusedRemoteProxyBroker: RemoteProxyBrokering, @unchecked Sendable {
+    func acquire(
+        configuration: WorkspaceRemoteConfiguration,
+        remotePath: String,
+        onUpdate: @escaping @Sendable (RemoteProxyBrokerUpdate) -> Void
+    ) -> RemoteProxyLease {
+        fatalError("Daemon upload tests do not acquire proxy leases")
+    }
+
+    func listPTY(configuration: WorkspaceRemoteConfiguration) throws -> [[String: Any]] { [] }
+    func closePTY(configuration: WorkspaceRemoteConfiguration, sessionID: String) throws {}
+    func resizePTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        cols: Int,
+        rows: Int
+    ) throws {}
+    func detachPTY(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String
+    ) throws {}
+    func startPTYBridge(
+        configuration: WorkspaceRemoteConfiguration,
+        sessionID: String,
+        attachmentID: String,
+        command: String?,
+        requireExisting: Bool
+    ) throws -> RemotePTYBridgeServer.Endpoint {
+        fatalError("Daemon upload tests do not start PTY bridges")
+    }
+}
+
+private struct DaemonUploadNoopReachabilityProbe: RemoteHostReachabilityProbing {
+    func probe(
+        destination: String,
+        port: Int?,
+        identityFile: String?,
+        sshOptions: [String],
+        completion: @escaping @Sendable (RemoteHostProbeOutcome) -> Void
+    ) {}
+}
+
+private struct DaemonUploadPassthroughRelayCommandRewriter: RemoteRelayCommandRewriting {
+    func rewriteRemoteRelayCommandLine(
+        _ commandLine: Data,
+        workspaceAliases: [UUID: UUID],
+        surfaceAliases: [UUID: UUID]
+    ) -> Data {
+        commandLine
+    }
+}
+
+private struct DaemonUploadStubBuildInfo: RemoteSessionBuildInfoProviding {
+    func appVersion() -> String? { nil }
+    func embeddedDaemonManifest() -> WorkspaceRemoteDaemonManifest? { nil }
+    func executableDirectoryURL() -> URL? { nil }
+}

--- a/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionProcessRunnerTests.swift
+++ b/Packages/CmuxRemoteSession/Tests/CmuxRemoteSessionTests/RemoteSessionProcessRunnerTests.swift
@@ -121,4 +121,32 @@ struct RemoteSessionProcessRunnerTests {
                 && nsError.localizedDescription == "sh timed out after 1s"
         }
     }
+
+    @Test("Timeout still fires when a large stdin write would block on a non-draining process")
+    func timeoutBoundsBlockedStdinWrite() {
+        remoteSubprocessTestLock.lock()
+        defer { remoteSubprocessTestLock.unlock() }
+        let runner = RemoteSessionProcessRunner()
+        // 1 MiB exceeds the OS pipe buffer (~64 KiB), so the write cannot finish
+        // until the child drains it; `sleep 30` never reads stdin. A synchronous
+        // pre-timeout write would block past the timeout, so the write must run
+        // off the timeout path for the 1s budget to still terminate the process.
+        let oversizedStdin = Data(count: 1_048_576)
+        #expect {
+            try runner.run(
+                RemoteProcessRequest(
+                    executable: "/bin/sh",
+                    arguments: ["-c", "sleep 30"],
+                    stdin: oversizedStdin,
+                    timeout: 1
+                ),
+                operation: nil
+            )
+        } throws: { error in
+            let nsError = error as NSError
+            return nsError.domain == "cmux.remote.process"
+                && nsError.code == 2
+                && nsError.localizedDescription == "sh timed out after 1s"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`cmux ssh prod/web` (any SSH alias with a `/` in it) never connects — it just keeps
"connecting" and ends up as `[ssh:error]`, even though plain `ssh prod/web` works
fine in a normal terminal.

**Why it happens:** to start a remote session, cmux uploads its helper binary
(`cmuxd-remote`) to the host using `scp`. `scp` reads its argument as `host:path`,
but when the host is an alias containing a slash — `prod/web:/…` — `scp` mistakes
the whole thing for a *local* file path and never uploads anything. With the helper
missing on the remote, the session can never finish bootstrapping and retries forever.

**Fix:** upload the binary over `ssh` instead of `scp` — `ssh <dest> 'cat > <path>'`
with the binary piped on stdin. `ssh` takes the destination as a plain argument (no
`host:path` parsing), so slash aliases work. Normal targets (`user@host`, plain
aliases) were never affected and behave exactly as before.

**Not included (follow-up):** drag-and-drop file upload in
`Sources/TerminalSSHSessionDetector.swift` uses the same `scp host:path` pattern and
has the same slash issue — intentionally left for a separate PR.

## Testing

- Two-commit red/green per the repo regression policy:
  - Commit 1 adds `RemoteDaemonUploadTests` only — fails with `cmux.remote.daemon Code=31 "failed to upload cmuxd-remote: scp should not be used for slash aliases"`.
  - Commit 2 applies the fix — test passes and asserts the upload goes over `ssh` stdin (not scp) for a slash alias.
- `swift test` for `CmuxRemoteSession`: **33 tests green**, no regressions.
- No UI changes. No localization changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized remote daemon binary installation with an improved file transfer mechanism for enhanced reliability and performance
  * Enhanced remote process execution stdin handling to better enforce timeout boundaries

* **Tests**
  * Added comprehensive validation test suite for remote daemon binary upload procedures
  * Added timeout boundary condition tests for remote process execution with blocked stdin

<!-- end of auto-generated comment: release notes by coderabbit.ai -->