### PR TITLE
Stop main window drifting down on sleep/wake

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -97,6 +97,58 @@ final class CmuxMainWindow: NSWindow {
         guard !isSoftHiddenForVisibilityController else { return }
         super.flagsChanged(with: event)
     }
+
+    /// cmux owns main-window placement: it persists and restores window frames
+    /// itself and disables AppKit window restoration (`isRestorable = false`),
+    /// re-applying the saved frame only at startup.
+    ///
+    /// On a display/system sleep→wake (the kind a locked Mac eventually goes
+    /// through — the lock keystroke itself is not the trigger) AppKit re-runs
+    /// its constrain pass over every window. The default implementation does not
+    /// only clamp off-screen windows back into view; it also repositions windows
+    /// that are *already fully on-screen*, which is what we observe as the
+    /// window creeping each sleep cycle. The exact reposition is AppKit-internal
+    /// and depends on the display arrangement and each screen's menu-bar /
+    /// safe-area insets, so it is neither a fixed titlebar-height nudge nor
+    /// limited to a window whose titlebar sits under the menu bar — it also hits
+    /// e.g. a window in the bottom half of an external display, and likely other
+    /// arrangements. Because cmux never re-asserts the saved frame after wake,
+    /// whatever the re-constrain produced sticks and accumulates.
+    ///
+    /// Fix: refuse the re-constrain for any frame that is already reachable on
+    /// some screen, and defer to AppKit's default only when the frame would
+    /// otherwise be stranded off-screen (e.g. a display was disconnected), so a
+    /// genuinely lost window can still be pulled back into view.
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        if Self.shouldPreserveFrameDuringConstrain(
+            frameRect,
+            visibleFrames: NSScreen.screens.map(\.visibleFrame)
+        ) {
+            return frameRect
+        }
+        return super.constrainFrameRect(frameRect, to: screen)
+    }
+
+    /// Whether `proposedFrame` is reachable enough across `visibleFrames` that
+    /// AppKit's constraining pass should be skipped. The frame qualifies when it
+    /// overlaps some screen's visible area by at least `minimumVisibleExtent`
+    /// points in both dimensions (or its full extent, when smaller) — i.e. a
+    /// usable, grabbable slice of the window is on-screen.
+    nonisolated static func shouldPreserveFrameDuringConstrain(
+        _ proposedFrame: NSRect,
+        visibleFrames: [NSRect],
+        minimumVisibleExtent: CGFloat = 60
+    ) -> Bool {
+        let requiredWidth = min(proposedFrame.width, minimumVisibleExtent)
+        let requiredHeight = min(proposedFrame.height, minimumVisibleExtent)
+        for visibleFrame in visibleFrames {
+            let intersection = proposedFrame.intersection(visibleFrame)
+            if intersection.width >= requiredWidth, intersection.height >= requiredHeight {
+                return true
+            }
+        }
+        return false
+    }
 }
 
 extension CmuxMainWindow {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		C19C5E0300000000000000A3 /* CmuxIPCService in Frameworks */ = {isa = PBXBuildFile; productRef = C19C5E0200000000000000A2 /* CmuxIPCService */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
+		D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */; };
 		799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		CA1F0A01CA1F0A01CA1F0A01 /* CmuxModalAlertPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */; };
@@ -1240,6 +1241,7 @@
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
 		E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxLifecycleEventPublishing.swift; sourceTree = "<group>"; };
 		2F0C07000000000000000001 /* CmuxMainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxMainWindow.swift; sourceTree = "<group>"; };
+		D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxMainWindowConstrainFrameTests.swift; sourceTree = "<group>"; };
 		CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxModalAlertPresentation.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXOpenCommandTests.swift; sourceTree = "<group>"; };
 		A9F100000000000000000005 /* CmuxRuntimeDebugCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxRuntimeDebugCapture.swift; sourceTree = "<group>"; };
@@ -2822,6 +2824,7 @@
 				C0DEC0DE000000000000F203 /* CommandPaletteNucleoFixtures.swift */,
 				A50019B3 /* SettingsSearchIndexTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
+				D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
 				8D828DA0070335773EBAE83F /* BrowserSystemProxyMirrorTests.swift */,
 				C59240010000000000000004 /* BrowserDownloadFilenameResolverTests.swift */,
@@ -4148,6 +4151,7 @@
 				E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */,
 				C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 				E7E000000000000000000003 /* CmuxEventBusTests.swift in Sources */,
+				D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */,
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -1,0 +1,56 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+#if DEBUG
+@MainActor
+final class CmuxMainWindowConstrainFrameTests: XCTestCase {
+    // On a display/system sleep→wake, AppKit re-runs its constrain pass over
+    // every window and repositions even windows that are already fully
+    // on-screen; cmux never re-asserts its saved frame afterward, so the window
+    // creeps each sleep cycle. CmuxMainWindow.constrainFrameRect must leave an
+    // on-screen frame untouched so AppKit can no longer move it. A titlebar
+    // flush under the menu bar is one such on-screen frame (and an easy,
+    // deterministic one to construct), but it is not the only triggering
+    // arrangement.
+    func testConstrainPreservesOnScreenFrameOverlappingMenuBar() throws {
+        guard let screen = NSScreen.main else {
+            throw XCTSkip("No screen available for constrainFrameRect regression")
+        }
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let size = NSSize(width: 800, height: 600)
+        // Flush against the very top of the physical screen so the titlebar
+        // overlaps the menu bar — one on-screen placement AppKit's default
+        // constrain pass would push downward.
+        let proposed = NSRect(
+            x: screen.visibleFrame.midX - size.width / 2,
+            y: screen.frame.maxY - size.height,
+            width: size.width,
+            height: size.height
+        )
+
+        let constrained = window.constrainFrameRect(proposed, to: screen)
+
+        XCTAssertEqual(constrained.origin.x, proposed.origin.x, accuracy: 0.5)
+        XCTAssertEqual(constrained.origin.y, proposed.origin.y, accuracy: 0.5)
+        XCTAssertEqual(constrained.size.width, proposed.size.width, accuracy: 0.5)
+        XCTAssertEqual(constrained.size.height, proposed.size.height, accuracy: 0.5)
+    }
+}
+#endif

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -17,7 +17,7 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
     // on-screen frame untouched so AppKit can no longer move it. A titlebar
     // flush under the menu bar is one such on-screen frame (and an easy,
     // deterministic one to construct), but it is not the only triggering
-    // arrangement.
+    // arrangement — see the screen-agnostic helper cases below.
     func testConstrainPreservesOnScreenFrameOverlappingMenuBar() throws {
         guard let screen = NSScreen.main else {
             throw XCTSkip("No screen available for constrainFrameRect regression")
@@ -51,6 +51,51 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
         XCTAssertEqual(constrained.origin.y, proposed.origin.y, accuracy: 0.5)
         XCTAssertEqual(constrained.size.width, proposed.size.width, accuracy: 0.5)
         XCTAssertEqual(constrained.size.height, proposed.size.height, accuracy: 0.5)
+    }
+
+    // The decision helper is screen-agnostic, so these cases run deterministically
+    // on CI regardless of the test host's display configuration.
+
+    func testPreservesFrameFullyInsideVisibleArea() {
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let frame = NSRect(x: 100, y: 100, width: 800, height: 600)
+        XCTAssertTrue(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
+    func testPreservesFrameWhoseTitlebarOverlapsMenuBarBand() {
+        // The visible area excludes a 37pt menu-bar band at the top; the window's
+        // titlebar pokes into it — the placement AppKit would otherwise push down.
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 863)
+        let frame = NSRect(x: 320, y: 263, width: 800, height: 637) // maxY 900 > 863
+        XCTAssertTrue(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
+    func testDoesNotPreserveFrameStrandedOffScreen() {
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let frame = NSRect(x: 3000, y: 2000, width: 800, height: 600)
+        XCTAssertFalse(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
+    func testDoesNotPreserveBarelyPeekingFrame() {
+        let visible = NSRect(x: 0, y: 0, width: 1440, height: 900)
+        // Only ~20pt of the window overlaps the bottom-left corner — not grabbable.
+        let frame = NSRect(x: -780, y: -580, width: 800, height: 600)
+        XCTAssertFalse(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [visible])
+        )
+    }
+
+    func testDoesNotPreserveWhenNoScreensAvailable() {
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        XCTAssertFalse(
+            CmuxMainWindow.shouldPreserveFrameDuringConstrain(frame, visibleFrames: [])
+        )
     }
 }
 #endif


### PR DESCRIPTION
> _Note: this PR was prepared by an AI agent (Claude) on the author's behalf._

## Problem

After the Mac sleeps and wakes (e.g. you lock with `Ctrl+Cmd+Q` and come back later, or the display sleeps), the cmux main window shifts downward, and it accumulates across sleep/wake cycles. The lock keystroke itself is not the trigger — the sleep→wake is.

## Cause

This is AppKit re-constraining the window, not cmux repositioning it. None of cmux's own observers move the window here (`sessionDidResignActive` only saves a snapshot; `didWake` only restarts the socket listener; `applicationDidBecomeActive` only re-places windows when none is visible).

On a display/system sleep→wake, AppKit re-runs its constrain pass (`constrainFrameRect(_:to:)`) over every window. The default implementation does **not only** clamp off-screen windows back into view — it also repositions windows that are *already fully on-screen*, which is what shows up as the per-cycle creep. The exact reposition is AppKit-internal and depends on the display arrangement and each screen's menu-bar / safe-area insets, so:

- it is **not** a fixed titlebar-height nudge (the move is larger), and
- it is **not** limited to a window whose titlebar sits under the menu bar — it also hits e.g. a window occupying the bottom half of an external display, and likely other arrangements.

The main window is `.fullSizeContentView`, and cmux disables OS window restoration (`isRestorable = false`), re-applying its saved frame only at startup. Because nothing re-asserts the saved frame after wake, whatever AppKit's re-constrain produced sticks and accumulates.

## Fix

Override `CmuxMainWindow.constrainFrameRect(_:to:)` to leave an already-reachable frame untouched, only falling back to AppKit's default constraining when the proposed frame would otherwise be stranded off-screen (e.g. a display was disconnected), so a lost window can still be pulled back into view. cmux already owns and clamps its own window placement, so deferring to AppKit's re-constrain here only produced the drift. The reachability decision is factored into a pure, testable helper.

## Tests (two-commit red/green)

1. **Failing test** — `testConstrainPreservesOnScreenFrameOverlappingMenuBar` asserts that constraining an on-screen frame leaves it untouched (a titlebar-under-menu-bar frame is used as one easy, deterministic on-screen case). Verified red-by-assertion without the fix (inherited `NSWindow.constrainFrameRect` moves it).
2. **Fix** — adds the override plus deterministic, screen-agnostic coverage of the `shouldPreserveFrameDuringConstrain` helper (inside / menu-bar-overlap / stranded / barely-peeking / no-screens).

A third commit corrects code/test comments that had mis-stated the cause. All 6 tests pass green locally on macOS 26.5.1 (M2 Max). Test file is wired into `project.pbxproj` and passes `lint-pbxproj-test-wiring.sh`.

## Verification

Reproduced and confirmed fixed on the reporter's macOS (26.5.1 Tahoe) via a tagged Debug build and a real sleep/wake cycle — the window now stays put with no cumulative creep.

See also the note below on overlap with #2667.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window positioning during sleep/wake to prevent the app from subtly shifting the window when the proposed location is already reachable on-screen, especially when the title bar overlaps the system menu bar area.

* **Tests**
  * Added debug-only regression and unit tests to verify frame-preservation behavior for on-screen, off-screen, edge-overlap, and empty visible-region scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->