### PR TITLE
Vault sidebar: always offer "Show more" for folder sections so capped folders stay reachable (#6302)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -51,7 +51,7 @@
 1941	Sources/KeyboardShortcutSettingsFileStore.swift
 1880	Sources/RestorableAgentSession.swift
 1860	cmuxTests/NotificationAndMenuBarTests.swift
-1794	Sources/SessionIndexStore.swift
+1810	Sources/SessionIndexStore.swift
 1748	Sources/WindowDragHandleView.swift
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -158,7 +158,7 @@
 620	cmuxTests/TerminalNotificationQueueTests.swift
 615	cmuxTests/RemoteTmuxControlParserTests.swift
 614	Sources/PortScanner.swift
-614	cmuxTests/SessionIndexViewTests.swift
+663	cmuxTests/SessionIndexViewTests.swift
 608	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
 606	Sources/SettingsNavigation.swift
 604	Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteNucleoFFITests.swift

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -150,6 +150,8 @@ struct SectionKey: Hashable {
 
     static func agent(_ a: SessionAgent) -> SectionKey { SectionKey(raw: "agent:" + a.rawValue) }
     static func directory(_ path: String?) -> SectionKey { SectionKey(raw: "dir:" + (path ?? "")) }
+
+    var isDirectory: Bool { raw.hasPrefix("dir:") }
 }
 
 struct IndexSection: Identifiable, Equatable {
@@ -159,6 +161,11 @@ struct IndexSection: Identifiable, Equatable {
     let entries: [SessionEntry]
 
     var id: SectionKey { key }
+
+    /// Whether to render the "Show more" affordance for this section.
+    func shouldOfferShowMore(rowLimit: Int) -> Bool {
+        entries.count > rowLimit
+    }
 }
 
 enum SectionIcon: Equatable {

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -163,8 +163,17 @@ struct IndexSection: Identifiable, Equatable {
     var id: SectionKey { key }
 
     /// Whether to render the "Show more" affordance for this section.
+    ///
+    /// Directory sections are derived from `scanAll()`'s global, per-agent-capped
+    /// pool, so their in-memory `entries` are only a preview that can under-report
+    /// a folder's true on-disk session count (issue #6302). "Show more" is the
+    /// only trigger for the complete folder-scoped query (`loadDirectorySnapshot`),
+    /// so always offer it for directory sections; otherwise a folder that
+    /// contributed ≤ `rowLimit` sessions to the capped pool would have the rest of
+    /// its sessions permanently unreachable from the UI. Agent sections aren't
+    /// folder-truncated this way, so they keep the simple count threshold.
     func shouldOfferShowMore(rowLimit: Int) -> Bool {
-        entries.count > rowLimit
+        key.isDirectory || entries.count > rowLimit
     }
 }
 

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -394,7 +394,7 @@ private struct IndexSectionView: View, Equatable {
                         .equatable()
                         .id(entry.id)
                 }
-                if section.entries.count > rowLimit {
+                if section.shouldOfferShowMore(rowLimit: rowLimit) {
                     showMoreButton
                 }
                 Spacer(minLength: 2)

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -341,6 +341,55 @@ final class SessionIndexViewTests: XCTestCase {
         XCTAssertEqual(outcome.entries.map(\.sessionId), ["codex-transcript-match"])
     }
 
+    // Regression for https://github.com/manaflow-ai/cmux/issues/6302.
+    // The always-visible sidebar list is built from `scanAll()`, which loads
+    // only each agent's 30 most-recent sessions across ALL folders and then
+    // groups that already-capped pool by folder. A folder can therefore
+    // contribute ≤ collapsedRowLimit sessions to the in-memory list even
+    // though more exist on disk. "Show more" is the ONLY trigger for the
+    // complete folder-scoped query (`loadDirectorySnapshot`), so it must be
+    // offered for every directory section regardless of the truncated count —
+    // otherwise the rest of a folder's sessions are permanently unreachable.
+    func testDirectorySectionOffersShowMoreEvenWhenUnderRowLimit() {
+        let section = IndexSection(
+            key: .directory("/Users/me/dev/codexbarlite"),
+            title: "codexbarlite",
+            icon: .folder,
+            entries: [makeEntry(title: "a"), makeEntry(title: "b")]
+        )
+
+        XCTAssertTrue(section.shouldOfferShowMore(rowLimit: 5))
+    }
+
+    func testNoFolderDirectorySectionOffersShowMore() {
+        let section = IndexSection(
+            key: .directory(nil),
+            title: "(no folder)",
+            icon: .folder,
+            entries: [makeEntry(title: "x")]
+        )
+
+        XCTAssertTrue(section.shouldOfferShowMore(rowLimit: 5))
+    }
+
+    func testAgentSectionUsesRowCountThresholdForShowMore() {
+        let under = IndexSection(
+            key: .agent(.claude),
+            title: "Claude",
+            icon: .agent(.claude),
+            entries: [makeEntry(title: "a"), makeEntry(title: "b")]
+        )
+        XCTAssertFalse(under.shouldOfferShowMore(rowLimit: 5))
+
+        let over = IndexSection(
+            key: .agent(.claude),
+            title: "Claude",
+            icon: .agent(.claude),
+            entries: (0..<6).map { makeEntry(title: "s\($0)") }
+        )
+        XCTAssertTrue(over.shouldOfferShowMore(rowLimit: 5))
+    }
+
     func testSectionPopoverHostCoordinatorSkipsHiddenRefreshes() {
         let harness = makeHarness()
         let coordinator = harness.host.makeCoordinator()


### PR DESCRIPTION
Closes #6302

## Problem

The Vault sidebar (grouped **By folder**, or with **This folder only** on) silently truncates a folder's session list and — for folders that contributed ≤ 5 sessions to the cached pool — renders **no "Show more" link**, leaving the rest of that folder's sessions permanently unreachable from the UI.

Concrete repro from the issue: `~/dev/codexbarlite` shows only 2 sessions with no "Show more", even though more exist on disk.

## Root cause

The always-visible sidebar list is built from `scanAll()`, which loads only each agent's **30 most-recent sessions across ALL folders** (`cwdFilter: nil`, `perAgentLimit = 30`), then groups that already-capped pool by folder. So a folder whose sessions are scattered across many folders for a 30+-session agent only gets the few sessions that happened to land in some agent's global newest-30.

The "Show more" button — the **only** trigger for the complete folder-scoped disk query (`loadDirectorySnapshot(cwd:)`, `cwdFilter` set, `limit: 10_000`) — was gated on the count of that already-truncated in-memory pool:

```swift
if section.entries.count > rowLimit { showMoreButton }   // rowLimit = 5
```

A folder that contributed ≤ 5 sessions to the capped pool never rendered the button, so the complete per-folder query was never reachable.

## Fix

Make "Show more" always reachable for **directory** sections, since their in-memory `entries` are only a preview of the per-agent-capped global scan and cannot be trusted as the true on-disk count. Agent sections aren't folder-truncated this way, so they keep the simple count threshold.

```swift
func shouldOfferShowMore(rowLimit: Int) -> Bool {
    key.isDirectory || entries.count > rowLimit
}
```

Clicking "Show more" on a directory section opens the popover whose empty-query path runs the authoritative folder-scoped `loadDirectorySnapshot(cwd:)` query (`limit: 10_000`), which surfaces every on-disk session for that folder regardless of the global cap. This is the "always offer it per folder" alternative the issue lists; it's contained and avoids reworking the synchronous, carefully-tuned section/`LazyVStack` snapshot-boundary architecture.

Tradeoff: a genuinely-complete small folder now also shows "Show more". Clicking it opens the same sessions plus the per-folder search box, so it's not purely redundant; the upside is that no folder's sessions can ever be stranded.

## Tests

Added `SessionIndexViewTests` (already wired into `cmuxTests`), following the repo's two-commit red/green policy:

- **Commit 1** introduces a `shouldOfferShowMore(rowLimit:)` seam that still encodes the old count-only behavior, plus the regression tests — the directory test goes **red**.
- **Commit 2** flips the seam to `key.isDirectory || entries.count > rowLimit` — tests go **green**.

New tests:
- `testDirectorySectionOffersShowMoreEvenWhenUnderRowLimit` — a directory section with 2 entries must offer "Show more".
- `testNoFolderDirectorySectionOffersShowMore` — the "(no folder)" bucket too.
- `testAgentSectionUsesRowCountThresholdForShowMore` — agent sections keep the count threshold (no false positive).

## Verification

- `./scripts/reload.sh --tag issue-6302` → **BUILD SUCCEEDED** (full app compiles with the change).
- Unit tests run in CI via the `cmux-unit` scheme. (Local `xcodebuild test` could not run here only because this machine's first-on-PATH `/usr/local/bin/cargo` is a Homebrew rust that can't cross-build the unrelated Command-Palette Nucleo FFI — rustup's cargo builds it fine; not related to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784319585&installation_id=133855650&pr_number=6327&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6327&signature=f85b43f8990421f018fe1a9f43e6899922230af539549e7b07fa7a2e4899e3ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show “Show more” for folder sections in the Vault sidebar so truncated folders remain reachable. Agent sections keep the existing count-based threshold.

- **Bug Fixes**
  - Added `SectionKey.isDirectory` and `IndexSection.shouldOfferShowMore(rowLimit:)`: always true for directory sections; agents still use `entries.count > rowLimit`.
  - Ensures the popover’s folder-scoped `loadDirectorySnapshot(cwd:)` path is always reachable for directories, surfacing all on-disk sessions.

<sup>Written for commit fa9d0fe584278d7ad8e3105306cb9ed9598cde3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session index display by refining when the "Show more" button appears. Directory sections now always offer the button to ensure users can access all sessions, while regular sections display it based on content volume.

* **Tests**
  * Added test coverage for "Show more" behavior across different section types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->