### PR TITLE
iOS: make notification setup self-explaining (fix "notifications don't work")

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePushCoordinator.swift
@@ -66,6 +66,25 @@ public final class MobilePushCoordinator {
     private static let pendingDeeplinkLifetime: TimeInterval = 120
     @ObservationIgnored private let now: () -> Date
 
+    /// Reads the current OS notification authorization. Injected so the settings
+    /// UI (and its tests) can reflect whether the OS would actually deliver a
+    /// banner without depending on ``UNUserNotificationCenter`` directly.
+    @ObservationIgnored private let authorizationStatusProvider:
+        @Sendable () async -> NotificationAuthorizationStatus
+
+    /// The OS-level notification authorization, decoupled from
+    /// ``UNAuthorizationStatus`` so the value can cross actor and test
+    /// boundaries and drive the settings UI.
+    public enum NotificationAuthorizationStatus: Sendable, Equatable {
+        /// The user has never been asked; opting in will show the OS prompt.
+        case notDetermined
+        /// The user (or MDM) turned cmux notifications off in iOS Settings.
+        /// Re-enabling requires a trip to Settings; the in-app toggle cannot.
+        case denied
+        /// The OS will deliver banners (authorized, provisional, or ephemeral).
+        case authorized
+    }
+
     /// Creates a push coordinator.
     /// - Parameters:
     ///   - registration: The injected push-registration service.
@@ -81,13 +100,25 @@ public final class MobilePushCoordinator {
     ///     any store exists. Defaults to the standard-defaults-backed queue.
     ///   - now: Clock seam for the pending-deeplink expiry. Defaults to
     ///     `Date.init`.
+    ///   - authorizationStatusProvider: Reads the live OS authorization status.
+    ///     Defaults to ``UNUserNotificationCenter``; injectable for tests.
     public init(
         registration: any PushRegistering,
         analytics: any AnalyticsEmitting = NoopAnalytics(),
         defaults: UserDefaults = .standard,
         deliveredNotificationClearer: any DeliveredNotificationClearing = SystemDeliveredNotificationClearer(),
         pendingDismissQueue: PendingNotificationDismissQueue = PendingNotificationDismissQueue(),
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        authorizationStatusProvider: @escaping @Sendable () async -> NotificationAuthorizationStatus = {
+            switch await UNUserNotificationCenter.current().notificationSettings().authorizationStatus {
+            case .denied:
+                return .denied
+            case .authorized, .provisional, .ephemeral:
+                return .authorized
+            default:
+                return .notDetermined
+            }
+        }
     ) {
         self.registration = registration
         self.analytics = analytics
@@ -95,10 +126,18 @@ public final class MobilePushCoordinator {
         self.deliveredNotificationClearer = deliveredNotificationClearer
         self.pendingDismissQueue = pendingDismissQueue
         self.now = now
+        self.authorizationStatusProvider = authorizationStatusProvider
     }
 
     /// Whether the user has opted into phone notifications (synchronous mirror).
     public var isEnabled: Bool { defaults.bool(forKey: Self.enabledKey) }
+
+    /// The live OS notification authorization. The in-app opt-in cannot grant
+    /// notifications the OS has denied; the settings UI uses this to send the
+    /// user to iOS Settings instead of silently no-op'ing a tap.
+    public func authorizationStatus() async -> NotificationAuthorizationStatus {
+        await authorizationStatusProvider()
+    }
 
     /// Point routing at the active store (called by the root view on appear).
     public func bind(store: CMUXMobileShellStore) {
@@ -135,10 +174,27 @@ public final class MobilePushCoordinator {
         }
     }
 
+    /// The result of an opt-in attempt, so the settings UI can show the right
+    /// next step instead of leaving a denied tap silently doing nothing.
+    public enum EnableOutcome: Sendable, Equatable {
+        /// The OS will deliver banners; the phone side is fully opted in.
+        case granted
+        /// The user just declined the OS prompt this run. The toggle stays off.
+        case declined
+        /// Notifications are off in iOS Settings, so the in-app toggle cannot
+        /// grant them. The UI must route the user to iOS Settings.
+        case blockedBySystemSettings
+    }
+
     /// Opt in: request system authorization, register for remote notifications,
-    /// and persist the flag. Returns whether authorization was granted.
+    /// and persist the flag.
+    ///
+    /// When notifications were already denied in iOS Settings, the OS does not
+    /// re-prompt and `requestAuthorization` returns `false`; that case returns
+    /// ``EnableOutcome/blockedBySystemSettings`` so the UI can send the user to
+    /// Settings rather than silently failing.
     @discardableResult
-    public func enable() async -> Bool {
+    public func enable() async -> EnableOutcome {
         let priorStatus = await UNUserNotificationCenter.current()
             .notificationSettings().authorizationStatus
         // Only an undetermined status produces a real OS prompt; gate the
@@ -157,12 +213,12 @@ public final class MobilePushCoordinator {
                 "trigger": .string("settings_toggle"),
                 "was_os_level_predenied": .bool(priorStatus == .denied),
             ])
-            return false
+            return priorStatus == .notDetermined ? .declined : .blockedBySystemSettings
         }
         analytics.capture("ios_push_optin_granted", ["trigger": .string("settings_toggle")])
         await registration.setEnabled(true)
         UIApplication.shared.registerForRemoteNotifications()
-        return true
+        return .granted
     }
 
     /// Opt out: stop receiving pushes and remove the token server-side.

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -4,6 +4,7 @@ import CmuxMobileShell
 import CmuxMobileSupport
 import CmuxMobileWorkspace
 import SwiftUI
+import UIKit
 
 /// The mobile app's settings page. Surfaces the signed-in account (so the user
 /// can confirm which cmux account this device uses — the account must match the
@@ -27,6 +28,9 @@ struct MobileSettingsView: View {
     /// `isEnabled` as a non-observable `UserDefaults` read, so reading it
     /// directly in `body` would not re-render when it flips.
     @State private var notificationsEnabled = false
+    /// Live OS authorization, so the section can route to iOS Settings when the
+    /// in-app toggle cannot grant notifications the system has denied.
+    @State private var notificationAuthorization: MobilePushCoordinator.NotificationAuthorizationStatus = .notDetermined
     @State private var showingHostPicker = false
     @State private var showingOnboarding = false
     @State private var showingSetupHelp = false
@@ -171,16 +175,9 @@ struct MobileSettingsView: View {
                     .accessibilityIdentifier("MobileSettingsPreviewLines")
                 }
 
-                Section(L10n.string("mobile.settings.notifications", defaultValue: "Notifications")) {
+                Section {
                     Button {
-                        Task {
-                            if notificationsEnabled {
-                                await pushCoordinator.disable()
-                                notificationsEnabled = false
-                            } else {
-                                notificationsEnabled = await pushCoordinator.enable()
-                            }
-                        }
+                        Task { await toggleNotifications() }
                     } label: {
                         Label(
                             notificationsEnabled
@@ -190,6 +187,28 @@ struct MobileSettingsView: View {
                         )
                     }
                     .accessibilityIdentifier("MobileSettingsNotifications")
+
+                    // The in-app opt-in cannot override an iOS Settings denial;
+                    // surface that explicitly with a one-tap route to Settings
+                    // instead of a tap that silently does nothing.
+                    if notificationAuthorization == .denied {
+                        Button {
+                            openSystemNotificationSettings()
+                        } label: {
+                            Label(
+                                L10n.string(
+                                    "mobile.notifications.openSettings",
+                                    defaultValue: "Open iOS Settings"
+                                ),
+                                systemImage: "gear"
+                            )
+                        }
+                        .accessibilityIdentifier("MobileSettingsNotificationsOpenSettings")
+                    }
+                } header: {
+                    Text(L10n.string("mobile.settings.notifications", defaultValue: "Notifications"))
+                } footer: {
+                    Text(notificationsFooter)
                 }
 
                 Section(L10n.string("mobile.settings.about", defaultValue: "About")) {
@@ -207,6 +226,7 @@ struct MobileSettingsView: View {
                 }
             }
             .onAppear { notificationsEnabled = pushCoordinator.isEnabled }
+            .task { notificationAuthorization = await pushCoordinator.authorizationStatus() }
             .navigationTitle(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -252,6 +272,50 @@ struct MobileSettingsView: View {
             }
         }
         .accessibilityIdentifier("MobileSettingsView")
+    }
+
+    /// Drive the opt-in/opt-out and reconcile both the in-app flag and the live
+    /// OS authorization, so a denied prompt flips the section into its
+    /// "Open iOS Settings" state instead of silently staying off.
+    private func toggleNotifications() async {
+        if notificationsEnabled {
+            await pushCoordinator.disable()
+            notificationsEnabled = false
+        } else {
+            switch await pushCoordinator.enable() {
+            case .granted:
+                notificationsEnabled = true
+            case .declined, .blockedBySystemSettings:
+                notificationsEnabled = false
+            }
+        }
+        notificationAuthorization = await pushCoordinator.authorizationStatus()
+    }
+
+    /// Open this app's iOS Settings page so the user can re-enable notifications
+    /// the system has denied (the in-app toggle cannot).
+    private func openSystemNotificationSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    /// Footer copy that names the two requirements a phone-only opt-in does not
+    /// satisfy: the OS permission, and the paired Mac's forwarding toggle. The
+    /// most common "notifications don't work" cause is a fully opted-in phone
+    /// whose Mac never enabled forwarding, which the phone alone cannot reveal.
+    private var notificationsFooter: String {
+        switch notificationAuthorization {
+        case .denied:
+            return L10n.string(
+                "mobile.notifications.footer.denied",
+                defaultValue: "Notifications are turned off for cmux in iOS Settings. Open Settings to allow them, then turn on \"Forward notifications to my iPhone\" on your Mac in cmux Settings > Notifications."
+            )
+        case .notDetermined, .authorized:
+            return L10n.string(
+                "mobile.notifications.footer.setup",
+                defaultValue: "Also turn on \"Forward notifications to my iPhone\" on your Mac in cmux Settings > Notifications. Agent notifications are sent only while you are away from the Mac unless you choose Always."
+            )
+        }
     }
 
     /// Which setup gate to mark as the user's current blocker. Settings is reached

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -4353,6 +4353,74 @@
         }
       }
     },
+    "mobile.notifications.footer.denied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications are turned off for cmux in iOS Settings. Open Settings to allow them, then turn on \"Forward notifications to my iPhone\" on your Mac in cmux Settings > Notifications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSの設定でcmuxの通知がオフになっています。設定を開いて通知を許可し、Macのcmuxの設定＞通知で「iPhoneに通知を転送」をオンにしてください。"
+          }
+        }
+      }
+    },
+    "mobile.notifications.footer.setup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Also turn on \"Forward notifications to my iPhone\" on your Mac in cmux Settings > Notifications. Agent notifications are sent only while you are away from the Mac unless you choose Always."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macのcmuxの設定＞通知で「iPhoneに通知を転送」もオンにしてください。エージェント通知は、「常に」を選択しない限り、Macから離れている間のみ送信されます。"
+          }
+        }
+      }
+    },
+    "mobile.notifications.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open iOS Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOSの設定を開く"
+          }
+        }
+      }
+    },
+    "mobile.settings.notifications": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知"
+          }
+        }
+      }
+    },
     "mobile.notifications.disable": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -4034,3 +4034,28 @@ private struct InertPushRegistration: PushRegistering {
     #expect(store.deeplinkWorkspaceNavigationRequest == nil)
     #expect(store.consumeDeeplinkWorkspaceNavigationRequest() == nil)
 }
+
+// MARK: - Push notification authorization surfacing
+
+/// The settings UI needs to know when the OS has *denied* notifications so it
+/// can route the user to iOS Settings instead of leaving the in-app toggle
+/// silently doing nothing — the most common "notifications don't work" cause.
+/// `authorizationStatus()` must report the injected provider's value verbatim.
+@Test @MainActor func pushCoordinatorReportsDeniedSystemAuthorization() async {
+    let coordinator = MobilePushCoordinator(
+        registration: InertPushRegistration(),
+        authorizationStatusProvider: { .denied }
+    )
+    #expect(await coordinator.authorizationStatus() == .denied)
+}
+
+/// A granted (or provisional/ephemeral) OS authorization surfaces as
+/// `.authorized`, so the settings section shows the plain setup footer rather
+/// than the "Open iOS Settings" route.
+@Test @MainActor func pushCoordinatorReportsAuthorizedSystemAuthorization() async {
+    let coordinator = MobilePushCoordinator(
+        registration: InertPushRegistration(),
+        authorizationStatusProvider: { .authorized }
+    )
+    #expect(await coordinator.authorizationStatus() == .authorized)
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/6270.

TestFlight feedback ("Notifications don't work") traces to a discoverability and feedback gap, not a broken delivery path. The whole APNs pipeline (device-token registration, production entitlement on the beta bundle, the Mac-side forward, presence gating, dismiss-sync) is correct. What is wrong is that the phone made it impossible for a tester to know they were not actually set up.

The phone Notifications setting was a single bare button. It never reflected the result of the OS permission prompt, and it never told the user that the paired Mac must also turn on "Forward notifications to my iPhone." That Mac toggle defaults off and is invisible from the phone, so the single most common "notifications don't work" state is a fully opted-in phone whose Mac never enabled forwarding. And if the user had denied the OS prompt, tapping the button silently did nothing.

Changes:
- `MobilePushCoordinator` exposes the live OS authorization status (injected, so it is testable without `UNUserNotificationCenter`), and `enable()` returns an `EnableOutcome` distinguishing granted / declined-this-run / blocked-by-system-settings.
- `MobileSettingsView` reflects that: a denied OS authorization shows an "Open iOS Settings" button, and the footer always names the second requirement (enable forwarding on the Mac), so a phone-only opt-in no longer looks complete when it is not.

Localization: new strings added to `Localizable.xcstrings` with en + ja. Two coordinator regression tests added for the authorization-status surfacing.

This is a principled fix: it surfaces the real two-gate truth (OS permission + Mac forwarding) and gives a concrete next step for each gate, rather than papering over a silent button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784239990&installation_id=133855650&pr_number=6276&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6276&signature=4466b8dff1685f3ec5d10fc15f321d4f668b9fb971a0e61c8f96895d94f32988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UX and clearer opt-in outcomes only; push registration behavior is unchanged aside from distinguishing system-denied from user-declined.
> 
> **Overview**
> Improves iOS Settings so users can see why agent notifications might not work, instead of a single toggle that can fail silently.
> 
> **`MobilePushCoordinator`** now exposes testable OS authorization via `authorizationStatus()` and maps `enable()` results to **`EnableOutcome`** (granted, declined this session, or blocked in iOS Settings when the OS was already denied).
> 
> **`MobileSettingsView`** loads that authorization, handles outcomes in `toggleNotifications()`, shows **Open iOS Settings** when the OS has denied notifications, and adds section footers that explain both gates: iOS permission and enabling **Forward notifications to my iPhone** on the paired Mac.
> 
> Adds **en/ja** strings for the new copy and two coordinator tests for denied vs authorized authorization reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c629a961491a0f7324e99be45c343caf145907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make iOS notification setup clear and actionable by showing OS permission status, offering an “Open iOS Settings” route when denied, and explaining the Mac forwarding requirement. This reduces “notifications don’t work” reports by surfacing the two gates (iOS permission + Mac forwarding).

- **New Features**
  - `MobilePushCoordinator`: exposes async authorization status and returns `EnableOutcome` (.granted, .declined, .blockedBySystemSettings); provider is injectable for tests.
  - `MobileSettingsView`: uses new outcomes, shows “Open iOS Settings” when denied, and adds a footer that explains enabling “Forward notifications to my iPhone” on the Mac; reads live status on appear.
  - Localization: new strings (en, ja) for notifications header, footer, and settings action.
  - Tests: add two coordinator tests for authorization status surfacing.

<sup>Written for commit 48c629a961491a0f7324e99be45c343caf145907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to check current notification authorization status in settings.
  * Settings now dynamically displays an "Open iOS Settings" button when notifications are denied by the system.
  * Improved messaging to clarify when notifications are blocked by system settings versus user preference.

* **Tests**
  * Added tests for notification authorization status functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->