### PR TITLE
Centralize agent continuation replay policy

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14975,6 +14975,8 @@ struct CMUXCLI {
               close-left | close-right | close-others
               new-terminal-right | new-browser-right
               move-to-new-workspace
+              fork | fork-right | fork-left | fork-top | fork-bottom
+              fork-new-tab | fork-new-workspace
               reload | duplicate
               pin | unpin
               mark-unread
@@ -14992,6 +14994,7 @@ struct CMUXCLI {
             Example:
               cmux tab-action --tab tab:3 --action pin
               cmux tab-action --action close-right
+              cmux tab-action --action fork-right
               cmux tab-action --tab tab:2 --action move-to-new-workspace
               cmux tab-action --tab tab:2 --action rename --title "build logs"
             """

--- a/Packages/CMUXAgentContinuation/Package.swift
+++ b/Packages/CMUXAgentContinuation/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CMUXAgentContinuation",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CMUXAgentContinuation",
+            targets: ["CMUXAgentContinuation"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CMUXAgentContinuation",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CMUXAgentContinuationTests",
+            dependencies: ["CMUXAgentContinuation"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/AgentContinuationEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/AgentContinuationEnvironmentPolicy.swift
@@ -1,0 +1,255 @@
+import Foundation
+
+/// Selects the non-secret environment values required to continue an agent session.
+public enum AgentContinuationEnvironmentPolicy {
+    private static let commonKeys: Set<String> = [
+        "GH_HOST",
+        "USE_BUILTIN_RIPGREP",
+    ]
+
+    private static let keysByKind: [String: Set<String>] = [
+        "amp": [
+            "AMP_LOG_FILE",
+            "AMP_LOG_LEVEL",
+            "AMP_SETTINGS_FILE",
+            "AMP_URL",
+        ],
+        "antigravity": [
+            "GEMINI_CLI_HOME",
+        ],
+        "claude": [
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_MODEL",
+            "CLAUDE_CONFIG_DIR",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CMUX_CUSTOM_CLAUDE_PATH",
+        ],
+        "codex": [
+            "CODEX_HOME",
+        ],
+        "codebuddy": [
+            "CODEBUDDY_BASE_URL",
+            "CODEBUDDY_CONFIG_DIR",
+            "CODEBUDDY_ENV_FILE",
+            "CODEBUDDY_INTERNET_ENVIRONMENT",
+            "CODEBUDDY_MODEL",
+            "CODEBUDDY_SMALL_FAST_MODEL",
+        ],
+        "copilot": [
+            "COPILOT_GH_HOST",
+            "COPILOT_HOME",
+            "COPILOT_MODEL",
+            "COPILOT_OFFLINE",
+            "COPILOT_PROVIDER_BASE_URL",
+            "COPILOT_PROVIDER_MAX_OUTPUT_TOKENS",
+            "COPILOT_PROVIDER_MAX_PROMPT_TOKENS",
+            "COPILOT_PROVIDER_MODEL_ID",
+            "COPILOT_PROVIDER_TYPE",
+            "COPILOT_PROVIDER_WIRE_API",
+            "COPILOT_PROVIDER_WIRE_MODEL",
+        ],
+        "cursor": [
+            "CURSOR_AGENT_HOME",
+            "CURSOR_CONFIG_DIR",
+            "CURSOR_HOME",
+        ],
+        "factory": [],
+        "gemini": [
+            "GEMINI_CLI_HOME",
+        ],
+        "grok": [
+            "GROK_HOME",
+            "GROK_SANDBOX",
+        ],
+        "hermes-agent": [
+            "CODEX_HOME",
+            "CUSTOM_BASE_URL",
+            "HERMES_CODEX_BASE_URL",
+            "HERMES_HOME",
+        ],
+        "kiro": [
+            "KIRO_HOME",
+            "KIRO_LOG_LEVEL",
+            "KIRO_LOG_NO_COLOR",
+        ],
+        "omp": [
+            "PI_CACHE_RETENTION",
+            "PI_CODING_AGENT_DIR",
+            "PI_CODING_AGENT_SESSION_DIR",
+            "PI_CONFIG_DIR",
+            "PI_OFFLINE",
+            "PI_PACKAGE_DIR",
+            "PI_SKIP_VERSION_CHECK",
+        ],
+        "opencode": [
+            "OPENCODE_CONFIG_DIR",
+        ],
+        "pi": [
+            "PI_CACHE_RETENTION",
+            "PI_CODING_AGENT_DIR",
+            "PI_CODING_AGENT_SESSION_DIR",
+            "PI_CONFIG_DIR",
+            "PI_OFFLINE",
+            "PI_PACKAGE_DIR",
+            "PI_SKIP_VERSION_CHECK",
+        ],
+        "qoder": [
+            "QODER_CONFIG_DIR",
+        ],
+        "rovodev": [
+            "CMUX_ROVODEV_SESSIONS_DIR",
+        ],
+    ]
+
+    private static let nodeOptionsKinds: Set<String> = [
+        "claude",
+    ]
+
+    /// Returns the continuation-safe environment for `kind`.
+    public static func selectedEnvironment(from env: [String: String], kind: String? = nil) -> [String: String] {
+        let normalizedKind = canonicalKind(kind)
+        let allowedKeys = commonKeys.union(normalizedKind.flatMap { keysByKind[$0] } ?? [])
+        var result: [String: String] = [:]
+        for key in allowedKeys.sorted() {
+            guard let value = sanitizedValue(key: key, value: env[key]) else { continue }
+            result[key] = value
+        }
+        if let normalizedKind,
+           nodeOptionsKinds.contains(normalizedKind),
+           let nodeOptions = selectedNodeOptions(from: env) {
+            result["NODE_OPTIONS"] = nodeOptions
+        }
+        return result
+    }
+
+    private static func canonicalKind(_ kind: String?) -> String? {
+        guard let normalized = kind?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !normalized.isEmpty
+        else {
+            return nil
+        }
+        switch normalized {
+        case "claudeteams", "claude-teams":
+            return "claude"
+        case "codexteams", "codex-teams":
+            return "codex"
+        case "omo", "omx", "omc":
+            return "opencode"
+        case "rovo", "rovo-dev", "rovodev":
+            return "rovodev"
+        default:
+            return normalized
+        }
+    }
+
+    /// Returns a sanitized value for a continuation-safe key, or `nil` when the key is not safe.
+    public static func sanitizedValue(key: String, value: String?) -> String? {
+        guard commonKeys.contains(key) || keysByKind.values.contains(where: { $0.contains(key) }) || key == "NODE_OPTIONS" else {
+            return nil
+        }
+        switch key {
+        case "CLAUDE_CONFIG_DIR":
+            return value.map { ClaudeConfigDirectoryPath.preferredPath($0) }
+        case "NODE_OPTIONS":
+            return sanitizedNodeOptions(value)
+        default:
+            return value
+        }
+    }
+
+    private static func selectedNodeOptions(from env: [String: String]) -> String? {
+        switch normalizedValue(env["CMUX_ORIGINAL_NODE_OPTIONS_PRESENT"]) {
+        case "1":
+            return sanitizedNodeOptions(env["CMUX_ORIGINAL_NODE_OPTIONS"])
+        case "0":
+            return nil
+        default:
+            return sanitizedNodeOptions(env["NODE_OPTIONS"])
+        }
+    }
+
+    private static func sanitizedNodeOptions(_ rawValue: String?) -> String? {
+        let tokens = rawValue?
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init) ?? []
+        guard !tokens.isEmpty else { return nil }
+
+        var sanitized: [String] = []
+        var index = 0
+        var shouldDropInjectedHeapCap = false
+        while index < tokens.count {
+            let token = tokens[index]
+
+            if shouldDropInjectedHeapCap, isInjectedNodeHeapCap(tokens, index: index) {
+                index += nodeHeapCapWidth(tokens, index: index)
+                shouldDropInjectedHeapCap = false
+                continue
+            }
+            shouldDropInjectedHeapCap = false
+
+            if isRequireOption(token), index + 1 < tokens.count,
+               isCmuxNodeOptionsRestoreModulePath(tokens[index + 1]) {
+                index += 2
+                shouldDropInjectedHeapCap = true
+                continue
+            }
+            if let path = inlineRequireOptionPath(token),
+               isCmuxNodeOptionsRestoreModulePath(path) {
+                index += 1
+                shouldDropInjectedHeapCap = true
+                continue
+            }
+
+            sanitized.append(token)
+            index += 1
+        }
+
+        let joined = sanitized.joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return joined.isEmpty ? nil : joined
+    }
+
+    private static func normalizedValue(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func isRequireOption(_ token: String) -> Bool {
+        token == "--require" || token == "-r"
+    }
+
+    private static func inlineRequireOptionPath(_ token: String) -> String? {
+        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
+            return String(token.dropFirst(prefix.count))
+        }
+        return nil
+    }
+
+    private static func isCmuxNodeOptionsRestoreModulePath(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
+        guard URL(fileURLWithPath: trimmed).lastPathComponent == "restore-node-options.cjs" else {
+            return false
+        }
+        return trimmed.contains("/cmux-")
+    }
+
+    private static func isInjectedNodeHeapCap(_ tokens: [String], index: Int) -> Bool {
+        guard index < tokens.count else { return false }
+        let token = tokens[index]
+        if token == "--max-old-space-size" {
+            return index + 1 < tokens.count && tokens[index + 1] == "4096"
+        }
+        return token == "--max-old-space-size=4096"
+    }
+
+    private static func nodeHeapCapWidth(_ tokens: [String], index: Int) -> Int {
+        guard index < tokens.count else { return 1 }
+        return tokens[index] == "--max-old-space-size" ? min(2, tokens.count - index) : 1
+    }
+}

--- a/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/ClaudeConfigDirectoryPath.swift
+++ b/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/ClaudeConfigDirectoryPath.swift
@@ -1,0 +1,26 @@
+public import Foundation
+
+/// Resolves legacy Claude account-manager config roots to their current location.
+public enum ClaudeConfigDirectoryPath {
+    /// Returns the preferred config path for `rawPath`, migrating old subrouter roots when possible.
+    public static func preferredPath(
+        _ rawPath: String,
+        fileManager: FileManager = .default,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return rawPath }
+
+        let standardized = ((trimmed as NSString).expandingTildeInPath as NSString).standardizingPath
+        let home = ((homeDirectory as NSString).expandingTildeInPath as NSString).standardizingPath
+        let legacyRoot = ((home as NSString).appendingPathComponent(".subrouter/codex/claude") as NSString).standardizingPath
+        guard standardized == legacyRoot || standardized.hasPrefix(legacyRoot + "/") else { return standardized }
+
+        let accountRoot = ((home as NSString).appendingPathComponent(".codex-accounts/claude") as NSString).standardizingPath
+        let candidate = accountRoot + String(standardized.dropFirst(legacyRoot.count))
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: candidate, isDirectory: &isDirectory) && isDirectory.boolValue
+            ? candidate
+            : standardized
+    }
+}

--- a/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/CodexContinuationArguments.swift
+++ b/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/CodexContinuationArguments.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+/// Rewrites Codex launch argv into the option tail that is safe to replay for resume/fork.
+public struct CodexContinuationArguments: Sendable, Equatable {
+    private let valueOptions: Set<String>
+    private let droppedOptions: Set<String>
+    private let droppedOptionPrefixes: [String]
+    private let variadicDroppedOptions: Set<String>
+    private let rejectedCommands: Set<String>
+    private let runtimeOnlyOptions: Set<String>
+    private let continuationCommands: Set<String>
+
+    /// Creates a Codex continuation rewriter.
+    public init(
+        valueOptions: Set<String> = [
+            "--add-dir",
+            "--ask-for-approval",
+            "-a",
+            "--cd",
+            "-C",
+            "--config",
+            "-c",
+            "--disable",
+            "--enable",
+            "--image",
+            "-i",
+            "--local-provider",
+            "--model",
+            "-m",
+            "--profile",
+            "-p",
+            "--remote",
+            "--remote-auth-token-env",
+            "--sandbox",
+            "-s",
+        ],
+        droppedOptions: Set<String> = [
+            "--all",
+            "--image",
+            "-i",
+            "--last",
+            "--remote",
+            "--remote-auth-token-env",
+        ],
+        droppedOptionPrefixes: [String] = [
+            "--image=",
+            "--remote=",
+            "--remote-auth-token-env=",
+        ],
+        variadicDroppedOptions: Set<String> = [
+            "--image",
+            "-i",
+        ],
+        rejectedCommands: Set<String> = [
+            "app",
+            "app-server",
+            "apply",
+            "archive",
+            "cloud",
+            "completion",
+            "debug",
+            "delete",
+            "doctor",
+            "exec",
+            "exec-server",
+            "features",
+            "help",
+            "login",
+            "logout",
+            "mcp",
+            "mcp-server",
+            "plugin",
+            "remote-control",
+            "review",
+            "sandbox",
+            "unarchive",
+            "update",
+        ],
+        runtimeOnlyOptions: Set<String> = [
+            "--use-system-ca",
+        ],
+        continuationCommands: Set<String> = [
+            "fork",
+            "resume",
+        ]
+    ) {
+        self.valueOptions = valueOptions
+        self.droppedOptions = droppedOptions
+        self.droppedOptionPrefixes = droppedOptionPrefixes
+        self.variadicDroppedOptions = variadicDroppedOptions
+        self.rejectedCommands = rejectedCommands
+        self.runtimeOnlyOptions = runtimeOnlyOptions
+        self.continuationCommands = continuationCommands
+    }
+
+    /// Returns the replay-safe option tail, preserving unknown option tokens by default.
+    public func preservedTail(_ args: [String]) -> [String]? {
+        rewrite(args).preserved
+    }
+
+    /// Returns the replay-safe option tail for a captured `fork` launch.
+    public func preservedForkTail(_ args: [String]) -> [String]? {
+        rewrite(args).preserved
+    }
+
+    private func rewrite(_ args: [String]) -> RewriteResult {
+        var result: [String] = []
+        var index = 0
+        var previousUnknownOptionNeedsValue = false
+        var skippingContinuationSession = false
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" {
+                break
+            }
+
+            if !isOption(arg) {
+                if continuationCommands.contains(arg) {
+                    index += 1
+                    skippingContinuationSession = true
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                if rejectedCommands.contains(arg) {
+                    return .rejected
+                }
+                if skippingContinuationSession, looksLikeSessionIdentifier(arg) {
+                    index += 1
+                    while index < args.count, !isOption(args[index]) {
+                        index += 1
+                    }
+                    skippingContinuationSession = false
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                if previousUnknownOptionNeedsValue,
+                   containsContinuationCommand(after: index, in: args) {
+                    result.append(arg)
+                    index += 1
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                break
+            }
+
+            previousUnknownOptionNeedsValue = false
+            if droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) }) || runtimeOnlyOption(arg) {
+                index += droppedOptionWidth(args, index: index)
+                continue
+            }
+            if droppedOptions.contains(optionName(arg)) {
+                index += droppedOptionWidth(args, index: index)
+                continue
+            }
+
+            if arg.contains("=") {
+                result.append(arg)
+                index += 1
+                continue
+            }
+
+            if valueOptions.contains(arg) {
+                let width = optionWidth(args, index: index)
+                result.append(contentsOf: args[index..<min(args.count, index + width)])
+                index += width
+                continue
+            }
+
+            result.append(arg)
+            previousUnknownOptionNeedsValue = true
+            index += 1
+        }
+        return .accepted(result)
+    }
+
+    private func containsContinuationCommand(after start: Int, in args: [String]) -> Bool {
+        guard start < args.count else { return false }
+        var index = start
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" {
+                return false
+            }
+            if continuationCommands.contains(arg) {
+                return true
+            }
+            index += 1
+        }
+        return false
+    }
+
+    private func optionWidth(_ args: [String], index: Int) -> Int {
+        let arg = args[index]
+        if arg.contains("=") {
+            return 1
+        }
+        guard valueOptions.contains(arg), index + 1 < args.count else {
+            return 1
+        }
+        return 2
+    }
+
+    private func droppedOptionWidth(_ args: [String], index: Int) -> Int {
+        let arg = args[index]
+        if arg.contains("=") {
+            return 1
+        }
+        guard variadicDroppedOptions.contains(arg) else {
+            return optionWidth(args, index: index)
+        }
+        var end = index + 1
+        while end < args.count, !isOption(args[end]) {
+            end += 1
+        }
+        return max(1, end - index)
+    }
+
+    private func looksLikeSessionIdentifier(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 20 else { return false }
+        if trimmed.hasPrefix("019") {
+            return true
+        }
+        let allowed = CharacterSet(charactersIn: "0123456789abcdefABCDEF-")
+        return trimmed.unicodeScalars.allSatisfy { allowed.contains($0) } && trimmed.contains("-")
+    }
+
+    private func runtimeOnlyOption(_ arg: String) -> Bool {
+        runtimeOnlyOptions.contains(optionName(arg))
+    }
+
+    private func optionName(_ arg: String) -> String {
+        guard let equals = arg.firstIndex(of: "=") else { return arg }
+        return String(arg[..<equals])
+    }
+
+    private func isOption(_ arg: String) -> Bool {
+        arg.hasPrefix("-") && arg != "-"
+    }
+
+    private enum RewriteResult: Equatable {
+        case accepted([String])
+        case rejected
+
+        var preserved: [String]? {
+            switch self {
+            case .accepted(let args):
+                return args
+            case .rejected:
+                return nil
+            }
+        }
+    }
+}

--- a/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/CursorContinuationArguments.swift
+++ b/Packages/CMUXAgentContinuation/Sources/CMUXAgentContinuation/CursorContinuationArguments.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// Rewrites Cursor Agent launch argv into the option tail that is safe to replay for resume.
+public struct CursorContinuationArguments: Sendable, Equatable {
+    private let valueOptions: Set<String>
+    private let optionalValueOptions: Set<String>
+    private let droppedOptions: Set<String>
+    private let droppedOptionPrefixes: [String]
+    private let rejectedOptions: Set<String>
+    private let rejectedCommands: Set<String>
+    private let continuationCommands: Set<String>
+
+    /// Creates a Cursor continuation rewriter.
+    public init(
+        valueOptions: Set<String> = [
+            "--api-key",
+            "-H",
+            "--header",
+            "--mode",
+            "--model",
+            "--output-format",
+            "--resume",
+            "--sandbox",
+            "--workspace",
+            "-w",
+            "--worktree",
+            "--worktree-base",
+        ],
+        optionalValueOptions: Set<String> = [
+            "-w",
+            "--resume",
+            "--worktree",
+        ],
+        droppedOptions: Set<String> = [
+            "--api-key",
+            "-H",
+            "--header",
+            "--continue",
+            "--resume",
+            "--workspace",
+            "-w",
+            "--worktree",
+            "--worktree-base",
+            "--skip-worktree-setup",
+        ],
+        droppedOptionPrefixes: [String] = [
+            "--api-key=",
+            "--header=",
+            "-H=",
+            "--resume=",
+            "--workspace=",
+            "--worktree=",
+            "--worktree-base=",
+        ],
+        rejectedOptions: Set<String> = [
+            "--cloud",
+            "--output-format",
+            "--print",
+            "-p",
+            "--stream-partial-output",
+        ],
+        rejectedCommands: Set<String> = [
+            "about",
+            "create-chat",
+            "generate-rule",
+            "help",
+            "install-shell-integration",
+            "login",
+            "logout",
+            "ls",
+            "mcp",
+            "models",
+            "rule",
+            "status",
+            "uninstall-shell-integration",
+            "update",
+            "whoami",
+        ],
+        continuationCommands: Set<String> = [
+            "resume",
+        ]
+    ) {
+        self.valueOptions = valueOptions
+        self.optionalValueOptions = optionalValueOptions
+        self.droppedOptions = droppedOptions
+        self.droppedOptionPrefixes = droppedOptionPrefixes
+        self.rejectedOptions = rejectedOptions
+        self.rejectedCommands = rejectedCommands
+        self.continuationCommands = continuationCommands
+    }
+
+    /// Returns the replay-safe option tail, preserving unknown option tokens by default.
+    public func preservedTail(_ args: [String]) -> [String]? {
+        var tail = args
+        if tail.first == "agent" {
+            tail.removeFirst()
+        }
+        return rewrite(tail).preserved
+    }
+
+    private func rewrite(_ args: [String]) -> RewriteResult {
+        var result: [String] = []
+        var index = 0
+        var previousUnknownOptionNeedsValue = false
+        var skippingContinuationSession = false
+
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" {
+                break
+            }
+
+            if !isOption(arg) {
+                if continuationCommands.contains(arg) {
+                    index += 1
+                    skippingContinuationSession = true
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                if rejectedCommands.contains(arg) {
+                    return .rejected
+                }
+                if skippingContinuationSession {
+                    index += 1
+                    while index < args.count, !isOption(args[index]) {
+                        index += 1
+                    }
+                    skippingContinuationSession = false
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                if previousUnknownOptionNeedsValue,
+                   containsContinuationCommand(after: index, in: args) {
+                    result.append(arg)
+                    index += 1
+                    previousUnknownOptionNeedsValue = false
+                    continue
+                }
+                break
+            }
+
+            previousUnknownOptionNeedsValue = false
+            if rejectedOptions.contains(optionName(arg)) {
+                return .rejected
+            }
+            if droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) })
+                || droppedOptions.contains(optionName(arg)) {
+                index += optionWidth(args, index: index)
+                continue
+            }
+
+            if arg.contains("=") {
+                result.append(arg)
+                index += 1
+                continue
+            }
+
+            if valueOptions.contains(arg) {
+                let width = optionWidth(args, index: index)
+                result.append(contentsOf: args[index..<min(args.count, index + width)])
+                index += width
+                continue
+            }
+
+            result.append(arg)
+            previousUnknownOptionNeedsValue = true
+            index += 1
+        }
+        return .accepted(result)
+    }
+
+    private func containsContinuationCommand(after start: Int, in args: [String]) -> Bool {
+        guard start < args.count else { return false }
+        var index = start
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" {
+                return false
+            }
+            if continuationCommands.contains(arg) {
+                return true
+            }
+            index += 1
+        }
+        return false
+    }
+
+    private func optionWidth(_ args: [String], index: Int) -> Int {
+        let arg = args[index]
+        if arg.contains("=") {
+            return 1
+        }
+        guard valueOptions.contains(arg), index + 1 < args.count else {
+            return 1
+        }
+        if optionalValueOptions.contains(arg), isOption(args[index + 1]) {
+            return 1
+        }
+        return 2
+    }
+
+    private func optionName(_ arg: String) -> String {
+        guard let equals = arg.firstIndex(of: "=") else { return arg }
+        return String(arg[..<equals])
+    }
+
+    private func isOption(_ arg: String) -> Bool {
+        arg.hasPrefix("-") && arg != "-"
+    }
+
+    private enum RewriteResult: Equatable {
+        case accepted([String])
+        case rejected
+
+        var preserved: [String]? {
+            switch self {
+            case .accepted(let args):
+                return args
+            case .rejected:
+                return nil
+            }
+        }
+    }
+}

--- a/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/AgentContinuationEnvironmentPolicyTests.swift
+++ b/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/AgentContinuationEnvironmentPolicyTests.swift
@@ -1,0 +1,100 @@
+import CMUXAgentContinuation
+import Testing
+
+@Suite("AgentContinuationEnvironmentPolicy")
+struct AgentContinuationEnvironmentPolicyTests {
+    @Test("Codex keeps CODEX_HOME and drops Claude account environment")
+    func codexKeepsCodexHomeAndDropsClaudeAccountEnvironment() {
+        let selected = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+                "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1781081935106",
+                "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+                "OPENAI_API_KEY": "secret",
+            ],
+            kind: "codex"
+        )
+
+        #expect(selected == [
+            "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+        ])
+    }
+
+    @Test("Wrapper launcher names use the underlying agent environment policy")
+    func wrapperLauncherNamesUseUnderlyingAgentEnvironmentPolicy() {
+        let codexTeams = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+                "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1781081935106",
+                "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+            ],
+            kind: "codexTeams"
+        )
+        let openCodeAlias = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "OPENCODE_CONFIG_DIR": "/Users/example/.opencode-alt",
+                "CLAUDE_CONFIG_DIR": "/Users/example/.claude",
+            ],
+            kind: "omo"
+        )
+
+        #expect(codexTeams == [
+            "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+        ])
+        #expect(openCodeAlias == [
+            "OPENCODE_CONFIG_DIR": "/Users/example/.opencode-alt",
+        ])
+    }
+
+    @Test("Cursor keeps config roots without persisting auth")
+    func cursorKeepsConfigRootsWithoutPersistingAuth() {
+        let selected = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "CURSOR_CONFIG_DIR": "/Users/example/.cursor-alt",
+                "CURSOR_AGENT_HOME": "/Users/example/.cursor-agent",
+                "CURSOR_HOME": "/Users/example/.cursor-home",
+                "CURSOR_API_KEY": "secret",
+                "OPENAI_API_KEY": "secret",
+            ],
+            kind: "cursor"
+        )
+
+        #expect(selected == [
+            "CURSOR_AGENT_HOME": "/Users/example/.cursor-agent",
+            "CURSOR_CONFIG_DIR": "/Users/example/.cursor-alt",
+            "CURSOR_HOME": "/Users/example/.cursor-home",
+        ])
+    }
+
+    @Test("Antigravity keeps Gemini home without persisting auth")
+    func antigravityKeepsGeminiHomeWithoutPersistingAuth() {
+        let selected = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "GEMINI_CLI_HOME": "/Users/example/.gemini-alt",
+                "GEMINI_API_KEY": "secret",
+            ],
+            kind: "antigravity"
+        )
+
+        #expect(selected == [
+            "GEMINI_CLI_HOME": "/Users/example/.gemini-alt",
+        ])
+    }
+
+    @Test("Claude keeps Claude environment and drops Codex home")
+    func claudeKeepsClaudeEnvironmentAndDropsCodexHome() {
+        let selected = AgentContinuationEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+                "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1781081935106",
+                "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+            ],
+            kind: "claude"
+        )
+
+        #expect(selected == [
+            "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+            "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1781081935106",
+        ])
+    }
+}

--- a/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/CodexContinuationArgumentsTests.swift
+++ b/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/CodexContinuationArgumentsTests.swift
@@ -1,0 +1,84 @@
+import CMUXAgentContinuation
+import Testing
+
+@Suite("CodexContinuationArguments")
+struct CodexContinuationArgumentsTests {
+    @Test("Preserves future boolean flags and yolo for resume")
+    func preservesFutureBooleanFlagsAndYoloForResume() {
+        let preserved = CodexContinuationArguments().preservedTail([
+            "--yolo",
+            "--future-runtime-flag",
+            "--model",
+            "gpt-5.4",
+            "initial prompt must not replay",
+        ])
+
+        #expect(preserved == [
+            "--yolo",
+            "--future-runtime-flag",
+            "--model",
+            "gpt-5.4",
+        ])
+    }
+
+    @Test("Preserves future equals-value flags")
+    func preservesFutureEqualsValueFlags() {
+        let preserved = CodexContinuationArguments().preservedTail([
+            "--future-mode=fast",
+            "--model",
+            "gpt-5.4",
+            "initial prompt must not replay",
+        ])
+
+        #expect(preserved == [
+            "--future-mode=fast",
+            "--model",
+            "gpt-5.4",
+        ])
+    }
+
+    @Test("Preserves unknown value flags before explicit fork command")
+    func preservesUnknownValueFlagsBeforeExplicitForkCommand() {
+        let preserved = CodexContinuationArguments().preservedForkTail([
+            "--future-profile",
+            "experimental",
+            "fork",
+            "019dad34-d218-7943-b81a-eddac5c87951",
+            "--yolo",
+            "fork prompt must not replay",
+        ])
+
+        #expect(preserved == [
+            "--future-profile",
+            "experimental",
+            "--yolo",
+        ])
+    }
+
+    @Test("Drops transient remotes, image prompts, and old session selectors")
+    func dropsTransientArguments() {
+        let preserved = CodexContinuationArguments().preservedForkTail([
+            "--image",
+            "/tmp/screenshot.png",
+            "--remote",
+            "ws://127.0.0.1:1",
+            "--remote-auth-token-env=CODEX_TOKEN",
+            "fork",
+            "019dad34-d218-7943-b81a-eddac5c87951",
+            "--model",
+            "gpt-5.4",
+            "fork prompt must not replay",
+        ])
+
+        #expect(preserved == [
+            "--model",
+            "gpt-5.4",
+        ])
+    }
+
+    @Test("Rejects noninteractive commands")
+    func rejectsNoninteractiveCommands() {
+        #expect(CodexContinuationArguments().preservedTail(["exec", "fix this"]) == nil)
+        #expect(CodexContinuationArguments().preservedTail(["review", "--base", "main"]) == nil)
+    }
+}

--- a/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/CursorContinuationArgumentsTests.swift
+++ b/Packages/CMUXAgentContinuation/Tests/CMUXAgentContinuationTests/CursorContinuationArgumentsTests.swift
@@ -1,0 +1,57 @@
+import CMUXAgentContinuation
+import Testing
+
+@Suite("CursorContinuationArguments")
+struct CursorContinuationArgumentsTests {
+    @Test("Drops old resume selectors, workspace selectors, auth, and original prompt")
+    func dropsOldResumeWorkspaceAuthAndPrompt() {
+        let preserved = CursorContinuationArguments().preservedTail([
+            "agent",
+            "--model",
+            "gpt-5.4",
+            "--resume",
+            "old-chat",
+            "--workspace",
+            "/tmp/old repo",
+            "-H",
+            "Authorization: Bearer secret",
+            "--sandbox",
+            "enabled",
+            "initial prompt should not replay",
+        ])
+
+        #expect(preserved == [
+            "--model",
+            "gpt-5.4",
+            "--sandbox",
+            "enabled",
+        ])
+    }
+
+    @Test("Preserves future Cursor flags before explicit resume command")
+    func preservesFutureFlagsBeforeExplicitResumeCommand() {
+        let preserved = CursorContinuationArguments().preservedTail([
+            "--future-mode",
+            "sticky",
+            "--future-bool",
+            "resume",
+            "cursor-chat-123",
+            "--model",
+            "gpt-5.4",
+        ])
+
+        #expect(preserved == [
+            "--future-mode",
+            "sticky",
+            "--future-bool",
+            "--model",
+            "gpt-5.4",
+        ])
+    }
+
+    @Test("Rejects noninteractive Cursor launches")
+    func rejectsNoninteractiveLaunches() {
+        #expect(CursorContinuationArguments().preservedTail(["--print", "fix this"]) == nil)
+        #expect(CursorContinuationArguments().preservedTail(["login"]) == nil)
+    }
+}

--- a/Packages/CMUXAgentLaunch/Package.swift
+++ b/Packages/CMUXAgentLaunch/Package.swift
@@ -13,12 +13,16 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(path: "../CMUXAgentContinuation"),
         .package(path: "../CMUXAgentVault"),
     ],
     targets: [
         .target(
             name: "CMUXAgentLaunch",
-            dependencies: ["CMUXAgentVault"]
+            dependencies: [
+                "CMUXAgentVault",
+                "CMUXAgentContinuation",
+            ]
         ),
         .testTarget(
             name: "CMUXAgentLaunchTests",

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CMUXAgentContinuation
 
 public enum ClaudeConfigDirectoryPath {
     public static func preferredPath(
@@ -6,201 +7,20 @@ public enum ClaudeConfigDirectoryPath {
         fileManager: FileManager = .default,
         homeDirectory: String = NSHomeDirectory()
     ) -> String {
-        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return rawPath }
-
-        let standardized = ((trimmed as NSString).expandingTildeInPath as NSString).standardizingPath
-        let home = ((homeDirectory as NSString).expandingTildeInPath as NSString).standardizingPath
-        let legacyRoot = ((home as NSString).appendingPathComponent(".subrouter/codex/claude") as NSString).standardizingPath
-        guard standardized == legacyRoot || standardized.hasPrefix(legacyRoot + "/") else { return standardized }
-
-        let accountRoot = ((home as NSString).appendingPathComponent(".codex-accounts/claude") as NSString).standardizingPath
-        let candidate = accountRoot + String(standardized.dropFirst(legacyRoot.count))
-        var isDirectory: ObjCBool = false
-        return fileManager.fileExists(atPath: candidate, isDirectory: &isDirectory) && isDirectory.boolValue
-            ? candidate
-            : standardized
+        CMUXAgentContinuation.ClaudeConfigDirectoryPath.preferredPath(
+            rawPath,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
     }
 }
 
 public enum AgentLaunchEnvironmentPolicy {
-    private static let hermesAgentEnvironmentKeys: Set<String> = [
-        "CUSTOM_BASE_URL",
-        "HERMES_CODEX_BASE_URL",
-    ]
-
-    private static let safeEnvironmentKeys: Set<String> = [
-        // AMP_API_KEY is intentionally NOT allowlisted: it's a secret.
-        // Amp resolves auth from ~/.config/amp/settings.json on resume.
-        "AMP_LOG_FILE",
-        "AMP_LOG_LEVEL",
-        "AMP_SETTINGS_FILE",
-        "AMP_URL",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_MODEL",
-        "CLAUDE_CONFIG_DIR",
-        "CMUX_CUSTOM_CLAUDE_PATH",
-        "CMUX_ROVODEV_SESSIONS_DIR",
-        "CODEX_HOME",
-        "CODEBUDDY_BASE_URL",
-        "CODEBUDDY_CONFIG_DIR",
-        "CODEBUDDY_ENV_FILE",
-        "CODEBUDDY_INTERNET_ENVIRONMENT",
-        "CODEBUDDY_MODEL",
-        "CODEBUDDY_SMALL_FAST_MODEL",
-        "COPILOT_GH_HOST",
-        "COPILOT_HOME",
-        "COPILOT_MODEL",
-        "COPILOT_OFFLINE",
-        "COPILOT_PROVIDER_BASE_URL",
-        "COPILOT_PROVIDER_MAX_OUTPUT_TOKENS",
-        "COPILOT_PROVIDER_MAX_PROMPT_TOKENS",
-        "COPILOT_PROVIDER_MODEL_ID",
-        "COPILOT_PROVIDER_TYPE",
-        "COPILOT_PROVIDER_WIRE_API",
-        "COPILOT_PROVIDER_WIRE_MODEL",
-        "CUSTOM_BASE_URL",
-        "GEMINI_CLI_HOME",
-        "GH_HOST",
-        "GROK_HOME",
-        "GROK_SANDBOX",
-        "HERMES_CODEX_BASE_URL",
-        "HERMES_HOME",
-        "KIRO_HOME",
-        "KIRO_LOG_LEVEL",
-        "KIRO_LOG_NO_COLOR",
-        "NODE_OPTIONS",
-        "OPENCODE_CONFIG_DIR",
-        "PI_CACHE_RETENTION",
-        "PI_CONFIG_DIR",
-        "PI_CODING_AGENT_DIR",
-        "PI_CODING_AGENT_SESSION_DIR",
-        "PI_OFFLINE",
-        "PI_PACKAGE_DIR",
-        "PI_SKIP_VERSION_CHECK",
-        "QODER_CONFIG_DIR",
-        "USE_BUILTIN_RIPGREP"
-    ]
-
     public static func selectedEnvironment(from env: [String: String], kind: String? = nil) -> [String: String] {
-        var result: [String: String] = [:]
-        for key in safeEnvironmentKeys.sorted() where key != "NODE_OPTIONS" {
-            guard let value = sanitizedValue(key: key, value: env[key]) else { continue }
-            result[key] = value
-        }
-        if let nodeOptions = selectedNodeOptions(from: env) {
-            result["NODE_OPTIONS"] = nodeOptions
-        }
-        if kind != "hermes-agent" {
-            for key in hermesAgentEnvironmentKeys {
-                result.removeValue(forKey: key)
-            }
-        }
-        return result
+        AgentContinuationEnvironmentPolicy.selectedEnvironment(from: env, kind: kind)
     }
 
     public static func sanitizedValue(key: String, value: String?) -> String? {
-        guard safeEnvironmentKeys.contains(key) else { return nil }
-        switch key {
-        case "CLAUDE_CONFIG_DIR":
-            return value.map { ClaudeConfigDirectoryPath.preferredPath($0) }
-        case "NODE_OPTIONS":
-            return sanitizedNodeOptions(value)
-        default:
-            return value
-        }
-    }
-
-    private static func selectedNodeOptions(from env: [String: String]) -> String? {
-        switch normalizedValue(env["CMUX_ORIGINAL_NODE_OPTIONS_PRESENT"]) {
-        case "1":
-            return sanitizedNodeOptions(env["CMUX_ORIGINAL_NODE_OPTIONS"])
-        case "0":
-            return nil
-        default:
-            return sanitizedNodeOptions(env["NODE_OPTIONS"])
-        }
-    }
-
-    private static func sanitizedNodeOptions(_ rawValue: String?) -> String? {
-        let tokens = rawValue?
-            .split(whereSeparator: \.isWhitespace)
-            .map(String.init) ?? []
-        guard !tokens.isEmpty else { return nil }
-
-        var sanitized: [String] = []
-        var index = 0
-        var shouldDropInjectedHeapCap = false
-        while index < tokens.count {
-            let token = tokens[index]
-
-            if shouldDropInjectedHeapCap, isInjectedNodeHeapCap(tokens, index: index) {
-                index += nodeHeapCapWidth(tokens, index: index)
-                shouldDropInjectedHeapCap = false
-                continue
-            }
-            shouldDropInjectedHeapCap = false
-
-            if isRequireOption(token), index + 1 < tokens.count,
-               isCmuxNodeOptionsRestoreModulePath(tokens[index + 1]) {
-                index += 2
-                shouldDropInjectedHeapCap = true
-                continue
-            }
-            if let path = inlineRequireOptionPath(token),
-               isCmuxNodeOptionsRestoreModulePath(path) {
-                index += 1
-                shouldDropInjectedHeapCap = true
-                continue
-            }
-
-            sanitized.append(token)
-            index += 1
-        }
-
-        let joined = sanitized.joined(separator: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return joined.isEmpty ? nil : joined
-    }
-
-    private static func normalizedValue(_ value: String?) -> String? {
-        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty else {
-            return nil
-        }
-        return trimmed
-    }
-
-    private static func isRequireOption(_ token: String) -> Bool {
-        token == "--require" || token == "-r"
-    }
-
-    private static func inlineRequireOptionPath(_ token: String) -> String? {
-        for prefix in ["--require=", "-r="] where token.hasPrefix(prefix) {
-            return String(token.dropFirst(prefix.count))
-        }
-        return nil
-    }
-
-    private static func isCmuxNodeOptionsRestoreModulePath(_ value: String) -> Bool {
-        let trimmed = value.trimmingCharacters(in: CharacterSet(charactersIn: "'\""))
-        guard URL(fileURLWithPath: trimmed).lastPathComponent == "restore-node-options.cjs" else {
-            return false
-        }
-        return trimmed.contains("/cmux-")
-    }
-
-    private static func isInjectedNodeHeapCap(_ tokens: [String], index: Int) -> Bool {
-        guard index < tokens.count else { return false }
-        let token = tokens[index]
-        if token == "--max-old-space-size" {
-            return index + 1 < tokens.count && tokens[index + 1] == "4096"
-        }
-        return token == "--max-old-space-size=4096"
-    }
-
-    private static func nodeHeapCapWidth(_ tokens: [String], index: Int) -> Int {
-        guard index < tokens.count else { return 1 }
-        return tokens[index] == "--max-old-space-size" ? min(2, tokens.count - index) : 1
+        AgentContinuationEnvironmentPolicy.sanitizedValue(key: key, value: value)
     }
 }

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CMUXAgentContinuation
 
 public enum AgentLaunchSanitizer {
     // Runtime/interpreter flags may appear in captured process argv, but they
@@ -81,7 +82,7 @@ public enum AgentLaunchSanitizer {
         case "claude":
             return preserveOptions(args, policy: claudePolicy)
         case "codex":
-            return preserveOptions(args, policy: codexPolicy)
+            return CodexContinuationArguments().preservedTail(args)
         case "grok":
             return preserveOptions(args, policy: grokPolicy)
         case "pi", "omp":
@@ -105,11 +106,7 @@ public enum AgentLaunchSanitizer {
             }
             return preserveOptions(tail, policy: ampPolicy)
         case "cursor":
-            var tail = args
-            if tail.first == "agent" {
-                tail.removeFirst()
-            }
-            return preserveOptions(tail, policy: cursorPolicy)
+            return CursorContinuationArguments().preservedTail(args)
         case "gemini":
             return preserveOptions(args, policy: geminiPolicy)
         case "kiro":
@@ -163,11 +160,7 @@ public enum AgentLaunchSanitizer {
     }
 
     public static func preservedCodexForkArguments(args: [String]) -> [String]? {
-        var tail = args
-        if let forkCommand = codexForkCommand(in: tail) {
-            tail = dropCodexForkPositionals(tail, forkCommand: forkCommand)
-        }
-        return preserveOptions(tail, policy: codexPolicy)
+        CodexContinuationArguments().preservedForkTail(args)
     }
 
     public static func removingSavedWorkingDirectoryOptions(
@@ -208,81 +201,7 @@ public enum AgentLaunchSanitizer {
     }
 
     private static func preservedCodexLaunchArguments(args: [String]) -> [String]? {
-        if codexForkCommand(in: args) != nil {
-            return preservedCodexForkArguments(args: args)
-        }
-        return preservedArguments(kind: "codex", args: args)
-    }
-
-    private struct CodexForkCommand {
-        let forkIndex: Int
-        let sessionIndex: Int
-    }
-
-    private static func codexForkCommand(in args: [String]) -> CodexForkCommand? {
-        var index = 0
-        while index < args.count {
-            let arg = args[index]
-            if arg == "--" {
-                return nil
-            }
-            if !arg.hasPrefix("-") || arg == "-" {
-                guard arg == "fork",
-                      let sessionIndex = codexForkCommandSessionIndex(args, forkIndex: index) else {
-                    return nil
-                }
-                return CodexForkCommand(forkIndex: index, sessionIndex: sessionIndex)
-            }
-            let width = optionWidth(args, index: index, policy: codexPolicy)
-            if codexPolicy.variadicOptions.contains(arg) {
-                let end = min(args.count, index + width)
-                if index + 2 < end {
-                    for candidateIndex in (index + 2)..<end where args[candidateIndex] == "fork" {
-                        if let sessionIndex = codexForkCommandSessionIndex(args, forkIndex: candidateIndex) {
-                            return CodexForkCommand(forkIndex: candidateIndex, sessionIndex: sessionIndex)
-                        }
-                    }
-                }
-            }
-            index += width
-        }
-        return nil
-    }
-
-    private static func codexForkCommandSessionIndex(_ args: [String], forkIndex: Int) -> Int? {
-        var index = forkIndex + 1
-        while index < args.count {
-            let argument = args[index]
-            if argument == "--" {
-                return nil
-            }
-            if !argument.hasPrefix("-") || argument == "-" {
-                return looksLikeCodexSessionIdentifier(argument) ? index : nil
-            }
-            let width = optionWidth(args, index: index, policy: codexPolicy)
-            if codexPolicy.variadicOptions.contains(argument) {
-                let end = min(args.count, index + width)
-                if index + 2 < end {
-                    for candidateIndex in (index + 2)..<end {
-                        if looksLikeCodexSessionIdentifier(args[candidateIndex]) {
-                            return candidateIndex
-                        }
-                    }
-                }
-            }
-            index += width
-        }
-        return nil
-    }
-
-    private static func looksLikeCodexSessionIdentifier(_ value: String) -> Bool {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 20 else { return false }
-        if trimmed.hasPrefix("019") {
-            return true
-        }
-        let allowed = CharacterSet(charactersIn: "0123456789abcdefABCDEF-")
-        return trimmed.unicodeScalars.allSatisfy { allowed.contains($0) } && trimmed.contains("-")
+        CodexContinuationArguments().preservedTail(args)
     }
 
     private static func preserveOptions(_ args: [String], policy: Policy) -> [String]? {
@@ -344,58 +263,6 @@ public enum AgentLaunchSanitizer {
             }
 
             result.append(contentsOf: args[index..<min(args.count, index + width)])
-            index += width
-        }
-
-        return result
-    }
-
-    private static func dropCodexForkPositionals(_ args: [String], forkCommand: CodexForkCommand) -> [String] {
-        var result: [String] = []
-        var index = 0
-
-        while index < args.count {
-            let arg = args[index]
-            if arg == "--" {
-                break
-            }
-            if index == forkCommand.forkIndex {
-                index += 1
-                continue
-            }
-            if index == forkCommand.sessionIndex {
-                index += 1
-                while index < args.count, !args[index].hasPrefix("-") {
-                    index += 1
-                }
-                continue
-            }
-            if !arg.hasPrefix("-") || arg == "-" {
-                index += 1
-                continue
-            }
-
-            let width = optionWidth(args, index: index, policy: codexPolicy)
-            let end = min(args.count, index + width)
-            if codexPolicy.variadicOptions.contains(arg),
-               forkCommand.forkIndex > index,
-               forkCommand.forkIndex < end {
-                if forkCommand.forkIndex > index + 1 {
-                    result.append(contentsOf: args[index..<forkCommand.forkIndex])
-                }
-                index = forkCommand.forkIndex
-                continue
-            }
-            if codexPolicy.variadicOptions.contains(arg),
-               forkCommand.sessionIndex > index,
-               forkCommand.sessionIndex < end {
-                if forkCommand.sessionIndex > index + 1 {
-                    result.append(contentsOf: args[index..<forkCommand.sessionIndex])
-                }
-                index = forkCommand.sessionIndex
-                continue
-            }
-            result.append(contentsOf: args[index..<end])
             index += width
         }
 

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -3,6 +3,23 @@ import Testing
 
 @Suite("AgentLaunchEnvironmentPolicy")
 struct AgentLaunchEnvironmentPolicyTests {
+    @Test("Codex continuation preserves CODEX_HOME without Claude account environment")
+    func codexContinuationPreservesCodexHomeWithoutClaudeAccountEnvironment() {
+        let selected = AgentLaunchEnvironmentPolicy.selectedEnvironment(
+            from: [
+                "ANTHROPIC_BASE_URL": "http://subrouter-team:31415",
+                "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1781081935106",
+                "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+                "OPENAI_API_KEY": "secret-should-not-persist",
+            ],
+            kind: "codex"
+        )
+
+        #expect(selected == [
+            "CODEX_HOME": "/Users/example/.codex-accounts/codex/_p1781081935106",
+        ])
+    }
+
     @Test("Preserves OMP config roots without persisting secrets")
     func preservesOmpConfigRootsWithoutPersistingSecrets() {
         let selected = AgentLaunchEnvironmentPolicy.selectedEnvironment(

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -65,6 +65,32 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
+    @Test("Preserves future Codex flags through continuation API")
+    func preservesFutureCodexFlagsThroughContinuationAPI() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "codex",
+                    "--yolo",
+                    "--future-runtime-flag",
+                    "--future-mode=fast",
+                    "--model",
+                    "gpt-5.4",
+                    "initial prompt should not replay",
+                ],
+                launcher: "codex",
+                fallbackKind: "codex"
+            ) == [
+                "codex",
+                "--yolo",
+                "--future-runtime-flag",
+                "--future-mode=fast",
+                "--model",
+                "gpt-5.4",
+            ]
+        )
+    }
+
     @Test("Detects Codex fork after startup image options")
     func detectsCodexForkAfterStartupImageOptions() {
         #expect(

--- a/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
+++ b/Packages/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemTabAction.swift
@@ -10,6 +10,8 @@ extension ControlCommandCoordinator {
         "close_left", "close_right", "close_others",
         "new_terminal_right", "new_browser_right",
         "reload", "duplicate", "move_to_new_workspace", "detach_to_workspace", "detach_to_new_workspace",
+        "fork", "fork_conversation",
+        "fork_right", "fork_left", "fork_top", "fork_bottom", "fork_new_tab", "fork_new_workspace",
         "pin", "unpin", "mark_read", "mark_unread",
     ]
 

--- a/Sources/AgentForkSupport.swift
+++ b/Sources/AgentForkSupport.swift
@@ -396,7 +396,7 @@ enum AgentForkSupport {
     ) -> [String: String] {
         var processEnvironment = sanitizedBaseEnvironmentForOpenCodeProbe(baseEnvironment)
         if let environment {
-            let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment)
+            let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment, kind: "opencode")
             for (key, value) in selectedEnvironment {
                 processEnvironment[key] = value
             }
@@ -429,7 +429,7 @@ enum AgentForkSupport {
             }
             processEnvironment[key] = value
         }
-        let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment)
+        let selectedEnvironment = AgentLaunchEnvironmentPolicy.selectedEnvironment(from: environment, kind: "opencode")
         for (key, value) in selectedEnvironment {
             processEnvironment[key] = value
         }

--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -121,6 +121,9 @@ extension ContentView {
                    let forkPanelId = forkWorkspace.focusedPanelId {
                     forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
                 }
+                if let forkPanelId = forkWorkspace.focusedPanelId {
+                    forkWorkspace.setSurfaceResumeBinding(launch.resumeBinding, panelId: forkPanelId)
+                }
                 didFork = true
             case .right, .left, .top, .bottom:
                 didFork = false

--- a/Sources/TerminalController+ControlSystemContext2.swift
+++ b/Sources/TerminalController+ControlSystemContext2.swift
@@ -270,6 +270,9 @@ extension TerminalController {
                    let forkPanelId = forkWorkspace.focusedPanelId {
                     forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
                 }
+                if let forkPanelId = forkWorkspace.focusedPanelId {
+                    forkWorkspace.setSurfaceResumeBinding(launch.resumeBinding, panelId: forkPanelId)
+                }
                 var payload: [String: Any] = [
                     "action": action,
                     "window_id": windowId?.uuidString ?? NSNull(),

--- a/Sources/TerminalController+ControlSystemContext2.swift
+++ b/Sources/TerminalController+ControlSystemContext2.swift
@@ -69,6 +69,27 @@ extension TerminalController {
             ))
         }
 
+        func forkDestination(for action: String) -> AgentConversationForkDestination? {
+            switch action {
+            case "fork_conversation", "fork":
+                return AgentConversationForkDefaultSettings.current()
+            case "fork_right", "fork_conversation_right", "fork_to_right":
+                return .right
+            case "fork_left", "fork_conversation_left", "fork_to_left":
+                return .left
+            case "fork_top", "fork_conversation_top", "fork_to_top":
+                return .top
+            case "fork_bottom", "fork_conversation_bottom", "fork_to_bottom":
+                return .bottom
+            case "fork_new_tab", "fork_conversation_new_tab", "fork_to_new_tab":
+                return .newTab
+            case "fork_new_workspace", "fork_conversation_new_workspace", "fork_to_new_workspace":
+                return .newWorkspace
+            default:
+                return nil
+            }
+        }
+
         func insertionIndexToRight(anchorTabId: TabID, inPane paneId: PaneID) -> Int {
             let tabs = workspace.bonsplitController.tabs(inPane: paneId)
             guard let anchorIndex = tabs.firstIndex(where: { $0.id == anchorTabId }) else { return tabs.count }
@@ -175,6 +196,103 @@ extension TerminalController {
                 return .duplicateFailed
             }
             return finish(.created(newPanel.id))
+
+        case let action where forkDestination(for: action) != nil:
+            guard let snapshot = workspace.forkableAgentSnapshot(forPanelId: surfaceId) else {
+                return .bridged(.err(
+                    code: "invalid_state",
+                    message: "No forkable agent session found for tab",
+                    data: nil
+                ))
+            }
+            let isRemote = workspace.isRemoteTerminalSurface(surfaceId)
+            guard ContentView.commandPaletteSnapshotForkAvailability(
+                snapshot,
+                isRemoteTerminal: isRemote
+            ) == .supportedWithoutProbe else {
+                return .bridged(.err(
+                    code: "invalid_state",
+                    message: "Agent session cannot be forked from CLI without a probe",
+                    data: nil
+                ))
+            }
+            guard let destination = forkDestination(for: action) else {
+                return .unknownAction
+            }
+            if let direction = destination.splitDirection {
+                guard let forkedPanel = workspace.forkAgentConversation(
+                    fromPanelId: surfaceId,
+                    snapshot: snapshot,
+                    direction: direction
+                ) else {
+                    return .createFailed
+                }
+                return finish(.created(forkedPanel.id))
+            }
+            switch destination {
+            case .newTab:
+                guard let anchorTabId = workspace.surfaceIdFromPanelId(surfaceId),
+                      let paneId = workspace.paneId(forPanelId: surfaceId) else {
+                    return .tabPaneNotFound
+                }
+                guard let forkedPanel = workspace.forkAgentConversationToNewTab(
+                    fromPanelId: surfaceId,
+                    snapshot: snapshot,
+                    anchorTabId: anchorTabId,
+                    paneId: paneId
+                ) else {
+                    return .createFailed
+                }
+                return finish(.created(forkedPanel.id))
+            case .newWorkspace:
+                guard let launch = workspace.forkAgentWorkspaceLaunch(
+                    fromPanelId: surfaceId,
+                    snapshot: snapshot
+                ) else {
+                    return .createFailed
+                }
+                let forkWorkspace = tabManager.addWorkspace(
+                    workingDirectory: launch.terminalWorkingDirectory,
+                    initialTerminalCommand: launch.initialTerminalCommand,
+                    initialTerminalInput: launch.initialTerminalInput,
+                    initialTerminalEnvironment: launch.initialTerminalEnvironment,
+                    inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
+                    autoWelcomeIfNeeded: false
+                )
+                if let remoteConfiguration = launch.remoteConfiguration {
+                    forkWorkspace.configureRemoteConnection(
+                        remoteConfiguration,
+                        autoConnect: launch.autoConnectRemoteConfiguration
+                    )
+                }
+                if let workingDirectory = launch.workingDirectory,
+                   launch.terminalWorkingDirectory == nil,
+                   let forkPanelId = forkWorkspace.focusedPanelId {
+                    forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
+                }
+                var payload: [String: Any] = [
+                    "action": action,
+                    "window_id": windowId?.uuidString ?? NSNull(),
+                    "window_ref": v2Ref(kind: .window, uuid: windowId),
+                    "workspace_id": workspace.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: workspace.id),
+                    "surface_id": surfaceId.uuidString,
+                    "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                    "tab_id": surfaceId.uuidString,
+                    "tab_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                    "created_workspace_id": forkWorkspace.id.uuidString,
+                    "created_workspace_ref": v2Ref(kind: .workspace, uuid: forkWorkspace.id),
+                ]
+                if let forkPanelId = forkWorkspace.focusedPanelId {
+                    payload["created_surface_id"] = forkPanelId.uuidString
+                    payload["created_surface_ref"] = v2Ref(kind: .surface, uuid: forkPanelId)
+                    payload["created_tab_id"] = forkPanelId.uuidString
+                    payload["created_tab_ref"] = v2Ref(kind: .surface, uuid: forkPanelId)
+                }
+                return .bridged(.ok(JSONValue(foundationObject: payload) ?? .object([:])))
+            case .right, .left, .top, .bottom:
+                return .unknownAction
+            }
 
         case "new_terminal_right", "new_terminal_to_right", "new_terminal_tab_to_right":
             guard let anchorTabId = workspace.surfaceIdFromPanelId(surfaceId),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10737,6 +10737,7 @@ final class Workspace: Identifiable, ObservableObject {
         var initialTerminalCommand: String?
         var initialTerminalInput: String
         var initialTerminalEnvironment: [String: String]
+        var resumeBinding: SurfaceResumeBindingSnapshot
         var remoteConfiguration: WorkspaceRemoteConfiguration?
         var autoConnectRemoteConfiguration: Bool
     }
@@ -10758,6 +10759,10 @@ final class Workspace: Identifiable, ObservableObject {
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: !isRemoteFork
+              ),
+              let resumeBinding = forkAgentResumeBinding(
+                  snapshot: launchSnapshot,
+                  workingDirectory: workingDirectory
               ) else {
             return nil
         }
@@ -10768,6 +10773,7 @@ final class Workspace: Identifiable, ObservableObject {
             initialTerminalCommand: remoteConfiguration?.terminalStartupCommand ?? remoteStartupCommand,
             initialTerminalInput: startupInput,
             initialTerminalEnvironment: isRemoteFork ? (remoteConfiguration?.sshTerminalStartupEnvironment ?? [:]) : [:],
+            resumeBinding: resumeBinding,
             remoteConfiguration: remoteConfiguration,
             autoConnectRemoteConfiguration: remoteConfiguration != nil
         )
@@ -10811,6 +10817,10 @@ final class Workspace: Identifiable, ObservableObject {
            remoteStartupCommand != nil,
            let workingDirectory {
             updatePanelDirectory(panelId: forkedPanel.id, directory: workingDirectory)
+        }
+        if let forkedPanel,
+           let resumeBinding = forkAgentResumeBinding(snapshot: launchSnapshot, workingDirectory: workingDirectory) {
+            setSurfaceResumeBinding(resumeBinding, panelId: forkedPanel.id)
         }
         if forkedPanel == nil, let zoomedPaneId {
             _ = bonsplitController.togglePaneZoom(inPane: zoomedPaneId)
@@ -10913,10 +10923,30 @@ final class Workspace: Identifiable, ObservableObject {
             if remoteStartupCommand != nil, let workingDirectory {
                 updatePanelDirectory(panelId: forkedPanel.id, directory: workingDirectory)
             }
+            if let resumeBinding = forkAgentResumeBinding(snapshot: launchSnapshot, workingDirectory: workingDirectory) {
+                setSurfaceResumeBinding(resumeBinding, panelId: forkedPanel.id)
+            }
         } else if let zoomedPaneId {
             _ = bonsplitController.togglePaneZoom(inPane: zoomedPaneId)
         }
         return forkedPanel
+    }
+
+    private func forkAgentResumeBinding(
+        snapshot: SessionRestorableAgentSnapshot,
+        workingDirectory: String?
+    ) -> SurfaceResumeBindingSnapshot? {
+        guard let forkCommand = snapshot.forkCommand else { return nil }
+        return SurfaceResumeBindingSnapshot(
+            name: snapshot.agentDisplayName,
+            kind: snapshot.kind.rawValue,
+            command: forkCommand,
+            cwd: workingDirectory,
+            checkpointId: snapshot.sessionId,
+            source: "agent-hook",
+            autoResume: true,
+            approvalPolicy: .auto
+        )
     }
 
     private func forkAgentRemoteStartupCommand(fromPanelId panelId: UUID) -> String? {
@@ -12594,6 +12624,9 @@ extension Workspace: BonsplitDelegate {
            launch.terminalWorkingDirectory == nil,
            let forkPanelId = forkWorkspace.focusedPanelId {
             forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
+        }
+        if let forkPanelId = forkWorkspace.focusedPanelId {
+            forkWorkspace.setSurfaceResumeBinding(launch.resumeBinding, panelId: forkPanelId)
         }
         return true
     }

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -746,33 +746,105 @@ final class AgentHibernationTests: XCTestCase {
     }
 
     func testSupportedAgentSnapshotsHaveResumeCommandsForHibernation() {
-        let cwd = "/tmp/cmux-agent-hibernation"
         let sessionId = "session-123"
-        let launchCommands: [(RestorableAgentKind, AgentLaunchCommandSnapshot)] = [
-            (.claude, launch("claude", "/usr/local/bin/claude", cwd: cwd)),
-            (.codex, launch("codex", "/usr/local/bin/codex", cwd: cwd)),
-            (.opencode, launch("opencode", "/usr/local/bin/opencode", cwd: cwd)),
-            (.pi, launch("pi", "/usr/local/bin/pi", cwd: cwd)),
-            (.amp, launch("amp", "/usr/local/bin/amp", cwd: cwd)),
-            (.cursor, launch("cursor", "/usr/local/bin/cursor-agent", cwd: cwd)),
-            (.gemini, launch("gemini", "/usr/local/bin/gemini", cwd: cwd)),
-            (.rovodev, launch("rovodev", "/usr/local/bin/acli", arguments: ["/usr/local/bin/acli", "rovodev", "run"], cwd: cwd)),
-            (.hermesAgent, launch("hermes-agent", "/usr/local/bin/hermes", cwd: cwd)),
-            (.copilot, launch("copilot", "/usr/local/bin/copilot", cwd: cwd)),
-            (.codebuddy, launch("codebuddy", "/usr/local/bin/codebuddy", cwd: cwd)),
-            (.factory, launch("factory", "/usr/local/bin/droid", cwd: cwd)),
-            (.qoder, launch("qoder", "/usr/local/bin/qodercli", cwd: cwd)),
-        ]
 
-        for (kind, launchCommand) in launchCommands {
+        XCTAssertEqual(
+            Set(allBuiltInContinuationFixtures().map(\.kind)),
+            Set(allBuiltInRestorableAgentKindsForContinuation),
+            "Every built-in restorable agent kind must have a continuation fixture"
+        )
+
+        for fixture in allBuiltInContinuationFixtures() {
             let snapshot = SessionRestorableAgentSnapshot(
-                kind: kind,
+                kind: fixture.kind,
                 sessionId: sessionId,
-                workingDirectory: cwd,
-                launchCommand: launchCommand
+                workingDirectory: fixture.cwd,
+                launchCommand: fixture.launchCommand
             )
-            XCTAssertNotNil(snapshot.resumeCommand, "\(kind.rawValue) should be resumable before hibernation can use it")
+            let resumeCommand = snapshot.resumeCommand
+            XCTAssertNotNil(resumeCommand, "\(fixture.kind.rawValue) should be resumable before hibernation can use it")
+            XCTAssertTrue(resumeCommand?.contains(sessionId) == true, "\(fixture.kind.rawValue) resume must reference the session id")
+            XCTAssertTrue(
+                resumeCommand?.contains("cd -- '\(fixture.cwd)'") == true,
+                "\(fixture.kind.rawValue) resume must preserve its working directory"
+            )
             XCTAssertFalse(snapshot.agentDisplayName.isEmpty)
+        }
+    }
+
+    func testBuiltInAgentForkSupportMatrixIsExplicitForHibernationAndSessionRestore() {
+        let forkableKinds: Set<RestorableAgentKind> = [.claude, .codex, .opencode]
+        let sessionId = "session-123"
+
+        for fixture in allBuiltInContinuationFixtures() {
+            let snapshot = SessionRestorableAgentSnapshot(
+                kind: fixture.kind,
+                sessionId: sessionId,
+                workingDirectory: fixture.cwd,
+                launchCommand: fixture.launchCommand
+            )
+            if forkableKinds.contains(fixture.kind) {
+                let forkCommand = snapshot.forkCommand
+                XCTAssertNotNil(forkCommand, "\(fixture.kind.rawValue) must keep its fork command")
+                XCTAssertTrue(forkCommand?.contains(sessionId) == true, "\(fixture.kind.rawValue) fork must reference the session id")
+                XCTAssertTrue(
+                    forkCommand?.contains("cd -- '\(fixture.cwd)'") == true,
+                    "\(fixture.kind.rawValue) fork must preserve its working directory"
+                )
+                XCTAssertNotNil(
+                    snapshot.forkStartupInput(temporaryDirectory: FileManager.default.temporaryDirectory),
+                    "\(fixture.kind.rawValue) fork must be launchable as terminal startup input"
+                )
+            } else {
+                XCTAssertNil(snapshot.forkCommand, "\(fixture.kind.rawValue) is resume-only unless a registry fork template is declared")
+            }
+        }
+    }
+
+    @MainActor
+    func testHibernatedSessionRestoreKeepsEveryBuiltInAgentWithoutRunningResume() throws {
+        for fixture in allBuiltInContinuationFixtures() {
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourcePanel = try XCTUnwrap(source.terminalPanel(for: sourcePanelId))
+            let agent = SessionRestorableAgentSnapshot(
+                kind: fixture.kind,
+                sessionId: "session-\(fixture.kind.rawValue)",
+                workingDirectory: fixture.cwd,
+                launchCommand: fixture.launchCommand
+            )
+
+            sourcePanel.enterAgentHibernation(
+                agent: agent,
+                lastActivityAt: Date(timeIntervalSince1970: 10),
+                hibernatedAt: Date(timeIntervalSince1970: 20)
+            )
+            let snapshot = source.sessionSnapshot(includeScrollback: false)
+            let sourcePanelSnapshot = try XCTUnwrap(
+                snapshot.panels.first { $0.id == sourcePanelId },
+                "\(fixture.kind.rawValue) hibernated source panel should snapshot"
+            )
+            XCTAssertNotNil(
+                sourcePanelSnapshot.terminal?.hibernation,
+                "\(fixture.kind.rawValue) hibernation metadata should persist into the session snapshot"
+            )
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelSnapshot = try XCTUnwrap(
+                restored.sessionSnapshot(includeScrollback: false).panels.first { panel in
+                    panel.terminal?.agent?.kind == fixture.kind
+                },
+                "\(fixture.kind.rawValue) hibernated panel should restore"
+            )
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelSnapshot.id))
+
+            XCTAssertFalse(
+                restoredPanel.surface.debugInitialInputMetadata().hasInitialInput,
+                "\(fixture.kind.rawValue) hibernated restore must not auto-run the resume command"
+            )
+            XCTAssertEqual(restoredPanelSnapshot.terminal?.agent?.sessionId, "session-\(fixture.kind.rawValue)")
+            XCTAssertEqual(restoredPanelSnapshot.terminal?.agent?.workingDirectory, fixture.cwd)
         }
     }
 
@@ -1116,5 +1188,53 @@ final class AgentHibernationTests: XCTestCase {
             capturedAt: nil,
             source: nil
         )
+    }
+
+    private struct ContinuationFixture {
+        var kind: RestorableAgentKind
+        var cwd: String
+        var launchCommand: AgentLaunchCommandSnapshot
+    }
+
+    private var allBuiltInRestorableAgentKindsForContinuation: [RestorableAgentKind] {
+        [
+            .claude,
+            .codex,
+            .grok,
+            .pi,
+            .amp,
+            .cursor,
+            .gemini,
+            .kiro,
+            .antigravity,
+            .opencode,
+            .rovodev,
+            .hermesAgent,
+            .copilot,
+            .codebuddy,
+            .factory,
+            .qoder,
+        ]
+    }
+
+    private func allBuiltInContinuationFixtures(cwd: String = "/tmp/cmux-agent-hibernation") -> [ContinuationFixture] {
+        [
+            ContinuationFixture(kind: .claude, cwd: cwd, launchCommand: launch("claude", "/usr/local/bin/claude", cwd: cwd)),
+            ContinuationFixture(kind: .codex, cwd: cwd, launchCommand: launch("codex", "/usr/local/bin/codex", cwd: cwd)),
+            ContinuationFixture(kind: .grok, cwd: cwd, launchCommand: launch("grok", "/usr/local/bin/grok", cwd: cwd)),
+            ContinuationFixture(kind: .pi, cwd: cwd, launchCommand: launch("pi", "/usr/local/bin/pi", cwd: cwd)),
+            ContinuationFixture(kind: .amp, cwd: cwd, launchCommand: launch("amp", "/usr/local/bin/amp", cwd: cwd)),
+            ContinuationFixture(kind: .cursor, cwd: cwd, launchCommand: launch("cursor", "/usr/local/bin/cursor-agent", cwd: cwd)),
+            ContinuationFixture(kind: .gemini, cwd: cwd, launchCommand: launch("gemini", "/usr/local/bin/gemini", cwd: cwd)),
+            ContinuationFixture(kind: .kiro, cwd: cwd, launchCommand: launch("kiro", "/usr/local/bin/kiro-cli", arguments: ["/usr/local/bin/kiro-cli", "chat"], cwd: cwd)),
+            ContinuationFixture(kind: .antigravity, cwd: cwd, launchCommand: launch("antigravity", "/usr/local/bin/agy", cwd: cwd)),
+            ContinuationFixture(kind: .opencode, cwd: cwd, launchCommand: launch("opencode", "/usr/local/bin/opencode", cwd: cwd)),
+            ContinuationFixture(kind: .rovodev, cwd: cwd, launchCommand: launch("rovodev", "/usr/local/bin/acli", arguments: ["/usr/local/bin/acli", "rovodev", "run"], cwd: cwd)),
+            ContinuationFixture(kind: .hermesAgent, cwd: cwd, launchCommand: launch("hermes-agent", "/usr/local/bin/hermes", cwd: cwd)),
+            ContinuationFixture(kind: .copilot, cwd: cwd, launchCommand: launch("copilot", "/usr/local/bin/copilot", cwd: cwd)),
+            ContinuationFixture(kind: .codebuddy, cwd: cwd, launchCommand: launch("codebuddy", "/usr/local/bin/codebuddy", cwd: cwd)),
+            ContinuationFixture(kind: .factory, cwd: cwd, launchCommand: launch("factory", "/usr/local/bin/droid", cwd: cwd)),
+            ContinuationFixture(kind: .qoder, cwd: cwd, launchCommand: launch("qoder", "/usr/local/bin/qodercli", cwd: cwd)),
+        ]
     }
 }

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -33,7 +33,10 @@ extension CLINotifyProcessIntegrationRegressionTests {
                     "enabled",
                     "initial prompt should not persist"
                 ],
-                extraEnvironment: [:],
+                extraEnvironment: [
+                    "CURSOR_CONFIG_DIR": "/tmp/cursor config",
+                    "CURSOR_API_KEY": "secret"
+                ],
                 expectedArguments: [
                     "/Users/example/.local/bin/cursor-agent",
                     "--model",
@@ -41,7 +44,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                     "--sandbox",
                     "enabled"
                 ],
-                expectedEnvironment: nil
+                expectedEnvironment: ["CURSOR_CONFIG_DIR": "/tmp/cursor config"]
             ),
             GenericHookPersistenceScenario(
                 agent: "gemini",
@@ -3276,7 +3279,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             XCTAssertEqual(params["auto_resume"] as? Bool, true)
             XCTAssertEqual(
                 params["command"] as? String,
-                "cd '\(workspace.path)' && '\(scenario.executable)' 'chat' '--resume-id' '\(scenario.sessionId)' '--agent' 'cmux' '--trust-tools' 'fs_read,fs_write'"
+                "{ cd -- '\(workspace.path)' 2>/dev/null || [ ! -d '\(workspace.path)' ]; } && '\(scenario.executable)' 'chat' '--resume-id' '\(scenario.sessionId)' '--agent' 'cmux' '--trust-tools' 'fs_read,fs_write'"
             )
             XCTAssertEqual(params["environment"] as? [String: String], scenario.expectedEnvironment)
             XCTAssertFalse(

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -163,7 +163,7 @@ extension SocketListenerAcceptPolicyTests {
                     "initial prompt should not replay"
                 ],
                 workingDirectory: "/tmp/cursor repo",
-                environment: nil,
+                environment: ["CURSOR_CONFIG_DIR": "/tmp/cursor config", "CURSOR_API_KEY": "secret"],
                 capturedAt: 123,
                 source: "process"
             )
@@ -366,7 +366,7 @@ extension SocketListenerAcceptPolicyTests {
 
         XCTAssertEqual(
             cursor.resumeCommand,
-            "{ cd -- '/tmp/cursor repo' 2>/dev/null || [ ! -d '/tmp/cursor repo' ]; } && '/Users/example/.local/bin/cursor-agent' '--resume' 'cursor-chat-123' '--model' 'gpt-5.4' '--sandbox' 'enabled'"
+            "{ cd -- '/tmp/cursor repo' 2>/dev/null || [ ! -d '/tmp/cursor repo' ]; } && 'env' 'CURSOR_CONFIG_DIR=/tmp/cursor config' '/Users/example/.local/bin/cursor-agent' '--resume' 'cursor-chat-123' '--model' 'gpt-5.4' '--sandbox' 'enabled'"
         )
         XCTAssertEqual(
             copilot.resumeCommand,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -5338,7 +5338,8 @@ extension SessionPersistenceTests {
         XCTAssertTrue(input.contains("config set model.api_mode"))
         XCTAssertTrue(input.contains("codex_responses"))
         XCTAssertTrue(input.contains("gpt-5.5"))
-        XCTAssertTrue(input.contains("'--provider' '\\''custom'\\'''") || input.contains("'--provider' 'custom'"))
+        XCTAssertTrue(input.contains("--provider"))
+        XCTAssertTrue(input.contains("custom"))
         XCTAssertFalse(input.contains("openai-codex"))
     }
 
@@ -5360,8 +5361,9 @@ extension SessionPersistenceTests {
             promptForApproval: false
         ))
 
-        XCTAssertTrue(input.contains("'/opt/homebrew/bin/hermes' config set model.provider"))
-        XCTAssertTrue(input.contains("'/opt/homebrew/bin/hermes' config set model.base_url"))
+        XCTAssertTrue(input.contains("/opt/homebrew/bin/hermes"))
+        XCTAssertTrue(input.contains("config set model.provider"))
+        XCTAssertTrue(input.contains("config set model.base_url"))
     }
 
     func testHermesAgentHookSurfaceResumeBootstrapStaysInsideCwdGuard() throws {
@@ -5385,8 +5387,10 @@ extension SessionPersistenceTests {
         let cdRange = try XCTUnwrap(input.range(of: "cd --"))
         let bootstrapRange = try XCTUnwrap(input.range(of: "config set model.provider"))
         XCTAssertLessThan(cdRange.lowerBound, bootstrapRange.lowerBound)
-        XCTAssertTrue(input.contains("'./hermes' config set model.provider"))
-        XCTAssertTrue(input.contains("'./hermes' '--provider' 'custom' '--resume'"))
+        XCTAssertTrue(input.contains("./hermes"))
+        XCTAssertTrue(input.contains("--provider"))
+        XCTAssertTrue(input.contains("custom"))
+        XCTAssertTrue(input.contains("--resume"))
     }
 
     func testHermesAgentHookSurfaceResumeReplacesExistingBootstrap() throws {
@@ -5452,7 +5456,8 @@ extension SessionPersistenceTests {
         ))
 
         XCTAssertFalse(input.contains("config set model.provider"))
-        XCTAssertTrue(input.contains("'--provider' '\\''anthropic'\\'''") || input.contains("'--provider' 'anthropic'"))
+        XCTAssertTrue(input.contains("--provider"))
+        XCTAssertTrue(input.contains("anthropic"))
     }
 
     private func makeSurfaceResumeApprovalStoreURL() throws -> URL {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -5796,6 +5796,14 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertEqual(workspace.focusedPanelId, forkPanel.id)
         XCTAssertEqual(forkPanel.requestedWorkingDirectory, "/tmp/fork repo")
         XCTAssertEqual(forkPanel.surface.initialInput, snapshot.forkCommand.map { $0 + "\n" })
+        let resumeBinding = try XCTUnwrap(workspace.surfaceResumeBinding(panelId: forkPanel.id))
+        XCTAssertEqual(resumeBinding.kind, "codex")
+        XCTAssertEqual(resumeBinding.command, snapshot.forkCommand)
+        XCTAssertEqual(resumeBinding.cwd, "/tmp/fork repo")
+        XCTAssertEqual(resumeBinding.checkpointId, snapshot.sessionId)
+        XCTAssertEqual(resumeBinding.source, "agent-hook")
+        XCTAssertEqual(resumeBinding.autoResume, true)
+        XCTAssertEqual(resumeBinding.approvalPolicy, .auto)
         let split = try rootSplit(in: workspace)
         let sourcePaneId = try XCTUnwrap(workspace.paneId(forPanelId: sourcePanelId)).id.uuidString
         let forkPaneId = try XCTUnwrap(workspace.paneId(forPanelId: forkPanel.id)).id.uuidString
@@ -6244,6 +6252,16 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             launch.initialTerminalInput,
             "{ cd -- '/tmp/local fork repo' 2>/dev/null || [ ! -d '/tmp/local fork repo' ]; } && '/Users/example/.bun/bin/codex' 'fork' '019dad34-d218-7943-b81a-eddac5c87951'\n"
         )
+        XCTAssertEqual(launch.resumeBinding.kind, "codex")
+        XCTAssertEqual(
+            launch.resumeBinding.command,
+            "{ cd -- '/tmp/local fork repo' 2>/dev/null || [ ! -d '/tmp/local fork repo' ]; } && '/Users/example/.bun/bin/codex' 'fork' '019dad34-d218-7943-b81a-eddac5c87951'"
+        )
+        XCTAssertEqual(launch.resumeBinding.cwd, "/tmp/local fork repo")
+        XCTAssertEqual(launch.resumeBinding.checkpointId, snapshot.sessionId)
+        XCTAssertEqual(launch.resumeBinding.source, "agent-hook")
+        XCTAssertEqual(launch.resumeBinding.autoResume, true)
+        XCTAssertEqual(launch.resumeBinding.approvalPolicy, .auto)
     }
 
     func testForkAgentConversationInRemoteConfiguredLocalWorkspaceAllowsLauncherScript() throws {
@@ -6894,6 +6912,14 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             snapshot.forkCommand.map { $0 + "\n" },
             "Forked tab should boot with the snapshot's --fork-session command"
         )
+        let resumeBinding = try XCTUnwrap(workspace.surfaceResumeBinding(panelId: forkPanel.id))
+        XCTAssertEqual(resumeBinding.kind, "claude")
+        XCTAssertEqual(resumeBinding.command, snapshot.forkCommand)
+        XCTAssertEqual(resumeBinding.cwd, "/tmp/fork repo")
+        XCTAssertEqual(resumeBinding.checkpointId, snapshot.sessionId)
+        XCTAssertEqual(resumeBinding.source, "agent-hook")
+        XCTAssertEqual(resumeBinding.autoResume, true)
+        XCTAssertEqual(resumeBinding.approvalPolicy, .auto)
     }
 
     func testForkAgentConversationToNewTabPlacesForkImmediatelyRightOfAnchor() throws {


### PR DESCRIPTION
## Summary
- add isolated `CMUXAgentContinuation` package for continuation-safe argv and env replay
- preserve future Codex flags like `--yolo` while dropping stale session selectors, startup prompts, images, and remote transports
- preserve Cursor config roots and replay-safe Cursor flags through the same continuation abstraction
- make `CMUXAgentLaunch` a compatibility shim over the package and keep OpenCode probe env kind-scoped

## Tests
- `swift test` in `Packages/CMUXAgentContinuation`
- `swift test` in `Packages/CMUXAgentLaunch`
- `xcodebuild -quiet -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-continuation-test -only-testing:cmuxTests/SessionPersistenceTests -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testGenericHookAgentsPersistSanitizedLaunchCommandsForSessionRestore -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testAdditionalHookAgentResumeCommandsUseVerifiedCLIResumeFlags -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testAgentLaunchSanitizerMatchesAdditionalHookAgentResumePolicies test`

## Dogfood
- tagged reload pending: `cont`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784237995&installation_id=133855650&pr_number=6268&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6268&signature=8ef0607999f7268d1020eab58de7325b1a7619429ffe197b15ca3398015b14cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session resume/fork launch paths and env persistence across many agent kinds; incorrect argv/env filtering could break resume or leak secrets, but behavior is heavily test-backed.
> 
> **Overview**
> Introduces **`CMUXAgentContinuation`** as the shared place for **replay-safe agent env and argv** (per-kind env allowlists, Codex/Cursor rewriters that keep unknown flags but drop secrets, stale session selectors, prompts, and remotes). **`CMUXAgentLaunch`** now delegates to that package instead of owning duplicate policy; OpenCode version probes pass **`kind: "opencode"`** so env filtering stays scoped.
> 
> **Tab / CLI fork:** `tab-action` and the control socket gain **fork** actions (default, directional splits, new tab, new workspace). Fork paths attach a **`SurfaceResumeBindingSnapshot`** on the new surface so forked agent tabs can auto-resume; workspace-fork launch payloads carry the same binding. CLI fork is blocked when the agent needs a probe that isn’t available without the UI.
> 
> Tests expand built-in agent continuation/fixture coverage (resume/fork matrix, hibernation restore) and assert Cursor config env is persisted without API keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e27beaae2f5483d60eb83477657d2ca0706b995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes agent continuation replay rules in `CMUXAgentContinuation` and routes `CMUXAgentLaunch` through it. Adds fork actions, persists resume bindings, and validates hibernation continuation across all built-in agents.

- **Refactors**
  - Introduced `AgentContinuationEnvironmentPolicy` (per-kind env allowlists, kind alias mapping, safe `NODE_OPTIONS`).
  - Delegated Codex/Cursor argv and env sanitization to `CMUXAgentContinuation`; moved Claude config path to `ClaudeConfigDirectoryPath`; OpenCode probe env is kind-scoped.

- **New Features**
  - Added `tab-action` forks (`fork`, directional splits, new tab, new workspace) with control-socket routing; guard CLI fork when a probe is required.
  - Persist resume bindings on fork for auto-resume; include Cursor `CURSOR_CONFIG_DIR` in persisted env.
  - Hibernation: covered all built-in agents; resume commands keep cwd and session id; only `claude`, `codex`, and `opencode` expose fork commands.

<sup>Written for commit 7e27beaae2f5483d60eb83477657d2ca0706b995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added replay-safe continuation/resume argument preservation for Codex and Cursor, plus kind-aware environment filtering and improved Claude config directory resolution.
  * Expanded tab-action support to include fork actions (directional, fork, new tab/workspace) and updated `cmux` help text.
* **Bug Fixes**
  * Improved session restoration so Cursor/Codex resume includes the correct environment and resume bindings, including for new-workspace and fork flows.
* **Tests**
  * Added/updated coverage for environment selection, continuation argument rewriting, fork/resume behavior, and restored session expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->