### PR TITLE
Harden memory diagnostics for long-session surface leaks

### DIFF
--- a/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistry.swift
+++ b/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistry.swift
@@ -109,6 +109,23 @@ public final class TerminalSurfaceRegistry: TerminalSurfaceRegistering, Sendable
         return surfaceFocusPlacements[id] == .rightSidebarDock
     }
 
+    /// A bounded count snapshot for leak diagnostics and crash/app-hang telemetry.
+    public func diagnosticSnapshot() -> TerminalSurfaceRegistryDiagnosticSnapshot {
+        lock.lock()
+        let objects = surfaces.allObjects.compactMap { $0 as? any TerminalSurfacing }
+        let runtimeSurfaceCount = runtimeSurfaceOwners.count
+        lock.unlock()
+
+        let workspaceSurfaceCount = objects.filter { $0.focusPlacement == .workspace }.count
+        let rightSidebarDockSurfaceCount = objects.filter { $0.focusPlacement == .rightSidebarDock }.count
+        return TerminalSurfaceRegistryDiagnosticSnapshot(
+            registeredSurfaceCount: objects.count,
+            workspaceSurfaceCount: workspaceSurfaceCount,
+            rightSidebarDockSurfaceCount: rightSidebarDockSurfaceCount,
+            runtimeSurfaceCount: runtimeSurfaceCount
+        )
+    }
+
     /// All live registered surfaces, ordered by id for stable iteration.
     public func allSurfaces() -> [any TerminalSurfacing] {
         lock.lock()

--- a/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistry.swift
+++ b/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistry.swift
@@ -114,10 +114,20 @@ public final class TerminalSurfaceRegistry: TerminalSurfaceRegistering, Sendable
         lock.lock()
         let objects = surfaces.allObjects.compactMap { $0 as? any TerminalSurfacing }
         let runtimeSurfaceCount = runtimeSurfaceOwners.count
+        var workspaceSurfaceCount = 0
+        var rightSidebarDockSurfaceCount = 0
+        for object in objects {
+            switch surfaceFocusPlacements[object.id] {
+            case .workspace:
+                workspaceSurfaceCount += 1
+            case .rightSidebarDock:
+                rightSidebarDockSurfaceCount += 1
+            case .none:
+                break
+            }
+        }
         lock.unlock()
 
-        let workspaceSurfaceCount = objects.filter { $0.focusPlacement == .workspace }.count
-        let rightSidebarDockSurfaceCount = objects.filter { $0.focusPlacement == .rightSidebarDock }.count
         return TerminalSurfaceRegistryDiagnosticSnapshot(
             registeredSurfaceCount: objects.count,
             workspaceSurfaceCount: workspaceSurfaceCount,

--- a/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistryDiagnosticSnapshot.swift
+++ b/Packages/CmuxTerminalEngine/Sources/CmuxTerminalEngine/SurfaceRegistry/TerminalSurfaceRegistryDiagnosticSnapshot.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A bounded count snapshot of the terminal surface registry.
+public struct TerminalSurfaceRegistryDiagnosticSnapshot: Equatable, Sendable {
+    /// The number of live surface model objects still registered.
+    public let registeredSurfaceCount: Int
+
+    /// The number of registered surfaces hosted in normal workspace panes.
+    public let workspaceSurfaceCount: Int
+
+    /// The number of registered surfaces hosted in the right-sidebar dock.
+    public let rightSidebarDockSurfaceCount: Int
+
+    /// The number of native runtime surface pointers still owned by registered surfaces.
+    public let runtimeSurfaceCount: Int
+
+    /// Creates a diagnostic snapshot.
+    ///
+    /// - Parameters:
+    ///   - registeredSurfaceCount: The number of live surface model objects.
+    ///   - workspaceSurfaceCount: The number of workspace-hosted surfaces.
+    ///   - rightSidebarDockSurfaceCount: The number of right-sidebar dock surfaces.
+    ///   - runtimeSurfaceCount: The number of native runtime surface pointers.
+    public init(
+        registeredSurfaceCount: Int,
+        workspaceSurfaceCount: Int,
+        rightSidebarDockSurfaceCount: Int,
+        runtimeSurfaceCount: Int
+    ) {
+        self.registeredSurfaceCount = registeredSurfaceCount
+        self.workspaceSurfaceCount = workspaceSurfaceCount
+        self.rightSidebarDockSurfaceCount = rightSidebarDockSurfaceCount
+        self.runtimeSurfaceCount = runtimeSurfaceCount
+    }
+
+    /// Returns the JSON-compatible representation used by diagnostics and telemetry.
+    public func payload() -> [String: Any] {
+        [
+            "registered_surface_count": registeredSurfaceCount,
+            "workspace_surface_count": workspaceSurfaceCount,
+            "right_sidebar_dock_surface_count": rightSidebarDockSurfaceCount,
+            "runtime_surface_count": runtimeSurfaceCount
+        ]
+    }
+}

--- a/Packages/CmuxTerminalEngine/Tests/CmuxTerminalEngineTests/TerminalSurfaceRegistryTests.swift
+++ b/Packages/CmuxTerminalEngine/Tests/CmuxTerminalEngineTests/TerminalSurfaceRegistryTests.swift
@@ -157,4 +157,29 @@ struct TerminalSurfaceRegistryTests {
         registry.unregister(surface)
         #expect(registry.surface(id: surface.id) == nil)
     }
+
+    @Test func diagnosticSnapshotDropsUnregisteredSurfacesAndRuntimePointers() throws {
+        let registry = TerminalSurfaceRegistry()
+        let retained = FakeSurface(focusPlacement: .workspace)
+        var closed: FakeSurface? = FakeSurface(focusPlacement: .rightSidebarDock)
+        let retainedRuntimeSurface = try #require(ghostty_surface_t(bitPattern: 0x1111))
+        let closedRuntimeSurface = try #require(ghostty_surface_t(bitPattern: 0x2222))
+
+        registry.register(retained)
+        registry.register(closed!)
+        registry.registerRuntimeSurface(retainedRuntimeSurface, ownerId: retained.id)
+        registry.registerRuntimeSurface(closedRuntimeSurface, ownerId: closed!.id)
+
+        registry.unregister(closed!)
+        registry.unregisterRuntimeSurface(closedRuntimeSurface, ownerId: closed!.id)
+        closed = nil
+
+        let snapshot = registry.diagnosticSnapshot()
+        #expect(snapshot.registeredSurfaceCount == 1)
+        #expect(snapshot.workspaceSurfaceCount == 1)
+        #expect(snapshot.rightSidebarDockSurfaceCount == 0)
+        #expect(snapshot.runtimeSurfaceCount == 1)
+        #expect(snapshot.payload()["registered_surface_count"] as? Int == 1)
+        #expect(snapshot.payload()["runtime_surface_count"] as? Int == 1)
+    }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -840,6 +840,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private let windowDecorationsController = WindowDecorationsController()
     private var menuBarExtraController: MenuBarExtraController?
     private var transientGlobalSearchMenuBarExtraController: MenuBarExtraController?
+    private var sentryMemoryContextTask: Task<Void, Never>?
     private var lastMenuBarExtraShouldInstall: Bool?
     private lazy var mainWindowVisibilityController = MainWindowVisibilityController(
         dependencies: .init(
@@ -1413,6 +1414,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if !isRunningUnderXCTest {
             GlobalSearchCoordinator.shared.start()
         }
+        startSentryMemoryContextRefresh()
         SystemWideHotkeyController.shared.start()
         AgentHibernationController.shared.start()
         RendererRealizationController.shared.start()
@@ -1926,6 +1928,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
+        sentryMemoryContextTask?.cancel()
+        sentryMemoryContextTask = nil
         isTerminatingApp = true
         // Plain quit detaches local ssh clients; explicit close already killed marked sessions.
         remoteTmuxController.detachAll()
@@ -1949,6 +1953,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         GhosttyCrashBreadcrumb.markCleanExit()
         StartupBreadcrumbLog.append("appDelegate.willTerminate.complete")
         enableSuddenTerminationIfNeeded()
+    }
+
+    private func startSentryMemoryContextRefresh() {
+        guard TelemetrySettings.enabledForCurrentLaunch, !isRunningUnderXCTestCached else { return }
+        sentryRefreshMemoryContext(reason: "startup")
+        sentryMemoryContextTask?.cancel()
+        sentryMemoryContextTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                // Intended periodic telemetry refresh; cancellation is wired to app termination.
+                do {
+                    try await Task.sleep(nanoseconds: 300 * 1_000_000_000)
+                } catch {
+                    break
+                }
+                guard self != nil else { break }
+                sentryRefreshMemoryContext(reason: "periodic")
+            }
+        }
     }
 
     func applicationWillResignActive(_ notification: Notification) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -840,7 +840,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private let windowDecorationsController = WindowDecorationsController()
     private var menuBarExtraController: MenuBarExtraController?
     private var transientGlobalSearchMenuBarExtraController: MenuBarExtraController?
-    private var sentryMemoryContextTask: Task<Void, Never>?
     private var lastMenuBarExtraShouldInstall: Bool?
     private lazy var mainWindowVisibilityController = MainWindowVisibilityController(
         dependencies: .init(
@@ -1413,8 +1412,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         installShortcutDefaultsObserver()
         if !isRunningUnderXCTest {
             GlobalSearchCoordinator.shared.start()
+            sentryStartMemoryContextRefresh()
         }
-        startSentryMemoryContextRefresh()
         SystemWideHotkeyController.shared.start()
         AgentHibernationController.shared.start()
         RendererRealizationController.shared.start()
@@ -1928,8 +1927,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
-        sentryMemoryContextTask?.cancel()
-        sentryMemoryContextTask = nil
+        sentryStopMemoryContextRefresh()
         isTerminatingApp = true
         // Plain quit detaches local ssh clients; explicit close already killed marked sessions.
         remoteTmuxController.detachAll()
@@ -1953,24 +1951,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         GhosttyCrashBreadcrumb.markCleanExit()
         StartupBreadcrumbLog.append("appDelegate.willTerminate.complete")
         enableSuddenTerminationIfNeeded()
-    }
-
-    private func startSentryMemoryContextRefresh() {
-        guard TelemetrySettings.enabledForCurrentLaunch, !isRunningUnderXCTestCached else { return }
-        sentryRefreshMemoryContext(reason: "startup")
-        sentryMemoryContextTask?.cancel()
-        sentryMemoryContextTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                // Intended periodic telemetry refresh; cancellation is wired to app termination.
-                do {
-                    try await Task.sleep(nanoseconds: 300 * 1_000_000_000)
-                } catch {
-                    break
-                }
-                guard self != nil else { break }
-                sentryRefreshMemoryContext(reason: "periodic")
-            }
-        }
     }
 
     func applicationWillResignActive(_ notification: Notification) {

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -4,7 +4,7 @@ import Foundation
 import Sentry
 
 @MainActor private var sentryMemoryContextRefreshTask: Task<Void, Never>?
-@MainActor private var sentryMemoryContextTimer: Timer?
+@MainActor private var sentryLastMemoryContextRefresh: Date?
 
 /// Add a Sentry breadcrumb for user-action context in hang/crash reports.
 func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String: Any]? = nil) {
@@ -13,6 +13,7 @@ func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String:
     crumb.message = message
     crumb.data = data
     SentrySDK.addBreadcrumb(crumb)
+    sentryRequestMemoryContextRefresh(reason: "breadcrumb.\(category)")
 }
 
 private func sentryCaptureMessage(
@@ -30,6 +31,7 @@ private func sentryCaptureMessage(
             scope.setContext(value: data, key: contextKey ?? category)
         }
     }
+    sentryRequestMemoryContextRefresh(reason: "capture.\(category)")
 }
 
 func sentryCaptureWarning(
@@ -53,28 +55,34 @@ func sentryCaptureError(
 @MainActor
 func sentryStartMemoryContextRefresh() {
     guard TelemetrySettings.enabledForCurrentLaunch else { return }
-    sentryStopMemoryContextRefresh()
-    sentryScheduleMemoryContextRefresh(reason: "startup")
-
-    let timer = Timer(timeInterval: 300, repeats: true) { _ in
-        Task { @MainActor in
-            sentryScheduleMemoryContextRefresh(reason: "periodic")
-        }
-    }
-    RunLoop.main.add(timer, forMode: .common)
-    sentryMemoryContextTimer = timer
+    sentryScheduleMemoryContextRefresh(reason: "startup", minimumInterval: 0)
 }
 
 @MainActor
 func sentryStopMemoryContextRefresh() {
-    sentryMemoryContextTimer?.invalidate()
-    sentryMemoryContextTimer = nil
     sentryMemoryContextRefreshTask?.cancel()
     sentryMemoryContextRefreshTask = nil
+    sentryLastMemoryContextRefresh = nil
+}
+
+private func sentryRequestMemoryContextRefresh(reason: String) {
+    guard TelemetrySettings.enabledForCurrentLaunch else { return }
+    Task { @MainActor in
+        sentryScheduleMemoryContextRefresh(reason: reason)
+    }
 }
 
 @MainActor
-private func sentryScheduleMemoryContextRefresh(reason: String) {
+private func sentryScheduleMemoryContextRefresh(
+    reason: String,
+    minimumInterval: TimeInterval = 300
+) {
+    let now = Date()
+    if let sentryLastMemoryContextRefresh,
+       now.timeIntervalSince(sentryLastMemoryContextRefresh) < minimumInterval {
+        return
+    }
+    sentryLastMemoryContextRefresh = now
     sentryMemoryContextRefreshTask?.cancel()
     sentryMemoryContextRefreshTask = Task.detached(priority: .utility) {
         await sentryRefreshMemoryContext(reason: reason)
@@ -99,6 +107,7 @@ func sentryRefreshMemoryContext(reason: String) async {
     let memorySource = appProcess?.memorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
     let residentMemorySource = appProcess?.residentMemorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
     let surfaceSnapshot = GhosttyApp.terminalSurfaceRegistry.diagnosticSnapshot()
+    guard !Task.isCancelled else { return }
 
     await MainActor.run {
         SentrySDK.configureScope { scope in

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -2,6 +2,8 @@ import Darwin
 import Foundation
 import Sentry
 
+@MainActor private var sentryMemoryContextTask: Task<Void, Never>?
+
 /// Add a Sentry breadcrumb for user-action context in hang/crash reports.
 func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String: Any]? = nil) {
     guard TelemetrySettings.enabledForCurrentLaunch else { return }
@@ -46,30 +48,65 @@ func sentryCaptureError(
     sentryCaptureMessage(message, level: .error, category: category, data: data, contextKey: contextKey)
 }
 
-/// Refresh the memory/surface context attached to future Sentry events.
 @MainActor
-func sentryRefreshMemoryContext(reason: String) {
+func sentryStartMemoryContextRefresh() {
+    guard TelemetrySettings.enabledForCurrentLaunch else { return }
+    sentryMemoryContextTask?.cancel()
+    sentryMemoryContextTask = Task.detached(priority: .utility) {
+        await sentryRefreshMemoryContext(reason: "startup")
+        while !Task.isCancelled {
+            // Intended periodic telemetry refresh; cancellation is wired to app termination.
+            do {
+                try await Task.sleep(nanoseconds: 300 * 1_000_000_000)
+            } catch {
+                break
+            }
+            await sentryRefreshMemoryContext(reason: "periodic")
+        }
+    }
+}
+
+@MainActor
+func sentryStopMemoryContextRefresh() {
+    sentryMemoryContextTask?.cancel()
+    sentryMemoryContextTask = nil
+}
+
+/// Refresh the memory/surface context attached to future Sentry events.
+func sentryRefreshMemoryContext(reason: String) async {
     guard TelemetrySettings.enabledForCurrentLaunch else { return }
 
     let processSnapshot = CmuxTopProcessSnapshot.captureCached(
         includeProcessDetails: false,
         maximumAge: 2
     )
-    let appProcess = processSnapshot.process(pid: Int(Darwin.getpid()))
-    SentrySDK.configureScope { scope in
-        scope.setContext(value: [
-            "reason": reason,
-            "sampled_at": ISO8601DateFormatter().string(from: processSnapshot.sampledAt),
-            "app": [
-                "pid": Int(Darwin.getpid()),
-                "physical_footprint_bytes": appProcess?.memoryBytes ?? 0,
-                "resident_bytes": appProcess?.residentBytes ?? 0,
-                "virtual_bytes": appProcess?.virtualBytes ?? 0,
-                "thread_count": appProcess?.threadCount ?? 0,
-                "memory_source": appProcess?.memorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue,
-                "resident_memory_source": appProcess?.residentMemorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
-            ],
-            "terminal_surfaces": GhosttyApp.terminalSurfaceRegistry.diagnosticSnapshot().payload()
-        ], key: "cmux.memory")
+    let pid = Int(Darwin.getpid())
+    let appProcess = processSnapshot.process(pid: pid)
+    let sampledAt = ISO8601DateFormatter().string(from: processSnapshot.sampledAt)
+    let physicalFootprintBytes = appProcess?.memoryBytes ?? 0
+    let residentBytes = appProcess?.residentBytes ?? 0
+    let virtualBytes = appProcess?.virtualBytes ?? 0
+    let threadCount = appProcess?.threadCount ?? 0
+    let memorySource = appProcess?.memorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
+    let residentMemorySource = appProcess?.residentMemorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
+    let surfaceSnapshot = GhosttyApp.terminalSurfaceRegistry.diagnosticSnapshot()
+
+    await MainActor.run {
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: [
+                "reason": reason,
+                "sampled_at": sampledAt,
+                "app": [
+                    "pid": pid,
+                    "physical_footprint_bytes": physicalFootprintBytes,
+                    "resident_bytes": residentBytes,
+                    "virtual_bytes": virtualBytes,
+                    "thread_count": threadCount,
+                    "memory_source": memorySource,
+                    "resident_memory_source": residentMemorySource
+                ],
+                "terminal_surfaces": surfaceSnapshot.payload()
+            ], key: "cmux.memory")
+        }
     }
 }

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CmuxTerminalEngine
 import Foundation
 import Sentry
 

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -1,3 +1,5 @@
+import Darwin
+import Foundation
 import Sentry
 
 /// Add a Sentry breadcrumb for user-action context in hang/crash reports.
@@ -42,4 +44,32 @@ func sentryCaptureError(
     contextKey: String? = nil
 ) {
     sentryCaptureMessage(message, level: .error, category: category, data: data, contextKey: contextKey)
+}
+
+/// Refresh the memory/surface context attached to future Sentry events.
+@MainActor
+func sentryRefreshMemoryContext(reason: String) {
+    guard TelemetrySettings.enabledForCurrentLaunch else { return }
+
+    let processSnapshot = CmuxTopProcessSnapshot.captureCached(
+        includeProcessDetails: false,
+        maximumAge: 2
+    )
+    let appProcess = processSnapshot.process(pid: Int(Darwin.getpid()))
+    SentrySDK.configureScope { scope in
+        scope.setContext(value: [
+            "reason": reason,
+            "sampled_at": ISO8601DateFormatter().string(from: processSnapshot.sampledAt),
+            "app": [
+                "pid": Int(Darwin.getpid()),
+                "physical_footprint_bytes": appProcess?.memoryBytes ?? 0,
+                "resident_bytes": appProcess?.residentBytes ?? 0,
+                "virtual_bytes": appProcess?.virtualBytes ?? 0,
+                "thread_count": appProcess?.threadCount ?? 0,
+                "memory_source": appProcess?.memorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue,
+                "resident_memory_source": appProcess?.residentMemorySource.rawValue ?? CmuxTopProcessMemorySource.unavailable.rawValue
+            ],
+            "terminal_surfaces": GhosttyApp.terminalSurfaceRegistry.diagnosticSnapshot().payload()
+        ], key: "cmux.memory")
+    }
 }

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -2,7 +2,8 @@ import Darwin
 import Foundation
 import Sentry
 
-@MainActor private var sentryMemoryContextTask: Task<Void, Never>?
+@MainActor private var sentryMemoryContextRefreshTask: Task<Void, Never>?
+@MainActor private var sentryMemoryContextTimer: Timer?
 
 /// Add a Sentry breadcrumb for user-action context in hang/crash reports.
 func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String: Any]? = nil) {
@@ -51,25 +52,32 @@ func sentryCaptureError(
 @MainActor
 func sentryStartMemoryContextRefresh() {
     guard TelemetrySettings.enabledForCurrentLaunch else { return }
-    sentryMemoryContextTask?.cancel()
-    sentryMemoryContextTask = Task.detached(priority: .utility) {
-        await sentryRefreshMemoryContext(reason: "startup")
-        while !Task.isCancelled {
-            // Intended periodic telemetry refresh; cancellation is wired to app termination.
-            do {
-                try await Task.sleep(nanoseconds: 300 * 1_000_000_000)
-            } catch {
-                break
-            }
-            await sentryRefreshMemoryContext(reason: "periodic")
+    sentryStopMemoryContextRefresh()
+    sentryScheduleMemoryContextRefresh(reason: "startup")
+
+    let timer = Timer(timeInterval: 300, repeats: true) { _ in
+        Task { @MainActor in
+            sentryScheduleMemoryContextRefresh(reason: "periodic")
         }
     }
+    RunLoop.main.add(timer, forMode: .common)
+    sentryMemoryContextTimer = timer
 }
 
 @MainActor
 func sentryStopMemoryContextRefresh() {
-    sentryMemoryContextTask?.cancel()
-    sentryMemoryContextTask = nil
+    sentryMemoryContextTimer?.invalidate()
+    sentryMemoryContextTimer = nil
+    sentryMemoryContextRefreshTask?.cancel()
+    sentryMemoryContextRefreshTask = nil
+}
+
+@MainActor
+private func sentryScheduleMemoryContextRefresh(reason: String) {
+    sentryMemoryContextRefreshTask?.cancel()
+    sentryMemoryContextRefreshTask = Task.detached(priority: .utility) {
+        await sentryRefreshMemoryContext(reason: reason)
+    }
 }
 
 /// Refresh the memory/surface context attached to future Sentry events.

--- a/scripts/capture-memory.sh
+++ b/scripts/capture-memory.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/capture-memory.sh --pid <pid> [--out <dir>] [--heavy]
+
+Capture memory diagnostics for a live process. The default capture is lightweight
+and safe for a primary cmux instance: ps, footprint, and vmmap -summary. Pass
+--heavy to also run leaks and malloc_history; use that only on a fresh profiled
+instance because heap walks can freeze a busy terminal host.
+USAGE
+}
+
+pid=""
+out_dir=""
+heavy="false"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pid)
+      pid="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out_dir="${2:-}"
+      shift 2
+      ;;
+    --heavy)
+      heavy="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "capture-memory: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$pid" =~ ^[0-9]+$ ]] || ! ps -p "$pid" >/dev/null 2>&1; then
+  echo "capture-memory: --pid must name a live process" >&2
+  usage
+  exit 2
+fi
+
+if [ -z "$out_dir" ]; then
+  out_dir="memory-capture-${pid}-$(date +%Y%m%d-%H%M%S)"
+fi
+mkdir -p "$out_dir"
+
+run_capture() {
+  local name="$1"
+  shift
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n'
+    "$@"
+  } > "$out_dir/$name.txt" 2>&1 || {
+    rc="$?"
+    printf '\ncommand exited with %s\n' "$rc" >> "$out_dir/$name.txt"
+  }
+}
+
+run_capture "ps" ps -o pid,ppid,lstart,etime,rss,vsz,command -p "$pid"
+run_capture "footprint-summary" footprint -summary -pid "$pid"
+run_capture "vmmap-summary" vmmap -summary "$pid"
+
+if [ "$heavy" = "true" ]; then
+  run_capture "leaks" leaks "$pid"
+  run_capture "malloc-history-all-by-size" malloc_history "$pid" -allBySize
+else
+  cat > "$out_dir/heavy-tools-skipped.txt" <<'EOF'
+Skipped leaks and malloc_history.
+
+Pass --heavy only for a fresh instance launched with MallocStackLogging when a
+heap walk is acceptable. Running heavy tools against a primary terminal-hosting
+cmux process can freeze the user's active terminal.
+EOF
+fi
+
+cat > "$out_dir/manifest.json" <<EOF
+{
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "pid": $pid,
+  "heavy": $heavy
+}
+EOF
+
+printf 'memory capture written to %s\n' "$out_dir"

--- a/scripts/capture-memory.sh
+++ b/scripts/capture-memory.sh
@@ -19,11 +19,21 @@ heavy="false"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --pid)
-      pid="${2:-}"
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "capture-memory: --pid requires a value" >&2
+        usage
+        exit 2
+      fi
+      pid="$2"
       shift 2
       ;;
     --out)
-      out_dir="${2:-}"
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "capture-memory: --out requires a value" >&2
+        usage
+        exit 2
+      fi
+      out_dir="$2"
       shift 2
       ;;
     --heavy)


### PR DESCRIPTION
Closes #6266

## Summary

This PR does not claim a speculative renderer/WebKit/native-heap fix. I first checked the version context from #6266:

- #5561's `publishV2` JSON retention fix is already on this branch/current main: `CmuxSocketEventMapper.publish` wraps the JSON parse/publish path in `autoreleasepool`, and `CmuxEventBusTests.testPublishV2ReadTextResponseDoesNotAccumulateOnLongLivedThread` covers the prior large-response leak.
- The reporter's 0.64.14 sample shape still points at native/GPU/WebKit memory rather than `publishV2`, but I could not get an accelerated current-main cloud repro because the cloud Mac lease timed out waiting for `cmux-loader-27648982604` to appear in local Tailscale/MagicDNS.

Given that, this PR ships the low-risk hardening requested in the issue:

1. `scripts/capture-memory.sh` captures `ps`, `footprint`, and `vmmap -summary` by default, with explicit `--heavy` for `leaks` and `malloc_history` only on a fresh profiled instance.
2. Sentry events carry a refreshed `cmux.memory` context containing app footprint/RSS/thread count and live terminal surface/runtime-surface counts. Sampling runs off the main actor and refreshes at startup plus activity-driven Sentry breadcrumb/capture points with a 5-minute throttle, with no timer or sleep loop.
3. `TerminalSurfaceRegistry` exposes a bounded diagnostic snapshot, with a regression invariant proving unregistered/deallocated surfaces and freed runtime pointers drop out of the counts.

## Evidence

Local live production cmux 0.64.16 (96), pid 72227, was sampled read-only with `footprint` and `vmmap -summary`:

- Physical footprint: 1.465 GB, peak 1.485 GB after ~82 minutes.
- Largest categories: `MALLOC_SMALL` 483 MB, `IOSurface` 431 MB, graphics unmapped 264 MB, `IOAccelerator` 100 MB.
- This is not the 11 GB 0.64.14 failure shape, but it confirms the useful telemetry categories for the next recurrence.

Sentry lookup was attempted with the provided workflow, but this shell is not authenticated (`sentry auth status` reports not authenticated) and no Sentry token/org/project environment variables are present, so the pid 708 event could not be fetched from here.

Cloud Mac accelerated repro was attempted through the required skill. GitHub Actions run https://github.com/manaflow-ai/cmux-loader/actions/runs/27648982604 reached the VM hold step, but local discovery timed out waiting for `cmux-loader-27648982604`; `macfleet devices` also could not be used because no local token is stored. The held runner was canceled.

## Testing

- Red commit: `aae49b5d7 test: add terminal surface registry diagnostics invariant` fails because `TerminalSurfaceRegistry.diagnosticSnapshot()` does not exist.
- Green focused test: `swift test --package-path Packages/CmuxTerminalEngine --filter TerminalSurfaceRegistryTests/diagnosticSnapshotDropsUnregisteredSurfacesAndRuntimePointers`
- Script syntax/smoke: `bash -n scripts/capture-memory.sh` and `scripts/capture-memory.sh --pid $$ --out /tmp/cmux-capture-memory-smoke-event-refresh-$$`
- Script malformed option checks for missing `--pid` and `--out` values.
- Guard checks: `./tests/test_ci_swift_file_length_budget.sh`, `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`, `./tests/test_ci_pbxproj_test_wiring.sh`, `./scripts/check-pbxproj.sh`.
- Local policy check: `/Users/austinwang/manaflow/cmuxterm-hq/skills/autoreview/scripts/cmux-policy-check --mode branch --base origin/main`.

No local app build, `reload.sh`, bare `xcodebuild`, or app launch was run.

## Demo Video

No demo video is available. The cloud Mac attempt did not become reachable through local Tailscale/MagicDNS, and this PR does not launch a local app build by instruction.

## Checklist

- [x] Confirmed #5561 publishV2 leak fix is already on current main.
- [x] Captured read-only local `footprint`/`vmmap -summary` evidence from the already-running production app.
- [x] Attempted Sentry lookup and documented authentication blocker.
- [x] Attempted cloud Mac accelerated repro and documented reachability blocker.
- [x] Added memory capture script with heavy tools gated behind `--heavy`.
- [x] Added Sentry memory/surface context hardening without main-actor sampling.
- [x] Added behavioral registry teardown invariant test.
- [x] Addressed CodeRabbit and Greptile actionable feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal surface diagnostic snapshot API to expose live registered and placement counts, plus runtime registration metrics.
  * Enabled refresh of Sentry memory/process context as the app launches and exits, and refreshes on relevant capture activity.
  * Introduced a new script to capture memory diagnostics for a target process (with an optional “heavy” mode).
* **Tests**
  * Added coverage verifying diagnostic snapshots exclude deallocated/unregistered surfaces and stale runtime pointers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->