### PR TITLE
fix(sidebar): apply workspaceGroups.byCwd color to ungrouped workspaces

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12337,6 +12337,14 @@ struct VerticalTabsSidebar: View {
             )
         }
 
+        // Resolve a byCwd color for ungrouped workspaces. Grouped workspaces
+        // already receive the color via the group header's resolvedConfig, so
+        // we skip the lookup there to avoid double-applying and to keep the
+        // store access out of the hot-path for the common (grouped) case.
+        let configuredColorHex: String? = tab.groupId == nil
+            ? cmuxConfigStore.resolveWorkspaceGroupConfig(forCwd: tab.currentDirectory)?.color
+            : nil
+
         let row = TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
@@ -12370,7 +12378,8 @@ struct VerticalTabsSidebar: View {
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             settings: renderContext.tabItemSettings,
             onContextMenuAppear: onContextMenuAppear,
-            onContextMenuDisappear: onContextMenuDisappear
+            onContextMenuDisappear: onContextMenuDisappear,
+            configuredColorHex: configuredColorHex
         )
         .equatable()
         .id(tab.id)
@@ -13162,7 +13171,8 @@ struct TabItemView: View, Equatable {
         lhs.workspaceGroupMenuSnapshot == rhs.workspaceGroupMenuSnapshot &&
         lhs.isBeingDragged == rhs.isBeingDragged &&
         lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
-        lhs.settings == rhs.settings
+        lhs.settings == rhs.settings &&
+        lhs.configuredColorHex == rhs.configuredColorHex
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing
@@ -13212,6 +13222,13 @@ struct TabItemView: View, Equatable {
     /// behind the open context menu.
     let onContextMenuAppear: () -> Void
     let onContextMenuDisappear: () -> Void
+    /// Color resolved from `cmux.json` `workspaceGroups.byCwd` for this
+    /// workspace's current directory. Supplied by the parent (which owns
+    /// `cmuxConfigStore`) to keep `TabItemView` free of store references
+    /// (snapshot-boundary rule). `nil` when the workspace is inside a group
+    /// (the group header already applies the byCwd color) or when no matching
+    /// byCwd entry exists. Falls back behind the workspace's own `customColor`.
+    let configuredColorHex: String?
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
     @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
@@ -14614,7 +14631,7 @@ struct TabItemView: View, Equatable {
             title: tab.title,
             customDescription: settings.showsWorkspaceDescription ? sidebarVisibleCustomDescription : nil,
             isPinned: tab.isPinned,
-            customColorHex: tab.customColor,
+            customColorHex: tab.customColor ?? configuredColorHex,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,


### PR DESCRIPTION
## Summary

Workspace groups already fall back to `cmux.json` `workspaceGroups.byCwd[cwd].color` when no explicit `customColor` is set — see `VerticalTabsSidebar+WorkspaceGroups.swift:20`:
```swift
let effectiveColor = group.customColor ?? resolvedConfig?.color
```

Standalone workspaces (not in a group) used `tab.customColor` with no `byCwd` fallback, so the same config key had no visual effect on ungrouped rows — **a silent inconsistency**.

## What changed

- In `workspaceRow(_:renderContext:)` inside `VerticalTabsSidebar`, resolve `byCwd` for the tab's `currentDirectory` when the workspace has no `groupId`, and pass the result down to `TabItemView` as `configuredColorHex: String?`.
- `TabItemView` uses `tab.customColor ?? configuredColorHex` in `makeWorkspaceSnapshot()`, giving `byCwd` the same fallback priority it already has for group headers. Explicit workspace color still wins.
- The store access stays in the parent so `TabItemView` remains free of `ObservableObject` references (snapshot-boundary rule from CLAUDE.md).
- `==` is updated to include `configuredColorHex` — rows only re-render when the resolved color actually changes.
- No new UI strings; no `xcodeproj` changes; no new files.

## After this fix

```json
// ~/.config/cmux/cmux.json
{
  "workspaceGroups": {
    "byCwd": {
      "~/BASE/projects/supermax/*": { "color": "#5B8CFF" },
      "~/BASE/projects/synapse*":   { "color": "#9B59B6" },
      "~/events-hub*":              { "color": "#27AE60" }
    }
  }
}
```

Ungrouped workspaces in matching directories now show the configured tint in the sidebar, matching the existing behavior for group anchors.

## Verification

- `swiftc -parse Sources/ContentView.swift`: pass
- `python3 -m json.tool Resources/Localizable.xcstrings`: pass (no xcstrings changes)
- `git diff --check HEAD`: pass
- `./scripts/check-pbxproj.sh`: pass
- `./scripts/lint-pbxproj-test-wiring.sh`: pass (230 test files, ok)
- No localization audit needed: zero new user-facing strings introduced.

Blocked locally: full `reload.sh` requires Xcode.app; only CommandLineTools present. Build + UI verification requires CI or maintainer machine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784210544&installation_id=133855650&pr_number=6246&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6246&signature=719fd50a209ef7244783cdc7b6d35c7773657cd99434357856204d9a497a0fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `workspaceGroups.byCwd` color to ungrouped workspaces in the sidebar so directory-based colors show up without a custom color. This aligns ungrouped rows with existing group header behavior.

- **Bug Fixes**
  - Resolve `byCwd` color for tabs without `groupId` in `VerticalTabsSidebar.workspaceRow` and pass down as `configuredColorHex`.
  - Use `tab.customColor ?? configuredColorHex` in `TabItemView` snapshot; explicit workspace color still wins.
  - Include `configuredColorHex` in `Equatable` to re-render only when the resolved color changes.

<sup>Written for commit de5f1d065c65379fd0c267f756198a5c2e7aa047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Workspace rows in the sidebar now support color configuration through external files. Non-grouped workspaces can resolve and display custom colors, enabling better visual organization and workspace identification. The sidebar color display has been enhanced to properly render and prioritize configured colors alongside workspace customizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->