### PR TITLE
Add cmux-vnc: native RFB (VNC) surface

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15428,11 +15428,11 @@ struct CMUXCLI {
             Create a new surface (tab) in a pane.
 
             Flags:
-              --type <terminal|browser|agent-session>   Surface type (default: terminal)
+              --type <terminal|browser|agent-session|vnc>   Surface type (default: terminal)
               --pane <id|ref|index>       Target pane
               --workspace <id|ref|index>  Target workspace (default: $CMUX_WORKSPACE_ID)
               --window <id|ref|index>     Window context for workspace/pane refs and indexes
-              --url <url>                 URL for browser surfaces
+              --url <url>                 URL for browser surfaces, or vnc://host:port for VNC
               --provider <codex|claude|opencode>
                                            Provider for agent-session surfaces (default: codex)
               --renderer <react|solid>    Renderer for agent-session surfaces (default: react)
@@ -15443,6 +15443,7 @@ struct CMUXCLI {
               cmux new-surface
               cmux new-surface --type browser --pane pane:1 --url https://example.com
               cmux new-surface --type agent-session --provider claude --renderer solid --focus true
+              cmux new-surface --type vnc --url vnc://127.0.0.1:5900 --focus true
             """
         case "close-surface":
             return """

--- a/Packages/CmuxVNC/Package.resolved
+++ b/Packages/CmuxVNC/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "639c3e5159332d08c1156cbde5bcf4e8422d9499d5f6b7a8f0d97402d56e1250",
+  "pins" : [
+    {
+      "identity" : "bigint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attaswift/BigInt.git",
+      "state" : {
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/CmuxVNC/Package.swift
+++ b/Packages/CmuxVNC/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxVNC",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxVNC",
+            targets: ["CmuxVNC"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxVNC",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxVNCTests",
+            dependencies: ["CmuxVNC"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+            ]
+        ),
+    ]
+)

--- a/Packages/CmuxVNC/Package.swift
+++ b/Packages/CmuxVNC/Package.swift
@@ -13,9 +13,16 @@ let package = Package(
             targets: ["CmuxVNC"]
         ),
     ],
+    dependencies: [
+        // Modular exponentiation for Apple Diffie-Hellman (VNC security type 30).
+        .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
+    ],
     targets: [
         .target(
             name: "CmuxVNC",
+            dependencies: [
+                .product(name: "BigInt", package: "BigInt"),
+            ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Client/RFBClient.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Client/RFBClient.swift
@@ -102,7 +102,8 @@ public actor RFBClient {
             let serverInit = try await RFBHandshake().negotiate(
                 source: transport,
                 sink: transport,
-                password: endpoint.password
+                password: endpoint.password,
+                username: endpoint.username
             )
             framebuffer = Framebuffer(width: serverInit.width, height: serverInit.height)
 

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Client/RFBClient.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Client/RFBClient.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// An event emitted by ``RFBClient`` as the session progresses. Delivered on an
+/// `AsyncStream`; consumers (the view) render frames and reflect state.
+public enum VNCClientEvent: Sendable, Equatable {
+    case connecting
+    case connected(width: Int, height: Int, name: String)
+    case frame(VNCFrameSnapshot)
+    case resized(width: Int, height: Int)
+    case bell
+    case serverCutText(String)
+    case disconnected(RFBError?)
+}
+
+/// A pointer button bit for `PointerEvent`.
+public struct VNCButtonMask: OptionSet, Sendable {
+    public let rawValue: UInt8
+    public init(rawValue: UInt8) { self.rawValue = rawValue }
+    public static let left = VNCButtonMask(rawValue: 1 << 0)
+    public static let middle = VNCButtonMask(rawValue: 1 << 1)
+    public static let right = VNCButtonMask(rawValue: 1 << 2)
+    public static let wheelUp = VNCButtonMask(rawValue: 1 << 3)
+    public static let wheelDown = VNCButtonMask(rawValue: 1 << 4)
+}
+
+/// Drives a single RFB session over a transport: handshake, format/encoding
+/// negotiation, the framebuffer-update loop, and outbound input. Owns its
+/// ``Framebuffer`` and never shares it; the UI receives `Sendable` snapshots.
+public actor RFBClient {
+    private let transport: NWConnectionTransport
+    private let endpoint: VNCEndpoint
+    private var framebuffer = Framebuffer(width: 0, height: 0)
+    private var running = false
+    private var continuation: AsyncStream<VNCClientEvent>.Continuation?
+
+    /// Encodings cmux advertises, most-preferred first. Hextile and RRE shrink
+    /// most desktop updates; CopyRect makes scrolling cheap; Raw is the
+    /// universal fallback; DesktopSize lets the server resize us.
+    private static let advertisedEncodings: [RFBClientMessage.Encoding] = [
+        .copyRect, .hextile, .rre, .raw, .desktopSize,
+    ]
+
+    public init(endpoint: VNCEndpoint) {
+        self.endpoint = endpoint
+        self.transport = NWConnectionTransport(host: endpoint.host, port: endpoint.port)
+    }
+
+    /// Starts the session and returns a stream of events. Cancelling the stream
+    /// (or calling ``stop()``) tears the connection down.
+    public func start() -> AsyncStream<VNCClientEvent> {
+        AsyncStream { continuation in
+            self.continuation = continuation
+            let task = Task { await self.run(continuation) }
+            continuation.onTermination = { _ in
+                task.cancel()
+                Task { await self.stop() }
+            }
+        }
+    }
+
+    public func stop() async {
+        running = false
+        await transport.close()
+        continuation?.finish()
+        continuation = nil
+    }
+
+    // MARK: Input
+
+    public func sendPointer(buttons: VNCButtonMask, x: Int, y: Int) async {
+        let clampedX = UInt16(clamping: max(0, x))
+        let clampedY = UInt16(clamping: max(0, y))
+        try? await transport.write(RFBClientMessage.pointerEvent(buttonMask: buttons.rawValue, x: clampedX, y: clampedY))
+    }
+
+    public func sendKey(keysym: UInt32, down: Bool) async {
+        try? await transport.write(RFBClientMessage.keyEvent(keysym: keysym, down: down))
+    }
+
+    public func sendCutText(_ text: String) async {
+        try? await transport.write(RFBClientMessage.clientCutText(text))
+    }
+
+    /// A scroll "click": press then release a wheel button.
+    public func sendScroll(up: Bool, x: Int, y: Int, ticks: Int = 1) async {
+        let button: VNCButtonMask = up ? .wheelUp : .wheelDown
+        let cx = UInt16(clamping: max(0, x))
+        let cy = UInt16(clamping: max(0, y))
+        for _ in 0 ..< max(1, ticks) {
+            try? await transport.write(RFBClientMessage.pointerEvent(buttonMask: button.rawValue, x: cx, y: cy))
+            try? await transport.write(RFBClientMessage.pointerEvent(buttonMask: 0, x: cx, y: cy))
+        }
+    }
+
+    // MARK: Session loop
+
+    private func run(_ continuation: AsyncStream<VNCClientEvent>.Continuation) async {
+        running = true
+        continuation.yield(.connecting)
+        do {
+            try await transport.connect()
+            let serverInit = try await RFBHandshake().negotiate(
+                source: transport,
+                sink: transport,
+                password: endpoint.password
+            )
+            framebuffer = Framebuffer(width: serverInit.width, height: serverInit.height)
+
+            try await transport.write(RFBClientMessage.setPixelFormat(.cmuxBGRX))
+            try await transport.write(RFBClientMessage.setEncodings(Self.advertisedEncodings))
+
+            continuation.yield(.connected(width: serverInit.width, height: serverInit.height, name: serverInit.name))
+
+            try await requestUpdate(incremental: false)
+
+            let decoder = RFBRectangleDecoder()
+            while running, !Task.isCancelled {
+                try await readServerMessage(decoder: decoder, continuation: continuation)
+            }
+            continuation.yield(.disconnected(nil))
+        } catch let error as RFBError {
+            continuation.yield(.disconnected(error))
+        } catch {
+            continuation.yield(.disconnected(.transport(error.localizedDescription)))
+        }
+        running = false
+        await transport.close()
+        continuation.finish()
+    }
+
+    private func requestUpdate(incremental: Bool) async throws {
+        guard framebuffer.width > 0, framebuffer.height > 0 else { return }
+        try await transport.write(RFBClientMessage.framebufferUpdateRequest(
+            incremental: incremental,
+            x: 0,
+            y: 0,
+            width: UInt16(clamping: framebuffer.width),
+            height: UInt16(clamping: framebuffer.height)
+        ))
+    }
+
+    private func readServerMessage(
+        decoder: RFBRectangleDecoder,
+        continuation: AsyncStream<VNCClientEvent>.Continuation
+    ) async throws {
+        let messageType = try await transport.readUInt8()
+        switch messageType {
+        case 0:
+            try await readFramebufferUpdate(decoder: decoder, continuation: continuation)
+        case 1: // SetColourMapEntries — ignored (we use true-colour).
+            _ = try await transport.readUInt8() // padding
+            _ = try await transport.readUInt16() // first colour
+            let count = try await transport.readUInt16()
+            if count > 0 { _ = try await transport.readExactly(Int(count) * 6) }
+        case 2: // Bell
+            continuation.yield(.bell)
+        case 3: // ServerCutText
+            _ = try await transport.readExactly(3) // padding
+            let text = try await transport.readLengthPrefixedString()
+            continuation.yield(.serverCutText(text))
+        default:
+            throw RFBError.protocolViolation("unknown server message \(messageType)")
+        }
+    }
+
+    private func readFramebufferUpdate(
+        decoder: RFBRectangleDecoder,
+        continuation: AsyncStream<VNCClientEvent>.Continuation
+    ) async throws {
+        _ = try await transport.readUInt8() // padding
+        let rectangleCount = try await transport.readUInt16()
+        var didResize = false
+        for _ in 0 ..< rectangleCount {
+            let header = try await transport.readRectangleHeader()
+            let previousWidth = framebuffer.width
+            let previousHeight = framebuffer.height
+            try await decoder.decode(header: header, from: transport, into: framebuffer)
+            if framebuffer.width != previousWidth || framebuffer.height != previousHeight {
+                didResize = true
+            }
+        }
+        if didResize {
+            continuation.yield(.resized(width: framebuffer.width, height: framebuffer.height))
+        }
+        continuation.yield(.frame(framebuffer.snapshot()))
+        // Ask for the next incremental update to keep the stream flowing.
+        try await requestUpdate(incremental: true)
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Client/VNCEndpoint.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Client/VNCEndpoint.swift
@@ -11,11 +11,15 @@ public struct VNCEndpoint: Equatable, Sendable {
     public var host: String
     public var port: UInt16
     public var password: String?
+    /// Account user name, required for Apple Diffie-Hellman auth (macOS Screen
+    /// Sharing). Parsed from `vnc://user:password@host`.
+    public var username: String?
 
-    public init(host: String, port: UInt16, password: String? = nil) {
+    public init(host: String, port: UInt16, password: String? = nil, username: String? = nil) {
         self.host = host
         self.port = port
         self.password = password
+        self.username = username
     }
 
     public init?(string raw: String) {
@@ -23,6 +27,7 @@ public struct VNCEndpoint: Equatable, Sendable {
         guard !text.isEmpty else { return nil }
 
         var password: String?
+        var username: String?
         if text.lowercased().hasPrefix("vnc://") {
             text = String(text.dropFirst("vnc://".count))
         }
@@ -30,12 +35,20 @@ public struct VNCEndpoint: Equatable, Sendable {
         if let slash = text.firstIndex(of: "/") {
             text = String(text[..<slash])
         }
-        // Optional userinfo carrying a password (`password@host` or `:password@host`).
+        // Optional userinfo: `password@host`, `:password@host`, or
+        // `user:password@host` (the last form carries the account name needed
+        // for Apple DH auth).
         if let at = text.lastIndex(of: "@") {
             let userinfo = String(text[..<at])
             text = String(text[text.index(after: at)...])
-            password = userinfo.hasPrefix(":") ? String(userinfo.dropFirst()) : userinfo
-            if password?.isEmpty == true { password = nil }
+            if let colon = userinfo.firstIndex(of: ":") {
+                let user = String(userinfo[..<colon])
+                let pass = String(userinfo[userinfo.index(after: colon)...])
+                username = user.isEmpty ? nil : user
+                password = pass.isEmpty ? nil : pass
+            } else {
+                password = userinfo.isEmpty ? nil : userinfo
+            }
         }
         guard !text.isEmpty else { return nil }
 
@@ -48,7 +61,7 @@ public struct VNCEndpoint: Equatable, Sendable {
             if rest.hasPrefix(":"), let parsed = UInt16(rest.dropFirst()) {
                 port = parsed
             }
-            self.init(host: host, port: port, password: password)
+            self.init(host: host, port: port, password: password, username: username)
             return
         }
 
@@ -57,7 +70,7 @@ public struct VNCEndpoint: Equatable, Sendable {
             let host = String(text[..<rawPortRange.lowerBound])
             let portText = String(text[rawPortRange.upperBound...])
             guard !host.isEmpty, let port = UInt16(portText) else { return nil }
-            self.init(host: host, port: port, password: password)
+            self.init(host: host, port: port, password: password, username: username)
             return
         }
 
@@ -67,11 +80,11 @@ public struct VNCEndpoint: Equatable, Sendable {
             guard !host.isEmpty, let value = Int(suffix), value >= 0 else { return nil }
             // Small numbers are VNC display numbers (5900 + N); larger are ports.
             let port = value < 100 ? UInt16(5900 + value) : UInt16(clamping: value)
-            self.init(host: host, port: port, password: password)
+            self.init(host: host, port: port, password: password, username: username)
             return
         }
 
-        self.init(host: text, port: 5900, password: password)
+        self.init(host: text, port: 5900, password: password, username: username)
     }
 
     /// A user-facing label like `host:5901`.

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Client/VNCEndpoint.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Client/VNCEndpoint.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// A parsed VNC target: host, port, and optional password.
+///
+/// Accepts `vnc://[password@]host[:port]`, `host:port`, `host::screen`
+/// (RealVNC-style display where `::N` means port `5900 + N` is *not* applied;
+/// `::` denotes a raw port), and bare `host`. A display suffix `host:N` where
+/// `N < 100` is treated as a screen number (port `5900 + N`), matching common
+/// VNC viewer conventions.
+public struct VNCEndpoint: Equatable, Sendable {
+    public var host: String
+    public var port: UInt16
+    public var password: String?
+
+    public init(host: String, port: UInt16, password: String? = nil) {
+        self.host = host
+        self.port = port
+        self.password = password
+    }
+
+    public init?(string raw: String) {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        var password: String?
+        if text.lowercased().hasPrefix("vnc://") {
+            text = String(text.dropFirst("vnc://".count))
+        }
+        // Strip a trailing path/query, if any.
+        if let slash = text.firstIndex(of: "/") {
+            text = String(text[..<slash])
+        }
+        // Optional userinfo carrying a password (`password@host` or `:password@host`).
+        if let at = text.lastIndex(of: "@") {
+            let userinfo = String(text[..<at])
+            text = String(text[text.index(after: at)...])
+            password = userinfo.hasPrefix(":") ? String(userinfo.dropFirst()) : userinfo
+            if password?.isEmpty == true { password = nil }
+        }
+        guard !text.isEmpty else { return nil }
+
+        // IPv6 literal in brackets: [::1]:5900 (checked first so its inner "::"
+        // is not mistaken for the raw-port separator below).
+        if text.hasPrefix("["), let close = text.firstIndex(of: "]") {
+            let host = String(text[text.index(after: text.startIndex)..<close])
+            var port: UInt16 = 5900
+            let rest = text[text.index(after: close)...]
+            if rest.hasPrefix(":"), let parsed = UInt16(rest.dropFirst()) {
+                port = parsed
+            }
+            self.init(host: host, port: port, password: password)
+            return
+        }
+
+        // Raw port separator "host::5905" beats the display-number heuristic.
+        if let rawPortRange = text.range(of: "::") {
+            let host = String(text[..<rawPortRange.lowerBound])
+            let portText = String(text[rawPortRange.upperBound...])
+            guard !host.isEmpty, let port = UInt16(portText) else { return nil }
+            self.init(host: host, port: port, password: password)
+            return
+        }
+
+        if let colon = text.lastIndex(of: ":") {
+            let host = String(text[..<colon])
+            let suffix = String(text[text.index(after: colon)...])
+            guard !host.isEmpty, let value = Int(suffix), value >= 0 else { return nil }
+            // Small numbers are VNC display numbers (5900 + N); larger are ports.
+            let port = value < 100 ? UInt16(5900 + value) : UInt16(clamping: value)
+            self.init(host: host, port: port, password: password)
+            return
+        }
+
+        self.init(host: text, port: 5900, password: password)
+    }
+
+    /// A user-facing label like `host:5901`.
+    public var displayLabel: String { "\(host):\(port)" }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/Framebuffer.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/Framebuffer.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// A 32-bit BGRX pixel buffer that mirrors the remote screen.
+///
+/// Pixels are stored as little-endian `UInt32` values (`0x00RRGGBB`), which is
+/// the format cmux negotiates with `SetPixelFormat`, so a `CGImage` can be
+/// built directly over the backing store with no conversion.
+///
+/// Marked `@unchecked Sendable` because it is confined to the single read loop
+/// of one ``RFBClient`` actor: the decoder writes it, the loop snapshots it, and
+/// nothing else holds a reference. Hand-offs to the UI always go through the
+/// immutable ``snapshot()`` (`VNCFrameSnapshot`), never this instance.
+public final class Framebuffer: @unchecked Sendable {
+    public private(set) var width: Int
+    public private(set) var height: Int
+    /// Row-major BGRX pixels, `width * height` long.
+    public private(set) var pixels: [UInt32]
+
+    public init(width: Int, height: Int) {
+        self.width = max(0, width)
+        self.height = max(0, height)
+        self.pixels = [UInt32](repeating: 0xFF00_0000, count: self.width * self.height)
+    }
+
+    /// Resizes the buffer (used by the DesktopSize pseudo-encoding), preserving
+    /// the overlapping top-left region so a live resize does not flash black.
+    public func resize(width newWidth: Int, height newHeight: Int) {
+        let w = max(0, newWidth)
+        let h = max(0, newHeight)
+        guard w != width || h != height else { return }
+        var next = [UInt32](repeating: 0xFF00_0000, count: w * h)
+        let copyW = min(w, width)
+        let copyH = min(h, height)
+        if copyW > 0 {
+            pixels.withUnsafeBufferPointer { src in
+                next.withUnsafeMutableBufferPointer { dst in
+                    for row in 0 ..< copyH {
+                        let from = row * width
+                        let to = row * w
+                        dst.baseAddress!.advanced(by: to)
+                            .update(from: src.baseAddress!.advanced(by: from), count: copyW)
+                    }
+                }
+            }
+        }
+        pixels = next
+        width = w
+        height = h
+    }
+
+    /// Fills an axis-aligned rectangle with a single colour.
+    public func fill(x: Int, y: Int, width rectWidth: Int, height rectHeight: Int, color: UInt32) {
+        guard rectWidth > 0, rectHeight > 0 else { return }
+        let clampedX = max(0, x)
+        let clampedY = max(0, y)
+        let maxX = min(width, x + rectWidth)
+        let maxY = min(height, y + rectHeight)
+        guard maxX > clampedX, maxY > clampedY else { return }
+        pixels.withUnsafeMutableBufferPointer { buffer in
+            for row in clampedY ..< maxY {
+                let base = row * width
+                for col in clampedX ..< maxX {
+                    buffer[base + col] = color
+                }
+            }
+        }
+    }
+
+    /// Writes a tightly-packed run of BGRX pixels into a rectangle, row by row.
+    public func blit(x: Int, y: Int, width rectWidth: Int, height rectHeight: Int, pixels source: [UInt32]) {
+        guard rectWidth > 0, rectHeight > 0 else { return }
+        guard source.count >= rectWidth * rectHeight else { return }
+        pixels.withUnsafeMutableBufferPointer { dst in
+            source.withUnsafeBufferPointer { src in
+                for row in 0 ..< rectHeight {
+                    let destRow = y + row
+                    guard destRow >= 0, destRow < height else { continue }
+                    let srcBase = row * rectWidth
+                    let dstBase = destRow * width
+                    for col in 0 ..< rectWidth {
+                        let destCol = x + col
+                        guard destCol >= 0, destCol < width else { continue }
+                        dst[dstBase + destCol] = src[srcBase + col]
+                    }
+                }
+            }
+        }
+    }
+
+    /// Copies a rectangle from one location to another (CopyRect encoding).
+    /// Handles overlap by choosing a row/column iteration order that does not
+    /// clobber not-yet-read source pixels.
+    public func copyRect(srcX: Int, srcY: Int, toX: Int, toY: Int, width rectWidth: Int, height rectHeight: Int) {
+        guard rectWidth > 0, rectHeight > 0 else { return }
+        pixels.withUnsafeMutableBufferPointer { buffer in
+            let rowOrder: StrideThrough<Int> = toY > srcY
+                ? stride(from: rectHeight - 1, through: 0, by: -1)
+                : stride(from: 0, through: rectHeight - 1, by: 1)
+            for row in rowOrder {
+                let sy = srcY + row
+                let dy = toY + row
+                guard sy >= 0, sy < height, dy >= 0, dy < height else { continue }
+                let colOrder: StrideThrough<Int> = toX > srcX
+                    ? stride(from: rectWidth - 1, through: 0, by: -1)
+                    : stride(from: 0, through: rectWidth - 1, by: 1)
+                for col in colOrder {
+                    let sx = srcX + col
+                    let dx = toX + col
+                    guard sx >= 0, sx < width, dx >= 0, dx < width else { continue }
+                    buffer[dy * width + dx] = buffer[sy * width + sx]
+                }
+            }
+        }
+    }
+
+    /// A `Sendable` copy for hand-off to the UI/render layer.
+    public func snapshot() -> VNCFrameSnapshot {
+        VNCFrameSnapshot(
+            width: width,
+            height: height,
+            pixels: pixels.withUnsafeBytes { Data($0) }
+        )
+    }
+}
+
+/// An immutable, `Sendable` snapshot of the framebuffer for the render layer.
+public struct VNCFrameSnapshot: Sendable, Equatable {
+    public let width: Int
+    public let height: Int
+    /// BGRX bytes, `width * height * 4` long.
+    public let pixels: Data
+
+    public init(width: Int, height: Int, pixels: Data) {
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/RFBRectangle.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/RFBRectangle.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// The header of one rectangle inside a `FramebufferUpdate` (RFC 6143 §7.6.1).
+public struct RFBRectangleHeader: Equatable, Sendable {
+    public var x: Int
+    public var y: Int
+    public var width: Int
+    public var height: Int
+    public var encoding: Int32
+
+    public init(x: Int, y: Int, width: Int, height: Int, encoding: Int32) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+        self.encoding = encoding
+    }
+}
+
+extension RFBByteSource {
+    /// Reads one rectangle header (12 bytes).
+    func readRectangleHeader() async throws -> RFBRectangleHeader {
+        let x = try await readUInt16()
+        let y = try await readUInt16()
+        let w = try await readUInt16()
+        let h = try await readUInt16()
+        let encoding = try await readInt32()
+        return RFBRectangleHeader(x: Int(x), y: Int(y), width: Int(w), height: Int(h), encoding: encoding)
+    }
+
+    /// Reads a single 32-bit BGRX pixel (little-endian, matching the format
+    /// cmux negotiates). Returns a host `UInt32` of `0x00RRGGBB`.
+    func readPixel() async throws -> UInt32 {
+        let b = try await readExactly(4)
+        return UInt32(b[0]) | (UInt32(b[1]) << 8) | (UInt32(b[2]) << 16) | (UInt32(b[3]) << 24)
+    }
+
+    /// Reads `count` packed BGRX pixels in a single bulk read.
+    func readPixels(count: Int) async throws -> [UInt32] {
+        guard count > 0 else { return [] }
+        let bytes = try await readExactly(count * 4)
+        var pixels = [UInt32](repeating: 0, count: count)
+        bytes.withUnsafeBufferPointer { src in
+            for i in 0 ..< count {
+                let o = i * 4
+                pixels[i] = UInt32(src[o]) | (UInt32(src[o + 1]) << 8)
+                    | (UInt32(src[o + 2]) << 16) | (UInt32(src[o + 3]) << 24)
+            }
+        }
+        return pixels
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/RFBRectangleDecoder.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Framebuffer/RFBRectangleDecoder.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Decodes the body of a single `FramebufferUpdate` rectangle into a
+/// ``Framebuffer``. Supports Raw, CopyRect, RRE, and Hextile encodings, plus
+/// the DesktopSize pseudo-encoding. Unknown encodings throw rather than
+/// silently desync the stream.
+public struct RFBRectangleDecoder: Sendable {
+    public init() {}
+
+    public func decode(
+        header: RFBRectangleHeader,
+        from source: any RFBByteSource,
+        into framebuffer: Framebuffer
+    ) async throws {
+        switch RFBClientMessage.Encoding(rawValue: header.encoding) {
+        case .raw:
+            try await decodeRaw(header, source, framebuffer)
+        case .copyRect:
+            try await decodeCopyRect(header, source, framebuffer)
+        case .rre:
+            try await decodeRRE(header, source, framebuffer)
+        case .hextile:
+            try await decodeHextile(header, source, framebuffer)
+        case .desktopSize:
+            framebuffer.resize(width: header.width, height: header.height)
+        default:
+            throw RFBError.protocolViolation("unsupported encoding \(header.encoding)")
+        }
+    }
+
+    private func decodeRaw(
+        _ header: RFBRectangleHeader,
+        _ source: any RFBByteSource,
+        _ framebuffer: Framebuffer
+    ) async throws {
+        let pixels = try await source.readPixels(count: header.width * header.height)
+        framebuffer.blit(x: header.x, y: header.y, width: header.width, height: header.height, pixels: pixels)
+    }
+
+    private func decodeCopyRect(
+        _ header: RFBRectangleHeader,
+        _ source: any RFBByteSource,
+        _ framebuffer: Framebuffer
+    ) async throws {
+        let srcX = try await source.readUInt16()
+        let srcY = try await source.readUInt16()
+        framebuffer.copyRect(
+            srcX: Int(srcX),
+            srcY: Int(srcY),
+            toX: header.x,
+            toY: header.y,
+            width: header.width,
+            height: header.height
+        )
+    }
+
+    private func decodeRRE(
+        _ header: RFBRectangleHeader,
+        _ source: any RFBByteSource,
+        _ framebuffer: Framebuffer
+    ) async throws {
+        let subrectCount = try await source.readUInt32()
+        let background = try await source.readPixel()
+        framebuffer.fill(x: header.x, y: header.y, width: header.width, height: header.height, color: background)
+        for _ in 0 ..< subrectCount {
+            let color = try await source.readPixel()
+            let sx = try await source.readUInt16()
+            let sy = try await source.readUInt16()
+            let sw = try await source.readUInt16()
+            let sh = try await source.readUInt16()
+            framebuffer.fill(
+                x: header.x + Int(sx),
+                y: header.y + Int(sy),
+                width: Int(sw),
+                height: Int(sh),
+                color: color
+            )
+        }
+    }
+
+    private func decodeHextile(
+        _ header: RFBRectangleHeader,
+        _ source: any RFBByteSource,
+        _ framebuffer: Framebuffer
+    ) async throws {
+        // Subencoding mask bits.
+        let raw: UInt8 = 1
+        let backgroundSpecified: UInt8 = 2
+        let foregroundSpecified: UInt8 = 4
+        let anySubrects: UInt8 = 8
+        let subrectsColoured: UInt8 = 16
+
+        var background: UInt32 = 0xFF00_0000
+        var foreground: UInt32 = 0xFFFF_FFFF
+
+        var tileY = 0
+        while tileY < header.height {
+            let tileHeight = min(16, header.height - tileY)
+            var tileX = 0
+            while tileX < header.width {
+                let tileWidth = min(16, header.width - tileX)
+                let originX = header.x + tileX
+                let originY = header.y + tileY
+
+                let mask = try await source.readUInt8()
+                if mask & raw != 0 {
+                    let pixels = try await source.readPixels(count: tileWidth * tileHeight)
+                    framebuffer.blit(x: originX, y: originY, width: tileWidth, height: tileHeight, pixels: pixels)
+                } else {
+                    if mask & backgroundSpecified != 0 {
+                        background = try await source.readPixel()
+                    }
+                    if mask & foregroundSpecified != 0 {
+                        foreground = try await source.readPixel()
+                    }
+                    framebuffer.fill(x: originX, y: originY, width: tileWidth, height: tileHeight, color: background)
+                    if mask & anySubrects != 0 {
+                        let count = try await source.readUInt8()
+                        let coloured = mask & subrectsColoured != 0
+                        for _ in 0 ..< count {
+                            let color = coloured ? try await source.readPixel() : foreground
+                            let xy = try await source.readUInt8()
+                            let wh = try await source.readUInt8()
+                            let subX = Int(xy >> 4)
+                            let subY = Int(xy & 0x0F)
+                            let subW = Int(wh >> 4) + 1
+                            let subH = Int(wh & 0x0F) + 1
+                            framebuffer.fill(
+                                x: originX + subX,
+                                y: originY + subY,
+                                width: subW,
+                                height: subH,
+                                color: color
+                            )
+                        }
+                    }
+                }
+                tileX += 16
+            }
+            tileY += 16
+        }
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Input/VNCKeyMap.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Input/VNCKeyMap.swift
@@ -1,0 +1,72 @@
+#if canImport(AppKit)
+import AppKit
+
+/// Translates macOS key events into X11 keysyms for RFB `KeyEvent` messages.
+public enum VNCKeyMap {
+    /// Special keys identified by hardware `keyCode` (layout-independent).
+    private static let specialKeysyms: [UInt16: UInt32] = [
+        36: 0xFF0D,  // Return
+        76: 0xFF8D,  // Keypad Enter
+        48: 0xFF09,  // Tab
+        51: 0xFF08,  // Delete (Backspace)
+        53: 0xFF1B,  // Escape
+        117: 0xFFFF, // Forward Delete
+        115: 0xFF50, // Home
+        119: 0xFF57, // End
+        116: 0xFF55, // Page Up
+        121: 0xFF56, // Page Down
+        123: 0xFF51, // Left
+        124: 0xFF53, // Right
+        125: 0xFF54, // Down
+        126: 0xFF52, // Up
+        122: 0xFFBE, // F1
+        120: 0xFFBF, // F2
+        99: 0xFFC0,  // F3
+        118: 0xFFC1, // F4
+        96: 0xFFC2,  // F5
+        97: 0xFFC3,  // F6
+        98: 0xFFC4,  // F7
+        100: 0xFFC5, // F8
+        101: 0xFFC6, // F9
+        109: 0xFFC7, // F10
+        103: 0xFFC8, // F11
+        111: 0xFFC9, // F12
+    ]
+
+    /// Returns the keysym for a key-down/up event, or `nil` if it has no mapping.
+    public static func keysym(for event: NSEvent) -> UInt32? {
+        if let special = specialKeysyms[event.keyCode] {
+            return special
+        }
+        let withModifiers = event.characters ?? ""
+        let withoutModifiers = event.charactersIgnoringModifiers ?? ""
+        // With Control held, `characters` is a control code; prefer the base key.
+        let controlDown = event.modifierFlags.contains(.control)
+        let source = (controlDown || withModifiers.isEmpty) ? withoutModifiers : withModifiers
+        guard let scalar = source.unicodeScalars.first else { return nil }
+        return keysym(forScalar: scalar)
+    }
+
+    static func keysym(forScalar scalar: Unicode.Scalar) -> UInt32 {
+        let value = scalar.value
+        // Latin-1 maps directly; other Unicode uses the X11 0x01000000 plane.
+        return value <= 0xFF ? value : (0x0100_0000 + value)
+    }
+
+    /// Keysym for a modifier flag, used on `flagsChanged`. Command maps to
+    /// Super, Option to Alt, matching common server expectations.
+    public static func modifierKeysym(for flag: NSEvent.ModifierFlags) -> UInt32? {
+        switch flag {
+        case .shift: return 0xFFE1   // Shift_L
+        case .control: return 0xFFE3 // Control_L
+        case .option: return 0xFFE9  // Alt_L
+        case .command: return 0xFFEB // Super_L
+        case .capsLock: return 0xFFE5 // Caps_Lock
+        default: return nil
+        }
+    }
+
+    /// The modifier flags cmux forwards, in a stable order.
+    public static let trackedModifiers: [NSEvent.ModifierFlags] = [.shift, .control, .option, .command]
+}
+#endif

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Network/NWConnectionTransport.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Network/NWConnectionTransport.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Network
+
+/// An `NWConnection`-backed RFB transport. Conforms to both ``RFBByteSource``
+/// and ``RFBByteSink``; the connection's own serial queue plus this actor's
+/// isolation guarantee that whole messages are read and written atomically and
+/// never interleave.
+public actor NWConnectionTransport: RFBByteSource, RFBByteSink {
+    private let connection: NWConnection
+    private var inboundBuffer: [UInt8] = []
+    private var didStart = false
+
+    public init(host: String, port: UInt16) {
+        let endpointHost = NWEndpoint.Host(host)
+        let endpointPort = NWEndpoint.Port(rawValue: port) ?? .vnc
+        let tcp = NWProtocolTCP.Options()
+        tcp.noDelay = true // latency over throughput: don't coalesce input events
+        self.connection = NWConnection(host: endpointHost, port: endpointPort, using: NWParameters(tls: nil, tcp: tcp))
+    }
+
+    /// Opens the TCP connection, returning when it is `.ready`.
+    public func connect() async throws {
+        guard !didStart else { return }
+        didStart = true
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let resumed = ResumeOnce()
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    if resumed.tryResume() { continuation.resume() }
+                case .failed(let error), .waiting(let error):
+                    if resumed.tryResume() { continuation.resume(throwing: RFBError.transport(error.localizedDescription)) }
+                case .cancelled:
+                    if resumed.tryResume() { continuation.resume(throwing: RFBError.connectionClosed) }
+                default:
+                    break
+                }
+            }
+            connection.start(queue: .global(qos: .userInitiated))
+        }
+        connection.stateUpdateHandler = nil
+    }
+
+    public func close() {
+        connection.cancel()
+    }
+
+    public func write(_ bytes: [UInt8]) async throws {
+        guard !bytes.isEmpty else { return }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            connection.send(content: Data(bytes), completion: .contentProcessed { error in
+                if let error {
+                    continuation.resume(throwing: RFBError.transport(error.localizedDescription))
+                } else {
+                    continuation.resume()
+                }
+            })
+        }
+    }
+
+    public func readExactly(_ count: Int) async throws -> [UInt8] {
+        guard count > 0 else { return [] }
+        while inboundBuffer.count < count {
+            let chunk = try await receiveChunk()
+            inboundBuffer.append(contentsOf: chunk)
+        }
+        let result = Array(inboundBuffer.prefix(count))
+        inboundBuffer.removeFirst(count)
+        return result
+    }
+
+    private func receiveChunk() async throws -> [UInt8] {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[UInt8], Error>) in
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, isComplete, error in
+                if let error {
+                    continuation.resume(throwing: RFBError.transport(error.localizedDescription))
+                    return
+                }
+                if let data, !data.isEmpty {
+                    continuation.resume(returning: [UInt8](data))
+                    return
+                }
+                if isComplete {
+                    continuation.resume(throwing: RFBError.connectionClosed)
+                    return
+                }
+                // No bytes yet and not complete: return empty so the caller loops.
+                continuation.resume(returning: [])
+            }
+        }
+    }
+}
+
+/// Guards a continuation against being resumed more than once from
+/// `stateUpdateHandler`, which can fire repeatedly.
+private final class ResumeOnce: @unchecked Sendable {
+    private let lock = NSLock()
+    private var resumed = false
+    func tryResume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if resumed { return false }
+        resumed = true
+        return true
+    }
+}
+
+private extension NWEndpoint.Port {
+    static let vnc = NWEndpoint.Port(rawValue: 5900)!
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/AppleDHAuthentication.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/AppleDHAuthentication.swift
@@ -1,0 +1,128 @@
+import BigInt
+import CommonCrypto
+import CryptoKit
+import Foundation
+import Security
+
+/// Apple Diffie-Hellman authentication (VNC security type 30), used by macOS
+/// Screen Sharing / Apple Remote Desktop.
+///
+/// The server sends DH parameters (generator, prime, its public key). The
+/// client performs a DH exchange, derives an AES-128 key as `MD5(shared
+/// secret)`, and sends `AES-128-ECB(key, {username[64], password[64]})`
+/// followed by its own public key. Both username and password are UTF-8,
+/// NUL-terminated, and padded to 64 bytes with random data.
+///
+/// Reference implementations: NeatVNC `src/auth/apple-dh.c`, the rfbproto spec,
+/// and the Caffeinated Bitstream write-up.
+public enum AppleDHAuthentication {
+    /// The DH parameters a server advertises for security type 30.
+    public struct ServerParams: Equatable, Sendable {
+        public var generator: UInt16
+        public var keyLength: Int
+        public var prime: [UInt8]
+        public var serverPublicKey: [UInt8]
+
+        public init(generator: UInt16, keyLength: Int, prime: [UInt8], serverPublicKey: [UInt8]) {
+            self.generator = generator
+            self.keyLength = keyLength
+            self.prime = prime
+            self.serverPublicKey = serverPublicKey
+        }
+    }
+
+    /// The client's reply: encrypted credentials followed by the client public key.
+    public struct Response: Equatable, Sendable {
+        public var encryptedCredentials: [UInt8] // always 128 bytes
+        public var clientPublicKey: [UInt8]       // keyLength bytes
+    }
+
+    /// Computes the type-30 response. `privateKey`, when supplied, makes the DH
+    /// exchange deterministic for tests; otherwise a CSPRNG value is used.
+    /// `padding` (128 bytes) overrides the random credential padding for tests.
+    public static func response(
+        params: ServerParams,
+        username: String,
+        password: String,
+        privateKey: [UInt8]? = nil,
+        padding: [UInt8]? = nil
+    ) -> Response? {
+        let keyLength = params.keyLength
+        guard keyLength > 0, params.prime.count == keyLength, params.serverPublicKey.count == keyLength else {
+            return nil
+        }
+
+        let prime = BigUInt(Data(params.prime))
+        guard prime > 0 else { return nil }
+        let generator = BigUInt(params.generator)
+        let priv = BigUInt(Data(privateKey ?? randomBytes(keyLength)))
+
+        let clientPublic = generator.power(priv, modulus: prime)
+        let sharedSecret = BigUInt(Data(params.serverPublicKey)).power(priv, modulus: prime)
+
+        let sharedBytes = leftPad(sharedSecret.serialize(), to: keyLength)
+        let aesKey = Array(Insecure.MD5.hash(data: Data(sharedBytes))) // 16 bytes
+
+        let credentials = buildCredentials(username: username, password: password, padding: padding)
+        guard let ciphertext = aes128ECBEncrypt(key: aesKey, plaintext: credentials), ciphertext.count == 128 else {
+            return nil
+        }
+
+        let clientPublicBytes = leftPad(clientPublic.serialize(), to: keyLength)
+        return Response(encryptedCredentials: ciphertext, clientPublicKey: clientPublicBytes)
+    }
+
+    /// 128-byte credential block: username in bytes 0..<64, password in
+    /// 64..<128, each NUL-terminated, remaining bytes random.
+    static func buildCredentials(username: String, password: String, padding: [UInt8]?) -> [UInt8] {
+        var buffer = padding ?? randomBytes(128)
+        if buffer.count != 128 { buffer = randomBytes(128) }
+        let user = Array(username.utf8.prefix(63))
+        for i in user.indices { buffer[i] = user[i] }
+        buffer[user.count] = 0
+        let pass = Array(password.utf8.prefix(63))
+        for i in pass.indices { buffer[64 + i] = pass[i] }
+        buffer[64 + pass.count] = 0
+        return buffer
+    }
+
+    static func leftPad(_ data: Data, to length: Int) -> [UInt8] {
+        let bytes = [UInt8](data)
+        if bytes.count == length { return bytes }
+        if bytes.count > length { return Array(bytes.suffix(length)) }
+        return [UInt8](repeating: 0, count: length - bytes.count) + bytes
+    }
+
+    static func aes128ECBEncrypt(key: [UInt8], plaintext: [UInt8]) -> [UInt8]? {
+        guard key.count == kCCKeySizeAES128 else { return nil }
+        var output = [UInt8](repeating: 0, count: plaintext.count)
+        let outputCapacity = output.count
+        var moved = 0
+        let status = key.withUnsafeBytes { keyPtr in
+            plaintext.withUnsafeBytes { dataPtr in
+                output.withUnsafeMutableBytes { outPtr in
+                    CCCrypt(
+                        CCOperation(kCCEncrypt),
+                        CCAlgorithm(kCCAlgorithmAES128),
+                        CCOptions(kCCOptionECBMode),
+                        keyPtr.baseAddress, key.count,
+                        nil,
+                        dataPtr.baseAddress, plaintext.count,
+                        outPtr.baseAddress, outputCapacity,
+                        &moved
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { return nil }
+        return Array(output.prefix(moved))
+    }
+
+    static func randomBytes(_ count: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: count)
+        if SecRandomCopyBytes(kSecRandomDefault, count, &bytes) != errSecSuccess {
+            for i in bytes.indices { bytes[i] = UInt8.random(in: 0...255) }
+        }
+        return bytes
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBByteSink.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBByteSink.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A destination for client-to-server bytes. Backed by `NWConnection` at
+/// runtime, by an array in tests.
+public protocol RFBByteSink: Sendable {
+    func write(_ bytes: [UInt8]) async throws
+}
+
+/// An in-memory ``RFBByteSink`` that records everything written, for tests.
+public actor InMemoryByteSink: RFBByteSink {
+    public private(set) var written: [UInt8] = []
+
+    public init() {}
+
+    public func write(_ bytes: [UInt8]) async throws {
+        written.append(contentsOf: bytes)
+    }
+
+    public func contents() -> [UInt8] { written }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBByteSource.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBByteSource.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// An ordered, demand-driven source of bytes from an RFB server.
+///
+/// RFB runs over a TCP stream, so a single logical message can arrive split
+/// across several reads. Rather than juggle a cursor over a growing buffer,
+/// decoders pull exactly the bytes they need and the source blocks until they
+/// are available. The real implementation is backed by `NWConnection`; tests
+/// back it with an in-memory array.
+public protocol RFBByteSource: Sendable {
+    /// Returns exactly `count` bytes, awaiting more from the stream as needed.
+    /// Throws ``RFBError/connectionClosed`` if the stream ends first.
+    func readExactly(_ count: Int) async throws -> [UInt8]
+}
+
+public extension RFBByteSource {
+    func readUInt8() async throws -> UInt8 {
+        try await readExactly(1)[0]
+    }
+
+    func readUInt16() async throws -> UInt16 {
+        let b = try await readExactly(2)
+        return (UInt16(b[0]) << 8) | UInt16(b[1])
+    }
+
+    func readInt32() async throws -> Int32 {
+        Int32(bitPattern: try await readUInt32())
+    }
+
+    func readUInt32() async throws -> UInt32 {
+        let b = try await readExactly(4)
+        return (UInt32(b[0]) << 24) | (UInt32(b[1]) << 16) | (UInt32(b[2]) << 8) | UInt32(b[3])
+    }
+
+    /// Reads a 32-bit big-endian length prefix followed by that many bytes.
+    func readLengthPrefixedString() async throws -> String {
+        let length = try await readUInt32()
+        guard length > 0 else { return "" }
+        let bytes = try await readExactly(Int(length))
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+/// An in-memory ``RFBByteSource`` for tests and replay.
+public actor InMemoryByteSource: RFBByteSource {
+    private let bytes: [UInt8]
+    private var offset = 0
+
+    public init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    public func readExactly(_ count: Int) async throws -> [UInt8] {
+        guard count >= 0 else { throw RFBError.protocolViolation("negative read") }
+        guard offset + count <= bytes.count else { throw RFBError.connectionClosed }
+        defer { offset += count }
+        return Array(bytes[offset ..< offset + count])
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBClientMessage.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBClientMessage.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Encoders for the client-to-server messages cmux sends (RFC 6143 §7.5).
+///
+/// Every encoder is a pure function returning the exact wire bytes, which makes
+/// the protocol layer trivially unit-testable without a live socket.
+public enum RFBClientMessage {
+    /// Server-to-client encoding identifiers we advertise, best first. The
+    /// server picks the first it supports for each rectangle.
+    public enum Encoding: Int32, Sendable {
+        case raw = 0
+        case copyRect = 1
+        case rre = 2
+        case hextile = 5
+        // Pseudo-encodings (advertised so the server may use them).
+        case desktopSize = -223
+        case cursor = -239
+    }
+
+    private static func u16(_ value: UInt16) -> [UInt8] {
+        [UInt8(value >> 8), UInt8(value & 0xFF)]
+    }
+
+    private static func u32(_ value: UInt32) -> [UInt8] {
+        [UInt8(value >> 24), UInt8((value >> 16) & 0xFF), UInt8((value >> 8) & 0xFF), UInt8(value & 0xFF)]
+    }
+
+    /// `SetPixelFormat` (message type 0): pin the server to our render format.
+    public static func setPixelFormat(_ format: RFBPixelFormat) -> [UInt8] {
+        var bytes: [UInt8] = [0, 0, 0, 0] // type + 3 padding
+        bytes.append(contentsOf: format.encoded())
+        return bytes
+    }
+
+    /// `SetEncodings` (message type 2).
+    public static func setEncodings(_ encodings: [Encoding]) -> [UInt8] {
+        var bytes: [UInt8] = [2, 0] // type + 1 padding
+        bytes.append(contentsOf: u16(UInt16(encodings.count)))
+        for encoding in encodings {
+            bytes.append(contentsOf: u32(UInt32(bitPattern: encoding.rawValue)))
+        }
+        return bytes
+    }
+
+    /// `FramebufferUpdateRequest` (message type 3). `incremental == false`
+    /// asks for a full refresh of the region.
+    public static func framebufferUpdateRequest(
+        incremental: Bool,
+        x: UInt16,
+        y: UInt16,
+        width: UInt16,
+        height: UInt16
+    ) -> [UInt8] {
+        var bytes: [UInt8] = [3, incremental ? 1 : 0]
+        bytes.append(contentsOf: u16(x))
+        bytes.append(contentsOf: u16(y))
+        bytes.append(contentsOf: u16(width))
+        bytes.append(contentsOf: u16(height))
+        return bytes
+    }
+
+    /// `KeyEvent` (message type 4). `key` is an X11 keysym.
+    public static func keyEvent(keysym: UInt32, down: Bool) -> [UInt8] {
+        var bytes: [UInt8] = [4, down ? 1 : 0, 0, 0]
+        bytes.append(contentsOf: u32(keysym))
+        return bytes
+    }
+
+    /// `PointerEvent` (message type 5). `buttonMask` bit 0 = left, 1 = middle,
+    /// 2 = right, 3 = wheel-up, 4 = wheel-down.
+    public static func pointerEvent(buttonMask: UInt8, x: UInt16, y: UInt16) -> [UInt8] {
+        var bytes: [UInt8] = [5, buttonMask]
+        bytes.append(contentsOf: u16(x))
+        bytes.append(contentsOf: u16(y))
+        return bytes
+    }
+
+    /// `ClientCutText` (message type 6): clipboard text from client to server.
+    public static func clientCutText(_ text: String) -> [UInt8] {
+        let latin1 = text.unicodeScalars.map { UInt8($0.value > 0xFF ? 0x3F : $0.value) }
+        var bytes: [UInt8] = [6, 0, 0, 0]
+        bytes.append(contentsOf: u32(UInt32(latin1.count)))
+        bytes.append(contentsOf: latin1)
+        return bytes
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBError.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBError.swift
@@ -16,6 +16,9 @@ public enum RFBError: Error, Equatable, Sendable {
     case protocolViolation(String)
     /// A password was required but none was supplied.
     case passwordRequired
+    /// The server requires Apple authentication, which needs both a user name
+    /// and password (e.g. `vnc://user:password@host`).
+    case credentialsRequired
 }
 
 extension RFBError: LocalizedError {
@@ -35,6 +38,8 @@ extension RFBError: LocalizedError {
             return "Protocol error: \(detail)"
         case .passwordRequired:
             return "A password is required to connect."
+        case .credentialsRequired:
+            return "This server requires a user name and password (vnc://user:password@host)."
         }
     }
 }

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBError.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBError.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Errors surfaced by the RFB client.
+public enum RFBError: Error, Equatable, Sendable {
+    /// The peer closed the connection (or it dropped) before enough bytes arrived.
+    case connectionClosed
+    /// The underlying transport reported a failure.
+    case transport(String)
+    /// The server announced a protocol version we cannot speak.
+    case unsupportedProtocolVersion(String)
+    /// The server offered no security type we support.
+    case noSupportedSecurityType([UInt8])
+    /// VNC authentication failed (bad password) or the security handshake was rejected.
+    case authenticationFailed(String)
+    /// A server message did not conform to the protocol.
+    case protocolViolation(String)
+    /// A password was required but none was supplied.
+    case passwordRequired
+}
+
+extension RFBError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .connectionClosed:
+            return "The connection closed."
+        case .transport(let message):
+            return message
+        case .unsupportedProtocolVersion(let version):
+            return "Unsupported RFB protocol version: \(version)"
+        case .noSupportedSecurityType:
+            return "The server offered no supported authentication method."
+        case .authenticationFailed(let reason):
+            return reason.isEmpty ? "Authentication failed." : reason
+        case .protocolViolation(let detail):
+            return "Protocol error: \(detail)"
+        case .passwordRequired:
+            return "A password is required to connect."
+        }
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBHandshake.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBHandshake.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Result of `ServerInit` (RFC 6143 §7.3.2): the remote screen geometry, its
+/// native pixel format, and its name.
+public struct RFBServerInit: Equatable, Sendable {
+    public var width: Int
+    public var height: Int
+    public var pixelFormat: RFBPixelFormat
+    public var name: String
+
+    public init(width: Int, height: Int, pixelFormat: RFBPixelFormat, name: String) {
+        self.width = width
+        self.height = height
+        self.pixelFormat = pixelFormat
+        self.name = name
+    }
+}
+
+/// Drives the RFB version, security, and initialisation handshake. Pure with
+/// respect to transport: it only reads from an ``RFBByteSource`` and writes to
+/// an ``RFBByteSink``, so the whole negotiation is unit-testable end to end.
+public struct RFBHandshake {
+    public init() {}
+
+    private static let none: UInt8 = 1
+    private static let vncAuth: UInt8 = 2
+
+    /// Negotiates and returns `ServerInit`. Throws ``RFBError`` on any failure.
+    public func negotiate(
+        source: any RFBByteSource,
+        sink: any RFBByteSink,
+        password: String?,
+        shared: Bool = true
+    ) async throws -> RFBServerInit {
+        let serverMinor = try await readProtocolVersion(source)
+        let agreedMinor = min(serverMinor, 8) >= 8 ? 8 : (serverMinor >= 7 ? 7 : 3)
+        try await sink.write(Array("RFB 003.\(String(format: "%03d", agreedMinor))\n".utf8))
+
+        let chosen = try await negotiateSecurity(
+            source: source,
+            sink: sink,
+            agreedMinor: agreedMinor,
+            password: password
+        )
+
+        if chosen == Self.vncAuth {
+            try await performVNCAuth(source: source, sink: sink, password: password)
+        }
+
+        // SecurityResult: always for 3.8; for VNC auth on any version; never for
+        // None on < 3.8.
+        if agreedMinor >= 8 || chosen == Self.vncAuth {
+            try await readSecurityResult(source, includeReason: agreedMinor >= 8)
+        }
+
+        try await sink.write([shared ? 1 : 0]) // ClientInit
+        return try await readServerInit(source)
+    }
+
+    private func readProtocolVersion(_ source: any RFBByteSource) async throws -> Int {
+        let bytes = try await source.readExactly(12)
+        let text = String(decoding: bytes, as: UTF8.self)
+        // Expected form "RFB 003.008\n".
+        guard text.hasPrefix("RFB "), let dotIndex = text.firstIndex(of: ".") else {
+            throw RFBError.unsupportedProtocolVersion(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        let minorDigits = text[text.index(after: dotIndex)...].prefix { $0.isNumber }
+        guard let minor = Int(minorDigits) else {
+            throw RFBError.unsupportedProtocolVersion(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return minor
+    }
+
+    private func negotiateSecurity(
+        source: any RFBByteSource,
+        sink: any RFBByteSink,
+        agreedMinor: Int,
+        password: String?
+    ) async throws -> UInt8 {
+        let offered: [UInt8]
+        if agreedMinor >= 7 {
+            let count = try await source.readUInt8()
+            guard count > 0 else {
+                let reason = try await source.readLengthPrefixedString()
+                throw RFBError.authenticationFailed(reason)
+            }
+            offered = try await source.readExactly(Int(count))
+        } else {
+            // 3.3: the server dictates a single security type as a U32.
+            let type = try await source.readUInt32()
+            guard type != 0 else {
+                let reason = try await source.readLengthPrefixedString()
+                throw RFBError.authenticationFailed(reason)
+            }
+            offered = [UInt8(truncatingIfNeeded: type)]
+            // No client selection byte is sent in 3.3.
+            try validateSelectable(offered, password: password)
+            return offered.contains(Self.vncAuth) && password != nil ? Self.vncAuth : Self.none
+        }
+
+        let chosen = try preferredSecurity(from: offered, password: password)
+        try await sink.write([chosen])
+        return chosen
+    }
+
+    private func preferredSecurity(from offered: [UInt8], password: String?) throws -> UInt8 {
+        // Prefer VNC auth when a password is available; otherwise None.
+        if password != nil, offered.contains(Self.vncAuth) {
+            return Self.vncAuth
+        }
+        if offered.contains(Self.none) {
+            return Self.none
+        }
+        if offered.contains(Self.vncAuth) {
+            // Server requires auth but we have no password.
+            throw RFBError.passwordRequired
+        }
+        throw RFBError.noSupportedSecurityType(offered)
+    }
+
+    private func validateSelectable(_ offered: [UInt8], password: String?) throws {
+        if offered.contains(Self.none) { return }
+        if offered.contains(Self.vncAuth) {
+            if password == nil { throw RFBError.passwordRequired }
+            return
+        }
+        throw RFBError.noSupportedSecurityType(offered)
+    }
+
+    private func performVNCAuth(
+        source: any RFBByteSource,
+        sink: any RFBByteSink,
+        password: String?
+    ) async throws {
+        guard let password else { throw RFBError.passwordRequired }
+        let challenge = try await source.readExactly(16)
+        let response = VNCAuthentication.challengeResponse(challenge: challenge, password: password)
+        guard response.count == 16 else {
+            throw RFBError.authenticationFailed("Failed to compute authentication response.")
+        }
+        try await sink.write(response)
+    }
+
+    private func readSecurityResult(_ source: any RFBByteSource, includeReason: Bool) async throws {
+        let result = try await source.readUInt32()
+        guard result == 0 else {
+            let reason = includeReason ? (try? await source.readLengthPrefixedString()) ?? "" : ""
+            throw RFBError.authenticationFailed(reason.isEmpty ? "Authentication failed." : reason)
+        }
+    }
+
+    private func readServerInit(_ source: any RFBByteSource) async throws -> RFBServerInit {
+        let width = try await source.readUInt16()
+        let height = try await source.readUInt16()
+        let formatBytes = try await source.readExactly(16)
+        guard let format = RFBPixelFormat(formatBytes[...]) else {
+            throw RFBError.protocolViolation("malformed ServerInit pixel format")
+        }
+        let name = try await source.readLengthPrefixedString()
+        return RFBServerInit(width: Int(width), height: Int(height), pixelFormat: format, name: name)
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBHandshake.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBHandshake.swift
@@ -24,12 +24,14 @@ public struct RFBHandshake {
 
     private static let none: UInt8 = 1
     private static let vncAuth: UInt8 = 2
+    private static let appleDH: UInt8 = 30
 
     /// Negotiates and returns `ServerInit`. Throws ``RFBError`` on any failure.
     public func negotiate(
         source: any RFBByteSource,
         sink: any RFBByteSink,
         password: String?,
+        username: String? = nil,
         shared: Bool = true
     ) async throws -> RFBServerInit {
         let serverMinor = try await readProtocolVersion(source)
@@ -40,16 +42,19 @@ public struct RFBHandshake {
             source: source,
             sink: sink,
             agreedMinor: agreedMinor,
-            password: password
+            password: password,
+            username: username
         )
 
         if chosen == Self.vncAuth {
             try await performVNCAuth(source: source, sink: sink, password: password)
+        } else if chosen == Self.appleDH {
+            try await performAppleDHAuth(source: source, sink: sink, username: username, password: password)
         }
 
-        // SecurityResult: always for 3.8; for VNC auth on any version; never for
-        // None on < 3.8.
-        if agreedMinor >= 8 || chosen == Self.vncAuth {
+        // SecurityResult: always for 3.8; for any real auth on any version;
+        // never for None on < 3.8.
+        if agreedMinor >= 8 || chosen == Self.vncAuth || chosen == Self.appleDH {
             try await readSecurityResult(source, includeReason: agreedMinor >= 8)
         }
 
@@ -75,7 +80,8 @@ public struct RFBHandshake {
         source: any RFBByteSource,
         sink: any RFBByteSink,
         agreedMinor: Int,
-        password: String?
+        password: String?,
+        username: String?
     ) async throws -> UInt8 {
         let offered: [UInt8]
         if agreedMinor >= 7 {
@@ -94,35 +100,32 @@ public struct RFBHandshake {
             }
             offered = [UInt8(truncatingIfNeeded: type)]
             // No client selection byte is sent in 3.3.
-            try validateSelectable(offered, password: password)
-            return offered.contains(Self.vncAuth) && password != nil ? Self.vncAuth : Self.none
+            return try preferredSecurity(from: offered, password: password, username: username)
         }
 
-        let chosen = try preferredSecurity(from: offered, password: password)
+        let chosen = try preferredSecurity(from: offered, password: password, username: username)
         try await sink.write([chosen])
         return chosen
     }
 
-    private func preferredSecurity(from offered: [UInt8], password: String?) throws -> UInt8 {
-        // Prefer VNC auth when a password is available; otherwise None.
-        if password != nil, offered.contains(Self.vncAuth) {
+    private func preferredSecurity(from offered: [UInt8], password: String?, username: String?) throws -> UInt8 {
+        // Prefer Apple DH (most secure, needs user+password), then VNC auth,
+        // then None.
+        if offered.contains(Self.appleDH), username != nil, password != nil {
+            return Self.appleDH
+        }
+        if offered.contains(Self.vncAuth), password != nil {
             return Self.vncAuth
         }
         if offered.contains(Self.none) {
             return Self.none
         }
-        if offered.contains(Self.vncAuth) {
-            // Server requires auth but we have no password.
-            throw RFBError.passwordRequired
+        // Nothing we can satisfy with the supplied credentials.
+        if offered.contains(Self.appleDH) {
+            throw RFBError.credentialsRequired
         }
-        throw RFBError.noSupportedSecurityType(offered)
-    }
-
-    private func validateSelectable(_ offered: [UInt8], password: String?) throws {
-        if offered.contains(Self.none) { return }
         if offered.contains(Self.vncAuth) {
-            if password == nil { throw RFBError.passwordRequired }
-            return
+            throw RFBError.passwordRequired
         }
         throw RFBError.noSupportedSecurityType(offered)
     }
@@ -139,6 +142,38 @@ public struct RFBHandshake {
             throw RFBError.authenticationFailed("Failed to compute authentication response.")
         }
         try await sink.write(response)
+    }
+
+    private func performAppleDHAuth(
+        source: any RFBByteSource,
+        sink: any RFBByteSink,
+        username: String?,
+        password: String?
+    ) async throws {
+        guard let username, let password else { throw RFBError.credentialsRequired }
+        let generator = try await source.readUInt16()
+        let keyLength = Int(try await source.readUInt16())
+        guard keyLength > 0, keyLength <= 1024 else {
+            throw RFBError.protocolViolation("invalid Apple DH key length \(keyLength)")
+        }
+        let prime = try await source.readExactly(keyLength)
+        let serverPublicKey = try await source.readExactly(keyLength)
+
+        let params = AppleDHAuthentication.ServerParams(
+            generator: generator,
+            keyLength: keyLength,
+            prime: prime,
+            serverPublicKey: serverPublicKey
+        )
+        guard let response = AppleDHAuthentication.response(
+            params: params,
+            username: username,
+            password: password
+        ) else {
+            throw RFBError.authenticationFailed("Failed to compute Apple DH response.")
+        }
+        try await sink.write(response.encryptedCredentials)
+        try await sink.write(response.clientPublicKey)
     }
 
     private func readSecurityResult(_ source: any RFBByteSource, includeReason: Bool) async throws {

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBPixelFormat.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/RFBPixelFormat.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// An RFB `PIXEL_FORMAT` (RFC 6143 §7.4). Sixteen bytes on the wire.
+///
+/// cmux always negotiates a fixed 32-bit little-endian true-colour format so
+/// the decoded framebuffer maps 1:1 onto a `CGImage` with no per-pixel
+/// swizzling. The server's native format (parsed from `ServerInit`) is kept
+/// only for completeness; we override it immediately with `SetPixelFormat`.
+public struct RFBPixelFormat: Equatable, Sendable {
+    public var bitsPerPixel: UInt8
+    public var depth: UInt8
+    public var bigEndian: Bool
+    public var trueColor: Bool
+    public var redMax: UInt16
+    public var greenMax: UInt16
+    public var blueMax: UInt16
+    public var redShift: UInt8
+    public var greenShift: UInt8
+    public var blueShift: UInt8
+
+    public init(
+        bitsPerPixel: UInt8,
+        depth: UInt8,
+        bigEndian: Bool,
+        trueColor: Bool,
+        redMax: UInt16,
+        greenMax: UInt16,
+        blueMax: UInt16,
+        redShift: UInt8,
+        greenShift: UInt8,
+        blueShift: UInt8
+    ) {
+        self.bitsPerPixel = bitsPerPixel
+        self.depth = depth
+        self.bigEndian = bigEndian
+        self.trueColor = trueColor
+        self.redMax = redMax
+        self.greenMax = greenMax
+        self.blueMax = blueMax
+        self.redShift = redShift
+        self.greenShift = greenShift
+        self.blueShift = blueShift
+    }
+
+    /// Bytes per pixel for the negotiated format.
+    public var bytesPerPixel: Int { Int(bitsPerPixel) / 8 }
+
+    /// The fixed format cmux requests: 32 bpp, depth 24, little-endian,
+    /// true-colour, channels at shifts B=0, G=8, R=16. In a little-endian
+    /// `UInt32` a pixel reads `0x00RRGGBB`; in memory the bytes are `B G R X`,
+    /// which is exactly Core Graphics' `BGRX` (`noneSkipFirst` +
+    /// `byteOrder32Little`). This keeps the render path allocation- and
+    /// swizzle-free.
+    public static let cmuxBGRX = RFBPixelFormat(
+        bitsPerPixel: 32,
+        depth: 24,
+        bigEndian: false,
+        trueColor: true,
+        redMax: 255,
+        greenMax: 255,
+        blueMax: 255,
+        redShift: 16,
+        greenShift: 8,
+        blueShift: 0
+    )
+
+    /// Serialises the 16-byte wire representation.
+    public func encoded() -> [UInt8] {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(16)
+        bytes.append(bitsPerPixel)
+        bytes.append(depth)
+        bytes.append(bigEndian ? 1 : 0)
+        bytes.append(trueColor ? 1 : 0)
+        bytes.append(UInt8(redMax >> 8)); bytes.append(UInt8(redMax & 0xFF))
+        bytes.append(UInt8(greenMax >> 8)); bytes.append(UInt8(greenMax & 0xFF))
+        bytes.append(UInt8(blueMax >> 8)); bytes.append(UInt8(blueMax & 0xFF))
+        bytes.append(redShift)
+        bytes.append(greenShift)
+        bytes.append(blueShift)
+        bytes.append(contentsOf: [0, 0, 0]) // padding
+        return bytes
+    }
+
+    /// Parses a 16-byte wire representation. Returns `nil` if short.
+    public init?(_ bytes: ArraySlice<UInt8>) {
+        guard bytes.count >= 16 else { return nil }
+        let b = Array(bytes)
+        self.init(
+            bitsPerPixel: b[0],
+            depth: b[1],
+            bigEndian: b[2] != 0,
+            trueColor: b[3] != 0,
+            redMax: (UInt16(b[4]) << 8) | UInt16(b[5]),
+            greenMax: (UInt16(b[6]) << 8) | UInt16(b[7]),
+            blueMax: (UInt16(b[8]) << 8) | UInt16(b[9]),
+            redShift: b[10],
+            greenShift: b[11],
+            blueShift: b[12]
+        )
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/VNCAuthentication.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/Protocol/VNCAuthentication.swift
@@ -1,0 +1,61 @@
+import Foundation
+import CommonCrypto
+
+/// Classic VNC authentication (security type 2, RFC 6143 §7.2.2).
+///
+/// The server sends a 16-byte random challenge. The client encrypts it with
+/// single-DES in ECB mode, keyed by the password (truncated/zero-padded to 8
+/// bytes). The historical quirk: each key byte's bit order is reversed before
+/// use. The 16-byte response is the two encrypted 8-byte blocks.
+public enum VNCAuthentication {
+    /// Reverses the bit order of a byte (`0b0000_0001` -> `0b1000_0000`).
+    static func reverseBits(_ byte: UInt8) -> UInt8 {
+        var value = byte
+        var result: UInt8 = 0
+        for _ in 0 ..< 8 {
+            result = (result << 1) | (value & 1)
+            value >>= 1
+        }
+        return result
+    }
+
+    /// Builds the 8-byte DES key from a password using the VNC bit-reversal rule.
+    static func desKey(from password: String) -> [UInt8] {
+        var key = [UInt8](repeating: 0, count: 8)
+        let bytes = Array(password.utf8.prefix(8))
+        for (index, byte) in bytes.enumerated() {
+            key[index] = reverseBits(byte)
+        }
+        return key
+    }
+
+    /// Computes the 16-byte challenge response for `password`.
+    public static func challengeResponse(challenge: [UInt8], password: String) -> [UInt8] {
+        let key = desKey(from: password)
+        // The challenge is always 16 bytes; encrypt as two independent ECB blocks.
+        var output = [UInt8](repeating: 0, count: challenge.count)
+        let outputCapacity = output.count
+        var numBytesEncrypted = 0
+        let status = key.withUnsafeBytes { keyPtr in
+            challenge.withUnsafeBytes { dataPtr in
+                output.withUnsafeMutableBytes { outPtr in
+                    CCCrypt(
+                        CCOperation(kCCEncrypt),
+                        CCAlgorithm(kCCAlgorithmDES),
+                        CCOptions(kCCOptionECBMode),
+                        keyPtr.baseAddress,
+                        kCCKeySizeDES,
+                        nil,
+                        dataPtr.baseAddress,
+                        challenge.count,
+                        outPtr.baseAddress,
+                        outputCapacity,
+                        &numBytesEncrypted
+                    )
+                }
+            }
+        }
+        guard status == kCCSuccess else { return [] }
+        return Array(output.prefix(numBytesEncrypted))
+    }
+}

--- a/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
@@ -23,6 +23,10 @@ public final class VNCSurfaceView: NSView {
     /// Called on the main actor for every client event (state, bell, clipboard).
     public var onEvent: ((VNCClientEvent) -> Void)?
 
+    /// Called when the user interacts (mouse/keys) so the host can mark this
+    /// surface focused in its own model.
+    public var onFocusRequested: (() -> Void)?
+
     public init(client: RFBClient) {
         self.client = client
         super.init(frame: .zero)
@@ -172,7 +176,7 @@ public final class VNCSurfaceView: NSView {
 
     // MARK: Mouse
 
-    public override func mouseDown(with event: NSEvent) { window?.makeFirstResponder(self); currentButtons.insert(.left); sendPointer(for: event) }
+    public override func mouseDown(with event: NSEvent) { onFocusRequested?(); window?.makeFirstResponder(self); currentButtons.insert(.left); sendPointer(for: event) }
     public override func mouseUp(with event: NSEvent) { currentButtons.remove(.left); sendPointer(for: event) }
     public override func mouseDragged(with event: NSEvent) { sendPointer(for: event) }
     public override func rightMouseDown(with event: NSEvent) { currentButtons.insert(.right); sendPointer(for: event) }

--- a/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
@@ -33,12 +33,26 @@ public final class VNCSurfaceView: NSView {
         wantsLayer = true
         layer?.backgroundColor = NSColor.black.cgColor
         layer?.contentsGravity = .resizeAspect
-        layer?.magnificationFilter = .nearest // crisp pixels when scaled up
+        // Remote desktops are usually shown smaller than their native size
+        // (downscaled). Default `.linear` minification without mipmaps looks
+        // soft/blurry; trilinear (mipmapped) keeps text crisp when shrinking,
+        // and nearest keeps it sharp when enlarging.
+        layer?.minificationFilter = .trilinear
+        layer?.magnificationFilter = .nearest
         startInputPump()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) unavailable") }
+
+    /// Keep the layer's backing resolution matched to the screen so the
+    /// framebuffer is rasterised at native Retina density, not upscaled from 1x.
+    public override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        if let scale = window?.backingScaleFactor {
+            layer?.contentsScale = scale
+        }
+    }
 
     public override var isFlipped: Bool { true }
     public override var acceptsFirstResponder: Bool { true }
@@ -211,6 +225,9 @@ public final class VNCSurfaceView: NSView {
     public override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.acceptsMouseMovedEvents = true
+        if let scale = window?.backingScaleFactor {
+            layer?.contentsScale = scale
+        }
     }
 
     // MARK: Keyboard

--- a/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
+++ b/Packages/CmuxVNC/Sources/CmuxVNC/View/VNCSurfaceView.swift
@@ -1,0 +1,240 @@
+#if canImport(AppKit)
+import AppKit
+import QuartzCore
+
+/// A native, layer-backed view that renders an RFB framebuffer and forwards
+/// mouse/keyboard input to the server. No WebKit, no intermediate bitmap
+/// server: decoded BGRX pixels go straight into a `CALayer` as a `CGImage`,
+/// and the GPU compositor scales them aspect-fit.
+@MainActor
+public final class VNCSurfaceView: NSView {
+    private let client: RFBClient
+    private let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+    private var remoteSize = CGSize.zero
+    private var currentButtons: VNCButtonMask = []
+    private var activeModifiers: Set<UInt32> = []
+    private var trackingAreaRef: NSTrackingArea?
+
+    private var inputContinuation: AsyncStream<InputCommand>.Continuation?
+    private var pumpTask: Task<Void, Never>?
+    private var eventTask: Task<Void, Never>?
+
+    /// Called on the main actor for every client event (state, bell, clipboard).
+    public var onEvent: ((VNCClientEvent) -> Void)?
+
+    public init(client: RFBClient) {
+        self.client = client
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+        layer?.contentsGravity = .resizeAspect
+        layer?.magnificationFilter = .nearest // crisp pixels when scaled up
+        startInputPump()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) unavailable") }
+
+    public override var isFlipped: Bool { true }
+    public override var acceptsFirstResponder: Bool { true }
+    public override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    // MARK: Lifecycle
+
+    /// Begins the session: consumes client events, rendering frames as they land.
+    public func connect() {
+        guard eventTask == nil else { return }
+        eventTask = Task { [weak self] in
+            guard let stream = await self?.client.start() else { return }
+            for await event in stream {
+                guard let self else { break }
+                await self.handle(event)
+            }
+        }
+    }
+
+    public func disconnect() {
+        eventTask?.cancel()
+        eventTask = nil
+        Task { [client] in await client.stop() }
+    }
+
+    deinit {
+        inputContinuation?.finish()
+        pumpTask?.cancel()
+        eventTask?.cancel()
+    }
+
+    private func handle(_ event: VNCClientEvent) async {
+        switch event {
+        case .connected(let width, let height, _), .resized(let width, let height):
+            remoteSize = CGSize(width: width, height: height)
+        case .frame(let snapshot):
+            render(snapshot)
+        case .serverCutText(let text):
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+        default:
+            break
+        }
+        onEvent?(event)
+    }
+
+    // MARK: Rendering
+
+    private func render(_ snapshot: VNCFrameSnapshot) {
+        guard snapshot.width > 0, snapshot.height > 0 else { return }
+        remoteSize = CGSize(width: snapshot.width, height: snapshot.height)
+        let bytesPerRow = snapshot.width * 4
+        guard snapshot.pixels.count >= bytesPerRow * snapshot.height else { return }
+        guard let provider = CGDataProvider(data: snapshot.pixels as CFData) else { return }
+        let bitmapInfo = CGBitmapInfo(rawValue:
+            CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue)
+        let image = CGImage(
+            width: snapshot.width,
+            height: snapshot.height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        )
+        CATransaction.begin()
+        CATransaction.setDisableActions(true) // no implicit fade between frames
+        layer?.contents = image
+        CATransaction.commit()
+    }
+
+    /// The rectangle (in view coords) the framebuffer image occupies, aspect-fit.
+    private var displayedRect: CGRect {
+        guard remoteSize.width > 0, remoteSize.height > 0 else { return bounds }
+        let scale = min(bounds.width / remoteSize.width, bounds.height / remoteSize.height)
+        let width = remoteSize.width * scale
+        let height = remoteSize.height * scale
+        return CGRect(x: (bounds.width - width) / 2, y: (bounds.height - height) / 2, width: width, height: height)
+    }
+
+    /// Maps a view point to remote framebuffer coordinates, or `nil` if outside.
+    private func remotePoint(for event: NSEvent) -> (x: Int, y: Int)? {
+        let local = convert(event.locationInWindow, from: nil)
+        let rect = displayedRect
+        guard rect.width > 0, rect.height > 0 else { return nil }
+        let scaleX = remoteSize.width / rect.width
+        let scaleY = remoteSize.height / rect.height
+        let rx = (local.x - rect.minX) * scaleX
+        let ry = (local.y - rect.minY) * scaleY
+        let cx = Int(rx.rounded(.down))
+        let cy = Int(ry.rounded(.down))
+        let clampedX = min(max(0, cx), Int(remoteSize.width) - 1)
+        let clampedY = min(max(0, cy), Int(remoteSize.height) - 1)
+        return (clampedX, clampedY)
+    }
+
+    // MARK: Input pump (preserves event order)
+
+    private enum InputCommand: Sendable {
+        case pointer(buttons: VNCButtonMask, x: Int, y: Int)
+        case key(keysym: UInt32, down: Bool)
+        case scroll(up: Bool, x: Int, y: Int, ticks: Int)
+    }
+
+    private func startInputPump() {
+        let stream = AsyncStream<InputCommand> { continuation in
+            self.inputContinuation = continuation
+        }
+        pumpTask = Task { [client] in
+            for await command in stream {
+                switch command {
+                case .pointer(let buttons, let x, let y):
+                    await client.sendPointer(buttons: buttons, x: x, y: y)
+                case .key(let keysym, let down):
+                    await client.sendKey(keysym: keysym, down: down)
+                case .scroll(let up, let x, let y, let ticks):
+                    await client.sendScroll(up: up, x: x, y: y, ticks: ticks)
+                }
+            }
+        }
+    }
+
+    private func enqueue(_ command: InputCommand) {
+        inputContinuation?.yield(command)
+    }
+
+    private func sendPointer(for event: NSEvent) {
+        guard let point = remotePoint(for: event) else { return }
+        enqueue(.pointer(buttons: currentButtons, x: point.x, y: point.y))
+    }
+
+    // MARK: Mouse
+
+    public override func mouseDown(with event: NSEvent) { window?.makeFirstResponder(self); currentButtons.insert(.left); sendPointer(for: event) }
+    public override func mouseUp(with event: NSEvent) { currentButtons.remove(.left); sendPointer(for: event) }
+    public override func mouseDragged(with event: NSEvent) { sendPointer(for: event) }
+    public override func rightMouseDown(with event: NSEvent) { currentButtons.insert(.right); sendPointer(for: event) }
+    public override func rightMouseUp(with event: NSEvent) { currentButtons.remove(.right); sendPointer(for: event) }
+    public override func rightMouseDragged(with event: NSEvent) { sendPointer(for: event) }
+    public override func otherMouseDown(with event: NSEvent) { currentButtons.insert(.middle); sendPointer(for: event) }
+    public override func otherMouseUp(with event: NSEvent) { currentButtons.remove(.middle); sendPointer(for: event) }
+    public override func otherMouseDragged(with event: NSEvent) { sendPointer(for: event) }
+    public override func mouseMoved(with event: NSEvent) { sendPointer(for: event) }
+
+    public override func scrollWheel(with event: NSEvent) {
+        guard let point = remotePoint(for: event) else { return }
+        let delta = event.scrollingDeltaY
+        guard delta != 0 else { return }
+        let ticks = min(5, max(1, Int(abs(delta).rounded(.up) / 3)))
+        enqueue(.scroll(up: delta > 0, x: point.x, y: point.y, ticks: ticks))
+    }
+
+    public override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingAreaRef { removeTrackingArea(existing) }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseMoved, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingAreaRef = area
+    }
+
+    public override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        window?.acceptsMouseMovedEvents = true
+    }
+
+    // MARK: Keyboard
+
+    public override func keyDown(with event: NSEvent) {
+        guard let keysym = VNCKeyMap.keysym(for: event) else { return }
+        enqueue(.key(keysym: keysym, down: true))
+        enqueue(.key(keysym: keysym, down: false))
+    }
+
+    public override func keyUp(with event: NSEvent) {
+        // Key release is paired with the press above; nothing extra to send for
+        // auto-repeat-style typing. Modifier transitions arrive via flagsChanged.
+    }
+
+    public override func flagsChanged(with event: NSEvent) {
+        for flag in VNCKeyMap.trackedModifiers {
+            guard let keysym = VNCKeyMap.modifierKeysym(for: flag) else { continue }
+            let isDown = event.modifierFlags.contains(flag)
+            let wasDown = activeModifiers.contains(keysym)
+            if isDown, !wasDown {
+                activeModifiers.insert(keysym)
+                enqueue(.key(keysym: keysym, down: true))
+            } else if !isDown, wasDown {
+                activeModifiers.remove(keysym)
+                enqueue(.key(keysym: keysym, down: false))
+            }
+        }
+    }
+}
+#endif

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/AppleDHAuthenticationTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/AppleDHAuthenticationTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+import CryptoKit
+import CommonCrypto
+@testable import CmuxVNC
+
+final class AppleDHAuthenticationTests: XCTestCase {
+    // MARK: Credential layout
+
+    func testCredentialLayout() {
+        let padding = [UInt8](repeating: 0xAA, count: 128)
+        let cred = AppleDHAuthentication.buildCredentials(username: "alice", password: "s3cret", padding: padding)
+        XCTAssertEqual(cred.count, 128)
+        // Username at 0..<64, NUL-terminated.
+        XCTAssertEqual(Array(cred[0..<5]), Array("alice".utf8))
+        XCTAssertEqual(cred[5], 0)
+        XCTAssertEqual(cred[6], 0xAA) // random padding preserved past the NUL
+        // Password at 64..<128, NUL-terminated.
+        XCTAssertEqual(Array(cred[64..<70]), Array("s3cret".utf8))
+        XCTAssertEqual(cred[70], 0)
+        XCTAssertEqual(cred[71], 0xAA)
+    }
+
+    func testCredentialTruncatesLongFields() {
+        let longName = String(repeating: "x", count: 100)
+        let cred = AppleDHAuthentication.buildCredentials(username: longName, password: longName, padding: [UInt8](repeating: 0, count: 128))
+        // Truncated to 63 bytes + NUL terminator at index 63.
+        XCTAssertEqual(cred[63], 0)
+        XCTAssertEqual(cred[127], 0)
+        XCTAssertEqual(Array(cred[0..<63]), Array(repeating: UInt8(ascii: "x"), count: 63))
+    }
+
+    // MARK: AES-128-ECB (FIPS-197 known-answer)
+
+    func testAES128ECBKnownAnswer() {
+        let key: [UInt8] = [0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c]
+        let plaintext: [UInt8] = [0x6b,0xc1,0xbe,0xe2,0x2e,0x40,0x9f,0x96,0xe9,0x3d,0x7e,0x11,0x73,0x93,0x17,0x2a]
+        let expected: [UInt8] = [0x3a,0xd7,0x7b,0xb4,0x0d,0x7a,0x36,0x60,0xa8,0x9e,0xca,0xf3,0x24,0x66,0xef,0x97]
+        XCTAssertEqual(AppleDHAuthentication.aes128ECBEncrypt(key: key, plaintext: plaintext), expected)
+    }
+
+    // MARK: Full DH response with tiny deterministic parameters
+
+    func testResponseWithKnownSmallDHParameters() throws {
+        // p=23, g=5, server public=8, client private=6 (1-byte key length).
+        // clientPub = 5^6 mod 23 = 8 ; shared = 8^6 mod 23 = 13 (computed by hand).
+        let params = AppleDHAuthentication.ServerParams(
+            generator: 5, keyLength: 1, prime: [23], serverPublicKey: [8]
+        )
+        let padding = (0..<128).map { UInt8($0) }
+        let resp = try XCTUnwrap(AppleDHAuthentication.response(
+            params: params, username: "bob", password: "pw", privateKey: [6], padding: padding
+        ))
+
+        XCTAssertEqual(resp.clientPublicKey, [8], "5^6 mod 23 == 8")
+        XCTAssertEqual(resp.encryptedCredentials.count, 128)
+
+        // Reconstruct the expected ciphertext from the known shared secret (13).
+        let aesKey = Array(Insecure.MD5.hash(data: Data([13])))
+        let expectedCreds = AppleDHAuthentication.buildCredentials(username: "bob", password: "pw", padding: padding)
+        let expectedCipher = AppleDHAuthentication.aes128ECBEncrypt(key: aesKey, plaintext: expectedCreds)
+        XCTAssertEqual(resp.encryptedCredentials, expectedCipher)
+
+        // And decrypting with the shared key recovers the credentials.
+        let recovered = aes128ECBDecrypt(key: aesKey, ciphertext: resp.encryptedCredentials)
+        XCTAssertEqual(Array(recovered[0..<3]), Array("bob".utf8))
+        XCTAssertEqual(Array(recovered[64..<66]), Array("pw".utf8))
+    }
+
+    func testResponseRejectsMismatchedLengths() {
+        let params = AppleDHAuthentication.ServerParams(
+            generator: 2, keyLength: 4, prime: [1, 2, 3], serverPublicKey: [1, 2, 3, 4]
+        )
+        XCTAssertNil(AppleDHAuthentication.response(params: params, username: "a", password: "b"))
+    }
+
+    private func aes128ECBDecrypt(key: [UInt8], ciphertext: [UInt8]) -> [UInt8] {
+        var out = [UInt8](repeating: 0, count: ciphertext.count)
+        let cap = out.count
+        var moved = 0
+        _ = key.withUnsafeBytes { k in ciphertext.withUnsafeBytes { c in out.withUnsafeMutableBytes { o in
+            CCCrypt(CCOperation(kCCDecrypt), CCAlgorithm(kCCAlgorithmAES128), CCOptions(kCCOptionECBMode),
+                    k.baseAddress, key.count, nil, c.baseAddress, ciphertext.count, o.baseAddress, cap, &moved)
+        }}}
+        return Array(out.prefix(moved))
+    }
+}

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/FramebufferDecoderTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/FramebufferDecoderTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import CmuxVNC
+
+final class FramebufferDecoderTests: XCTestCase {
+    /// Little-endian BGRX bytes for a host `0x00RRGGBB` pixel.
+    private func pixelBytes(_ value: UInt32) -> [UInt8] {
+        [UInt8(value & 0xFF), UInt8((value >> 8) & 0xFF), UInt8((value >> 16) & 0xFF), UInt8((value >> 24) & 0xFF)]
+    }
+
+    func testRawEncoding() async throws {
+        let fb = Framebuffer(width: 2, height: 2)
+        let colors: [UInt32] = [0x00FF0000, 0x0000FF00, 0x000000FF, 0x00FFFFFF]
+        var stream: [UInt8] = []
+        for c in colors { stream.append(contentsOf: pixelBytes(c)) }
+
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 2, height: 2, encoding: 0)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertEqual(fb.pixels, colors)
+    }
+
+    func testCopyRectEncoding() async throws {
+        let fb = Framebuffer(width: 2, height: 1)
+        fb.fill(x: 0, y: 0, width: 1, height: 1, color: 0x00AB_CDEF)
+        // CopyRect from (0,0) to (1,0).
+        let stream: [UInt8] = [0, 0, 0, 0] // srcX=0, srcY=0
+        let header = RFBRectangleHeader(x: 1, y: 0, width: 1, height: 1, encoding: 1)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertEqual(fb.pixels[1], 0x00AB_CDEF)
+    }
+
+    func testRREEncoding() async throws {
+        let fb = Framebuffer(width: 4, height: 4)
+        let background: UInt32 = 0x0011_2233
+        let foreground: UInt32 = 0x00AA_BBCC
+        var stream: [UInt8] = [0, 0, 0, 1] // 1 subrect
+        stream.append(contentsOf: pixelBytes(background))
+        stream.append(contentsOf: pixelBytes(foreground))
+        stream.append(contentsOf: [0, 1, 0, 1, 0, 2, 0, 2]) // x=1,y=1,w=2,h=2
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 4, height: 4, encoding: 2)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertEqual(fb.pixels[0], background)           // corner
+        XCTAssertEqual(fb.pixels[1 * 4 + 1], foreground)   // inside subrect
+        XCTAssertEqual(fb.pixels[2 * 4 + 2], foreground)   // inside subrect
+        XCTAssertEqual(fb.pixels[3 * 4 + 3], background)   // outside subrect
+    }
+
+    func testHextileSolidBackgroundTile() async throws {
+        let fb = Framebuffer(width: 16, height: 16)
+        let background: UInt32 = 0x0012_3456
+        // One tile, BackgroundSpecified only (mask = 2), no subrects.
+        var stream: [UInt8] = [2]
+        stream.append(contentsOf: pixelBytes(background))
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 16, height: 16, encoding: 5)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertTrue(fb.pixels.allSatisfy { $0 == background })
+    }
+
+    func testHextileRawTile() async throws {
+        let fb = Framebuffer(width: 2, height: 2)
+        let colors: [UInt32] = [0x00111111, 0x00222222, 0x00333333, 0x00444444]
+        var stream: [UInt8] = [1] // Raw bit
+        for c in colors { stream.append(contentsOf: pixelBytes(c)) }
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 2, height: 2, encoding: 5)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertEqual(fb.pixels, colors)
+    }
+
+    func testHextileForegroundSubrect() async throws {
+        let fb = Framebuffer(width: 16, height: 16)
+        let background: UInt32 = 0x0000_0000
+        let foreground: UInt32 = 0x00FF_FFFF
+        // mask = bg(2) | fg(4) | anySubrects(8) = 14, then 1 subrect (uncoloured).
+        var stream: [UInt8] = [14]
+        stream.append(contentsOf: pixelBytes(background))
+        stream.append(contentsOf: pixelBytes(foreground))
+        stream.append(1)          // 1 subrect
+        stream.append(0x00)       // x=0, y=0
+        stream.append(0x00)       // w=1, h=1
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 16, height: 16, encoding: 5)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource(stream), into: fb)
+
+        XCTAssertEqual(fb.pixels[0], foreground)
+        XCTAssertEqual(fb.pixels[1], background)
+    }
+
+    func testDesktopSizeResizesFramebuffer() async throws {
+        let fb = Framebuffer(width: 4, height: 4)
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 8, height: 6, encoding: -223)
+        try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource([]), into: fb)
+        XCTAssertEqual(fb.width, 8)
+        XCTAssertEqual(fb.height, 6)
+        XCTAssertEqual(fb.pixels.count, 48)
+    }
+
+    func testUnknownEncodingThrows() async {
+        let fb = Framebuffer(width: 1, height: 1)
+        let header = RFBRectangleHeader(x: 0, y: 0, width: 1, height: 1, encoding: 999)
+        do {
+            try await RFBRectangleDecoder().decode(header: header, from: InMemoryByteSource([]), into: fb)
+            XCTFail("expected throw")
+        } catch let error as RFBError {
+            if case .protocolViolation = error { return }
+            XCTFail("unexpected \(error)")
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
+    func testFramebufferResizePreservesTopLeft() {
+        let fb = Framebuffer(width: 2, height: 2)
+        fb.blit(x: 0, y: 0, width: 2, height: 2, pixels: [1, 2, 3, 4])
+        fb.resize(width: 3, height: 3)
+        XCTAssertEqual(fb.pixels[0], 1)
+        XCTAssertEqual(fb.pixels[1], 2)
+        XCTAssertEqual(fb.width, 3)
+    }
+}

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/RFBProtocolTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/RFBProtocolTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import CmuxVNC
+
+final class RFBProtocolTests: XCTestCase {
+    // MARK: PixelFormat
+
+    func testPixelFormatRoundTrip() {
+        let format = RFBPixelFormat.cmuxBGRX
+        let encoded = format.encoded()
+        XCTAssertEqual(encoded.count, 16)
+        let decoded = RFBPixelFormat(encoded[...])
+        XCTAssertEqual(decoded, format)
+    }
+
+    func testCmuxFormatIsLittleEndianTrueColor() {
+        let format = RFBPixelFormat.cmuxBGRX
+        XCTAssertEqual(format.bitsPerPixel, 32)
+        XCTAssertEqual(format.bytesPerPixel, 4)
+        XCTAssertFalse(format.bigEndian)
+        XCTAssertTrue(format.trueColor)
+        XCTAssertEqual(format.redShift, 16)
+        XCTAssertEqual(format.greenShift, 8)
+        XCTAssertEqual(format.blueShift, 0)
+    }
+
+    // MARK: Client messages
+
+    func testFramebufferUpdateRequestBytes() {
+        let bytes = RFBClientMessage.framebufferUpdateRequest(
+            incremental: true, x: 0, y: 0, width: 0x0102, height: 0x0304
+        )
+        XCTAssertEqual(bytes, [3, 1, 0, 0, 0, 0, 0x01, 0x02, 0x03, 0x04])
+    }
+
+    func testSetEncodingsBytes() {
+        let bytes = RFBClientMessage.setEncodings([.raw, .copyRect])
+        XCTAssertEqual(bytes, [2, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1])
+    }
+
+    func testPointerEventBytes() {
+        let bytes = RFBClientMessage.pointerEvent(buttonMask: 0b1, x: 0x00FF, y: 0x0100)
+        XCTAssertEqual(bytes, [5, 1, 0x00, 0xFF, 0x01, 0x00])
+    }
+
+    func testKeyEventBytes() {
+        let bytes = RFBClientMessage.keyEvent(keysym: 0xFF0D, down: true)
+        XCTAssertEqual(bytes, [4, 1, 0, 0, 0x00, 0x00, 0xFF, 0x0D])
+    }
+
+    // MARK: VNC authentication
+
+    func testReverseBits() {
+        XCTAssertEqual(VNCAuthentication.reverseBits(0x01), 0x80)
+        XCTAssertEqual(VNCAuthentication.reverseBits(0x02), 0x40)
+        XCTAssertEqual(VNCAuthentication.reverseBits(0x80), 0x01)
+        XCTAssertEqual(VNCAuthentication.reverseBits(0xFF), 0xFF)
+        XCTAssertEqual(VNCAuthentication.reverseBits(0x00), 0x00)
+    }
+
+    func testDesKeyTruncatesAndReverses() {
+        let key = VNCAuthentication.desKey(from: "ABCDEFGHIJ")
+        XCTAssertEqual(key.count, 8)
+        XCTAssertEqual(key[0], VNCAuthentication.reverseBits(UInt8(ascii: "A")))
+        XCTAssertEqual(key[7], VNCAuthentication.reverseBits(UInt8(ascii: "H")))
+    }
+
+    func testChallengeResponseIsSixteenBytesAndDeterministic() {
+        let challenge = (0 ..< 16).map { UInt8($0) }
+        let a = VNCAuthentication.challengeResponse(challenge: challenge, password: "secret")
+        let b = VNCAuthentication.challengeResponse(challenge: challenge, password: "secret")
+        XCTAssertEqual(a.count, 16)
+        XCTAssertEqual(a, b)
+    }
+
+    func testChallengeResponseUsesECBPerBlock() {
+        // In ECB mode the first output block depends only on the first input
+        // block, so encrypting only the first 8 challenge bytes must reproduce
+        // the first 8 bytes of the full 16-byte response.
+        let challenge = (0 ..< 16).map { UInt8($0) }
+        let full = VNCAuthentication.challengeResponse(challenge: challenge, password: "secret")
+        let firstBlock = VNCAuthentication.challengeResponse(challenge: Array(challenge.prefix(8)), password: "secret")
+        XCTAssertEqual(Array(full.prefix(8)), firstBlock)
+    }
+
+    func testDifferentPasswordsProduceDifferentResponses() {
+        let challenge = [UInt8](repeating: 0xAB, count: 16)
+        let a = VNCAuthentication.challengeResponse(challenge: challenge, password: "alpha")
+        let b = VNCAuthentication.challengeResponse(challenge: challenge, password: "bravo")
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: Handshake
+
+    private func makeServerInitBytes(width: UInt16, height: UInt16, name: String) -> [UInt8] {
+        var bytes: [UInt8] = [UInt8(width >> 8), UInt8(width & 0xFF), UInt8(height >> 8), UInt8(height & 0xFF)]
+        bytes.append(contentsOf: RFBPixelFormat.cmuxBGRX.encoded())
+        let nameBytes = Array(name.utf8)
+        bytes.append(contentsOf: [0, 0, UInt8(nameBytes.count >> 8), UInt8(nameBytes.count & 0xFF)])
+        bytes.append(contentsOf: nameBytes)
+        return bytes
+    }
+
+    func testHandshakeNoneSecurity38() async throws {
+        var stream = Array("RFB 003.008\n".utf8)
+        stream.append(contentsOf: [1, 1])           // 1 security type: None
+        stream.append(contentsOf: [0, 0, 0, 0])     // SecurityResult OK
+        stream.append(contentsOf: makeServerInitBytes(width: 1024, height: 768, name: "screen"))
+
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        let init0 = try await RFBHandshake().negotiate(source: source, sink: sink, password: nil)
+
+        XCTAssertEqual(init0.width, 1024)
+        XCTAssertEqual(init0.height, 768)
+        XCTAssertEqual(init0.name, "screen")
+
+        let written = await sink.contents()
+        var expected = Array("RFB 003.008\n".utf8)
+        expected.append(1) // chose None
+        expected.append(1) // ClientInit shared flag
+        XCTAssertEqual(written, expected)
+    }
+
+    func testHandshakeVNCAuth38() async throws {
+        let challenge = (0 ..< 16).map { UInt8($0 &* 7 &+ 3) }
+        var stream = Array("RFB 003.008\n".utf8)
+        stream.append(contentsOf: [1, 2])           // 1 security type: VNC auth
+        stream.append(contentsOf: challenge)        // 16-byte challenge
+        stream.append(contentsOf: [0, 0, 0, 0])     // SecurityResult OK
+        stream.append(contentsOf: makeServerInitBytes(width: 800, height: 600, name: "vm"))
+
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        let init0 = try await RFBHandshake().negotiate(source: source, sink: sink, password: "hunter2")
+
+        XCTAssertEqual(init0.width, 800)
+        XCTAssertEqual(init0.height, 600)
+
+        let written = await sink.contents()
+        var expected = Array("RFB 003.008\n".utf8)
+        expected.append(2) // chose VNC auth
+        expected.append(contentsOf: VNCAuthentication.challengeResponse(challenge: challenge, password: "hunter2"))
+        expected.append(1) // ClientInit
+        XCTAssertEqual(written, expected)
+    }
+
+    func testHandshakeAuthFailureThrows() async {
+        var stream = Array("RFB 003.008\n".utf8)
+        stream.append(contentsOf: [1, 2])           // VNC auth
+        stream.append(contentsOf: [UInt8](repeating: 0, count: 16)) // challenge
+        stream.append(contentsOf: [0, 0, 0, 1])     // SecurityResult failed
+        stream.append(contentsOf: [0, 0, 0, 7])     // reason length 7
+        stream.append(contentsOf: Array("bad pwd".utf8))
+
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        do {
+            _ = try await RFBHandshake().negotiate(source: source, sink: sink, password: "x")
+            XCTFail("expected failure")
+        } catch let error as RFBError {
+            XCTAssertEqual(error, .authenticationFailed("bad pwd"))
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testHandshakePasswordRequiredWhenOnlyVNCOffered() async {
+        var stream = Array("RFB 003.008\n".utf8)
+        stream.append(contentsOf: [1, 2]) // only VNC auth offered
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        do {
+            _ = try await RFBHandshake().negotiate(source: source, sink: sink, password: nil)
+            XCTFail("expected passwordRequired")
+        } catch let error as RFBError {
+            XCTAssertEqual(error, .passwordRequired)
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+}

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/RFBProtocolTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/RFBProtocolTests.swift
@@ -164,6 +164,48 @@ final class RFBProtocolTests: XCTestCase {
         }
     }
 
+    func testHandshakeSelectsAppleDHAndAuthenticates() async throws {
+        // keyLength = 1 (p=23, g=5, serverPub=8); SecurityResult OK, then ServerInit.
+        var stream = Array("RFB 003.889\n".utf8)
+        stream.append(contentsOf: [4, 30, 33, 35, 36])  // 4 types, Apple-only
+        stream.append(contentsOf: [0, 5])               // generator = 5 (u16)
+        stream.append(contentsOf: [0, 1])               // key length = 1 (u16)
+        stream.append(23)                               // prime
+        stream.append(8)                                // server public key
+        stream.append(contentsOf: [0, 0, 0, 0])         // SecurityResult OK
+        stream.append(contentsOf: makeServerInitBytes(width: 1440, height: 900, name: "mac"))
+
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        let info = try await RFBHandshake().negotiate(
+            source: source, sink: sink, password: "pw", username: "bob"
+        )
+        XCTAssertEqual(info.width, 1440)
+        XCTAssertEqual(info.name, "mac")
+
+        let written = await sink.contents()
+        // version reply (12) + selection byte 30 + 128-byte ciphertext + 1-byte
+        // client public key + ClientInit shared flag.
+        XCTAssertEqual(written.count, 12 + 1 + 128 + 1 + 1)
+        XCTAssertEqual(written[12], 30, "selected Apple DH")
+        XCTAssertEqual(written.last, 1, "ClientInit shared")
+    }
+
+    func testHandshakeCredentialsRequiredWhenOnlyAppleOffered() async {
+        var stream = Array("RFB 003.889\n".utf8)
+        stream.append(contentsOf: [1, 30]) // only Apple DH
+        let source = InMemoryByteSource(stream)
+        let sink = InMemoryByteSink()
+        do {
+            _ = try await RFBHandshake().negotiate(source: source, sink: sink, password: "pw", username: nil)
+            XCTFail("expected credentialsRequired")
+        } catch let error as RFBError {
+            XCTAssertEqual(error, .credentialsRequired)
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
     func testHandshakePasswordRequiredWhenOnlyVNCOffered() async {
         var stream = Array("RFB 003.008\n".utf8)
         stream.append(contentsOf: [1, 2]) // only VNC auth offered

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/VNCEndpointTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/VNCEndpointTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import CmuxVNC
+
+final class VNCEndpointTests: XCTestCase {
+    func testBareHostDefaultsTo5900() {
+        XCTAssertEqual(VNCEndpoint(string: "host.local"), VNCEndpoint(host: "host.local", port: 5900))
+    }
+
+    func testDisplayNumberMapsToPort() {
+        XCTAssertEqual(VNCEndpoint(string: "host:1"), VNCEndpoint(host: "host", port: 5901))
+        XCTAssertEqual(VNCEndpoint(string: "host:2"), VNCEndpoint(host: "host", port: 5902))
+    }
+
+    func testExplicitPort() {
+        XCTAssertEqual(VNCEndpoint(string: "host:5999"), VNCEndpoint(host: "host", port: 5999))
+    }
+
+    func testDoubleColonRawPort() {
+        XCTAssertEqual(VNCEndpoint(string: "host::5905"), VNCEndpoint(host: "host", port: 5905))
+    }
+
+    func testVncSchemeAndPassword() {
+        XCTAssertEqual(
+            VNCEndpoint(string: "vnc://secret@10.0.0.5:5901"),
+            VNCEndpoint(host: "10.0.0.5", port: 5901, password: "secret")
+        )
+        XCTAssertEqual(
+            VNCEndpoint(string: "vnc://:pw@box"),
+            VNCEndpoint(host: "box", port: 5900, password: "pw")
+        )
+    }
+
+    func testIPv6Literal() {
+        XCTAssertEqual(VNCEndpoint(string: "[::1]:5902"), VNCEndpoint(host: "::1", port: 5902))
+        XCTAssertEqual(VNCEndpoint(string: "[fe80::1]"), VNCEndpoint(host: "fe80::1", port: 5900))
+    }
+
+    func testTrailingPathStripped() {
+        XCTAssertEqual(VNCEndpoint(string: "vnc://host:5901/ignored"), VNCEndpoint(host: "host", port: 5901))
+    }
+
+    func testEmptyIsNil() {
+        XCTAssertNil(VNCEndpoint(string: "   "))
+    }
+
+    func testDisplayLabel() {
+        XCTAssertEqual(VNCEndpoint(host: "h", port: 5901).displayLabel, "h:5901")
+    }
+}

--- a/Packages/CmuxVNC/Tests/CmuxVNCTests/VNCEndpointTests.swift
+++ b/Packages/CmuxVNC/Tests/CmuxVNCTests/VNCEndpointTests.swift
@@ -30,6 +30,19 @@ final class VNCEndpointTests: XCTestCase {
         )
     }
 
+    func testUsernameAndPassword() {
+        XCTAssertEqual(
+            VNCEndpoint(string: "vnc://bob:secret@10.0.0.5:5901"),
+            VNCEndpoint(host: "10.0.0.5", port: 5901, password: "secret", username: "bob")
+        )
+    }
+
+    func testPasswordOnlyHasNoUsername() {
+        let ep = VNCEndpoint(string: "vnc://secret@host")
+        XCTAssertEqual(ep?.password, "secret")
+        XCTAssertNil(ep?.username)
+    }
+
     func testIPv6Literal() {
         XCTAssertEqual(VNCEndpoint(string: "[::1]:5902"), VNCEndpoint(host: "::1", port: 5902))
         XCTAssertEqual(VNCEndpoint(string: "[fe80::1]"), VNCEndpoint(host: "fe80::1", port: 5900))

--- a/Packages/CmuxWorkspaceCore/Sources/CmuxWorkspaceCore/Values/SurfaceKind.swift
+++ b/Packages/CmuxWorkspaceCore/Sources/CmuxWorkspaceCore/Values/SurfaceKind.swift
@@ -31,4 +31,6 @@ public struct SurfaceKind: RawRepresentable, Hashable, Sendable {
     public static let project = SurfaceKind(rawValue: "project")
     /// A browser pane owned by a sidebar extension.
     public static let extensionBrowser = SurfaceKind(rawValue: "extensionBrowser")
+    /// A native VNC (RFB) remote-display pane.
+    public static let vnc = SurfaceKind(rawValue: "vnc")
 }

--- a/Sources/Canvas/WorkspaceCanvasHostView.swift
+++ b/Sources/Canvas/WorkspaceCanvasHostView.swift
@@ -74,6 +74,7 @@ struct WorkspaceCanvasHostView: View {
         case .agentSession: return "sparkles"
         case .project: return "folder"
         case .extensionBrowser: return "puzzlepiece.extension"
+        case .vnc: return "display"
         }
     }
 

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -726,6 +726,8 @@ final class ClosedItemHistoryStore: ObservableObject {
             return String(localized: "menu.history.recentlyClosed.panel.project", defaultValue: "Project")
         case .extensionBrowser:
             return String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
+        case .vnc:
+            return String(localized: "menu.history.recentlyClosed.panel.vnc", defaultValue: "VNC")
         }
     }
 

--- a/Sources/CmuxLifecycleEventPublishing.swift
+++ b/Sources/CmuxLifecycleEventPublishing.swift
@@ -221,6 +221,8 @@ extension Workspace {
             return "project"
         case .extensionBrowser:
             return "extension_browser"
+        case .vnc:
+            return "vnc"
         }
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5696,6 +5696,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.kind.project", defaultValue: "Project")
         case .extensionBrowser:
             return String(localized: "sidebar.extensions.browser.title", defaultValue: "Sidebar Extensions")
+        case .vnc:
+            return String(localized: "commandPalette.kind.vnc", defaultValue: "VNC")
         }
     }
 
@@ -5717,6 +5719,8 @@ struct ContentView: View {
             return ["project", "xcode", "build", "settings", "schemes", "targets"]
         case .extensionBrowser:
             return ["sidebar", "extensions", "extensionkit", "browser"]
+        case .vnc:
+            return ["vnc", "remote", "screen", "display", "rfb"]
         }
     }
 
@@ -11146,6 +11150,8 @@ struct VerticalTabsSidebar: View {
         case .project:
             return .project
         case .extensionBrowser:
+            return .unknown
+        case .vnc:
             return .unknown
         }
     }

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -12,6 +12,7 @@ public enum PanelType: String, Codable, Sendable {
     case agentSession
     case project
     case extensionBrowser
+    case vnc
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -120,6 +120,17 @@ struct PanelContentView: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+        case .vnc:
+            if let vncPanel = panel as? VNCPanel {
+                VNCPanelView(
+                    panel: vncPanel,
+                    isFocused: isFocused,
+                    isVisibleInUI: isVisibleInUI,
+                    portalPriority: portalPriority,
+                    appearance: appearance,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         }
     }
 
@@ -139,7 +150,7 @@ struct PanelContentView: View {
         switch panel.panelType {
         case .markdown, .filePreview, .rightSidebarTool, .agentSession, .project, .extensionBrowser:
             return true
-        case .terminal, .browser:
+        case .terminal, .browser, .vnc:
             return false
         }
     }

--- a/Sources/Panels/VNCCredentialStore.swift
+++ b/Sources/Panels/VNCCredentialStore.swift
@@ -1,0 +1,155 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+/// Stores VNC passwords and gates retrieval behind Touch ID.
+///
+/// The secret is kept in the login Keychain (per bundle id), falling back to a
+/// `0600` file when the Keychain is unavailable (ad-hoc Debug builds without a
+/// matching `keychain-access-groups` entitlement return `errSecMissingEntitlement`).
+/// Either way, reads go through `LAContext.evaluatePolicy(.deviceOwnerAuthentication)`,
+/// so a password only leaves storage after a successful Touch ID (or device
+/// passcode) check. This needs no special entitlement, so it works on dev builds.
+enum VNCCredentialStore {
+    private static var service: String {
+        let bundle = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
+        return "\(bundle).vnc"
+    }
+
+    private static func account(host: String, port: UInt16) -> String {
+        "\(host):\(port)"
+    }
+
+    // MARK: - Existence (no prompt)
+
+    /// Whether a password is stored for `host:port`, without prompting.
+    static func hasCredential(host: String, port: UInt16) -> Bool {
+        if keychainReadData(account: account(host: host, port: port), prompt: false) != nil {
+            return true
+        }
+        return fileRead()[account(host: host, port: port)] != nil
+    }
+
+    // MARK: - Save (no prompt)
+
+    static func save(host: String, port: UInt16, password: String) {
+        let acct = account(host: host, port: port)
+        if keychainWrite(password, account: acct) { return }
+        // Keychain unavailable: fall back to a 0600 file.
+        var map = fileRead()
+        map[acct] = password
+        fileWrite(map)
+    }
+
+    // MARK: - Load (Touch ID gated)
+
+    /// Returns the stored password after a Touch ID / passcode check, or `nil`
+    /// if the user cancels, biometrics fail, or nothing is stored.
+    static func load(host: String, port: UInt16, reason: String) async -> String? {
+        let acct = account(host: host, port: port)
+        guard hasCredential(host: host, port: port) else { return nil }
+
+        let context = LAContext()
+        var policyError: NSError?
+        let policy: LAPolicy = .deviceOwnerAuthentication
+        guard context.canEvaluatePolicy(policy, error: &policyError) else {
+            // No biometrics/passcode available at all; do not silently release.
+            return nil
+        }
+        let authorized: Bool = await withCheckedContinuation { continuation in
+            context.evaluatePolicy(policy, localizedReason: reason) { success, _ in
+                continuation.resume(returning: success)
+            }
+        }
+        guard authorized else { return nil }
+
+        if let data = keychainReadData(account: acct, prompt: false),
+           let password = String(data: data, encoding: .utf8) {
+            return password
+        }
+        return fileRead()[acct]
+    }
+
+    // MARK: - Delete
+
+    static func delete(host: String, port: UInt16) {
+        let acct = account(host: host, port: port)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: acct,
+        ]
+        SecItemDelete(query as CFDictionary)
+        var map = fileRead()
+        if map.removeValue(forKey: acct) != nil {
+            fileWrite(map)
+        }
+    }
+
+    // MARK: - Keychain
+
+    private static func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    private static func keychainReadData(account: String, prompt: Bool) -> Data? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        if !prompt {
+            let context = LAContext()
+            context.interactionNotAllowed = true
+            query[kSecUseAuthenticationContext as String] = context
+        }
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    private static func keychainWrite(_ value: String, account: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        let lookup = baseQuery(account: account)
+        let updateStatus = SecItemUpdate(lookup as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+        if updateStatus != errSecItemNotFound { return false }
+        var insert = lookup
+        insert[kSecValueData as String] = data
+        insert[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(insert as CFDictionary, nil) == errSecSuccess
+    }
+
+    // MARK: - File fallback
+
+    private static var fileURL: URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        let bundle = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
+        return base.appendingPathComponent("cmux/\(bundle)/vnc-credentials.json")
+    }
+
+    private static func fileRead() -> [String: String] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let map = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return map
+    }
+
+    private static func fileWrite(_ map: [String: String]) {
+        let fm = FileManager.default
+        let dir = fileURL.deletingLastPathComponent()
+        do {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+            let data = try JSONEncoder().encode(map)
+            try data.write(to: fileURL, options: [.atomic])
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        } catch {
+            // Best effort; storage is optional.
+        }
+    }
+}

--- a/Sources/Panels/VNCPanel.swift
+++ b/Sources/Panels/VNCPanel.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Combine
+import CmuxVNC
+import Foundation
+
+/// Connection state for a ``VNCPanel``, surfaced to the view for status UI.
+enum VNCConnectionState: Equatable {
+    case connecting
+    case connected
+    case disconnected(String?)
+}
+
+/// A native VNC (RFB) viewer surface. Renders a remote framebuffer with the
+/// `CmuxVNC` engine (no WebKit, no system Screen Sharing app) and forwards
+/// mouse/keyboard input. The panel owns the live session so split/tab layout
+/// churn never tears down or reconnects the stream.
+@MainActor
+final class VNCPanel: Panel, ObservableObject {
+    let id: UUID
+    let panelType: PanelType = .vnc
+
+    private(set) var workspaceId: UUID
+
+    /// The remote target. Frozen for the life of the panel; reconnect reuses it.
+    let endpoint: VNCEndpoint
+
+    /// Tab title: the server's desktop name once known, else `host:port`.
+    @Published private(set) var displayTitle: String
+
+    @Published private(set) var connectionState: VNCConnectionState = .connecting
+
+    /// Bumped each time a fresh session is built so the host view recreates the
+    /// native surface (which owns the new client).
+    @Published private(set) var sessionToken: Int = 0
+
+    /// Token incremented to trigger the focus flash animation.
+    @Published private(set) var focusFlashToken: Int = 0
+
+    var displayIcon: String? { "display" }
+
+    /// The current native surface view, owned here so it outlives view churn.
+    private(set) var surfaceView: VNCSurfaceView
+
+    private var isClosed = false
+
+    init(workspaceId: UUID, endpoint: VNCEndpoint, autoConnect: Bool = true) {
+        self.id = UUID()
+        self.workspaceId = workspaceId
+        self.endpoint = endpoint
+        self.displayTitle = endpoint.displayLabel
+        self.surfaceView = VNCSurfaceView(client: RFBClient(endpoint: endpoint))
+        configure(surfaceView)
+        if autoConnect {
+            connect()
+        }
+    }
+
+    private func configure(_ view: VNCSurfaceView) {
+        view.onEvent = { [weak self] event in
+            self?.handle(event)
+        }
+    }
+
+    /// The endpoint string for persistence, e.g. `vnc://host:5901`. Password is
+    /// intentionally never persisted.
+    var persistableConnectionString: String {
+        "vnc://\(endpoint.host):\(endpoint.port)"
+    }
+
+    // MARK: - Connection
+
+    func connect() {
+        guard !isClosed else { return }
+        connectionState = .connecting
+        surfaceView.connect()
+    }
+
+    /// Tears down the current session and starts a fresh one against the same
+    /// endpoint. Used by the "Reconnect" affordance after a drop.
+    func reconnect() {
+        guard !isClosed else { return }
+        surfaceView.disconnect()
+        let view = VNCSurfaceView(client: RFBClient(endpoint: endpoint))
+        configure(view)
+        surfaceView = view
+        sessionToken += 1
+        connectionState = .connecting
+        view.connect()
+    }
+
+    private func handle(_ event: VNCClientEvent) {
+        switch event {
+        case .connecting:
+            connectionState = .connecting
+        case .connected(_, _, let name):
+            connectionState = .connected
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                displayTitle = trimmed
+            }
+        case .disconnected(let error):
+            connectionState = .disconnected(error?.errorDescription)
+        case .bell:
+            NSSound.beep()
+        case .frame, .resized, .serverCutText:
+            break
+        }
+    }
+
+    // MARK: - Panel protocol
+
+    func focus() {
+        guard !isClosed else { return }
+        _ = surfaceView.window?.makeFirstResponder(surfaceView)
+    }
+
+    func unfocus() {
+        // No panel-local first responder to relinquish beyond the surface itself.
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        surfaceView.disconnect()
+    }
+
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {
+        _ = reason
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
+        focusFlashToken += 1
+    }
+}

--- a/Sources/Panels/VNCPanel.swift
+++ b/Sources/Panels/VNCPanel.swift
@@ -5,6 +5,7 @@ import Foundation
 
 /// Connection state for a ``VNCPanel``, surfaced to the view for status UI.
 enum VNCConnectionState: Equatable {
+    case authenticating
     case connecting
     case connected
     case disconnected(String?)
@@ -21,13 +22,18 @@ final class VNCPanel: Panel, ObservableObject {
 
     private(set) var workspaceId: UUID
 
-    /// The remote target. Frozen for the life of the panel; reconnect reuses it.
+    /// The remote target as supplied (may have no password). Frozen for the life
+    /// of the panel; reconnect/unlock reuses it.
     let endpoint: VNCEndpoint
 
     /// Tab title: the server's desktop name once known, else `host:port`.
     @Published private(set) var displayTitle: String
 
     @Published private(set) var connectionState: VNCConnectionState = .connecting
+
+    /// Whether a Touch ID-gated password is stored for this host, enabling the
+    /// "Unlock" / "Forget" affordances.
+    @Published private(set) var hasSavedPassword: Bool = false
 
     /// Bumped each time a fresh session is built so the host view recreates the
     /// native surface (which owns the new client).
@@ -42,16 +48,22 @@ final class VNCPanel: Panel, ObservableObject {
     private(set) var surfaceView: VNCSurfaceView
 
     private var isClosed = false
+    /// Set when the active session used an inline password we should persist on
+    /// a successful connect (Touch ID-gated thereafter).
+    private var passwordToSaveOnConnect: String?
 
     init(workspaceId: UUID, endpoint: VNCEndpoint, autoConnect: Bool = true) {
         self.id = UUID()
         self.workspaceId = workspaceId
         self.endpoint = endpoint
         self.displayTitle = endpoint.displayLabel
+        self.hasSavedPassword = VNCCredentialStore.hasCredential(host: endpoint.host, port: endpoint.port)
+        // A placeholder session; `beginConnect()` builds the real one (possibly
+        // after a Touch ID unlock).
         self.surfaceView = VNCSurfaceView(client: RFBClient(endpoint: endpoint))
         configure(surfaceView)
         if autoConnect {
-            connect()
+            beginConnect()
         }
     }
 
@@ -61,24 +73,64 @@ final class VNCPanel: Panel, ObservableObject {
         }
     }
 
-    /// The endpoint string for persistence, e.g. `vnc://host:5901`. Password is
-    /// intentionally never persisted.
+    /// The endpoint string for persistence, e.g. `vnc://user@host:5901`. The
+    /// password is never persisted in the session snapshot (it lives in the
+    /// Keychain instead).
     var persistableConnectionString: String {
-        "vnc://\(endpoint.host):\(endpoint.port)"
+        if let username = endpoint.username, !username.isEmpty {
+            return "vnc://\(username)@\(endpoint.host):\(endpoint.port)"
+        }
+        return "vnc://\(endpoint.host):\(endpoint.port)"
     }
 
     // MARK: - Connection
 
-    func connect() {
+    /// Decides how to connect: directly with an inline password, by unlocking a
+    /// saved password via Touch ID, or anonymously.
+    private func beginConnect() {
         guard !isClosed else { return }
-        connectionState = .connecting
-        surfaceView.connect()
+        if let password = endpoint.password, !password.isEmpty {
+            // Inline password: connect now and remember it on success.
+            passwordToSaveOnConnect = password
+            startSession(with: endpoint)
+        } else if VNCCredentialStore.hasCredential(host: endpoint.host, port: endpoint.port) {
+            unlockAndConnect()
+        } else {
+            passwordToSaveOnConnect = nil
+            startSession(with: endpoint)
+        }
     }
 
-    /// Tears down the current session and starts a fresh one against the same
-    /// endpoint. Used by the "Reconnect" affordance after a drop.
-    func reconnect() {
-        guard !isClosed else { return }
+    /// Prompts for Touch ID, then connects with the unlocked password.
+    private func unlockAndConnect() {
+        connectionState = .authenticating
+        let host = endpoint.host
+        let port = endpoint.port
+        let reason = String(
+            localized: "vnc.touchid.reason",
+            defaultValue: "unlock the saved VNC password"
+        )
+        Task { [weak self] in
+            let password = await VNCCredentialStore.load(host: host, port: port, reason: reason)
+            guard let self, !self.isClosed else { return }
+            guard let password else {
+                self.connectionState = .disconnected(String(
+                    localized: "vnc.status.touchidRequired",
+                    defaultValue: "Touch ID is required to unlock the saved password."
+                ))
+                return
+            }
+            self.passwordToSaveOnConnect = nil // already stored
+            self.startSession(with: self.endpointWithPassword(password))
+        }
+    }
+
+    private func endpointWithPassword(_ password: String) -> VNCEndpoint {
+        VNCEndpoint(host: endpoint.host, port: endpoint.port, password: password, username: endpoint.username)
+    }
+
+    /// Tears down any current session and starts a fresh one.
+    private func startSession(with endpoint: VNCEndpoint) {
         surfaceView.disconnect()
         let view = VNCSurfaceView(client: RFBClient(endpoint: endpoint))
         configure(view)
@@ -88,15 +140,35 @@ final class VNCPanel: Panel, ObservableObject {
         view.connect()
     }
 
+    /// Reconnect affordance after a drop: re-runs the full decision (Touch ID if needed).
+    func reconnect() {
+        guard !isClosed else { return }
+        beginConnect()
+    }
+
+    /// Forget the stored password for this host.
+    func forgetSavedPassword() {
+        VNCCredentialStore.delete(host: endpoint.host, port: endpoint.port)
+        hasSavedPassword = false
+    }
+
     private func handle(_ event: VNCClientEvent) {
         switch event {
         case .connecting:
-            connectionState = .connecting
+            if connectionState != .authenticating {
+                connectionState = .connecting
+            }
         case .connected(_, _, let name):
             connectionState = .connected
             let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty {
                 displayTitle = trimmed
+            }
+            // Persist a working inline password, Touch ID-gated for next time.
+            if let password = passwordToSaveOnConnect {
+                VNCCredentialStore.save(host: endpoint.host, port: endpoint.port, password: password)
+                passwordToSaveOnConnect = nil
+                hasSavedPassword = true
             }
         case .disconnected(let error):
             connectionState = .disconnected(error?.errorDescription)

--- a/Sources/Panels/VNCPanelView.swift
+++ b/Sources/Panels/VNCPanelView.swift
@@ -1,0 +1,93 @@
+import AppKit
+import CmuxVNC
+import SwiftUI
+
+/// Hosts a ``VNCPanel``'s native framebuffer surface and overlays connection
+/// status. The pixel path is entirely native (CALayer); SwiftUI only draws the
+/// surrounding chrome.
+struct VNCPanelView: View {
+    @ObservedObject var panel: VNCPanel
+    let isFocused: Bool
+    let isVisibleInUI: Bool
+    let portalPriority: Int
+    let appearance: PanelAppearance
+    let onRequestPanelFocus: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black
+
+            VNCSurfaceHost(panel: panel, isFocused: isFocused, onRequestPanelFocus: onRequestPanelFocus)
+                .id(panel.sessionToken)
+
+            statusOverlay
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var statusOverlay: some View {
+        switch panel.connectionState {
+        case .connecting:
+            VStack(spacing: 10) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(String(localized: "vnc.status.connecting", defaultValue: "Connecting…"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.8))
+                Text(panel.endpoint.displayLabel)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            .padding(20)
+            .background(.black.opacity(0.5), in: RoundedRectangle(cornerRadius: 10))
+        case .disconnected(let message):
+            VStack(spacing: 12) {
+                Image(systemName: "display.trianglebadge.exclamationmark")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.white.opacity(0.7))
+                Text(String(localized: "vnc.status.disconnected", defaultValue: "Disconnected"))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.9))
+                if let message, !message.isEmpty {
+                    Text(message)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.6))
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 320)
+                }
+                Button {
+                    panel.reconnect()
+                } label: {
+                    Text(String(localized: "vnc.action.reconnect", defaultValue: "Reconnect"))
+                }
+                .controlSize(.regular)
+            }
+            .padding(24)
+            .background(.black.opacity(0.6), in: RoundedRectangle(cornerRadius: 12))
+        case .connected:
+            EmptyView()
+        }
+    }
+}
+
+/// Bridges the package's `VNCSurfaceView` into SwiftUI. The panel owns the view
+/// instance; recreation is driven by `panel.sessionToken` via `.id(...)`.
+private struct VNCSurfaceHost: NSViewRepresentable {
+    let panel: VNCPanel
+    let isFocused: Bool
+    let onRequestPanelFocus: () -> Void
+
+    func makeNSView(context: Context) -> VNCSurfaceView {
+        let view = panel.surfaceView
+        view.onFocusRequested = onRequestPanelFocus
+        return view
+    }
+
+    func updateNSView(_ nsView: VNCSurfaceView, context: Context) {
+        nsView.onFocusRequested = onRequestPanelFocus
+        if isFocused, nsView.window?.firstResponder !== nsView {
+            nsView.window?.makeFirstResponder(nsView)
+        }
+    }
+}

--- a/Sources/Panels/VNCPanelView.swift
+++ b/Sources/Panels/VNCPanelView.swift
@@ -28,6 +28,20 @@ struct VNCPanelView: View {
     @ViewBuilder
     private var statusOverlay: some View {
         switch panel.connectionState {
+        case .authenticating:
+            VStack(spacing: 10) {
+                Image(systemName: "touchid")
+                    .font(.system(size: 30))
+                    .foregroundStyle(Color(red: 0.96, green: 0.36, blue: 0.36))
+                Text(String(localized: "vnc.status.authenticating", defaultValue: "Waiting for Touch ID…"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.85))
+                Text(panel.endpoint.displayLabel)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.5))
+            }
+            .padding(22)
+            .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
         case .connecting:
             VStack(spacing: 10) {
                 ProgressView()
@@ -56,12 +70,30 @@ struct VNCPanelView: View {
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: 320)
                 }
-                Button {
-                    panel.reconnect()
-                } label: {
-                    Text(String(localized: "vnc.action.reconnect", defaultValue: "Reconnect"))
+                HStack(spacing: 10) {
+                    Button {
+                        panel.reconnect()
+                    } label: {
+                        if panel.hasSavedPassword {
+                            Label(
+                                String(localized: "vnc.action.unlock", defaultValue: "Unlock with Touch ID"),
+                                systemImage: "touchid"
+                            )
+                        } else {
+                            Text(String(localized: "vnc.action.reconnect", defaultValue: "Reconnect"))
+                        }
+                    }
+                    .controlSize(.regular)
+
+                    if panel.hasSavedPassword {
+                        Button {
+                            panel.forgetSavedPassword()
+                        } label: {
+                            Text(String(localized: "vnc.action.forgetPassword", defaultValue: "Forget Password"))
+                        }
+                        .controlSize(.regular)
+                    }
                 }
-                .controlSize(.regular)
             }
             .padding(24)
             .background(.black.opacity(0.6), in: RoundedRectangle(cornerRadius: 12))

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -34,7 +34,7 @@ enum GlobalSearchDocuments {
             kind = .browser
         case .markdown:
             kind = .markdown
-        case .terminal, .filePreview, .rightSidebarTool, .agentSession, .project, .extensionBrowser:
+        case .terminal, .filePreview, .rightSidebarTool, .agentSession, .project, .extensionBrowser, .vnc:
             kind = .title
         }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1605,6 +1605,11 @@ struct SessionFilePreviewPanelSnapshot: Codable, Sendable {
     var filePath: String
 }
 
+struct SessionVNCPanelSnapshot: Codable, Sendable {
+    /// `vnc://host:port`. The password is intentionally never persisted.
+    var connectionString: String
+}
+
 struct SessionRightSidebarToolPanelSnapshot: Codable, Sendable {
     var mode: RightSidebarMode?
 
@@ -1730,6 +1735,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var rightSidebarTool: SessionRightSidebarToolPanelSnapshot?
     var agentSession: SessionAgentSessionPanelSnapshot? = nil
     var project: SessionProjectPanelSnapshot?
+    var vnc: SessionVNCPanelSnapshot? = nil
 }
 
 extension SessionPanelSnapshot: WorkspaceSessionRemoteRestorePanelSnapshot {}

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import CmuxControlSocket
+import CmuxVNC
 import Foundation
 
 /// The surface-domain lifecycle witnesses (`split` / `respawn` / `create` /
@@ -357,6 +358,15 @@ extension TerminalController {
                 workingDirectory: inputs.workingDirectory,
                 focus: focus
             )?.id
+        } else if panelType == .vnc {
+            guard let endpoint = VNCEndpoint(string: inputs.urlRaw ?? "") else {
+                return .createFailed
+            }
+            newPanelId = ws.newVNCSurface(
+                inPane: paneId,
+                endpoint: endpoint,
+                focus: focus
+            )?.id
         } else {
             switch ws.newTerminalSurfaceOutcome(
                 inPane: paneId,
@@ -455,6 +465,7 @@ extension TerminalController {
         case "filepreview": return .filePreview
         case "rightsidebartool": return .rightSidebarTool
         case "agentsession": return .agentSession
+        case "vnc": return .vnc
         default: return nil
         }
     }

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -327,6 +327,8 @@ final class PaneDropTargetView: NSView {
             return nil
         case .extensionBrowser:
             return nil
+        case .vnc:
+            return nil
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1,6 +1,7 @@
 import CmuxFoundation
 import Foundation
 import CmuxCore
+import CmuxVNC
 import CmuxRemoteDaemon
 import CmuxRemoteSession
 import CmuxRemoteWorkspace
@@ -452,6 +453,7 @@ extension Workspace {
         let rightSidebarToolSnapshot: SessionRightSidebarToolPanelSnapshot?
         let agentSessionSnapshot: SessionAgentSessionPanelSnapshot?
         let projectSnapshot: SessionProjectPanelSnapshot?
+        var vncSnapshot: SessionVNCPanelSnapshot? = nil
         switch panel.panelType {
         case .terminal:
             guard let terminalPanel = panel as? TerminalPanel else { return nil }
@@ -610,6 +612,16 @@ extension Workspace {
             agentSessionSnapshot = nil
         case .extensionBrowser:
             return nil
+        case .vnc:
+            guard let vncPanel = panel as? VNCPanel else { return nil }
+            terminalSnapshot = nil
+            browserSnapshot = nil
+            markdownSnapshot = nil
+            filePreviewSnapshot = nil
+            rightSidebarToolSnapshot = nil
+            agentSessionSnapshot = nil
+            projectSnapshot = nil
+            vncSnapshot = SessionVNCPanelSnapshot(connectionString: vncPanel.persistableConnectionString)
         }
 
         return SessionPanelSnapshot(
@@ -633,7 +645,8 @@ extension Workspace {
             filePreview: filePreviewSnapshot,
             rightSidebarTool: rightSidebarToolSnapshot,
             agentSession: agentSessionSnapshot,
-            project: projectSnapshot
+            project: projectSnapshot,
+            vnc: vncSnapshot
         )
     }
 
@@ -1413,6 +1426,18 @@ extension Workspace {
             return projectPanel.id
         case .extensionBrowser:
             return nil
+        case .vnc:
+            guard let connectionString = snapshot.vnc?.connectionString,
+                  let endpoint = VNCEndpoint(string: connectionString),
+                  let vncPanel = newVNCSurface(
+                    inPane: paneId,
+                    endpoint: endpoint,
+                    focus: false
+                  ) else {
+                return nil
+            }
+            applySessionPanelMetadata(snapshot, toPanelId: vncPanel.id)
+            return vncPanel.id
         }
     }
 
@@ -3735,6 +3760,8 @@ final class Workspace: Identifiable, ObservableObject {
             return SurfaceKind.project.rawValue
         case .extensionBrowser:
             return SurfaceKind.extensionBrowser.rawValue
+        case .vnc:
+            return SurfaceKind.vnc.rawValue
         }
     }
 
@@ -7853,6 +7880,80 @@ final class Workspace: Identifiable, ObservableObject {
 
         installMarkdownPanelSubscription(markdownPanel)
         return markdownPanel
+    }
+
+    @discardableResult
+    func newVNCSurface(
+        inPane paneId: PaneID,
+        endpoint: VNCEndpoint,
+        focus: Bool? = nil,
+        targetIndex: Int? = nil
+    ) -> VNCPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+
+        let vncPanel = VNCPanel(workspaceId: id, endpoint: endpoint)
+        panels[vncPanel.id] = vncPanel
+        panelTitles[vncPanel.id] = vncPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: vncPanel.displayTitle,
+            icon: vncPanel.displayIcon,
+            kind: SurfaceKind.vnc.rawValue,
+            isDirty: vncPanel.isDirty,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: vncPanel.id)
+            panelTitles.removeValue(forKey: vncPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = vncPanel.id
+        if let targetIndex {
+            _ = bonsplitController.reorderTab(newTabId, toIndex: targetIndex)
+        }
+        publishCmuxSurfaceCreated(vncPanel.id, paneId: paneId, kind: "vnc", origin: "vnc_tab", focused: shouldFocusNewTab)
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: vncPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installVNCPanelSubscription(vncPanel)
+        return vncPanel
+    }
+
+    private func installVNCPanelSubscription(_ vncPanel: VNCPanel) {
+        let subscription = vncPanel.$displayTitle
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak vncPanel] newTitle in
+                guard let self,
+                      let vncPanel,
+                      let tabId = self.surfaceIdFromPanelId(vncPanel.id) else { return }
+                guard let existing = self.bonsplitController.tab(tabId) else { return }
+
+                if self.panelTitles[vncPanel.id] != newTitle {
+                    self.panelTitles[vncPanel.id] = newTitle
+                }
+                let resolvedTitle = self.resolvedPanelTitle(panelId: vncPanel.id, fallback: newTitle)
+                guard existing.title != resolvedTitle else { return }
+                self.bonsplitController.updateTab(
+                    tabId,
+                    title: resolvedTitle,
+                    hasCustomTitle: self.panelCustomTitles[vncPanel.id] != nil
+                )
+            }
+        panelSubscriptions[vncPanel.id] = subscription
     }
 
     @discardableResult

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -880,6 +880,7 @@
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
+		CF0000000000000000000D02 /* VNCCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000000000000000000D01 /* VNCCredentialStore.swift */; };
 		CF0000000000000000000A02 /* VNCPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000000000000000000A01 /* VNCPanel.swift */; };
 		CF0000000000000000000B02 /* VNCPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000000000000000000B01 /* VNCPanelView.swift */; };
 		A500120C /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001222 /* WindowAccessor.swift */; };
@@ -1819,6 +1820,7 @@
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
+		CF0000000000000000000D01 /* VNCCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/VNCCredentialStore.swift; sourceTree = "<group>"; };
 		CF0000000000000000000A01 /* VNCPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/VNCPanel.swift; sourceTree = "<group>"; };
 		CF0000000000000000000B01 /* VNCPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/VNCPanelView.swift; sourceTree = "<group>"; };
 		A5001222 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
@@ -2546,6 +2548,7 @@
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				CF0000000000000000000A01 /* VNCPanel.swift */,
+				CF0000000000000000000D01 /* VNCCredentialStore.swift */,
 				CF0000000000000000000B01 /* VNCPanelView.swift */,
 				A50014F0 /* MarkdownPanelFileLinkResolver.swift */,
 				F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */,
@@ -3948,6 +3951,7 @@
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
+				CF0000000000000000000D02 /* VNCCredentialStore.swift in Sources */,
 				CF0000000000000000000A02 /* VNCPanel.swift in Sources */,
 				CF0000000000000000000B02 /* VNCPanelView.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */; };
 		CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0200000000CDFEED02 /* CmuxUpdater */; };
 		CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */; };
+		CF0000000000000000000C03 /* CmuxVNC in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000000000000000000C02 /* CmuxVNC */; };
 		D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */; };
 		D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */; };
 		C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */; };
@@ -879,6 +880,8 @@
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
+		CF0000000000000000000A02 /* VNCPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000000000000000000A01 /* VNCPanel.swift */; };
+		CF0000000000000000000B02 /* VNCPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0000000000000000000B01 /* VNCPanelView.swift */; };
 		A500120C /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001222 /* WindowAccessor.swift */; };
 		063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 		A5001700A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */; };
@@ -1816,6 +1819,8 @@
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
+		CF0000000000000000000A01 /* VNCPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/VNCPanel.swift; sourceTree = "<group>"; };
+		CF0000000000000000000B01 /* VNCPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/VNCPanelView.swift; sourceTree = "<group>"; };
 		A5001222 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		A5001701A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowAppearanceSnapshot.swift; sourceTree = "<group>"; };
@@ -1955,6 +1960,7 @@
 				CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */,
 				CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */,
 				CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */,
+				CF0000000000000000000C03 /* CmuxVNC in Frameworks */,
 				5E55200000000000000000B3 /* CmuxWindowing in Frameworks */,
 				E3B7A3000000000000000113 /* CmuxWorkspaceCore in Frameworks */,
 				E3B7A30000000000000000E3 /* CmuxWorkspaceNavigation in Frameworks */,
@@ -2539,6 +2545,8 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5001418 /* MarkdownPanel.swift */,
+				CF0000000000000000000A01 /* VNCPanel.swift */,
+				CF0000000000000000000B01 /* VNCPanelView.swift */,
 				A50014F0 /* MarkdownPanelFileLinkResolver.swift */,
 				F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */,
 				F5168A040000000000000002 /* MarkdownFontFamily.swift */,
@@ -3064,6 +3072,7 @@
 				E3B7A30000000000000000E2 /* CmuxWorkspaceNavigation */,
 				E3B7A30000000000000000F2 /* CmuxPanes */,
 				E3B7A3000000000000000112 /* CmuxWorkspaceCore */,
+				CF0000000000000000000C02 /* CmuxVNC */,
 				E3B7A3000000000000000102 /* CmuxWorkspaces */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
 				CD0CFE5200000000CD0CFE52 /* CmuxSettings */,
@@ -3258,6 +3267,7 @@
 				E3B7A30000000000000000E1 /* XCLocalSwiftPackageReference "CmuxWorkspaceNavigation" */,
 				E3B7A30000000000000000F1 /* XCLocalSwiftPackageReference "CmuxPanes" */,
 				E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */,
+				CF0000000000000000000C01 /* XCLocalSwiftPackageReference "CmuxVNC" */,
 				E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */,
 				C750100000000000000000A1 /* XCLocalSwiftPackageReference "CmuxControlSocket" */,
 				C9A2B00000000000000000B1 /* XCLocalSwiftPackageReference "CmuxAppKitSupportUI" */,
@@ -3938,6 +3948,8 @@
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
+				CF0000000000000000000A02 /* VNCPanel.swift in Sources */,
+				CF0000000000000000000B02 /* VNCPanelView.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001700A1B2C3D4E5F60718 /* WindowAppearanceSnapshot.swift in Sources */,
 				A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */,
@@ -4876,6 +4888,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaceCore;
 		};
+		CF0000000000000000000C01 /* XCLocalSwiftPackageReference "CmuxVNC" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CmuxVNC;
+		};
 		E3B7A3000000000000000101 /* XCLocalSwiftPackageReference "CmuxWorkspaces" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CmuxWorkspaces;
@@ -5155,6 +5171,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E3B7A3000000000000000111 /* XCLocalSwiftPackageReference "CmuxWorkspaceCore" */;
 			productName = CmuxWorkspaceCore;
+		};
+		CF0000000000000000000C02 /* CmuxVNC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CF0000000000000000000C01 /* XCLocalSwiftPackageReference "CmuxVNC" */;
+			productName = CmuxVNC;
 		};
 		E3B7A3000000000000000102 /* CmuxWorkspaces */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## Summary
Adds **cmux-vnc**, a native VNC (RFB) surface. A new `vnc` surface kind renders a remote framebuffer directly into a `CALayer` and forwards mouse/keyboard input. No WebKit, no shelling out to the system Screen Sharing app: the entire pixel and protocol path is native Swift.

New package `Packages/CmuxVNC` implements the Remote Framebuffer protocol (RFC 6143) from scratch:
- Handshake for RFB 3.3 / 3.7 / 3.8; security types **None** and **VNC password** (single-DES challenge/response via CommonCrypto, with the classic bit-reversed key).
- Encodings: **Raw, CopyRect, RRE, Hextile**, plus the **DesktopSize** pseudo-encoding for live resize.
- Fixed 32-bit little-endian **BGRX** pixel format negotiated via `SetPixelFormat`, so decoded pixels map 1:1 onto a `CGImage` with zero per-pixel conversion.
- `NWConnection` transport with `TCP_NODELAY` (latency over throughput), actor-driven update loop, `Sendable` frame snapshots handed to the UI.
- `VNCSurfaceView` (AppKit): `CALayer` framebuffer rendering + pointer/keyboard/scroll forwarding with X11 keysym mapping.

App integration:
- `SurfaceKind.vnc` / `PanelType.vnc`; `VNCPanel` + `VNCPanelView` (status overlay, reconnect).
- Create via CLI `cmux new-surface --type vnc --url vnc://host:port` and the control socket `surface.create`.
- Session persist/restore (`SessionVNCPanelSnapshot`; password intentionally not persisted).
- Localized strings (en + ja).

## How it works
The server pushes framebuffer updates; each rectangle is decoded into a row-major `UInt32` BGRX buffer owned solely by the connection actor, then snapshotted (immutable, `Sendable`) and rendered as a `CGImage` set on the layer's `contents`. Input events are funnelled through a single serial pump so ordering is preserved (modifier-down before key, etc.).

This is a principled implementation: clean protocol/transport/render separation, the codec is pure and unit-tested independent of any socket, and the framebuffer never crosses an actor boundary except as an immutable snapshot.

## Testing
- `swift test` in `Packages/CmuxVNC`: **33 unit tests** pass (pixel-format round-trip, client-message byte encoding, DES/VNC-auth, full handshake for None + VNC-auth + failure paths, Raw/CopyRect/RRE/Hextile/DesktopSize decoders, endpoint parsing).
- Manually verified end-to-end against a loopback RFB test server (handshake → ServerInit → raw framebuffer render).

## Notes / follow-ups
- Auth supported: None + VNC password. Apple Screen Sharing's proprietary auth (type 30) and TLS/`ZRLE`/`Tight` are not yet implemented (Hextile/RRE/CopyRect cover most servers).
- `surface.split --type vnc` falls back to a terminal split for now (matches existing agent-session behavior); only `surface.create` makes VNC panes.

---

## Update: Apple Diffie-Hellman auth + sharper scaling

**Apple DH (VNC security type 30)** — the client now connects to macOS Screen Sharing / Apple Remote Desktop directly with the account user name + password (`vnc://user:password@host`), no server-side legacy-VNC configuration. DH key exchange (BigInt modexp) → `MD5(shared secret)` AES-128 key → `AES-128-ECB({username[64], password[64]})`. Verified against a real macOS host: the DH/AES framing reaches `SecurityResult` (rejecting a deliberately wrong password). References: NeatVNC `apple-dh.c`, rfbproto spec, Caffeinated Bitstream.

**Sharper rendering** — trilinear (mipmapped) minification + nearest magnification + Retina `contentsScale` so downscaled remote desktops aren't blurry.

Engine tests now: **42** (`swift test` in `Packages/CmuxVNC`). Adds a `BigInt` (attaswift) dependency for modular exponentiation.

**Touch ID-gated passwords** — a working inline VNC password is auto-saved to the Keychain (file fallback on ad-hoc dev builds); later connects with the password omitted (`vnc://user@host`) prompt for Touch ID via `LAContext.deviceOwnerAuthentication` to unlock it. Includes a "Waiting for Touch ID…" state and Unlock/Forget affordances. Verified end to end on a dev build: save lands in the Keychain and the system Touch ID dialog appears on reconnect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added VNC (RFB) remote desktop support with interactive mouse/keyboard input and clipboard synchronization.
  * Extended `cmux new-surface` with `--type vnc`, including `vnc://host:port` URL support.
  * Introduced a VNC panel with connection status UI, focus handling, and automatic reconnect.

* **Improvements**
  * Added Touch ID–gated credential flow, reconnect and “forget password” actions, plus richer connection messaging.
  * Enhanced VNC endpoint parsing (including optional usernames) and improved session save/restore for connection details (passwords remain unpersisted).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->