### PR TITLE
feat: change workspace nav shortcuts to ctrl+opt+↑/↓ (arrow-key navigation)

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -374,9 +374,9 @@ enum KeyboardShortcutSettings {
             case .triggerFlash:
                 return StoredShortcut(key: "h", command: true, shift: true, option: false, control: false)
             case .nextSidebarTab:
-                return StoredShortcut(key: "]", command: true, shift: false, option: false, control: true)
+                return StoredShortcut(key: "↓", command: false, shift: false, option: true, control: true)
             case .prevSidebarTab:
-                return StoredShortcut(key: "[", command: true, shift: false, option: false, control: true)
+                return StoredShortcut(key: "↑", command: false, shift: false, option: true, control: true)
             case .focusHistoryBack:
                 return StoredShortcut(key: "[", command: true, shift: false, option: false, control: false)
             case .focusHistoryForward:

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -92,8 +92,8 @@ export const shortcutCategories: ShortcutCategory[] = [
         description: { en: "Go to workspace", ja: "ワークスペースへ移動" },
         note: { en: "workspace switcher", ja: "ワークスペーススイッチャー" },
       },
-      { id: "nextSidebarTab", combos: [["⌃", "⌘", "]"]], description: { en: "Next workspace", ja: "次のワークスペース" } },
-      { id: "prevSidebarTab", combos: [["⌃", "⌘", "["]], description: { en: "Previous workspace", ja: "前のワークスペース" } },
+      { id: "nextSidebarTab", combos: [["⌃", "⌥", "↓"]], description: { en: "Next workspace", ja: "次のワークスペース" } },
+      { id: "prevSidebarTab", combos: [["⌃", "⌥", "↑"]], description: { en: "Previous workspace", ja: "前のワークスペース" } },
       {
         id: "focusHistoryBack",
         combos: [["⌘", "["]],


### PR DESCRIPTION
## Summary

Change the default keyboard shortcuts for **Next Workspace** / **Previous Workspace** from `⌃⌘]` / `⌃⌘[` to `⌃⌥↓` / `⌃⌥↑`.

## Motivation

Arrow keys make navigation direction immediately discoverable:
- **↑** moves up the workspace list
- **↓** moves down the workspace list

The previous bracket shortcuts (`cmd+ctrl+]/[`) require knowing an implicit convention and mirror the history navigation bindings (`cmd+]/[`) in a confusing way.

### No conflicts

`ctrl+opt+↑/↓` is free on a clean macOS install:
- `cmd+opt+↑/↓` → already used by **Focus Pane Up/Down**
- `ctrl+opt+<letter>` → only `cmd+ctrl+opt+.` exists (toggleSidebarMode, needs cmd too)
- bare `opt+↑/↓` → grabbed by the terminal (escape sequences); cmux gets nothing

### Backward compatibility

Users who prefer the old bracket shortcuts can restore them via `~/.config/cmux/cmux.json`:
```json
"shortcuts": {
  "bindings": {
    "nextSidebarTab": "cmd+ctrl+]",
    "prevSidebarTab": "cmd+ctrl+["
  }
}
```

## Changes

- `Sources/KeyboardShortcutSettings.swift`: update `nextSidebarTab` / `prevSidebarTab` defaults
- `web/data/cmux-shortcuts.ts`: update shortcut display in docs (⌃⌥↓ / ⌃⌥↑)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784213327&installation_id=133855650&pr_number=6248&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6248&signature=ab98fad5bb4647214eb5c9a49a63db397e3b0cd8884f9525c82ba8fa3ff4de86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the default workspace navigation shortcuts to ⌃⌥↓ (next) and ⌃⌥↑ (previous), replacing ⌃⌘] / ⌃⌘[, for clearer arrow-key direction and to avoid confusion with history keys. Updated `Sources/KeyboardShortcutSettings.swift` and `web/data/cmux-shortcuts.ts` to reflect the new bindings.

<sup>Written for commit 5ef66ec2b46cfed0559cdf192f930f21fbd8384c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated keyboard shortcuts for sidebar tab navigation. The "Next Sidebar Tab" and "Previous Sidebar Tab" commands now use arrow keys (↑/↓) with Option+Control modifiers, replacing the previous bracket key combinations for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->