### PR TITLE
Preserve Claude flags after multi-value --dangerously-load-development-channels

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -51,6 +51,7 @@ extension AgentLaunchSanitizer {
             "--allowedTools",
             "--allowed-tools",
             "--betas",
+            "--dangerously-load-development-channels",
             "--disallowedTools",
             "--disallowed-tools",
             "--file",

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -82,6 +82,44 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
+    @Test("Preserves variadic --dangerously-load-development-channels values and following flags")
+    func preservesVariadicDangerouslyLoadDevelopmentChannels() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "claude",
+                    "--mcp-config",
+                    "/home/me/.mcp.json",
+                    "--dangerously-load-development-channels",
+                    "server:alpha",
+                    "server:beta",
+                    "server:gamma",
+                    "--debug-file",
+                    "/tmp/cc-debug.log",
+                    "--dangerously-skip-permissions",
+                    "--agent",
+                    "example-agent",
+                    "initial prompt should not replay",
+                ],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == [
+                "claude",
+                "--mcp-config",
+                "/home/me/.mcp.json",
+                "--dangerously-load-development-channels",
+                "server:alpha",
+                "server:beta",
+                "server:gamma",
+                "--debug-file",
+                "/tmp/cc-debug.log",
+                "--dangerously-skip-permissions",
+                "--agent",
+                "example-agent",
+            ]
+        )
+    }
+
     @Test("Drops Claude startup files")
     func dropsClaudeStartupFiles() {
         #expect(


### PR DESCRIPTION
## Summary
- Add `--dangerously-load-development-channels` to `claudePolicy.variadicOptions` so multi-value invocations of this flag don't strand later flags as unexpected positionals during resume.
- Without this, an argv that passes more than one channel value (e.g. `--dangerously-load-development-channels server:a server:b server:c`) makes `preserveOptions` treat the second value as a stray positional and `break` out of the parse loop — silently dropping every flag that came after, including `--agents`, `--agent`, `--debug-file`, and `--dangerously-skip-permissions`. All four are explicitly allowlisted in `claudePolicy.valueOptions`, so the intent to preserve them was already there; this PR just clears the path.
- Strictly additive change. The `optionWidth` variadic branch stops at the next `-`-prefixed token, so it preserves more for this flag and never less.
- Closes #6235.

## Tests
- `swift test --package-path Packages/CMUXAgentLaunch` — 85 tests pass (84 existing + 1 new). All existing assertions unchanged.
- New test simulates the broken argv shape from #6235 and asserts every allowlisted flag survives.

## Notes for reviewer
- `codeBuddyPolicy` in `AgentLaunchSanitizerAdditionalPolicies.swift` declares `--dangerously-load-development-channels` in its `valueOptions` and is missing from its own `variadicOptions` too — same shape of bug. I don't have evidence of codebuddy's CLI semantics for this flag, so this PR keeps the change strictly to the claude case I have evidence for. Easy to extend in a follow-up if you confirm codebuddy accepts the flag the same way.

---
🤖 Drafted and filed by [Claude Code](https://claude.com/claude-code) (Opus 4.7) on behalf of [@thebrubaker](https://github.com/thebrubaker), who reviewed and approved before submission. Verification + words above are the agent's.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239437&installation_id=133855650&pr_number=6273&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6273&signature=105656a7c07568021106708e3ccd480415e871f02cf94779d81ce6074df03921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix argv parsing for Claude when `--dangerously-load-development-channels` has multiple values by adding it to `claudePolicy.variadicOptions` and adding a test to lock this behavior. This preserves later flags during resume, so `--agent`, `--agents`, `--debug-file`, and `--dangerously-skip-permissions` are kept.

<sup>Written for commit 769d28ba9eae6b33c18bb48725a5802418070d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the development channels launch flag and proper handling of its associated values during argument processing.

* **Tests**
  * Added verification test for development channels flag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->