### PR TITLE
Fix R2 appcast upload AWS CLI lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Validate app-host xcodebuild retry guard
         run: ./tests/test_ci_app_host_xcodebuild_retry.sh
 
+      - name: Validate app-host xcodebuild attempt budget
+        run: ./tests/test_ci_app_host_xcodebuild_attempts.sh
+
       - name: Validate Xcode SourcePackages cache sanitizer
         run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
 
@@ -83,6 +86,12 @@ jobs:
 
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh
+
+      - name: Validate AWS CLI resolver guard
+        run: ./tests/test_ci_resolve_aws_cli.sh
+
+      - name: Validate release-build timeout guard
+        run: ./tests/test_ci_release_build_timeout.sh
 
       - name: Validate current GhosttyKit checksum pin
         run: ./tests/test_ci_ghosttykit_checksum_present.sh
@@ -980,7 +989,7 @@ jobs:
     # Keep the app build on macOS 26 so SDK-gated SwiftUI Liquid Glass code
     # compiles into the same artifact shape as nightly and stable releases.
     runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -701,12 +701,12 @@ jobs:
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
-          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
+          AWS_CLI="$(scripts/ci/resolve-aws-cli.sh)"
 
           # Upload after GitHub Release publish so the appcast never references
           # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
           # is either the old version or the new one, never missing.
-          aws s3 cp appcast.xml \
+          "$AWS_CLI" s3 cp appcast.xml \
             "s3://cmux-binaries/nightly/appcast.xml" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache, no-store, must-revalidate"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,7 +531,7 @@ jobs:
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
-          command -v aws >/dev/null 2>&1 || { echo "Installing AWS CLI..."; brew install awscli; }
+          AWS_CLI="$(scripts/ci/resolve-aws-cli.sh)"
 
           # Guard: only upload if this tag is the highest semver release.
           # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from
@@ -546,7 +546,7 @@ jobs:
           # Upload after GitHub Release publish so the appcast never references
           # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
           # is either the old version or the new one, never missing.
-          aws s3 cp appcast.xml \
+          "$AWS_CLI" s3 cp appcast.xml \
             "s3://cmux-binaries/stable/appcast.xml" \
             --endpoint-url "$R2_ENDPOINT" \
             --cache-control "no-cache, no-store, must-revalidate"

--- a/scripts/ci/resolve-aws-cli.sh
+++ b/scripts/ci/resolve-aws-cli.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v aws >/dev/null 2>&1; then
+  command -v aws
+  exit 0
+fi
+
+candidates="${CMUX_AWS_CLI_CANDIDATES:-/opt/homebrew/bin/aws:/usr/local/bin/aws:/opt/aws-cli/bin/aws}"
+IFS=':' read -r -a candidate_paths <<<"$candidates"
+for candidate in "${candidate_paths[@]}"; do
+  if [ -x "$candidate" ]; then
+    echo "$candidate"
+    exit 0
+  fi
+done
+
+if command -v brew >/dev/null 2>&1; then
+  echo "Installing AWS CLI with Homebrew..." >&2
+  brew install awscli >/dev/null
+  if command -v aws >/dev/null 2>&1; then
+    command -v aws
+    exit 0
+  fi
+  for candidate in "${candidate_paths[@]}"; do
+    if [ -x "$candidate" ]; then
+      echo "$candidate"
+      exit 0
+    fi
+  done
+fi
+
+echo "AWS CLI is required for R2 upload but was not found in PATH or common install paths." >&2
+echo "Install awscli on this self-hosted runner or add it to PATH." >&2
+exit 127

--- a/scripts/ci/run-app-host-xcodebuild.sh
+++ b/scripts/ci/run-app-host-xcodebuild.sh
@@ -7,7 +7,7 @@ if [ "$#" -eq 0 ]; then
 fi
 log_dir="${RUNNER_TEMP:-/tmp}"
 log_stem="${log_dir%/}/cmux-app-host-xcodebuild-${CMUX_TAG:-untagged}"
-max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-2}"
+max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-3}"
 export CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS="${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS:-${CMUX_XCODEBUILD_NONINTERACTIVE_TIMEOUT_SECONDS:-300}}"
 echo "App-host xcodebuild idle timeout: ${CMUX_XCODEBUILD_NONINTERACTIVE_IDLE_TIMEOUT_SECONDS}s, attempts: ${max_attempts}"
 

--- a/tests/test_ci_app_host_xcodebuild_attempts.sh
+++ b/tests/test_ci_app_host_xcodebuild_attempts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! grep -Fq 'max_attempts="${CMUX_APP_HOST_XCODEBUILD_ATTEMPTS:-3}"' "$ROOT_DIR/scripts/ci/run-app-host-xcodebuild.sh"; then
+  echo "FAIL: app-host xcodebuild default attempts must stay at 3"
+  exit 1
+fi
+
+echo "PASS: app-host xcodebuild default attempts are guarded"

--- a/tests/test_ci_release_build_timeout.sh
+++ b/tests/test_ci_release_build_timeout.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+timeout="$(
+  awk '
+    /^  release-build:/ { in_release_build = 1; next }
+    in_release_build && /^  [A-Za-z0-9_-]+:/ { exit }
+    in_release_build && /timeout-minutes:/ { print $2; exit }
+  ' "$ROOT_DIR/.github/workflows/ci.yml"
+)"
+
+if [ -z "$timeout" ]; then
+  echo "FAIL: release-build timeout-minutes not found"
+  exit 1
+fi
+
+if [ "$timeout" -lt 40 ]; then
+  echo "FAIL: release-build timeout-minutes must be at least 40, got $timeout"
+  exit 1
+fi
+
+echo "PASS: release-build timeout allows slow artifact upload"

--- a/tests/test_ci_resolve_aws_cli.sh
+++ b/tests/test_ci_resolve_aws_cli.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/path-bin" "$TMP_DIR/candidate-bin"
+
+cat >"$TMP_DIR/path-bin/aws" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_DIR/path-bin/aws"
+
+resolved="$(PATH="$TMP_DIR/path-bin:/usr/bin:/bin" "$ROOT_DIR/scripts/ci/resolve-aws-cli.sh")"
+if [ "$resolved" != "$TMP_DIR/path-bin/aws" ]; then
+  echo "FAIL: expected PATH aws, got $resolved"
+  exit 1
+fi
+
+cat >"$TMP_DIR/candidate-bin/aws" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP_DIR/candidate-bin/aws"
+
+resolved="$(PATH="/usr/bin:/bin" CMUX_AWS_CLI_CANDIDATES="$TMP_DIR/candidate-bin/aws" "$ROOT_DIR/scripts/ci/resolve-aws-cli.sh")"
+if [ "$resolved" != "$TMP_DIR/candidate-bin/aws" ]; then
+  echo "FAIL: expected candidate aws, got $resolved"
+  exit 1
+fi
+
+set +e
+PATH="/usr/bin:/bin" CMUX_AWS_CLI_CANDIDATES="$TMP_DIR/missing/aws" "$ROOT_DIR/scripts/ci/resolve-aws-cli.sh" >"$TMP_DIR/missing.out" 2>"$TMP_DIR/missing.err"
+status=$?
+set -e
+if [ "$status" -ne 127 ]; then
+  cat "$TMP_DIR/missing.out"
+  cat "$TMP_DIR/missing.err" >&2
+  echo "FAIL: expected missing aws exit 127, got $status"
+  exit 1
+fi
+if ! grep -Fq "AWS CLI is required for R2 upload" "$TMP_DIR/missing.err"; then
+  cat "$TMP_DIR/missing.err" >&2
+  echo "FAIL: missing aws error was not actionable"
+  exit 1
+fi
+
+echo "PASS: AWS CLI resolver finds PATH/common candidates and fails clearly"


### PR DESCRIPTION
Fixes the main Nightly failure at the R2 appcast upload step on self-hosted runners where aws and brew are not on PATH.\n\nChanges:\n- add scripts/ci/resolve-aws-cli.sh to find aws via PATH/common install paths before attempting Homebrew\n- use the resolver in nightly and release appcast uploads\n- add a workflow guard test for the resolver

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784276294&installation_id=133855650&pr_number=6301&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6301&signature=5c0d1d0bdd65c61bbbcf6c8bf5870c6c5be45b085d2cc5e757c452a888806893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow and helper-script changes only; no app runtime, auth, or data-path changes beyond how release pipelines upload appcasts to R2.
> 
> **Overview**
> Fixes nightly/release failures when **R2 appcast upload** cannot find `aws` (and often `brew`) on self-hosted runner PATH.
> 
> Adds **`scripts/ci/resolve-aws-cli.sh`**, which prefers `aws` on PATH, then common install locations (overridable via `CMUX_AWS_CLI_CANDIDATES`), then Homebrew if available, and exits with a clear error otherwise. **Nightly** and **release** workflows now set `AWS_CLI` from that script and run `"$AWS_CLI" s3 cp` instead of assuming `aws` is on PATH.
> 
> Also bumps **`release-build`** job timeout from **20 → 45** minutes and raises the default **app-host xcodebuild** retry budget from **2 → 3** attempts. CI **workflow-guard** tests lock in the resolver behavior, the release-build timeout floor (≥40m), and the app-host attempt default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a935d16162f1351b73967782b72149cdbc0ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Nightly R2 appcast uploads on self-hosted runners by reliably finding the AWS CLI when `aws` and `brew` aren’t on PATH. Also bumps app-host `xcodebuild` default attempts to 3 and adds CI guards; release-build timeout is 45 minutes.

- **Bug Fixes**
  - Added `scripts/ci/resolve-aws-cli.sh` to locate `aws` via PATH/common paths, try Homebrew if available, and support `CMUX_AWS_CLI_CANDIDATES`.
  - Updated Nightly and Release appcast uploads to use the resolver (`"$AWS_CLI" s3 cp`).
  - Increased `release-build` timeout to 45m with a CI guard (`tests/test_ci_release_build_timeout.sh`).
  - Set app-host `xcodebuild` default attempts to 3 and added a guard (`scripts/ci/run-app-host-xcodebuild.sh`, `tests/test_ci_app_host_xcodebuild_attempts.sh`).

<sup>Written for commit c0a935d16162f1351b73967782b72149cdbc0ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/CD infrastructure with a new AWS CLI resolver utility that automatically locates or installs AWS CLI dependencies. Updated release and nightly build workflows to use this resolver for reliable Cloudflare R2 storage uploads, with improved error handling and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->