### PR TITLE
Founders Edition welcome email: announce iOS beta launch + collect TestFlight email

### DIFF
--- a/web/app/api/stripe/founders-welcome/welcome-email.ts
+++ b/web/app/api/stripe/founders-welcome/welcome-email.ts
@@ -39,6 +39,10 @@ function buildBody(name: string): string {
       "text me on iMessage or WhatsApp, or we can just continue talking here. " +
       "I've CC'd my cofounder as well.",
     "",
+    "cmux iOS Beta is out for cmux Founder's Edition! If you have a different " +
+      "TestFlight email, please reply to this email with the new email address. " +
+      "Otherwise, we'll send it to the one on file.",
+    "",
     "Best,",
     "Austin",
   ].join("\n");

--- a/web/tests/founders-welcome-email.test.ts
+++ b/web/tests/founders-welcome-email.test.ts
@@ -108,4 +108,37 @@ describe("buildFoundersWelcomeEmail", () => {
     expect(named.text.startsWith("Hi Ada!")).toBe(true);
     expect(anonymous.text.startsWith("Hi there!")).toBe(true);
   });
+
+  test("announces the iOS beta and asks for a corrected TestFlight email", () => {
+    const email = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "customer@example.com",
+      sessionRef: "cs_test_aaa",
+    });
+
+    const iosBetaParagraph =
+      "cmux iOS Beta is out for cmux Founder's Edition! If you have a different " +
+      "TestFlight email, please reply to this email with the new email address. " +
+      "Otherwise, we'll send it to the one on file.";
+
+    // The new paragraph must be present verbatim (lowercase "cmux", "cmux
+    // Founder's Edition", and one-word "TestFlight" are intentional brand/style).
+    expect(email.text).toContain(iosBetaParagraph);
+
+    // It must be its own block — separated by blank lines from the surrounding
+    // paragraphs — and sit after the contact details, just above the sign-off.
+    const paragraphs = email.text.split("\n\n");
+    expect(paragraphs).toContain(iosBetaParagraph);
+
+    const contactIndex = paragraphs.findIndex((p) =>
+      p.startsWith("My number is"),
+    );
+    const iosBetaIndex = paragraphs.indexOf(iosBetaParagraph);
+    const signOffIndex = paragraphs.findIndex((p) => p.startsWith("Best,"));
+
+    expect(contactIndex).toBeGreaterThanOrEqual(0);
+    expect(signOffIndex).toBeGreaterThanOrEqual(0);
+    expect(iosBetaIndex).toBeGreaterThan(contactIndex);
+    expect(iosBetaIndex).toBeLessThan(signOffIndex);
+  });
 });


### PR DESCRIPTION
## What

Adds one paragraph to the auto-sent **cmux Founder's Edition** welcome email (`web/app/api/stripe/founders-welcome/welcome-email.ts`, `buildBody`):

1. Announces that the **cmux iOS Beta** is out for Founder's Edition.
2. Asks the recipient to reply with a different **TestFlight** email if theirs differs from the one on file.

The new paragraph sits after the contact-details paragraph, just above the sign-off.

This is a **copy-only** change. No changes to send / threading / idempotency logic, subject, sender, cc, or reply-to. No new env vars, no Stripe/Resend wiring changes.

## Full new email body (what the customer receives)

```
Hi {first name}!

Thank you for being one of the first ever customers of cmux :)

My number is +1(714) 699-0169 and Lawrence's number is +1(949) 302-0749. Our emails are austin@manaflow.ai and lawrence@manaflow.ai. Feel free to text me on iMessage or WhatsApp, or we can just continue talking here. I've CC'd my cofounder as well.

cmux iOS Beta is out for cmux Founder's Edition! If you have a different TestFlight email, please reply to this email with the new email address. Otherwise, we'll send it to the one on file.

Best,
Austin
```

(Greeting falls back to `Hi there!` when no name is on file — unchanged.)

## Tests

Updated `web/tests/founders-welcome-email.test.ts` with a case asserting the new paragraph is present verbatim and correctly placed (after the contact details, above the sign-off). The existing subject / cc / reply-to / threading assertions are unchanged.

- `bun test tests/founders-welcome-email.test.ts` → 7 pass / 0 fail
- `bun tsc --noEmit` → clean
- `eslint` on the touched files → clean

## Notes on copy (intentional)

Lowercase `cmux` and `cmux Founder's Edition` (apostrophe-s) brand style, and Apple's product is one word: `TestFlight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784244955&installation_id=133855650&pr_number=6280&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6280&signature=b11445649d42b537f7c586cad18d39d87c0a1f8024556b9dabd21278d8c67a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a paragraph to the cmux Founder's Edition welcome email to announce the iOS beta and ask recipients to reply with a different TestFlight email if needed. No changes to sending logic or headers; tests assert the new paragraph and its placement (after contact details, before the sign-off).

<sup>Written for commit 23290dda57b459592395372c6e06cd4fb826a496. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Founders now receive updated welcome email mentioning cmux iOS Beta availability.
  * Email includes instructions to reply with a TestFlight email address for beta access if desired.

* **Tests**
  * Added regression test to verify new email content appears correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->