### PR TITLE
iOS: top-right + adds a terminal to current workspace, not a new workspace

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -153,7 +153,7 @@ struct WorkspaceDetailView: View {
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 chatToggleButton
-                newWorkspaceToolbarButton
+                newTerminalToolbarButton
                 terminalPickerToolbarButton
             }
         }
@@ -250,7 +250,7 @@ struct WorkspaceDetailView: View {
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 chatToggleButton
-                newWorkspaceToolbarButton
+                newTerminalToolbarButton
                 terminalPickerToolbarButton
             }
         }
@@ -363,7 +363,7 @@ struct WorkspaceDetailView: View {
             #if os(iOS)
             ToolbarItemGroup(placement: .topBarTrailing) {
                 chatToggleButton
-                newWorkspaceToolbarButton
+                newTerminalToolbarButton
                 terminalPickerToolbarButton
             }
             #else
@@ -388,17 +388,21 @@ struct WorkspaceDetailView: View {
 
     @ViewBuilder
     private var terminalToolbarButtons: some View {
-        newWorkspaceToolbarButton
+        newTerminalToolbarButton
         terminalPickerToolbarButton
     }
 
-    private var newWorkspaceToolbarButton: some View {
-        Button(action: createWorkspaceFromToolbar) {
-            Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus.square.on.square")
+    /// The prominent top-bar "+" adds a terminal to the *current* workspace,
+    /// matching the intuitive expectation (TestFlight feedback: a "+" next to
+    /// the terminal should make another terminal here, not spin up a whole new
+    /// workspace). Creating a new workspace lives in the picker menu instead.
+    private var newTerminalToolbarButton: some View {
+        Button(action: createTerminalFromToolbar) {
+            Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
                 .labelStyle(.iconOnly)
         }
         .foregroundStyle(TerminalPalette.foreground)
-        .accessibilityIdentifier("MobileTerminalNewWorkspaceButton")
+        .accessibilityIdentifier("MobileTerminalNewTerminalButton")
     }
 
     // The picker is a native SwiftUI `Menu`, which renders as the platform menu

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -234,7 +234,7 @@ final class cmuxUITests: XCTestCase {
     }
 
     @MainActor
-    func testWorkspaceToolbarCreatesWorkspaceAndTerminal() async throws {
+    func testWorkspaceToolbarCreatesTerminalAndWorkspace() async throws {
         let server = try MobileSyncMockHostServer()
         let port = try await server.start()
         defer { server.stop() }
@@ -242,7 +242,21 @@ final class cmuxUITests: XCTestCase {
         let app = try launchConnectedApp(port: port)
         try openSelectedWorkspaceIfNeeded(app)
 
-        tap(app.buttons["MobileTerminalNewWorkspaceButton"], in: app)
+        // The prominent top-bar "+" adds a terminal to the CURRENT workspace
+        // (the intuitive expectation from TestFlight feedback), not a brand-new
+        // workspace. workspace-main seeds two terminals, so the new one is #3.
+        tap(app.buttons["MobileTerminalNewTerminalButton"], in: app)
+        await assertHostSelection(
+            workspaceID: "workspace-main",
+            terminalID: "workspace-main-terminal-3",
+            server: server
+        )
+
+        tap(app.buttons["MobileTerminalDropdown"], in: app)
+        assertTerminalMenuItemExists("workspace-main-terminal-3", in: app)
+
+        // Creating a whole new workspace lives in the picker menu.
+        tapMenuItem(app.buttons["MobileNewWorkspaceMenuItem"], in: app)
         await assertHostSelection(
             workspaceID: "workspace-3",
             terminalID: "workspace-3-terminal-1",
@@ -251,15 +265,6 @@ final class cmuxUITests: XCTestCase {
 
         tap(app.buttons["MobileTerminalDropdown"], in: app)
         assertTerminalMenuItemExists("workspace-3-terminal-1", in: app)
-        tapMenuItem(app.buttons["MobileNewTerminalMenuItem"], in: app)
-        await assertHostSelection(
-            workspaceID: "workspace-3",
-            terminalID: "workspace-3-terminal-2",
-            server: server
-        )
-
-        tap(app.buttons["MobileTerminalDropdown"], in: app)
-        assertTerminalMenuItemExists("workspace-3-terminal-2", in: app)
     }
 
     @MainActor


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/6271

TestFlight feedback (Austin, iPhone): the prominent top-right "+" next to the terminal created a whole new workspace plus terminal. Users expect a "+" next to the terminal to add another terminal to the workspace they are already in.

This remaps the prominent top-bar button in `WorkspaceDetailView` from New Workspace (`plus.square.on.square` -> `createWorkspace`) to New Terminal (`plus` -> `createTerminal`, scoped to the current workspace). Creating a brand-new workspace stays available in the terminal picker menu alongside New Terminal and New Browser, so nothing is lost; only the prominent affordance changes to the intuitive action. Reuses the existing localized keys `mobile.terminal.new` / `mobile.workspace.new` (en + ja already present).

The toolbar UITest is updated to assert the corrected behavior: the prominent "+" adds a terminal to the current workspace (`workspace-main-terminal-3`), and the menu's New Workspace entry creates `workspace-3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized toolbar action and accessibility identifier change with existing create flows; no auth or sync protocol changes.
> 
> **Overview**
> The **prominent top-bar “+”** in workspace detail (terminal, chat, and browser chrome) now **creates a new terminal in the current workspace** via `createTerminalFromToolbar`, with a plain **plus** icon and accessibility id `MobileTerminalNewTerminalButton`. It no longer creates a new workspace from that slot.
> 
> **New workspace** stays available in the **terminal picker menu** (`MobileNewWorkspaceMenuItem`); behavior is unchanged there, only which action owns the visible “+”.
> 
> The UI test **`testWorkspaceToolbarCreatesTerminalAndWorkspace`** is updated to tap the new terminal button first (expects `workspace-main` / `workspace-main-terminal-3`), then use the menu for a new workspace (`workspace-3` / `workspace-3-terminal-1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001a26409cc05724b0df214b32bb88830fcb605b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239622&installation_id=133855650&pr_number=6275&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6275&signature=7b2df9ce178b88a0580d90c2f8feb5c855c8fdfa2d4813b53267ab9be36fac93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On iOS, the top-right "+" now adds a new terminal to the current workspace instead of creating a new workspace. Fixes #6271; "New Workspace" remains in the terminal picker menu.

- **Bug Fixes**
  - Remapped the top-bar button in `WorkspaceDetailView` to `createTerminal` (`plus`, uses `mobile.terminal.new`); kept new workspace in the picker (uses `mobile.workspace.new`).
  - Updated UITest to validate the new behavior and renamed the accessibility id to `MobileTerminalNewTerminalButton`.

<sup>Written for commit 001a26409cc05724b0df214b32bb88830fcb605b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * The "+" button in the top toolbar now creates a new terminal in your current workspace
  * New workspace creation is now available through the menu picker

<!-- end of auto-generated comment: release notes by coderabbit.ai -->