### PR TITLE
Enable terminal selection lookup

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4688,6 +4688,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = performBindingAction("copy_to_clipboard")
     }
 
+    @IBAction func lookUpSelection(_ sender: Any?) {
+        _ = showDefinitionForCurrentSelection()
+    }
+
+    @IBAction func showDefinitionForSelection(_ sender: Any?) {
+        _ = showDefinitionForCurrentSelection()
+    }
+
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
         guard let terminalSurface else { return }
         let paneId = terminalSurface.owningWorkspace()?.paneId(forPanelId: terminalSurface.id)?.id
@@ -4751,6 +4759,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case #selector(copy(_:)):
             guard let surface = surface else { return false }
             return ghostty_surface_has_selection(surface)
+        case #selector(lookUpSelection(_:)), #selector(showDefinitionForSelection(_:)):
+            return readLookupSelectionSnapshot() != nil
         case #selector(paste(_:)):
             return GhosttyApp.terminalPasteboard.hasString(for: GHOSTTY_CLIPBOARD_STANDARD)
         case #selector(pasteAsPlainText(_:)):
@@ -4762,6 +4772,55 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         default:
             return true
         }
+    }
+
+    @discardableResult
+    private func showDefinitionForCurrentSelection() -> Bool {
+        guard let snapshot = readLookupSelectionSnapshot() else { return false }
+        showDefinition(
+            for: NSAttributedString(string: snapshot.string),
+            at: definitionBaselineOrigin(for: snapshot)
+        )
+        return true
+    }
+
+    private func readLookupSelectionSnapshot() -> SelectionSnapshot? {
+        guard let snapshot = readSelectionSnapshot() else { return nil }
+        guard !snapshot.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return snapshot
+    }
+
+    private func definitionBaselineOrigin(for snapshot: SelectionSnapshot) -> NSPoint {
+        let x = min(max(snapshot.topLeft.x - 2, 0), max(bounds.width - 1, 0))
+        let yFromTop = snapshot.topLeft.y + 2
+        let y = min(max(bounds.height - yFromTop, 0), max(bounds.height - 1, 0))
+        return NSPoint(x: x, y: y)
+    }
+
+    private func lookupMenuTitle(for selection: String) -> String {
+        let collapsedSelection = selection
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let previewLimit = 48
+        let preview: String
+        if collapsedSelection.count > previewLimit {
+            let limited = collapsedSelection.prefix(previewLimit)
+            if let lastWhitespace = limited.lastIndex(where: { $0.isWhitespace }),
+               lastWhitespace > limited.startIndex {
+                preview = String(limited[..<lastWhitespace]) + "..."
+            } else {
+                preview = String(limited) + "..."
+            }
+        } else {
+            preview = collapsedSelection
+        }
+        let format = String(
+            localized: "terminalContextMenu.lookUpFormat",
+            defaultValue: "Look Up “%@”"
+        )
+        return String(format: format, preview)
     }
 
     // MARK: - Accessibility
@@ -5006,6 +5065,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
     func shouldSuppressShiftSpaceFallbackTextForTesting(event: NSEvent, markedTextBefore: Bool) -> Bool {
         shouldSuppressShiftSpaceFallbackText(event: event, markedTextBefore: markedTextBefore)
+    }
+    func lookupMenuTitleForTesting(_ selection: String) -> String {
+        lookupMenuTitle(for: selection)
     }
     // Test-only IME point override so firstRect behavior can be regression tested.
     private var imePointOverrideForTesting: (x: Double, y: Double, width: Double, height: Double)?
@@ -6772,6 +6834,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyEquivalent: ""
             )
             item.target = self
+            if let lookupSnapshot = readLookupSelectionSnapshot() {
+                let lookupItem = menu.addItem(
+                    withTitle: lookupMenuTitle(for: lookupSnapshot.string),
+                    action: #selector(lookUpSelection(_:)),
+                    keyEquivalent: ""
+                )
+                lookupItem.target = self
+            }
         }
         let pasteItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.paste", defaultValue: "Paste"),

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2758,6 +2758,15 @@ final class GhosttyResponderResolutionTests: XCTestCase {
             "Ghostty responder resolution must avoid NSTextView.delegate because AppKit exposes it as unsafe-unretained"
         )
     }
+
+    func testLookupMenuTitleUsesCompactSelectionPreview() {
+        let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let title = ghosttyView.lookupMenuTitleForTesting(
+            "  alpha\nbeta\tgamma delta epsilon zeta eta theta iota kappa lambda  "
+        )
+
+        XCTAssertEqual(title, "Look Up “alpha beta gamma delta epsilon zeta eta theta...”")
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a terminal selection lookup action that calls AppKit's native Dictionary/Look Up popover for selected Ghostty text.
- Adds the action to the terminal context menu when the selection has non-whitespace text, and wires the standard showDefinitionForSelection responder selector.
- Adds focused coverage for compact lookup menu preview titles.

## Testing
- `python3 -m json.tool Resources/Localizable.xcstrings >/tmp/cmux-localizable-check.json`
- `git diff --check`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-lookup build`\n- `xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-lookup build`\n\nLocal `xcodebuild test` was not run because repo policy forbids local test actions on the user Mac.\n\n## Localization\n- Reused existing `terminalContextMenu.lookUpFormat` translations in `Resources/Localizable.xcstrings` for English, Japanese, and Korean.\n- Parsed the string catalog successfully.\n\n## Issues\n- User request: enable looking up highlighted terminal text in cmux.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784313782&installation_id=133855650&pr_number=6317&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6317&signature=64ab623e066af7b02945fcfd8ead8f2746f95d9a9f222eebc5e1f471dd0c4dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Look Up action for selected terminal text that invokes `AppKit`’s native Dictionary popover and adds a context menu item when non‑whitespace text is selected. Also wires the standard `showDefinitionForSelection:` selector and compacts the menu title preview.

- **New Features**
  - Adds context menu item: Look Up “<compact preview>” using existing `terminalContextMenu.lookUpFormat` strings.
  - Implements `lookUpSelection:` and `showDefinitionForSelection:` to show the popover at the selection baseline.
  - Validates availability only when a non‑whitespace selection exists; includes a test for compact preview formatting.

<sup>Written for commit 176e5b9d0297f6f5e993504ab93d6c7495e402aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added definition lookup functionality for terminal text selections
  * Context menu now includes "Look Up..." option for selected text, enabling quick access to definitions

* **Tests**
  * Added test coverage for lookup menu title formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->