### PR TITLE
Fix Universal Clipboard RTFD paste text

### DIFF
--- a/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService+TextContents.swift
+++ b/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService+TextContents.swift
@@ -10,6 +10,10 @@ extension TerminalPasteboardService: TerminalClipboardReading {
     public func stringContents(from pasteboard: NSPasteboard) -> String? {
         let types = pasteboard.types ?? []
 
+        if let remoteClipboardText = remoteClipboardText(from: pasteboard, types: types) {
+            return remoteClipboardText
+        }
+
         if let sharedPasteboardText = sharedPasteboardRTFDText(from: pasteboard, types: types) {
             return sharedPasteboardText
         }
@@ -104,6 +108,19 @@ extension TerminalPasteboardService {
         return attributedStringContents(from: pasteboard, type: .rtfd, documentType: .rtfd)
     }
 
+    private func remoteClipboardText(
+        from pasteboard: NSPasteboard,
+        types: [NSPasteboard.PasteboardType]
+    ) -> String? {
+        guard types.contains(Self.remoteClipboardType),
+              types.contains(.fileURL) || types.contains(.URL),
+              types.contains(where: isRemoteClipboardRichTextType) else {
+            return nil
+        }
+
+        return plainTextContents(from: pasteboard)
+    }
+
     private func sharedPasteboardRTFDText(
         from pasteboard: NSPasteboard,
         types: [NSPasteboard.PasteboardType]
@@ -195,6 +212,12 @@ extension TerminalPasteboardService {
 
     private func isRichTextType(_ type: NSPasteboard.PasteboardType) -> Bool {
         type == .html || type == .rtf || type == .rtfd
+    }
+
+    private func isRemoteClipboardRichTextType(_ type: NSPasteboard.PasteboardType) -> Bool {
+        isRichTextType(type)
+            || type == Self.flatRTFDType
+            || type == Self.uikitAttributedStringType
     }
 
     func hasImageData(in pasteboard: NSPasteboard) -> Bool {

--- a/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService+TextContents.swift
+++ b/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService+TextContents.swift
@@ -10,6 +10,10 @@ extension TerminalPasteboardService: TerminalClipboardReading {
     public func stringContents(from pasteboard: NSPasteboard) -> String? {
         let types = pasteboard.types ?? []
 
+        if let sharedPasteboardText = sharedPasteboardRTFDText(from: pasteboard, types: types) {
+            return sharedPasteboardText
+        }
+
         if (types.contains(.fileURL) || types.contains(.URL)),
            let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL],
            !urls.isEmpty {
@@ -100,6 +104,23 @@ extension TerminalPasteboardService {
         return attributedStringContents(from: pasteboard, type: .rtfd, documentType: .rtfd)
     }
 
+    private func sharedPasteboardRTFDText(
+        from pasteboard: NSPasteboard,
+        types: [NSPasteboard.PasteboardType]
+    ) -> String? {
+        guard types.contains(.rtfd),
+              hasSharedPasteboardRTFDFileURL(in: pasteboard, types: types),
+              let richText = richTextContents(from: pasteboard) else {
+            return nil
+        }
+
+        if let plainText = plainTextContents(from: pasteboard),
+           PasteboardTextFidelity.shouldPreferPlainText(plainText, overRichText: richText) {
+            return plainText
+        }
+        return richText
+    }
+
     private func plainTextContents(from pasteboard: NSPasteboard) -> String? {
         let allTypes = pasteboard.types ?? []
 
@@ -134,6 +155,28 @@ extension TerminalPasteboardService {
             return true
         }
         return hasImageData(in: pasteboard)
+    }
+
+    private func hasSharedPasteboardRTFDFileURL(
+        in pasteboard: NSPasteboard,
+        types: [NSPasteboard.PasteboardType]
+    ) -> Bool {
+        guard (types.contains(.fileURL) || types.contains(.URL)),
+              let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
+            return false
+        }
+
+        return urls.contains { url in
+            guard url.isFileURL,
+                  url.pathExtension.caseInsensitiveCompare("rtfd") == .orderedSame else {
+                return false
+            }
+
+            let components = url.standardizedFileURL.pathComponents
+            return components.contains("group.com.apple.coreservices.useractivityd")
+                && components.contains("shared-pasteboard")
+                && components.contains("items")
+        }
     }
 
     private func isPlainTextType(_ type: NSPasteboard.PasteboardType) -> Bool {

--- a/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService.swift
+++ b/Packages/CmuxTerminalServices/Sources/CmuxTerminalServices/Pasteboard/TerminalPasteboardService.swift
@@ -46,6 +46,9 @@ public final class TerminalPasteboardService: Sendable {
     }
 
     static let utf8PlainTextType = NSPasteboard.PasteboardType("public.utf8-plain-text")
+    static let remoteClipboardType = NSPasteboard.PasteboardType("com.apple.is-remote-clipboard")
+    static let flatRTFDType = NSPasteboard.PasteboardType("com.apple.flat-rtfd")
+    static let uikitAttributedStringType = NSPasteboard.PasteboardType("com.apple.uikit.attributedstring")
     static let temporaryImageFilenamePrefix = "clipboard-"
     static let objectReplacementCharacter = Character(UnicodeScalar(0xFFFC)!)
     /// Mirrors the clipboard-image size cap applied to every materialization

--- a/Packages/CmuxTerminalServices/Tests/CmuxTerminalServicesTests/TerminalPasteboardServiceTests.swift
+++ b/Packages/CmuxTerminalServices/Tests/CmuxTerminalServicesTests/TerminalPasteboardServiceTests.swift
@@ -81,6 +81,26 @@ struct PasteboardTextContentsTests {
         #expect(contents == "/tmp/with\\ space.png")
     }
 
+    @Test func universalClipboardRTFDFileURLPrefersRichText() throws {
+        let scratch = ScratchPasteboard()
+        let service = TerminalPasteboardService()
+        let text = "copied from iPhone"
+        let rtfdData = try NSAttributedString(string: text).data(
+            from: NSRange(location: 0, length: text.utf16.count),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtfd]
+        )
+        let backingURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard/items")
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("\(UUID().uuidString).rtfd")
+
+        scratch.pasteboard.clearContents()
+        #expect(scratch.pasteboard.writeObjects([backingURL as NSURL]))
+        scratch.pasteboard.setData(rtfdData, forType: .rtfd)
+
+        #expect(service.stringContents(from: scratch.pasteboard) == text)
+    }
+
     @Test func imageOnlyHTMLWithNoVisibleTextReturnsNil() throws {
         let scratch = ScratchPasteboard()
         let service = TerminalPasteboardService()

--- a/Packages/CmuxTerminalServices/Tests/CmuxTerminalServicesTests/TerminalPasteboardServiceTests.swift
+++ b/Packages/CmuxTerminalServices/Tests/CmuxTerminalServicesTests/TerminalPasteboardServiceTests.swift
@@ -101,6 +101,25 @@ struct PasteboardTextContentsTests {
         #expect(service.stringContents(from: scratch.pasteboard) == text)
     }
 
+    @Test func universalClipboardRemoteTextPrefersPlainTextOverRTFDFileURL() throws {
+        let scratch = ScratchPasteboard()
+        let service = TerminalPasteboardService()
+        let text = "copied from iPhone after repro"
+        let backingURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard/items")
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("\(UUID().uuidString).rtfd")
+
+        scratch.pasteboard.clearContents()
+        #expect(scratch.pasteboard.writeObjects([backingURL as NSURL]))
+        scratch.pasteboard.setString(text, forType: .init("public.utf8-plain-text"))
+        scratch.pasteboard.setString(text, forType: .string)
+        scratch.pasteboard.setData(Data("not locally decodable rtfd".utf8), forType: .rtfd)
+        scratch.pasteboard.setString("1", forType: .init("com.apple.is-remote-clipboard"))
+
+        #expect(service.stringContents(from: scratch.pasteboard) == text)
+    }
+
     @Test func imageOnlyHTMLWithNoVisibleTextReturnsNil() throws {
         let scratch = ScratchPasteboard()
         let service = TerminalPasteboardService()


### PR DESCRIPTION
## Summary
- Prefer Apple remote clipboard plain-text flavors before file URL materialization for rich-text Universal Clipboard payloads.
- Keep the earlier shared-pasteboard RTFD rich-text fallback for locally decodable payloads.
- Add regression coverage for the real failed shape from `/tmp/cmux-debug-rtfd.log`: `com.apple.is-remote-clipboard` + `public.file-url` + `public.utf8-plain-text` + RTFD backing data.

## Testing
- `swift test --package-path Packages/CmuxTerminalServices` (17 tests passed)
- `./scripts/reload-cloud.sh --tag rtfd`
- Dogloop evidence from `/tmp/cmux-debug-rtfd.log`: iPhone paste exposed `com.apple.is-remote-clipboard`, `public.file-url`, `com.apple.flat-rtfd`, `public.utf8-plain-text`, `NSStringPboardType`, then resolved to `prepared=fileURLs(count:1)`.

## Issues
- Reported in chat: iPhone Universal Clipboard paste inserted `/Users/lawrence/Library/Group Containers/group.com.apple.coreservices.useractivityd/shared-pasteboard/items/.../*.rtfd` instead of copied text.