### PR TITLE
Fix workflow-guard-tests: expect Warp-pinned release signing runner (#6264 follow-up)

### DIFF
--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -38,8 +38,8 @@ require_job_contains \
 require_job_contains \
   "$RELEASE_FILE" \
   "build-sign-notarize" \
-  'runs-on: ${{ vars.MACOS_RUNNER_26 || '\''warp-macos-26-arm64-6x'\'' }}' \
-  "release must build the app on macOS 26"
+  'runs-on: warp-macos-26-arm64-6x' \
+  "release must sign+notarize on the macOS 26 Warp runner (pinned, not vars.MACOS_RUNNER_26, because the self-hosted minis lack the Developer-ID/WWDR signing chain; see #6264)"
 
 require_job_contains \
   "$CI_FILE" \


### PR DESCRIPTION
#6264 pinned the release signing job to `warp-macos-26-arm64-6x`, but `test_ci_release_sdk_lane.sh` still asserted the old `vars.MACOS_RUNNER_26 || ...` string, so `workflow-guard-tests` (required) now fails on main and every open PR. Update the guard's expected `runs-on` for `build-sign-notarize` to the pinned Warp runner. Guards verified passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784236383&installation_id=133855650&pr_number=6265&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6265&signature=e78fb6d04f43a124b15e049f3844354f8acbdff0558dd7f0489f6eb380f2bc64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to CI guard strings; no runtime, auth, or release workflow behavior is modified.
> 
> **Overview**
> **Fixes failing `workflow-guard-tests`** after #6264 pinned release signing to Warp: the guard for `build-sign-notarize` in `tests/test_ci_release_sdk_lane.sh` still required the previous `runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}` string.
> 
> The assertion now expects **`runs-on: warp-macos-26-arm64-6x`** only, with an updated failure message documenting why signing stays pinned (self-hosted minis lack the Developer-ID/WWDR chain). No workflow YAML changes in this PR—test expectations only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437934b02e3ff8ab91bcd5699b08e0ef1a9ee6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix workflow guard by updating `tests/test_ci_release_sdk_lane.sh` to expect the pinned Warp macOS runner for release signing. The `build-sign-notarize` job now asserts `runs-on: warp-macos-26-arm64-6x`, matching #6264 and restoring green `workflow-guard-tests` on main and PRs.

<sup>Written for commit 437934b02e3ff8ab91bcd5699b08e0ef1a9ee6c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI/CD release lane assertions to ensure the build-sign-notarize job runs on the correct infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->