### PR TITLE
Fix sidebar git metadata for reftable repos

### DIFF
--- a/Packages/CmuxGit/Package.swift
+++ b/Packages/CmuxGit/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
         ),
         .testTarget(
             name: "CmuxGitTests",
-            dependencies: ["CmuxGit"],
+            dependencies: [
+                "CmuxGit",
+                .product(name: "CmuxProcess", package: "CmuxProcess"),
+            ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),

--- a/Packages/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -1,4 +1,5 @@
 import Foundation
+internal import CmuxProcess
 
 /// Reads a directory's git metadata directly from the on-disk repository,
 /// without spawning a `git` process.
@@ -34,8 +35,17 @@ import Foundation
 /// if meta.isRepository, meta.isDirty { showDirtyIndicator() }
 /// ```
 public struct GitMetadataService: Sendable {
+    private let commands: any CommandRunning
+
     /// Creates a git-metadata service.
-    public init() {}
+    public init() {
+        self.commands = CommandRunner()
+    }
+
+    /// Creates a git-metadata service with an injected command runner.
+    init(commands: any CommandRunning) {
+        self.commands = commands
+    }
 
     /// Reads a point-in-time git snapshot for `directory`.
     ///
@@ -51,13 +61,26 @@ public struct GitMetadataService: Sendable {
             return .notARepository
         }
         let trackedChanges = Self.gitTrackedChangesSnapshot(repository: repository)
+        let directHeadSignature = Self.gitHeadSignature(repository: repository)
+        if Self.repositoryUsesReftable(repository: repository) {
+            let fallback = await Self.gitCLIReftableMetadata(repository: repository, commands: commands)
+            return GitWorkspaceMetadata(
+                isRepository: true,
+                branch: fallback.branch,
+                isDirty: fallback.isDirty ?? trackedChanges.isDirty,
+                indexSignature: trackedChanges.indexSignature,
+                indexContentSignature: trackedChanges.indexContentSignature,
+                headSignature: fallback.headSignature ?? directHeadSignature
+            )
+        }
+
         return GitWorkspaceMetadata(
             isRepository: true,
             branch: Self.gitBranchName(repository: repository),
             isDirty: trackedChanges.isDirty,
             indexSignature: trackedChanges.indexSignature,
             indexContentSignature: trackedChanges.indexContentSignature,
-            headSignature: Self.gitHeadSignature(repository: repository)
+            headSignature: directHeadSignature
         )
     }
 

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Reftable.swift
@@ -1,0 +1,129 @@
+import Foundation
+internal import CmuxProcess
+
+extension GitMetadataService {
+    private static let reftableGitCommandTimeout: TimeInterval = 5
+
+    /// Whether this repository stores refs in git's reftable backend.
+    ///
+    /// Reftable worktrees can have a placeholder `HEAD` file such as
+    /// `ref: refs/heads/.invalid`; the real symbolic ref lives in the reftable
+    /// data. Fall back to `git` for those repositories rather than rendering the
+    /// placeholder as a branch name in the sidebar.
+    nonisolated static func repositoryUsesReftable(repository: ResolvedGitRepository) -> Bool {
+        gitConfigValue(repository: repository, section: "extensions", key: "refStorage")?
+            .caseInsensitiveCompare("reftable") == .orderedSame
+    }
+
+    nonisolated static func gitCLIReftableMetadata(
+        repository: ResolvedGitRepository,
+        commands: any CommandRunning
+    ) async -> (branch: String?, isDirty: Bool?, headSignature: String?) {
+        async let fullRef = gitCLIOutput(
+            repository: repository,
+            commands: commands,
+            arguments: ["symbolic-ref", "--quiet", "HEAD"]
+        )
+        async let commit = gitCLIOutput(
+            repository: repository,
+            commands: commands,
+            arguments: ["rev-parse", "--verify", "HEAD"]
+        )
+        async let status = gitCLIOutput(
+            repository: repository,
+            commands: commands,
+            arguments: ["status", "--porcelain", "--untracked-files=no"]
+        )
+
+        let ref = await trimmedNonEmpty(fullRef)
+        let branch = normalizedBranchName(shortBranchName(fromFullRef: ref))
+        let commitValue = await trimmedNonEmpty(commit)
+        let statusValue = await status
+
+        let headSignature: String? = {
+            if let ref {
+                return commitValue.map { "ref: \(ref)\n\($0)" } ?? "ref: \(ref)"
+            }
+            return commitValue
+        }()
+
+        return (
+            branch: branch,
+            isDirty: statusValue.map { !$0.isEmpty },
+            headSignature: headSignature
+        )
+    }
+
+    private nonisolated static func gitCLIOutput(
+        repository: ResolvedGitRepository,
+        commands: any CommandRunning,
+        arguments: [String]
+    ) async -> String? {
+        await commands.runStandardOutput(
+            directory: repository.workTreeRoot,
+            executable: "git",
+            arguments: arguments,
+            timeout: reftableGitCommandTimeout
+        )
+    }
+
+    private nonisolated static func shortBranchName(fromFullRef ref: String?) -> String? {
+        let prefix = "refs/heads/"
+        guard let ref, ref.hasPrefix(prefix) else { return nil }
+        return String(ref.dropFirst(prefix.count))
+    }
+
+    private nonisolated static func trimmedNonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private nonisolated static func gitConfigValue(
+        repository: ResolvedGitRepository,
+        section targetSection: String,
+        key targetKey: String
+    ) -> String? {
+        let targetSection = targetSection.lowercased()
+        let targetKey = targetKey.lowercased()
+        var value: String?
+
+        for configURL in gitConfigURLs(repository: repository) {
+            guard let config = try? String(contentsOf: configURL, encoding: .utf8) else {
+                continue
+            }
+
+            var inTargetSection = false
+            for rawLine in config.components(separatedBy: .newlines) {
+                let line = gitConfigLineRemovingInlineComment(rawLine)
+                    .trimmingCharacters(in: .whitespaces)
+                guard !line.isEmpty else { continue }
+
+                if let section = gitConfigSectionName(fromHeader: line) {
+                    inTargetSection = section == targetSection
+                    continue
+                }
+
+                guard inTargetSection else { continue }
+                let parts = line.split(separator: "=", maxSplits: 1).map {
+                    $0.trimmingCharacters(in: .whitespaces)
+                }
+                guard parts.count == 2, parts[0].lowercased() == targetKey else {
+                    continue
+                }
+
+                value = gitConfigUnquotedValue(parts[1])
+            }
+        }
+
+        return trimmedNonEmpty(value)
+    }
+
+    private nonisolated static func gitConfigSectionName(fromHeader line: String) -> String? {
+        guard line.hasPrefix("["), line.hasSuffix("]") else { return nil }
+        let body = line.dropFirst().dropLast().trimmingCharacters(in: .whitespaces)
+        guard !body.isEmpty else { return nil }
+        let name = body.split(whereSeparator: { $0 == " " || $0 == "\t" }).first.map(String.init) ?? body
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed.lowercased()
+    }
+}

--- a/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
+++ b/Packages/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+WatchPaths.swift
@@ -30,7 +30,7 @@ extension GitMetadataService {
         return watchedPaths.sorted()
     }
 
-    /// The metadata paths (`HEAD`, `index`, `refs`, `packed-refs`, every reachable
+    /// The metadata paths (`HEAD`, `index`, `refs`, `packed-refs`, `reftable`, every reachable
     /// `config`) for a single resolved repository.
     nonisolated static func gitRepositoryMetadataWatchPaths(
         repository: ResolvedGitRepository
@@ -39,8 +39,10 @@ extension GitMetadataService {
             URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD").path,
             URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("index").path,
             URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("refs").path,
+            URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("reftable").path,
             URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("refs").path,
             URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("packed-refs").path,
+            URL(fileURLWithPath: repository.commonDirectory).appendingPathComponent("reftable").path,
         ] + gitConfigURLs(repository: repository).map(\.path)
     }
 

--- a/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CmuxGit
+import CmuxProcess
 
 @Suite struct GitMetadataServiceTests {
     // MARK: Repository resolution
@@ -93,6 +94,28 @@ import Testing
         let meta = await service.workspaceMetadata(for: fixture.root.path)
         #expect(meta.isRepository)
         #expect(meta.branch == nil)
+    }
+
+    @Test func reftableWorkspaceMetadataFallsBackToGitCLI() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch(".invalid")
+        try fixture.writeConfig("""
+        [extensions]
+            refStorage = reftable
+        """)
+        let commit = String(repeating: "a", count: 40)
+        let service = GitMetadataService(commands: StubCommandRunner(outputs: [
+            StubCommandRunner.key(["symbolic-ref", "--quiet", "HEAD"]): .success("refs/heads/feature/reftable\n"),
+            StubCommandRunner.key(["rev-parse", "--verify", "HEAD"]): .success("\(commit)\n"),
+            StubCommandRunner.key(["status", "--porcelain", "--untracked-files=no"]): .success(" M tracked.txt\n"),
+        ]))
+
+        let meta = await service.workspaceMetadata(for: fixture.root.path)
+
+        #expect(meta.isRepository)
+        #expect(meta.branch == "feature/reftable")
+        #expect(meta.isDirty)
+        #expect(meta.headSignature == "ref: refs/heads/feature/reftable\n\(commit)")
     }
 
     // MARK: Dirty detection (index v2)
@@ -232,11 +255,15 @@ import Testing
 
     // MARK: Watched paths
 
-    @Test func watchedPathsIncludeHeadIndexRefsAndConfig() async throws {
+    @Test func watchedPathsIncludeHeadIndexRefsReftableAndConfig() async throws {
         let fixture = try GitRepositoryFixture()
         try fixture.writeBranch("main")
         try fixture.writeConfig("[core]\n\trepositoryformatversion = 0\n")
         try fixture.writeIndex(GitIndexFixture(version: 2, entries: []))
+        try FileManager.default.createDirectory(
+            at: fixture.gitDirectory.appendingPathComponent("reftable"),
+            withIntermediateDirectories: true
+        )
 
         let service = GitMetadataService()
         let paths = try #require(await service.watchedPaths(for: fixture.root.path))
@@ -244,6 +271,7 @@ import Testing
         #expect(paths.contains(fixture.gitDirectory.appendingPathComponent("HEAD").standardizedFileURL.path))
         #expect(paths.contains(fixture.gitDirectory.appendingPathComponent("index").standardizedFileURL.path))
         #expect(paths.contains(fixture.gitDirectory.appendingPathComponent("config").standardizedFileURL.path))
+        #expect(paths.contains(fixture.gitDirectory.appendingPathComponent("reftable").standardizedFileURL.path))
         #expect(paths.contains(fixture.root.standardizedFileURL.path))
     }
 
@@ -330,5 +358,40 @@ import Testing
         #expect(pthread_main_np() != 0) // we start on the main actor's thread
         let hopped = await GitMetadataService().executionHopsOffCallersThread()
         #expect(hopped, "nonisolated async must hop off the caller's thread (SE-0338)")
+    }
+}
+
+private struct StubCommandRunner: CommandRunning {
+    let outputs: [String: CommandResult]
+
+    static func key(_ arguments: [String]) -> String {
+        arguments.joined(separator: "\u{0}")
+    }
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        outputs[Self.key(arguments)] ?? CommandResult(
+            stdout: nil,
+            stderr: nil,
+            exitStatus: 1,
+            timedOut: false,
+            executionError: nil
+        )
+    }
+}
+
+private extension CommandResult {
+    static func success(_ stdout: String) -> CommandResult {
+        CommandResult(
+            stdout: stdout,
+            stderr: "",
+            exitStatus: 0,
+            timedOut: false,
+            executionError: nil
+        )
     }
 }

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -479,7 +479,16 @@ _cmux_git_branch_for_path() {
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
     IFS= read -r head_line < "$head_path" || return 1
     [[ "$head_line" == "$prefix"* ]] || return 1
-    printf '%s\n' "${head_line#$prefix}"
+    local branch="${head_line#$prefix}"
+    if [[ "$branch" == ".invalid" ]] && command -v git >/dev/null 2>&1; then
+        local git_branch=""
+        git_branch="$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        if [[ -n "$git_branch" && "$git_branch" != ".invalid" ]]; then
+            printf '%s\n' "$git_branch"
+            return 0
+        fi
+    fi
+    printf '%s\n' "$branch"
 }
 
 _cmux_set_git_active_pwd() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -679,7 +679,16 @@ _cmux_git_branch_for_path() {
     [[ -n "$head_path" && -r "$head_path" ]] || return 1
     head_line="$(<"$head_path")"
     [[ "$head_line" == "$prefix"* ]] || return 1
-    print -r -- "${head_line#$prefix}"
+    local branch="${head_line#$prefix}"
+    if [[ "$branch" == ".invalid" ]] && command -v git >/dev/null 2>&1; then
+        local git_branch=""
+        git_branch="$(git -C "$repo_path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        if [[ -n "$git_branch" && "$git_branch" != ".invalid" ]]; then
+            print -r -- "$git_branch"
+            return 0
+        fi
+    fi
+    print -r -- "$branch"
 }
 
 _cmux_set_git_active_pwd() {


### PR DESCRIPTION
## Summary
- detect repositories using `extensions.refStorage = reftable` and fall back to `git` for branch, head signature, and tracked dirty state
- watch reftable metadata directories so sidebar branch metadata refreshes after checkouts
- update bash/zsh shell integration to avoid reporting the `.invalid` placeholder branch for reftable worktrees

## Context
In reftable worktrees, the on-disk `HEAD` file can contain `ref: refs/heads/.invalid` while the real symbolic ref lives in the reftable data. Directly parsing `HEAD` made the sidebar show `.invalid*` instead of the actual branch.

## Test plan
- `cd Packages/CmuxGit && env -i HOME="$HOME" PATH="/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Xcode.app/Contents/Developer/usr/bin:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin" DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" swift test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784213544&installation_id=133855650&pr_number=6249&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6249&signature=fc01c31d6e4232ea2b0ae561e093bee99b41bfad75816f46f28bdd914ac645ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect sidebar branch and dirty state for Git reftable repositories by detecting reftable storage, falling back to `git` for metadata, and refreshing on ref changes.

- **Bug Fixes**
  - Detect `extensions.refStorage = reftable` and use `git` to resolve branch, HEAD commit/signature, and tracked-dirty status.
  - Watch `.git/reftable` in both worktree and common dirs so branch updates after checkouts are reflected.
  - Bash/Zsh: avoid showing `.invalid` by querying `git symbolic-ref --short HEAD` when needed.

- **Dependencies**
  - Injected a command runner into `GitMetadataService`; tests now depend on `CmuxProcess` for a stubbed runner.

<sup>Written for commit 8e12832e1d308a9d7a0c7a7603471a7702f503cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Git repositories using the reftable ref storage format.
  * Improved branch detection and metadata resolution for repositories with special configurations.
  * Enhanced file system monitoring to track reftable metadata changes.

* **Tests**
  * Added test coverage for reftable repository handling and branch detection fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->