### PR TITLE
iOS: restore hold-to-repeat Backspace on the terminal keyboard

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -54,6 +54,23 @@ final class TerminalInputTextView: UITextView {
 
     override var canBecomeFirstResponder: Bool { true }
 
+    /// Force the software keyboard to believe there is always text to delete so
+    /// it keeps auto-repeating ``deleteBackward()`` while Backspace is held.
+    ///
+    /// The keyboard's hold-to-repeat timer for Backspace only keeps firing while
+    /// the first responder reports `hasText == true`; the moment it reads
+    /// `false`, the repeat stops after a single delete. This view keeps a
+    /// perpetually-empty document (every committed keystroke is forwarded to the
+    /// Mac and the local buffer is cleared), so the inherited `UITextView.hasText`
+    /// returned `false` and hold-to-repeat backspace died after one character.
+    /// Returning a constant `true` (the technique iSH's `TerminalView` uses) keeps
+    /// the repeat alive: "it's always ok to send a delete".
+    ///
+    /// Because `hasText` is now a forced constant, internal byte-routing must NOT
+    /// key off it; ``deleteBackward()`` and its modifier guards key off
+    /// ``markedTextRange`` (IME composition in progress) instead.
+    override var hasText: Bool { true }
+
     override var keyCommands: [UIKeyCommand]? {
         guard markedTextRange == nil else { return nil }
         return TerminalHardwareKeyResolver.makeKeyCommands(
@@ -521,7 +538,13 @@ final class TerminalInputTextView: UITextView {
     }
 
     override func deleteBackward() {
-        if commandAccessoryArmed, markedTextRange == nil, !hasText {
+        // Every guard below keys off `markedTextRange` (an IME composition is in
+        // progress), NOT `hasText`. `hasText` is now a forced constant `true` so
+        // the keyboard auto-repeats Backspace, so it can no longer mean "the local
+        // document is empty". While composing, the delete edits the marked text
+        // locally (`super.deleteBackward()`); otherwise it is a real backspace
+        // that must reach the Mac.
+        if commandAccessoryArmed, markedTextRange == nil {
             if !commandAccessorySticky {
                 setCommandAccessoryArmed(false)
             }
@@ -529,7 +552,7 @@ final class TerminalInputTextView: UITextView {
             onEscapeSequence?(Data([0x15]))
             return
         }
-        if alternateAccessoryArmed, markedTextRange == nil, !hasText {
+        if alternateAccessoryArmed, markedTextRange == nil {
             if !alternateAccessorySticky {
                 setAlternateAccessoryArmed(false)
             }
@@ -541,14 +564,14 @@ final class TerminalInputTextView: UITextView {
             }
             return
         }
-        if controlAccessoryArmed, markedTextRange == nil, !hasText {
+        if controlAccessoryArmed, markedTextRange == nil {
             if !controlAccessorySticky {
                 setControlAccessoryArmed(false)
             }
             onBackspace?()
             return
         }
-        if shiftAccessoryArmed, markedTextRange == nil, !hasText {
+        if shiftAccessoryArmed, markedTextRange == nil {
             // Shift does not change Backspace, but a one-shot ⇧ must still be
             // consumed here so it cannot leak onto the next key (matching the
             // Control branch above).
@@ -558,7 +581,10 @@ final class TerminalInputTextView: UITextView {
             onBackspace?()
             return
         }
-        if markedTextRange != nil || hasText {
+        // While composing (marked text present), let UITextView edit the marked
+        // string locally so the IME candidate updates; the committed result still
+        // flows to the Mac via the normal insert/textChange path.
+        if markedTextRange != nil {
             super.deleteBackward()
             return
         }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalInputBackspaceRepeatTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalInputBackspaceRepeatTests.swift
@@ -1,0 +1,50 @@
+#if canImport(UIKit)
+import Foundation
+import Testing
+import UIKit
+
+@testable import CmuxMobileTerminal
+
+/// Behavioral tests for hold-to-repeat Backspace on the iOS terminal input view.
+///
+/// The iOS terminal input is a `UITextView` that keeps a perpetually-empty
+/// document: every committed keystroke is forwarded to the Mac and the local
+/// buffer is cleared. The software keyboard's auto-repeat timer for Backspace
+/// only keeps firing `deleteBackward()` while the first responder reports
+/// `hasText == true`. With the inherited empty-document `hasText`, that reads
+/// `false`, so holding Backspace deleted exactly one character and then stopped.
+///
+/// These lock the contract that makes hold-to-repeat work (iSH's technique):
+/// `hasText` is a forced constant `true`, and `deleteBackward()` keeps emitting a
+/// real backspace to the Mac on every repeat tick when no IME composition is
+/// active. They drive the view directly so no live keyboard is required.
+@MainActor
+@Suite("Terminal input hold-to-repeat Backspace")
+struct TerminalInputBackspaceRepeatTests {
+    /// The keyboard's repeat gate. If this is `false`, the system stops
+    /// auto-repeating `deleteBackward()` after the first delete and hold-to-repeat
+    /// Backspace is dead. It must be a constant `true`.
+    @Test("hasText is always true so the keyboard auto-repeats Backspace")
+    func hasTextIsAlwaysTrue() {
+        let view = TerminalInputTextView()
+        #expect(view.hasText)
+    }
+
+    /// Simulates the keyboard's auto-repeat firing `deleteBackward()` repeatedly
+    /// while Backspace is held: every tick on an empty document (no IME marked
+    /// text) must reach the Mac as a backspace, not be swallowed after the first.
+    @Test("each held-Backspace repeat tick sends a backspace to the Mac")
+    func heldBackspaceRepeatsToTheMac() {
+        let view = TerminalInputTextView()
+        var backspaces = 0
+        view.onBackspace = { backspaces += 1 }
+
+        // No IME composition is active, so each repeat tick is a real backspace.
+        for _ in 0 ..< 5 {
+            view.deleteBackward()
+        }
+
+        #expect(backspaces == 5)
+    }
+}
+#endif


### PR DESCRIPTION
Holding Backspace on the iOS terminal keyboard deleted one character and then stopped, instead of repeat-deleting continuously while held.

## Root cause

`TerminalInputTextView` is a `UITextView` that keeps a perpetually-empty local document: every committed keystroke is forwarded to the Mac, then the local buffer is cleared. The software keyboard's auto-repeat timer for Backspace only keeps firing `deleteBackward()` while the first responder reports `hasText == true`. With the inherited empty-document `hasText` reading `false`, the repeat died after the first delete.

The working hold-to-repeat mechanism was developed in the unmerged native-input PRs (https://github.com/manaflow-ai/cmux/pull/5573, https://github.com/manaflow-ai/cmux/pull/5596, documentless variant in commit `2577f2312`) but never landed on `main`. So `main` still has the plain `UITextView` with no `hasText` override and Backspace routing that gates on `hasText`. This is the regression.

## Fix

Applies the minimal, principled piece of that prior work that fits a `UITextView` (iSH's technique):

- Override `hasText -> true` so the keyboard keeps auto-repeating Backspace ("it's always ok to send a delete").
- Re-key `deleteBackward()` off `markedTextRange` (IME composition in progress) instead of `hasText`. Since `hasText` is now a forced constant, the armed-modifier guards drop their `!hasText` condition and the local-edit branch routes on `markedTextRange != nil` only. While composing, the delete edits the marked text locally; otherwise it is a real backspace forwarded to the Mac on every repeat tick.

Principled, not a hack: it restores the documented mechanism the prior fix used and removes the now-meaningless `hasText` byte-routing rather than papering over it. The IME composition path (Japanese/CJK) is preserved by keying local edits off `markedTextRange`.

## Tests

Two-commit red/green structure in `ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalInputBackspaceRepeatTests.swift`:
- Commit 1 adds the failing test (asserts `hasText == true`, the keyboard's repeat gate). Red on `main` because the inherited empty-document `hasText` is `false`.
- Commit 2 adds the fix. Green.

## Residual risk

Low. The change is confined to one view. The armed-modifier Backspace ladders (⌘/⌥/⌃/⇧ + Backspace) are exercised by the existing `TerminalInputAccessoryShiftTests`; those guards now key off `markedTextRange` only, which is the same condition they already required (they previously also required `!hasText`, which was always true for the empty document, so behavior is unchanged for the non-composing case). Dictation/autocorrect committed blocks are unaffected (they ride `insertText`/`textChange`, not `deleteBackward`).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784256146&installation_id=133855650&pr_number=6288&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6288&signature=3881c135af6946d45b69595d826e8fbabbe5446976a786e7989cf92c5a49d523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-view input routing change; non-composing behavior matches the prior empty-document case, with IME guarded via marked text only.
> 
> **Overview**
> Holding Backspace on the iOS terminal software keyboard only deleted once because UIKit stops auto-repeating `deleteBackward()` when `hasText` is false, and the proxy’s local `UITextView` stays empty after each keystroke is forwarded to the Mac.
> 
> **`TerminalInputTextView`** now overrides **`hasText`** to always return **`true`** (same approach as iSH) so the keyboard keeps firing repeat deletes. **`deleteBackward()`** no longer uses **`hasText`** for routing: accessory-modifier branches drop their **`!hasText`** checks, and local vs Mac backspace is decided only by **`markedTextRange`** (IME composition still edits marked text locally).
> 
> New **`TerminalInputBackspaceRepeatTests`** assert **`hasText`** is always true and that five successive **`deleteBackward()`** calls each invoke **`onBackspace`** when not composing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318abaa11c143fa3d4f7cf0e6fa23c1057f8b4b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores hold-to-repeat Backspace on the iOS terminal keyboard so holding the key continuously deletes characters as expected. Forces the input view to always report `hasText == true` and updates delete handling to respect IME composition.

- **Bug Fixes**
  - Always return `true` for `hasText` to keep the keyboard’s Backspace auto-repeat active.
  - Route `deleteBackward` by `markedTextRange` to preserve IME; remove `hasText` checks and forward real backspace on each repeat when not composing.
  - Add tests to assert `hasText == true` and that repeated deletes reach the terminal.

<sup>Written for commit 318abaa11c143fa3d4f7cf0e6fa23c1057f8b4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Backspace key hold-to-repeat functionality in the iOS terminal input view.
  * Enhanced input method editor (IME) composition state handling for modifier key operations.

* **Tests**
  * Added test suite to validate sustained Backspace repeat behavior on empty input during keyboard hold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->