### PR TITLE
fix(grok): fast-path PreToolUse hooks and native tool classification

### DIFF
--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -261,6 +261,23 @@ struct FeedEventClassifier {
         "generate_image",
     ]
 
+    /// Grok Build emits lowercase native names (`write`, `search_replace`, …)
+    /// and Cursor-compat names (`Write`, `Shell`). Match case-insensitively
+    /// only for the `grok` source.
+    private static let grokSideEffectingToolAliases: Set<String> = [
+        "write",
+        "edit",
+        "multiedit",
+        "bash",
+        "notebookedit",
+        "apply_patch",
+        "shell",
+        "search_replace",
+        "write_to_file",
+        "replace_file_content",
+        "multi_replace_file_content",
+    ]
+
     /// Kiro emits lowercase / internal tool names (`fs_write`,
     /// `execute_bash`, `use_aws`, …) absent from ``sideEffectingTools``.
     /// Matched case-insensitively, but only for the `kiro` source, so another
@@ -300,6 +317,9 @@ struct FeedEventClassifier {
         guard !toolName.isEmpty else { return false }
         if sideEffectingTools.contains(toolName) {
             return true
+        }
+        if source == "grok" {
+            return grokSideEffectingToolAliases.contains(toolName.lowercased())
         }
         if source == "kiro" {
             return kiroSideEffectingToolAliases.contains(toolName.lowercased())

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -27129,6 +27129,26 @@ struct CMUXCLI {
         // approval reviewer. Most nested agents use milliseconds. Codex, Grok,
         // and Antigravity hook schemas use seconds, so normalize before writing.
         for agentEvent in def.feedHookEvents {
+            if def.name == "grok", agentEvent == "PreToolUse" {
+                let pretoolPath = Self.grokPreToolUseHookScriptPath(for: def)
+                let feedTimeoutMs = feedHookTimeoutMs(for: def, agentEvent: agentEvent)
+                switch def.format {
+                case .nested:
+                    var groups = result[agentEvent] as? [[String: Any]] ?? []
+                    let timeout = nestedFeedHookTimeout(feedTimeoutMs, for: def)
+                    groups.insert([
+                        "hooks": [[
+                            "type": "command",
+                            "command": pretoolPath,
+                            "timeout": timeout,
+                        ] as [String: Any]]
+                    ] as [String: Any], at: 0)
+                    result[agentEvent] = groups
+                default:
+                    break
+                }
+                continue
+            }
             let feedCmd = feedHookCommand(for: def, agentEvent: agentEvent)
             let feedTimeoutMs = feedHookTimeoutMs(for: def, agentEvent: agentEvent)
             switch def.format {
@@ -28421,6 +28441,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         try pruneLegacyGrokHookFileIfNeeded(def: def, configDir: configDir, primaryFilePath: filePath)
 
+        if def.name == "grok" {
+            try installGrokPreToolHookScripts(configDir: configDir)
+        }
+
         // Post-install actions
         if let action = def.postInstallAction {
             switch action {
@@ -28469,6 +28493,83 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
             }
         }
+    }
+
+    private static func grokPreToolUseHookScriptPath(for def: AgentHookDef) -> String {
+        let hooksRoot = def.resolvedConfigDir()
+        let grokHome = URL(fileURLWithPath: hooksRoot, isDirectory: true)
+            .deletingLastPathComponent()
+            .path
+        return "\(grokHome)/bin/cmux-grok-pretooluse.sh"
+    }
+
+    private func installGrokPreToolHookScripts(configDir: String) throws {
+        let grokHome = URL(fileURLWithPath: configDir, isDirectory: true)
+            .deletingLastPathComponent()
+        let binDir = grokHome.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+
+        let scriptNames = ["cmux-grok-pretooluse.sh", "cmux-grok-hooks-ensure.sh"]
+        for scriptName in scriptNames {
+            guard let bundledURL = Self.bundledGrokHookScriptURL(named: scriptName) else { continue }
+            let destination = binDir.appendingPathComponent(scriptName, isDirectory: false)
+            if !FileManager.default.fileExists(atPath: destination.path)
+                || (try? bundledURL.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate)
+                    .map({ bundledDate in
+                        (try? destination.resourceValues(forKeys: [.contentModificationDateKey])
+                            .contentModificationDate)
+                            .map { $0 < bundledDate } ?? true
+                    }) ?? true
+            {
+                if FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+                try FileManager.default.copyItem(at: bundledURL, to: destination)
+            }
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destination.path)
+        }
+
+        let ensureScript = binDir.appendingPathComponent("cmux-grok-hooks-ensure.sh", isDirectory: false)
+        guard FileManager.default.isExecutableFile(atPath: ensureScript.path) else { return }
+        let result = try runHookMaintenanceScript(at: ensureScript)
+        if result != 0 {
+            print("Warning: cmux-grok-hooks-ensure.sh exited with status \(result)")
+        }
+    }
+
+    private func runHookMaintenanceScript(at url: URL) throws -> Int32 {
+        let process = Process()
+        process.executableURL = url
+        process.arguments = []
+        var env = ProcessInfo.processInfo.environment
+        env["GROK_HOME"] = url.deletingLastPathComponent().deletingLastPathComponent().path
+        process.environment = env
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus
+    }
+
+    private static func bundledGrokHookScriptURL(named scriptName: String) -> URL? {
+        let candidates: [URL?] = [
+            Bundle.main.url(
+                forResource: scriptName.replacingOccurrences(of: ".sh", with: ""),
+                withExtension: "sh",
+                subdirectory: "bin"
+            ),
+            Bundle.main.resourceURL?
+                .appendingPathComponent("bin/\(scriptName)", isDirectory: false),
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Resources/bin/\(scriptName)", isDirectory: false),
+        ]
+        for candidate in candidates {
+            guard let url = candidate,
+                  FileManager.default.isReadableFile(atPath: url.path) else { continue }
+            return url
+        }
+        return nil
     }
 
     private func pruneLegacyGrokHookFileIfNeeded(
@@ -33373,6 +33474,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 return "{}"
             }
             if source == "antigravity" {
+                let reason = mode == "deny"
+                    ? "User denied permission via cmux Feed."
+                    : "User approved via cmux Feed."
+                return encode([
+                    "decision": mode == "deny" ? "deny" : "allow",
+                    "reason": reason,
+                ])
+            }
+            if source == "grok" {
                 let reason = mode == "deny"
                     ? "User denied permission via cmux Feed."
                     : "User approved via cmux Feed."

--- a/Resources/bin/cmux-grok-hooks-ensure.sh
+++ b/Resources/bin/cmux-grok-hooks-ensure.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Idempotent repair for Grok Build + cmux PreToolUse integration.
+# Safe to run on every SessionStart and after `cmux hooks grok install`.
+# cmux-grok-ensure-v1
+set -euo pipefail
+
+GROK_HOME="${GROK_HOME:-$HOME/.grok}"
+HOOKS_DIR="$GROK_HOME/hooks"
+BIN_DIR="$GROK_HOME/bin"
+SELF="$BIN_DIR/cmux-grok-hooks-ensure.sh"
+SESSION_JSON="$HOOKS_DIR/cmux-session.json"
+ENSURE_JSON="$HOOKS_DIR/cmux-grok-ensure.json"
+PRETOL="$BIN_DIR/cmux-grok-pretooluse.sh"
+MARKER="cmux-grok-pretool-v1"
+LOCK_DIR="$GROK_HOME/.locks"
+LOCK="$LOCK_DIR/cmux-grok-hooks-ensure.lock"
+
+mkdir -p "$BIN_DIR" "$HOOKS_DIR" "$LOCK_DIR"
+
+if ! mkdir "$LOCK" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
+
+_bundled_pretool() {
+  local candidates=(
+    "/Applications/cmux.app/Contents/Resources/bin/cmux-grok-pretooluse.sh"
+  )
+  if [[ -n "${CMUX_BUNDLED_CLI_PATH:-}" ]]; then
+    candidates+=("$(dirname "$CMUX_BUNDLED_CLI_PATH")/cmux-grok-pretooluse.sh")
+  fi
+  local c
+  for c in "${candidates[@]}"; do
+    [[ -n "$c" && -f "$c" ]] || continue
+    printf '%s' "$c"
+    return 0
+  done
+  return 1
+}
+
+_install_pretool() {
+  if bundled="$(_bundled_pretool 2>/dev/null || true)" && [[ -n "$bundled" ]]; then
+    if [[ ! -f "$PRETOL" ]] || [[ "$bundled" -nt "$PRETOL" ]]; then
+      cp "$bundled" "$PRETOL"
+    fi
+  elif [[ ! -x "$PRETOL" ]]; then
+    echo "cmux-grok-hooks-ensure: missing $PRETOL and no bundled copy" >&2
+    return 1
+  fi
+  chmod +x "$PRETOL"
+  chmod +x "$SELF" 2>/dev/null || true
+}
+
+_write_ensure_hook_json() {
+  local ensure_cmd
+  ensure_cmd="$(printf '%s' "$SELF" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()))')"
+  cat >"$ENSURE_JSON" <<EOF
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": $ensure_cmd,
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+}
+
+_repair_session_json() {
+  [[ -f "$SESSION_JSON" ]] || return 0
+  python3 - "$SESSION_JSON" "$PRETOL" "$MARKER" <<'PY'
+import json, sys
+
+path, pretool, marker = sys.argv[1:4]
+with open(path, encoding="utf-8") as f:
+    data = json.load(f)
+hooks = data.setdefault("hooks", {})
+groups = hooks.get("PreToolUse")
+if not isinstance(groups, list):
+    groups = []
+    hooks["PreToolUse"] = groups
+
+def is_cmux_feed(cmd: str) -> bool:
+    return "cmux-grok-hook-v2" in cmd and "hooks feed --source grok --event PreToolUse" in cmd
+
+def is_pretool(cmd: str) -> bool:
+    return "cmux-grok-pretooluse.sh" in cmd or marker in cmd
+
+new_groups = []
+pretool_group = None
+for group in groups:
+    if not isinstance(group, dict):
+        continue
+    hook_list = group.get("hooks")
+    if not isinstance(hook_list, list):
+        new_groups.append(group)
+        continue
+    kept = []
+    for h in hook_list:
+        if not isinstance(h, dict):
+            continue
+        cmd = h.get("command", "")
+        if is_cmux_feed(cmd):
+            continue
+        if is_pretool(cmd):
+            pretool_group = {
+                "hooks": [{
+                    "type": "command",
+                    "command": pretool,
+                    "timeout": 120,
+                }]
+            }
+            continue
+        kept.append(h)
+    if kept:
+        new_groups.append({"hooks": kept})
+
+if pretool_group is None:
+    pretool_group = {
+        "hooks": [{
+            "type": "command",
+            "command": pretool,
+            "timeout": 120,
+        }]
+    }
+
+hooks["PreToolUse"] = [pretool_group] + new_groups
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+}
+
+_install_pretool
+_write_ensure_hook_json
+_repair_session_json
+
+exit 0

--- a/Resources/bin/cmux-grok-pretooluse.sh
+++ b/Resources/bin/cmux-grok-pretooluse.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# cmux-grok-pretool-v1 — PreToolUse bridge for Grok Build inside cmux.
+# Installed/maintained by cmux-grok-hooks-ensure.sh (survives cmux app updates).
+set -euo pipefail
+
+if printenv CMUX_GROK_HOOKS_DISABLED 2>/dev/null | grep -qx 1; then
+  echo '{}'
+  exit 0
+fi
+
+event_json="$(cat)"
+tool_name="$(
+  printf '%s' "$event_json" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('toolName') or d.get('tool_name') or '')
+" 2>/dev/null || true
+)"
+
+grok_should_skip_feed_blocking() {
+  if printenv CMUX_GROK_FEED_SKIP_BLOCKING 2>/dev/null | grep -qx 1; then
+    return 0
+  fi
+  local config="${GROK_HOME:-$HOME/.grok}/config.toml"
+  [[ -f "$config" ]] || return 1
+  if grep -Eq '^[[:space:]]*permission_mode[[:space:]]*=[[:space:]]*"?always-approve"?[[:space:]]*$' "$config"; then
+    return 0
+  fi
+  if grep -Eq '^[[:space:]]*permission_mode[[:space:]]*=[[:space:]]*"?bypassPermissions"?[[:space:]]*$' "$config"; then
+    return 0
+  fi
+  if grep -Eq '^[[:space:]]*yolo[[:space:]]*=[[:space:]]*true[[:space:]]*$' "$config"; then
+    return 0
+  fi
+  return 1
+}
+
+grok_tool_needs_feed_approval() {
+  local t
+  t="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$t" in
+    write|edit|multiedit|bash|notebookedit|apply_patch|shell|write_to_file|replace_file_content|multi_replace_file_content|search_replace)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Auto-approve / yolo: never block on cmux Feed (avoids 120s PreToolUse stalls).
+if grok_should_skip_feed_blocking; then
+  echo '{}'
+  exit 0
+fi
+
+# Read-only / telemetry tools: skip feed subprocess entirely.
+if ! grok_tool_needs_feed_approval "$tool_name"; then
+  echo '{}'
+  exit 0
+fi
+
+CMUX_BIN="${CMUX_BIN:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+if [[ ! -x "$CMUX_BIN" ]] && command -v cmux >/dev/null 2>&1; then
+  CMUX_BIN="$(command -v cmux)"
+fi
+SOCK="${CMUX_SOCKET_PATH:-${CMUX_SOCK:-$HOME/.local/state/cmux/cmux.sock}}"
+
+if [[ ! -x "$CMUX_BIN" ]] || [[ ! -S "$SOCK" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+printf '%s' "$event_json" | "$CMUX_BIN" --socket "$SOCK" hooks feed --source grok --event PreToolUse
+exit $?

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -161,6 +161,8 @@
 		C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00020000000000000002 /* CloudVMActionLauncher.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */; };
+		GROK000102A1B2C3D4E5F719 /* cmux-grok-hooks-ensure.sh in Copy CLI */ = {isa = PBXBuildFile; fileRef = GROK000101A1B2C3D4E5F719 /* cmux-grok-hooks-ensure.sh */; };
+		GROK000202A1B2C3D4E5F719 /* cmux-grok-pretooluse.sh in Copy CLI */ = {isa = PBXBuildFile; fileRef = GROK000201A1B2C3D4E5F719 /* cmux-grok-pretooluse.sh */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
 		B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000030A1B2C3D4E5F60719 /* cmux_open.swift */; };
@@ -1012,6 +1014,8 @@
 			files = (
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */,
+				GROK000102A1B2C3D4E5F719 /* cmux-grok-hooks-ensure.sh in Copy CLI */,
+				GROK000202A1B2C3D4E5F719 /* cmux-grok-pretooluse.sh in Copy CLI */,
 				C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 			);
@@ -1186,6 +1190,8 @@
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
 		C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-claude-wrapper"; sourceTree = SOURCE_ROOT; };
+		GROK000101A1B2C3D4E5F719 /* cmux-grok-hooks-ensure.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-grok-hooks-ensure.sh"; sourceTree = SOURCE_ROOT; };
+		GROK000201A1B2C3D4E5F719 /* cmux-grok-pretooluse.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-grok-pretooluse.sh"; sourceTree = SOURCE_ROOT; };
 		A5001000 /* cmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
 		B9000001A1B2C3D4E5F60719 /* cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmux.swift; sourceTree = "<group>"; };
@@ -2030,6 +2036,8 @@
 				B2E7294509CC42FE9191870E /* xterm-ghostty */,
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 				C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
+				GROK000101A1B2C3D4E5F719 /* cmux-grok-hooks-ensure.sh */,
+				GROK000201A1B2C3D4E5F719 /* cmux-grok-pretooluse.sh */,
 				C1ADE10001A1B2C3D4E5F719 /* grok */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -1079,6 +1079,78 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(feedEvents.first?["_ppid"] as? Int, 525252)
     }
 
+    func testGrokFeedDenyUsesGrokDecisionShape() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("grok-feed-deny")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-feed-deny-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "33333333-3333-3333-3333-333333333333"
+        let surfaceId = "44444444-4444-4444-4444-444444444444"
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: [
+                    "status": "resolved",
+                    "decision": [
+                        "kind": "permission",
+                        "mode": "deny",
+                    ],
+                ]
+            )
+        }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "feed", "--source", "grok", "--event", "PreToolUse"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "PWD": root.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_WORKSPACE_ID": workspaceId,
+                "CMUX_SURFACE_ID": surfaceId,
+                "CMUX_GROK_PID": "424242",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: #"{"hook_event_name":"PreToolUse","session_id":"grok-session-123","cwd":"\#(root.path)","toolName":"write","tool_input":{"path":"\#(root.appendingPathComponent("README.md").path)"}}"#,
+            timeout: 5
+        )
+        wait(for: [serverHandled], timeout: 5)
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), #"{"decision":"deny","reason":"User denied permission via cmux Feed."}"#)
+
+        let feedEvents = state.commands.compactMap { command -> [String: Any]? in
+            guard let payload = self.jsonObject(command),
+                  payload["method"] as? String == "feed.push",
+                  let params = payload["params"] as? [String: Any],
+                  let event = params["event"] as? [String: Any] else {
+                return nil
+            }
+            return event
+        }
+        XCTAssertEqual(feedEvents.count, 1, "Expected one Grok Feed event, saw \(state.commands)")
+        XCTAssertEqual(feedEvents.first?["hook_event_name"] as? String, "PermissionRequest")
+        XCTAssertEqual(feedEvents.first?["_source"] as? String, "grok")
+        XCTAssertEqual(feedEvents.first?["tool_name"] as? String, "write")
+    }
+
     /// The Feed permission modes that allow a tool (`once` / `always` / `all`
     /// / `bypass`, the WorkstreamPermissionMode raw values) must exit 0 so
     /// Kiro proceeds; an unrecognized/malformed mode must fail closed with
@@ -2867,6 +2939,28 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
         XCTAssertEqual(notificationTimeouts, [5])
         XCTAssertEqual(preToolUseTimeouts, [120])
+        let preToolUseCommands = preToolUseGroups
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+            .compactMap { $0["command"] as? String }
+        XCTAssertTrue(
+            preToolUseCommands.contains { $0.hasSuffix("/bin/cmux-grok-pretooluse.sh") },
+            "Expected Grok PreToolUse to use the fast-path pretool script, saw \(preToolUseCommands)"
+        )
+        XCTAssertFalse(
+            preToolUseCommands.contains { $0.contains("hooks feed --source grok --event PreToolUse") },
+            "Grok PreToolUse must not use the pinned feed one-liner, saw \(preToolUseCommands)"
+        )
+        let pretoolScript = root
+            .appendingPathComponent(".grok", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux-grok-pretooluse.sh", isDirectory: false)
+        let ensureScript = root
+            .appendingPathComponent(".grok", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("cmux-grok-hooks-ensure.sh", isDirectory: false)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: pretoolScript.path))
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: ensureScript.path))
         XCTAssertFalse(
             allCommands.contains { $0.contains("[ -n \"$CMUX_SURFACE_ID\" ]") },
             "Grok strips CMUX_* from hook subprocesses, so installed commands must not gate on CMUX_SURFACE_ID. Saw \(allCommands)"
@@ -2923,17 +3017,21 @@ extension CLINotifyProcessIntegrationRegressionTests {
             .compactMap { $0["command"] as? String }
 
         XCTAssertFalse(allCommands.isEmpty)
+        let pinnedDispatchCommands = allCommands.filter {
+            !$0.hasSuffix("/bin/cmux-grok-pretooluse.sh")
+        }
+        XCTAssertFalse(pinnedDispatchCommands.isEmpty)
         XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("cmux-grok-hook-v2") },
-            "Expected installed Grok hooks to carry the owned-hook marker, saw \(allCommands)"
+            pinnedDispatchCommands.allSatisfy { $0.contains("cmux-grok-hook-v2") },
+            "Expected pinned Grok hooks to carry the owned-hook marker, saw \(pinnedDispatchCommands)"
         )
         XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("'\(pinnedCLI.path)'") },
-            "Expected installed Grok hooks to pin the installing CLI path, saw \(allCommands)"
+            pinnedDispatchCommands.allSatisfy { $0.contains("'\(pinnedCLI.path)'") },
+            "Expected pinned Grok hooks to pin the installing CLI path, saw \(pinnedDispatchCommands)"
         )
         XCTAssertTrue(
-            allCommands.allSatisfy { $0.contains("--socket '\(socketPath)'") },
-            "Expected installed Grok hooks to pin the installing socket path, saw \(allCommands)"
+            pinnedDispatchCommands.allSatisfy { $0.contains("--socket '\(socketPath)'") },
+            "Expected pinned Grok hooks to pin the installing socket path, saw \(pinnedDispatchCommands)"
         )
         XCTAssertFalse(
             allCommands.contains { $0.contains("$CMUX_") },

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -93,6 +93,15 @@ struct FeedEventClassificationTests {
         #expect(classify("gemini", "PreToolUse", tool: "Read").actionable == false)
     }
 
+    /// Grok Build emits lowercase native tool names that must escalate like
+    /// Cursor-style `Write`/`Bash` names.
+    @Test func grokPreToolUseEscalatesNativeWriteAliases() {
+        #expect(classify("grok", "PreToolUse", tool: "Write").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "write").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "search_replace").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "read_file").actionable == false)
+    }
+
     /// Even on the maybe-approval (generic pre-tool) path, the two dedicated
     /// approval tool names route to their own wire kinds — they are never
     /// collapsed into a generic `PermissionRequest`. Guards the shared


### PR DESCRIPTION
## Summary

Fixes Grok Build + cmux integration issues that caused PreToolUse hook timeouts and incorrect Feed permission responses.

- **Fast-path PreToolUse**: Replace the pinned feed one-liner with bundled `cmux-grok-pretooluse.sh` that skips read-only tools, honors `always-approve`/`yolo` config, and only escalates side-effecting tools to cmux Feed.
- **Self-healing hooks**: `cmux-grok-hooks-ensure.sh` repairs hook JSON after `cmux hooks grok install` and on SessionStart.
- **Grok-shaped Feed decisions**: Emit `{"decision":"allow|deny","reason":"..."}` instead of generic `hookSpecificOutput` for Grok PreToolUse deny/allow.
- **Native tool aliases**: Classify lowercase Grok tool names (`write`, `search_replace`, `bash`, etc.) as actionable for Feed escalation.
- **Bundle scripts**: Ship both scripts in `Contents/Resources/bin/` and install to `~/.grok/bin/` on hook setup.

## Problem

Grok Build inside cmux suffered from:
1. PreToolUse hooks timing out (heavy pinned dispatch + 5s default timeout)
2. Feed decisions in wrong JSON shape for Grok's blocking hook contract
3. Lowercase native tool names not escalating to Feed approvals

Related: cmux#4220, cmux#5473 (similar antigravity pattern).

## Test plan

- [x] `grokPreToolUseEscalatesNativeWriteAliases` (Swift Testing)
- [x] `testGrokFeedDenyUsesGrokDecisionShape` (new)
- [x] `testGrokHookInstallRoutesNotificationEventToNotificationSubcommand` (updated for pretool script)
- [x] `testGrokHookInstallPinsInstallingCLIAndSocketWithoutCMUXInterpolation` (updated)
- [x] `testGrokHookInstallPreservesUserWrappedLegacyCommands`
- [x] `testGrokHookInstallPreservesLegacyFileMetadataWhenPruningOwnedHooks`
- [x] Integration: pretool fast-path for `read_file` / `always-approve` write tools
- [x] Integration: `cmux hooks grok install` installs scripts to `~/.grok/bin/`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784291209&installation_id=133855650&pr_number=6308&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6308&signature=c860267f1acd41eb686a190eac55555cee60c6af57dca7248fdcb0b171261e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Grok PreToolUse timeouts and wrong permission responses by fast-pathing through a bundled script and returning Grok-shaped Feed decisions. Installs self-healing hook scripts and classifies Grok-native tool names so only side-effecting tools block for approval.

- **Bug Fixes**
  - PreToolUse now runs via `cmux-grok-pretooluse.sh`, avoiding the pinned feed one‑liner that caused 5s+ timeouts; it skips read-only tools and honors `always-approve`/`yolo`.
  - Feed responses for Grok PreToolUse use `{"decision":"allow|deny","reason":"..."}`.
  - Lowercase Grok tool aliases (e.g., write, bash, search_replace) are classified as side-effecting and escalate to Feed.

- **New Features**
  - Bundle `cmux-grok-pretooluse.sh` and `cmux-grok-hooks-ensure.sh` and install to `~/.grok/bin/` during `cmux hooks grok install`.
  - Self-healing ensure script repairs `cmux-session.json` and keeps the pretool fast-path first in the PreToolUse chain.
  - Grok PreToolUse hook injection auto-references the pretool script with normalized timeouts; fallback to Feed only when needed.

<sup>Written for commit a1c3c8ca232f8014c88385ec21846dffe486d737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Grok integration with improved tool permission handling and feed classification
  * Added automated Grok hook script installation and maintenance

* **Tests**
  * Added comprehensive test coverage for Grok-specific permission decisions and hook installation verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->