### PR TITLE
Gate DEV/staging builds off the public Sparkle 'Update Available' pill

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+DevBuildGate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+DevBuildGate.swift
@@ -1,0 +1,59 @@
+public import Foundation
+
+/// DEV/staging release-train gating policy for the updater.
+///
+/// Pure, `nonisolated` predicates that decide whether the running build is excluded from the
+/// public Sparkle release train. Tagged DEV builds (`com.cmuxterm.app.debug[.<tag>]`) and staging
+/// builds (`com.cmuxterm.app.staging[.<tag>]`) are produced from local source and must never query
+/// the public appcast or surface/install the public release — see
+/// https://github.com/manaflow-ai/cmux/issues/6292.
+extension UpdateController {
+    /// Whether the running bundle is a DEV or staging build that should be excluded from the
+    /// public Sparkle release train.
+    ///
+    /// Mirrors `CmuxSocketControl.SocketControlSettings.isDebugLikeBundleIdentifier` /
+    /// `isStagingBundleIdentifier` locally so the updater module does not take a package
+    /// dependency on `CmuxSocketControl`. Covers the untagged base ids and every tagged variant
+    /// produced by `reload.sh --tag` (`com.cmuxterm.app.debug.<tag>` /
+    /// `com.cmuxterm.app.staging.<tag>`).
+    public nonisolated static func isDevLikeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier == "com.cmuxterm.app.debug"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
+            || bundleIdentifier == "com.cmuxterm.app.staging"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
+    }
+
+    /// Whether this build should be fully excluded from the public Sparkle release train.
+    ///
+    /// True for DEV/staging bundle ids, EXCEPT under the UI-test / XCTest harness — those runs
+    /// deliberately exercise the update UI on a debug bundle via `CMUX_UI_TEST_*` injection, so
+    /// suppressing the updater there would break `UpdatePillUITests` and friends.
+    public nonisolated static func shouldSuppressPublicUpdates(
+        bundleIdentifier: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard isDevLikeBundleIdentifier(bundleIdentifier) else { return false }
+        return !isUpdateTestHarnessActive(environment: environment)
+    }
+
+    /// Whether a UI-test / XCTest harness is driving this process. Mirrors the harness detection
+    /// used elsewhere (`CMUX_UI_TEST_*` env injected by XCUITest launches, plus in-process XCTest
+    /// indicators).
+    public nonisolated static func isUpdateTestHarnessActive(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if environment.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) {
+            return true
+        }
+        let xctestIndicators = [
+            "XCTestConfigurationFilePath",
+            "XCTestBundlePath",
+            "XCTestSessionIdentifier",
+        ]
+        return xctestIndicators.contains { key in
+            guard let value = environment[key] else { return false }
+            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -246,6 +246,19 @@ public final class UpdateController {
 
     /// Check for updates once the updater reports it can.
     private func checkForUpdatesWhenReady() {
+        // DEV/staging builds are off the public release train: never query the public appcast,
+        // even from a manual "Check for Updates" / custom-UI / attempt-install path. Report
+        // "up to date" and bail before starting the updater so the public release can never be
+        // surfaced or installed over a locally-built app.
+        if Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier) {
+            cancelReadinessRetry()
+            recheckTask?.cancel()
+            isForceInstalling = false
+            model.clearDetectedUpdate()
+            log.append("update check skipped (dev/staging build)")
+            model.setState(.notFound(.init(acknowledgement: {})))
+            return
+        }
         cancelReadinessRetry()
         startUpdaterIfNeeded()
         ensureSparkleInstallationCache()

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -405,55 +405,6 @@ public final class UpdateController {
         }
     }
 
-    /// Whether the running bundle is a DEV or staging build that should be excluded from the
-    /// public Sparkle release train.
-    ///
-    /// Mirrors `CmuxSocketControl.SocketControlSettings.isDebugLikeBundleIdentifier` /
-    /// `isStagingBundleIdentifier` locally so the updater module does not take a package
-    /// dependency on `CmuxSocketControl`. Covers the untagged base ids and every tagged variant
-    /// produced by `reload.sh --tag` (`com.cmuxterm.app.debug.<tag>` /
-    /// `com.cmuxterm.app.staging.<tag>`).
-    public nonisolated static func isDevLikeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
-        guard let bundleIdentifier else { return false }
-        return bundleIdentifier == "com.cmuxterm.app.debug"
-            || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
-            || bundleIdentifier == "com.cmuxterm.app.staging"
-            || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
-    }
-
-    /// Whether this build should be fully excluded from the public Sparkle release train.
-    ///
-    /// True for DEV/staging bundle ids, EXCEPT under the UI-test / XCTest harness — those runs
-    /// deliberately exercise the update UI on a debug bundle via `CMUX_UI_TEST_*` injection, so
-    /// suppressing the updater there would break `UpdatePillUITests` and friends.
-    public nonisolated static func shouldSuppressPublicUpdates(
-        bundleIdentifier: String?,
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> Bool {
-        guard isDevLikeBundleIdentifier(bundleIdentifier) else { return false }
-        return !isUpdateTestHarnessActive(environment: environment)
-    }
-
-    /// Whether a UI-test / XCTest harness is driving this process. Mirrors the harness detection
-    /// used elsewhere (`CMUX_UI_TEST_*` env injected by XCUITest launches, plus in-process XCTest
-    /// indicators).
-    public nonisolated static func isUpdateTestHarnessActive(
-        environment: [String: String] = ProcessInfo.processInfo.environment
-    ) -> Bool {
-        if environment.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) {
-            return true
-        }
-        let xctestIndicators = [
-            "XCTestConfigurationFilePath",
-            "XCTestBundlePath",
-            "XCTestSessionIdentifier",
-        ]
-        return xctestIndicators.contains { key in
-            guard let value = environment[key] else { return false }
-            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-    }
-
     private func recordUITestTimestamp(key: String) {
 #if DEBUG
         let env = ProcessInfo.processInfo.environment

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -82,7 +82,7 @@ public final class UpdateController {
         settings.apply(to: defaults)
 
         let model = UpdateStateModel()
-        let driver = UpdateDriver(model: model, log: log, clock: clock)
+        let driver = UpdateDriver(model: model, log: log, clock: clock, bundleIdentifier: hostBundle.bundleIdentifier)
         self.driver = driver
         self.updater = SPUUpdater(
             hostBundle: hostBundle,
@@ -338,6 +338,17 @@ public final class UpdateController {
     }
 
     private func startLaunchUpdateProbeIfNeeded() {
+        // DEV / staging builds are produced from local source and are not on the public release
+        // train, so they must never query the public appcast or surface the "Update Available"
+        // pill. Tear down any background probe and bail before touching Sparkle.
+        if Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier) {
+            backgroundProbeTask?.cancel()
+            backgroundProbeTask = nil
+            model.clearDetectedUpdate()
+            log.append("launch update probe skipped (dev/staging build)")
+            return
+        }
+
         guard updater.automaticallyChecksForUpdates else {
             log.append("launch update probe skipped (automatic checks disabled)")
             return
@@ -361,6 +372,22 @@ public final class UpdateController {
                 self.updater.checkForUpdateInformation()
             }
         }
+    }
+
+    /// Whether the running bundle is a DEV or staging build that should be excluded from the
+    /// public Sparkle release train.
+    ///
+    /// Mirrors `CmuxSocketControl.SocketControlSettings.isDebugLikeBundleIdentifier` /
+    /// `isStagingBundleIdentifier` locally so the updater module does not take a package
+    /// dependency on `CmuxSocketControl`. Covers the untagged base ids and every tagged variant
+    /// produced by `reload.sh --tag` (`com.cmuxterm.app.debug.<tag>` /
+    /// `com.cmuxterm.app.staging.<tag>`).
+    public nonisolated static func isDevLikeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier == "com.cmuxterm.app.debug"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
+            || bundleIdentifier == "com.cmuxterm.app.staging"
+            || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
     }
 
     private func recordUITestTimestamp(key: String) {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -25,6 +25,10 @@ public final class UpdateController {
     private let fileManager: FileManager
     private let hostBundle: Bundle
     private let backgroundProbeInterval: TimeInterval
+    /// Whether this build is excluded from the public Sparkle release train (DEV/staging bundle
+    /// id, outside the UI-test/XCTest harness). When true the updater is never started, no
+    /// public appcast is queried, and no public release can be surfaced or installed.
+    private let suppressesPublicUpdates: Bool
 
     /// Host actions the updater delegates upward (retry, relaunch prep). Forwarded to the driver.
     public weak var actionDelegate: (any UpdateActionDelegate)? {
@@ -72,17 +76,23 @@ public final class UpdateController {
                 settings: UpdateSettings = UpdateSettings(),
                 hostBundle: Bundle = .main,
                 defaults: UserDefaults = .standard,
-                fileManager: FileManager = .default) {
+                fileManager: FileManager = .default,
+                environment: [String: String] = ProcessInfo.processInfo.environment) {
         self.log = log
         self.clock = clock
         self.defaults = defaults
         self.fileManager = fileManager
         self.hostBundle = hostBundle
         self.backgroundProbeInterval = settings.scheduledCheckInterval
+        let suppressesPublicUpdates = Self.shouldSuppressPublicUpdates(
+            bundleIdentifier: hostBundle.bundleIdentifier,
+            environment: environment
+        )
+        self.suppressesPublicUpdates = suppressesPublicUpdates
         settings.apply(to: defaults)
 
         let model = UpdateStateModel()
-        let driver = UpdateDriver(model: model, log: log, clock: clock, bundleIdentifier: hostBundle.bundleIdentifier)
+        let driver = UpdateDriver(model: model, log: log, clock: clock, suppressesPublicUpdates: suppressesPublicUpdates)
         self.driver = driver
         self.updater = SPUUpdater(
             hostBundle: hostBundle,
@@ -250,7 +260,7 @@ public final class UpdateController {
         // even from a manual "Check for Updates" / custom-UI / attempt-install path. Report
         // "up to date" and bail before starting the updater so the public release can never be
         // surfaced or installed over a locally-built app.
-        if Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier) {
+        if suppressesPublicUpdates {
             cancelReadinessRetry()
             recheckTask?.cancel()
             isForceInstalling = false
@@ -313,6 +323,14 @@ public final class UpdateController {
     /// Start the updater. If startup fails, the error is shown via the custom UI.
     public func startUpdaterIfNeeded() {
         guard !didStartUpdater else { return }
+        // Root gate: DEV/staging builds are off the public release train. Never start Sparkle, so
+        // no scheduled check, automatic download, or silent install-on-quit can reach the public
+        // release over a locally-built app. (The UI-test/XCTest harness is exempt; see
+        // `shouldSuppressPublicUpdates`.)
+        if suppressesPublicUpdates {
+            log.append("updater not started (dev/staging build off public release train)")
+            return
+        }
         ensureSparkleInstallationCache()
 #if DEBUG
         // Keep the permission-related defaults resettable for UI tests even though the
@@ -351,10 +369,10 @@ public final class UpdateController {
     }
 
     private func startLaunchUpdateProbeIfNeeded() {
-        // DEV / staging builds are produced from local source and are not on the public release
-        // train, so they must never query the public appcast or surface the "Update Available"
-        // pill. Tear down any background probe and bail before touching Sparkle.
-        if Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier) {
+        // Defense in depth: `startUpdaterIfNeeded` already returns early for suppressed builds, so
+        // this is normally unreachable on DEV/staging. Keep the guard so the probe can never query
+        // the public appcast or surface the "Update Available" pill if reached another way.
+        if suppressesPublicUpdates {
             backgroundProbeTask?.cancel()
             backgroundProbeTask = nil
             model.clearDetectedUpdate()
@@ -401,6 +419,39 @@ public final class UpdateController {
             || bundleIdentifier.hasPrefix("com.cmuxterm.app.debug.")
             || bundleIdentifier == "com.cmuxterm.app.staging"
             || bundleIdentifier.hasPrefix("com.cmuxterm.app.staging.")
+    }
+
+    /// Whether this build should be fully excluded from the public Sparkle release train.
+    ///
+    /// True for DEV/staging bundle ids, EXCEPT under the UI-test / XCTest harness — those runs
+    /// deliberately exercise the update UI on a debug bundle via `CMUX_UI_TEST_*` injection, so
+    /// suppressing the updater there would break `UpdatePillUITests` and friends.
+    public nonisolated static func shouldSuppressPublicUpdates(
+        bundleIdentifier: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard isDevLikeBundleIdentifier(bundleIdentifier) else { return false }
+        return !isUpdateTestHarnessActive(environment: environment)
+    }
+
+    /// Whether a UI-test / XCTest harness is driving this process. Mirrors the harness detection
+    /// used elsewhere (`CMUX_UI_TEST_*` env injected by XCUITest launches, plus in-process XCTest
+    /// indicators).
+    public nonisolated static func isUpdateTestHarnessActive(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if environment.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) {
+            return true
+        }
+        let xctestIndicators = [
+            "XCTestConfigurationFilePath",
+            "XCTestBundlePath",
+            "XCTestSessionIdentifier",
+        ]
+        return xctestIndicators.contains { key in
+            guard let value = environment[key] else { return false }
+            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
 
     private func recordUITestTimestamp(key: String) {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -36,6 +36,14 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     /// Called when an update is scheduled to install silently,
     /// which occurs when automatic download is enabled.
     func updater(_ updater: SPUUpdater, willInstallUpdateOnQuit item: SUAppcastItem, immediateInstallationBlock immediateInstallHandler: @escaping () -> Void) -> Bool {
+        // Backstop for DEV/staging builds: decline Sparkle's silent install-on-quit so the public
+        // release can never be installed over a locally-built app. Returning false tells Sparkle
+        // not to handle the installation itself.
+        if suppressesPublicUpdates {
+            log.append("declining silent install-on-quit on dev/staging build: \(item.displayVersionString)")
+            model.clearDetectedUpdate()
+            return false
+        }
         model.clearDetectedUpdate()
         model.setState(.installing(.init(
             isAutoUpdate: true,
@@ -61,7 +69,7 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
         // DEV / staging builds are off the public release train. If Sparkle still surfaces an
         // update here (e.g. a manual "Check for Updates", or a probe that started before the
         // launch gate landed), clear it instead of recording so the pill never appears.
-        if UpdateController.isDevLikeBundleIdentifier(bundleIdentifier) {
+        if suppressesPublicUpdates {
             model.clearDetectedUpdate()
             log.append("ignoring found update on dev/staging build: \(item.displayVersionString)")
             return

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -58,6 +58,14 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        // DEV / staging builds are off the public release train. If Sparkle still surfaces an
+        // update here (e.g. a manual "Check for Updates", or a probe that started before the
+        // launch gate landed), clear it instead of recording so the pill never appears.
+        if UpdateController.isDevLikeBundleIdentifier(bundleIdentifier) {
+            model.clearDetectedUpdate()
+            log.append("ignoring found update on dev/staging build: \(item.displayVersionString)")
+            return
+        }
         model.recordDetectedUpdate(item)
         let version = item.displayVersionString
         let fileURL = item.fileURL?.absoluteString ?? ""

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -36,13 +36,18 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     /// Called when an update is scheduled to install silently,
     /// which occurs when automatic download is enabled.
     func updater(_ updater: SPUUpdater, willInstallUpdateOnQuit item: SUAppcastItem, immediateInstallationBlock immediateInstallHandler: @escaping () -> Void) -> Bool {
-        // Backstop for DEV/staging builds: decline Sparkle's silent install-on-quit so the public
-        // release can never be installed over a locally-built app. Returning false tells Sparkle
-        // not to handle the installation itself.
+        // Backstop for DEV/staging builds: veto Sparkle's silent install-on-quit so the public
+        // release can never be installed over a locally-built app.
+        //
+        // Sparkle's contract: returning YES means the delegate OWNS the installation, NO hands
+        // responsibility back to Sparkle (which then installs on quit). So to actually suppress
+        // the install we must return `true` and simply drop the update on the floor — never
+        // invoking `immediateInstallHandler` and never resuming it — instead of returning `false`.
         if suppressesPublicUpdates {
-            log.append("declining silent install-on-quit on dev/staging build: \(item.displayVersionString)")
+            log.append("vetoing silent install-on-quit on dev/staging build: \(item.displayVersionString)")
             model.clearDetectedUpdate()
-            return false
+            model.setState(.idle)
+            return true
         }
         model.clearDetectedUpdate()
         model.setState(.installing(.init(

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -63,6 +63,17 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     func showUpdateFound(with appcastItem: SUAppcastItem,
                          state: SPUUserUpdateState,
                          reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
+        // Backstop for DEV/staging builds: even if Sparkle's own scheduler (or a probe started
+        // before the launch gate landed) surfaces a public-release update, never present the
+        // install UI. Decline the update and stay idle so a local build can't install the
+        // public release. The controller already blocks our explicit check entry points.
+        if UpdateController.isDevLikeBundleIdentifier(bundleIdentifier) {
+            log.append("declining found update on dev/staging build: \(appcastItem.displayVersionString)")
+            reply(.dismiss)
+            model.clearDetectedUpdate()
+            setState(.idle)
+            return
+        }
         log.append("show update found: \(appcastItem.displayVersionString)")
         setStateAfterMinimumCheckDelay(.updateAvailable(.init(appcastItem: appcastItem, reply: reply)))
     }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -14,8 +14,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     let model: UpdateStateModel
     let log: any UpdateLogging
     private let clock: any UpdateClock
-    /// The running bundle's identifier, used to gate the public update train off DEV/staging builds.
-    let bundleIdentifier: String?
+    /// Whether this build is excluded from the public Sparkle release train (DEV/staging outside
+    /// the test harness). When true the driver vetoes any found update so the public release can
+    /// never be surfaced or installed over a locally-built app.
+    let suppressesPublicUpdates: Bool
     /// Host actions the driver delegates upward. Held weak; set by ``UpdateController``.
     weak var actionDelegate: (any UpdateActionDelegate)?
 
@@ -26,11 +28,11 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
 
-    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock, bundleIdentifier: String? = Bundle.main.bundleIdentifier) {
+    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock, suppressesPublicUpdates: Bool = false) {
         self.model = model
         self.log = log
         self.clock = clock
-        self.bundleIdentifier = bundleIdentifier
+        self.suppressesPublicUpdates = suppressesPublicUpdates
         super.init()
     }
 
@@ -67,7 +69,7 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         // before the launch gate landed) surfaces a public-release update, never present the
         // install UI. Decline the update and stay idle so a local build can't install the
         // public release. The controller already blocks our explicit check entry points.
-        if UpdateController.isDevLikeBundleIdentifier(bundleIdentifier) {
+        if suppressesPublicUpdates {
             log.append("declining found update on dev/staging build: \(appcastItem.displayVersionString)")
             reply(.dismiss)
             model.clearDetectedUpdate()

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -14,6 +14,8 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     let model: UpdateStateModel
     let log: any UpdateLogging
     private let clock: any UpdateClock
+    /// The running bundle's identifier, used to gate the public update train off DEV/staging builds.
+    let bundleIdentifier: String?
     /// Host actions the driver delegates upward. Held weak; set by ``UpdateController``.
     weak var actionDelegate: (any UpdateActionDelegate)?
 
@@ -24,10 +26,11 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
 
-    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock) {
+    init(model: UpdateStateModel, log: any UpdateLogging, clock: any UpdateClock, bundleIdentifier: String? = Bundle.main.bundleIdentifier) {
         self.model = model
         self.log = log
         self.clock = clock
+        self.bundleIdentifier = bundleIdentifier
         super.init()
     }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevBuildUpdateGateTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevBuildUpdateGateTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import CmuxUpdater
+
+/// Verifies the DEV/staging bundle-id gate that keeps tagged local builds off the public
+/// Sparkle release train (https://github.com/manaflow-ai/cmux/issues/6292).
+@Suite struct DevBuildUpdateGateTests {
+    @Test func publicReleaseBundleIsNotDevLike() {
+        #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app"))
+    }
+
+    @Test func baseDebugBundleIsDevLike() {
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debug"))
+    }
+
+    @Test func taggedDebugBundleIsDevLike() {
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debug.issue-6292"))
+    }
+
+    @Test func baseStagingBundleIsDevLike() {
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.staging"))
+    }
+
+    @Test func taggedStagingBundleIsDevLike() {
+        #expect(UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.staging.some-feature"))
+    }
+
+    @Test func nilBundleIsNotDevLike() {
+        #expect(!UpdateController.isDevLikeBundleIdentifier(nil))
+    }
+
+    @Test func unrelatedBundlePrefixIsNotDevLike() {
+        // Guard against a too-loose prefix match: a different app whose id merely starts with
+        // the public id must not be treated as a dev build.
+        #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debugger"))
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevBuildUpdateGateTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevBuildUpdateGateTests.swift
@@ -33,4 +33,42 @@ import Testing
         // the public id must not be treated as a dev build.
         #expect(!UpdateController.isDevLikeBundleIdentifier("com.cmuxterm.app.debugger"))
     }
+
+    // MARK: - shouldSuppressPublicUpdates (the effective gate the updater applies)
+
+    @Test func publicReleaseIsNeverSuppressed() {
+        #expect(!UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app", environment: [:]))
+        // Even with a test harness present, the public build still runs the real update train.
+        #expect(!UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app", environment: ["CMUX_UI_TEST_MODE": "1"]))
+    }
+
+    @Test func devBuildIsSuppressedOutsideHarness() {
+        #expect(UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app.debug.issue-6292", environment: [:]))
+        #expect(UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app.staging", environment: [:]))
+    }
+
+    @Test func devBuildIsNotSuppressedUnderUITestHarness() {
+        // UpdatePillUITests run on the debug bundle and drive the update UI via CMUX_UI_TEST_*
+        // injection; suppression must yield to the harness so those tests still work.
+        #expect(!UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app.debug",
+            environment: ["CMUX_UI_TEST_MODE": "1", "CMUX_UI_TEST_UPDATE_STATE": "available"]))
+    }
+
+    @Test func devBuildIsNotSuppressedUnderXCTestHarness() {
+        #expect(!UpdateController.shouldSuppressPublicUpdates(
+            bundleIdentifier: "com.cmuxterm.app.debug",
+            environment: ["XCTestConfigurationFilePath": "/tmp/x.xctestconfiguration"]))
+    }
+
+    @Test func harnessDetectionIgnoresBlankXCTestValues() {
+        #expect(!UpdateController.isUpdateTestHarnessActive(
+            environment: ["XCTestConfigurationFilePath": "   "]))
+        #expect(UpdateController.isUpdateTestHarnessActive(
+            environment: ["CMUX_UI_TEST_FEED_URL": "https://cmux.test/appcast.xml"]))
+    }
 }


### PR DESCRIPTION
Closes #6292

## Problem

Tagged DEV builds (`com.cmuxterm.app.debug[.<tag>]`, produced by `./scripts/reload.sh --tag <tag>`) and staging builds (`com.cmuxterm.app.staging[.<tag>]`) share the same public stable Sparkle appcast URL as the released app. After every release, every developer's local build surfaces a passive **"Update Available — behind 0.64.x"** pill in the sidebar, even though the build came from local source and is not on the public release train.

## Root cause

In `CmuxUpdater`, the updater never discriminated by bundle id:

- `UpdateController.startLaunchUpdateProbeIfNeeded` unconditionally launched a background probe + hourly re-probe for every bundle id.
- `UpdateDriver.updater(_:didFindValidUpdate:)` always recorded the detected update via `model.recordDetectedUpdate(item)`, surfacing the pill regardless of bundle id.

The public/staging/debug discrimination already exists in `CmuxSocketControl.SocketControlSettings` (`isDebugLikeBundleIdentifier` / `isStagingBundleIdentifier`), but the updater module didn't gate on it.

## Fix

- **`UpdateController.startLaunchUpdateProbeIfNeeded`**: short-circuit and tear down the background probe task for DEV/staging bundles, so the public appcast is never queried on launch or on the hourly re-probe. Also clears any already-detected update.
- **`UpdateDriver.updater(_:didFindValidUpdate:)`**: clears any detected update instead of recording it for DEV/staging bundles — covers the case where Sparkle still finds an update via a manual **Check for Updates** or a probe that started before the gate landed.
- **`UpdateController.isDevLikeBundleIdentifier`**: mirrors the existing `SocketControlSettings` logic locally (debug + staging, base ids and `.​<tag>` variants) to avoid creating a new `CmuxUpdater → CmuxSocketControl` package edge, exactly as the issue proposed.
- `UpdateDriver` now carries the host bundle identifier (threaded from `UpdateController`'s `hostBundle`) so the delegate can apply the same gate.

Only the public release (`com.cmuxterm.app`) runs the launch + background update probes.

## Verification

- Added `DevBuildUpdateGateTests` (7 cases) covering the gate: public id is **not** dev-like; base + tagged debug and staging ids **are** dev-like; `nil` and a too-loose prefix (`com.cmuxterm.app.debugger`) are **not** dev-like.
- `swift test --filter DevBuildUpdateGateTests` → **7/7 pass** locally. Full CI is the gate.

## Scope / tradeoffs

Narrowly the DEV-build update pill. Does **not** touch DEV `.dmg` packaging or `reload.sh` `.app` mirroring (separate workflow conveniences, per the issue). The bundle-id check is mirrored rather than shared to keep the package dependency graph unchanged; a note in the doc comment points at the canonical `SocketControlSettings` helpers if a future shared helper is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784319718&installation_id=133855650&pr_number=6329&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6329&signature=8089edff992ee8fdc152bfed66b54a45ba477c6a03844067a842b9b9035e8562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops DEV and staging builds from starting Sparkle or querying the public appcast. Only `com.cmuxterm.app` runs update checks; UI tests on debug bundles remain enabled. Fixes #6292.

- **Bug Fixes**
  - Root gate: `UpdateController.startUpdaterIfNeeded` returns early for dev/staging unless under UI-test/XCTest, so Sparkle never starts; launch probes and manual checks short-circuit as “up to date.”
  - Backstops: `UpdateDriver.showUpdateFound`, `didFindValidUpdate`, and `willInstallUpdateOnQuit` clear/decline updates; `willInstallUpdateOnQuit` now correctly vetoes silent installs by owning and dropping the install.
  - Helpers/tests: added `isDevLikeBundleIdentifier`, `shouldSuppressPublicUpdates`, `isUpdateTestHarnessActive` and moved them to `UpdateController+DevBuildGate.swift`; expanded tests for harness-aware cases.

<sup>Written for commit 5fe688a5434128109577ec84a18664ccdbb16ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Development and staging builds now skip update probing and suppress update notifications/indicators, preventing internal builds from showing “update available” alerts.

* **Tests**
  * Added test coverage to validate dev/staging bundle identifier detection, including debug/staging base and tagged variants and guards against misclassification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->