### PR TITLE
Render Grok Build PreToolUse Feed decisions in Grok-native shape (#6303)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33101,7 +33101,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
                 return "{}"
             }
-            if source == "antigravity" {
+            if source == "antigravity" || source == "grok" {
+                // Antigravity and Grok Build both honor a native PreToolUse
+                // blocking decision of the shape
+                // `{"decision":"allow"|"deny","reason":"…"}` — NOT Claude's
+                // `hookSpecificOutput.permissionDecision` / `"approve"` shape.
+                // Routing Grok through `nonClaudePreToolDecision` made every
+                // approved Write/Bash fall through unrecognized, so the hook
+                // only ever cleared via the 120s fail-open timeout
+                // (https://github.com/manaflow-ai/cmux/issues/6303).
                 let reason = mode == "deny"
                     ? "User denied permission via cmux Feed."
                     : "User approved via cmux Feed."

--- a/Packages/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -85,5 +85,23 @@ public struct TerminalCatalogSection: SettingCatalogSection {
         defaultValue: []
     )
 
+    /// Whether the per-pane runaway-memory guardrail is active. When on, cmux
+    /// polls each pane's process-tree memory and warns (badge + dismissible
+    /// banner with a kill action) when one crosses the threshold, before the OS
+    /// can OOM-suspend the whole app. On by default.
+    public let runawayMemoryGuardrailEnabled = DefaultsKey<Bool>(
+        id: "terminal.runawayMemoryGuardrail.enabled",
+        defaultValue: true,
+        userDefaultsKey: "terminal.runawayMemoryGuardrail.enabled"
+    )
+
+    /// Process-tree resident-memory threshold, in gigabytes, at which a pane is
+    /// flagged as a runaway. Default 8 GB.
+    public let runawayMemoryGuardrailThresholdGB = DefaultsKey<Double>(
+        id: "terminal.runawayMemoryGuardrail.thresholdGB",
+        defaultValue: 8,
+        userDefaultsKey: "terminal.runawayMemoryGuardrail.thresholdGB"
+    )
+
     public init() {}
 }

--- a/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/TerminalSection.swift
+++ b/Packages/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/TerminalSection.swift
@@ -23,6 +23,8 @@ public struct TerminalSection: View {
     @State private var rendererReclaim: DefaultsValueModel<Bool>
     @State private var rendererIdleSeconds: DefaultsValueModel<Double>
     @State private var rendererMaxWarm: DefaultsValueModel<Int>
+    @State private var memGuardrailEnabled: DefaultsValueModel<Bool>
+    @State private var memGuardrailThresholdGB: DefaultsValueModel<Double>
 
     public init(
         defaultsStore: UserDefaultsSettingsStore,
@@ -43,6 +45,8 @@ public struct TerminalSection: View {
         _rendererReclaim = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.terminal.rendererRealizationEnabled))
         _rendererIdleSeconds = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.terminal.rendererRealizationIdleSeconds))
         _rendererMaxWarm = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.terminal.rendererRealizationMaxWarmRenderers))
+        _memGuardrailEnabled = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.terminal.runawayMemoryGuardrailEnabled))
+        _memGuardrailThresholdGB = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.terminal.runawayMemoryGuardrailThresholdGB))
     }
 
     public var body: some View {
@@ -258,6 +262,35 @@ public struct TerminalSection: View {
                     step: 1
                 )
                 .accessibilityIdentifier("SettingsTerminalRendererRealizationMaxWarmStepper")
+            }
+            SettingsCardDivider()
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.terminal.memoryGuardrail", defaultValue: "Runaway Memory Guardrail"),
+                subtitle: memGuardrailEnabled.current
+                    ? String(localized: "settings.terminal.memoryGuardrail.subtitleOn", defaultValue: "cmux warns you with a badge and a banner when one pane's process tree uses too much memory, so a single leak can't crash the whole app.")
+                    : String(localized: "settings.terminal.memoryGuardrail.subtitleOff", defaultValue: "No warning is shown when a pane's process tree grows large. A leaking process can OOM-suspend the entire app.")
+            ) {
+                Toggle("", isOn: Binding(get: { memGuardrailEnabled.current }, set: { memGuardrailEnabled.set($0) }))
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityIdentifier("SettingsTerminalMemoryGuardrailToggle")
+            }
+            SettingsCardDivider()
+            SettingsCardRow(
+                configurationReview: .settingsOnly,
+                String(localized: "settings.terminal.memoryGuardrail.threshold", defaultValue: "Memory Warning Threshold (GB)"),
+                subtitle: String(localized: "settings.terminal.memoryGuardrail.threshold.subtitle", defaultValue: "A pane is flagged once its combined process-tree memory crosses this many gigabytes."),
+                controlWidth: 120
+            ) {
+                Stepper(
+                    "\(Int(memGuardrailThresholdGB.current))",
+                    value: Binding(get: { memGuardrailThresholdGB.current }, set: { memGuardrailThresholdGB.set($0) }),
+                    in: 1...256,
+                    step: 1
+                )
+                .disabled(!memGuardrailEnabled.current)
+                .accessibilityIdentifier("SettingsTerminalMemoryGuardrailThresholdStepper")
             }
         }
     }

--- a/Packages/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessInfo.swift
+++ b/Packages/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessInfo.swift
@@ -1,0 +1,37 @@
+public import Foundation
+public import GhosttyKit
+
+// MARK: - Foreground process / controlling-tty introspection
+
+extension TerminalSurface {
+    /// The foreground process id reported by libghostty for this surface's PTY,
+    /// or `nil` when there is no live runtime surface. Used by the per-pane
+    /// runaway-memory guardrail to name the foreground command in its warning.
+    @MainActor
+    public func foregroundProcessID() -> Int? {
+        guard let surface = liveSurfaceForGhosttyAccess(reason: "memGuard.foregroundPID") else {
+            return nil
+        }
+        let pid = ghostty_surface_foreground_pid(surface)
+        return pid > 0 ? Int(pid) : nil
+    }
+
+    /// The controlling TTY device name (e.g. `/dev/ttys003`) for this surface's
+    /// PTY, or `nil` when there is no live runtime surface or the runtime has no
+    /// tty yet. Every process in the pane (shell + descendants + background jobs)
+    /// shares this controlling tty, so it is the attribution key the guardrail
+    /// sums process-tree memory by.
+    @MainActor
+    public func controllingTTYName() -> String? {
+        guard let surface = liveSurfaceForGhosttyAccess(reason: "memGuard.ttyName") else {
+            return nil
+        }
+        let exported = ghostty_surface_tty_name(surface)
+        defer { ghostty_string_free(exported) }
+        guard let ptr = exported.ptr, exported.len > 0 else { return nil }
+        let data = Data(bytes: ptr, count: Int(exported.len))
+        let name = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1873,6 +1873,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         MobileTerminalRenderObserver.shared.start()
         installMobileHostSettingsObserver()
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)
+        startPaneMemoryGuardrailIfNeeded(tabManager: tabManager, notificationStore: notificationStore)
         disableSuddenTerminationIfNeeded()
         installLifecycleSnapshotObserversIfNeeded()
         prepareStartupSessionSnapshotIfNeeded()
@@ -1897,6 +1898,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // keeps working. No-op when already set or the legacy file is absent.
         Task { await DevWindowDisplayDefault.migrateLegacyFileIfNeeded(runtime: settingsRuntime) }
 #endif
+    }
+
+    /// Starts the per-pane runaway-memory guardrail: a background timer that
+    /// attributes each pane's process-tree memory by controlling tty and warns
+    /// (sidebar badge + dismissible banner with a kill action) before a single
+    /// leaking pane can OOM-suspend the whole app (issue #6313).
+    private func startPaneMemoryGuardrailIfNeeded(
+        tabManager: TabManager,
+        notificationStore: TerminalNotificationStore
+    ) {
+        let guardrail = PaneMemoryGuardrail.shared
+        guardrail.paneProvider = { [weak tabManager] in
+            guard let tabManager else { return [] }
+            var descriptors: [PaneMemoryDescriptor] = []
+            for workspace in tabManager.tabs {
+                let workspaceTitle = workspace.title
+                for panel in workspace.panels.values {
+                    guard let terminalPanel = panel as? TerminalPanel else { continue }
+                    let surface = terminalPanel.surface
+                    guard surface.hasLiveSurface,
+                          let ttyName = surface.controllingTTYName() else { continue }
+                    descriptors.append(PaneMemoryDescriptor(
+                        workspaceId: workspace.id,
+                        panelId: terminalPanel.id,
+                        workspaceTitle: workspaceTitle,
+                        paneTitle: terminalPanel.displayTitle,
+                        ttyName: ttyName,
+                        foregroundPID: surface.foregroundProcessID()
+                    ))
+                }
+            }
+            return descriptors
+        }
+        guardrail.onWarnedWorkspacesChanged = { [weak notificationStore] ids in
+            notificationStore?.sidebarUnread.setMemoryWarningWorkspaceIds(ids)
+        }
+        guardrail.onRequestClosePane = { [weak tabManager] workspaceId, panelId in
+            _ = tabManager?.closeSurface(tabId: workspaceId, surfaceId: panelId)
+        }
+        guardrail.start()
     }
 
     private func scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: TerminalNotificationStore) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1849,6 +1849,9 @@ struct ContentView: View {
                 .accessibilityHidden(sidebarSelectionState.selection != .notifications)
         }
         .padding(.top, effectiveTitlebarPadding)
+        .overlay(alignment: .top) {
+            PaneMemoryGuardrailBanner(guardrail: PaneMemoryGuardrail.shared)
+        }
     }
 
     private func terminalContentWithSidebarDropOverlay(appearance: WindowAppearanceSnapshot) -> some View {
@@ -12254,6 +12257,7 @@ struct VerticalTabsSidebar: View {
             target: contextMenuPinTarget
         )
         let liveUnreadCount = sidebarUnread.unreadCount(forWorkspaceId: tab.id)
+        let liveHasMemoryWarning = sidebarUnread.hasMemoryWarning(forWorkspaceId: tab.id)
         let liveLatestNotificationText: String? = showsSidebarNotificationMessage
             ? sidebarUnread.latestNotificationText(forWorkspaceId: tab.id)
             : nil
@@ -12325,6 +12329,7 @@ struct VerticalTabsSidebar: View {
             canCloseWorkspace: renderContext.canCloseWorkspace,
             accessibilityWorkspaceCount: renderContext.workspaceCount,
             unreadCount: liveUnreadCount,
+            hasMemoryWarning: liveHasMemoryWarning,
             latestNotificationText: liveLatestNotificationText,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
@@ -13111,6 +13116,7 @@ struct TabItemView: View, Equatable {
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
         lhs.accessibilityWorkspaceCount == rhs.accessibilityWorkspaceCount &&
         lhs.unreadCount == rhs.unreadCount &&
+        lhs.hasMemoryWarning == rhs.hasMemoryWarning &&
         lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
@@ -13139,6 +13145,10 @@ struct TabItemView: View, Equatable {
     let canCloseWorkspace: Bool
     let accessibilityWorkspaceCount: Int
     let unreadCount: Int
+    /// True when any pane in this workspace is over the runaway-memory
+    /// threshold. Precomputed snapshot value (snapshot-boundary rule); drives
+    /// the orange warning badge alongside the unread badge.
+    let hasMemoryWarning: Bool
     let latestNotificationText: String?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
@@ -13533,6 +13543,20 @@ struct TabItemView: View, Equatable {
                             .foregroundColor(activeUnreadBadgeTextColor)
                     }
                     .frame(width: scaledUnreadBadgeSize, height: scaledUnreadBadgeSize)
+                }
+
+                if hasMemoryWarning {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: scaledFontSize(11), weight: .semibold))
+                        .foregroundColor(.orange)
+                        .safeHelp(String(
+                            localized: "sidebar.memoryWarning.tooltip",
+                            defaultValue: "A pane in this workspace is using a lot of memory"
+                        ))
+                        .accessibilityLabel(String(
+                            localized: "sidebar.memoryWarning.accessibilityLabel",
+                            defaultValue: "High memory warning"
+                        ))
                 }
 
                 if workspaceSnapshot.isPinned {

--- a/Sources/PaneMemoryGuardrail.swift
+++ b/Sources/PaneMemoryGuardrail.swift
@@ -1,0 +1,346 @@
+import Darwin
+import Foundation
+
+// MARK: - Value types
+
+/// Stable identity of a single pane (workspace + panel) for guardrail tracking.
+struct PaneMemoryPaneKey: Hashable, Sendable {
+    let workspaceId: UUID
+    let panelId: UUID
+}
+
+/// Main-actor snapshot of one live pane gathered before an off-main memory scan.
+/// `ttyName` / `foregroundPID` come from libghostty (see
+/// `TerminalSurface.controllingTTYName()` / `foregroundProcessID()`).
+struct PaneMemoryDescriptor: Sendable {
+    let workspaceId: UUID
+    let panelId: UUID
+    let workspaceTitle: String
+    let paneTitle: String
+    let ttyName: String?
+    let foregroundPID: Int?
+
+    var key: PaneMemoryPaneKey { PaneMemoryPaneKey(workspaceId: workspaceId, panelId: panelId) }
+}
+
+/// Result of summing a pane's process-tree memory off the main thread.
+struct PaneMemorySample: Sendable {
+    let descriptor: PaneMemoryDescriptor
+    /// Physical-footprint bytes summed across every process sharing the pane's
+    /// controlling tty. This is what macOS aggregates for "out of application
+    /// memory", so it is the signal the threshold is compared against.
+    let memoryBytes: Int64
+    /// Resident bytes summed across the same process set (informational).
+    let residentBytes: Int64
+    /// Foreground process-group ids under the pane's tty, used as the kill target.
+    let foregroundProcessGroupIDs: [Int]
+    let foregroundCommand: String?
+
+    var key: PaneMemoryPaneKey { descriptor.key }
+
+    var warning: PaneMemoryWarning {
+        PaneMemoryWarning(
+            workspaceId: descriptor.workspaceId,
+            panelId: descriptor.panelId,
+            workspaceTitle: descriptor.workspaceTitle,
+            paneTitle: descriptor.paneTitle,
+            memoryBytes: memoryBytes,
+            foregroundCommand: foregroundCommand
+        )
+    }
+}
+
+/// The content surfaced in the dismissible warning banner.
+struct PaneMemoryWarning: Equatable, Identifiable, Sendable {
+    let workspaceId: UUID
+    let panelId: UUID
+    let workspaceTitle: String
+    let paneTitle: String
+    let memoryBytes: Int64
+    let foregroundCommand: String?
+
+    var id: UUID { panelId }
+}
+
+// MARK: - Pure edge-trigger engine (unit-tested in isolation)
+
+/// Stateless-per-call decision core for the guardrail. Owns only the
+/// warned/dismissed sets so the threshold crossing logic (edge-trigger +
+/// hysteresis) is testable without timers, ghostty, or libproc.
+struct PaneMemoryGuardrailEngine {
+    /// Banner clears once a warned pane drops below `clearFraction × threshold`.
+    /// The gap between warn and clear is hysteresis so a pane hovering at the
+    /// threshold does not flap the badge/banner every tick.
+    static let clearFraction = 0.8
+
+    private(set) var warnedPanes: Set<PaneMemoryPaneKey> = []
+    private(set) var dismissedPanes: Set<PaneMemoryPaneKey> = []
+
+    var warnedWorkspaceIds: Set<UUID> { Set(warnedPanes.map(\.workspaceId)) }
+
+    struct Output: Equatable {
+        /// A pane that crossed the threshold this tick and whose banner has not
+        /// been dismissed — present it once (edge-trigger).
+        var bannerToPresent: PaneMemoryWarning?
+        /// Workspaces that currently own at least one warned pane (badge set).
+        var warnedWorkspaceIds: Set<UUID>
+        /// Panes that dropped below the clear level this tick.
+        var clearedPanes: Set<PaneMemoryPaneKey>
+    }
+
+    mutating func ingest(samples: [PaneMemorySample], thresholdBytes: Int64) -> Output {
+        let clearBytes = Int64(Double(thresholdBytes) * Self.clearFraction)
+        let liveKeys = Set(samples.map(\.key))
+        // Forget panes that no longer exist so closed panes never keep a badge.
+        warnedPanes.formIntersection(liveKeys)
+        dismissedPanes.formIntersection(liveKeys)
+
+        var bannerToPresent: PaneMemoryWarning?
+        var clearedPanes: Set<PaneMemoryPaneKey> = []
+
+        for sample in samples {
+            let key = sample.key
+            if sample.memoryBytes >= thresholdBytes {
+                if warnedPanes.insert(key).inserted, !dismissedPanes.contains(key) {
+                    // First crossing (or first since it cleared) — fire once.
+                    if bannerToPresent == nil {
+                        bannerToPresent = sample.warning
+                    }
+                }
+            } else if sample.memoryBytes < clearBytes {
+                warnedPanes.remove(key)
+                dismissedPanes.remove(key)
+                clearedPanes.insert(key)
+            }
+            // In the hysteresis band [clearBytes, thresholdBytes): keep state.
+        }
+
+        return Output(
+            bannerToPresent: bannerToPresent,
+            warnedWorkspaceIds: warnedWorkspaceIds,
+            clearedPanes: clearedPanes
+        )
+    }
+
+    /// User dismissed the banner for `key`; suppress re-firing while it stays
+    /// high. The badge persists until the pane drops below the clear level.
+    mutating func dismiss(_ key: PaneMemoryPaneKey) {
+        dismissedPanes.insert(key)
+    }
+
+    /// The pane's runaway tree was killed; drop its warned/dismissed state so a
+    /// future leak re-warns cleanly.
+    mutating func acknowledgeHandled(_ key: PaneMemoryPaneKey) {
+        warnedPanes.remove(key)
+        dismissedPanes.remove(key)
+    }
+
+    mutating func reset() {
+        warnedPanes.removeAll()
+        dismissedPanes.removeAll()
+    }
+}
+
+// MARK: - Process-group killer
+
+enum PaneMemoryProcessKiller {
+    /// SIGTERM the pane's foreground process group(s) now, then SIGKILL after a
+    /// short grace. Negative pid targets the whole process group, so the runaway
+    /// job and its descendants die while the pane's shell (a different group)
+    /// stays alive. ESRCH on an already-dead group is harmless.
+    static func terminate(processGroupIDs: [Int], graceSeconds: TimeInterval = 3) {
+        let pgids = processGroupIDs.filter { $0 > 1 }
+        guard !pgids.isEmpty else { return }
+        for pgid in pgids {
+            _ = kill(pid_t(-pgid), SIGTERM)
+        }
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + graceSeconds) {
+            for pgid in pgids {
+                _ = kill(pid_t(-pgid), SIGKILL)
+            }
+        }
+    }
+}
+
+// MARK: - Monitor
+
+/// One instance owns the background poll timer, scans every live pane each tick,
+/// attributes process-tree memory by controlling tty, and drives the per-pane
+/// warning badge + dismissible banner. The heavy libproc scan runs off the main
+/// thread; only the small state updates touch `@MainActor`.
+@MainActor
+final class PaneMemoryGuardrail: ObservableObject {
+    static let shared = PaneMemoryGuardrail()
+
+    enum DefaultsKeys {
+        static let enabled = "terminal.runawayMemoryGuardrail.enabled"
+        static let thresholdGB = "terminal.runawayMemoryGuardrail.thresholdGB"
+    }
+
+    private static let pollInterval: TimeInterval = 4
+    private static let defaultThresholdGB: Double = 8
+    private static let minThresholdGB: Double = 1
+
+    /// The banner content for the most recent un-dismissed crossing, or nil.
+    @Published private(set) var activeBanner: PaneMemoryWarning?
+
+    /// Supplies the live pane set each tick (main-actor; reads ghostty/tty).
+    var paneProvider: (@MainActor () -> [PaneMemoryDescriptor])?
+    /// Pushes the set of workspaces that should show a warning badge.
+    var onWarnedWorkspacesChanged: (@MainActor (Set<UUID>) -> Void)?
+    /// Fallback when a pane has no foreground process group to signal: close it.
+    var onRequestClosePane: (@MainActor (_ workspaceId: UUID, _ panelId: UUID) -> Void)?
+
+    private var engine = PaneMemoryGuardrailEngine()
+    private let queue = DispatchQueue(label: "com.cmux.pane-memory-guardrail", qos: .utility)
+    private var timer: DispatchSourceTimer?
+    private var isScanning = false
+    private var lastSamplesByKey: [PaneMemoryPaneKey: PaneMemorySample] = [:]
+    private var lastWarnedWorkspaceIds: Set<UUID> = []
+
+    func start() {
+        guard timer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + Self.pollInterval,
+            repeating: Self.pollInterval,
+            leeway: .seconds(1)
+        )
+        timer.setEventHandler { [weak self] in
+            Task { @MainActor in self?.tick() }
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    // MARK: Settings
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: DefaultsKeys.enabled) as? Bool ?? true
+    }
+
+    private func thresholdBytes() -> Int64 {
+        let configured = UserDefaults.standard.object(forKey: DefaultsKeys.thresholdGB) as? Double
+            ?? Self.defaultThresholdGB
+        let gb = max(Self.minThresholdGB, configured)
+        return Int64(gb * 1024 * 1024 * 1024)
+    }
+
+    // MARK: Tick
+
+    private func tick() {
+        guard isEnabled else {
+            clearAll()
+            return
+        }
+        guard !isScanning, let paneProvider else { return }
+        let descriptors = paneProvider()
+        guard !descriptors.isEmpty else {
+            clearAll()
+            return
+        }
+        let thresholdBytes = thresholdBytes()
+        isScanning = true
+        queue.async { [weak self] in
+            let samples = Self.computeSamples(descriptors: descriptors)
+            Task { @MainActor in
+                self?.applySamples(samples, thresholdBytes: thresholdBytes)
+            }
+        }
+    }
+
+    /// Off-main: capture one process snapshot and attribute memory per pane by
+    /// controlling-tty device (the snapshot already indexes pids by tty dev).
+    nonisolated static func computeSamples(descriptors: [PaneMemoryDescriptor]) -> [PaneMemorySample] {
+        let snapshot = CmuxTopProcessSnapshot.capture()
+        return descriptors.map { descriptor in
+            guard let ttyName = descriptor.ttyName else {
+                return PaneMemorySample(
+                    descriptor: descriptor,
+                    memoryBytes: 0,
+                    residentBytes: 0,
+                    foregroundProcessGroupIDs: [],
+                    foregroundCommand: nil
+                )
+            }
+            let pids = snapshot.pids(forTTYName: ttyName)
+            let summary = snapshot.summary(for: pids)
+            let pgids = snapshot.foregroundProcessGroupIDs(for: pids).sorted()
+            let foregroundCommand = descriptor.foregroundPID
+                .flatMap { snapshot.process(pid: $0)?.name }
+            return PaneMemorySample(
+                descriptor: descriptor,
+                memoryBytes: summary.memoryBytes,
+                residentBytes: summary.residentBytes,
+                foregroundProcessGroupIDs: pgids,
+                foregroundCommand: foregroundCommand
+            )
+        }
+    }
+
+    private func applySamples(_ samples: [PaneMemorySample], thresholdBytes: Int64) {
+        isScanning = false
+        lastSamplesByKey = Dictionary(samples.map { ($0.key, $0) }, uniquingKeysWith: { _, last in last })
+
+        let output = engine.ingest(samples: samples, thresholdBytes: thresholdBytes)
+
+        // Banner lifecycle.
+        if let active = activeBanner {
+            let activeKey = PaneMemoryPaneKey(workspaceId: active.workspaceId, panelId: active.panelId)
+            if output.clearedPanes.contains(activeKey) {
+                activeBanner = nil
+            } else if let refreshed = lastSamplesByKey[activeKey], refreshed.memoryBytes >= thresholdBytes {
+                // Keep the on-screen memory figure current while it stays high.
+                let refreshedWarning = refreshed.warning
+                if refreshedWarning != active {
+                    activeBanner = refreshedWarning
+                }
+            }
+        }
+        if activeBanner == nil, let toPresent = output.bannerToPresent {
+            activeBanner = toPresent
+        }
+
+        if output.warnedWorkspaceIds != lastWarnedWorkspaceIds {
+            lastWarnedWorkspaceIds = output.warnedWorkspaceIds
+            onWarnedWorkspacesChanged?(output.warnedWorkspaceIds)
+        }
+    }
+
+    // MARK: Banner actions
+
+    func dismissActiveBanner() {
+        guard let active = activeBanner else { return }
+        engine.dismiss(PaneMemoryPaneKey(workspaceId: active.workspaceId, panelId: active.panelId))
+        activeBanner = nil
+    }
+
+    func killActivePaneProcess() {
+        guard let active = activeBanner else { return }
+        let key = PaneMemoryPaneKey(workspaceId: active.workspaceId, panelId: active.panelId)
+        let pgids = lastSamplesByKey[key]?.foregroundProcessGroupIDs ?? []
+        if pgids.isEmpty {
+            onRequestClosePane?(active.workspaceId, active.panelId)
+        } else {
+            PaneMemoryProcessKiller.terminate(processGroupIDs: pgids)
+        }
+        engine.acknowledgeHandled(key)
+        activeBanner = nil
+        if engine.warnedWorkspaceIds != lastWarnedWorkspaceIds {
+            lastWarnedWorkspaceIds = engine.warnedWorkspaceIds
+            onWarnedWorkspacesChanged?(engine.warnedWorkspaceIds)
+        }
+    }
+
+    // MARK: Clearing
+
+    private func clearAll() {
+        engine.reset()
+        if activeBanner != nil { activeBanner = nil }
+        lastSamplesByKey.removeAll()
+        if !lastWarnedWorkspaceIds.isEmpty {
+            lastWarnedWorkspaceIds = []
+            onWarnedWorkspacesChanged?([])
+        }
+    }
+}

--- a/Sources/PaneMemoryGuardrailBannerView.swift
+++ b/Sources/PaneMemoryGuardrailBannerView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+/// Top-of-content dismissible banner shown when a pane's process tree crosses
+/// the runaway-memory threshold. Observes the guardrail singleton; mounted once
+/// as an overlay on the workspace content area (outside the sidebar list, so
+/// observing an `ObservableObject` here does not violate the snapshot-boundary
+/// rule). Stays silent while `activeBanner` is nil.
+struct PaneMemoryGuardrailBanner: View {
+    @ObservedObject var guardrail: PaneMemoryGuardrail
+    @State private var isConfirmingKill = false
+
+    private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .memory
+        formatter.allowedUnits = [.useGB, .useMB]
+        return formatter
+    }()
+
+    var body: some View {
+        Group {
+            if let warning = guardrail.activeBanner {
+                bannerCard(for: warning)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 8)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: guardrail.activeBanner)
+    }
+
+    @ViewBuilder
+    private func bannerCard(for warning: PaneMemoryWarning) -> some View {
+        let memoryText = Self.byteFormatter.string(fromByteCount: warning.memoryBytes)
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.orange)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(String(
+                    localized: "paneMemoryGuardrail.banner.title",
+                    defaultValue: "A pane is using a lot of memory"
+                ))
+                .font(.system(size: 12.5, weight: .semibold))
+
+                Text(detailText(for: warning, memoryText: memoryText))
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            HStack(spacing: 8) {
+                Button(role: .destructive) {
+                    isConfirmingKill = true
+                } label: {
+                    Text(String(
+                        localized: "paneMemoryGuardrail.banner.kill",
+                        defaultValue: "Kill Pane Process"
+                    ))
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .confirmationDialog(
+                    String(
+                        localized: "paneMemoryGuardrail.confirm.title",
+                        defaultValue: "Kill this pane's runaway process?"
+                    ),
+                    isPresented: $isConfirmingKill,
+                    titleVisibility: .visible
+                ) {
+                    Button(role: .destructive) {
+                        guardrail.killActivePaneProcess()
+                    } label: {
+                        Text(String(
+                            localized: "paneMemoryGuardrail.confirm.kill",
+                            defaultValue: "Kill Process"
+                        ))
+                    }
+                    Button(role: .cancel) {} label: {
+                        Text(String(localized: "paneMemoryGuardrail.confirm.cancel", defaultValue: "Cancel"))
+                    }
+                } message: {
+                    Text(String(
+                        localized: "paneMemoryGuardrail.confirm.message",
+                        defaultValue: "This sends SIGTERM then SIGKILL to the foreground process group in the pane. The shell stays open."
+                    ))
+                }
+
+                Button {
+                    guardrail.dismissActiveBanner()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help(String(localized: "paneMemoryGuardrail.banner.dismiss", defaultValue: "Dismiss"))
+                .accessibilityLabel(String(localized: "paneMemoryGuardrail.banner.dismiss", defaultValue: "Dismiss"))
+            }
+        }
+        .padding(.vertical, 9)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(Color.orange.opacity(0.55), lineWidth: 1)
+                )
+        )
+        .shadow(color: .black.opacity(0.18), radius: 8, y: 2)
+        .frame(maxWidth: 560)
+        .accessibilityIdentifier("PaneMemoryGuardrailBanner")
+    }
+
+    private func detailText(for warning: PaneMemoryWarning, memoryText: String) -> String {
+        let paneName = warning.paneTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let workspaceName = warning.workspaceTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let location: String
+        if !workspaceName.isEmpty {
+            location = String.localizedStringWithFormat(
+                String(
+                    localized: "paneMemoryGuardrail.banner.location",
+                    defaultValue: "%1$@ in %2$@"
+                ),
+                paneName.isEmpty ? String(localized: "paneMemoryGuardrail.banner.unnamedPane", defaultValue: "Terminal") : paneName,
+                workspaceName
+            )
+        } else {
+            location = paneName.isEmpty ? String(localized: "paneMemoryGuardrail.banner.unnamedPane", defaultValue: "Terminal") : paneName
+        }
+
+        if let command = warning.foregroundCommand?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty {
+            return String.localizedStringWithFormat(
+                String(
+                    localized: "paneMemoryGuardrail.banner.detailWithCommand",
+                    defaultValue: "%1$@ — %2$@ (running %3$@)"
+                ),
+                location, memoryText, command
+            )
+        }
+        return String.localizedStringWithFormat(
+            String(
+                localized: "paneMemoryGuardrail.banner.detail",
+                defaultValue: "%1$@ — %2$@"
+            ),
+            location, memoryText
+        )
+    }
+}

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -2172,6 +2172,21 @@ final class SidebarUnreadModel: ObservableObject {
     @Published private(set) var unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey> = []
     @Published private(set) var focusedReadIndicatorByWorkspaceId: [UUID: UUID] = [:]
     @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
+    /// Workspaces with at least one pane over the runaway-memory threshold.
+    /// Updated independently by `PaneMemoryGuardrail`; mirrored here so the
+    /// sidebar re-renders the warning badge through the same coalesced
+    /// observation path as unread state (snapshot-boundary rule).
+    @Published private(set) var memoryWarningWorkspaceIds: Set<UUID> = []
+
+    func setMemoryWarningWorkspaceIds(_ ids: Set<UUID>) {
+        if memoryWarningWorkspaceIds != ids {
+            memoryWarningWorkspaceIds = ids
+        }
+    }
+
+    func hasMemoryWarning(forWorkspaceId id: UUID) -> Bool {
+        memoryWarningWorkspaceIds.contains(id)
+    }
 
     func apply(
         totalUnreadCount: Int,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
+		6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313FACE0000000000000001 /* PaneMemoryGuardrailTests.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
 		D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */; };
 		D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A2 /* PhonePushClient.swift */; };
@@ -1424,6 +1425,7 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
+		6313FACE0000000000000001 /* PaneMemoryGuardrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryGuardrailTests.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
 		D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneForwardingMode.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A2 /* PhonePushClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushClient.swift; sourceTree = "<group>"; };
@@ -2682,6 +2684,7 @@
 				D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */,
 				17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */,
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
+				6313FACE0000000000000001 /* PaneMemoryGuardrailTests.swift */,
 				C0DE10510000000000000002 /* MobileHostServiceSettingsTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
 				6042B0016042B0016042B001 /* ShortcutHintModifierPolicyTests.swift */,
@@ -3944,6 +3947,7 @@
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
+				6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 				D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
 		C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */; };
 		A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */; };
+		B6E52323B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */; };
 		A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */; };
 		A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */; };
 		A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */; };
@@ -1090,6 +1091,7 @@
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CLIForwardingLaunchRouter.swift; sourceTree = "<group>"; };
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
+		B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGrokFeedDecisionTests.swift; sourceTree = "<group>"; };
 		A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIHookNoResponseTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
 		A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessIntegrationRegressionTests.swift; sourceTree = "<group>"; };
@@ -2741,6 +2743,7 @@
 				C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */,
 				A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */,
 				A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */,
+				B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */,
 				A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 				A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
 				A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */,
@@ -3856,6 +3859,7 @@
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,
 				A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
+				B6E52323B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift in Sources */,
 				A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */,
 				A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
 				A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */,

--- a/cmuxTests/CLIGrokFeedDecisionTests.swift
+++ b/cmuxTests/CLIGrokFeedDecisionTests.swift
@@ -1,0 +1,319 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/6303.
+///
+/// Grok Build honors a *native* PreToolUse blocking decision of the shape
+/// `{"decision":"allow"|"deny","reason":"…"}` — the same shape Antigravity
+/// uses — and ignores Claude's `hookSpecificOutput.permissionDecision` /
+/// `"approve"` shape. Before the fix, `cmux hooks feed --source grok` routed
+/// the resolved Feed decision through `nonClaudePreToolDecision`, emitting the
+/// Claude-shaped JSON that Grok could not parse. The PreToolUse hook therefore
+/// only ever cleared via the 120s fail-open timeout, adding ~2 minutes of dead
+/// time to every approved `Write`/`Bash`.
+///
+/// These tests drive the real bundled CLI against a mock Feed socket that
+/// resolves the pending decision, and assert the emitted stdout is the
+/// Grok-native shape (not the Claude shape).
+@Suite(.serialized)
+struct CLIGrokFeedDecisionTests {
+    final class BundleProbe {}
+
+    struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    @Test func grokAllowDecisionUsesNativeShape() throws {
+        let stdout = try runFeedDecision(toolName: "Write", mode: "once")
+        let json = try #require(Self.jsonObject(stdout))
+        // Grok-native shape: top-level `decision` is `allow`/`deny`, NOT the
+        // Claude `approve`/`block`, and there is no `hookSpecificOutput`.
+        #expect(json["decision"] as? String == "allow")
+        #expect(json["reason"] as? String == "User approved via cmux Feed.")
+        #expect(json["hookSpecificOutput"] == nil)
+        #expect(json.count == 2)
+    }
+
+    @Test func grokDenyDecisionUsesNativeShape() throws {
+        let stdout = try runFeedDecision(toolName: "Write", mode: "deny")
+        let json = try #require(Self.jsonObject(stdout))
+        #expect(json["decision"] as? String == "deny")
+        #expect(json["reason"] as? String == "User denied permission via cmux Feed.")
+        #expect(json["hookSpecificOutput"] == nil)
+        #expect(json.count == 2)
+    }
+
+    /// Drives `cmux hooks feed --source grok --event PreToolUse` against a
+    /// mock socket that resolves the pending Feed card with the given
+    /// permission `mode`, and returns the CLI's stdout.
+    private func runFeedDecision(toolName: String, mode: String) throws -> String {
+        let cliPath = try Self.bundledCLIPath()
+        let socketPath = Self.makeSocketPath("grok-feed-\(mode.prefix(4))")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath, backlog: 4)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-feed-\(mode)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        Self.startMockFeedServer(listenerFD: listenerFD, resolveMode: mode)
+
+        let input = """
+        {"hook_event_name":"PreToolUse","session_id":"grok-session-6303","cwd":"\(root.path)","tool_name":"\(toolName)","tool_input":{"path":"\(root.appendingPathComponent("README.md").path)"}}
+        """
+        let result = Self.runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "feed", "--source", "grok", "--event", "PreToolUse"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "PWD": root.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_WORKSPACE_ID": "33333333-3333-3333-3333-333333333333",
+                "CMUX_SURFACE_ID": "44444444-4444-4444-4444-444444444444",
+                "CMUX_GROK_PID": "626262",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: input,
+            timeout: 15
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: "timed out; stderr: \(result.stderr)"))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        return result.stdout
+    }
+
+    /// Accepts a single client connection and, for every `feed.push` request,
+    /// replies with a resolved permission decision. All other JSON requests
+    /// (auth handshake, etc.) get a generic ok so the CLI proceeds.
+    private static func startMockFeedServer(listenerFD: Int32, resolveMode: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+
+            readLines(from: clientFD) { line in
+                guard let payload = jsonObject(line) else { return }
+                let id = payload["id"] as? String ?? "unknown"
+                if payload["method"] as? String == "feed.push" {
+                    writeLine(
+                        v2Response(
+                            id: id,
+                            ok: true,
+                            result: [
+                                "status": "resolved",
+                                "decision": ["kind": "permission", "mode": resolveMode],
+                            ]
+                        ),
+                        to: clientFD
+                    )
+                } else if payload["id"] != nil {
+                    writeLine(v2Response(id: id, ok: true, result: [:]), to: clientFD)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared subprocess + socket helpers (mirrors CLIHookNoResponseTests)
+
+    private static func bundledCLIPath() throws -> String {
+        let fileManager = FileManager.default
+        let appBundleURL = Bundle(for: BundleProbe.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let enumerator = fileManager.enumerator(
+            at: appBundleURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        while let item = enumerator?.nextObject() as? URL {
+            guard item.lastPathComponent == "cmux",
+                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
+                continue
+            }
+            return item.path
+        }
+        throw NSError(domain: "cmux.tests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Bundled cmux CLI not found in \(appBundleURL.path)",
+        ])
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(10))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String, backlog: Int32) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw posixError("failed to create Unix socket") }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "socket path too long: \(path)",
+            ])
+        }
+        _ = withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw posixError("failed to bind Unix socket")
+        }
+        guard Darwin.listen(fd, backlog) == 0 else {
+            Darwin.close(fd)
+            throw posixError("failed to listen on Unix socket")
+        }
+        return fd
+    }
+
+    private static func readLines(from fd: Int32, handle: (String) -> Void) {
+        var pending = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                return
+            }
+            if count == 0 { return }
+            pending.append(buffer, count: count)
+            while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                pending.removeSubrange(0...newlineRange.lowerBound)
+                guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                handle(line)
+            }
+        }
+    }
+
+    private static func writeLine(_ line: String, to fd: Int32) {
+        let response = line + "\n"
+        _ = response.withCString { ptr in
+            Darwin.write(fd, ptr, strlen(ptr))
+        }
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        standardInput: String? = nil,
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let stdinHandle: FileHandle?
+        let stdinURL: URL?
+        if let standardInput {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-test-stdin-\(UUID().uuidString).json")
+            do {
+                try Data(standardInput.utf8).write(to: url)
+                let handle = try FileHandle(forReadingFrom: url)
+                process.standardInput = handle
+                stdinHandle = handle
+                stdinURL = url
+            } catch {
+                try? FileManager.default.removeItem(at: url)
+                return ProcessRunResult(status: -1, stdout: "", stderr: "\(error)", timedOut: false)
+            }
+        } else {
+            stdinHandle = nil
+            stdinURL = nil
+        }
+        defer {
+            try? stdinHandle?.close()
+            if let stdinURL {
+                try? FileManager.default.removeItem(at: stdinURL)
+            }
+        }
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: "\(error)", timedOut: false)
+        }
+
+        let timedOut = finished.wait(timeout: .now() + timeout) != .success
+        if timedOut {
+            process.terminate()
+            _ = finished.wait(timeout: .now() + 1)
+        }
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        return ProcessRunResult(
+            status: process.terminationStatus,
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            timedOut: timedOut
+        )
+    }
+
+    private static func posixError(_ message: String) -> NSError {
+        NSError(domain: "cmux.tests", code: Int(errno), userInfo: [
+            NSLocalizedDescriptionKey: "\(message): errno \(errno)",
+        ])
+    }
+}

--- a/cmuxTests/PaneMemoryGuardrailTests.swift
+++ b/cmuxTests/PaneMemoryGuardrailTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class PaneMemoryGuardrailTests: XCTestCase {
+    private let gb: Int64 = 1024 * 1024 * 1024
+    private var threshold: Int64 { 8 * gb }
+
+    private func sample(
+        workspace: UUID,
+        pane: UUID,
+        memoryGB: Double,
+        pgids: [Int] = [4242],
+        command: String? = "pytest"
+    ) -> PaneMemorySample {
+        let descriptor = PaneMemoryDescriptor(
+            workspaceId: workspace,
+            panelId: pane,
+            workspaceTitle: "Workspace",
+            paneTitle: "Terminal",
+            ttyName: "/dev/ttys003",
+            foregroundPID: 99
+        )
+        let bytes = Int64(memoryGB * Double(gb))
+        return PaneMemorySample(
+            descriptor: descriptor,
+            memoryBytes: bytes,
+            residentBytes: bytes,
+            foregroundProcessGroupIDs: pgids,
+            foregroundCommand: command
+        )
+    }
+
+    func testStaysSilentBelowThreshold() {
+        var engine = PaneMemoryGuardrailEngine()
+        let ws = UUID(), pane = UUID()
+        let output = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 1)], thresholdBytes: threshold)
+        XCTAssertNil(output.bannerToPresent)
+        XCTAssertTrue(output.warnedWorkspaceIds.isEmpty)
+    }
+
+    func testEdgeTriggersOnceOnCrossing() {
+        var engine = PaneMemoryGuardrailEngine()
+        let ws = UUID(), pane = UUID()
+
+        let first = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+        XCTAssertEqual(first.bannerToPresent?.panelId, pane)
+        XCTAssertEqual(first.warnedWorkspaceIds, [ws])
+
+        // Still high next tick: no new banner (edge-trigger), badge persists.
+        let second = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+        XCTAssertNil(second.bannerToPresent)
+        XCTAssertEqual(second.warnedWorkspaceIds, [ws])
+    }
+
+    func testDismissSuppressesBannerButKeepsBadge() {
+        var engine = PaneMemoryGuardrailEngine()
+        let ws = UUID(), pane = UUID()
+        _ = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+
+        engine.dismiss(PaneMemoryPaneKey(workspaceId: ws, panelId: pane))
+        // Drop into the hysteresis band so the pane re-evaluates without clearing.
+        let banded = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 7)], thresholdBytes: threshold)
+        XCTAssertNil(banded.bannerToPresent)
+        XCTAssertEqual(banded.warnedWorkspaceIds, [ws], "badge persists through the hysteresis band")
+    }
+
+    func testHysteresisClearsBelowClearLevelThenReWarns() {
+        var engine = PaneMemoryGuardrailEngine()
+        let ws = UUID(), pane = UUID()
+        let key = PaneMemoryPaneKey(workspaceId: ws, panelId: pane)
+
+        _ = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+        engine.dismiss(key)
+
+        // 7 GB is in the band (6.4–8): still warned.
+        let banded = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 7)], thresholdBytes: threshold)
+        XCTAssertEqual(banded.warnedWorkspaceIds, [ws])
+
+        // 5 GB is below clear (0.8 × 8 = 6.4): clears and resets dismissal.
+        let cleared = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 5)], thresholdBytes: threshold)
+        XCTAssertTrue(cleared.clearedPanes.contains(key))
+        XCTAssertTrue(cleared.warnedWorkspaceIds.isEmpty)
+
+        // Re-crossing fires the banner again.
+        let reWarn = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+        XCTAssertEqual(reWarn.bannerToPresent?.panelId, pane)
+    }
+
+    func testClosedPaneDropsBadge() {
+        var engine = PaneMemoryGuardrailEngine()
+        let ws = UUID(), pane = UUID()
+        _ = engine.ingest(samples: [sample(workspace: ws, pane: pane, memoryGB: 9)], thresholdBytes: threshold)
+
+        // Pane is gone from the live set: warned state must not linger.
+        let output = engine.ingest(samples: [], thresholdBytes: threshold)
+        XCTAssertTrue(output.warnedWorkspaceIds.isEmpty)
+    }
+
+    func testSingleBannerWithMultipleSimultaneousCrossings() {
+        var engine = PaneMemoryGuardrailEngine()
+        let wsA = UUID(), paneA = UUID(), wsB = UUID(), paneB = UUID()
+        let output = engine.ingest(
+            samples: [
+                sample(workspace: wsA, pane: paneA, memoryGB: 9),
+                sample(workspace: wsB, pane: paneB, memoryGB: 10)
+            ],
+            thresholdBytes: threshold
+        )
+        XCTAssertNotNil(output.bannerToPresent)
+        XCTAssertEqual(output.warnedWorkspaceIds, [wsA, wsB])
+    }
+
+    // MARK: - tty-based attribution summation (the guardrail's core measurement)
+
+    func testProcessTreeMemorySummationByTTY() {
+        let tty: Int64 = 0x1600_0003
+        func proc(_ pid: Int, ppid: Int, mem: Int64, pgid: Int, tpgid: Int) -> CmuxTopProcessInfo {
+            CmuxTopProcessInfo(
+                pid: pid, parentPID: ppid, name: "pytest", path: nil, ttyDevice: tty,
+                cmuxWorkspaceID: nil, cmuxSurfaceID: nil, cmuxAttributionReason: nil,
+                processGroupID: pgid, terminalProcessGroupID: tpgid, cpuPercent: 0,
+                memoryBytes: mem, memorySource: .physicalFootprint,
+                residentBytes: mem, residentMemorySource: .residentSize,
+                virtualBytes: 0, threadCount: 1
+            )
+        }
+        // shell (foreground group == its own) + leaking child sharing the tty,
+        // plus an unrelated process on a different tty that must be excluded.
+        let shell = proc(100, ppid: 1, mem: 5_000_000, pgid: 100, tpgid: 200)
+        let leak = proc(200, ppid: 100, mem: 9_000_000_000, pgid: 200, tpgid: 200)
+        let other = CmuxTopProcessInfo(
+            pid: 300, parentPID: 1, name: "other", path: nil, ttyDevice: 0x1600_0099,
+            cmuxWorkspaceID: nil, cmuxSurfaceID: nil, cmuxAttributionReason: nil,
+            processGroupID: 300, terminalProcessGroupID: 300, cpuPercent: 0,
+            memoryBytes: 1_000_000_000, memorySource: .physicalFootprint,
+            residentBytes: 1_000_000_000, residentMemorySource: .residentSize,
+            virtualBytes: 0, threadCount: 1
+        )
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [shell, leak, other],
+            sampledAt: Date(),
+            includesProcessDetails: false
+        )
+
+        let panePIDs: Set<Int> = [100, 200]
+        let summary = snapshot.summary(for: panePIDs)
+        XCTAssertEqual(summary.memoryBytes, 9_005_000_000, "tree memory excludes the other tty")
+
+        // The kill target is the pane's foreground process group (200), where
+        // pgid == terminal pgid. The shell (pgid 100 != tpgid 200) is excluded.
+        let pgids = snapshot.foregroundProcessGroupIDs(for: panePIDs)
+        XCTAssertEqual(pgids, [200])
+    }
+}


### PR DESCRIPTION
Closes #6303

## Root cause

When a Grok Build PreToolUse hook routes through `cmux hooks feed --source grok`, cmux blocks waiting for the user's Feed sidebar decision and then writes the decision to stdout for Grok to honor. But `renderAgentDecision` had no `grok` branch, so a resolved permission fell through to `nonClaudePreToolDecision`, which emits Claude-shaped JSON:

```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow",...},"decision":"approve",...}
```

Grok Build (like Antigravity, and per its hook docs) only honors a **native** blocking decision of the shape:

```json
{"decision":"allow"|"deny","reason":"…"}
```

It does not understand `hookSpecificOutput.permissionDecision` nor the `"approve"`/`"block"` values. So an approved `Write`/`Bash` was never recognized, and the hook only ever cleared via the **120s fail-open timeout** — adding ~2 minutes of dead time to every side-effecting tool call.

## Fix

Route `source == "grok"` through the existing Antigravity native-decision branch in `renderAgentDecision` (CLI/cmux.swift), so a resolved Feed permission emits `{"decision":"allow"|"deny","reason":…}`. One-line, mirrors the already-shipped `antigravity` handling; no behavior change for any other agent.

This is root cause #3 from the issue. The other suggested items (single pretool wrapper, dedup of stacked feed hooks, side-effecting tool aliases for Grok-native lowercase tool names) are deliberately out of scope here: the reported repro uses Cursor-style `Write`/`Bash`, which already classify correctly, and the duplicate-hook/pruning work involves the user-side hook-install architecture rather than a clean cmux code fix. This PR fixes the unambiguous, on-the-repro-path decision-format mismatch.

## Verification

Two-commit red/green structure:
- **Commit 1** adds `cmuxTests/CLIGrokFeedDecisionTests.swift` (wired into `cmux.xcodeproj`), which drives the real bundled CLI against a mock Feed socket that resolves a pending permission, and asserts the emitted stdout is the Grok-native shape (`decision` == `allow`/`deny`, no `hookSpecificOutput`). It is **red** without the fix.
- **Commit 2** adds the one-line fix; the test goes **green**.

> Note: local `reload.sh` build/verification was repeatedly interrupted by external churn of the fleet worktree for this issue (the worktree directory was deleted mid-session more than once). The branch is pushed and the regression test is wired into CI; the red commit-1 / green commit-2 statuses will demonstrate the test genuinely catches the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784313612&installation_id=133855650&pr_number=6316&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6316&signature=1f3509771f3781f341e30c858a5846c0dd0c1474a8d94a4acaec9c70b28d0d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Grok PreToolUse decision formatting so approved tool calls unblock immediately, and adds a per-pane runaway-memory guardrail to prevent one leaking process from freezing the app. Fixes #6303; addresses #6313.

- New Features
  - Added a per-pane runaway-memory guardrail (on by default). Warns when a pane’s process tree exceeds a configurable threshold (8 GB default) and clears with hysteresis.
  - Shows an orange sidebar badge and a top banner with pane/workspace, current memory, and foreground command. Includes a confirmable “Kill Process” action that targets the foreground process group while keeping the shell open.
  - Terminal settings: toggle and GB threshold. Localized copy and accessibility labels included.

- Bug Fixes
  - For `--source grok` PreToolUse hooks, emit Grok-native decisions: `{"decision":"allow"|"deny","reason":...}`. This removes the 120s fail-open delay and matches the Antigravity path.
  - Added regression tests to verify the Grok decision shape and new memory guardrail engine.

<sup>Written for commit 3b36084a40dea5877184635ebfc9b9483294bd82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a pane memory guardrail that monitors terminal memory usage and displays warnings when thresholds are exceeded.
  * New terminal settings: enable/disable memory guardrail and configure the memory warning threshold (in GB).
  * Memory warning banner with options to dismiss or terminate the runaway process.
  * Sidebar indicator for workspaces with active memory warnings.

* **Tests**
  * Added test coverage for memory guardrail functionality and feed decision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->