### PR TITLE
Stream cmuxd-remote bootstrap upload over SSH instead of scp (#6207)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -12,7 +12,7 @@
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7926	Sources/Panels/BrowserPanelView.swift
 7356	cmuxTests/WorkspaceUnitTests.swift
-7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
+7240	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
 6154	Sources/TabManager.swift

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
@@ -179,8 +179,19 @@ public struct RemoteSessionProcessRunner: RemoteSessionProcessRunning {
         defer { operation?.clearCancellationHandler() }
 
         if let stdin, let pipe = process.standardInput as? Pipe {
-            pipe.fileHandleForWriting.write(stdin)
-            try? pipe.fileHandleForWriting.close()
+            // Write stdin on a background queue so a large or stalled payload
+            // (e.g. the cmuxd-remote upload streamed over ssh) cannot block this
+            // thread before the timeout/termination path below is armed: if the
+            // timeout fires or the op is cancelled, the process is terminated,
+            // the pipe breaks, and this write fails harmlessly instead of
+            // wedging the caller's serial queue. F_SETNOSIGPIPE turns a broken
+            // pipe into an EPIPE error rather than a process-killing SIGPIPE.
+            let writeHandle = pipe.fileHandleForWriting
+            _ = fcntl(writeHandle.fileDescriptor, F_SETNOSIGPIPE, 1)
+            DispatchQueue.global(qos: .utility).async {
+                try? writeHandle.write(contentsOf: stdin)
+                try? writeHandle.close()
+            }
         }
 
         func terminateProcessAndWait() {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -327,8 +327,8 @@ extension RemoteSessionCoordinator {
         do {
             binaryData = try Data(contentsOf: localBinary)
         } catch {
-            throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
-                NSLocalizedDescriptionKey: "failed to read cmuxd-remote for upload: \(error.localizedDescription)",
+            throw NSError(domain: "cmux.remote.daemon", code: 33, userInfo: [
+                NSLocalizedDescriptionKey: "failed to read the local cmuxd-remote binary before upload",
             ])
         }
         let uploadScript = "cat > \(remoteTempPath.shellSingleQuoted)"

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -320,26 +320,32 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        let scpSSHOptions = backgroundSSHOptions(configuration.sshOptions)
-        var scpArgs: [String] = ["-q"]
-        if !hasSSHOptionKey(scpSSHOptions, key: "StrictHostKeyChecking") {
-            scpArgs += ["-o", "StrictHostKeyChecking=accept-new"]
+        // Stream the binary over the SSH channel itself instead of scp/sftp.
+        // scp/sftp sessions are commonly jailed/chrooted to a different root
+        // than the interactive shell — or disabled entirely — so the temp
+        // path that is valid for `ssh` exec is often invalid (or inaccessible)
+        // for scp, which is the root cause of the bootstrap upload failures in
+        // issue #6207. Piping the bytes through `cat > tempPath` over the same
+        // ssh transport guarantees identical path/permission semantics. `-T`
+        // disables PTY allocation so terminal line-discipline processing can
+        // not corrupt the binary stream.
+        let binaryData: Data
+        do {
+            binaryData = try Data(contentsOf: localBinary)
+        } catch {
+            throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
+                NSLocalizedDescriptionKey: "failed to read cmuxd-remote for upload: \(error.localizedDescription)",
+            ])
         }
-        scpArgs += ["-o", "ControlMaster=no"]
-        if let port = configuration.port {
-            scpArgs += ["-P", String(port)]
-        }
-        if let identityFile = configuration.identityFile,
-           !identityFile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            scpArgs += ["-i", identityFile]
-        }
-        for option in scpSSHOptions {
-            scpArgs += ["-o", option]
-        }
-        scpArgs += [localBinary.path, "\(configuration.destination):\(remoteTempPath)"]
-        let scpResult = try scpExec(arguments: scpArgs, timeout: 45)
-        guard scpResult.status == 0 else {
-            let detail = Self.bestErrorLine(stderr: scpResult.stderr, stdout: scpResult.stdout) ?? "scp exited \(scpResult.status)"
+        let uploadScript = "cat > \(remoteTempPath.shellSingleQuoted)"
+        let uploadCommand = "sh -c \(uploadScript.shellSingleQuoted)"
+        let uploadResult = try sshExec(
+            arguments: sshCommonArguments(batchMode: true) + ["-T", configuration.destination, uploadCommand],
+            stdin: binaryData,
+            timeout: 45
+        )
+        guard uploadResult.status == 0 else {
+            let detail = Self.bestErrorLine(stderr: uploadResult.stderr, stdout: uploadResult.stdout) ?? "ssh exited \(uploadResult.status)"
             throw NSError(domain: "cmux.remote.daemon", code: 31, userInfo: [
                 NSLocalizedDescriptionKey: "failed to upload cmuxd-remote: \(detail)",
             ])

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Bootstrap.swift
@@ -320,15 +320,9 @@ extension RemoteSessionCoordinator {
             ])
         }
 
-        // Stream the binary over the SSH channel itself instead of scp/sftp.
-        // scp/sftp sessions are commonly jailed/chrooted to a different root
-        // than the interactive shell — or disabled entirely — so the temp
-        // path that is valid for `ssh` exec is often invalid (or inaccessible)
-        // for scp, which is the root cause of the bootstrap upload failures in
-        // issue #6207. Piping the bytes through `cat > tempPath` over the same
-        // ssh transport guarantees identical path/permission semantics. `-T`
-        // disables PTY allocation so terminal line-discipline processing can
-        // not corrupt the binary stream.
+        // Stream the binary over the SSH channel (cat > tempPath) instead of
+        // scp/sftp, which is commonly jailed/chrooted or disabled (issue #6207);
+        // `-T` disables PTY allocation so it cannot corrupt the binary stream.
         let binaryData: Data
         do {
             binaryData = try Data(contentsOf: localBinary)

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2025,7 +2025,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
     }
 
     @MainActor
-    func testDaemonBootstrapUploadUsesAbsoluteHomePathForScpDestination() throws {
+    func testDaemonBootstrapUploadStreamsBinaryOverSSHToAbsoluteHomePath() throws {
+        // Issue #6207: the bootstrap upload must flow through the ssh transport
+        // (cat > tempPath, binary on stdin), not scp/sftp, so it works on hosts
+        // that jail/chroot or disable scp.
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory.appendingPathComponent(
             "cmux-remote-daemon-upload-\(UUID().uuidString)",
@@ -2055,10 +2058,16 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             }
         }
 
-        let scpInvoked = DispatchSemaphore(value: 0)
+        let uploadInvoked = DispatchSemaphore(value: 0)
         let lock = NSLock()
-        var scpDestination: String?
-        let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
+        var uploadCommand: String?
+        var uploadStdin: Data?
+        var uploadHadNoTTYFlag = false
+        let remoteProcessScript: RemoteProcessScript = { executable, arguments, stdin, _ in
+            if executable == "/usr/bin/scp" {
+                XCTFail("bootstrap upload must not shell out to scp (issue #6207)")
+                return (status: 1, stdout: "", stderr: "scp must not be used")
+            }
             if executable == "/usr/bin/ssh" {
                 let command = arguments.last ?? ""
                 if command.contains("uname -s") {
@@ -2076,14 +2085,16 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
+                if command.contains("cat >") {
+                    lock.lock()
+                    uploadCommand = command
+                    uploadStdin = stdin
+                    uploadHadNoTTYFlag = arguments.contains("-T")
+                    lock.unlock()
+                    uploadInvoked.signal()
+                    return (status: 1, stdout: "", stderr: "intentional stop after upload capture")
+                }
                 return (status: 0, stdout: "", stderr: "")
-            }
-            if executable == "/usr/bin/scp" {
-                lock.lock()
-                scpDestination = arguments.last
-                lock.unlock()
-                scpInvoked.signal()
-                return (status: 1, stdout: "", stderr: "intentional stop after upload destination capture")
             }
             XCTFail("unexpected executable \(executable)")
             return (status: 1, stdout: "", stderr: "unexpected executable")
@@ -2108,19 +2119,23 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        XCTAssertEqual(scpInvoked.wait(timeout: .now() + 2), .success)
+        XCTAssertEqual(uploadInvoked.wait(timeout: .now() + 2), .success)
         lock.lock()
-        let capturedDestination = scpDestination
+        let capturedCommand = uploadCommand
+        let capturedStdin = uploadStdin
+        let capturedNoTTYFlag = uploadHadNoTTYFlag
         lock.unlock()
-        let destination = try XCTUnwrap(capturedDestination)
+        let command = try XCTUnwrap(capturedCommand)
         XCTAssertTrue(
-            destination.hasPrefix("test@hpc.example:/home/test/.cmux/bin/cmuxd-remote/"),
-            "expected scp to target an absolute path under remote HOME, got \(destination)"
+            command.contains("cat > '/home/test/.cmux/bin/cmuxd-remote/"),
+            "expected upload to cat into an absolute path under remote HOME, got \(command)"
         )
         XCTAssertTrue(
-            destination.contains("/linux-amd64/cmuxd-remote.tmp-"),
-            "expected daemon platform temp path in \(destination)"
+            command.contains("/linux-amd64/cmuxd-remote.tmp-"),
+            "expected daemon platform temp path in \(command)"
         )
+        XCTAssertTrue(capturedNoTTYFlag, "expected -T to disable PTY allocation for the binary stream")
+        XCTAssertEqual(capturedStdin, Data("fake daemon".utf8), "expected the daemon bytes on ssh stdin")
     }
 
     @MainActor
@@ -2142,11 +2157,15 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             }
         }
 
-        let scpInvoked = DispatchSemaphore(value: 0)
+        let uploadInvoked = DispatchSemaphore(value: 0)
         let lock = NSLock()
-        var scpDestination: String?
+        var uploadCommand: String?
         let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
             let executableName = URL(fileURLWithPath: executable).lastPathComponent
+            if executable == "/usr/bin/scp" {
+                XCTFail("bootstrap reinstall must not shell out to scp (issue #6207)")
+                return (status: 1, stdout: "", stderr: "scp must not be used")
+            }
             if executable == "/usr/bin/ssh" {
                 let command = arguments.last ?? ""
                 if command.contains("uname -s") {
@@ -2171,14 +2190,14 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
+                if command.contains("cat >") {
+                    lock.lock()
+                    uploadCommand = command
+                    lock.unlock()
+                    uploadInvoked.signal()
+                    return (status: 1, stdout: "", stderr: "intentional stop after capability reinstall")
+                }
                 return (status: 0, stdout: "", stderr: "")
-            }
-            if executable == "/usr/bin/scp" {
-                lock.lock()
-                scpDestination = arguments.last
-                lock.unlock()
-                scpInvoked.signal()
-                return (status: 1, stdout: "", stderr: "intentional stop after capability reinstall")
             }
             if executableName == "go" {
                 if let outputFlagIndex = arguments.firstIndex(of: "-o"),
@@ -2217,14 +2236,14 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        XCTAssertEqual(scpInvoked.wait(timeout: .now() + 2), .success)
+        XCTAssertEqual(uploadInvoked.wait(timeout: .now() + 2), .success)
         lock.lock()
-        let capturedDestination = scpDestination
+        let capturedCommand = uploadCommand
         lock.unlock()
-        let destination = try XCTUnwrap(capturedDestination)
+        let command = try XCTUnwrap(capturedCommand)
         XCTAssertTrue(
-            destination.hasPrefix("test@hpc.example:/home/test/.cmux/bin/cmuxd-remote/"),
-            "expected missing pty.session to reinstall the old daemon, got \(destination)"
+            command.contains("cat > '/home/test/.cmux/bin/cmuxd-remote/"),
+            "expected missing pty.session to reinstall the old daemon over ssh, got \(command)"
         )
     }
 


### PR DESCRIPTION
Closes #6207

## Root cause

The cmuxd-remote bootstrap uploaded the daemon binary with `scp`:

```
scp <local> user@host:<HOME>/.cmux/bin/cmuxd-remote/<ver>/<plat>/cmuxd-remote.tmp-XXXX
```

But `scp`/`sftp` sessions frequently have *different* server-side semantics
than an interactive SSH shell: they are commonly jailed/chrooted to a
different root, or disabled entirely. So the temp path that is valid for
`ssh` exec (and that the rest of the bootstrap — `mkdir`, `chmod`/`mv`,
`serve --stdio` — relies on) is often invalid or inaccessible for `scp`,
producing failures like the one in the issue:

```
/usr/bin/scp: dest open ".../.cmux/bin/cmuxd-remote/0.64.10/linux-amd64/cmuxd-remote.tmp-...": No such file or directory
```

## Fix

Stream the binary over the **same SSH transport** the rest of the bootstrap
already uses, instead of `scp`:

```
cat <local-binary> | ssh -T user@host 'sh -c "cat > <temp-path>"'
```

Implemented in `uploadRemoteDaemonBinaryLocked` (`RemoteSessionCoordinator+Bootstrap.swift`):
the local binary is read into memory and piped to `cat > tempPath` via the
existing `sshExec(..., stdin:)` seam. `-T` disables PTY allocation so terminal
line-discipline processing cannot corrupt the binary stream. The surrounding
`mkdir -p`, `chmod 755 && mv`, and error codes (30/31/32) are unchanged, so
path/permission semantics are now guaranteed identical to ssh exec.

The drag-and-drop file upload path (`uploadDroppedFilesLocked`) still uses
`scp` — it transfers arbitrary user files to `/tmp` and is out of scope for
this bug.

## Verification

- `swift test` for the `CmuxRemoteSession` package passes (32 tests).
- Updated the two app-level bootstrap-upload tests in
  `WorkspaceRemoteConnectionTests.swift` that previously pinned `scp`:
  - `testDaemonBootstrapUploadStreamsBinaryOverSSHToAbsoluteHomePath` now
    asserts the upload flows over `ssh -T` with `cat > '<absolute HOME path>/…/cmuxd-remote.tmp-…'`,
    the daemon bytes on stdin, and **fails if `scp` is invoked at all**.
  - `testPersistentPTYBootstrapReinstallsOldDaemonMissingPTYCapability`
    asserts the capability-driven reinstall likewise streams over ssh.
- Full Xcode build is delegated to CI (local builds are not this project's flow).

## Tradeoff

The binary (~10–20 MB) is read into memory and written to ssh stdin in one
pass. stdout/stderr are drained concurrently by the runner's background
readers, so there is no pipe-fill deadlock. This matches the existing
`sshExec(stdin:)` usage and is well within acceptable memory for a one-shot
bootstrap upload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784319459&installation_id=133855650&pr_number=6324&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6324&signature=f10f1cefc74e5d9d2edfeed5ef64cb099dcf98af736d1b6c8b3b9e4cbb0d73bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream the cmuxd-remote bootstrap upload over the existing SSH session instead of `scp` to avoid jailed/chrooted sftp semantics and failures on hosts that disable `scp`. Also write stdin off-thread so timeouts can interrupt stalled uploads; closes #6207.

- **Bug Fixes**
  - Replaced `scp` with `ssh -T` piping to `cat > <temp-path>` in the bootstrap upload.
  - Wrote subprocess stdin on a background queue and set `F_SETNOSIGPIPE` to prevent hangs and allow timeout-driven termination.
  - Added error code 33 for local binary read failures with a path-free message; kept server-side upload failure under code 31.
  - Updated tests to assert `ssh -T` with `cat >` to an absolute HOME path, verify daemon bytes on stdin, and fail if `scp` is invoked.

- **Refactors**
  - Trimmed the upload comment to stay within budget and raised the test file length budget for the new SSH-upload assertions.

<sup>Written for commit b52dcdc87aef4da30e036f7bf267af2da28b3e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the remote daemon bootstrap process to upload the binary over SSH by streaming its contents directly to the target, then proceed with the existing install steps.
* **Bug Fixes**
  * Improved stdin handling for remote processes by writing asynchronously and preventing SIGPIPE-related crashes when pipes are interrupted.
* **Tests**
  * Strengthened bootstrap tests to ensure uploads use SSH streaming (no `scp`) and validate the streamed bytes and required SSH options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->