### PR TITLE
fix: preserve terminal scrollback during TextBox resize

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7583,12 +7583,46 @@ final class GhosttySurfaceScrollView: NSView {
     private var scrollbarTrackingArea: NSTrackingArea?
     private var isLiveScrolling = false
     private var lastSentRow: Int?
-    /// Tracks whether the user has scrolled away from the bottom to review scrollback.
-    /// When true, auto-scroll should be suspended to prevent the "doomscroll" bug
-    /// where the terminal fights the user's scroll position.
-    private var userScrolledAwayFromBottom = false
-    private var pendingExplicitWheelScroll = false
-    private var allowExplicitScrollbarSync = false
+    /// Single source of truth for whether passive scrollbar packets may move the viewport.
+    ///
+    /// The AppKit wrapper treats `contentView.bounds.origin.y == 0` as live-bottom.
+    /// A user wheel event creates a one-packet explicit sync window; `synchronizeScrollView()`
+    /// then resolves the state from the actual AppKit pixel target so row and point thresholds
+    /// cannot diverge.
+    private enum ScrollFollowState: Equatable {
+        case followingOutput
+        case reviewingScrollback
+        case awaitingExplicitScrollbarSync(previousWasReviewing: Bool)
+
+        var allowsScrollbarSync: Bool {
+            switch self {
+            case .followingOutput, .awaitingExplicitScrollbarSync:
+                return true
+            case .reviewingScrollback:
+                return false
+            }
+        }
+
+        var isAwaitingExplicitScrollbarSync: Bool {
+            if case .awaitingExplicitScrollbarSync = self {
+                return true
+            }
+            return false
+        }
+
+        var isReviewingScrollback: Bool {
+            switch self {
+            case .followingOutput:
+                return false
+            case .reviewingScrollback:
+                return true
+            case .awaitingExplicitScrollbarSync(let previousWasReviewing):
+                return previousWasReviewing
+            }
+        }
+    }
+
+    private var scrollFollowState: ScrollFollowState = .followingOutput
     /// Threshold in points from bottom to consider "at bottom" (allows for minor float drift)
     private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true
@@ -8074,7 +8108,7 @@ final class GhosttySurfaceScrollView: NSView {
             object: surfaceView,
             queue: .main
         ) { [weak self] _ in
-            self?.pendingExplicitWheelScroll = true
+            self?.beginExplicitScrollbarSync()
         })
 
         observers.append(NotificationCenter.default.addObserver(
@@ -10576,33 +10610,31 @@ final class GhosttySurfaceScrollView: NSView {
                 // Check if we're currently at the bottom (with threshold for float drift)
                 let currentOrigin = scrollView.contentView.bounds.origin
                 let distanceFromBottom = currentOrigin.y
-                let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
+                let isAtBottom = !isReviewingScrollback(distanceFromBottom: distanceFromBottom)
 
-                // Update userScrolledAwayFromBottom based on current position.
                 // During an explicit wheel-driven sync, preserve the intent from the
                 // target scrollbar packet instead of letting the pre-sync bottom
                 // position clear the review state before the viewport moves.
-                if isAtBottom && !allowExplicitScrollbarSync {
-                    userScrolledAwayFromBottom = false
+                let isExplicitScrollbarSync = scrollFollowState.isAwaitingExplicitScrollbarSync
+                if isAtBottom && !isExplicitScrollbarSync {
+                    scrollFollowState = .followingOutput
                 }
 
-                // Passive bottom packets should not override an explicit scrollback review,
-                // but the first scrollbar packet caused by the user's own wheel input should
-                // still move the viewport to the requested scrollback position.
-                let shouldAutoScroll = !userScrolledAwayFromBottom || allowExplicitScrollbarSync
-
-                if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
+                // Passive bottom packets should not override a scrollback review, but the
+                // first scrollbar packet caused by the user's own wheel input should still
+                // move the viewport to the requested position.
+                if scrollFollowState.allowsScrollbarSync && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
                     scrollView.contentView.scroll(to: targetOrigin)
                     didChangeGeometry = true
                 }
-                if allowExplicitScrollbarSync {
-                    userScrolledAwayFromBottom = targetOrigin.y > Self.scrollToBottomThreshold
+                if isExplicitScrollbarSync {
+                    scrollFollowState = resolvedScrollFollowState(distanceFromBottom: targetOrigin.y)
                 }
                 lastSentRow = Int(scrollbar.offset)
             }
         }
 
-        allowExplicitScrollbarSync = false
+        restorePreviousScrollFollowStateIfExplicitSyncCouldNotResolve()
 
         if didChangeGeometry {
             scrollView.reflectScrolledClipView(scrollView.contentView)
@@ -10622,12 +10654,8 @@ final class GhosttySurfaceScrollView: NSView {
         let distanceFromBottom = visibleRect.origin.y
         let scrollOffset = documentHeight - visibleRect.origin.y - visibleRect.height
 
-        // Track if user has scrolled away from bottom to review scrollback
-        if distanceFromBottom > Self.scrollToBottomThreshold {
-            userScrolledAwayFromBottom = true
-        } else {
-            userScrolledAwayFromBottom = false
-        }
+        // Track if user has scrolled away from bottom to review scrollback.
+        scrollFollowState = resolvedScrollFollowState(distanceFromBottom: distanceFromBottom)
 
         let row = Int(scrollOffset / cellHeight)
 
@@ -10636,16 +10664,35 @@ final class GhosttySurfaceScrollView: NSView {
         _ = surfaceView.performBindingAction("scroll_to_row:\(row)")
     }
 
+    private func resolvedScrollFollowState(distanceFromBottom: CGFloat) -> ScrollFollowState {
+        isReviewingScrollback(distanceFromBottom: distanceFromBottom)
+            ? .reviewingScrollback
+            : .followingOutput
+    }
+
+    private func isReviewingScrollback(distanceFromBottom: CGFloat) -> Bool {
+        distanceFromBottom > Self.scrollToBottomThreshold
+    }
+
+    private func beginExplicitScrollbarSync() {
+        guard !scrollFollowState.isAwaitingExplicitScrollbarSync else { return }
+        scrollFollowState = .awaitingExplicitScrollbarSync(
+            previousWasReviewing: scrollFollowState.isReviewingScrollback
+        )
+    }
+
+    private func restorePreviousScrollFollowStateIfExplicitSyncCouldNotResolve() {
+        guard case .awaitingExplicitScrollbarSync(let previousWasReviewing) = scrollFollowState else {
+            return
+        }
+        scrollFollowState = previousWasReviewing ? .reviewingScrollback : .followingOutput
+    }
+
     private func handleScrollbarUpdate(_ notification: Notification) {
         guard let scrollbar = notification.userInfo?[GhosttyNotificationKey.scrollbar] as? GhosttyScrollbar else {
             return
         }
         let wasVisible = scrollView.hasVerticalScroller
-        if pendingExplicitWheelScroll {
-            userScrolledAwayFromBottom = scrollbar.offset + scrollbar.len < scrollbar.total
-            allowExplicitScrollbarSync = true
-            pendingExplicitWheelScroll = false
-        }
         surfaceView.scrollbar = scrollbar
         let isVisible = shouldShowTerminalScrollBar()
         if wasVisible != isVisible {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10575,13 +10575,14 @@ final class GhosttySurfaceScrollView: NSView {
 
                 // Check if we're currently at the bottom (with threshold for float drift)
                 let currentOrigin = scrollView.contentView.bounds.origin
-                let documentHeight = documentView.frame.height
-                let viewportHeight = scrollView.contentView.bounds.height
-                let distanceFromBottom = documentHeight - currentOrigin.y - viewportHeight
+                let distanceFromBottom = currentOrigin.y
                 let isAtBottom = distanceFromBottom <= Self.scrollToBottomThreshold
 
-                // Update userScrolledAwayFromBottom based on current position
-                if isAtBottom {
+                // Update userScrolledAwayFromBottom based on current position.
+                // During an explicit wheel-driven sync, preserve the intent from the
+                // target scrollbar packet instead of letting the pre-sync bottom
+                // position clear the review state before the viewport moves.
+                if isAtBottom && !allowExplicitScrollbarSync {
                     userScrolledAwayFromBottom = false
                 }
 
@@ -10593,6 +10594,9 @@ final class GhosttySurfaceScrollView: NSView {
                 if shouldAutoScroll && !pointApproximatelyEqual(currentOrigin, targetOrigin) {
                     scrollView.contentView.scroll(to: targetOrigin)
                     didChangeGeometry = true
+                }
+                if allowExplicitScrollbarSync {
+                    userScrolledAwayFromBottom = targetOrigin.y > Self.scrollToBottomThreshold
                 }
                 lastSentRow = Int(scrollbar.offset)
             }
@@ -10615,12 +10619,13 @@ final class GhosttySurfaceScrollView: NSView {
 
         let visibleRect = scrollView.contentView.documentVisibleRect
         let documentHeight = documentView.frame.height
+        let distanceFromBottom = visibleRect.origin.y
         let scrollOffset = documentHeight - visibleRect.origin.y - visibleRect.height
 
         // Track if user has scrolled away from bottom to review scrollback
-        if scrollOffset > Self.scrollToBottomThreshold {
+        if distanceFromBottom > Self.scrollToBottomThreshold {
             userScrolledAwayFromBottom = true
-        } else if scrollOffset <= 0 {
+        } else {
             userScrolledAwayFromBottom = false
         }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4137,6 +4137,74 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         )
     }
 
+    func testNativeScrollbackReviewSurvivesTextBoxLikeTerminalResize() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surfaceView = ScrollbarPostingSurfaceView(frame: NSRect(x: 0, y: 0, width: 160, height: 120))
+        surfaceView.cellSize = CGSize(width: 10, height: 10)
+        let hostedView = GhosttySurfaceScrollView(surfaceView: surfaceView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let scrollView = hostedView.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView else {
+            XCTFail("Expected hosted terminal scroll view")
+            return
+        }
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: surfaceView,
+            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 100, offset: 90, len: 10)]
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        XCTAssertEqual(scrollView.contentView.bounds.origin.y, 0, accuracy: 0.01)
+
+        let reviewedScrollbackOrigin = CGPoint(x: 0, y: 900)
+        scrollView.contentView.scroll(to: reviewedScrollbackOrigin)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        NotificationCenter.default.post(
+            name: NSScrollView.didLiveScrollNotification,
+            object: scrollView
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        XCTAssertEqual(scrollView.contentView.bounds.origin.y, reviewedScrollbackOrigin.y, accuracy: 0.01)
+
+        hostedView.frame.size.height = 200
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: surfaceView,
+            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 100, offset: 90, len: 10)]
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+
+        XCTAssertGreaterThan(
+            scrollView.contentView.bounds.origin.y,
+            100,
+            "A TextBox-height resize while reviewing scrollback must not let a passive bottom packet yank the viewport back to live output"
+        )
+    }
+
     func testInactiveOverlayVisibilityTracksRequestedState() {
         let hostedView = GhosttySurfaceScrollView(
             surfaceView: GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 80, height: 50))


### PR DESCRIPTION
## Summary

- Preserve manual terminal scrollback review when a TextBox-driven layout change resizes the terminal wrapper.
- Add a regression that simulates reviewing native scrollback, shrinking the terminal area like a multiline TextBox newline, then receiving a passive bottom scrollbar packet.

This is a narrow alternative to the broader open scrollback PR #4792, which currently has conflicts/failed checks. The symptom overlaps #1847/#5799, but this PR keeps the patch minimal to the TextBox/resize snap path.

Root cause: `GhosttySurfaceScrollView` uses a non-flipped AppKit document view where live bottom is `contentView.bounds.origin.y == 0`. The previous follow/review checks used `documentHeight - origin.y - viewportHeight` as a bottom distance, which could clear scrollback review intent and let passive bottom packets yank the viewport down after a TextBox resize.

## Testing

- [x] Targeted regression before the fix failed on `main` with `origin.y == 0` after the passive bottom packet.
- [x] `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-textbox-scroll-pr -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testNativeScrollbackReviewSurvivesTextBoxLikeTerminalResize -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testExplicitWheelScrollKeepsScrollbackPinnedAgainstLaterBottomPacket`
- [x] `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag textbox-scroll-resize-pr`

Notes: local Zig is 0.16.0 while this checkout's build script expects 0.15.2, so the validation used `CMUX_SKIP_ZIG_BUILD=1`.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not included; regression coverage exercises the AppKit scroll wrapper path directly.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784268782&installation_id=133855650&pr_number=6296&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6296&signature=8752a642fe9514ee27ce536ec9d10cd3860258940fffb24dfc67f722ddfadf3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves manual terminal scrollback during TextBox-driven resizes so the viewport doesn’t snap back to live output when a passive “bottom” packet arrives. Consolidates scroll-follow intent into one state so wheel-driven syncs resolve correctly in the non-flipped AppKit coordinate system.

- **Bug Fixes**
  - Detect “at bottom” via `contentView.bounds.origin.y` with a small threshold (non-flipped).
  - Replace parallel flags with a single `ScrollFollowState`; wheel events open a one-packet explicit sync resolved from the AppKit target origin, while passive packets can’t override scrollback review.
  - Add regression test `testNativeScrollbackReviewSurvivesTextBoxLikeTerminalResize`.

<sup>Written for commit 5d8aeebd61b037473e901c600425824742fb8758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrollback position being reset to live output when resizing the terminal window
  * Improved accuracy of preserving user-reviewed scrollback content during terminal resize operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->