### PR TITLE
Retry SSH PTY resize relay

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11898,6 +11898,40 @@ struct CMUXCLI {
         throw CLIError(message: "ssh-pty-attach: bridge status exceeded \(maxStatusBytes) bytes")
     }
 
+    private static let sshPTYResizeRetryDelays: [TimeInterval] = [0.05, 0.15, 0.35]
+
+    private func sendSSHPTYResize(
+        client: SocketClient,
+        workspaceId: String,
+        surfaceID: String?,
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        cols: Int,
+        rows: Int,
+        socketLock: NSLock
+    ) throws {
+        socketLock.lock()
+        defer { socketLock.unlock() }
+        var params: [String: Any] = [
+            "workspace_id": workspaceId,
+            "session_id": sessionID,
+            "attachment_id": attachmentID,
+            "attachment_token": attachmentToken,
+            "cols": cols,
+            "rows": rows,
+        ]
+        if let surfaceID {
+            params["surface_id"] = surfaceID
+            params["allow_moved_surface"] = true
+        }
+        _ = try client.sendV2(
+            method: "workspace.remote.pty_resize",
+            params: params,
+            responseTimeout: 2.0
+        )
+    }
+
     private func startSSHPTYResizeSource(
         client: SocketClient,
         workspaceId: String,
@@ -11908,27 +11942,40 @@ struct CMUXCLI {
         socketLock: NSLock
     ) -> DispatchSourceSignal {
         signal(SIGWINCH, SIG_IGN)
+        let queue = DispatchQueue(label: "com.cmux.ssh-pty.resize")
+        var resizeGeneration: UInt64 = 0
+
+        func sendLatestResize(attempt: Int, generation: UInt64) {
+            let size = self.currentCLITerminalSize()
+            do {
+                try self.sendSSHPTYResize(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceID: surfaceID,
+                    sessionID: sessionID,
+                    attachmentID: attachmentID,
+                    attachmentToken: attachmentToken,
+                    cols: size.cols,
+                    rows: size.rows,
+                    socketLock: socketLock
+                )
+            } catch {
+                guard attempt < Self.sshPTYResizeRetryDelays.count else { return }
+                let delay = Self.sshPTYResizeRetryDelays[attempt]
+                queue.asyncAfter(deadline: .now() + delay) {
+                    guard generation == resizeGeneration else { return }
+                    sendLatestResize(attempt: attempt + 1, generation: generation)
+                }
+            }
+        }
+
         let source = DispatchSource.makeSignalSource(
             signal: SIGWINCH,
-            queue: DispatchQueue(label: "com.cmux.ssh-pty.resize")
+            queue: queue
         )
         source.setEventHandler {
-            let size = self.currentCLITerminalSize()
-            socketLock.lock()
-            defer { socketLock.unlock() }
-            var params: [String: Any] = [
-                "workspace_id": workspaceId,
-                "session_id": sessionID,
-                "attachment_id": attachmentID,
-                "attachment_token": attachmentToken,
-                "cols": size.cols,
-                "rows": size.rows,
-            ]
-            if let surfaceID {
-                params["surface_id"] = surfaceID
-                params["allow_moved_surface"] = true
-            }
-            _ = try? client.sendV2(method: "workspace.remote.pty_resize", params: params)
+            resizeGeneration &+= 1
+            sendLatestResize(attempt: 0, generation: resizeGeneration)
         }
         source.resume()
         return source


### PR DESCRIPTION
Fixes #6306.
Related to #5700.

### Summary

SSH PTY attach currently forwards pane resize changes through `workspace.remote.pty_resize` from the SIGWINCH handler, but delivery is best-effort and failures are silently dropped. If that send races a stale or temporarily unavailable remote-session control path, the remote PTY can miss the current size while output continues to flow.

This change adds a small coalesced retry loop for SSH PTY resize delivery:

- sends resize updates through a helper that surfaces delivery errors
- retries failed delivery with short delays
- coalesces rapid resize events so only the latest generation continues retrying
- re-reads the terminal size before each retry

### Validation

- `xcrun swiftc -parse CLI/cmux.swift`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784283819&installation_id=133855650&pr_number=6307&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6307&signature=205fd3b0f712af828a027821b165b24b88f29611b25223fc014433b2f58add1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SSH PTY resize delivery reliable by adding a coalesced retry loop so the remote PTY doesn’t miss size updates during brief control-path hiccups.

- **Bug Fixes**
  - Send resize via a helper that surfaces errors and uses a 2s `sendV2` timeout.
  - Retry on failure with short delays [0.05, 0.15, 0.35]; only the latest resize keeps retrying.
  - Re-read terminal size before each retry to always send the current size.
  - Use a dedicated queue and `NSLock` for thread-safe sends; include `allow_moved_surface` when `surface_id` is present.

<sup>Written for commit 24b7d7e45ed693cd24793acc7b381c847099ef90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH terminal window resize reliability with automatic retry logic on failures and better concurrency handling to prevent stale resize operations from interfering with newer events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->