### PR TITLE
Fix nightly prune on signing runners without gh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Validate xcodebuild noninteractive crash prompt guard
         run: python3 tests/test_ci_xcodebuild_noninteractive_helper.py
 
+      - name: Validate app-host xcodebuild retry guard
+        run: ./tests/test_ci_app_host_xcodebuild_retry.sh
+
       - name: Validate Xcode SourcePackages cache sanitizer
         run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
 

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -8,6 +8,7 @@ fi
 log_dir="${RUNNER_TEMP:-/tmp}"
 log_stem="${log_dir%/}/cmux-app-host-xcodebuild-${CMUX_TAG:-untagged}"
 max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-2}"
+export CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-900}"
 
 attempt=1
 while [ "$attempt" -le "$max_attempts" ]; do
@@ -28,8 +29,12 @@ while [ "$attempt" -le "$max_attempts" ]; do
   fi
 
   if [ "$status" -ne 0 ]; then
-    if [ "$attempt" -lt "$max_attempts" ] && grep -Fq 'The test runner hung before establishing connection.' "$log_path"; then
-      echo "Retrying app-host xcodebuild after XCTest startup hang (attempt $attempt/$max_attempts)" >&2
+    if [ "$attempt" -lt "$max_attempts" ] && { [ "$status" -eq 124 ] || grep -Fq 'The test runner hung before establishing connection.' "$log_path"; }; then
+      if [ "$status" -eq 124 ]; then
+        echo "Retrying app-host xcodebuild after ${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS}s timeout (attempt $attempt/$max_attempts)" >&2
+      else
+        echo "Retrying app-host xcodebuild after XCTest startup hang (attempt $attempt/$max_attempts)" >&2
+      fi
       pkill -x "cmux DEV" || true
       attempt=$((attempt + 1))
       continue

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -8,7 +8,8 @@ fi
 log_dir="${RUNNER_TEMP:-/tmp}"
 log_stem="${log_dir%/}/cmux-app-host-xcodebuild-${CMUX_TAG:-untagged}"
 max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-2}"
-export CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-900}"
+export CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-300}"
+echo "App-host xcodebuild timeout: ${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS}s, attempts: ${max_attempts}"
 
 attempt=1
 while [ "$attempt" -le "$max_attempts" ]; do

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -14,9 +14,11 @@ echo "App-host xcodebuild idle timeout: ${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TI
 attempt=1
 while [ "$attempt" -le "$max_attempts" ]; do
   log_path="${log_stem}-attempt-${attempt}.log"
+  : >"$log_path"
   set +e
-  scripts/ci/xcodebuild_noninteractive.py xcodebuild "$@" 2>&1 | tee "$log_path"
-  status=${PIPESTATUS[0]}
+  CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH="$log_path" \
+    scripts/ci/xcodebuild_noninteractive.py xcodebuild "$@"
+  status=$?
   set -e
 
   if grep -Fq 'path = "/tmp/cmux-debug.sock"' "$log_path"; then

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -8,8 +8,8 @@ fi
 log_dir="${RUNNER_TEMP:-/tmp}"
 log_stem="${log_dir%/}/cmux-app-host-xcodebuild-${CMUX_TAG:-untagged}"
 max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-2}"
-export CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-300}"
-echo "App-host xcodebuild timeout: ${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS}s, attempts: ${max_attempts}"
+export CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS:-${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-300}}"
+echo "App-host xcodebuild idle timeout: ${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS}s, attempts: ${max_attempts}"
 
 attempt=1
 while [ "$attempt" -le "$max_attempts" ]; do
@@ -32,7 +32,7 @@ while [ "$attempt" -le "$max_attempts" ]; do
   if [ "$status" -ne 0 ]; then
     if [ "$attempt" -lt "$max_attempts" ] && { [ "$status" -eq 124 ] || grep -Fq 'The test runner hung before establishing connection.' "$log_path"; }; then
       if [ "$status" -eq 124 ]; then
-        echo "Retrying app-host xcodebuild after ${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS}s timeout (attempt $attempt/$max_attempts)" >&2
+        echo "Retrying app-host xcodebuild after ${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS}s idle timeout (attempt $attempt/$max_attempts)" >&2
       else
         echo "Retrying app-host xcodebuild after XCTest startup hang (attempt $attempt/$max_attempts)" >&2
       fi

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -30,12 +30,15 @@ while [ "$attempt" -le "$max_attempts" ]; do
   fi
 
   if [ "$status" -ne 0 ]; then
-    if [ "$attempt" -lt "$max_attempts" ] && { [ "$status" -eq 124 ] || grep -Fq 'The test runner hung before establishing connection.' "$log_path"; }; then
-      if [ "$status" -eq 124 ]; then
-        echo "Retrying app-host xcodebuild after ${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS}s idle timeout (attempt $attempt/$max_attempts)" >&2
-      else
-        echo "Retrying app-host xcodebuild after XCTest startup hang (attempt $attempt/$max_attempts)" >&2
-      fi
+    retry_reason=""
+    if [ "$status" -eq 124 ]; then
+      retry_reason="${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS}s idle timeout"
+    elif grep -Fq 'The test runner hung before establishing connection.' "$log_path"; then
+      retry_reason="XCTest startup hang"
+    fi
+
+    if [ -n "$retry_reason" ] && [ "$attempt" -lt "$max_attempts" ]; then
+      echo "Retrying app-host xcodebuild after ${retry_reason} (attempt $attempt/$max_attempts)" >&2
       pkill -x "cmux DEV" || true
       attempt=$((attempt + 1))
       continue

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -6,10 +6,13 @@ from __future__ import annotations
 import os
 import pty
 import select
+import signal
 import sys
+import time
 
 
 SWIFT_CRASH_PROMPT = b"Press space to interact, D to debug, or any other key to quit"
+TIMEOUT_EXIT_CODE = 124
 
 
 def child_exit_code(status: int) -> int:
@@ -20,6 +23,55 @@ def child_exit_code(status: int) -> int:
     return 1
 
 
+def timeout_seconds() -> float | None:
+    raw = os.environ.get("CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS")
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except ValueError:
+        print(
+            "CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS must be numeric",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    if seconds <= 0:
+        return None
+    return seconds
+
+
+def terminate_child(pid: int) -> None:
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            finished, _ = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if finished:
+            return
+        time.sleep(0.1)
+
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+
+
 def main() -> int:
     if len(sys.argv) < 2:
         print(
@@ -28,16 +80,34 @@ def main() -> int:
         )
         return 2
 
+    timeout = timeout_seconds()
+    deadline = time.monotonic() + timeout if timeout else None
+
     pid, fd = pty.fork()
     if pid == 0:
+        try:
+            os.setsid()
+        except OSError:
+            pass
         os.execvp(sys.argv[1], sys.argv[1:])
 
     prompt_window = b""
+    timed_out = False
     while True:
+        select_timeout = None
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            select_timeout = min(1, remaining)
+
         try:
-            readable, _, _ = select.select([fd], [], [])
+            readable, _, _ = select.select([fd], [], [], select_timeout)
         except OSError:
             break
+        if not readable:
+            continue
         if fd not in readable:
             continue
 
@@ -55,6 +125,12 @@ def main() -> int:
             # noninteractive quit path and let xcodebuild continue reporting.
             os.write(fd, b"q")
             prompt_window = b""
+
+    if timed_out:
+        assert timeout is not None
+        print(f"Timed out after {timeout:g}s: {' '.join(sys.argv[1:])}", file=sys.stderr)
+        terminate_child(pid)
+        return TIMEOUT_EXIT_CODE
 
     _, status = os.waitpid(pid, 0)
     return child_exit_code(status)

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -80,13 +80,21 @@ def write_child_output(chunk: bytes, log_file: BinaryIO | None, stdout_fd: int) 
         log_file.write(chunk)
         log_file.flush()
 
-    try:
-        os.write(stdout_fd, chunk)
-    except BlockingIOError:
-        # GitHub log streaming can apply backpressure during very noisy
-        # xcodebuild phases. Keep the timeout loop moving; the full output is
-        # still persisted to the per-attempt log file.
+        try:
+            os.write(stdout_fd, chunk)
+        except BlockingIOError:
+            # GitHub log streaming can apply backpressure during very noisy
+            # xcodebuild phases. Keep the timeout loop moving; the full output
+            # is still persisted to the per-attempt log file.
+            return
         return
+
+    view = memoryview(chunk)
+    while view:
+        written = os.write(stdout_fd, view)
+        if written <= 0:
+            return
+        view = view[written:]
 
 
 def main() -> int:
@@ -104,10 +112,11 @@ def main() -> int:
     if log_path:
         log_file = open(log_path, "ab", buffering=0)
     stdout_fd = sys.stdout.fileno()
-    try:
-        os.set_blocking(stdout_fd, False)
-    except OSError:
-        pass
+    if log_file is not None:
+        try:
+            os.set_blocking(stdout_fd, False)
+        except OSError:
+            pass
 
     pid, fd = pty.fork()
     if pid == 0:

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -23,15 +23,17 @@ def child_exit_code(status: int) -> int:
     return 1
 
 
-def timeout_seconds() -> float | None:
-    raw = os.environ.get("CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS")
+def idle_timeout_seconds() -> float | None:
+    raw = os.environ.get("CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS")
+    if raw is None:
+        raw = os.environ.get("CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS")
     if not raw:
         return None
     try:
         seconds = float(raw)
     except ValueError:
         print(
-            "CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS must be numeric",
+            "CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS must be numeric",
             file=sys.stderr,
         )
         raise SystemExit(2)
@@ -80,7 +82,7 @@ def main() -> int:
         )
         return 2
 
-    timeout = timeout_seconds()
+    timeout = idle_timeout_seconds()
     deadline = time.monotonic() + timeout if timeout else None
 
     pid, fd = pty.fork()
@@ -119,6 +121,8 @@ def main() -> int:
             break
 
         os.write(sys.stdout.fileno(), chunk)
+        if timeout:
+            deadline = time.monotonic() + timeout
         prompt_window = (prompt_window + chunk)[-4096:]
         if SWIFT_CRASH_PROMPT in prompt_window:
             # The Swift crash backtracer asks for one key. Send q to choose the
@@ -128,7 +132,7 @@ def main() -> int:
 
     if timed_out:
         assert timeout is not None
-        print(f"Timed out after {timeout:g}s: {' '.join(sys.argv[1:])}", file=sys.stderr)
+        print(f"Idle timed out after {timeout:g}s: {' '.join(sys.argv[1:])}", file=sys.stderr)
         terminate_child(pid)
         return TIMEOUT_EXIT_CODE
 

--- a/scripts/ci/xcodebuild_noninteractive.py
+++ b/scripts/ci/xcodebuild_noninteractive.py
@@ -9,6 +9,7 @@ import select
 import signal
 import sys
 import time
+from typing import BinaryIO
 
 
 SWIFT_CRASH_PROMPT = b"Press space to interact, D to debug, or any other key to quit"
@@ -74,6 +75,20 @@ def terminate_child(pid: int) -> None:
             return
 
 
+def write_child_output(chunk: bytes, log_file: BinaryIO | None, stdout_fd: int) -> None:
+    if log_file is not None:
+        log_file.write(chunk)
+        log_file.flush()
+
+    try:
+        os.write(stdout_fd, chunk)
+    except BlockingIOError:
+        # GitHub log streaming can apply backpressure during very noisy
+        # xcodebuild phases. Keep the timeout loop moving; the full output is
+        # still persisted to the per-attempt log file.
+        return
+
+
 def main() -> int:
     if len(sys.argv) < 2:
         print(
@@ -84,6 +99,15 @@ def main() -> int:
 
     timeout = idle_timeout_seconds()
     deadline = time.monotonic() + timeout if timeout else None
+    log_path = os.environ.get("CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH")
+    log_file: BinaryIO | None = None
+    if log_path:
+        log_file = open(log_path, "ab", buffering=0)
+    stdout_fd = sys.stdout.fileno()
+    try:
+        os.set_blocking(stdout_fd, False)
+    except OSError:
+        pass
 
     pid, fd = pty.fork()
     if pid == 0:
@@ -120,7 +144,7 @@ def main() -> int:
         if not chunk:
             break
 
-        os.write(sys.stdout.fileno(), chunk)
+        write_child_output(chunk, log_file, stdout_fd)
         if timeout:
             deadline = time.monotonic() + timeout
         prompt_window = (prompt_window + chunk)[-4096:]
@@ -133,10 +157,17 @@ def main() -> int:
     if timed_out:
         assert timeout is not None
         print(f"Idle timed out after {timeout:g}s: {' '.join(sys.argv[1:])}", file=sys.stderr)
+        if log_file is not None:
+            log_file.write(
+                f"Idle timed out after {timeout:g}s: {' '.join(sys.argv[1:])}\n".encode()
+            )
+            log_file.close()
         terminate_child(pid)
         return TIMEOUT_EXIT_CODE
 
     _, status = os.waitpid(pid, 0)
+    if log_file is not None:
+        log_file.close()
     return child_exit_code(status)
 
 

--- a/scripts/prune_nightly_release_assets.py
+++ b/scripts/prune_nightly_release_assets.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
 import re
+import urllib.error
+import urllib.request
 
 
 IMMUTABLE_ASSET_PATTERNS = [
@@ -51,6 +55,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+class GitHubAPIError(RuntimeError):
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
 def gh_json(*args: str) -> dict:
     proc = subprocess.run(
         ["gh", *args],
@@ -63,9 +74,55 @@ def gh_json(*args: str) -> dict:
     return json.loads(proc.stdout)
 
 
+def github_token() -> str | None:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+
+def github_api_url(path: str) -> str:
+    api_base = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    return f"{api_base}/{path.lstrip('/')}"
+
+
+def github_api_json(method: str, path: str) -> dict:
+    token = github_token()
+    if token:
+        request = urllib.request.Request(
+            github_api_url(path),
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "cmux-nightly-prune",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            message = exc.read().decode("utf-8", errors="replace")
+            raise GitHubAPIError(exc.code, message) from exc
+        if not body:
+            return {}
+        return json.loads(body)
+
+    if shutil.which("gh"):
+        args = ["api"]
+        if method != "GET":
+            args.extend(["-X", method])
+        args.append(path)
+        return gh_json(*args)
+
+    raise RuntimeError("Set GH_TOKEN or install gh to access the GitHub API")
+
+
 def load_release(repo: str, release_tag: str) -> dict | None:
     try:
-        return gh_json("api", f"repos/{repo}/releases/tags/{release_tag}")
+        return github_api_json("GET", f"repos/{repo}/releases/tags/{release_tag}")
+    except GitHubAPIError as exc:
+        if exc.status == 404 or "not found" in exc.message.lower():
+            return None
+        raise
     except subprocess.CalledProcessError as exc:
         message = (exc.stderr or exc.output or "").lower()
         if "404" in message or "not found" in message:
@@ -118,16 +175,7 @@ def delete_assets(repo: str, assets: list[ReleaseAsset]) -> None:
     total = len(assets)
     for index, asset in enumerate(assets, start=1):
         log(f"[{index}/{total}] deleting {asset.name}")
-        subprocess.run(
-            [
-                "gh",
-                "api",
-                "-X",
-                "DELETE",
-                f"repos/{repo}/releases/assets/{asset.asset_id}",
-            ],
-            check=True,
-        )
+        github_api_json("DELETE", f"repos/{repo}/releases/assets/{asset.asset_id}")
 
 
 def main() -> int:

--- a/scripts/prune_nightly_release_assets.py
+++ b/scripts/prune_nightly_release_assets.py
@@ -71,6 +71,8 @@ def gh_json(*args: str) -> dict:
     if proc.returncode != 0:
         stderr = (proc.stderr or proc.stdout).strip()
         raise subprocess.CalledProcessError(proc.returncode, proc.args, output=proc.stdout, stderr=stderr)
+    if not proc.stdout:
+        return {}
     return json.loads(proc.stdout)
 
 

--- a/tests/test_ci_app_host_xcodebuild_retry.sh
+++ b/tests/test_ci_app_host_xcodebuild_retry.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/xcodebuild" <<'SH'
+#!/usr/bin/env bash
+sleep 10
+SH
+chmod +x "$TMP_DIR/xcodebuild"
+
+set +e
+PATH="$TMP_DIR:$PATH" \
+RUNNER_TEMP="$TMP_DIR" \
+CMUX_APP_HOST_XCODEBUILD_ATTEMPTS=2 \
+CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS=0.1 \
+  bash "$ROOT_DIR/scripts/ci/run-app-host-xcodebuild.sh" test >"$TMP_DIR/output.log" 2>&1
+status=$?
+set -e
+
+if [ "$status" -ne 124 ]; then
+  cat "$TMP_DIR/output.log"
+  echo "FAIL: expected wrapper to exit with final timeout status 124, got $status"
+  exit 1
+fi
+
+if ! grep -Fq "Retrying app-host xcodebuild after 0.1s idle timeout (attempt 1/2)" "$TMP_DIR/output.log"; then
+  cat "$TMP_DIR/output.log"
+  echo "FAIL: wrapper did not retry after idle timeout"
+  exit 1
+fi
+
+timeout_count="$(grep -Fc "Idle timed out after 0.1s" "$TMP_DIR/output.log")"
+if [ "$timeout_count" -ne 2 ]; then
+  cat "$TMP_DIR/output.log"
+  echo "FAIL: expected two timed-out attempts, got $timeout_count"
+  exit 1
+fi
+
+echo "PASS: app-host xcodebuild wrapper retries idle timeouts"

--- a/tests/test_ci_nightly_prune_python_compat.sh
+++ b/tests/test_ci_nightly_prune_python_compat.sh
@@ -18,6 +18,40 @@ assert spec.loader is not None
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 assert callable(module.load_release)
+
+class FakeResponse:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.body
+
+requests = []
+
+def fake_urlopen(request):
+    requests.append((request.get_method(), request.full_url))
+    if request.get_method() == "DELETE":
+        return FakeResponse(b"")
+    return FakeResponse(b'{"assets": []}')
+
+module.urllib.request.urlopen = fake_urlopen
+module.os.environ["GH_TOKEN"] = "test-token"
+module.os.environ["GITHUB_API_URL"] = "https://api.example.test"
+module.os.environ["PATH"] = ""
+
+release = module.load_release("manaflow-ai/cmux", "nightly")
+assert release == {"assets": []}
+module.delete_assets("manaflow-ai/cmux", [module.ReleaseAsset(asset_id=123, name="old.dmg", build=1)])
+assert requests == [
+    ("GET", "https://api.example.test/repos/manaflow-ai/cmux/releases/tags/nightly"),
+    ("DELETE", "https://api.example.test/repos/manaflow-ai/cmux/releases/assets/123"),
+]
 PY
 
 echo "PASS: nightly prune script is compatible with older macOS runner Python"

--- a/tests/test_ci_nightly_prune_python_compat.sh
+++ b/tests/test_ci_nightly_prune_python_compat.sh
@@ -52,6 +52,27 @@ assert requests == [
     ("GET", "https://api.example.test/repos/manaflow-ai/cmux/releases/tags/nightly"),
     ("DELETE", "https://api.example.test/repos/manaflow-ai/cmux/releases/assets/123"),
 ]
+
+class FakeProc:
+    returncode = 0
+    stdout = ""
+    stderr = ""
+
+gh_calls = []
+
+def fake_run(args, capture_output=None, text=None):
+    gh_calls.append(args)
+    return FakeProc()
+
+module.os.environ.pop("GH_TOKEN")
+module.os.environ.pop("GITHUB_TOKEN", None)
+module.shutil.which = lambda name: "/fake/gh" if name == "gh" else None
+module.subprocess.run = fake_run
+
+module.delete_assets("manaflow-ai/cmux", [module.ReleaseAsset(asset_id=456, name="older.dmg", build=1)])
+assert gh_calls == [
+    ["gh", "api", "-X", "DELETE", "repos/manaflow-ai/cmux/releases/assets/456"],
+]
 PY
 
 echo "PASS: nightly prune script is compatible with older macOS runner Python"

--- a/tests/test_ci_xcodebuild_noninteractive_helper.py
+++ b/tests/test_ci_xcodebuild_noninteractive_helper.py
@@ -88,6 +88,27 @@ def main() -> int:
         print("FAIL: helper did not report idle timeout")
         return 1
 
+    direct_output_child = "import sys; sys.stdout.write('x' * 262144); sys.stdout.flush()"
+    direct_output_result = subprocess.run(
+        [sys.executable, str(HELPER), sys.executable, "-c", direct_output_child],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+    if direct_output_result.returncode != 0:
+        print(direct_output_result.stdout, end="")
+        print(direct_output_result.stderr, end="", file=sys.stderr)
+        print(f"FAIL: expected direct output child exit 0, got {direct_output_result.returncode}")
+        return 1
+    if direct_output_result.stdout.count("x") != 262144:
+        print(direct_output_result.stderr, end="", file=sys.stderr)
+        print(
+            f"FAIL: direct helper output was truncated to {direct_output_result.stdout.count('x')} bytes"
+        )
+        return 1
+
     with tempfile.TemporaryDirectory() as tmp:
         log_path = Path(tmp) / "helper.log"
         log_child = "print('child-log-line', flush=True)"

--- a/tests/test_ci_xcodebuild_noninteractive_helper.py
+++ b/tests/test_ci_xcodebuild_noninteractive_helper.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import textwrap
 import os
+import tempfile
 from pathlib import Path
 
 
@@ -86,6 +87,31 @@ def main() -> int:
         print(timeout_result.stderr, end="", file=sys.stderr)
         print("FAIL: helper did not report idle timeout")
         return 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "helper.log"
+        log_child = "print('child-log-line', flush=True)"
+        log_result = subprocess.run(
+            [sys.executable, str(HELPER), sys.executable, "-c", log_child],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                **os.environ,
+                "CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH": str(log_path),
+            },
+        )
+        if log_result.returncode != 0:
+            print(log_result.stdout, end="")
+            print(log_result.stderr, end="", file=sys.stderr)
+            print(f"FAIL: expected log child exit 0, got {log_result.returncode}")
+            return 1
+        if "child-log-line" not in log_path.read_text():
+            print(log_result.stdout, end="")
+            print(log_result.stderr, end="", file=sys.stderr)
+            print("FAIL: helper did not write child output to log path")
+            return 1
 
     print("PASS: xcodebuild noninteractive helper dismisses crash prompts and idle-times out stuck children")
     return 0

--- a/tests/test_ci_xcodebuild_noninteractive_helper.py
+++ b/tests/test_ci_xcodebuild_noninteractive_helper.py
@@ -65,7 +65,7 @@ def main() -> int:
     )
     timeout_env = {
         **os.environ,
-        "CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS": "0.2",
+        "CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS": "0.2",
     }
     timeout_result = subprocess.run(
         [sys.executable, str(HELPER), sys.executable, "-c", timeout_child],
@@ -81,13 +81,13 @@ def main() -> int:
         print(timeout_result.stderr, end="", file=sys.stderr)
         print(f"FAIL: expected timeout exit 124, got {timeout_result.returncode}")
         return 1
-    if "Timed out after 0.2s" not in timeout_result.stderr:
+    if "Idle timed out after 0.2s" not in timeout_result.stderr:
         print(timeout_result.stdout, end="")
         print(timeout_result.stderr, end="", file=sys.stderr)
-        print("FAIL: helper did not report timeout")
+        print("FAIL: helper did not report idle timeout")
         return 1
 
-    print("PASS: xcodebuild noninteractive helper dismisses crash prompts and times out stuck children")
+    print("PASS: xcodebuild noninteractive helper dismisses crash prompts and idle-times out stuck children")
     return 0
 
 

--- a/tests/test_ci_xcodebuild_noninteractive_helper.py
+++ b/tests/test_ci_xcodebuild_noninteractive_helper.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+import os
 from pathlib import Path
 
 
@@ -54,7 +55,39 @@ def main() -> int:
         print("FAIL: helper did not answer each crash prompt with q")
         return 1
 
-    print("PASS: xcodebuild noninteractive helper dismisses crash prompts")
+    timeout_child = textwrap.dedent(
+        """
+        import time
+
+        print("ready", flush=True)
+        time.sleep(10)
+        """
+    )
+    timeout_env = {
+        **os.environ,
+        "CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS": "0.2",
+    }
+    timeout_result = subprocess.run(
+        [sys.executable, str(HELPER), sys.executable, "-c", timeout_child],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=5,
+        env=timeout_env,
+    )
+    if timeout_result.returncode != 124:
+        print(timeout_result.stdout, end="")
+        print(timeout_result.stderr, end="", file=sys.stderr)
+        print(f"FAIL: expected timeout exit 124, got {timeout_result.returncode}")
+        return 1
+    if "Timed out after 0.2s" not in timeout_result.stderr:
+        print(timeout_result.stdout, end="")
+        print(timeout_result.stderr, end="", file=sys.stderr)
+        print("FAIL: helper did not report timeout")
+        return 1
+
+    print("PASS: xcodebuild noninteractive helper dismisses crash prompts and times out stuck children")
     return 0
 
 


### PR DESCRIPTION
## Summary
- add regression coverage for nightly prune when `GH_TOKEN` exists but `gh` is absent from `PATH`
- call the GitHub REST API directly from Python when `GH_TOKEN`/`GITHUB_TOKEN` is available
- keep `gh api` as a local fallback for developer runs without an exported token

## Why
Nightly on `austins-mac-mini-ci2` failed in `Prune old nightly release assets` with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'gh'
```

The signing job already has `GH_TOKEN`, so the prune script should not require the GitHub CLI on that runner.

## Test
- `PYTHON_BIN=python3 bash ./tests/test_ci_nightly_prune_python_compat.sh`
- `PYTHON_BIN=/Applications/Xcode.app/Contents/Developer/usr/bin/python3 bash ./tests/test_ci_nightly_prune_python_compat.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784268561&installation_id=133855650&pr_number=6295&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6295&signature=9cdabfd11510a8817017242cbc5664cfa09a0f215039cb2e394233ebb5690e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI scripts and nightly release maintenance; prune deletes only when `--execute` is used, and xcodebuild behavior is gated by env vars on macOS test jobs.
> 
> **Overview**
> Fixes **nightly asset pruning** on signing runners that have `GH_TOKEN` but no `gh` on `PATH` by calling the GitHub REST API from Python when a token is set, with `gh api` only as a fallback when no token is exported.
> 
> Hardens **app-host `xcodebuild`** in CI: `xcodebuild_noninteractive.py` gains an **idle timeout** (configurable via `CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS`, exit **124**), optional per-attempt logging, and non-blocking stdout so log backpressure cannot stall the watchdog. `run-app-host-xcodebuild.sh` wires that timeout in, writes logs via `CMUX_XCODEBUILD_NONINTERACTIVE_LOG_PATH`, and **retries** on idle timeout or the known XCTest startup hang.
> 
> CI adds guards for the new retry behavior and extends existing tests for the helper timeout, large output, log path, and prune REST/`gh` fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c5c548623cd6c533a62da2ba92d8eaec5a42793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nightly prune on signing runners without `gh`, and harden app-host `xcodebuild` with an idle-based, retryable timeout to prevent CI hangs. Keeps direct stdout lossless while avoiding log backpressure via per-attempt log files.

- **Bug Fixes**
  - Nightly prune: use GitHub REST via `urllib` when `GH_TOKEN`/`GITHUB_TOKEN` is set (optional `GITHUB_API_URL`), fall back to `gh api` only without a token, and handle 404s and empty DELETE bodies. Tests mock `urlopen`, clear `PATH`, verify GET/DELETE URLs, and cover `gh` fallback.
  - App-host `xcodebuild`: idle timeout via `CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS` (or legacy var), resets on output, kills the child process group, exits 124, and retries on exit 124 or XCTest startup hangs. Wrapper writes per-attempt logs (no `tee`) and prints retry reason; helper uses non-blocking stdout only when logging to avoid backpressure and preserves lossless direct output. CI tests cover timeout 124, two timed-out attempts with final 124, log-path writes, and lossless large stdout.

<sup>Written for commit 5c5c548623cd6c533a62da2ba92d8eaec5a42793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Nightly release asset pruning now uses GitHub’s REST API to load releases and delete assets, with improved behavior when a release is missing and support for a custom API base URL and authentication.
* **New Features**
  * CI `xcodebuild` non-interactive mode now adds an idle-timeout mechanism (defaulting via env), updates retry messaging, and treats timeout exit code `124` as a non-interactive hang.
* **Tests**
  * Added CI coverage validating REST GET/DELETE and fallback to the `gh` CLI when no token is present.
  * Extended coverage for the helper’s timeout exit code and stderr output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->