### PR TITLE
Fix terminal Liquid Glass rendering as opaque black on macOS 27 (#5860)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -27,7 +27,7 @@
 4227	Sources/BrowserWindowPortal.swift
 3937	Sources/Feed/FeedPanelView.swift
 3926	cmuxTests/TabManagerUnitTests.swift
-3903	cmuxTests/WindowAndDragTests.swift
+3931	cmuxTests/WindowAndDragTests.swift
 3734	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 3699	cmuxTests/CLIGenericHookPersistenceTests.swift
 3397	Sources/CmuxConfig.swift
@@ -185,7 +185,7 @@
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 556	Sources/Panels/BrowserAutomation.swift
 551	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
-547	Sources/Windowing/WindowGlassEffect.swift
+559	Sources/Windowing/WindowGlassEffect.swift
 541	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
 540	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 539	CLI/CMUXCLI+Themes.swift

--- a/Sources/Windowing/WindowGlassEffect.swift
+++ b/Sources/Windowing/WindowGlassEffect.swift
@@ -354,15 +354,27 @@ enum WindowGlassEffect {
         }
     }
 
+    /// macOS 27 changed how `NSGlassEffectView` composites its tint color: a
+    /// near-opaque dark tint (a typical dark terminal background) now renders the
+    /// glass as a solid dark fill rather than a translucent material. Suppress
+    /// cmux's terminal-derived tint there so the native glass renders unmodified;
+    /// macOS 26 keeps the original tinted behavior. See issue #5860.
+    static func suppressesNativeGlassTint(
+        operatingSystemVersion: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> Bool {
+        operatingSystemVersion.majorVersion >= 27
+    }
+
     private static func updateNativeGlassConfiguration(
         on glassView: NSView,
         color: NSColor?,
         style: Style?,
         cornerRadius: CGFloat?
     ) {
+        let effectiveColor = suppressesNativeGlassTint() ? nil : color
         let tintSelector = NSSelectorFromString("setTintColor:")
         if glassView.responds(to: tintSelector) {
-            glassView.perform(tintSelector, with: color)
+            glassView.perform(tintSelector, with: effectiveColor)
         }
 
         if let cornerRadius {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -105,6 +105,34 @@ final class WindowGlassEffectTests: XCTestCase {
         XCTAssertGreaterThan(tintOverlay.alphaValue, 0)
     }
 
+    func testSuppressesNativeGlassTintOnMacOS27Plus() {
+        // macOS 27 composites NSGlassEffectView's tint as a solid dark fill, so
+        // cmux's terminal-derived tint must be suppressed there (issue #5860).
+        XCTAssertTrue(
+            WindowGlassEffect.suppressesNativeGlassTint(
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0)
+            )
+        )
+        XCTAssertTrue(
+            WindowGlassEffect.suppressesNativeGlassTint(
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 28, minorVersion: 1, patchVersion: 0)
+            )
+        )
+    }
+
+    func testKeepsNativeGlassTintOnMacOS26AndEarlier() {
+        XCTAssertFalse(
+            WindowGlassEffect.suppressesNativeGlassTint(
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 9, patchVersion: 9)
+            )
+        )
+        XCTAssertFalse(
+            WindowGlassEffect.suppressesNativeGlassTint(
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 7, patchVersion: 4)
+            )
+        )
+    }
+
     private static func windowContainsGlassBackground(_ window: NSWindow) -> Bool {
         guard let contentView = window.contentView else { return false }
         let root = contentView.superview ?? contentView


### PR DESCRIPTION
Closes #5860

## Root cause
`WindowGlassEffect` backs the window with a native `NSGlassEffectView` and tints it via `setTintColor:` using the terminal's background color at its background opacity. macOS 27 changed how `NSGlassEffectView` composites that tint: a near-opaque dark tint (a typical dark terminal background) now renders the glass as a **solid dark fill** rather than a translucent material. On macOS 26 the same tint was subtle. This is the "AppKit semantics change silently between macOS major versions" class of issue already called out in `CLAUDE.md`.

## Fix
Suppress cmux's terminal-derived tint on the native glass on **macOS 27+** by passing `nil` to `setTintColor:`, letting `NSGlassEffectView` render its material unmodified. macOS 26 keeps the original tinted behavior. The gate is a small pure helper `WindowGlassEffect.suppressesNativeGlassTint(operatingSystemVersion:)` (major version >= 27), which is unit-tested.

The inactive-window dim overlay (a separate `tintOverlay` NSView) is unchanged — it is not affected by the native glass compositing change.

## Tests
- `testSuppressesNativeGlassTintOnMacOS27Plus` / `testKeepsNativeGlassTintOnMacOS26AndEarlier` in `cmuxTests/WindowAndDragTests.swift` cover the version gate (added to the already-wired `WindowGlassEffectTests` class).

## Tradeoff
The actual compositing behavior is OS-runtime-specific and cannot be asserted in a headless unit test, so coverage is on the pure version-gate decision; the visual outcome was confirmed empirically on macOS 27.0 (per the issue).

Swift file-length budget refreshed for the additions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320232&installation_id=133855650&pr_number=6334&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6334&signature=79d2fb2d8bfb4ad65026a91f02d97e850d5ec896cbff99ed14d9a43f4df082a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal glass rendering as opaque black on macOS 27 by disabling the native tint, and adds a per-pane runaway-memory guardrail to warn and help stop leaking processes before they can freeze the app.

- **Bug Fixes**
  - macOS 27: suppress tinting of `NSGlassEffectView` so terminal glass stays translucent; macOS 26 keeps the original tint.
  - Introduced `WindowGlassEffect.suppressesNativeGlassTint(...)` (gated on major >= 27) with unit tests.

- **New Features**
  - Per-pane runaway-memory guardrail (on by default, 8 GB threshold): shows an orange sidebar badge and a dismissible banner with the pane and foreground command.
  - Scanner attributes memory via controlling TTY; updates banner with hysteresis to avoid flapping.
  - “Kill Pane Process” sends SIGTERM then SIGKILL to the pane’s foreground process group; falls back to closing the pane if no group is found.
  - New Terminal settings: toggle and threshold (GB). Added localized strings, unit tests for the edge-trigger engine, and `TerminalSurface` accessors for foreground PID and TTY.

<sup>Written for commit 0641de541c2d004ef528e17485c27a3a58b5dadb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

