### PR TITLE
Restore pane header title after terminal restart (#5931)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17583	Sources/AppDelegate.swift
 15920	Sources/ContentView.swift
 14225	Sources/TerminalController.swift
-12646	Sources/Workspace.swift
+12658	Sources/Workspace.swift
 12115	cmuxTests/AppDelegateShortcutRoutingTests.swift
 11731	Sources/GhosttyTerminalView.swift
 11388	Sources/Panels/BrowserPanel.swift
@@ -31,7 +31,7 @@
 3734	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
 3397	Sources/CmuxConfig.swift
-3331	cmuxTests/TabManagerSessionSnapshotTests.swift
+3361	cmuxTests/TabManagerSessionSnapshotTests.swift
 3055	Sources/Update/UpdateTitlebarAccessory.swift
 2878	Sources/SessionIndexView.swift
 2871	cmuxTests/CMUXOpenCommandTests.swift

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1425,6 +1425,18 @@ extension Workspace {
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle, source: snapshot.customTitleSource ?? .user)
         setPanelPinned(panelId: panelId, pinned: snapshot.isPinned)
 
+        // The bonsplit tab header only refreshes when `updateTab` is called; the writes
+        // above never reach it (`setPanelCustomTitle` skips the sync when there is no
+        // custom title), so push the restored title to the tab now, mirroring
+        // `updatePanelTitle`, instead of waiting for the next OSC title update.
+        if let panel = panels[panelId], let tabId = surfaceIdFromPanelId(panelId) {
+            bonsplitController.updateTab(
+                tabId,
+                title: resolvedPanelTitle(panelId: panelId, fallback: panelTitles[panelId] ?? panel.displayTitle),
+                hasCustomTitle: panelCustomTitles[panelId] != nil
+            )
+        }
+
         if snapshot.isManuallyUnread {
             markPanelUnread(panelId)
         } else {

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -3224,6 +3224,36 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertEqual(configuration.terminalStartupCommand, "ssh -tt dev@example.com")
     }
 
+    /// Regression for https://github.com/manaflow-ai/cmux/issues/5931 — a restored
+    /// terminal pane header showed the default "Terminal" title instead of its real
+    /// title until a command ran. `applySessionPanelMetadata` wrote the restored title
+    /// into `panelTitles` but never pushed it to the bonsplit tab header.
+    func testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let panelId = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true)?.id)
+
+        let restoredTitle = "~/projects/cmux"
+        workspace.updatePanelTitle(panelId: panelId, title: restoredTitle)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+        drainMainQueue()
+
+        let restoredWorkspace = try XCTUnwrap(restored.selectedWorkspace)
+        let restoredPanelId = try XCTUnwrap(
+            restoredWorkspace.panelTitles.first(where: { $0.value == restoredTitle })?.key
+        )
+        let restoredTabId = try XCTUnwrap(restoredWorkspace.surfaceIdFromPanelId(restoredPanelId))
+        let restoredTab = try XCTUnwrap(restoredWorkspace.bonsplitController.tab(restoredTabId))
+
+        XCTAssertEqual(restoredTab.title, restoredTitle)
+        XCTAssertNotEqual(restoredTab.title, "Terminal")
+    }
+
     private static func persistentSSHWorkspaceSnapshot(
         panel: SessionPanelSnapshot,
         focusedPanelId: UUID


### PR DESCRIPTION
## Summary

After restarting the terminal, restored pane header tabs all showed the generic title **"Terminal"** instead of their real title (e.g. the working-directory path). The real title only appeared once a command ran in the pane. Workspace/sidebar titles restored correctly — only pane headers were wrong.

Closes #5931

## Root cause

Pane header tabs are rendered by the **bonsplit** tab layer, which is decoupled from SwiftUI and only updates when something explicitly calls `bonsplitController.updateTab(...)`.

On restore:
1. `newTerminalSurface()` creates the bonsplit tab with the default `"Terminal"` title.
2. `applySessionPanelMetadata()` (`Sources/Workspace.swift`) writes the restored title into `panelTitles` — but never calls `bonsplitController.updateTab`. `setPanelCustomTitle` (the only call it makes that *can* sync the tab) returns early without syncing when there is no custom title, which is the common restore case.

So the visible header stayed `"Terminal"` until Ghostty later emitted an OSC title sequence through `updatePanelTitle()` — the only other title path that calls `updateTab`.

The sidebar works because workspace-title restore mutates the `@Published var title`, which SwiftUI observes; the bonsplit tab layer has no such observation.

## Fix

In `applySessionPanelMetadata`, after restoring the title, push the resolved title to the bonsplit tab — mirroring the sync `updatePanelTitle`/`setPanelCustomTitle` already perform. The resolved title also accounts for any restored custom title.

## Tests

Added `testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab` (two-commit red/green): sets a pane title, snapshots, restores into a fresh `TabManager`, and asserts the restored bonsplit tab title matches the real title (not `"Terminal"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320228&installation_id=133855650&pr_number=6333&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6333&signature=f5609f87dc232a2e45e48a008fd6105395b8c3f5da524ec493aee2321f33d825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores correct terminal pane header titles immediately after restart by pushing the resolved title to the bonsplit tab during session restore. Adds a regression test to ensure the "Terminal" placeholder doesn’t reappear (#5931).

- **Bug Fixes**
  - Push the resolved title to the bonsplit tab by calling updateTab in applySessionPanelMetadata, including when no custom title is set.
  - Add test `testRestoredTerminalPaneHeaderTitleSyncsToBonsplitTab` to assert the restored tab title matches the real title.

<sup>Written for commit cdc52a38dfde6b2f65afd9ac4f555faca0d1d8cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Session restoration now immediately syncs restored terminal panel header titles to the corresponding bonsplit tab headers, including custom titles, preventing temporary mismatches or fallback/default titles during recovery.

## Tests
- Added a regression test covering restored terminal panel title synchronization with bonsplit tab headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->