### PR TITLE
iOS: stop pausing background music on text submit

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -52,15 +52,9 @@ final class ComposerDictationController {
     /// so partials append rather than overwrite.
     private var baseText: String = ""
 
-    /// Whether THIS controller actually activated the shared `AVAudioSession`
-    /// (i.e. `beginRecognition()` got past `setActive(true)`). Gates all engine /
-    /// session teardown so a teardown when dictation never ran is a true no-op.
-    ///
-    /// Without this guard, `stopEngineAndSession()` runs on every send/blur/cancel
-    /// even when the mic was never used: touching `audioEngine.inputNode` spins up
-    /// the input hardware and `setActive(false, .notifyOthersOnDeactivation)` pokes
-    /// the shared session, which interrupts other apps' audio (background music
-    /// pausing and resuming on every text submit). Only deactivate a session we own.
+    /// Whether THIS controller activated the shared `AVAudioSession` (`setActive`
+    /// in `beginRecognition()`). Gates teardown so a send/blur/cancel with no
+    /// dictation in flight never pokes the audio system. See ``stopEngineAndSession()``.
     private var didActivateSession = false
 
     /// The callback that writes merged text back into the composer. Held while
@@ -350,9 +344,7 @@ final class ComposerDictationController {
             // that enforce the documented restrictions.
             try session.setCategory(.record, mode: .measurement)
             try session.setActive(true)
-            // We now own the active session; teardown must deactivate it (and only
-            // then). Set before any further setup so a failure past this point
-            // still tears the session down on the failStart path.
+            // Set before later setup so a failure still deactivates on failStart.
             didActivateSession = true
         } catch {
             failStart()
@@ -471,11 +463,10 @@ final class ComposerDictationController {
     /// session. Shared by the graceful stop (which keeps the recognition task and
     /// callback alive) and the hard `teardown()`. Safe to call repeatedly.
     private func stopEngineAndSession() {
-        // No-op unless we actually activated the session. A send/blur/cancel with
-        // no dictation in flight must not touch the audio system at all: accessing
-        // `audioEngine.inputNode` powers up the mic input route and deactivating the
-        // shared session interrupts other apps' playback (background music pausing
-        // then resuming on every text submit). Only tear down a session we own.
+        // No-op unless we activated the session. Otherwise this would touch the
+        // audio system on every send/blur/cancel: accessing `audioEngine.inputNode`
+        // powers up the mic route and `setActive(false, .notifyOthersOnDeactivation)`
+        // interrupts other apps' playback (music pausing/resuming on every submit).
         guard didActivateSession else { return }
         didActivateSession = false
         if audioEngine.isRunning {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -52,6 +52,17 @@ final class ComposerDictationController {
     /// so partials append rather than overwrite.
     private var baseText: String = ""
 
+    /// Whether THIS controller actually activated the shared `AVAudioSession`
+    /// (i.e. `beginRecognition()` got past `setActive(true)`). Gates all engine /
+    /// session teardown so a teardown when dictation never ran is a true no-op.
+    ///
+    /// Without this guard, `stopEngineAndSession()` runs on every send/blur/cancel
+    /// even when the mic was never used: touching `audioEngine.inputNode` spins up
+    /// the input hardware and `setActive(false, .notifyOthersOnDeactivation)` pokes
+    /// the shared session, which interrupts other apps' audio (background music
+    /// pausing and resuming on every text submit). Only deactivate a session we own.
+    private var didActivateSession = false
+
     /// The callback that writes merged text back into the composer. Held while
     /// listening AND through a graceful stop (so the final result can refine the
     /// committed text); cleared on cleanup so a late callback cannot mutate the
@@ -339,6 +350,10 @@ final class ComposerDictationController {
             // that enforce the documented restrictions.
             try session.setCategory(.record, mode: .measurement)
             try session.setActive(true)
+            // We now own the active session; teardown must deactivate it (and only
+            // then). Set before any further setup so a failure past this point
+            // still tears the session down on the failStart path.
+            didActivateSession = true
         } catch {
             failStart()
             return
@@ -456,6 +471,13 @@ final class ComposerDictationController {
     /// session. Shared by the graceful stop (which keeps the recognition task and
     /// callback alive) and the hard `teardown()`. Safe to call repeatedly.
     private func stopEngineAndSession() {
+        // No-op unless we actually activated the session. A send/blur/cancel with
+        // no dictation in flight must not touch the audio system at all: accessing
+        // `audioEngine.inputNode` powers up the mic input route and deactivating the
+        // shared session interrupts other apps' playback (background music pausing
+        // then resuming on every text submit). Only tear down a session we own.
+        guard didActivateSession else { return }
+        didActivateSession = false
         if audioEngine.isRunning {
             audioEngine.stop()
         }


### PR DESCRIPTION
## Problem

On iOS, submitting text in the terminal composer momentarily paused (then resumed) the user's background music (Spotify/Apple Music). The composer's `send()` was interacting with the microphone/audio session on every submit even when voice dictation was never used.

## Root cause

`send()` (and field blur / terminal switch) call `dictation.cancel()` unconditionally. The send-path comment even claimed `cancel()` is "a no-op" when idle, but it isn't:

`cancel()` → `teardown()` → `stopEngineAndSession()`, which always:
- accessed `audioEngine.inputNode.removeTap(onBus: 0)` — touching `AVAudioEngine.inputNode` powers up the mic input route, and
- called `AVAudioSession.setActive(false, options: .notifyOthersOnDeactivation)` on the shared session.

Both poke the system audio session on every submit, which interrupts other apps' playback. Hence music pausing + resuming each time you hit send.

## Fix

Track whether `beginRecognition()` actually activated the session (`didActivateSession`, set right after `setActive(true)` succeeds) and make `stopEngineAndSession()` a true no-op when we never activated it. A send with no dictation in flight now never touches the audio system. A session we did activate is torn down exactly as before, including the failed-start path (the flag is set before any post-`setActive` setup that could throw).

Principled fix: it removes the entire class of "teardown touches audio when nothing was started" rather than special-casing the send path. Only deactivate a session we own.

## Test

`ComposerDictationController` is iOS-only (`#if os(iOS)`, AVFoundation/Speech) and not host-compilable, so the existing host tests cover only the pure text-merger and state machine; there is no host seam for the AVFoundation teardown. A meaningful automated test would require a large audio-session injection seam, so this is verified by on-device dogfood: with background music playing, submit text repeatedly in the iOS composer and confirm the music keeps playing uninterrupted, and that voice dictation still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784263990&installation_id=133855650&pr_number=6290&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6290&signature=c33cb4aa3d01f080f5c6c049c4dc04a8dcae4b4201fde2ba47bcd3b3253c52d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to iOS dictation teardown; behavior when dictation actually ran is unchanged, with lower risk of unintended audio side effects when idle.
> 
> **Overview**
> Fixes background music briefly pausing on every composer **send** when voice dictation was never used.
> 
> `send()`, blur, and terminal switches call `dictation.cancel()`, which always reached `stopEngineAndSession()` and touched `AVAudioEngine.inputNode` plus `AVAudioSession.setActive(false, .notifyOthersOnDeactivation)` even in **idle** state. **`ComposerDictationController`** now tracks **`didActivateSession`** (set right after a successful `setActive(true)` in `beginRecognition()`) and **`stopEngineAndSession()`** returns immediately when that flag is false, so teardown only runs for a session this controller actually activated. Active dictation and failed-start cleanup still deactivate as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd6ed10a5340bca4094736ae25188bb47a30352e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop pausing background music on iOS when sending text in the composer. We now only touch the `AVAudioSession` if voice dictation actually started.

- **Bug Fixes**
  - Track `didActivateSession` after `setActive(true)` and gate `stopEngineAndSession()` to no-op unless we activated the session, so sends/blur/switch without dictation no longer interrupt other apps’ audio. Teardown is unchanged when dictation runs.

- **Refactors**
  - Trimmed comments to keep `ComposerDictationController.swift` under the 500-line limit. No behavior change.

<sup>Written for commit bd6ed10a5340bca4094736ae25188bb47a30352e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the shared audio session could be incorrectly deactivated when dictation fails to start or voice input is disabled. Dictation now only stops and deactivates the session if it was successfully activated, improving audio stability for other features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->