### PR TITLE
Fix browser pane reloading on physical Enter while web content is focused

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -4614,6 +4614,11 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             }
 #endif
             guard editor?.hasMarkedText() != true else { return false }
+            // Only act while the field is being edited. WebKit replays an unhandled
+            // Return from focused web content back through performKeyEquivalent to
+            // this unfocused field; without the guard it submits and navigates the
+            // pane (#6250).
+            guard editor != nil else { return false }
             let keyCode = event.keyCode
             let modifiers = event.modifierFlags.intersection([.command, .control, .shift, .option, .function])
             // When a non-Latin input source is active (Korean, Chinese, Japanese),

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -1496,3 +1496,133 @@ final class OmnibarSuggestionRankingTests: XCTestCase {
         XCTAssertNil(result, "Should not inline-complete when display text does not start with typed prefix")
     }
 }
+
+/// Regression coverage for #6250: a replayed Return from focused web content must
+/// not make the unfocused omnibar submit. The handler should act only while the
+/// field is being edited (`editor`, i.e. `currentEditor()`, is non-nil).
+@MainActor
+final class BrowserOmnibarUnfocusedReturnRoutingTests: XCTestCase {
+    private final class HandlerSpy {
+        var submitCount = 0
+        var escapeCount = 0
+        var moveDeltas: [Int] = []
+    }
+
+    private func makeCoordinator(spy: HandlerSpy) -> OmnibarTextFieldRepresentable.Coordinator {
+        OmnibarTextFieldRepresentable.Coordinator(
+            parent: OmnibarTextFieldRepresentable(
+                panelId: UUID(),
+                fontSize: 12,
+                text: .constant(""),
+                isFocused: .constant(false),
+                selectAllRequestId: 0,
+                inlineCompletion: nil,
+                placeholder: "",
+                onTap: {},
+                onSubmit: { spy.submitCount += 1 },
+                onEscape: { spy.escapeCount += 1 },
+                onFieldLostFocus: {},
+                onMoveSelection: { spy.moveDeltas.append($0) },
+                onDeleteSelectedSuggestion: {},
+                onAcceptInlineCompletion: {},
+                onDeleteBackwardWithInlineSelection: {},
+                onClearTypedPrefixWithInlineSelection: {},
+                onDeleteWordBackwardWithInlineSelection: {},
+                onSelectionChanged: { _, _ in },
+                shouldSuppressWebViewFocus: { false }
+            )
+        )
+    }
+
+    private func keyEvent(
+        keyCode: UInt16,
+        characters: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: characters,
+                charactersIgnoringModifiers: characters,
+                isARepeat: false,
+                keyCode: keyCode
+            ),
+            file: file,
+            line: line
+        )
+    }
+
+    func testReturnDoesNotSubmitWhenFieldIsNotBeingEdited() throws {
+        let spy = HandlerSpy()
+        let coordinator = makeCoordinator(spy: spy)
+        let returnEvent = try keyEvent(keyCode: 36, characters: "\r")
+
+        let handled = coordinator.handleKeyEvent(returnEvent, editor: nil)
+
+        XCTAssertFalse(handled, "Return must not be claimed by the omnibar while it is not being edited")
+        XCTAssertEqual(spy.submitCount, 0, "Return must not submit the omnibar buffer, which would navigate/reload the page")
+    }
+
+    func testKeypadEnterDoesNotSubmitWhenFieldIsNotBeingEdited() throws {
+        let spy = HandlerSpy()
+        let coordinator = makeCoordinator(spy: spy)
+        let enterEvent = try keyEvent(keyCode: 76, characters: "\u{3}")
+
+        let handled = coordinator.handleKeyEvent(enterEvent, editor: nil)
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(spy.submitCount, 0)
+    }
+
+    func testReturnSubmitsWhenFieldIsBeingEdited() throws {
+        let spy = HandlerSpy()
+        let coordinator = makeCoordinator(spy: spy)
+        let returnEvent = try keyEvent(keyCode: 36, characters: "\r")
+        let editor = NSTextView()
+
+        let handled = coordinator.handleKeyEvent(returnEvent, editor: editor)
+
+        XCTAssertTrue(handled, "Return should still submit while the omnibar field is being edited")
+        XCTAssertEqual(spy.submitCount, 1)
+    }
+
+    func testEscapeAndArrowsAreInertWhenFieldIsNotBeingEdited() throws {
+        let spy = HandlerSpy()
+        let coordinator = makeCoordinator(spy: spy)
+
+        let escape = try keyEvent(keyCode: 53, characters: "\u{1B}")
+        let up = try keyEvent(keyCode: 126, characters: String(UnicodeScalar(NSUpArrowFunctionKey)!))
+        let down = try keyEvent(keyCode: 125, characters: String(UnicodeScalar(NSDownArrowFunctionKey)!))
+
+        XCTAssertFalse(coordinator.handleKeyEvent(escape, editor: nil))
+        XCTAssertFalse(coordinator.handleKeyEvent(up, editor: nil))
+        XCTAssertFalse(coordinator.handleKeyEvent(down, editor: nil))
+
+        XCTAssertEqual(spy.escapeCount, 0)
+        XCTAssertTrue(spy.moveDeltas.isEmpty, "Arrow navigation must not run while the omnibar is not being edited")
+    }
+
+    /// A window-less field has no field editor (`currentEditor()` is nil), so its
+    /// `performKeyEquivalent`, the path a replayed Return takes, must stay inert.
+    func testFieldPerformKeyEquivalentDoesNotSubmitReturnWhenNotEditing() throws {
+        let spy = HandlerSpy()
+        let coordinator = makeCoordinator(spy: spy)
+        let field = OmnibarNativeTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.onHandleKeyEvent = { [weak coordinator] event, editor in
+            coordinator?.handleKeyEvent(event, editor: editor) ?? false
+        }
+        XCTAssertNil(field.currentEditor(), "Precondition: a window-less field is not being edited")
+
+        let returnEvent = try keyEvent(keyCode: 36, characters: "\r")
+        let consumed = field.performKeyEquivalent(with: returnEvent)
+
+        XCTAssertFalse(consumed)
+        XCTAssertEqual(spy.submitCount, 0)
+    }
+}


### PR DESCRIPTION
Closes #6250.

## Problem

Pressing a physical Return/Enter while a browser pane's **web content** has focus performs a full page navigation to the URL shown in the omnibar, an unfocused omnibar submits itself. For ordinary pages this is a spurious reload; for SPAs it aborts in-flight `fetch`/`XHR` (the omnibar buffer mirrors the SPA's `pushState`/`replaceState` URL), which surfaces as data loss.

Only physical keypresses reproduce it (synthetic events never enter the AppKit pipeline), and only when the page does not `preventDefault()` the Enter.

## Root cause

Three pieces interact:

1. `OmnibarNativeTextField.performKeyEquivalent` forwards every key event to the coordinator regardless of focus. AppKit dispatches `performKeyEquivalent` across the whole window view hierarchy, so this runs even when the WKWebView is first responder.
2. `Coordinator.handleKeyEvent` handled the Return case (`case 36, 76`) with no check that the omnibar was being edited, calling `onSubmit()` → `navigateSmart(buffer)`.
3. `CmuxWebView.performKeyEquivalent` intentionally opts Return out of key-equivalent routing so WebKit gets the keyDown path (the form-submit fix, #426). When the web process reports the Enter as unhandled, WebKit replays it to the host, where it re-enters the key-equivalent machinery, reaches the omnibar via (1), and submits via (2). This matches the observed 56–189 ms delay and the "only when not `preventDefault`'d" behavior.

## Fix

Guard `Coordinator.handleKeyEvent` on `editor != nil`. `currentEditor()` (passed in as `editor`) is non-nil only while the field is first responder and being edited, so the WebKit-replay path goes inert while:

- the legitimate focused-submit path still works (verified by a test with a live editor), and
- the separate `control(_:textView:doCommandBy:)` `insertNewline:` submit path is untouched.

This also makes Escape and the arrow keys inert in the omnibar handler while web content is focused (same latent exposure in the same `switch`).

## Commits (two-commit regression structure)

1. **test** — adds behavioral coverage only; the negative cases fail without the fix, so CI on this commit should be red, proving the test catches the bug.
2. **fix** — adds the focus guard; CI should go green.

## Test plan

- `cmux-unit` `BrowserOmnibarUnfocusedReturnRoutingTests`: Return / keypad Enter with `editor == nil` do not call `onSubmit`; Escape and arrows are inert; the field's `performKeyEquivalent` does not submit on a non-edited field; Return **with** a live editor still submits.
- Built locally (`reload.sh --tag enter-reloads`) and `cmux-unit` `build-for-testing` both succeed. Tests run in CI per repo policy.
- Manual: open a browser pane, click into page content, press a physical Enter, the page no longer reloads/navigates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784224799&installation_id=133855650&pr_number=6251&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6251&signature=296ac44d50830b4b860f29eaa28f07007e9ac04bbc822162cdee424701740398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where pressing a physical Return/Enter while web content is focused submitted the omnibar and reloaded/navigated the page. Return/Enter now only submits when the omnibar is actively being edited. Fixes #6250.

- **Bug Fixes**
  - Guarded omnibar key handling to run only when `editor != nil` (field is first responder), preventing WebKit-replayed Return from triggering submit; Escape and arrow keys are ignored when not editing; submit still works during editing.
  - Added regression tests covering unfocused Return/keypad Enter inertness, Escape/arrow inertness, non-edited `performKeyEquivalent` staying inert, and the live-editor submit path.

<sup>Written for commit dbcca202432d60345a0ea7c05320fff30e2015bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where the omnibar search field would incorrectly process keyboard events (Return, Escape, arrow keys) when not actively focused, resulting in accidental submissions or unintended navigation in the browser pane.

* **Tests**
  * Added regression tests to verify omnibar keyboard routing behavior remains correct when the field is not actively being edited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->