### PR TITLE
CI: pin signing/notarization jobs to WarpBuild (fix self-hosted codesign errSecInternalComponent)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,13 +100,18 @@ jobs:
   build-sign-notarize-nightly:
     needs: decide
     if: needs.decide.outputs.should_build == 'true'
-    # Run on the macOS 15 host that carries the signing/notarization secrets.
+    # Pinned to WarpBuild, NOT vars.MACOS_RUNNER_15 (= cmux-aws-macos-15, a
+    # self-hosted mini): the self-hosted runners are not provisioned for
+    # codesigning (no Developer-ID/WWDR chain in the keychain), so `codesign`
+    # fails with "unable to build chain to self-signed root" / errSecInternalComponent.
+    # Signing + notarization must run on the Warp image that carries the chain
+    # until the self-hosted minis are provisioned for signing.
     # The Swift app still selects an Xcode with the macOS 26 SDK so it adopts
     # Liquid Glass on Tahoe. The Ghostty CLI helper is built separately and
     # injected before signing, preferring a pre-26 SDK when the runner image has
     # one but falling back to the selected app Xcode when the image only ships
     # Xcode 26. The helper build remains required and lipo-verified below.
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 30
     steps:
       - name: Checkout build ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,12 @@ jobs:
     # Build the app on macOS 26 so SDK-gated SwiftUI Liquid Glass code compiles
     # into stable releases. The real universal Ghostty CLI helper is built on
     # macOS 15 above because Zig 0.15.2 cannot link it on macOS 26.
-    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    # Pinned to WarpBuild, NOT vars.MACOS_RUNNER_26 (= cmux-macos-26, a
+    # self-hosted mini): this job codesigns + notarizes, and the self-hosted
+    # runners lack the Developer-ID/WWDR chain in their keychain, so codesign
+    # fails with errSecInternalComponent. Signing must run on the Warp image
+    # that carries the chain until the minis are provisioned for signing.
+    runs-on: warp-macos-26-arm64-6x
     # Notarization wait times vary on Apple's side; v0.64.14 finished at 19m16s
     # and v0.64.15 attempt 1 was killed by a 20-minute budget mid-notarization.
     timeout-minutes: 40


### PR DESCRIPTION
## Why
The nightly `build-sign-notarize-nightly` job fails repeatedly at "Codesign apps":
```
Warning: unable to build chain to self-signed root for signer "***"
cmux NIGHTLY.app/.../bin/cmux: errSecInternalComponent
```
Root cause: repo vars `MACOS_RUNNER_15 = cmux-aws-macos-15` and `MACOS_RUNNER_26 = cmux-macos-26` resolve to **self-hosted minis** that aren't provisioned for codesigning (their keychains lack the Developer-ID/WWDR chain). The Warp fallback label never triggers because the var is set. Same code signs fine on Warp (the 03:12 nightly succeeded); it fails whenever the job lands on a mini. (Same runner-routing root cause as the earlier `npm: command not found` nightly failure.)

## Fix
Pin the two jobs that codesign + notarize directly to the Warp images, bypassing the self-hosted vars:
- `nightly.yml` `build-sign-notarize-nightly` → `warp-macos-15-arm64-6x`
- `release.yml` `build-sign-notarize` → `warp-macos-26-arm64-6x`

The non-signing `build-ghostty-cli-helper` job stays on the shared var (it doesn't sign). This is "for now" — revert to the vars indirection once the minis are provisioned for signing (or moved behind runner groups). Workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784236186&installation_id=133855650&pr_number=6264&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6264&signature=82a80168d09bdfe420f4e6386c80a12f50c5cad77fd5cba8182e91706c0776ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only runner routing for two jobs; no app, signing secrets, or build script changes—only where CI executes existing sign/notarize steps.
> 
> **Overview**
> **Nightly and release codesign/notarize jobs no longer honor `vars.MACOS_RUNNER_15` / `vars.MACOS_RUNNER_26`**, which were routing those jobs to self-hosted minis where `codesign` fails with missing Developer-ID/WWDR chain (`errSecInternalComponent`).
> 
> `nightly.yml` **`build-sign-notarize-nightly`** now uses **`warp-macos-15-arm64-6x`**; `release.yml` **`build-sign-notarize`** uses **`warp-macos-26-arm64-6x`**. Inline comments document that this is temporary until self-hosted runners are provisioned for signing.
> 
> Non-signing work (e.g. release **`build-ghostty-cli-helper`**) is unchanged and still uses the repo runner vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2208eeaffc94ced68e0982c6b6895e7f2a0445f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the signing and notarization CI jobs to WarpBuild macOS runners to fix codesign failures on self-hosted minis. Nightly and release signing should now pass reliably.

- **Bug Fixes**
  - Pinned signing jobs to warp-macos-15-arm64-6x (nightly) and warp-macos-26-arm64-6x (release).
  - Self-hosted minis (from vars) lack the Developer-ID/WWDR chain, causing "unable to build chain to self-signed root" / errSecInternalComponent.
  - The non-signing build-ghostty-cli-helper job stays on the shared var.

<sup>Written for commit 2208eeaffc94ced68e0982c6b6895e7f2a0445f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build runner configurations to use pinned runner labels for improved build reliability and consistency across nightly and release pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->