### PR TITLE
CI: maintainer-approved artifact path for external fork PRs (#5976)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Validate Swift file length budget
         run: python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
 
+      - name: Validate fork PR artifact workflow guards
+        run: ./tests/test_ci_fork_pr_artifact.sh
+
   remote-daemon-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fork-pr-artifact.yml
+++ b/.github/workflows/fork-pr-artifact.yml
@@ -18,7 +18,19 @@ name: Fork PR artifact
 # a bare object, never a mutable ref), so a contributor cannot swap in different
 # code after approval. The build runs unsigned (CODE_SIGNING_ALLOWED=NO) with no
 # release secrets, and checkout uses `persist-credentials: false` so the
-# fork-authored build scripts never see the workflow token.
+# fork-authored build scripts never see the git credential.
+#
+# Cache isolation: this workflow uses NO Actions cache (not even restore-only).
+# ACTIONS_RUNTIME_TOKEN is present in any job that uploads artifacts, and a job
+# step can read it, so fork-authored build code could otherwise call the cache
+# API directly to write attacker-controlled entries into a cache scope that
+# trusted CI/release builds restore (spm-*, zig-packages-*, ghosttykit-*). By
+# never touching the shared cache namespace, this workflow's runs cannot seed
+# those caches; the build just runs cold. The residual exposure — that fork code
+# runs at all with a runtime token in the trusted repo context — is inherent to
+# building any code in Actions and is controlled by the mandatory maintainer
+# review of the exact approved SHA (including build scripts and Package.swift)
+# before dispatch.
 
 on:
   workflow_dispatch:
@@ -94,17 +106,13 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      # Restore-only: this workflow runs fork-authored build scripts, so it must
-      # never SAVE caches. A save step would persist attacker-controllable cache
-      # contents under keys that trusted CI/release builds later restore (cache
-      # poisoning). Reading existing trusted caches is safe; writing is not.
-      - name: Restore Zig packages
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/zig
-          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-packages-
-
+      # No Actions cache: this job runs fork-authored build scripts. Even a
+      # restore-only cache action is not enough, because ACTIONS_RUNTIME_TOKEN is
+      # present in the job (artifact upload needs it) and fork code could call
+      # the cache API directly to write attacker-controlled entries into a cache
+      # scope that trusted CI/release builds restore (e.g. spm-*, zig-packages-*,
+      # ghosttykit-*). So this workflow never touches the shared cache namespace
+      # at all and rebuilds cold. See SECURITY note at the top of this file.
       - name: Build universal Ghostty CLI helper
         run: |
           set -euo pipefail
@@ -162,37 +170,16 @@ jobs:
         run: |
           echo "sha=$(git -C ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # Restore-only (see Zig cache note above): never save fork-built caches
-      # under keys trusted builds restore.
-      - name: Restore GhosttyKit.xcframework
-        id: cache-ghosttykit-release
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: GhosttyKit.xcframework
-          key: ghosttykit-${{ steps.ghostty-revision.outputs.sha }}
-
+      # No Actions cache here either (see the cache note in the helper job and
+      # the SECURITY note at the top): always download the pre-built framework
+      # fresh rather than restoring it from the shared cache namespace.
       - name: Download pre-built GhosttyKit.xcframework
-        if: steps.cache-ghosttykit-release.outputs.cache-hit != 'true'
         run: |
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install Rust
         run: |
           ./scripts/install-rust-ci.sh
-
-      # Restore-only (see Zig cache note above): never save fork-built caches
-      # under keys trusted builds restore.
-      - name: Restore Swift packages
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .spm-cache
-          key: spm-release-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: |
-            spm-release-
-            spm-
-
-      - name: Sanitize Swift package cache
-        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
 
       - name: Build universal app (Release)
         run: |

--- a/.github/workflows/fork-pr-artifact.yml
+++ b/.github/workflows/fork-pr-artifact.yml
@@ -1,0 +1,247 @@
+name: Fork PR artifact
+
+# Maintainer-approved artifact path for external fork PRs.
+#
+# Why: cmux is a macOS app, so validating a fork contribution needs a full
+# Xcode build that most outside contributors cannot run locally (Command Line
+# Tools are not enough). The normal `CI` / `Activation performance` checks on a
+# fork PR wait for maintainer approval before they run, and they do not publish
+# a downloadable .app artifact, so a contributor has no self-serve way to get a
+# trusted build of their change. See https://github.com/manaflow-ai/cmux/issues/5976
+# (observed on PR #5491).
+#
+# Security model: this workflow is `workflow_dispatch` only. GitHub restricts
+# manual dispatch to users with write access to manaflow-ai/cmux, so only a
+# maintainer can run it — the same gate as "Require approval for outside
+# collaborators". The maintainer reviews the fork diff, then dispatches the
+# EXACT head commit SHA they reviewed. We build only that pinned SHA (fetched as
+# a bare object, never a mutable ref), so a contributor cannot swap in different
+# code after approval. The build runs unsigned (CODE_SIGNING_ALLOWED=NO) with no
+# release secrets, and checkout uses `persist-credentials: false` so the
+# fork-authored build scripts never see the workflow token.
+
+on:
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Exact reviewed PR head commit SHA to build (only this SHA is built; full 40-char SHA)"
+        required: true
+        type: string
+      pr_number:
+        description: "PR number (used for artifact naming and a head-SHA drift check)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  verify-sha:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.pin.outputs.sha }}
+    steps:
+      - name: Validate and pin the approved head SHA
+        id: pin
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Require a full 40-character commit SHA so the build target is exact
+          # and unambiguous, never a branch name or short SHA that could move.
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::head_sha must be a full 40-character commit SHA (got: '$HEAD_SHA')"
+            exit 1
+          fi
+
+          # If a PR number was supplied, warn (do not fail) when the PR's current
+          # head no longer matches the approved SHA — the contributor pushed new
+          # commits after the maintainer reviewed. We still build only the
+          # reviewed SHA below.
+          if [[ -n "$PR_NUMBER" ]]; then
+            CURRENT_HEAD="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' || echo '')"
+            echo "PR #${PR_NUMBER} current head: ${CURRENT_HEAD:-<unknown>}"
+            echo "Approved head_sha:       ${HEAD_SHA}"
+            if [[ -n "$CURRENT_HEAD" && "$CURRENT_HEAD" != "$HEAD_SHA" ]]; then
+              echo "::warning::PR #${PR_NUMBER} head ($CURRENT_HEAD) differs from the approved SHA ($HEAD_SHA); building the approved SHA only."
+            fi
+          fi
+
+          echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+  ghostty-cli-helper:
+    needs: verify-sha
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout approved SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.verify-sha.outputs.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      # Restore-only: this workflow runs fork-authored build scripts, so it must
+      # never SAVE caches. A save step would persist attacker-controllable cache
+      # contents under keys that trusted CI/release builds later restore (cache
+      # poisoning). Reading existing trusted caches is safe; writing is not.
+      - name: Restore Zig packages
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/zig
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
+
+      - name: Build universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          mkdir -p ghostty-cli-helper
+          ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
+          lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
+
+      - name: Upload universal Ghostty CLI helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fork-pr-ghostty-cli-helper-${{ needs.verify-sha.outputs.sha }}
+          path: ghostty-cli-helper/ghostty
+          if-no-files-found: error
+
+  build-app:
+    needs: [verify-sha, ghostty-cli-helper]
+    # Match release-build: macOS 26 so SDK-gated SwiftUI Liquid Glass code
+    # compiles into the same artifact shape as nightly and stable releases.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'warp-macos-26-arm64-6x' }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout approved SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.verify-sha.outputs.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
+            if [ -n "$XCODE_APP" ]; then
+              XCODE_DIR="$XCODE_APP/Contents/Developer"
+            else
+              echo "No Xcode.app found under /Applications" >&2
+              exit 1
+            fi
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+
+      - name: Capture Ghostty revision
+        id: ghostty-revision
+        run: |
+          echo "sha=$(git -C ghostty rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Restore-only (see Zig cache note above): never save fork-built caches
+      # under keys trusted builds restore.
+      - name: Restore GhosttyKit.xcframework
+        id: cache-ghosttykit-release
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: GhosttyKit.xcframework
+          key: ghosttykit-${{ steps.ghostty-revision.outputs.sha }}
+
+      - name: Download pre-built GhosttyKit.xcframework
+        if: steps.cache-ghosttykit-release.outputs.cache-hit != 'true'
+        run: |
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Install Rust
+        run: |
+          ./scripts/install-rust-ci.sh
+
+      # Restore-only (see Zig cache note above): never save fork-built caches
+      # under keys trusted builds restore.
+      - name: Restore Swift packages
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache
+          key: spm-release-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-release-
+            spm-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
+      - name: Build universal app (Release)
+        run: |
+          set -euo pipefail
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Release -derivedDataPath build-universal \
+            -destination 'generic/platform=macOS' \
+            -clonedSourcePackagesDirPath .spm-cache \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
+
+      - name: Download universal Ghostty CLI helper
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: fork-pr-ghostty-cli-helper-${{ needs.verify-sha.outputs.sha }}
+          path: ghostty-cli-helper
+
+      - name: Install universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          ./scripts/install-prebuilt-ghostty-cli-helper.sh \
+            ghostty-cli-helper/ghostty \
+            build-universal/Build/Products/Release/cmux.app
+
+      - name: Validate Release artifact slices
+        run: |
+          set -euo pipefail
+          APP_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
+          CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
+          HELPER_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
+          test -x "$APP_BINARY"
+          test -x "$CLI_BINARY"
+          test -x "$HELPER_BINARY"
+          file "$APP_BINARY" "$CLI_BINARY" "$HELPER_BINARY"
+          lipo "$APP_BINARY" -verify_arch arm64 x86_64
+          lipo "$CLI_BINARY" -verify_arch arm64 x86_64
+          lipo "$HELPER_BINARY" -verify_arch arm64 x86_64
+
+      - name: Package unsigned app
+        run: |
+          set -euo pipefail
+          mkdir -p fork-pr-artifact
+          ditto -c -k --sequesterRsrc --keepParent \
+            build-universal/Build/Products/Release/cmux.app \
+            fork-pr-artifact/cmux-unsigned.zip
+
+      - name: Upload unsigned app artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-unsigned-${{ inputs.pr_number || needs.verify-sha.outputs.sha }}
+          path: fork-pr-artifact/cmux-unsigned.zip
+          if-no-files-found: error

--- a/.github/workflows/fork-pr-artifact.yml
+++ b/.github/workflows/fork-pr-artifact.yml
@@ -227,9 +227,15 @@ jobs:
           test -x "$CLI_BINARY"
           test -x "$HELPER_BINARY"
           file "$APP_BINARY" "$CLI_BINARY" "$HELPER_BINARY"
+          # Match release-build: assert the app was compiled against the macOS 26
+          # SDK so a misrouted MACOS_RUNNER_26 or Xcode-selection drift cannot
+          # publish a fork artifact that is not release-equivalent.
+          SDK_VERSION="$(otool -l "$APP_BINARY" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
+          echo "App SDK version: $SDK_VERSION"
           lipo "$APP_BINARY" -verify_arch arm64 x86_64
           lipo "$CLI_BINARY" -verify_arch arm64 x86_64
           lipo "$HELPER_BINARY" -verify_arch arm64 x86_64
+          [[ "$SDK_VERSION" == 26.* ]]
 
       - name: Package unsigned app
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,41 @@ ssh cmux-vm 'cd /Users/cmux/cmux && xcodebuild -project cmux.xcodeproj -scheme c
 ssh cmux-vm 'cd /Users/cmux/cmux && xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug -destination "platform=macOS" -only-testing:cmuxUITests test'
 ```
 
+## Validating a fork PR without full Xcode
+
+cmux is a macOS app, so building it locally requires the full Xcode.app, not
+just the Command Line Tools. Outside contributors who only have Command Line
+Tools cannot produce a runnable `.app` locally, and the `CI` / `Activation
+performance` checks on a fork PR stay pending until a maintainer approves them
+and do not publish a downloadable build.
+
+To get a trusted build of a fork PR, a maintainer can dispatch the **Fork PR
+artifact** workflow (`.github/workflows/fork-pr-artifact.yml`):
+
+1. A maintainer reviews the fork diff and copies the exact PR **head commit
+   SHA** (the full 40-character SHA, e.g. from the PR's Commits tab or
+   `gh pr view <N> --json headRefOid -q .headRefOid`).
+2. They run the workflow against that SHA:
+
+   ```bash
+   gh workflow run "Fork PR artifact" --repo manaflow-ai/cmux \
+     -f head_sha=<full-40-char-head-sha> \
+     -f pr_number=<PR number>
+   ```
+
+   or via the Actions tab → **Fork PR artifact** → **Run workflow**.
+3. The workflow builds the same unsigned universal Release app that CI's
+   `release-build` job compiles and uploads it as the `cmux-unsigned-<PR>`
+   artifact (a `cmux-unsigned.zip`), downloadable from the run summary.
+
+Security: the workflow is `workflow_dispatch` only, so only users with write
+access to the repo can trigger it. It builds **only the exact SHA the
+maintainer entered** (fetched as a pinned commit object, never a mutable
+branch ref), so a contributor cannot substitute different code after review.
+The build is unsigned, uses no release secrets, and checks out with
+`persist-credentials: false` so the fork's build scripts never see the workflow
+token.
+
 ## Ghostty Submodule
 
 The `ghostty` submodule points to [manaflow-ai/ghostty](https://github.com/manaflow-ai/ghostty), a fork of the upstream Ghostty project.

--- a/tests/test_ci_fork_pr_artifact.sh
+++ b/tests/test_ci_fork_pr_artifact.sh
@@ -63,14 +63,15 @@ fi
 grep -Fq 'CODE_SIGNING_ALLOWED=NO' "$WF" \
   || fail "app build must stay unsigned (CODE_SIGNING_ALLOWED=NO)"
 
-# 5b. Caches must be restore-only. The save-capable actions/cache@ action would
-#     persist fork-built cache contents under keys trusted CI/release builds
-#     restore (cache poisoning). This workflow must use actions/cache/restore@.
-if grep -Eq 'uses:[[:space:]]*actions/cache@' "$WF"; then
-  fail "fork build must not use the save-capable actions/cache@; use actions/cache/restore@ (restore-only)"
+# 5b. No Actions cache at all. ACTIONS_RUNTIME_TOKEN is present in any job that
+#     uploads artifacts, so even a restore-only cache action is not enough —
+#     fork-authored build code could call the cache API directly and poison a
+#     cache scope that trusted CI/release builds restore (spm-*, zig-packages-*,
+#     ghosttykit-*). This workflow must never reference the shared cache
+#     namespace; it rebuilds cold instead.
+if grep -Eq 'uses:[[:space:]]*actions/cache' "$WF"; then
+  fail "fork build must not use any actions/cache action (cache poisoning risk); build cold instead"
 fi
-grep -Eq 'uses:[[:space:]]*actions/cache/restore@' "$WF" \
-  || fail "fork build must restore caches via actions/cache/restore@ (restore-only)"
 
 # 5c. The artifact must be release-equivalent: assert the app was built against
 #     the macOS 26 SDK (matches CI's release-build), so runner/Xcode drift

--- a/tests/test_ci_fork_pr_artifact.sh
+++ b/tests/test_ci_fork_pr_artifact.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/manaflow-ai/cmux/issues/5976.
+# The "Fork PR artifact" workflow gives maintainers a self-serve, secret-safe
+# way to build a downloadable macOS app artifact from an explicitly approved
+# fork PR head SHA. This guard locks the security-critical properties so a
+# future edit cannot silently turn it into a fork-code-runs-with-secrets path:
+#   - it is workflow_dispatch only (no pull_request/push trigger that an
+#     untrusted fork could fire),
+#   - it builds the exact reviewed head SHA (validated as a full 40-char SHA),
+#   - checkout pins that SHA and never persists credentials,
+#   - the build stays unsigned and on a paid macOS runner, and
+#   - it uploads the app artifact.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WF="$ROOT_DIR/.github/workflows/fork-pr-artifact.yml"
+
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
+
+[[ -f "$WF" ]] || fail "fork-pr-artifact.yml workflow is missing"
+
+# 1. Trigger must be workflow_dispatch ONLY. A pull_request or push trigger
+#    would let untrusted fork code run with repo context before approval.
+if ! awk '
+  /^on:/ { in_on=1; next }
+  in_on && /^[^[:space:]#]/ { in_on=0 }
+  in_on && /^[[:space:]]+workflow_dispatch:/ { saw_dispatch=1 }
+  in_on && /^[[:space:]]+(pull_request|pull_request_target|push):/ { saw_bad=1 }
+  END { exit !(saw_dispatch && !saw_bad) }
+' "$WF"; then
+  fail "workflow must trigger on workflow_dispatch only (no pull_request/push)"
+fi
+
+# 2. Must require the reviewed head SHA as an input.
+grep -Eq '^[[:space:]]+head_sha:' "$WF" \
+  || fail "workflow must expose a head_sha input"
+
+# 3. Must validate that head_sha is a full 40-character commit SHA so the build
+#    target is exact and cannot be a movable branch name.
+grep -Fq '^[0-9a-f]{40}$' "$WF" \
+  || fail "workflow must validate head_sha is a full 40-character commit SHA"
+
+# 4. Every checkout must pin the approved SHA and must not persist credentials
+#    (fork build scripts must never see the workflow token). Assert each
+#    checkout step's own `with:` block carries both properties.
+if ! awk '
+  /uses: actions\/checkout@/ { in_co=1; pinned=0; nocreds=0; total++; next }
+  in_co && /ref: \$\{\{ needs\.verify-sha\.outputs\.sha \}\}/ { pinned=1 }
+  in_co && /persist-credentials: false/ { nocreds=1 }
+  in_co && /^[[:space:]]*- name:/ { if (pinned && nocreds) good++; in_co=0 }
+  END {
+    if (in_co && pinned && nocreds) good++
+    exit !(total >= 2 && good == total)
+  }
+' "$WF"; then
+  fail "every actions/checkout must pin ref to the verified SHA and set persist-credentials: false"
+fi
+
+# 5. The build must stay unsigned (no release secrets needed before approval).
+grep -Fq 'CODE_SIGNING_ALLOWED=NO' "$WF" \
+  || fail "app build must stay unsigned (CODE_SIGNING_ALLOWED=NO)"
+
+# 5b. Caches must be restore-only. The save-capable actions/cache@ action would
+#     persist fork-built cache contents under keys trusted CI/release builds
+#     restore (cache poisoning). This workflow must use actions/cache/restore@.
+if grep -Eq 'uses:[[:space:]]*actions/cache@' "$WF"; then
+  fail "fork build must not use the save-capable actions/cache@; use actions/cache/restore@ (restore-only)"
+fi
+grep -Eq 'uses:[[:space:]]*actions/cache/restore@' "$WF" \
+  || fail "fork build must restore caches via actions/cache/restore@ (restore-only)"
+
+# 6. Both macOS jobs must run on a paid macOS runner, never a free GitHub runner.
+for job in ghostty-cli-helper build-app; do
+  if ! awk -v job="$job" '
+    $0 ~ "^  "job":" { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
+    in_job && /runs-on:.*(vars\.MACOS_RUNNER|blacksmith-[0-9]+vcpu-macos-|warp-macos-[0-9]+-arm64|depot-macos-)/ { saw=1 }
+    END { exit !saw }
+  ' "$WF"; then
+    fail "$job must run on a paid macOS runner (vars.MACOS_RUNNER_* or a Blacksmith/Warp/Depot label)"
+  fi
+done
+
+# 7. Must upload the built app as an artifact.
+if ! awk '
+  /- name: Upload unsigned app artifact/ { in_step=1; next }
+  in_step && /^[[:space:]]*- name:/ { in_step=0 }
+  in_step && /uses: actions\/upload-artifact@/ { saw_action=1 }
+  in_step && /if-no-files-found:[[:space:]]*error/ { saw_required=1 }
+  END { exit !(saw_action && saw_required) }
+' "$WF"; then
+  fail "workflow must upload the unsigned app as a required artifact"
+fi
+
+echo "PASS: fork-pr-artifact.yml is a maintainer-gated, SHA-pinned, unsigned artifact path"

--- a/tests/test_ci_fork_pr_artifact.sh
+++ b/tests/test_ci_fork_pr_artifact.sh
@@ -72,6 +72,12 @@ fi
 grep -Eq 'uses:[[:space:]]*actions/cache/restore@' "$WF" \
   || fail "fork build must restore caches via actions/cache/restore@ (restore-only)"
 
+# 5c. The artifact must be release-equivalent: assert the app was built against
+#     the macOS 26 SDK (matches CI's release-build), so runner/Xcode drift
+#     cannot publish a non-release-equivalent fork artifact.
+grep -Fq '[[ "$SDK_VERSION" == 26.* ]]' "$WF" \
+  || fail "app validation must assert the macOS 26 SDK (SDK_VERSION == 26.*) like release-build"
+
 # 6. Both macOS jobs must run on a paid macOS runner, never a free GitHub runner.
 for job in ghostty-cli-helper build-app; do
   if ! awk -v job="$job" '


### PR DESCRIPTION
Closes #5976

## Problem

External fork PRs have no self-serve way to validate a macOS app build. On a fork PR the `CI` / `Activation performance` checks stay pending until a maintainer approves them, and they never publish a downloadable `.app`. cmux is a macOS app that requires full Xcode (not just Command Line Tools) to build locally, so an outside contributor cannot validate their change or get an artifact until a maintainer manually intervenes. Observed on PR #5491.

## Fix

Add a new `workflow_dispatch`-only workflow `.github/workflows/fork-pr-artifact.yml` ("Fork PR artifact") that a maintainer runs against the **exact reviewed PR head SHA**:

```bash
gh workflow run "Fork PR artifact" --repo manaflow-ai/cmux \
  -f head_sha=<full-40-char-head-sha> -f pr_number=<N>
```

It mirrors CI's `release-build` lane — builds the unsigned universal Release app and bundles the universal Ghostty CLI helper, validates the slices stay universal, and uploads `cmux-unsigned.zip` as the `cmux-unsigned-<PR>` artifact.

## Security model

- **`workflow_dispatch` only** — GitHub restricts manual dispatch to users with write access, so only a maintainer can run it (same gate as "Require approval for outside collaborators"). No `pull_request`/`push` trigger an untrusted fork could fire.
- **Builds only the explicitly approved SHA** — the head SHA is validated as a full 40-char commit SHA and checked out as a pinned commit object (never a movable branch ref), so a contributor cannot substitute different code after review. If a `pr_number` is supplied, the workflow warns (does not silently build) when the PR's current head has drifted from the approved SHA.
- **No secret exposure** — the build is unsigned (`CODE_SIGNING_ALLOWED=NO`) with no release secrets, and every checkout uses `persist-credentials: false` so fork-authored build scripts never see the workflow token. `permissions:` is read-only.

## Tests / tradeoffs

- `tests/test_ci_fork_pr_artifact.sh` (wired into the `workflow-guard-tests` job) locks the security-critical properties: dispatch-only trigger, full-SHA validation, SHA-pinned + credential-less checkout, unsigned build, paid macOS runner, and a required artifact upload.
- Documented the path in `CONTRIBUTING.md`.
- Chose `workflow_dispatch` over a `safe to build` label/comment trigger: dispatch is inherently maintainer-gated and has a far smaller security surface (no `pull_request_target` + actor-permission validation needed). The maintainer pasting the exact reviewed SHA is the explicit-approval contract the issue asked for.
- No user-facing app/web strings changed, so no localization updates are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320201&installation_id=133855650&pr_number=6332&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6332&signature=68c95efa5a5411b9ba2dd586f4cf4ae2e7cfec9e940ea2851c861e2f4d133646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a maintainer-approved CI path to build a downloadable unsigned macOS app for external fork PRs. Builds a universal Release app from the exact reviewed 40‑char head SHA, asserts macOS 26 SDK parity with release builds, and uploads `cmux-unsigned.zip`; drops all Actions caching to eliminate cache‑poisoning risk.

- **New Features**
  - `Fork PR artifact` workflow (`.github/workflows/fork-pr-artifact.yml`), `workflow_dispatch` only with `head_sha` (required) and `pr_number` (optional); builds the app plus a universal Ghostty CLI helper and uploads `cmux-unsigned-<PR or SHA>`.
  - Security guardrails: read-only perms, SHA-pinned `actions/checkout` with `persist-credentials: false`, unsigned build, paid macOS runners, no Actions cache usage, and a drift warning if the PR head differs from the approved SHA.
  - CI and docs: adds `tests/test_ci_fork_pr_artifact.sh` (asserts `workflow_dispatch`-only, full-SHA validation, no `actions/cache`, unsigned build, paid runners, required artifact, and macOS 26 SDK), runs it from `ci.yml`; usage documented in `CONTRIBUTING.md`.

<sup>Written for commit d6c1ba986ac35724130231fa7286d82df0688010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

