### PR TITLE
Fix Grok Build PreToolUse 120s Feed timeout + decision format mismatch (#6303)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,7 +1,7 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-34475	CLI/cmux.swift
+34483	CLI/cmux.swift
 17583	Sources/AppDelegate.swift
 16578	Sources/ContentView.swift
 14225	Sources/TerminalController.swift

--- a/CLI/FeedEventClassifier.swift
+++ b/CLI/FeedEventClassifier.swift
@@ -261,6 +261,33 @@ struct FeedEventClassifier {
         "generate_image",
     ]
 
+    /// Grok Build emits its own lowercase native tool names (`write`,
+    /// `search_replace`, `bash`, …) that are absent from ``sideEffectingTools``,
+    /// while its Cursor-compatible harness emits the capitalized `Write` /
+    /// `Bash` that already match. Without these aliases the same logical tool
+    /// classifies inconsistently depending on which harness emitted it. Matched
+    /// case-insensitively, but only for the `grok` source, so another agent's
+    /// lowercase tool name is never broadened into an approval prompt.
+    /// See https://github.com/manaflow-ai/cmux/issues/6303.
+    private static let grokSideEffectingToolAliases: Set<String> = [
+        "bash",
+        "shell",
+        "terminal",
+        "run_command",
+        "run_terminal_cmd",
+        "write",
+        "edit",
+        "multiedit",
+        "str_replace",
+        "search_replace",
+        "replace_file_content",
+        "multi_replace_file_content",
+        "write_to_file",
+        "create_file",
+        "delete_file",
+        "apply_patch",
+    ]
+
     /// Kiro emits lowercase / internal tool names (`fs_write`,
     /// `execute_bash`, `use_aws`, …) absent from ``sideEffectingTools``.
     /// Matched case-insensitively, but only for the `kiro` source, so another
@@ -292,10 +319,10 @@ struct FeedEventClassifier {
     ]
 
     /// Whether a tool mutates state and deserves an approval prompt. Exact
-    /// match against ``sideEffectingTools`` for every source; the `kiro`
-    /// source additionally matches its case-insensitive internal aliases.
-    /// Kept source-scoped so another agent's lowercase tool name is not
-    /// escalated into an approval.
+    /// match against ``sideEffectingTools`` for every source; the `kiro` and
+    /// `grok` sources additionally match their case-insensitive native
+    /// aliases. Kept source-scoped so another agent's lowercase tool name is
+    /// not escalated into an approval.
     static func isSideEffectingTool(_ toolName: String, source: String) -> Bool {
         guard !toolName.isEmpty else { return false }
         if sideEffectingTools.contains(toolName) {
@@ -303,6 +330,9 @@ struct FeedEventClassifier {
         }
         if source == "kiro" {
             return kiroSideEffectingToolAliases.contains(toolName.lowercased())
+        }
+        if source == "grok" {
+            return grokSideEffectingToolAliases.contains(toolName.lowercased())
         }
         return false
     }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -33372,7 +33372,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 }
                 return "{}"
             }
-            if source == "antigravity" {
+            if source == "antigravity" || source == "grok" {
+                // Antigravity and Grok Build both honor a native PreToolUse
+                // blocking decision of the shape
+                // `{"decision":"allow"|"deny","reason":"…"}` — NOT Claude's
+                // `hookSpecificOutput.permissionDecision` / `"approve"` shape.
+                // Routing Grok through `nonClaudePreToolDecision` made every
+                // approved Write/Bash fall through unrecognized, so the hook
+                // only ever cleared via the 120s fail-open timeout
+                // (https://github.com/manaflow-ai/cmux/issues/6303).
                 let reason = mode == "deny"
                     ? "User denied permission via cmux Feed."
                     : "User approved via cmux Feed."

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
 		C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */; };
 		A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */; };
+		B6E52323B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */; };
 		A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */; };
 		A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */; };
 		A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */; };
@@ -1169,6 +1170,7 @@
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CLIForwardingLaunchRouter.swift; sourceTree = "<group>"; };
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
+		B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGrokFeedDecisionTests.swift; sourceTree = "<group>"; };
 		A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIHookNoResponseTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
 		A5D41204A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLINotifyProcessIntegrationRegressionTests.swift; sourceTree = "<group>"; };
@@ -2961,6 +2963,7 @@
 				C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */,
 				A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */,
 				A5D41212A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift */,
+				B6E52324B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift */,
 				A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 				A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
 				A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */,
@@ -4135,6 +4138,7 @@
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,
 				A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
+				B6E52323B2C3D4E5F6071829 /* CLIGrokFeedDecisionTests.swift in Sources */,
 				A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */,
 				A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
 				A5D41203A1B2C3D4E5F60718 /* CLINotifyProcessIntegrationRegressionTests.swift in Sources */,

--- a/cmuxTests/CLIGrokFeedDecisionTests.swift
+++ b/cmuxTests/CLIGrokFeedDecisionTests.swift
@@ -1,0 +1,319 @@
+import Darwin
+import Foundation
+import Testing
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/6303.
+///
+/// Grok Build honors a *native* PreToolUse blocking decision of the shape
+/// `{"decision":"allow"|"deny","reason":"…"}` — the same shape Antigravity
+/// uses — and ignores Claude's `hookSpecificOutput.permissionDecision` /
+/// `"approve"` shape. Before the fix, `cmux hooks feed --source grok` routed
+/// the resolved Feed decision through `nonClaudePreToolDecision`, emitting the
+/// Claude-shaped JSON that Grok could not parse. The PreToolUse hook therefore
+/// only ever cleared via the 120s fail-open timeout, adding ~2 minutes of dead
+/// time to every approved `Write`/`Bash`.
+///
+/// These tests drive the real bundled CLI against a mock Feed socket that
+/// resolves the pending decision, and assert the emitted stdout is the
+/// Grok-native shape (not the Claude shape).
+@Suite(.serialized)
+struct CLIGrokFeedDecisionTests {
+    final class BundleProbe {}
+
+    struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    @Test func grokAllowDecisionUsesNativeShape() throws {
+        let stdout = try runFeedDecision(toolName: "Write", mode: "once")
+        let json = try #require(Self.jsonObject(stdout))
+        // Grok-native shape: top-level `decision` is `allow`/`deny`, NOT the
+        // Claude `approve`/`block`, and there is no `hookSpecificOutput`.
+        #expect(json["decision"] as? String == "allow")
+        #expect(json["reason"] as? String == "User approved via cmux Feed.")
+        #expect(json["hookSpecificOutput"] == nil)
+        #expect(json.count == 2)
+    }
+
+    @Test func grokDenyDecisionUsesNativeShape() throws {
+        let stdout = try runFeedDecision(toolName: "Write", mode: "deny")
+        let json = try #require(Self.jsonObject(stdout))
+        #expect(json["decision"] as? String == "deny")
+        #expect(json["reason"] as? String == "User denied permission via cmux Feed.")
+        #expect(json["hookSpecificOutput"] == nil)
+        #expect(json.count == 2)
+    }
+
+    /// Drives `cmux hooks feed --source grok --event PreToolUse` against a
+    /// mock socket that resolves the pending Feed card with the given
+    /// permission `mode`, and returns the CLI's stdout.
+    private func runFeedDecision(toolName: String, mode: String) throws -> String {
+        let cliPath = try Self.bundledCLIPath()
+        let socketPath = Self.makeSocketPath("grok-feed-\(mode.prefix(4))")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath, backlog: 4)
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-feed-\(mode)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        Self.startMockFeedServer(listenerFD: listenerFD, resolveMode: mode)
+
+        let input = """
+        {"hook_event_name":"PreToolUse","session_id":"grok-session-6303","cwd":"\(root.path)","tool_name":"\(toolName)","tool_input":{"path":"\(root.appendingPathComponent("README.md").path)"}}
+        """
+        let result = Self.runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "feed", "--source", "grok", "--event", "PreToolUse"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "PWD": root.path,
+                "CMUX_SOCKET_PATH": socketPath,
+                "CMUX_WORKSPACE_ID": "33333333-3333-3333-3333-333333333333",
+                "CMUX_SURFACE_ID": "44444444-4444-4444-4444-444444444444",
+                "CMUX_GROK_PID": "626262",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            standardInput: input,
+            timeout: 15
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: "timed out; stderr: \(result.stderr)"))
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        return result.stdout
+    }
+
+    /// Accepts a single client connection and, for every `feed.push` request,
+    /// replies with a resolved permission decision. All other JSON requests
+    /// (auth handshake, etc.) get a generic ok so the CLI proceeds.
+    private static func startMockFeedServer(listenerFD: Int32, resolveMode: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else { return }
+            defer { Darwin.close(clientFD) }
+
+            readLines(from: clientFD) { line in
+                guard let payload = jsonObject(line) else { return }
+                let id = payload["id"] as? String ?? "unknown"
+                if payload["method"] as? String == "feed.push" {
+                    writeLine(
+                        v2Response(
+                            id: id,
+                            ok: true,
+                            result: [
+                                "status": "resolved",
+                                "decision": ["kind": "permission", "mode": resolveMode],
+                            ]
+                        ),
+                        to: clientFD
+                    )
+                } else if payload["id"] != nil {
+                    writeLine(v2Response(id: id, ok: true, result: [:]), to: clientFD)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared subprocess + socket helpers (mirrors CLIHookNoResponseTests)
+
+    private static func bundledCLIPath() throws -> String {
+        let fileManager = FileManager.default
+        let appBundleURL = Bundle(for: BundleProbe.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let enumerator = fileManager.enumerator(
+            at: appBundleURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        while let item = enumerator?.nextObject() as? URL {
+            guard item.lastPathComponent == "cmux",
+                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
+                continue
+            }
+            return item.path
+        }
+        throw NSError(domain: "cmux.tests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Bundled cmux CLI not found in \(appBundleURL.path)",
+        ])
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(10))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String, backlog: Int32) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw posixError("failed to create Unix socket") }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "socket path too long: \(path)",
+            ])
+        }
+        _ = withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw posixError("failed to bind Unix socket")
+        }
+        guard Darwin.listen(fd, backlog) == 0 else {
+            Darwin.close(fd)
+            throw posixError("failed to listen on Unix socket")
+        }
+        return fd
+    }
+
+    private static func readLines(from fd: Int32, handle: (String) -> Void) {
+        var pending = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = Darwin.read(fd, &buffer, buffer.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                return
+            }
+            if count == 0 { return }
+            pending.append(buffer, count: count)
+            while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                pending.removeSubrange(0...newlineRange.lowerBound)
+                guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                handle(line)
+            }
+        }
+    }
+
+    private static func writeLine(_ line: String, to fd: Int32) {
+        let response = line + "\n"
+        _ = response.withCString { ptr in
+            Darwin.write(fd, ptr, strlen(ptr))
+        }
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        standardInput: String? = nil,
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let stdinHandle: FileHandle?
+        let stdinURL: URL?
+        if let standardInput {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-test-stdin-\(UUID().uuidString).json")
+            do {
+                try Data(standardInput.utf8).write(to: url)
+                let handle = try FileHandle(forReadingFrom: url)
+                process.standardInput = handle
+                stdinHandle = handle
+                stdinURL = url
+            } catch {
+                try? FileManager.default.removeItem(at: url)
+                return ProcessRunResult(status: -1, stdout: "", stderr: "\(error)", timedOut: false)
+            }
+        } else {
+            stdinHandle = nil
+            stdinURL = nil
+        }
+        defer {
+            try? stdinHandle?.close()
+            if let stdinURL {
+                try? FileManager.default.removeItem(at: stdinURL)
+            }
+        }
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: "\(error)", timedOut: false)
+        }
+
+        let timedOut = finished.wait(timeout: .now() + timeout) != .success
+        if timedOut {
+            process.terminate()
+            _ = finished.wait(timeout: .now() + 1)
+        }
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        return ProcessRunResult(
+            status: process.terminationStatus,
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            timedOut: timedOut
+        )
+    }
+
+    private static func posixError(_ message: String) -> NSError {
+        NSError(domain: "cmux.tests", code: Int(errno), userInfo: [
+            NSLocalizedDescriptionKey: "\(message): errno \(errno)",
+        ])
+    }
+}

--- a/cmuxTests/FeedEventClassificationTests.swift
+++ b/cmuxTests/FeedEventClassificationTests.swift
@@ -155,4 +155,42 @@ struct FeedEventClassificationTests {
         #expect(classify("gemini", "PreToolUse", tool: "write").actionable == false)
         #expect(classify("gemini", "PreToolUse", tool: "execute_bash").actionable == false)
     }
+
+    // MARK: Grok (no dedicated approval event; native lowercase tool names)
+
+    /// Grok has no dedicated approval event, so its `PreToolUse` escalates
+    /// side-effecting tools to an approval. Its Cursor-compatible harness emits
+    /// the capitalized `Write` / `Bash` (already in `sideEffectingTools`) while
+    /// its native harness emits lowercase `write` / `search_replace` / `bash`.
+    /// Both spellings must classify identically, or the same logical tool
+    /// escalates inconsistently depending on harness.
+    /// https://github.com/manaflow-ai/cmux/issues/6303
+    @Test func grokPreToolUseEscalatesSideEffectingToolsBothSpellings() {
+        #expect(classify("grok", "PreToolUse", tool: "Write").name == "PermissionRequest")
+        #expect(classify("grok", "PreToolUse", tool: "Write").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "Bash").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "write").name == "PermissionRequest")
+        #expect(classify("grok", "PreToolUse", tool: "write").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "search_replace").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "bash").actionable == true)
+        #expect(classify("grok", "PreToolUse", tool: "run_terminal_cmd").actionable == true)
+    }
+
+    /// Read-only Grok tools stay non-actionable telemetry so the Actionable
+    /// view is not flooded.
+    @Test func grokReadOnlyToolsStayTelemetry() {
+        #expect(classify("grok", "PreToolUse", tool: "read").actionable == false)
+        #expect(classify("grok", "PreToolUse", tool: "read").name == "PreToolUse")
+        #expect(classify("grok", "PreToolUse", tool: "grep").actionable == false)
+        #expect(classify("grok", "PreToolUse", tool: "list_dir").actionable == false)
+    }
+
+    /// Grok's case-insensitive native aliases must stay scoped to grok: another
+    /// agent emitting a lowercase `write` / `search_replace` must NOT be
+    /// escalated (mirrors the kiro alias-leak guard).
+    @Test func grokToolAliasesDoNotLeakToOtherAgents() {
+        #expect(classify("gemini", "PreToolUse", tool: "search_replace").actionable == false)
+        #expect(classify("gemini", "PreToolUse", tool: "run_terminal_cmd").actionable == false)
+        #expect(classify("copilot", "PreToolUse", tool: "search_replace").actionable == false)
+    }
 }


### PR DESCRIPTION
Closes #6303

## Root causes

Grok Build's `PreToolUse` Feed bridge had two defects that combined into ~2 minutes of dead time on every approved `Write`/`Bash`:

1. **Decision format mismatch.** `renderAgentDecision` routed `source == "grok"` through the generic `nonClaudePreToolDecision` path, which emits Claude-shaped JSON (`hookSpecificOutput.permissionDecision` / `"approve"`/`"block"`). Grok's `PreToolUse` blocking hook honors a **native** `{"decision":"allow|deny","reason":...}` shape (the same shape Antigravity already gets) and ignored the Claude envelope — so even an *approved* tool never unblocked, and the hook only ever cleared via the 120s fail-open timeout.

2. **Inconsistent tool classification.** `FeedEventClassifier.isSideEffectingTool` matched the Cursor-compat capitalized `Write`/`Bash` but not Grok's native lowercase tool names (`write`, `search_replace`, `bash`, `run_terminal_cmd`, …). The same logical tool classified differently depending on which harness emitted it.

## Fix

- **`CLI/cmux.swift`** — `source == "grok"` now joins the Antigravity branch in `renderAgentDecision` and emits the native `{"decision":"allow|deny","reason":...}` shape, so an approved Write/Bash clears immediately instead of waiting out the 120s fail-open.
- **`CLI/FeedEventClassifier.swift`** — added `grokSideEffectingToolAliases`, matched case-insensitively and **scoped to the `grok` source** (mirrors the existing `kiro` alias handling), so Grok's native and Cursor-compat harnesses classify the same logical tool identically and no other agent's lowercase tool name is broadened into an approval prompt.

## Scope / tradeoff

The issue also lists duplicate-hook pruning and pinned-dispatch latency. Those are **user-side install-script concerns** (`~/.grok/bin/...` repair scripts), not cmux-code defects, so they are intentionally out of scope for this focused fix.

## Tests (two red/green pairs — visible in the Commits tab)

- `Add failing regression test for Grok PreToolUse decision shape` → `Render Grok Feed decisions in Grok-native shape`: `CLIGrokFeedDecisionTests` drives the real bundled CLI against a mock Feed socket and asserts the emitted stdout is the Grok-native shape (no `hookSpecificOutput`, top-level `decision == allow/deny`).
- `Add failing test for Grok native tool-name Feed classification` → `Classify Grok native lowercase tool names as side-effecting`: `FeedEventClassificationTests` asserts both capitalized and lowercase Grok tool names escalate identically, read-only tools stay telemetry, and the aliases do not leak to other agents.

## Verification

- `./scripts/reload.sh --tag issue-6303` clean Debug build.
- `cmuxTests`: `FeedEventClassificationTests` + `CLIGrokFeedDecisionTests` (wired into `cmux.xcodeproj`, verified by `scripts/lint-pbxproj-test-wiring.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784319195&installation_id=133855650&pr_number=6323&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6323&signature=01177bd3ab766d7deefed516b02618652c2ff4e249c9306049b7683d4290be2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Grok Build PreToolUse approvals that were waiting out the 120s fail-open by sending Grok’s native decision format. Also makes Grok’s lowercase tool names consistently trigger approval prompts.

- **Bug Fixes**
  - When `source == "grok"`, PreToolUse now emits `{"decision":"allow|deny","reason":...}` so approved `Write`/`Bash` unblock immediately.
  - Grok’s lowercase tools (e.g., `write`, `search_replace`, `bash`, `run_terminal_cmd`) are classified as side-effecting (case-insensitive, scoped to `grok` only).
  - Tests: added `CLIGrokFeedDecisionTests` and Grok cases in `FeedEventClassificationTests`.

- **Refactors**
  - Bumped `CLI/cmux.swift` line budget in `.github/swift-file-length-budget.tsv` to `34483` to keep CI passing after the Grok decision branch.

<sup>Written for commit e828074a577b8f2e5b6dd84cd1b9bd9dad6bd56a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced pane memory guardrail to monitor excessive memory usage with configurable warning thresholds
  * Added memory warning indicators in sidebar and top banner with process termination option
  * Added runaway memory guardrail settings in terminal preferences

* **Improvements**
  * Enhanced Grok integration for consistent tool handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->