### PR TITLE
fix(update): skip Sparkle update probe + suppress pill for DEV/staging builds

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -343,6 +343,14 @@ public final class UpdateController {
             return
         }
 
+        let bundleIdentifier = Bundle.main.bundleIdentifier
+        if Self.isDevLikeBundleIdentifier(bundleIdentifier) {
+            log.append("launch update probe skipped (dev build, bundle=\(bundleIdentifier ?? "nil"))")
+            backgroundProbeTask?.cancel()
+            backgroundProbeTask = nil
+            return
+        }
+
         // Probe immediately on launch so the sidebar can surface a passive update indicator
         // without waiting for Sparkle's scheduled check or opening interactive update UI.
         log.append("starting launch update probe")
@@ -415,5 +423,21 @@ public final class UpdateController {
         } catch {
             log.append("Failed creating Sparkle installation cache: \(error)")
         }
+    }
+
+    /// Returns `true` when the running bundle is a debug or staging build rather
+    /// than the public release. Such builds are produced locally (e.g. via
+    /// `./scripts/reload.sh --tag <tag>`) and should not surface the Sparkle
+    /// "Update Available" pill — the user explicitly built from local source and
+    /// the public appcast will always report a version mismatch.
+    ///
+    /// Mirrors `SocketControlSettings.isDebugLikeBundleIdentifier` /
+    /// `isStagingBundleIdentifier` without taking a cross-package dependency.
+    static func isDevLikeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier == "com.cmuxterm.app.debug"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
+            || bundleIdentifier == "com.cmuxterm.app.staging"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -58,13 +58,19 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
-        model.recordDetectedUpdate(item)
         let version = item.displayVersionString
         let fileURL = item.fileURL?.absoluteString ?? ""
-        if fileURL.isEmpty {
-            log.append("valid update found: \(version)")
+        let bundleIdentifier = Bundle.main.bundleIdentifier
+        if UpdateController.isDevLikeBundleIdentifier(bundleIdentifier) {
+            log.append("valid update suppressed for dev build: \(version) (bundle=\(bundleIdentifier ?? "nil"))")
+            model.clearDetectedUpdate()
         } else {
-            log.append("valid update found: \(version) (\(fileURL))")
+            model.recordDetectedUpdate(item)
+            if fileURL.isEmpty {
+                log.append("valid update found: \(version)")
+            } else {
+                log.append("valid update found: \(version) (\(fileURL))")
+            }
         }
     }
 


### PR DESCRIPTION

## Summary

Tagged DEV builds and staging builds (`./scripts/reload.sh --tag <tag>`, `reloads.sh`) currently surface Sparkle's "Update Available" pill whenever a newer public release exists, because they share the public appcast URL and the updater module does not gate probing on bundle id. This makes every dogfood build noisy after each upstream release.

Fixes #6292.

## What this PR does

1. **`UpdateController.startLaunchUpdateProbeIfNeeded`**: skip the launch probe entirely and tear down any pending background probe task when the running bundle is a DEV/staging bundle id, so Sparkle is never queried.
2. **`UpdateController.isDevLikeBundleIdentifier(_:)`** (new static helper): mirrors `SocketControlSettings.isDebugLikeBundleIdentifier` + `isStagingBundleIdentifier`. Defined locally in `CmuxUpdater` to avoid adding a new `CmuxUpdater → CmuxSocketControl` package edge — happy to refactor to a shared helper if upstream prefers.
3. **`UpdateDriver+SPUUpdaterDelegate.updater(_:didFindValidUpdate:)`**: when Sparkle still reports a valid update (e.g. via explicit "Check for Updates" user action), call `model.clearDetectedUpdate()` for DEV/staging bundles instead of `recordDetectedUpdate(item)`.

## Test plan

- [ ] Manual: `./scripts/reload.sh --tag dev-pill-check` then launch — sidebar must NOT show an update pill even after the default `scheduledCheckInterval` elapses.
- [ ] Manual: same tagged DEV build → open Update UI via menu → verify no "Update Available" surfaces despite a newer public release existing on the appcast.
- [ ] Manual: public release build (`/Applications/cmux.app`) → update pill still appears normally.
- [ ] Manual: staging build (`./scripts/reloads.sh`) → no update pill.
- [ ] Optional unit test: `UpdateController.isDevLikeBundleIdentifier` returns `true` for `com.cmuxterm.app.debug`, `com.cmuxterm.app.debug.fix-foo`, `com.cmuxterm.app.staging`, `com.cmuxterm.app.staging.foo`; returns `false` for `com.cmuxterm.app` and `nil`.

## Out of scope

The original fork commit also bundled DEV-build workflow tooling; this PR intentionally excludes them so the update-pill fix can land independently:

- `docs/dev-build-workflow.md` — workflow documentation.
- `scripts/package-dev-dmg.sh` — wraps a tagged DEV build as a `.dmg` for hand-off.
- `scripts/reload.sh` `.app` mirror under `~/Downloads/cmux-dev/` — Finder-friendly artifact location.

Happy to file a follow-up PR for the workflow tooling once this lands.

## Validation

- `./scripts/reload.sh --tag dev-pill-port` — Debug build compiles.
- Localization audit: only log strings changed (not user-facing). No catalog updates required.

## Prior art

- Extracted from fork branch `ctrixin-agent-notifications-copy-browser` commit `0d9685a95`, re-applied against the new `Packages/macOS/CmuxUpdater/...` layout after the Swift Package migration moved `Sources/Update/UpdateController.swift` → `Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift` and `Sources/Update/UpdateDelegate.swift` → `Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift`.

Agent-Model: claude-sonnet-4.6
Agent-Family: anthropic
Agent-Step: 0.1.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784265720&installation_id=133855650&pr_number=6294&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6294&signature=138c53119b383bb0917d01e31d70cd22828c43f3f51677b892c2c0e518e98d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing Sparkle “Update Available” pill in DEV and staging builds by gating the updater on bundle ID. Public release builds are unchanged.

- **Bug Fixes**
  - `UpdateController.startLaunchUpdateProbeIfNeeded`: skip the launch probe and cancel any background task for DEV/staging bundle IDs.
  - `UpdateController.isDevLikeBundleIdentifier(_:)`: new helper to detect `com.cmuxterm.app.debug(.…)` and `com.cmuxterm.app.staging(.…)`.
  - `UpdateDriver+SPUUpdaterDelegate.updater(_:didFindValidUpdate:)`: suppress and clear detected updates for DEV/staging, including manual “Check for Updates”.

<sup>Written for commit ecd02e1980638ebab3d405171d314485dc6be2be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development and staging builds now skip automatic periodic update checks and suppress detected updates to reduce unnecessary background activity during development.
  * Enhanced build environment detection to properly identify and handle debug and staging configurations, preventing unwanted update notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->