### PR TITLE
iOS: stop dictation teardown from interrupting background music

### DIFF
--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -42,6 +42,14 @@ final class ComposerDictationController {
     /// every teardown.
     private let audioEngine = AVAudioEngine()
 
+    /// Tracks whether this controller owns an active shared audio session, so
+    /// teardown only touches the engine/session when dictation actually started.
+    /// A hard cancel from idle (composer disappear, terminal switch, focus loss,
+    /// send) must NOT touch `AVAudioEngine.inputNode` or call `setActive(false)`:
+    /// either one perturbs the shared audio session and briefly interrupts other
+    /// apps' audio even though nothing was recorded.
+    private var audioSession = DictationAudioSessionOwnership()
+
     /// The in-flight recognition request, fed audio buffers from the engine tap.
     private var request: SFSpeechAudioBufferRecognitionRequest?
 
@@ -271,6 +279,11 @@ final class ComposerDictationController {
             // documented restrictions and would permanently disable the mic.
             try session.setCategory(.record, mode: .measurement)
             try session.setActive(true)
+            // From here we own an active session: a later teardown must stop the
+            // engine and deactivate. Recorded only after `setActive(true)` so a
+            // failure above (which never activated anything) tears down as a
+            // no-op and does not poke the shared session.
+            audioSession.markActivated()
         } catch {
             failStart()
             return
@@ -364,6 +377,14 @@ final class ComposerDictationController {
     /// session. Shared by the graceful stop (which keeps the recognition task and
     /// callback alive) and the hard `teardown()`. Safe to call repeatedly.
     private func stopEngineAndSession() {
+        // Only touch the engine/session when we actually activated one. A
+        // teardown from idle (composer disappear, terminal switch, focus loss, or
+        // send while dictation never ran) must be a true no-op: merely accessing
+        // `audioEngine.inputNode` instantiates the input audio unit and forces
+        // the shared `AVAudioSession` active, and `setActive(false, ...)` perturbs
+        // it again — either momentarily interrupts other apps' music (~1-2s)
+        // despite nothing being recorded. The guard makes those calls harmless.
+        guard audioSession.takeForTeardown() else { return }
         if audioEngine.isRunning {
             audioEngine.stop()
         }

--- a/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -99,3 +99,42 @@ struct ComposerDictationTextMerger {
         return base + " " + trimmedTranscript
     }
 }
+
+/// Tracks whether the dictation controller currently owns an active shared
+/// `AVAudioSession`, gating teardown so it only touches the engine/session when
+/// there is actually something to tear down. Factored out of the iOS-only
+/// controller so the ownership lifecycle is host-testable without AVFoundation.
+///
+/// This exists because teardown is otherwise destructive even from idle. The
+/// composer hard-cancels dictation on every disappear, terminal switch, focus
+/// loss, and send (so the mic is never left hot), and most of those happen when
+/// the user never dictated at all. Touching `AVAudioEngine.inputNode` (to remove
+/// the tap) instantiates the input audio unit and forces the shared audio
+/// session active, and `setActive(false, .notifyOthersOnDeactivation)` perturbs
+/// it again; either momentarily interrupts other apps' audio (a 1-2s music
+/// pause) even though nothing was ever recorded. Gating on real ownership makes
+/// a teardown-from-idle a true no-op, which is what those call sites always
+/// assumed it was.
+struct DictationAudioSessionOwnership {
+    /// Whether the controller activated the shared audio session and has not yet
+    /// torn it down.
+    private(set) var isActive = false
+
+    init() {}
+
+    /// Record that the controller just activated the shared audio session
+    /// (`setActive(true)` succeeded). From here a teardown must run.
+    mutating func markActivated() {
+        isActive = true
+    }
+
+    /// Claim ownership for a single teardown: returns `true` exactly once after a
+    /// `markActivated()`, clearing the flag so repeated teardowns and any
+    /// teardown that never activated a session are no-ops. The caller only
+    /// touches `AVAudioEngine` / `AVAudioSession` when this returns `true`.
+    mutating func takeForTeardown() -> Bool {
+        guard isActive else { return false }
+        isActive = false
+        return true
+    }
+}

--- a/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -194,6 +194,46 @@ import Testing
         }
     }
 
+    // MARK: - Audio session ownership (no music interruption from idle)
+
+    @Test func teardownFromIdleNeverTouchesAudioSession() {
+        // The regression: the composer hard-cancels dictation on every disappear,
+        // terminal switch, focus loss, and send, almost always while the user
+        // never dictated. If teardown ran the engine/session path then, it would
+        // poke the shared AVAudioSession and briefly pause other apps' music. With
+        // no prior activation, the teardown must claim nothing.
+        var ownership = DictationAudioSessionOwnership()
+        #expect(!ownership.isActive)
+        #expect(!ownership.takeForTeardown())
+        #expect(!ownership.takeForTeardown())
+    }
+
+    @Test func teardownAfterActivationRunsExactlyOnce() {
+        // A real dictation session activates, then the first teardown deactivates
+        // and clears ownership; any later teardown (a cancel racing a graceful
+        // stop, or a send right after) is a no-op so the session is never
+        // double-deactivated.
+        var ownership = DictationAudioSessionOwnership()
+        ownership.markActivated()
+        #expect(ownership.isActive)
+        #expect(ownership.takeForTeardown())
+        #expect(!ownership.isActive)
+        #expect(!ownership.takeForTeardown())
+    }
+
+    @Test func reactivationAfterTeardownIsOwnedAgain() {
+        // Starting dictation a second time (start → stop → start) re-arms
+        // ownership so the second session's teardown runs, while still leaving an
+        // idle controller's teardown a no-op.
+        var ownership = DictationAudioSessionOwnership()
+        ownership.markActivated()
+        #expect(ownership.takeForTeardown())
+        #expect(!ownership.takeForTeardown())
+        ownership.markActivated()
+        #expect(ownership.takeForTeardown())
+        #expect(!ownership.takeForTeardown())
+    }
+
     @Test func gracefulStopFinalizesOnlyFromListening() {
         // Mirrors the controller's `stop()` branch: a graceful stop finalizes from
         // `.listening` and otherwise falls back to a hard cancel (which finalizes


### PR DESCRIPTION
## Problem

On iOS, external music (Spotify, Apple Music, etc.) pauses for ~1-2 seconds in two situations, even when the user never used voice dictation:

1. Swiping back from a workspace that was navigated to.
2. Sending a prompt from the liquid-glass composer text field below the terminal.

## Root cause

`ComposerDictationController` hard-cancels dictation on every composer `onDisappear`, terminal switch, focus loss, and send, so the mic is never left hot. Almost all of those fire when the user never dictated at all. `cancel()` and `stop()` both route through `stopEngineAndSession()`, which ran **unconditionally**:

```swift
audioEngine.inputNode.removeTap(onBus: 0)
try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
```

Merely accessing `AVAudioEngine.inputNode` instantiates the input audio unit and forces the shared `AVAudioSession` active, and the `setActive(false, .notifyOthersOnDeactivation)` perturbs it again. Either one momentarily interrupts other apps' audio. The `send()` path even carried a comment claiming `cancel()` on an idle controller "is a no-op" — it wasn't.

Both reported repro paths (swipe-back `onDisappear` → `cancel()`, and `send()` → `cancel()`) funnel through this one teardown, which is why the same 1-2s pause shows up in both.

## Fix

Gate the engine/session teardown on real ownership. A new pure value type `DictationAudioSessionOwnership` is marked active only after `setActive(true)` succeeds and claimed once per teardown:

- Teardown from idle (composer disappear, terminal switch, focus loss, send while dictation never ran) is now a true no-op — it never touches `AVAudioEngine.inputNode` or the shared session, so background music is undisturbed.
- A real dictation session still stops the engine and deactivates the session exactly once (including the failed-start path, which activates before installing the tap).
- No double-deactivation when a hard `cancel()` races a graceful `stop()`.

This is a principled fix: it makes the teardown's actual behavior match what every call site already assumed (a no-op unless dictation is live), and it keeps legitimate dictation capture/teardown intact.

## Tests

`DictationAudioSessionOwnership` is factored out of the iOS-only controller so its lifecycle is host-testable (same pattern as the existing `ComposerDictationState` / `ComposerDictationTextMerger`). Added host tests in `ComposerDictationTests`:

- `teardownFromIdleNeverTouchesAudioSession` — the regression: no activation ⇒ teardown claims nothing.
- `teardownAfterActivationRunsExactlyOnce` — one deactivation per session, later teardowns are no-ops.
- `reactivationAfterTeardownIsOwnedAgain` — start → stop → start re-arms ownership.

The interrupting side-effect itself is a device-only `AVAudioSession` behavior, so a host red/green two-commit structure isn't applicable; these tests cover the ownership logic that encodes the fix. Verified via a tagged iOS build.

## Dogfood

Play music in another app, open the iOS app, navigate into a workspace, then swipe back — music should keep playing. Then tap the composer and send a prompt — music should keep playing. Before this change, each of those caused a ~1-2s pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784246898&installation_id=133855650&pr_number=6282&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6282&signature=fb7b52718a02e929ed2b2c3e13ae94219c3d3feb7bf067f5560f49bf0965c7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where external music paused for ~1–2s when leaving the composer or sending a prompt on iOS. Dictation teardown now runs only if dictation actually activated the audio session.

- Bug Fixes
  - Added `DictationAudioSessionOwnership` to track activation after `setActive(true)` and allow a single teardown.
  - Guarded teardown so idle paths are no-ops; real sessions stop once with no double-deactivation.
  - Added host tests covering idle no-op, run-once after activation, and re-activation.

<sup>Written for commit 5c82c9ac9862a3c2337382d20a18ff2a707a74f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced voice dictation stability by preventing unintended audio session interactions when dictation setup is incomplete or inactive.
* **Tests**
  * Added comprehensive test coverage for audio session lifecycle and ownership management during dictation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->