### PR TITLE
fix: omo subagent respawn pane disappears on click

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22235,10 +22235,12 @@ struct CMUXCLI {
             // launcher) plus OPENCODE_PORT so the attach command resolves the
             // `opencode` binary and reaches the right server.
             var respawnStartupEnv: [String: String] = [:]
-            if let path = ProcessInfo.processInfo.environment["PATH"] {
+            if let path = ProcessInfo.processInfo.environment["PATH"],
+               !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 respawnStartupEnv["PATH"] = path
             }
-            if let port = ProcessInfo.processInfo.environment["OPENCODE_PORT"] {
+            if let port = ProcessInfo.processInfo.environment["OPENCODE_PORT"],
+               !port.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 respawnStartupEnv["OPENCODE_PORT"] = port
             }
             if !respawnStartupEnv.isEmpty {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -22228,6 +22228,22 @@ struct CMUXCLI {
                !cwd.isEmpty {
                 params["working_directory"] = resolvePath(cwd)
             }
+            // The respawned surface runs the command (e.g. an omo
+            // `opencode attach …` line) through a non-login `/bin/sh -c`, which
+            // does not load the user's shell rc files. Forward the caller
+            // process PATH (populated with provider bin dirs by the omo
+            // launcher) plus OPENCODE_PORT so the attach command resolves the
+            // `opencode` binary and reaches the right server.
+            var respawnStartupEnv: [String: String] = [:]
+            if let path = ProcessInfo.processInfo.environment["PATH"] {
+                respawnStartupEnv["PATH"] = path
+            }
+            if let port = ProcessInfo.processInfo.environment["OPENCODE_PORT"] {
+                respawnStartupEnv["OPENCODE_PORT"] = port
+            }
+            if !respawnStartupEnv.isEmpty {
+                params["startup_environment"] = respawnStartupEnv
+            }
             _ = try client.sendV2(method: "surface.respawn", params: params)
 
         case "send-keys", "send":

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -338,7 +338,8 @@ extension ControlCommandCoordinator {
             hasSurfaceIDParam: hasNonNull(params, "surface_id"),
             requestedSurfaceID: uuid(params, "surface_id"),
             hasFocusParam: hasFocusParam,
-            requestedFocus: bool(params, "focus") ?? false
+            requestedFocus: bool(params, "focus") ?? false,
+            startupEnvironment: trimmedStringMap(params, keys: ["startup_environment", "initial_env"])
         )
 
         let resolution = context?.controlSurfaceRespawn(routing: routing, inputs: inputs)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceRespawnInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceRespawnInputs.swift
@@ -27,6 +27,11 @@ public struct ControlSurfaceRespawnInputs: Sendable, Equatable {
     /// The parsed `focus` value (used only when `hasFocusParam`); the app applies
     /// the socket focus-allowance gate.
     public let requestedFocus: Bool
+    /// Additional environment variables to inject into the respawned surface,
+    /// merged on top of the surface's existing environment. Used by callers such
+    /// as the `__tmux-compat respawn-pane` shim to propagate agent-specific
+    /// variables (e.g. `OPENCODE_PORT`) that are not managed cmux context vars.
+    public let startupEnvironment: [String: String]
 
     /// Creates respawn inputs.
     public init(
@@ -36,7 +41,8 @@ public struct ControlSurfaceRespawnInputs: Sendable, Equatable {
         hasSurfaceIDParam: Bool,
         requestedSurfaceID: UUID?,
         hasFocusParam: Bool,
-        requestedFocus: Bool
+        requestedFocus: Bool,
+        startupEnvironment: [String: String] = [:]
     ) {
         self.command = command
         self.tmuxStartCommand = tmuxStartCommand
@@ -45,5 +51,6 @@ public struct ControlSurfaceRespawnInputs: Sendable, Equatable {
         self.requestedSurfaceID = requestedSurfaceID
         self.hasFocusParam = hasFocusParam
         self.requestedFocus = requestedFocus
+        self.startupEnvironment = startupEnvironment
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
@@ -63,6 +63,19 @@ extension TerminalSurface {
 
         var env = baseConfig.environmentVariables
 
+        // Seed PATH from a caller-supplied override before the managed PATH
+        // logic below runs. The managed logic reads env["PATH"] first and only
+        // prepends cmux's own bin dir on top, so seeding here lets a respawn
+        // caller (e.g. the __tmux-compat respawn-pane shim forwarding the omo
+        // launcher PATH) contribute provider bin dirs that the app process's
+        // own PATH lacks when launched from Finder. PATH is a managed/protected
+        // key, so without this seed the override would be dropped by
+        // mergedStartupEnvironment.
+        if let overridePath = initialEnvironmentOverrides["PATH"],
+           !overridePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            env["PATH"] = overridePath
+        }
+
         var protectedStartupEnvironmentKeys: Set<String> = []
         Self.applyManagedTerminalIdentityEnvironment(
             to: &env,

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -445,8 +445,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
-    /// Whether the surface stays open after its startup command exits.
-    public func debugWaitAfterCommand() -> Bool {
+    public var waitAfterCommand: Bool {
         configTemplate?.waitAfterCommand ?? false
     }
 

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/SurfaceCallbacks/TerminalSurfaceControlling.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/SurfaceCallbacks/TerminalSurfaceControlling.swift
@@ -17,4 +17,10 @@ public protocol TerminalSurfaceControlling: AnyObject {
     /// The live runtime surface pointer, or `nil` when the runtime surface
     /// does not currently exist.
     var runtimeSurfacePointer: ghostty_surface_t? { get }
+
+    /// Whether the surface was configured to stay open after its startup
+    /// command exits (`wait-after-command`). When `true` the host should
+    /// decline to handle `SHOW_CHILD_EXITED` so Ghostty can display its
+    /// built-in "Process exited. Press any key…" prompt.
+    var waitAfterCommand: Bool { get }
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttySurfaceCallbackContextTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttySurfaceCallbackContextTests.swift
@@ -7,15 +7,18 @@ private final class FakeSurfaceController: TerminalSurfaceControlling {
     let surfaceId: UUID
     let owningTabId: UUID
     var runtimeSurfacePointer: ghostty_surface_t?
+    var waitAfterCommand: Bool
 
     init(
         surfaceId: UUID = UUID(),
         owningTabId: UUID = UUID(),
-        runtimeSurfacePointer: ghostty_surface_t? = nil
+        runtimeSurfacePointer: ghostty_surface_t? = nil,
+        waitAfterCommand: Bool = false
     ) {
         self.surfaceId = surfaceId
         self.owningTabId = owningTabId
         self.runtimeSurfacePointer = runtimeSurfacePointer
+        self.waitAfterCommand = waitAfterCommand
     }
 }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2710,7 +2710,12 @@ class GhosttyApp {
             // The child (shell) exited. Ghostty will fall back to printing
             // "Process exited. Press any key..." into the terminal unless the host
             // handles this action. For cmux, the correct behavior is to close
-            // the panel immediately (no prompt).
+            // the panel immediately (no prompt) — UNLESS the surface was
+            // configured with wait-after-command, in which case we let Ghostty
+            // display its own exit prompt so the user can read any error output.
+            if callbackContext?.surfaceController?.waitAfterCommand == true {
+                return false
+            }
 #if DEBUG
             cmuxDebugLog(
                 "surface.action.showChildExited tab=\(callbackTabId?.uuidString.prefix(5) ?? "nil") " +

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -259,6 +259,7 @@ extension TerminalController {
             command: inputs.command,
             workingDirectory: inputs.workingDirectory,
             tmuxStartCommand: inputs.tmuxStartCommand,
+            startupEnvironment: inputs.startupEnvironment,
             focus: focus
         ) else {
             return .respawnFailed(surfaceId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7320,6 +7320,7 @@ final class Workspace: Identifiable, ObservableObject {
         command: String,
         workingDirectory: String? = nil,
         tmuxStartCommand: String? = nil,
+        startupEnvironment: [String: String] = [:],
         focus: Bool? = nil
     ) -> TerminalPanel? {
         guard let oldPanel = terminalPanel(for: panelId),
@@ -7331,7 +7332,10 @@ final class Workspace: Identifiable, ObservableObject {
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedCommand.isEmpty else { return nil }
 
-        let inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
+        var inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
+        var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+        template.waitAfterCommand = true
+        inheritedConfig = template
         let requestedWorkingDirectory = resolvedTerminalStartupWorkingDirectory(
             requestedWorkingDirectory: workingDirectory,
             sourcePanelId: panelId
@@ -7346,6 +7350,9 @@ final class Workspace: Identifiable, ObservableObject {
         let replacementTmuxStartCommand = (startCommand?.isEmpty == false) ? startCommand : trimmedCommand
         let focusPlacement = oldPanel.surface.focusPlacement
         let launchContext = oldPanel.surface.launchContext
+        let oldSeededWorkspaceEnvironment = oldPanel.seededWorkspaceEnvironment
+        let inheritedOverrides = oldPanel.surface.respawnInitialEnvironmentOverrides
+            .filter { oldSeededWorkspaceEnvironment[$0.key] != $0.value }
         // Drop env this surface inherited from its (possibly previous) workspace,
         // then re-fold the current workspace's env below, so a terminal moved
         // between workspaces respawns with the destination's variables rather than
@@ -7354,9 +7361,10 @@ final class Workspace: Identifiable, ObservableObject {
         // shares a workspace key keeps its value. configureNewTerminalPanel
         // re-records the seeded env for the replacement panel against the current
         // workspace.
-        let oldSeededWorkspaceEnvironment = oldPanel.seededWorkspaceEnvironment
-        let initialEnvironmentOverrides = oldPanel.surface.respawnInitialEnvironmentOverrides
-            .filter { oldSeededWorkspaceEnvironment[$0.key] != $0.value }
+        // Merge the caller-supplied startup environment on top — keys passed
+        // through startup_environment (e.g. PATH, OPENCODE_PORT from the
+        // __tmux-compat respawn-pane shim) take precedence over inherited env.
+        let initialEnvironmentOverrides = inheritedOverrides.merging(startupEnvironment) { _, new in new }
         let additionalEnvironment = startupEnvironmentMergingWorkspaceEnvironment(
             oldPanel.surface.respawnAdditionalEnvironment.filter { oldSeededWorkspaceEnvironment[$0.key] != $0.value }
         )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7364,7 +7364,9 @@ final class Workspace: Identifiable, ObservableObject {
         // Merge the caller-supplied startup environment on top — keys passed
         // through startup_environment (e.g. PATH, OPENCODE_PORT from the
         // __tmux-compat respawn-pane shim) take precedence over inherited env.
-        let initialEnvironmentOverrides = inheritedOverrides.merging(startupEnvironment) { _, new in new }
+        let initialEnvironmentOverrides = inheritedOverrides.merging(
+            Self.sanitizedWorkspaceEnvironment(startupEnvironment)
+        ) { _, new in new }
         let additionalEnvironment = startupEnvironmentMergingWorkspaceEnvironment(
             oldPanel.surface.respawnAdditionalEnvironment.filter { oldSeededWorkspaceEnvironment[$0.key] != $0.value }
         )

--- a/cmuxTests/WorkspaceSplitStartupCommandTests.swift
+++ b/cmuxTests/WorkspaceSplitStartupCommandTests.swift
@@ -259,7 +259,6 @@ final class WorkspaceSplitStartupCommandTests: XCTestCase {
         let originalTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(originalPanelId))
         let originalPaneCount = workspace.bonsplitController.allPaneIds.count
         let originalTabCount = workspace.bonsplitController.tabs(inPane: originalPane).count
-        let originalWaitAfterCommand = placeholderPanel.surface.debugWaitAfterCommand()
 
         let respawnedPanel = try XCTUnwrap(workspace.respawnTerminalSurface(
             panelId: originalPanelId,
@@ -280,7 +279,7 @@ final class WorkspaceSplitStartupCommandTests: XCTestCase {
         XCTAssertEqual(respawnedPanel.requestedWorkingDirectory, requestedDirectory)
         XCTAssertEqual(respawnedPanel.surface.debugInitialCommand(), attachCommand)
         XCTAssertEqual(respawnedPanel.surface.debugTmuxStartCommand(), attachCommand)
-        XCTAssertEqual(respawnedPanel.surface.debugWaitAfterCommand(), originalWaitAfterCommand)
+        XCTAssertTrue(respawnedPanel.surface.waitAfterCommand)
         for (key, value) in startupEnvironment {
             XCTAssertEqual(respawnedPanel.surface.startupEnvironmentValue(key), value)
         }


### PR DESCRIPTION
## Problem

When `cmux omo` spawns a subagent and the user clicks the placeholder pane
to attach, two compounding bugs cause the pane to fail:

1. **Pane disappears immediately** — `respawnTerminalSurface()` doesn't set
   `waitAfterCommand=true`, and the `SHOW_CHILD_EXITED` handler unconditionally
   closes the panel.

2. **opencode: command not found** — the respawned surface runs `/bin/sh -c` as
   a non-login shell without the user's rc files, so provider binaries
   (`opencode`) outside system PATH aren't found.

## Fix

1. Set `waitAfterCommand=true` on respawned surfaces and let Ghostty show
   its exit prompt when `waitAfterCommand` is true.

2. Add `startup_environment` support to `surface.respawn`, forwarding `PATH` +
   `OPENCODE_PORT` from the `__tmux-compat respawn-pane` handler.

## Files changed

10 files, +57 / −12 lines including unit test update.

- `CLI/cmux.swift` — forward PATH + OPENCODE_PORT
- `ControlSurfaceRespawnInputs.swift` — add startupEnvironment field
- `ControlCommandCoordinator+Surface.swift` — parse startup_environment
- `TerminalController+ControlSurfaceContext2.swift` — forward to respawn
- `Workspace.swift` — accept startupEnvironment, set waitAfterCommand=true
- `TerminalSurfaceControlling.swift` — add waitAfterCommand protocol requirement
- `TerminalSurface.swift` — implement waitAfterCommand
- `GhosttyTerminalView.swift` — defer to Ghostty prompt when waitAfterCommand
- `GhosttySurfaceCallbackContextTests.swift` — update test stub
- `WorkspaceSplitStartupCommandTests.swift` — update test assertion

## Testing

- Unit test: `WorkspaceSplitStartupCommandTests` updated to assert respawned
  panel has `waitAfterCommand=true`
- Test stub: `FakeSurfaceController` updated for new protocol requirement
- Manual: omo subagent pane now stays open and shows attach output

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784293477&installation_id=133855650&pr_number=6309&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6309&signature=9831c95b150ee35eace58763ac05d16ec8256bf766b87928adf1a24a77a30836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the omo subagent attach pane disappearing on click. Respawned panes now stay open and show Ghostty’s exit prompt when needed, and the attach command reliably finds `opencode` via sanitized `PATH`/`OPENCODE_PORT` forwarding with `PATH` seeding.

- **Bug Fixes**
  - Force `waitAfterCommand=true` on respawn and expose `waitAfterCommand` via the surface controller; on child exit the host returns false so Ghostty shows its exit prompt instead of closing.
  - Add `startup_environment` (alias `initial_env`) to `surface.respawn`; the CLI forwards non-empty `PATH` and `OPENCODE_PORT` from `__tmux-compat respawn-pane`, Workspace sanitizes and merges them over inherited env, and the terminal seeds the forwarded `PATH` before cmux’s managed PATH logic so `/bin/sh -c` resolves `opencode` even when the app was launched from Finder.

<sup>Written for commit 7d4f5bff9405767ad6c05d0675543fa75d5b1eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal respawn now forwards configured startup environment values so the replacement session can reconnect/attach reliably (including key connectivity settings like `PATH` and port info).

* **Improvements**
  * “Wait after command” is now respected during respawn and exit handling, allowing Ghostty’s built-in exit prompt to appear when enabled.
  * Surface status now exposes `waitAfterCommand` as a direct property for clearer host behavior.

* **Tests**
  * Updated respawn test coverage to assert the new `waitAfterCommand` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->