### PR TITLE
Block browser discard during WebContent recovery

### DIFF
--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -48,6 +48,7 @@ final class BrowserHiddenWebViewDiscardManager {
     private var systemSleepObserverCenter: NotificationCenter?
     private var policyState = BrowserHiddenWebViewDiscardPolicy.resolved()
     private var scheduleGeneration: UInt64 = 0
+    private var webContentProcessRecoveryBlockUntil: Date?
 
     /// Sleep/wake state used to keep a hidden-webview discard from running in
     /// the fragile window right after system wake
@@ -77,6 +78,7 @@ final class BrowserHiddenWebViewDiscardManager {
         if !snapshot.hasCurrentURL { blockers.append("no_url") }
         if snapshot.isLoading || snapshot.webViewIsLoading { blockers.append("loading") }
         if snapshot.hasActiveMainFrameProvisionalNavigation { blockers.append("provisional_navigation") }
+        if isWebContentProcessRecoveryActive() { blockers.append("webcontent_recovery") }
         if snapshot.isDownloading || snapshot.activeDownloadCount != 0 { blockers.append("download") }
         if snapshot.isCapturingMedia { blockers.append("media_capture") }
         if snapshot.isPlayingMedia { blockers.append("media_playback") }
@@ -138,7 +140,10 @@ final class BrowserHiddenWebViewDiscardManager {
     }
 
     func noteWebContentProcessRecovery(now: Date = Date()) {
-        _ = now
+        webContentProcessRecoveryBlockUntil = now.addingTimeInterval(
+            BrowserHiddenWebViewDiscardPolicy.hiddenDelay
+        )
+        cancel()
     }
 
     /// Tracks system sleep/wake so discard countdowns armed before sleep do not
@@ -253,6 +258,7 @@ final class BrowserHiddenWebViewDiscardManager {
 
     func resetMetadata() {
         cancel()
+        webContentProcessRecoveryBlockUntil = nil
         isDiscardedForMemory = false
         discardedAt = nil
         lastDiscardReason = nil
@@ -265,6 +271,13 @@ final class BrowserHiddenWebViewDiscardManager {
         guard policyState != nextPolicyState else { return }
         policyState = nextPolicyState
         delegate?.hiddenWebViewDiscardManagerPolicyDidChange(self, reason: "policy_changed")
+    }
+
+    private func isWebContentProcessRecoveryActive(now: Date = Date()) -> Bool {
+        guard let blockUntil = webContentProcessRecoveryBlockUntil else { return false }
+        if now < blockUntil { return true }
+        webContentProcessRecoveryBlockUntil = nil
+        return false
     }
 
     private func stopOnMainActor() {

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -137,6 +137,10 @@ final class BrowserHiddenWebViewDiscardManager {
         discardTimer = nil
     }
 
+    func noteWebContentProcessRecovery(now: Date = Date()) {
+        _ = now
+    }
+
     /// Tracks system sleep/wake so discard countdowns armed before sleep do not
     /// fire shortly after wake. Injectable center for tests.
     func installSystemSleepObservers(center: NotificationCenter = NSWorkspace.shared.notificationCenter) {

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -49,6 +49,8 @@ final class BrowserHiddenWebViewDiscardManager {
     private var policyState = BrowserHiddenWebViewDiscardPolicy.resolved()
     private var scheduleGeneration: UInt64 = 0
     private var webContentProcessRecoveryBlockUntil: Date?
+    private static let webContentProcessRecoveryMinimumDelay =
+        BrowserHiddenWebViewDiscardPolicy.defaultHiddenDelay
 
     /// Sleep/wake state used to keep a hidden-webview discard from running in
     /// the fragile window right after system wake
@@ -140,8 +142,12 @@ final class BrowserHiddenWebViewDiscardManager {
     }
 
     func noteWebContentProcessRecovery(now: Date = Date()) {
+        let recoveryDelay = max(
+            BrowserHiddenWebViewDiscardPolicy.hiddenDelay,
+            Self.webContentProcessRecoveryMinimumDelay
+        )
         webContentProcessRecoveryBlockUntil = now.addingTimeInterval(
-            BrowserHiddenWebViewDiscardPolicy.hiddenDelay
+            recoveryDelay
         )
         cancel()
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5187,8 +5187,8 @@ final class BrowserPanel: Panel, ObservableObject {
             reason: "webcontent_process_terminated",
             waitForManualRecovery: true
         )
+        hiddenWebViewDiscardManager.noteWebContentProcessRecovery()
     }
-
     private func replaceWebViewPreservingState(
         from oldWebView: WKWebView,
         websiteDataStore: WKWebsiteDataStore,

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5179,8 +5179,8 @@ final class BrowserPanel: Panel, ObservableObject {
             usesTransparentWindow: usesTransparentWindow
         )
     }
-
     private func replaceWebViewAfterContentProcessTermination(for terminatedWebView: WKWebView) {
+        guard terminatedWebView === webView else { return }
         replaceWebViewPreservingState(
             from: terminatedWebView,
             websiteDataStore: websiteDataStore,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -155,11 +155,8 @@ struct BrowserHiddenWebViewDiscardMediaPlaybackTests {
             let manager = BrowserHiddenWebViewDiscardManager()
             let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
             manager.delegate = delegate
-
             #expect(manager.blockers(for: snapshot) == ["media_playback"])
-
             manager.scheduleIfNeeded(reason: "test.hidden")
-
             #expect(!manager.hasScheduledDiscard)
             #expect(delegate.discardRequestCount == 0)
         }
@@ -174,11 +171,8 @@ struct BrowserHiddenWebViewDiscardMediaPlaybackTests {
             let manager = BrowserHiddenWebViewDiscardManager()
             let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
             manager.delegate = delegate
-
             #expect(manager.blockers(for: snapshot) == [])
-
             manager.scheduleIfNeeded(reason: "test.hidden")
-
             #expect(manager.hasScheduledDiscard)
             #expect(delegate.discardRequestCount == 0)
         }
@@ -211,11 +205,8 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
         let manager = BrowserHiddenWebViewDiscardManager()
         let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
         manager.delegate = delegate
-
         XCTAssertEqual(manager.blockers(for: snapshot), ["media_capture"])
-
         manager.scheduleIfNeeded(reason: "test.hidden")
-
         XCTAssertFalse(manager.hasScheduledDiscard)
         XCTAssertEqual(delegate.discardRequestCount, 0)
     }
@@ -238,7 +229,7 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
     // Regression coverage for https://github.com/manaflow-ai/cmux/issues/5261:
     // a main-frame provisional navigation (e.g. a cross-origin process swap in
     // flight) must block a hidden-webview discard from replacing the WKWebView.
-    func testMainFrameProvisionalNavigationBlocksHiddenWebViewDiscardScheduling() {
+    func testWebKitRecoveryStatesBlockHiddenWebViewDiscardScheduling() {
         let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(
             hasActiveMainFrameProvisionalNavigation: true
         )
@@ -250,6 +241,14 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
 
         manager.scheduleIfNeeded(reason: "test.provisional")
 
+        XCTAssertFalse(manager.hasScheduledDiscard)
+        XCTAssertEqual(delegate.discardRequestCount, 0)
+
+        // Regression coverage for https://github.com/manaflow-ai/cmux/issues/4701.
+        delegate.snapshot = makeHiddenWebViewDiscardBlockerSnapshot()
+        manager.noteWebContentProcessRecovery()
+        XCTAssertEqual(manager.blockers(for: delegate.snapshot), ["webcontent_recovery"])
+        manager.scheduleIfNeeded(reason: "test.webContentRecovery")
         XCTAssertFalse(manager.hasScheduledDiscard)
         XCTAssertEqual(delegate.discardRequestCount, 0)
     }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -182,11 +182,12 @@ struct BrowserHiddenWebViewDiscardMediaPlaybackTests {
 @MainActor
 final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
     private var previousEnabled: Any?
-
+    private var previousHiddenDelay: Any?
     override func setUp() {
         super.setUp()
         let defaults = UserDefaults.standard
         previousEnabled = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
+        previousHiddenDelay = defaults.object(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
         defaults.set(true, forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
     }
 
@@ -197,9 +198,13 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
         } else {
             defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.enabledKey)
         }
+        if let previousHiddenDelay {
+            defaults.set(previousHiddenDelay, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+        } else {
+            defaults.removeObject(forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
+        }
         super.tearDown()
     }
-
     func testActiveMediaCaptureBlocksHiddenWebViewDiscardScheduling() {
         let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(isCapturingMedia: true)
         let manager = BrowserHiddenWebViewDiscardManager()
@@ -213,15 +218,11 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
 
     func testVisualAutomationCaptureBlocksHiddenWebViewDiscardScheduling() {
         let snapshot = makeHiddenWebViewDiscardBlockerSnapshot(isVisualAutomationCaptureActive: true)
-
         let manager = BrowserHiddenWebViewDiscardManager()
         let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
         manager.delegate = delegate
-
         XCTAssertEqual(manager.blockers(for: snapshot), ["visual_automation"])
-
         manager.scheduleIfNeeded(reason: "test.visualAutomation")
-
         XCTAssertFalse(manager.hasScheduledDiscard)
         XCTAssertEqual(delegate.discardRequestCount, 0)
     }
@@ -236,16 +237,15 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
         let manager = BrowserHiddenWebViewDiscardManager()
         let delegate = BrowserHiddenWebViewDiscardTestDelegate(snapshot: snapshot, hiddenAt: Date())
         manager.delegate = delegate
-
         XCTAssertEqual(manager.blockers(for: snapshot), ["provisional_navigation"])
-
         manager.scheduleIfNeeded(reason: "test.provisional")
-
         XCTAssertFalse(manager.hasScheduledDiscard)
         XCTAssertEqual(delegate.discardRequestCount, 0)
-
         // Regression coverage for https://github.com/manaflow-ai/cmux/issues/4701.
         delegate.snapshot = makeHiddenWebViewDiscardBlockerSnapshot()
+        manager.noteWebContentProcessRecovery()
+        XCTAssertEqual(manager.blockers(for: delegate.snapshot), ["webcontent_recovery"])
+        UserDefaults.standard.set(0, forKey: BrowserHiddenWebViewDiscardPolicy.hiddenDelayKey)
         manager.noteWebContentProcessRecovery()
         XCTAssertEqual(manager.blockers(for: delegate.snapshot), ["webcontent_recovery"])
         manager.scheduleIfNeeded(reason: "test.webContentRecovery")


### PR DESCRIPTION
## Summary
- Blocks Browser Memory Saver hidden-webview discard while WebKit is in WebContent process recovery.
- Extends the existing WebKit discard regression coverage to assert the `webcontent_recovery` blocker.

## Testing
- `./scripts/lint-pbxproj-test-wiring.sh` passed.
- `git diff --check` passed.
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag wkcrsh` passed and built `/Users/cmux-lawrence/Library/Developer/Xcode/DerivedData/cmux-wkcrsh/Build/Products/Debug/cmux DEV wkcrsh.app`.
- `./scripts/reload-cloud.sh --tag wkcrsh` failed before build with `RELOAD_ARGS[@]: unbound variable` in the cloud reload shim.
- `./scripts/reload.sh --tag wkcrsh` without `CMUX_SKIP_ZIG_BUILD=1` failed in the Ghostty CLI helper Zig build with unresolved macOS symbols from `/usr/local/bin/zig`.
- Local `xcodebuild test` not run per repo policy.

## Issues
- Fixes https://github.com/manaflow-ai/cmux/issues/4701
- Related: https://github.com/manaflow-ai/cmux/issues/5753
- Related: https://github.com/manaflow-ai/cmux/issues/5261

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784241756&installation_id=133855650&pr_number=6279&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6279&signature=0cf217215080c859a6dc94f4bf8686eacf33b3f75bac904557cb52753d71d718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing of WKWebView memory discard around WebContent process termination; mistakes could leave hidden tabs undiscarded longer or still discard during recovery, but scope is narrow and covered by regression tests.
> 
> **Overview**
> Adds a **`webcontent_recovery`** guard so Memory Saver does not schedule or run hidden-webview discard while WebKit is recovering from a WebContent process crash.
> 
> **`BrowserHiddenWebViewDiscardManager`** now tracks a cooldown (at least the configured hidden delay), exposes **`noteWebContentProcessRecovery()`** (cancels any armed timer), and treats recovery as a discard blocker until that window expires. Recovery state is cleared on **`resetMetadata()`**.
> 
> **`BrowserPanel`** calls that hook after **`replaceWebViewAfterContentProcessTermination`**, with a guard so only the current **`webView`** triggers recovery handling.
> 
> Tests assert **`webcontent_recovery`** blocks scheduling even when **`hiddenDelay`** is zero, alongside existing provisional-navigation coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5405a39fdea54a43b5eedfc5ac4fe632e049550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block hidden-webview discard while WebKit recovers the WebContent process, and enforce a minimum recovery window so the view isn’t replaced mid-recovery. This prevents crashes and preserves tab state.

- **Bug Fixes**
  - Added `webcontent_recovery` blocker in `BrowserHiddenWebViewDiscardManager`; cancels any scheduled discard and defers discard for at least the default hidden delay.
  - Introduced `noteWebContentProcessRecovery()`; now called only when the terminated `WKWebView` is the active `webView` in `BrowserPanel`.
  - Reset recovery state on manager reset; tests cover the blocker and the minimum-delay behavior.

<sup>Written for commit c5405a39fdea54a43b5eedfc5ac4fe632e049550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WebKit “web content process” recovery by introducing a dedicated recovery blocking window, so hidden web views are no longer discarded while recovery is active.

* **Tests**
  * Expanded coverage to validate recovery blocker states and ensure discard scheduling is not triggered during active recovery, including scenarios before and after recovery timing adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->