### PR TITLE
Fix browser download trigger parity

### DIFF
--- a/Sources/Panels/BrowserDownloadFilenameResolver.swift
+++ b/Sources/Panels/BrowserDownloadFilenameResolver.swift
@@ -164,7 +164,6 @@ nonisolated struct BrowserDownloadFilenameResolver: Sendable {
 
     private static let forceDownloadMIMETypes: Set<String> = [
         "application/gzip",
-        "application/json",
         "application/octet-stream",
         "application/x-gzip",
         "application/x-zip-compressed",

--- a/Sources/Panels/BrowserDownloadFilenameResolver.swift
+++ b/Sources/Panels/BrowserDownloadFilenameResolver.swift
@@ -8,6 +8,16 @@ nonisolated enum BrowserDownloadHTTPStatusDecision: Equatable, Sendable {
 }
 
 nonisolated struct BrowserDownloadFilenameResolver: Sendable {
+    func shouldForceDownload(
+        mimeType: String?,
+        contentDisposition: String?
+    ) -> Bool {
+        guard let contentDisposition else {
+            return false
+        }
+        return contentDisposition.lowercased().hasPrefix("attachment")
+    }
+
     func httpStatusDecision(for response: URLResponse?) -> BrowserDownloadHTTPStatusDecision {
         guard let httpResponse = response as? HTTPURLResponse else {
             return .allow

--- a/Sources/Panels/BrowserDownloadFilenameResolver.swift
+++ b/Sources/Panels/BrowserDownloadFilenameResolver.swift
@@ -12,10 +12,27 @@ nonisolated struct BrowserDownloadFilenameResolver: Sendable {
         mimeType: String?,
         contentDisposition: String?
     ) -> Bool {
-        guard let contentDisposition else {
+        if Self.contentDispositionRequestsAttachment(contentDisposition) {
+            return true
+        }
+        guard let normalizedMIMEType = Self.normalizedMIMEType(mimeType) else {
             return false
         }
-        return contentDisposition.lowercased().hasPrefix("attachment")
+        return Self.forceDownloadMIMETypes.contains(normalizedMIMEType)
+    }
+
+    func navigationResponseDownloadReason(
+        mimeType: String?,
+        canShowMIMEType: Bool,
+        contentDisposition: String?
+    ) -> String? {
+        if shouldForceDownload(mimeType: nil, contentDisposition: contentDisposition) {
+            return "content-disposition"
+        }
+        if shouldForceDownload(mimeType: mimeType, contentDisposition: nil) {
+            return "forceDownloadMIME"
+        }
+        return canShowMIMEType ? nil : "cannotShowMIME"
     }
 
     func httpStatusDecision(for response: URLResponse?) -> BrowserDownloadHTTPStatusDecision {
@@ -143,6 +160,32 @@ nonisolated struct BrowserDownloadFilenameResolver: Sendable {
 
     private var defaultFilename: String {
         String(localized: "browser.download.defaultFilename", defaultValue: "download")
+    }
+
+    private static let forceDownloadMIMETypes: Set<String> = [
+        "application/gzip",
+        "application/json",
+        "application/octet-stream",
+        "application/x-gzip",
+        "application/x-zip-compressed",
+        "application/zip",
+        "text/csv",
+    ]
+
+    private static func normalizedMIMEType(_ mimeType: String?) -> String? {
+        guard let rawType = mimeType?.split(separator: ";", maxSplits: 1).first else {
+            return nil
+        }
+        let normalized = rawType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func contentDispositionRequestsAttachment(_ contentDisposition: String?) -> Bool {
+        guard let rawType = contentDisposition?.split(separator: ";", maxSplits: 1).first else {
+            return false
+        }
+        return rawType.trimmingCharacters(in: .whitespacesAndNewlines)
+            .caseInsensitiveCompare("attachment") == .orderedSame
     }
 
     private func hasImageExtension(_ filename: String, matching imageType: UTType) -> Bool {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -9140,6 +9140,11 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
+        if navigationAction.shouldPerformDownload {
+            decisionHandler(.download)
+            return
+        }
+
         // Cmd+click and middle-click on regular links should always open in a new tab.
         if shouldOpenInNewTab,
            let requestURL = navigationAction.request.url {
@@ -9206,25 +9211,16 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
               responseURL, mime, canShow ? 1 : 0,
               navigationResponse.isForMainFrame ? 1 : 0)
 
-        // Check if this response should be treated as a download.
-        // Criteria: explicit Content-Disposition: attachment, or a MIME type
-        // that WebKit cannot render inline.
-        if let response = navigationResponse.response as? HTTPURLResponse {
-            let contentDisposition = response.value(forHTTPHeaderField: "Content-Disposition") ?? ""
-            if contentDisposition.lowercased().hasPrefix("attachment") {
-                NSLog("BrowserPanel download: content-disposition=attachment mime=%@ url=%@", mime, responseURL)
-                #if DEBUG
-                cmuxDebugLog("download.policy=download reason=content-disposition mime=\(mime)")
-                #endif
-                decisionHandler(.download)
-                return
-            }
-        }
-
-        if !canShow {
-            NSLog("BrowserPanel download: cannotShowMIME mime=%@ url=%@", mime, responseURL)
+        let contentDisposition = (navigationResponse.response as? HTTPURLResponse)?
+            .value(forHTTPHeaderField: "Content-Disposition")
+        if let reason = BrowserDownloadFilenameResolver().navigationResponseDownloadReason(
+            mimeType: mime,
+            canShowMIMEType: canShow,
+            contentDisposition: contentDisposition
+        ) {
+            NSLog("BrowserPanel download: %@ mime=%@ url=%@", reason, mime, responseURL)
             #if DEBUG
-            cmuxDebugLog("download.policy=download reason=cannotShowMIME mime=\(mime)")
+            cmuxDebugLog("download.policy=download reason=\(reason) mime=\(mime)")
             #endif
             decisionHandler(.download)
             return

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -613,6 +613,11 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
+        if navigationAction.shouldPerformDownload {
+            decisionHandler(.download)
+            return
+        }
+
         // Only guard main-frame navigations
         guard navigationAction.targetFrame?.isMainFrame != false else {
             decisionHandler(.allow)
@@ -647,15 +652,10 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
-        if let response = navigationResponse.response as? HTTPURLResponse {
-            let contentDisposition = response.value(forHTTPHeaderField: "Content-Disposition") ?? ""
-            if contentDisposition.lowercased().hasPrefix("attachment") {
-                decisionHandler(.download)
-                return
-            }
-        }
-
-        if !navigationResponse.canShowMIMEType {
+        let contentDisposition = (navigationResponse.response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition")
+        if BrowserDownloadFilenameResolver().navigationResponseDownloadReason(
+            mimeType: navigationResponse.response.mimeType, canShowMIMEType: navigationResponse.canShowMIMEType, contentDisposition: contentDisposition
+        ) != nil {
             decisionHandler(.download)
             return
         }

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -613,11 +613,6 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
-        if navigationAction.shouldPerformDownload {
-            decisionHandler(.download)
-            return
-        }
-
         // Only guard main-frame navigations
         guard navigationAction.targetFrame?.isMainFrame != false else {
             decisionHandler(.allow)
@@ -630,6 +625,11 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             cmuxDebugLog("popup.nav.insecureHTTP url=\(url.absoluteString)")
             #endif
             controller?.presentInsecureHTTPAlert(for: url, in: webView, decisionHandler: decisionHandler)
+            return
+        }
+
+        if navigationAction.shouldPerformDownload {
+            decisionHandler(.download)
             return
         }
 

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -1,0 +1,251 @@
+import Foundation
+import ObjectiveC
+import WebKit
+
+extension CmuxWebView {
+    private static let scriptedDownloadMessageHandlerName = "cmuxScriptedDownload"
+    private static var scriptedDownloadHandlerInstalledKey: UInt8 = 0
+    private static let scriptedDownloadInterceptionBootstrapScriptSource = """
+    (() => {
+      try {
+        if (window.__cmuxScriptedDownloadInstalled) return true;
+        window.__cmuxScriptedDownloadInstalled = true;
+
+        const handler = (() => {
+          try {
+            return window.webkit?.messageHandlers?.\(scriptedDownloadMessageHandlerName) ?? null;
+          } catch (_) {
+            return null;
+          }
+        })();
+        if (!handler) return false;
+
+        const objectURLs = new Map();
+        const URLCtor = window.URL || null;
+        const originalCreateObjectURL = URLCtor && URLCtor.createObjectURL;
+        const originalRevokeObjectURL = URLCtor && URLCtor.revokeObjectURL;
+
+        const postURLDownload = (url, suggestedFilename) => {
+          try {
+            handler.postMessage({
+              kind: "url",
+              url: String(url || ""),
+              suggestedFilename: String(suggestedFilename || "")
+            });
+          } catch (_) {}
+        };
+
+        const postDataURLDownload = (dataURL, suggestedFilename) => {
+          try {
+            handler.postMessage({
+              kind: "dataURL",
+              dataURL: String(dataURL || ""),
+              suggestedFilename: String(suggestedFilename || "")
+            });
+          } catch (_) {}
+        };
+
+        const readBlobForDownload = (blob, suggestedFilename) => {
+          try {
+            if (!blob) return;
+            const filename = String(suggestedFilename || blob.name || "");
+            const reader = new FileReader();
+            reader.onload = () => {
+              if (typeof reader.result === "string" && reader.result.length > 0) {
+                postDataURLDownload(reader.result, filename);
+              }
+            };
+            reader.readAsDataURL(blob);
+          } catch (_) {}
+        };
+
+        const postBlobURLDownload = (url, suggestedFilename) => {
+          try {
+            const storedBlob = objectURLs.get(String(url));
+            if (storedBlob) {
+              readBlobForDownload(storedBlob, suggestedFilename);
+              return;
+            }
+            fetch(url)
+              .then((response) => response.blob())
+              .then((blob) => readBlobForDownload(blob, suggestedFilename))
+              .catch(() => {});
+          } catch (_) {}
+        };
+
+        if (typeof originalCreateObjectURL === "function") {
+          URLCtor.createObjectURL = function(object) {
+            const url = originalCreateObjectURL.apply(this, arguments);
+            try {
+              if (object instanceof Blob) {
+                objectURLs.set(String(url), object);
+              }
+            } catch (_) {}
+            return url;
+          };
+        }
+
+        if (typeof originalRevokeObjectURL === "function") {
+          URLCtor.revokeObjectURL = function(url) {
+            try {
+              objectURLs.delete(String(url));
+            } catch (_) {}
+            return originalRevokeObjectURL.apply(this, arguments);
+          };
+        }
+
+        const anchorForEvent = (event) => {
+          try {
+            const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+            for (const node of path) {
+              if (!node || node.nodeType !== 1) continue;
+              const tag = String(node.tagName || "").toUpperCase();
+              if ((tag === "A" || tag === "AREA") && node.href) return node;
+            }
+            const target = event.target;
+            return target?.closest?.("a[href],area[href]") ?? null;
+          } catch (_) {
+            return null;
+          }
+        };
+
+        const suggestedFilenameForAnchor = (anchor) => {
+          try {
+            const attr = anchor.getAttribute("download");
+            if (typeof attr === "string" && attr.trim().length > 0) return attr;
+            if (typeof anchor.download === "string" && anchor.download.trim().length > 0) {
+              return anchor.download;
+            }
+          } catch (_) {}
+          return "";
+        };
+
+        const interceptAnchorDownload = (anchor) => {
+          try {
+            if (!anchor || !anchor.hasAttribute("download")) return false;
+            const href = String(anchor.href || anchor.getAttribute("href") || "");
+            if (!href) return false;
+            const scheme = href.split(":", 1)[0].toLowerCase();
+            const suggestedFilename = suggestedFilenameForAnchor(anchor);
+
+            if (scheme === "blob") {
+              postBlobURLDownload(href, suggestedFilename);
+              return true;
+            }
+            if (scheme === "data" || scheme === "http" || scheme === "https" || scheme === "file") {
+              postURLDownload(href, suggestedFilename);
+              return true;
+            }
+          } catch (_) {}
+          return false;
+        };
+
+        document.addEventListener("click", (event) => {
+          const anchor = anchorForEvent(event);
+          if (!interceptAnchorDownload(anchor)) return;
+          event.preventDefault();
+          event.stopPropagation();
+        }, true);
+
+        const anchorPrototype = window.HTMLAnchorElement?.prototype ?? null;
+        const originalAnchorClick = anchorPrototype?.click ?? null;
+        if (typeof originalAnchorClick === "function") {
+          anchorPrototype.click = function() {
+            if (interceptAnchorDownload(this)) return;
+            return originalAnchorClick.apply(this, arguments);
+          };
+        }
+
+        return true;
+      } catch (_) {
+        return false;
+      }
+    })();
+    """
+
+    func installScriptedDownloadInterception() {
+        let userContentController = configuration.userContentController
+        if objc_getAssociatedObject(
+            userContentController,
+            &Self.scriptedDownloadHandlerInstalledKey
+        ) != nil {
+            return
+        }
+
+        userContentController.addUserScript(
+            WKUserScript(
+                source: Self.scriptedDownloadInterceptionBootstrapScriptSource,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+        )
+        userContentController.add(
+            Self.sharedScriptedDownloadMessageHandler,
+            name: Self.scriptedDownloadMessageHandlerName
+        )
+        objc_setAssociatedObject(
+            userContentController,
+            &Self.scriptedDownloadHandlerInstalledKey,
+            NSNumber(value: true),
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
+    }
+
+    fileprivate func handleScriptedDownloadMessage(_ body: [String: Any]) {
+        guard let kind = body["kind"] as? String else { return }
+        let suggestedFilename = body["suggestedFilename"] as? String
+        let urlString: String?
+        switch kind {
+        case "url":
+            urlString = body["url"] as? String
+        case "dataURL":
+            urlString = body["dataURL"] as? String
+        default:
+            urlString = nil
+        }
+
+        guard let rawURL = urlString?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawURL.isEmpty,
+              let url = URL(string: rawURL) else {
+#if DEBUG
+            debugContextDownload("browser.scriptdl.message stage=rejectInvalid kind=\(kind)")
+#endif
+            return
+        }
+
+        startScriptedDownload(url, suggestedFilename: suggestedFilename)
+    }
+
+    private func startScriptedDownload(
+        _ url: URL,
+        suggestedFilename: String?
+    ) {
+        let traceID = Self.makeContextDownloadTraceID(prefix: "scriptdl")
+        debugContextDownload("browser.scriptdl.start trace=\(traceID) scheme=\(url.scheme ?? "nil")")
+        downloadURLViaSession(
+            url,
+            suggestedFilename: suggestedFilename,
+            sender: nil,
+            fallbackAction: nil,
+            fallbackTarget: nil,
+            traceID: traceID
+        )
+    }
+
+    private static let sharedScriptedDownloadMessageHandler = ScriptedDownloadMessageHandler()
+}
+
+private final class ScriptedDownloadMessageHandler: NSObject, WKScriptMessageHandler {
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard let webView = message.webView as? CmuxWebView,
+              let body = message.body as? [String: Any] else {
+            return
+        }
+        MainActor.assumeIsolated {
+            webView.handleScriptedDownloadMessage(body)
+        }
+    }
+}

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -18,7 +18,10 @@ extension CmuxWebView {
         const bridgeToken = "\(token)";
         const maxPayloadBytes = \(maxScriptedDownloadPayloadBytes);
         const maxDataURLCharacters = \(maxScriptedDownloadDataURLCharacters);
+        const trustedActivationWindowMs = 2000;
         let blobDownloadInFlight = false;
+        let lastTrustedActivationMs = 0;
+        let lastDownloadPostMs = 0;
 
         const handler = (() => {
           try {
@@ -34,6 +37,40 @@ extension CmuxWebView {
         const URLCtor = window.URL || null;
         const originalCreateObjectURL = URLCtor && URLCtor.createObjectURL;
         const originalRevokeObjectURL = URLCtor && URLCtor.revokeObjectURL;
+
+        const noteTrustedActivation = (event) => {
+          try {
+            if (event && event.isTrusted) lastTrustedActivationMs = Date.now();
+          } catch (_) {}
+        };
+
+        const hasUserActivation = (event) => {
+          try {
+            if (event && event.isTrusted) return true;
+            if (navigator.userActivation && navigator.userActivation.isActive) return true;
+            return Date.now() - lastTrustedActivationMs <= trustedActivationWindowMs;
+          } catch (_) {
+            return false;
+          }
+        };
+
+        const reserveDownloadPost = () => {
+          const now = Date.now();
+          if (now - lastDownloadPostMs < 500) return false;
+          lastDownloadPostMs = now;
+          return true;
+        };
+
+        const sameOriginDownloadURL = (href) => {
+          try {
+            const parsed = new URL(href, document.baseURI);
+            const scheme = parsed.protocol.toLowerCase();
+            if ((scheme === "http:" || scheme === "https:") && parsed.origin === window.location.origin) {
+              return parsed.href;
+            }
+          } catch (_) {}
+          return "";
+        };
 
         const postURLDownload = (url, suggestedFilename) => {
           try {
@@ -147,8 +184,13 @@ extension CmuxWebView {
           return "";
         };
 
-        const interceptAnchorDownload = (anchor) => {
+        ["pointerdown", "mousedown", "keydown", "click"].forEach((eventName) => {
+          document.addEventListener(eventName, noteTrustedActivation, true);
+        });
+
+        const interceptAnchorDownload = (anchor, event) => {
           try {
+            if (!hasUserActivation(event)) return false;
             if (!anchor || !anchor.hasAttribute("download")) return false;
             const href = String(anchor.href || anchor.getAttribute("href") || "");
             if (!href) return false;
@@ -156,11 +198,19 @@ extension CmuxWebView {
             const suggestedFilename = suggestedFilenameForAnchor(anchor);
 
             if (scheme === "blob") {
+              if (!reserveDownloadPost()) return false;
               return postBlobURLDownload(href, suggestedFilename);
             }
-            if (scheme === "data" || scheme === "http" || scheme === "https" || scheme === "file") {
+            if (scheme === "data") {
               if (scheme === "data" && href.length > maxDataURLCharacters) return false;
+              if (!reserveDownloadPost()) return false;
               postURLDownload(href, suggestedFilename);
+              return true;
+            }
+            if (scheme === "http" || scheme === "https") {
+              const sameOriginURL = sameOriginDownloadURL(href);
+              if (!sameOriginURL || !reserveDownloadPost()) return false;
+              postURLDownload(sameOriginURL, suggestedFilename);
               return true;
             }
           } catch (_) {}
@@ -169,7 +219,7 @@ extension CmuxWebView {
 
         document.addEventListener("click", (event) => {
           const anchor = anchorForEvent(event);
-          if (!interceptAnchorDownload(anchor)) return;
+          if (!interceptAnchorDownload(anchor, event)) return;
           event.preventDefault();
           event.stopPropagation();
         }, true);
@@ -178,7 +228,7 @@ extension CmuxWebView {
         const originalAnchorClick = anchorPrototype?.click ?? null;
         if (typeof originalAnchorClick === "function") {
           anchorPrototype.click = function() {
-            if (interceptAnchorDownload(this)) return;
+            if (interceptAnchorDownload(this, null)) return;
             return originalAnchorClick.apply(this, arguments);
           };
         }
@@ -270,6 +320,12 @@ extension CmuxWebView {
         _ url: URL,
         suggestedFilename: String?
     ) {
+        guard Self.isScriptedDownloadSupportedURL(url) else {
+#if DEBUG
+            debugContextDownload("browser.scriptdl.start stage=rejectUnsupportedScheme scheme=\(url.scheme ?? "nil")")
+#endif
+            return
+        }
         let traceID = Self.makeContextDownloadTraceID(prefix: "scriptdl")
         debugContextDownload("browser.scriptdl.start trace=\(traceID) scheme=\(url.scheme ?? "nil")")
         downloadURLViaSession(
@@ -280,6 +336,11 @@ extension CmuxWebView {
             fallbackTarget: nil,
             traceID: traceID
         )
+    }
+
+    private static func isScriptedDownloadSupportedURL(_ url: URL) -> Bool {
+        let scheme = url.scheme?.lowercased() ?? ""
+        return scheme == "http" || scheme == "https" || scheme == "data"
     }
 
     static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -61,17 +61,6 @@ extension CmuxWebView {
           return true;
         };
 
-        const sameOriginDownloadURL = (href) => {
-          try {
-            const parsed = new URL(href, document.baseURI);
-            const scheme = parsed.protocol.toLowerCase();
-            if ((scheme === "http:" || scheme === "https:") && parsed.origin === window.location.origin) {
-              return parsed.href;
-            }
-          } catch (_) {}
-          return "";
-        };
-
         const postURLDownload = (url, suggestedFilename) => {
           try {
             postMessage({
@@ -203,15 +192,9 @@ extension CmuxWebView {
               return postBlobURLDownload(href, suggestedFilename);
             }
             if (scheme === "data") {
-              if (scheme === "data" && href.length > maxDataURLCharacters) return false;
+              if (href.length > maxDataURLCharacters) return false;
               if (!reserveDownloadPost()) return false;
               postURLDownload(href, suggestedFilename);
-              return true;
-            }
-            if (scheme === "http" || scheme === "https") {
-              const sameOriginURL = sameOriginDownloadURL(href);
-              if (!sameOriginURL || !reserveDownloadPost()) return false;
-              postURLDownload(sameOriginURL, suggestedFilename);
               return true;
             }
           } catch (_) {}
@@ -312,6 +295,14 @@ extension CmuxWebView {
             return
         }
 
+        if url.scheme?.caseInsensitiveCompare("data") == .orderedSame,
+           rawURL.count > Self.maxScriptedDownloadDataURLCharacters {
+#if DEBUG
+            debugContextDownload("browser.scriptdl.message stage=rejectOversizeDataURL chars=\(rawURL.count)")
+#endif
+            return
+        }
+
         startScriptedDownload(url, suggestedFilename: suggestedFilename)
     }
 
@@ -339,7 +330,7 @@ extension CmuxWebView {
 
     private static func isScriptedDownloadSupportedURL(_ url: URL) -> Bool {
         let scheme = url.scheme?.lowercased() ?? ""
-        return scheme == "http" || scheme == "https" || scheme == "data"
+        return scheme == "data"
     }
 
     static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -5,11 +5,20 @@ import WebKit
 extension CmuxWebView {
     private static let scriptedDownloadMessageHandlerName = "cmuxScriptedDownload"
     private static var scriptedDownloadHandlerInstalledKey: UInt8 = 0
-    private static let scriptedDownloadInterceptionBootstrapScriptSource = """
+    private static var scriptedDownloadTokenKey: UInt8 = 0
+    private static let maxScriptedDownloadPayloadBytes = 100 * 1024 * 1024
+    private static let maxScriptedDownloadDataURLCharacters = 140 * 1024 * 1024
+
+    private static func scriptedDownloadInterceptionBootstrapScriptSource(token: String) -> String {
+        """
     (() => {
       try {
         if (window.__cmuxScriptedDownloadInstalled) return true;
         window.__cmuxScriptedDownloadInstalled = true;
+        const bridgeToken = "\(token)";
+        const maxPayloadBytes = \(maxScriptedDownloadPayloadBytes);
+        const maxDataURLCharacters = \(maxScriptedDownloadDataURLCharacters);
+        let blobDownloadInFlight = false;
 
         const handler = (() => {
           try {
@@ -19,6 +28,7 @@ extension CmuxWebView {
           }
         })();
         if (!handler) return false;
+        const postMessage = handler.postMessage.bind(handler);
 
         const objectURLs = new Map();
         const URLCtor = window.URL || null;
@@ -27,8 +37,9 @@ extension CmuxWebView {
 
         const postURLDownload = (url, suggestedFilename) => {
           try {
-            handler.postMessage({
+            postMessage({
               kind: "url",
+              token: bridgeToken,
               url: String(url || ""),
               suggestedFilename: String(suggestedFilename || "")
             });
@@ -37,8 +48,10 @@ extension CmuxWebView {
 
         const postDataURLDownload = (dataURL, suggestedFilename) => {
           try {
-            handler.postMessage({
+            if (String(dataURL || "").length > maxDataURLCharacters) return;
+            postMessage({
               kind: "dataURL",
+              token: bridgeToken,
               dataURL: String(dataURL || ""),
               suggestedFilename: String(suggestedFilename || "")
             });
@@ -48,29 +61,43 @@ extension CmuxWebView {
         const readBlobForDownload = (blob, suggestedFilename) => {
           try {
             if (!blob) return;
+            if (blobDownloadInFlight) return;
+            if (typeof blob.size === "number" && blob.size > maxPayloadBytes) return;
+            blobDownloadInFlight = true;
             const filename = String(suggestedFilename || blob.name || "");
             const reader = new FileReader();
+            const finish = () => {
+              blobDownloadInFlight = false;
+            };
             reader.onload = () => {
               if (typeof reader.result === "string" && reader.result.length > 0) {
                 postDataURLDownload(reader.result, filename);
               }
+              finish();
             };
+            reader.onerror = finish;
+            reader.onabort = finish;
             reader.readAsDataURL(blob);
-          } catch (_) {}
+          } catch (_) {
+            blobDownloadInFlight = false;
+          }
         };
 
         const postBlobURLDownload = (url, suggestedFilename) => {
           try {
             const storedBlob = objectURLs.get(String(url));
             if (storedBlob) {
+              if (typeof storedBlob.size === "number" && storedBlob.size > maxPayloadBytes) return false;
               readBlobForDownload(storedBlob, suggestedFilename);
-              return;
+              return true;
             }
             fetch(url)
               .then((response) => response.blob())
               .then((blob) => readBlobForDownload(blob, suggestedFilename))
               .catch(() => {});
+            return true;
           } catch (_) {}
+          return false;
         };
 
         if (typeof originalCreateObjectURL === "function") {
@@ -129,10 +156,10 @@ extension CmuxWebView {
             const suggestedFilename = suggestedFilenameForAnchor(anchor);
 
             if (scheme === "blob") {
-              postBlobURLDownload(href, suggestedFilename);
-              return true;
+              return postBlobURLDownload(href, suggestedFilename);
             }
             if (scheme === "data" || scheme === "http" || scheme === "https" || scheme === "file") {
+              if (scheme === "data" && href.length > maxDataURLCharacters) return false;
               postURLDownload(href, suggestedFilename);
               return true;
             }
@@ -162,6 +189,7 @@ extension CmuxWebView {
       }
     })();
     """
+    }
 
     func installScriptedDownloadInterception() {
         let userContentController = configuration.userContentController
@@ -172,9 +200,16 @@ extension CmuxWebView {
             return
         }
 
+        let token = UUID().uuidString
+        objc_setAssociatedObject(
+            self,
+            &Self.scriptedDownloadTokenKey,
+            token,
+            .OBJC_ASSOCIATION_COPY_NONATOMIC
+        )
         userContentController.addUserScript(
             WKUserScript(
-                source: Self.scriptedDownloadInterceptionBootstrapScriptSource,
+                source: Self.scriptedDownloadInterceptionBootstrapScriptSource(token: token),
                 injectionTime: .atDocumentStart,
                 forMainFrameOnly: true
             )
@@ -192,6 +227,15 @@ extension CmuxWebView {
     }
 
     fileprivate func handleScriptedDownloadMessage(_ body: [String: Any]) {
+        let expectedToken = objc_getAssociatedObject(self, &Self.scriptedDownloadTokenKey) as? String
+        guard let token = body["token"] as? String,
+              let expectedToken,
+              token == expectedToken else {
+#if DEBUG
+            debugContextDownload("browser.scriptdl.message stage=rejectToken")
+#endif
+            return
+        }
         guard let kind = body["kind"] as? String else { return }
         let suggestedFilename = body["suggestedFilename"] as? String
         let urlString: String?
@@ -200,6 +244,12 @@ extension CmuxWebView {
             urlString = body["url"] as? String
         case "dataURL":
             urlString = body["dataURL"] as? String
+            if let dataURL = urlString, dataURL.count > Self.maxScriptedDownloadDataURLCharacters {
+#if DEBUG
+                debugContextDownload("browser.scriptdl.message stage=rejectOversizeDataURL chars=\(dataURL.count)")
+#endif
+                return
+            }
         default:
             urlString = nil
         }
@@ -230,6 +280,36 @@ extension CmuxWebView {
             fallbackTarget: nil,
             traceID: traceID
         )
+    }
+
+    static func cookiesForDownloadRequest(_ cookies: [HTTPCookie], url: URL) -> [HTTPCookie] {
+        guard let host = url.host?.lowercased() else { return [] }
+        let requestPath = url.path.isEmpty ? "/" : url.path
+        let isHTTPS = url.scheme?.caseInsensitiveCompare("https") == .orderedSame
+        let now = Date.now
+
+        return cookies.filter { cookie in
+            if cookie.isSecure && !isHTTPS { return false }
+            if let expires = cookie.expiresDate, expires <= now { return false }
+            guard domain(cookie.domain, matches: host) else { return false }
+            return path(cookie.path, matches: requestPath)
+        }
+    }
+
+    private static func domain(_ cookieDomain: String, matches host: String) -> Bool {
+        let normalized = cookieDomain.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        guard !normalized.isEmpty else { return false }
+        if cookieDomain.hasPrefix(".") {
+            return host == normalized || host.hasSuffix(".\(normalized)")
+        }
+        return host == normalized
+    }
+
+    private static func path(_ cookiePath: String, matches requestPath: String) -> Bool {
+        let normalized = cookiePath.isEmpty ? "/" : cookiePath
+        if normalized == "/" || requestPath == normalized { return true }
+        guard requestPath.hasPrefix(normalized) else { return false }
+        return normalized.hasSuffix("/") || requestPath.dropFirst(normalized.count).first == "/"
     }
 
     private static let sharedScriptedDownloadMessageHandler = ScriptedDownloadMessageHandler()

--- a/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
+++ b/Sources/Panels/CmuxWebView+ScriptedDownloads.swift
@@ -97,9 +97,9 @@ extension CmuxWebView {
 
         const readBlobForDownload = (blob, suggestedFilename) => {
           try {
-            if (!blob) return;
-            if (blobDownloadInFlight) return;
-            if (typeof blob.size === "number" && blob.size > maxPayloadBytes) return;
+            if (!blob) return false;
+            if (blobDownloadInFlight) return false;
+            if (typeof blob.size === "number" && blob.size > maxPayloadBytes) return false;
             blobDownloadInFlight = true;
             const filename = String(suggestedFilename || blob.name || "");
             const reader = new FileReader();
@@ -115,9 +115,11 @@ extension CmuxWebView {
             reader.onerror = finish;
             reader.onabort = finish;
             reader.readAsDataURL(blob);
+            return true;
           } catch (_) {
             blobDownloadInFlight = false;
           }
+          return false;
         };
 
         const postBlobURLDownload = (url, suggestedFilename) => {
@@ -125,8 +127,7 @@ extension CmuxWebView {
             const storedBlob = objectURLs.get(String(url));
             if (storedBlob) {
               if (typeof storedBlob.size === "number" && storedBlob.size > maxPayloadBytes) return false;
-              readBlobForDownload(storedBlob, suggestedFilename);
-              return true;
+              return readBlobForDownload(storedBlob, suggestedFilename);
             }
             fetch(url)
               .then((response) => response.blob())
@@ -251,12 +252,7 @@ extension CmuxWebView {
         }
 
         let token = UUID().uuidString
-        objc_setAssociatedObject(
-            self,
-            &Self.scriptedDownloadTokenKey,
-            token,
-            .OBJC_ASSOCIATION_COPY_NONATOMIC
-        )
+        objc_setAssociatedObject(userContentController, &Self.scriptedDownloadTokenKey, token, .OBJC_ASSOCIATION_COPY_NONATOMIC)
         userContentController.addUserScript(
             WKUserScript(
                 source: Self.scriptedDownloadInterceptionBootstrapScriptSource(token: token),
@@ -277,7 +273,10 @@ extension CmuxWebView {
     }
 
     fileprivate func handleScriptedDownloadMessage(_ body: [String: Any]) {
-        let expectedToken = objc_getAssociatedObject(self, &Self.scriptedDownloadTokenKey) as? String
+        let expectedToken = objc_getAssociatedObject(
+            configuration.userContentController,
+            &Self.scriptedDownloadTokenKey
+        ) as? String
         guard let token = body["token"] as? String,
               let expectedToken,
               token == expectedToken else {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -1752,7 +1752,7 @@ final class CmuxWebView: WKWebView {
         cookieStore.getAllCookies { cookies in
             var request = URLRequest(url: url)
             request.httpMethod = "GET"
-            let cookieHeaders = HTTPCookie.requestHeaderFields(with: cookies)
+            let cookieHeaders = HTTPCookie.requestHeaderFields(with: Self.cookiesForDownloadRequest(cookies, url: url))
             for (key, value) in cookieHeaders {
                 request.setValue(value, forHTTPHeaderField: key)
             }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -326,7 +326,6 @@ final class CmuxWebView: WKWebView {
       }
     })();
     """
-
     private final class PasteAsPlainTextFocusMessageHandler: NSObject, WKScriptMessageHandler {
         func userContentController(
             _ userContentController: WKUserContentController,
@@ -404,12 +403,13 @@ final class CmuxWebView: WKWebView {
     override init(frame: NSRect, configuration: WKWebViewConfiguration) {
         super.init(frame: frame, configuration: configuration)
         installPasteAsPlainTextFocusTracking()
+        installScriptedDownloadInterception()
         installContextMenuLinkCapture()
     }
-
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         installPasteAsPlainTextFocusTracking()
+        installScriptedDownloadInterception()
         installContextMenuLinkCapture()
     }
 
@@ -957,7 +957,7 @@ final class CmuxWebView: WKWebView {
     private var fallbackDownloadLinkedFileTarget: AnyObject?
     private var fallbackDownloadLinkedFileAction: Selector?
 
-    private static func makeContextDownloadTraceID(prefix: String) -> String {
+    static func makeContextDownloadTraceID(prefix: String) -> String {
 #if DEBUG
         return "\(prefix)-\(UUID().uuidString.prefix(8))"
 #else
@@ -965,7 +965,7 @@ final class CmuxWebView: WKWebView {
 #endif
     }
 
-    private func debugContextDownload(_ message: @autoclosure () -> String) {
+    func debugContextDownload(_ message: @autoclosure () -> String) {
 #if DEBUG
         cmuxDebugLog(Self.redactedContextDownloadDebugMessage(message()))
 #endif
@@ -1161,7 +1161,7 @@ final class CmuxWebView: WKWebView {
     ) -> String {
         if let suggested = suggestedFilename?.trimmingCharacters(in: .whitespacesAndNewlines),
            !suggested.isEmpty {
-            return suggested
+            return BrowserDownloadFilenameResolver().suggestedFilename(suggestedFilename: suggested, response: nil, sourceURL: URL(fileURLWithPath: "download"), imageType: nil)
         }
         let ext = filenameExtension(forMIMEType: mimeType) ?? "bin"
         let base = (mimeType?.lowercased().hasPrefix("image/") ?? false) ? "image" : "download"
@@ -1605,7 +1605,7 @@ final class CmuxWebView: WKWebView {
         }
     }
 
-    private func downloadURLViaSession(
+    func downloadURLViaSession(
         _ url: URL,
         suggestedFilename: String?,
         sender: Any?,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */; };
 		D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */; };
 		D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */; };
+		C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */; };
 		A5001500 /* CmuxWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001510 /* CmuxWebView.swift */; };
 		D7C0DE00000000000000A103 /* CmuxWebViewContextMenuLinkCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A104 /* CmuxWebViewContextMenuLinkCaptureTests.swift */; };
 		D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */; };
@@ -1260,6 +1261,7 @@
 		7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+ContextMenuLinkCapture.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
+		C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/CmuxWebView+ScriptedDownloads.swift"; sourceTree = "<group>"; };
 		A5001510 /* CmuxWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebView.swift; sourceTree = "<group>"; };
 		D7C0DE00000000000000A104 /* CmuxWebViewContextMenuLinkCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewContextMenuLinkCaptureTests.swift; sourceTree = "<group>"; };
 		D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewDragRoutingTests.swift; sourceTree = "<group>"; };
@@ -2463,6 +2465,7 @@
 				B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */,
 				A5001412 /* BrowserPanel.swift */,
 				C59240010000000000000002 /* BrowserDownloadFilenameResolver.swift */,
+				C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */,
 				B3770BA00000000000000002 /* BrowserAutomation.swift */,
 				4472B0014472B0014472B001 /* BrowserScreenshot.swift */,
 				4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */,
@@ -3557,6 +3560,7 @@
 				C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */,
 				D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */,
 				D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */,
+				C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */,
 				A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */,

--- a/cmuxTests/BrowserDownloadFilenameResolverTests.swift
+++ b/cmuxTests/BrowserDownloadFilenameResolverTests.swift
@@ -11,6 +11,33 @@ import UniformTypeIdentifiers
 @Suite struct BrowserDownloadFilenameResolverTests {
     private let resolver = BrowserDownloadFilenameResolver()
 
+    @Test func downloadPolicyForcesChromeDownloadTypes() {
+        #expect(resolver.shouldForceDownload(mimeType: "text/csv", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "text/csv; charset=utf-8", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "application/json", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "application/zip", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "application/x-zip-compressed", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "application/octet-stream", contentDisposition: nil))
+        #expect(resolver.shouldForceDownload(mimeType: "application/gzip", contentDisposition: nil))
+    }
+
+    @Test func downloadPolicyKeepsInlineRenderableTypesInline() {
+        #expect(!resolver.shouldForceDownload(mimeType: "text/html", contentDisposition: nil))
+        #expect(!resolver.shouldForceDownload(mimeType: "image/png", contentDisposition: nil))
+        #expect(!resolver.shouldForceDownload(mimeType: "application/pdf", contentDisposition: nil))
+    }
+
+    @Test func downloadPolicyHonorsAttachmentForAnyType() {
+        #expect(resolver.shouldForceDownload(
+            mimeType: "text/html",
+            contentDisposition: "attachment; filename=index.html"
+        ))
+        #expect(resolver.shouldForceDownload(
+            mimeType: "application/pdf",
+            contentDisposition: "ATTACHMENT; filename=report.pdf"
+        ))
+    }
+
     @Test func rejectsNonSuccessHTTPStatusBeforeSavePanelNaming() throws {
         let url = try #require(URL(string: "https://example.test/logo.jpg"))
         let response = try #require(HTTPURLResponse(

--- a/cmuxTests/BrowserDownloadFilenameResolverTests.swift
+++ b/cmuxTests/BrowserDownloadFilenameResolverTests.swift
@@ -14,7 +14,6 @@ import UniformTypeIdentifiers
     @Test func downloadPolicyForcesChromeDownloadTypes() {
         #expect(resolver.shouldForceDownload(mimeType: "text/csv", contentDisposition: nil))
         #expect(resolver.shouldForceDownload(mimeType: "text/csv; charset=utf-8", contentDisposition: nil))
-        #expect(resolver.shouldForceDownload(mimeType: "application/json", contentDisposition: nil))
         #expect(resolver.shouldForceDownload(mimeType: "application/zip", contentDisposition: nil))
         #expect(resolver.shouldForceDownload(mimeType: "application/x-zip-compressed", contentDisposition: nil))
         #expect(resolver.shouldForceDownload(mimeType: "application/octet-stream", contentDisposition: nil))
@@ -25,6 +24,7 @@ import UniformTypeIdentifiers
         #expect(!resolver.shouldForceDownload(mimeType: "text/html", contentDisposition: nil))
         #expect(!resolver.shouldForceDownload(mimeType: "image/png", contentDisposition: nil))
         #expect(!resolver.shouldForceDownload(mimeType: "application/pdf", contentDisposition: nil))
+        #expect(!resolver.shouldForceDownload(mimeType: "application/json", contentDisposition: nil))
     }
 
     @Test func downloadPolicyHonorsAttachmentForAnyType() {

--- a/cmuxTests/BrowserDownloadFilenameResolverTests.swift
+++ b/cmuxTests/BrowserDownloadFilenameResolverTests.swift
@@ -120,6 +120,56 @@ import UniformTypeIdentifiers
         #expect(filename == "avatar.png")
     }
 
+    @Test func downloadCookiesMatchRequestDomainAndPath() throws {
+        let url = try #require(URL(string: "https://sub.example.test/reports/2026/export.csv"))
+        let cookies = [
+            try Self.cookie(name: "parent", domain: ".example.test", path: "/reports"),
+            try Self.cookie(name: "host", domain: "sub.example.test", path: "/reports/2026"),
+            try Self.cookie(name: "wrong-domain", domain: ".other.test", path: "/reports"),
+            try Self.cookie(name: "wrong-path", domain: ".example.test", path: "/admin"),
+        ]
+
+        let names = Set(CmuxWebView.cookiesForDownloadRequest(cookies, url: url).map(\.name))
+
+        #expect(names == ["parent", "host"])
+    }
+
+    @Test func downloadCookiesRejectSecureCookiesForHTTPAndExpiredCookies() throws {
+        let url = try #require(URL(string: "http://example.test/report.csv"))
+        let cookies = [
+            try Self.cookie(name: "plain", domain: "example.test"),
+            try Self.cookie(name: "secure", domain: "example.test", secure: true),
+            try Self.cookie(name: "expired", domain: "example.test", expires: Date(timeIntervalSince1970: 0)),
+            try Self.cookie(name: "future", domain: "example.test", expires: Date(timeIntervalSince1970: 4_102_444_800)),
+        ]
+
+        let names = Set(CmuxWebView.cookiesForDownloadRequest(cookies, url: url).map(\.name))
+
+        #expect(names == ["plain", "future"])
+    }
+
+    private static func cookie(
+        name: String,
+        domain: String,
+        path: String = "/",
+        secure: Bool = false,
+        expires: Date? = nil
+    ) throws -> HTTPCookie {
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: "1",
+            .domain: domain,
+            .path: path,
+        ]
+        if secure {
+            properties[.secure] = "TRUE"
+        }
+        if let expires {
+            properties[.expires] = expires
+        }
+        return try #require(HTTPCookie(properties: properties))
+    }
+
     private static let onePixelPNG = Data([
         0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
         0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,


### PR DESCRIPTION
Closes #6255

Also fixes the PDF download button portion of #4266 by routing `<a download>` / blob-backed downloads through cmux's native save flow. #4266 should remain open for the PDF print button.

Testing / proof so far:
- `python3 scripts/swift_file_length_budget.py`
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`

Not run yet: local tagged app build and manual CSV/PDF download verification. Per workspace build-serialization instructions, that waits until CI is green and the user explicitly tells me to launch the dev build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784229746&installation_id=133855650&pr_number=6258&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6258&signature=f5e1fd84b772da989af21994c0e9630f09311f4a75e04fde6390dc7ff855468e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns our in-app browser’s download behavior with Chrome. Adds native handling for `<a download>` links, classifies more responses as downloads, and requires a user gesture for scripted downloads.

- **Bug Fixes**
  - Route scripted downloads to native save: intercept `<a download>`; allow `blob:`/`data:` only (blobs converted to data URLs); require user activation, per‑tab tokens, 100 MB payload and 140 MB data‑URL caps, 500 ms post rate limit.
  - Honor `shouldPerformDownload` in both main and popup navigation delegates by early‑returning `.download`.
  - Treat `Content-Disposition: attachment` and common archive types (`text/csv`, `zip`/`gzip`, `octet-stream`) as downloads; fall back when MIME can’t render.
  - Centralize download policy and filename resolution in `BrowserDownloadFilenameResolver` with reasoned logs; send only domain/path/secure‑matching cookies on download requests, with tests for cookie scoping.

Closes #6255. Fixes the PDF download button portion of #4266 (print button still tracked there).

<sup>Written for commit a05348824afb03f66c05588816abdd52df6eabbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced download decisions using both MIME type and `Content-Disposition`, including `attachment` handling and MIME normalization.
  * Added scripted interception for user-initiated `download` links, including blob/data-url capture, native routing, token validation, and safer filename resolution.
  * Improved download request cookie selection with domain/path matching and secure/expired cookie filtering.
* **Bug Fixes**
  * Made download classification consistent across navigation and popup flows by centralizing the decision logic.
* **Tests**
  * Added tests for forced-vs-inline MIME types, `Content-Disposition: attachment`, and cookie matching/filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->