### PR TITLE
fix: dedupe terminal title updates to keep sidebar clickable during spinner output

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -60,6 +60,11 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// The live runtime surface pointer, or nil before creation/after teardown.
     public internal(set) var surface: ghostty_surface_t?
     weak var attachedView: (any TerminalSurfaceNativeViewing)?
+    /// Last terminal title this surface pushed through `ghosttyDidSetTitle`,
+    /// after spinner-character stripping. Used to dedupe frame-by-frame
+    /// spinner updates (pnpm/CLI tools emit one title change per frame) that
+    /// otherwise flood the sidebar and swallow click events.
+    private var lastPublishedTerminalTitle: String?
     // MARK: Injected collaborators (see TerminalSurfaceRuntimeDependencies)
     let registry: any TerminalSurfaceRegistering
     let engine: any TerminalEngineHosting
@@ -461,7 +466,46 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         tabId = newTabId
         attachedView?.tabId = newTabId
         surfaceView.tabId = newTabId
+        lastPublishedTerminalTitle = nil
     }
+
+    /// Returns the title to publish for `ghosttyDidSetTitle`, or `nil` to
+    /// suppress the post. Strips a leading spinner glyph (frame-by-frame
+    /// Unicode braille spinner characters emitted by pnpm and similar CLI
+    /// tools) so each frame does not produce a fresh title update, and
+    /// suppresses repeats after `lastPublishedTerminalTitle`.
+    @MainActor
+    public func publishableTerminalTitle(_ title: String) -> String? {
+        let stableTitle = Self.stableTerminalNotificationTitle(title)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stableTitle.isEmpty else { return nil }
+        guard lastPublishedTerminalTitle != stableTitle else { return nil }
+        lastPublishedTerminalTitle = stableTitle
+        return stableTitle
+    }
+
+    private static func stableTerminalNotificationTitle(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first,
+              terminalTitleSpinnerCharacters.contains(first) else {
+            return title
+        }
+
+        let afterSpinner = trimmed.index(after: trimmed.startIndex)
+        guard afterSpinner < trimmed.endIndex,
+              trimmed[afterSpinner].isWhitespace else {
+            return title
+        }
+
+        guard let remainderStart = trimmed[afterSpinner...].firstIndex(where: { !$0.isWhitespace }) else {
+            return title
+        }
+        return String(trimmed[remainderStart...])
+    }
+
+    private static let terminalTitleSpinnerCharacters = Set<Character>(
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    )
 
     deinit {
         claudeCommandShimInstallTask?.cancel()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2872,17 +2872,23 @@ class GhosttyApp {
             }
             return true
         case GHOSTTY_ACTION_SET_TITLE:
-            let title = action.action.set_title.title
+            let rawTitle = action.action.set_title.title
                 .flatMap { String(cString: $0) } ?? ""
             if let tabId = surfaceView.tabId,
-               let surfaceId = surfaceView.terminalSurface?.id {
-                let change = GhosttyTitleChange(tabId: tabId, surfaceId: surfaceId, title: title)
+               let terminalSurface = surfaceView.terminalSurface {
+                let surfaceId = terminalSurface.id
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: .ghosttyDidSetTitle,
-                        object: surfaceView,
-                        userInfo: change.userInfo
-                    )
+                    MainActor.assumeIsolated {
+                        guard let publishedTitle = terminalSurface.publishableTerminalTitle(rawTitle) else {
+                            return
+                        }
+                        let change = GhosttyTitleChange(tabId: tabId, surfaceId: surfaceId, title: publishedTitle)
+                        NotificationCenter.default.post(
+                            name: .ghosttyDidSetTitle,
+                            object: surfaceView,
+                            userInfo: change.userInfo
+                        )
+                    }
                 }
             }
             return true

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -561,7 +561,11 @@ class TabManager: ObservableObject {
             MainActor.assumeIsolated { [weak self] in
                 guard let self else { return }
                 guard let change = GhosttyTitleChange(notification: notification) else { return }
-                enqueuePanelTitleUpdate(tabId: change.tabId, panelId: change.surfaceId, title: change.title)
+                enqueuePanelTitleUpdate(
+                    tabId: change.tabId,
+                    panelId: change.surfaceId,
+                    title: Self.stableTerminalPanelTitle(change.title)
+                )
             }
         })
         observers.append(NotificationCenter.default.addObserver(
@@ -3282,13 +3286,21 @@ class TabManager: ObservableObject {
     private func enqueuePanelTitleUpdate(tabId: UUID, panelId: UUID, title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)
+        if pendingPanelTitleUpdates[key] == trimmed {
+            return
+        }
+        if let tab = tabs.first(where: { $0.id == tabId }),
+           tab.alreadyReflectsPanelTitleUpdate(panelId: panelId, title: trimmed),
+           selectedTabId != tabId {
+            return
+        }
 #if DEBUG
         cmuxDebugLog(
             "workspace.title.enqueue workspace=\(Self.debugShortWorkspaceId(tabId)) " +
             "panel=\(panelId.uuidString.prefix(5)) title=\"\(Self.debugTitlePreview(trimmed))\""
         )
 #endif
-        let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)
         pendingPanelTitleUpdates[key] = trimmed
         panelTitleUpdateCoalescer.signal { [weak self] in
             self?.flushPendingPanelTitleUpdates()
@@ -3303,6 +3315,32 @@ class TabManager: ObservableObject {
             updatePanelTitle(tabId: key.tabId, panelId: key.panelId, title: title)
         }
     }
+
+    /// Strips a leading spinner glyph (frame-by-frame Unicode braille spinner
+    /// characters from pnpm and similar CLI tools) from a terminal panel
+    /// title so each spinner frame does not enqueue a fresh panel title
+    /// update that thrashes the sidebar.
+    private static func stableTerminalPanelTitle(_ title: String) -> String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.first,
+              terminalTitleSpinnerCharacters.contains(first) else {
+            return title
+        }
+
+        let afterSpinner = trimmed.index(after: trimmed.startIndex)
+        guard afterSpinner < trimmed.endIndex,
+              trimmed[afterSpinner].isWhitespace else {
+            return title
+        }
+
+        let remainderStart = trimmed[afterSpinner...].firstIndex { !$0.isWhitespace }
+        guard let remainderStart else { return title }
+        return String(trimmed[remainderStart...])
+    }
+
+    private static let terminalTitleSpinnerCharacters = Set<Character>(
+        "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    )
 
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }

--- a/Sources/WindowToolbarController.swift
+++ b/Sources/WindowToolbarController.swift
@@ -38,9 +38,14 @@ final class WindowToolbarController: NSObject, NSToolbarDelegate {
             forName: .ghosttyDidSetTitle,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
             Task { @MainActor [weak self] in
-                self?.scheduleFocusedCommandTextUpdate()
+                guard let self,
+                      let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
+                      tabId == self.tabManager?.selectedTabId else {
+                    return
+                }
+                self.scheduleFocusedCommandTextUpdate()
             }
         })
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4177,6 +4177,18 @@ final class Workspace: Identifiable, ObservableObject {
         self.title = title
     }
 
+    /// Returns `true` if the workspace already visually reflects this panel
+    /// title update, so `enqueuePanelTitleUpdate` can skip re-flushing the
+    /// coalescer and avoid a spinner-frame feedback loop.
+    func alreadyReflectsPanelTitleUpdate(panelId: UUID, title: String) -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        guard panelTitles[panelId] == trimmed else { return false }
+        guard focusedPanelId == panelId else { return true }
+        guard processTitle == trimmed else { return false }
+        return customTitle != nil || self.title == trimmed
+    }
+
     func setCustomColor(_ hex: String?) {
         if let hex {
             customColor = WorkspaceTabColorSettings.normalizedHex(hex)

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -845,6 +845,65 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         XCTAssertNil(workspace.customTitle)
         XCTAssertNotEqual(workspace.panelTitles[splitPanel.id], Optional(workspace.title))
     }
+
+    func testCodexSpinnerTerminalTitlesCollapseToStablePanelTitle() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠋ cmux-ctrixin"
+            ]
+        )
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠹ cmux-ctrixin"
+            ]
+        )
+
+        drainMainQueue()
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+
+        workspace.title = "stale title"
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "⠼ cmux-ctrixin"
+            ]
+        )
+
+        XCTAssertTrue(
+            waitForCondition(timeout: 1.0) {
+                workspace.panelTitles[focusedPanelId] == "cmux-ctrixin" &&
+                    workspace.title == "cmux-ctrixin"
+            }
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION

## Summary

CLI tools that emit Unicode braille spinner characters (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) in the terminal title (pnpm, npm, cargo, etc.) cause cmux's sidebar to become unclickable while they run. The spinner updates the title on every animation frame, and every change flows through `ghosttyDidSetTitle` → `TabManager.enqueuePanelTitleUpdate` → `Workspace.updatePanelTitle` + `WindowToolbarController.scheduleFocusedCommandTextUpdate`. The resulting main-thread flood starves hit-testing so clicks are swallowed.

Fixes #6291.

## What this PR does

1. **`TerminalSurface.publishableTerminalTitle(_:)`** (new public method on the `CmuxTerminal` package's `TerminalSurface`): strips a leading spinner glyph + interstitial whitespace and dedupes against `lastPublishedTerminalTitle`. Returns `nil` when the post should be suppressed.
2. **`GhosttyTerminalView.swift` `GHOSTTY_ACTION_SET_TITLE`**: routes the title through `publishableTerminalTitle` and only posts `ghosttyDidSetTitle` when it returns a non-nil value.
3. **`TabManager.stableTerminalPanelTitle(_:)`** (private static): second-stage defense — strips spinner chars again at the panel-title enqueue boundary so non-terminal sources can't reintroduce the flood.
4. **`TabManager.enqueuePanelTitleUpdate`**: early-returns when the pending queue already holds the trimmed title, or when `Workspace.alreadyReflectsPanelTitleUpdate` confirms the workspace UI already shows it.
5. **`Workspace.alreadyReflectsPanelTitleUpdate(panelId:title:)`**: new read-only check that returns `true` when both `panelTitles[panelId]` and (for the focused panel) `processTitle`/`title` already reflect the update.
6. **`WindowToolbarController` `.ghosttyDidSetTitle` observer**: only schedules a command-text update when the post is for the currently selected tab.

## Test plan

- [ ] New regression test `TabManagerWorkspaceOwnershipTests.testCodexSpinnerTerminalTitlesCollapseToStablePanelTitle` — posts three spinner-prefixed titles (`⠋`, `⠹`, `⠼`) with the same stable text and asserts the workspace title stays at the stable text without intermediate spinner garbage. Also verifies dedup when the workspace title was externally mutated.
- [ ] Manual: run `pnpm install` in a workspace; sidebar clicks must stay responsive throughout the spinner.
- [ ] Manual: open multiple workspaces with active spinners; switching via sidebar click works immediately.
- [ ] Verify the existing `testFocusedPanelTitleRefreshesAutoWorkspaceTitleInSplitWorkspace` still passes (real title updates still propagate).

## Out of scope

The original fork commit bundled three other unrelated changes; this PR intentionally excludes them so the sidebar-freeze fix can land on its own:

- **CLI/cmux.swift** codex `PreToolUse` feed "Running" status publish — separate feature.
- **Resources/shell-integration/cmux-zsh-integration.zsh** `redraw=last` → `redraw=1` — fixes Powerlevel10k two-line prompt header on startup resize; separate display bug.
- **Sources/SessionPersistence.swift** trailing idle-prompt block stripping — separate scrollback replay bug.
- **`TabManager.workspacePullRequestRefreshForcesImmediate`** + `shellPrompt` prefix — workspace PR poll throttle. The relevant code now lives in the `CmuxSidebarGit` package after the god-model split (#5991); porting it requires a separate change against that module and a separate test target.

Happy to file follow-up PRs for any of the above once this lands.

## Validation

- `./scripts/reload.sh --tag spinner-port-verify` — Debug build compiles.
- `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/TabManagerWorkspaceOwnershipTests` (CI gate).
- Localization audit: no user-facing strings changed.

## Prior art

- Extracted from fork branch `ctrixin-agent-notifications-copy-browser` commit `e408be19b`, re-based against current `origin/main` after the `CmuxTerminal` / `CmuxSidebarGit` package refactor (#5991).
- The bundled PR #4808 carries this fix plus the unrelated items above; this PR splits out the sidebar-freeze portion so it can land independently while #4808 waits on review for the notifications feature.

Agent-Model: claude-sonnet-4.6
Agent-Family: anthropic
Agent-Step: 0.1.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784265718&installation_id=133855650&pr_number=6293&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6293&signature=94ad4dcbd8fe278080620fcc7bc221a0c0dc7b2766dccc15e682452d80ed086c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sidebar clicks from freezing by deduping and sanitizing terminal title updates, especially those with braille spinner prefixes from tools like pnpm/npm/cargo. Reduces main-thread churn so hit testing stays responsive. Fixes #6291.

- **Bug Fixes**
  - Added `publishableTerminalTitle(_:)` in `CmuxTerminal` to strip a leading spinner glyph + spaces and dedupe against the last published title.
  - `GHOSTTY_ACTION_SET_TITLE` now posts `ghosttyDidSetTitle` only when a publishable title is returned.
  - `TabManager` strips spinner chars again and skips enqueues when the same title is pending or the workspace already reflects it.
  - `WindowToolbarController` only updates command text for the selected tab.
  - Added a regression test that verifies spinner-prefixed titles collapse to a stable panel title.

<sup>Written for commit 74dcb905dbfb46854f66652134c227e033897cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal titles now automatically clean up loading spinner characters for better readability.

* **Improvements**
  * Reduced redundant title update notifications to improve UI responsiveness and prevent flickering.
  * Tab and workspace titles now sync more efficiently when terminal titles change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->