### PR TITLE
Recover blank Markdown viewer pane after dragging it to another column (#6144)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -56,7 +56,7 @@
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
-1574	cmuxTests/MarkdownPanelTests.swift
+1617	cmuxTests/MarkdownPanelTests.swift
 1560	cmuxTests/TextBoxMentionCompletionTests.swift
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1512	cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -104,7 +104,7 @@
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
-841	Sources/Panels/MarkdownWebRenderer.swift
+869	Sources/Panels/MarkdownWebRenderer.swift
 830	Sources/TaskManagerTypes.swift
 825	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
 810	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -56,7 +56,7 @@
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
-1625	cmuxTests/MarkdownPanelTests.swift
+1655	cmuxTests/MarkdownPanelTests.swift
 1560	cmuxTests/TextBoxMentionCompletionTests.swift
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1512	cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -104,7 +104,7 @@
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
-872	Sources/Panels/MarkdownWebRenderer.swift
+899	Sources/Panels/MarkdownWebRenderer.swift
 830	Sources/TaskManagerTypes.swift
 825	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
 810	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -56,7 +56,7 @@
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
-1617	cmuxTests/MarkdownPanelTests.swift
+1625	cmuxTests/MarkdownPanelTests.swift
 1560	cmuxTests/TextBoxMentionCompletionTests.swift
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1512	cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -104,7 +104,7 @@
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
-869	Sources/Panels/MarkdownWebRenderer.swift
+872	Sources/Panels/MarkdownWebRenderer.swift
 830	Sources/TaskManagerTypes.swift
 825	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
 810	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -32,6 +32,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                 webView.removeFromSuperview()
             }
             webView.onPointerDown = onRequestPanelFocus
+            webView.onReenterWindow = { [weak coordinator = context.coordinator] in
+                coordinator?.handleViewReenteredWindow()
+            }
             webView.navigationDelegate = context.coordinator
             webView.uiDelegate = context.coordinator
             applyBackground(to: webView)
@@ -58,6 +61,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         )
         let webView = MarkdownWebView(frame: .zero, configuration: config)
         webView.onPointerDown = onRequestPanelFocus
+        webView.onReenterWindow = { [weak coordinator = context.coordinator] in
+            coordinator?.handleViewReenteredWindow()
+        }
         webView.setValue(false, forKey: "drawsBackground")
         applyBackground(to: webView)
         webView.allowsBackForwardNavigationGestures = false
@@ -102,6 +108,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         nsView.navigationDelegate = nil
         nsView.uiDelegate = nil
         (nsView as? MarkdownWebView)?.onPointerDown = nil
+        (nsView as? MarkdownWebView)?.onReenterWindow = nil
         coordinator.cancelImageLoads()
     }
 
@@ -238,6 +245,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                 webView.navigationDelegate = nil
                 webView.uiDelegate = nil
                 webView.onPointerDown = nil
+                webView.onReenterWindow = nil
             }
             self.webView = nil
             isLoaded = false
@@ -727,7 +735,18 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         /// from the window WebKit can reclaim the WebContent process,
         /// leaving the panel permanently blank with no user-facing reload.
         func handleViewReenteredWindow() {
-            // Intentionally empty until the fix commit.
+            // A deliberate reattach is not a crash loop, so restore the full
+            // recovery budget. If the shell was lost while detached (WebContent
+            // process reclaimed, or the in-place recovery budget was exhausted),
+            // reload it so the document repaints instead of staying blank. A
+            // shell that is still loaded — alive but merely unpainted — is left
+            // intact; the host view's repaint nudge handles that case.
+            webContentProcessRecoveryAttempts = 0
+            guard !isLoaded, !isShellLoading else { return }
+            loadShell(
+                theme: lastTheme ?? pendingTheme,
+                initialMarkdown: lastMarkdown ?? pendingMarkdown
+            )
         }
 
         private func handleShellNavigationFailure(for webView: WKWebView, error: Error) {

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -721,6 +721,15 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             )
         }
 
+        /// Called when the host `MarkdownWebView` re-enters a window after
+        /// having been detached (e.g. a pane drag re-parents the hosting
+        /// views via `removeFromSuperview` → `addSubview`). While detached
+        /// from the window WebKit can reclaim the WebContent process,
+        /// leaving the panel permanently blank with no user-facing reload.
+        func handleViewReenteredWindow() {
+            // Intentionally empty until the fix commit.
+        }
+
         private func handleShellNavigationFailure(for webView: WKWebView, error: Error) {
             guard let currentWebView = self.webView, currentWebView === webView, isShellLoading else { return }
 #if DEBUG

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -32,6 +32,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                 webView.removeFromSuperview()
             }
             webView.onPointerDown = onRequestPanelFocus
+            webView.onLeaveWindow = { [weak coordinator = context.coordinator] in
+                coordinator?.handleViewLeftWindow()
+            }
             webView.onReenterWindow = { [weak coordinator = context.coordinator] in
                 coordinator?.handleViewReenteredWindow()
             }
@@ -61,6 +64,9 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         )
         let webView = MarkdownWebView(frame: .zero, configuration: config)
         webView.onPointerDown = onRequestPanelFocus
+        webView.onLeaveWindow = { [weak coordinator = context.coordinator] in
+            coordinator?.handleViewLeftWindow()
+        }
         webView.onReenterWindow = { [weak coordinator = context.coordinator] in
             coordinator?.handleViewReenteredWindow()
         }
@@ -108,6 +114,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         nsView.navigationDelegate = nil
         nsView.uiDelegate = nil
         (nsView as? MarkdownWebView)?.onPointerDown = nil
+        (nsView as? MarkdownWebView)?.onLeaveWindow = nil
         (nsView as? MarkdownWebView)?.onReenterWindow = nil
         coordinator.cancelImageLoads()
     }
@@ -146,6 +153,13 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         private var isShellLoading = false
         private var webContentProcessRecoveryAttempts = 0
         private let maxWebContentProcessRecoveryAttempts = 2
+        /// Whether the shell was confirmed loaded at the moment the host view
+        /// last left its window. Used to distinguish a blank state caused by
+        /// detaching the pane (WebKit suspending/reclaiming the detached view —
+        /// recoverable) from one caused by a payload that keeps crashing
+        /// WebContent while attached (a crash loop whose recovery budget must
+        /// not be reset by pane reparenting).
+        private var shellWasHealthyWhenDetached = false
 
         private struct ImageLoadResult {
             let data: Data
@@ -245,12 +259,14 @@ struct MarkdownWebRenderer: NSViewRepresentable {
                 webView.navigationDelegate = nil
                 webView.uiDelegate = nil
                 webView.onPointerDown = nil
+                webView.onLeaveWindow = nil
                 webView.onReenterWindow = nil
             }
             self.webView = nil
             isLoaded = false
             isShellLoading = false
             webContentProcessRecoveryAttempts = 0
+            shellWasHealthyWhenDetached = false
             cancelImageLoads()
             requestedLibs.removeAll()
         }
@@ -734,17 +750,28 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         /// views via `removeFromSuperview` → `addSubview`). While detached
         /// from the window WebKit can reclaim the WebContent process,
         /// leaving the panel permanently blank with no user-facing reload.
+        /// Records, at the moment the host view leaves its window, whether the
+        /// document was healthy. The blank state seen after re-entry is only
+        /// treated as a detach artifact (and recovered with a fresh budget) if
+        /// the shell was loaded when it was detached.
+        func handleViewLeftWindow() {
+            shellWasHealthyWhenDetached = isLoaded
+        }
+
         func handleViewReenteredWindow() {
-            // Only act when the shell was actually lost while detached
-            // (WebContent process reclaimed, or the in-place recovery budget
-            // exhausted). A still-loaded shell — alive but merely unpainted —
-            // is left intact; the host view's repaint nudge handles that case,
-            // and its per-payload crash budget must be preserved across this
-            // layout churn (see testMarkdownRendererKeepsRecoveryBudgetAfterShellReload).
-            guard !isLoaded, !isShellLoading else { return }
-            // A deliberate reattach is not a crash loop, so restore the full
-            // recovery budget before reloading the blank shell so the document
-            // repaints instead of staying permanently blank.
+            // A still-loaded shell — alive but merely unpainted — is left
+            // intact; the host view's repaint nudge handles that case.
+            guard !isLoaded else { return }
+            // Recover only when the document was healthy before the detach, so
+            // a payload that exhausted its crash-recovery budget while attached
+            // (a crash loop) is not granted a fresh budget by pane reparenting.
+            guard shellWasHealthyWhenDetached else { return }
+            shellWasHealthyWhenDetached = false
+            // A reload kicked off while detached can stall (no didFinish until
+            // the view is back in a window), so reload unconditionally — even
+            // mid-load. A deliberate reattach is not a crash loop, so restore
+            // the recovery budget so the document repaints instead of staying
+            // permanently blank.
             webContentProcessRecoveryAttempts = 0
             loadShell(
                 theme: lastTheme ?? pendingTheme,

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -735,14 +735,17 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         /// from the window WebKit can reclaim the WebContent process,
         /// leaving the panel permanently blank with no user-facing reload.
         func handleViewReenteredWindow() {
-            // A deliberate reattach is not a crash loop, so restore the full
-            // recovery budget. If the shell was lost while detached (WebContent
-            // process reclaimed, or the in-place recovery budget was exhausted),
-            // reload it so the document repaints instead of staying blank. A
-            // shell that is still loaded — alive but merely unpainted — is left
-            // intact; the host view's repaint nudge handles that case.
-            webContentProcessRecoveryAttempts = 0
+            // Only act when the shell was actually lost while detached
+            // (WebContent process reclaimed, or the in-place recovery budget
+            // exhausted). A still-loaded shell — alive but merely unpainted —
+            // is left intact; the host view's repaint nudge handles that case,
+            // and its per-payload crash budget must be preserved across this
+            // layout churn (see testMarkdownRendererKeepsRecoveryBudgetAfterShellReload).
             guard !isLoaded, !isShellLoading else { return }
+            // A deliberate reattach is not a crash loop, so restore the full
+            // recovery budget before reloading the blank shell so the document
+            // repaints instead of staying permanently blank.
+            webContentProcessRecoveryAttempts = 0
             loadShell(
                 theme: lastTheme ?? pendingTheme,
                 initialMarkdown: lastMarkdown ?? pendingMarkdown

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -21,6 +21,12 @@ final class WeakMarkdownScriptMessageHandler: NSObject, WKScriptMessageHandler {
 @MainActor
 final class MarkdownWebView: WKWebView {
     var onPointerDown: (() -> Void)?
+    /// Invoked when the view re-enters a window after being detached. Lets the
+    /// renderer coordinator recover content WebKit dropped while the view was
+    /// out of the window (e.g. a pane drag re-parented the hosting views).
+    var onReenterWindow: (() -> Void)?
+
+    private var needsRenderingReattach = false
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         PaneFirstClickFocusSettings.isEnabled()
@@ -29,6 +35,49 @@ final class MarkdownWebView: WKWebView {
     override func mouseDown(with event: NSEvent) {
         onPointerDown?()
         super.mouseDown(with: event)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window == nil {
+            // Leaving the window (the detach half of a pane re-parent). Drive
+            // WebKit's in-window lifecycle out so the matching re-entry below
+            // resumes rendering, mirroring the browser panel's recovery path.
+            needsRenderingReattach = true
+            callVoidSelectorIfAvailable("viewDidHide")
+            callVoidSelectorIfAvailable("_exitInWindow")
+        } else {
+            reattachRenderingState()
+            onReenterWindow?()
+        }
+    }
+
+    /// Resume WebKit's rendering after the view re-enters a window. WebKit can
+    /// suspend painting (or reclaim the WebContent process) while a WKWebView
+    /// is detached during a pane drag, which previously left the Markdown
+    /// viewer permanently blank. This nudges the in-window lifecycle back on
+    /// and forces a layout/display pass so the live document repaints.
+    private func reattachRenderingState() {
+        guard needsRenderingReattach else { return }
+        needsRenderingReattach = false
+        callVoidSelectorIfAvailable("viewDidUnhide")
+        callVoidSelectorIfAvailable("_enterInWindow")
+        callVoidSelectorIfAvailable("_endDeferringViewInWindowChangesSync")
+        needsLayout = true
+        needsDisplay = true
+        setNeedsDisplay(bounds)
+        layoutSubtreeIfNeeded()
+        displayIfNeeded()
+    }
+
+    /// Calls a private WKWebView lifecycle selector when present. Guarded by
+    /// `responds(to:)` so it degrades to a no-op if the selector is removed.
+    private func callVoidSelectorIfAvailable(_ rawSelector: String) {
+        let selector = NSSelectorFromString(rawSelector)
+        guard responds(to: selector) else { return }
+        typealias Fn = @convention(c) (AnyObject, Selector) -> Void
+        let fn = unsafeBitCast(method(for: selector), to: Fn.self)
+        fn(self, selector)
     }
 }
 

--- a/Sources/Panels/MarkdownWebSupport.swift
+++ b/Sources/Panels/MarkdownWebSupport.swift
@@ -21,6 +21,11 @@ final class WeakMarkdownScriptMessageHandler: NSObject, WKScriptMessageHandler {
 @MainActor
 final class MarkdownWebView: WKWebView {
     var onPointerDown: (() -> Void)?
+    /// Invoked when the view leaves its window (the detach half of a pane
+    /// re-parent). Lets the renderer coordinator record whether the document
+    /// was healthy at detach time so re-entry recovery can tell a detach
+    /// artifact apart from an attached crash loop.
+    var onLeaveWindow: (() -> Void)?
     /// Invoked when the view re-enters a window after being detached. Lets the
     /// renderer coordinator recover content WebKit dropped while the view was
     /// out of the window (e.g. a pane drag re-parented the hosting views).
@@ -46,6 +51,7 @@ final class MarkdownWebView: WKWebView {
             needsRenderingReattach = true
             callVoidSelectorIfAvailable("viewDidHide")
             callVoidSelectorIfAvailable("_exitInWindow")
+            onLeaveWindow?()
         } else {
             reattachRenderingState()
             onReenterWindow?()

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -480,6 +480,49 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
     }
 
+    func testMarkdownRendererReentersWindowReloadsShellAfterRecoveryBudgetExhausted() {
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let theme = MarkdownWebTheme.resolve(backgroundColor: .windowBackgroundColor)
+        coordinator.webView = webView
+        defer { coordinator.close() }
+
+        // Simulate the WebContent process being reclaimed while the pane was
+        // detached during a drag, exhausting the in-place recovery budget so
+        // the panel is left permanently blank.
+        coordinator.loadShell(theme: theme, initialMarkdown: "# Existing\n")
+        for _ in 0...2 {
+            coordinator.webViewWebContentProcessDidTerminate(webView)
+        }
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 2)
+        XCTAssertFalse(coordinator.isShellLoadingForTesting)
+
+        // Re-parenting the pane back into a window must recover the blank
+        // panel: reset the recovery budget and reload the shell.
+        coordinator.handleViewReenteredWindow()
+
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 0)
+        XCTAssertTrue(coordinator.isShellLoadingForTesting)
+    }
+
+    func testMarkdownRendererReentersWindowKeepsLoadedShell() {
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let theme = MarkdownWebTheme.resolve(backgroundColor: .windowBackgroundColor)
+        coordinator.webView = webView
+        defer { coordinator.close() }
+
+        // A still-loaded shell (WebContent process alive, just unpainted) must
+        // not be torn down and reloaded when the view re-enters a window.
+        coordinator.loadShell(theme: theme, initialMarkdown: "# Existing\n")
+        coordinator.webView(webView, didFinish: nil)
+        XCTAssertFalse(coordinator.isShellLoadingForTesting)
+
+        coordinator.handleViewReenteredWindow()
+
+        XCTAssertFalse(coordinator.isShellLoadingForTesting)
+    }
+
     func testMarkdownRendererNavigationFailureUnblocksFutureShellReload() {
         let coordinator = MarkdownWebRenderer.Coordinator()
         let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -515,12 +515,20 @@ final class MarkdownPanelTests: XCTestCase {
         // A still-loaded shell (WebContent process alive, just unpainted) must
         // not be torn down and reloaded when the view re-enters a window.
         coordinator.loadShell(theme: theme, initialMarkdown: "# Existing\n")
+        // Consume part of the per-payload crash-recovery budget, then finish a
+        // successful reload so the shell is loaded again.
+        coordinator.webViewWebContentProcessDidTerminate(webView)
         coordinator.webView(webView, didFinish: nil)
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 1)
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
 
         coordinator.handleViewReenteredWindow()
 
+        // Re-entry on a loaded shell must not reload it, and must preserve the
+        // per-payload crash budget so reparent/layout churn can't grant a
+        // crashing payload extra recovery cycles.
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 1)
     }
 
     func testMarkdownRendererNavigationFailureUnblocksFutureShellReload() {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -487,10 +487,13 @@ final class MarkdownPanelTests: XCTestCase {
         coordinator.webView = webView
         defer { coordinator.close() }
 
-        // Simulate the WebContent process being reclaimed while the pane was
-        // detached during a drag, exhausting the in-place recovery budget so
-        // the panel is left permanently blank.
+        // Document was healthy when the pane was dragged out of its column.
         coordinator.loadShell(theme: theme, initialMarkdown: "# Existing\n")
+        coordinator.webView(webView, didFinish: nil)
+        coordinator.handleViewLeftWindow()
+
+        // While detached, WebKit reclaimed the WebContent process and the
+        // in-place recovery budget was exhausted, leaving the panel blank.
         for _ in 0...2 {
             coordinator.webViewWebContentProcessDidTerminate(webView)
         }
@@ -522,6 +525,7 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 1)
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
 
+        coordinator.handleViewLeftWindow()
         coordinator.handleViewReenteredWindow()
 
         // Re-entry on a loaded shell must not reload it, and must preserve the
@@ -529,6 +533,32 @@ final class MarkdownPanelTests: XCTestCase {
         // crashing payload extra recovery cycles.
         XCTAssertFalse(coordinator.isShellLoadingForTesting)
         XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 1)
+    }
+
+    func testMarkdownRendererReentersWindowDoesNotReviveCrashLoopingPayload() {
+        let coordinator = MarkdownWebRenderer.Coordinator()
+        let webView = MarkdownWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let theme = MarkdownWebTheme.resolve(backgroundColor: .windowBackgroundColor)
+        coordinator.webView = webView
+        defer { coordinator.close() }
+
+        // A payload that keeps crashing WebContent *while attached* exhausts
+        // the recovery budget and is intentionally left blank by the crash-loop
+        // guard — the shell was never healthy when detached.
+        coordinator.loadShell(theme: theme, initialMarkdown: "# Crashy\n")
+        for _ in 0...2 {
+            coordinator.webViewWebContentProcessDidTerminate(webView)
+        }
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 2)
+        XCTAssertFalse(coordinator.isShellLoadingForTesting)
+
+        // Dragging the pane (detach while already blank) then re-entering must
+        // NOT grant the crashing payload a fresh budget or reload it.
+        coordinator.handleViewLeftWindow()
+        coordinator.handleViewReenteredWindow()
+
+        XCTAssertEqual(coordinator.webContentProcessRecoveryAttemptsForTesting, 2)
+        XCTAssertFalse(coordinator.isShellLoadingForTesting)
     }
 
     func testMarkdownRendererNavigationFailureUnblocksFutureShellReload() {


### PR DESCRIPTION
Closes #6144

## Root cause

Dragging a **Markdown-viewer pane** into another column collapses the source column and re-parents the hosting views (`removeFromSuperview` → `addSubview`). While the `WKWebView` is detached from the window, WebKit suspends its rendering and can reclaim the WebContent process. The post-layout reattach/refresh path only covered **terminal** panels — the Markdown web view never reacted to re-entering a window — so every Markdown tab in the moved pane stayed a **permanently blank** white area (tab titles and the file-path header still rendered). There is no user-facing reload for the Markdown viewer, so the only recovery was closing and reopening the file.

## Fix

`MarkdownWebView` now overrides `viewDidMoveToWindow`:

- **On detach** (`window == nil`): drive WebKit's in-window lifecycle out so the matching re-entry resumes rendering (mirrors the browser panel's recovery path).
- **On re-entry**: nudge the rendering state back on (private WKWebView lifecycle selectors, each guarded by `responds(to:)` so they degrade to no-ops if Apple removes them, plus a layout/display pass) so a live-but-unpainted document repaints. It also calls the renderer coordinator's new `handleViewReenteredWindow()`, which resets the crash-recovery budget and reloads the shell when the WebContent process was actually lost — recovering the permanent-blank case.

This reuses the same lifecycle-revival mechanism the browser panel already uses for the analogous "blank after move" class (#1294), extended to the Markdown viewer.

## Tradeoffs

- Uses private WKWebView lifecycle selectors via `responds(to:)`-guarded dispatch. This is an existing, established pattern in `BrowserPanelView` for the same blank-after-reparent problem; the guard makes it a safe no-op if the selectors ever disappear.

## Tests

Two-commit red/green regression structure in `cmuxTests/MarkdownPanelTests.swift`:

- Commit 1 adds the failing tests against an empty `handleViewReenteredWindow()` hook (red).
- Commit 2 implements the recovery (green).

`testMarkdownRendererReentersWindowReloadsShellAfterRecoveryBudgetExhausted` proves re-entry reloads the shell + resets the budget after the in-place recovery budget is exhausted; `testMarkdownRendererReentersWindowKeepsLoadedShell` proves a still-loaded shell is left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320139&installation_id=133855650&pr_number=6331&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6331&signature=cc9639652fe28be1433f0d3ad0de44f545001703d66a758ae3bbd590350319fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permanently blank Markdown viewer panes after dragging between columns by reviving `WKWebView` rendering on window re-entry. Reloads only when content was truly lost, preserving crash budgets and not reviving crash‑looping payloads.

- **Bug Fixes**
  - `MarkdownWebView` now handles detach/re-entry in `viewDidMoveToWindow`: drives out in-window lifecycle on detach, nudges it back on re-entry via guarded private selectors, forces layout/display, and notifies the coordinator on both leave and re-entry.
  - Wires `onLeaveWindow` and `onReenterWindow` in make/update; clears both on teardown.
  - Coordinator records if the shell was healthy at detach; on re-entry it reloads and resets the budget only when the shell was lost after a healthy detach. Keeps a loaded shell intact and does not grant a fresh budget to payloads that crash-loop while attached.
  - Adds regression tests covering: reload after budget exhaustion post-detach, preserve budget on re-entry with a loaded shell, and do not revive a crash-looping payload.

<sup>Written for commit c5a5cf33f050c68fcd42c123946135879ff11529. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

