### PR TITLE
Route Cmd+F to focused file-preview and markdown panes (#6050, #6049)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -15,14 +15,14 @@
 7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6222	cmuxTests/GhosttyConfigTests.swift
-6154	Sources/TabManager.swift
+6179	Sources/TabManager.swift
 6153	CLI/cmux_open.swift
 6074	Sources/TextBoxInput.swift
 5925	cmuxTests/TerminalAndGhosttyTests.swift
 5558	Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
 5526	cmuxTests/BrowserConfigTests.swift
 4516	Sources/cmuxApp.swift
-4467	Sources/Panels/FilePreviewPanel.swift
+4502	Sources/Panels/FilePreviewPanel.swift
 4401	cmuxTests/BrowserPanelTests.swift
 4227	Sources/BrowserWindowPortal.swift
 3937	Sources/Feed/FeedPanelView.swift

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -999,6 +999,9 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     private var saveGeneration = 0
     private var activeSaveGeneration: Int?
     private weak var textView: NSTextView?
+    /// Set when Cmd+F arrives before the text view is in a window; the find bar
+    /// is presented once the editor attaches (see ``presentPendingFindBarIfPossible()``).
+    fileprivate var pendingFindOnAttach = false
     private let focusCoordinator: FilePreviewFocusCoordinator
     private let textLoader: @Sendable (URL) async -> FilePreviewTextLoader.Result
 
@@ -1053,6 +1056,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     func attachTextView(_ textView: NSTextView) {
         self.textView = textView
         focusCoordinator.register(root: textView, primaryResponder: textView, intent: .textEditor)
+        presentPendingFindBarIfPossible()
     }
 
     func handleDroppedFileURLsAsText(_ urls: [URL]) -> Bool {
@@ -1067,6 +1071,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     func retryPendingFocus() {
         focusCoordinator.fulfillPendingFocusIfNeeded()
+        presentPendingFindBarIfPossible()
     }
 
     func attachPDFPreview(root: NSView, primaryResponder: NSView) {
@@ -4463,5 +4468,35 @@ private final class FilePreviewPointerObserverView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         nil
+    }
+}
+
+extension FilePreviewPanel: TextFindablePanel {
+    /// Presents the text editor's find bar. Find is only meaningful in `.text`
+    /// mode; other preview modes (PDF, image, media, Quick Look) report that
+    /// they do not own the Find action so the shortcut can fall through.
+    ///
+    /// If the text view is not yet attached to a window (e.g. Cmd+F arrives
+    /// during open/restore), the request is held and fulfilled once the editor
+    /// attaches via ``presentPendingFindBarIfPossible()``.
+    @discardableResult
+    func startTextFind() -> Bool {
+        guard previewMode == .text else { return false }
+        pendingFindOnAttach = true
+        presentPendingFindBarIfPossible()
+        return true
+    }
+
+    var findBarTextView: NSTextView? {
+        previewMode == .text ? textView : nil
+    }
+
+    fileprivate func presentPendingFindBarIfPossible() {
+        guard pendingFindOnAttach,
+              previewMode == .text,
+              let textView else { return }
+        if textView.cmuxPresentInlineFindBar() {
+            pendingFindOnAttach = false
+        }
     }
 }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -82,6 +82,9 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     private var saveGeneration: Int = 0
     private var activeSaveGeneration: Int?
     private var pendingSearchNeedle: String?
+    /// Set when Cmd+F arrives while in preview mode; the find bar is presented
+    /// once the text editor attaches after switching to `.text` mode.
+    private var pendingFindAfterModeSwitch = false
     private weak var textView: NSTextView?
     private var isClosed: Bool = false
     // NotificationCenter token; removal is thread-safe so deinit can drop it.
@@ -235,6 +238,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         guard displayMode == .text else { return }
         _ = textView?.window?.makeFirstResponder(textView)
         applyPendingSearchNeedleIfPossible()
+        presentPendingFindBarIfPossible()
     }
 
     func unfocus() {
@@ -269,6 +273,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     func attachTextView(_ textView: NSTextView) {
         self.textView = textView
+        presentPendingFindBarIfPossible()
     }
 
     func retryPendingFocus() {
@@ -418,6 +423,17 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         pendingSearchNeedle = nil
     }
 
+    private func presentPendingFindBarIfPossible() {
+        guard pendingFindAfterModeSwitch,
+              displayMode == .text,
+              let textView else { return }
+        // Keep the request pending until the editor is in a window so a Cmd+F
+        // issued while switching modes still opens the find bar once attached.
+        if textView.cmuxPresentInlineFindBar() {
+            pendingFindAfterModeSwitch = false
+        }
+    }
+
     // MARK: - File watcher
 
     /// Watches ``filePath`` for changes via ``CmuxFileWatch/FileWatcher``, which
@@ -448,5 +464,25 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         if let typographyDefaultsObserver {
             NotificationCenter.default.removeObserver(typographyDefaultsObserver)
         }
+    }
+}
+
+extension MarkdownPanel: TextFindablePanel {
+    /// Presents the text editor's find bar. In preview mode this first switches
+    /// to the raw-markdown TextEdit mode (consistent with `applySearchNeedle`),
+    /// then opens the find bar once the editor attaches. Always claims the Find
+    /// action so Cmd+F is never silently dropped (#6050, #6049).
+    @discardableResult
+    func startTextFind() -> Bool {
+        pendingFindAfterModeSwitch = true
+        if displayMode != .text {
+            setDisplayMode(.text)
+        }
+        presentPendingFindBarIfPossible()
+        return true
+    }
+
+    var findBarTextView: NSTextView? {
+        displayMode == .text ? textView : nil
     }
 }

--- a/Sources/Panels/PanelTextFind.swift
+++ b/Sources/Panels/PanelTextFind.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+/// A panel that can present an in-pane Find UI (Cmd+F) backed by an
+/// `NSTextView` find bar.
+///
+/// `Cmd+F` is intercepted globally by `KeyEventMonitor` and routed through
+/// `TabManager.startSearch()`. Terminal panels (manaflow-ai/cmux#158) and
+/// browser panels have bespoke find implementations; every *other* focused
+/// panel previously dropped the keystroke silently — there was no find bar and
+/// no feedback (manaflow-ai/cmux#6050, #6049). Panels that conform here opt the
+/// focused pane into that same global `Cmd+F` action.
+@MainActor
+protocol TextFindablePanel: AnyObject {
+    /// Present the panel's Find UI, focusing whatever responder hosts it.
+    ///
+    /// - Returns: `true` when this panel owns the Find action for its current
+    ///   state (so the keystroke is considered handled), `false` when it cannot
+    ///   currently offer find (and the shortcut should fall through).
+    @discardableResult
+    func startTextFind() -> Bool
+
+    /// The text view hosting this panel's find bar when find can currently act
+    /// on it (correct mode + attached), or `nil` otherwise. Used to route the
+    /// follow-up Find Next / Previous / Hide shortcuts to the same find bar.
+    var findBarTextView: NSTextView? { get }
+}
+
+extension NSTextView {
+    /// Focuses this text view and opens its inline find bar, mirroring a Cmd+F
+    /// press while the text view is first responder.
+    ///
+    /// The global Cmd+F handler swallows the keystroke before AppKit's standard
+    /// responder-chain routing can reach the text view, so we invoke
+    /// `performFindPanelAction(_:)` directly with the `showFindPanel` tag.
+    ///
+    /// - Returns: `true` when the find bar was presented, `false` when the text
+    ///   view is not yet in a window (so the caller can retry once it attaches).
+    @discardableResult
+    func cmuxPresentInlineFindBar() -> Bool {
+        guard let window else { return false }
+        usesFindBar = true
+        if window.firstResponder !== self {
+            window.makeFirstResponder(self)
+        }
+        cmuxPerformFindPanelAction(.showFindPanel)
+        return true
+    }
+
+    /// Invokes an `NSFindPanelAction` (e.g. `.next`, `.previous`) on this text
+    /// view, mirroring the corresponding Find menu command.
+    func cmuxPerformFindPanelAction(_ action: NSFindPanelAction) {
+        let trigger = NSMenuItem()
+        trigger.tag = Int(action.rawValue)
+        performFindPanelAction(trigger)
+    }
+
+    /// Hides the inline find bar hosted by the enclosing scroll view, if shown.
+    func cmuxHideFindBar() {
+        enclosingScrollView?.isFindBarVisible = false
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -826,9 +826,25 @@ class TabManager: ObservableObject {
 #endif
             return handled
         }
-        guard let browserPanel = focusedBrowserPanel else { return false }
-        browserPanel.startFind()
-        return browserPanel.searchState != nil
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.startFind()
+            return browserPanel.searchState != nil
+        }
+        // Other focused panels (file preview text, markdown) host an NSTextView
+        // find bar. Without this, Cmd+F was silently swallowed (#6050, #6049).
+        if let findablePanel = focusedTextFindablePanel {
+            return findablePanel.startTextFind()
+        }
+        return false
+    }
+
+    /// The focused panel when it can present its own in-pane Find UI (file
+    /// preview text, markdown), excluding terminal and browser panels which
+    /// have their own dedicated find paths handled above.
+    private var focusedTextFindablePanel: TextFindablePanel? {
+        guard let workspace = selectedWorkspace,
+              let panelId = workspace.focusedPanelId else { return nil }
+        return workspace.panels[panelId] as? TextFindablePanel
     }
 
     func searchSelection() {
@@ -851,8 +867,11 @@ class TabManager: ObservableObject {
             _ = panel.performBindingAction("search:next")
             return
         }
-
-        focusedBrowserPanel?.findNext()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.findNext()
+            return
+        }
+        focusedTextFindablePanel?.findBarTextView?.cmuxPerformFindPanelAction(.next)
     }
 
     func findPrevious() {
@@ -860,8 +879,11 @@ class TabManager: ObservableObject {
             _ = panel.performBindingAction("search:previous")
             return
         }
-
-        focusedBrowserPanel?.findPrevious()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.findPrevious()
+            return
+        }
+        focusedTextFindablePanel?.findBarTextView?.cmuxPerformFindPanelAction(.previous)
     }
 
     @discardableResult
@@ -941,8 +963,11 @@ class TabManager: ObservableObject {
             panel.searchState = nil
             return
         }
-
-        focusedBrowserPanel?.hideFind()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.hideFind()
+            return
+        }
+        focusedTextFindablePanel?.findBarTextView?.cmuxHideFindBar()
     }
 
     func makeWorkspaceForCreation(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
+		FF6050F2FF6050F2FF6050F2 /* PanelFindShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6050F1FF6050F1FF6050F1 /* PanelFindShortcutTests.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
@@ -1511,6 +1512,7 @@
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
+		FF6050F1FF6050F1FF6050F1 /* PanelFindShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelFindShortcutTests.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
@@ -2887,6 +2889,7 @@
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
+				FF6050F1FF6050F1FF6050F1 /* PanelFindShortcutTests.swift */,
 				C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */,
 				C0DEFC100000000000000002 /* FilePreviewTextEditorTextKitTests.swift */,
 				D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */,
@@ -4228,6 +4231,7 @@
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
+				FF6050F2FF6050F2FF6050F2 /* PanelFindShortcutTests.swift in Sources */,
 				C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 				D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -568,6 +568,7 @@
 		FF6050F2FF6050F2FF6050F2 /* PanelFindShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6050F1FF6050F1FF6050F1 /* PanelFindShortcutTests.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
+		FF6050A2FF6050A2FF6050A2 /* PanelTextFind.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6050A1FF6050A1FF6050A1 /* PanelTextFind.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
 		D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */; };
 		D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A2 /* PhonePushClient.swift */; };
@@ -1515,6 +1516,7 @@
 		FF6050F1FF6050F1FF6050F1 /* PanelFindShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelFindShortcutTests.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
+		FF6050A1FF6050A1FF6050A1 /* PanelTextFind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelTextFind.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
 		D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneForwardingMode.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A2 /* PhonePushClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushClient.swift; sourceTree = "<group>"; };
@@ -2543,6 +2545,7 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5001418 /* MarkdownPanel.swift */,
+				FF6050A1FF6050A1FF6050A1 /* PanelTextFind.swift */,
 				A50014F0 /* MarkdownPanelFileLinkResolver.swift */,
 				F5168A030000000000000002 /* MarkdownFontSizeSettings.swift */,
 				F5168A040000000000000002 /* MarkdownFontFamily.swift */,
@@ -3733,6 +3736,7 @@
 				A5001400 /* Panel.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */,
+				FF6050A2FF6050A2FF6050A2 /* PanelTextFind.swift in Sources */,
 				A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */,
 				D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */,
 				D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */,

--- a/cmuxTests/PanelFindShortcutTests.swift
+++ b/cmuxTests/PanelFindShortcutTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for manaflow-ai/cmux#6050 / #6049: pressing Cmd+F while a
+/// non-terminal, non-browser pane is focused used to be silently swallowed.
+/// `Cmd+F` is intercepted globally and routed through `TabManager.startSearch()`,
+/// which previously only handled terminal and browser panels and dropped the
+/// keystroke for file-preview and markdown panes.
+@MainActor
+final class PanelFindShortcutTests: XCTestCase {
+    private func makeTempFile(name: String, contents: String) throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-panel-find-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directoryURL) }
+        let fileURL = directoryURL.appendingPathComponent(name)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+
+    func testFindShortcutIsHandledForFocusedFilePreviewTextPane() throws {
+        let fileURL = try makeTempFile(name: "config.toml", contents: "[server]\nport = 8080\n")
+
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
+        let panel = try XCTUnwrap(
+            workspace.newFilePreviewSurface(inPane: paneId, filePath: fileURL.path, focus: true)
+        )
+        defer { panel.close() }
+
+        XCTAssertEqual(workspace.focusedPanelId, panel.id)
+        XCTAssertEqual(panel.previewMode, .text)
+        XCTAssertTrue(
+            manager.startSearch(),
+            "Cmd+F should be handled (not silently dropped) for a focused file-preview text pane."
+        )
+    }
+
+    func testFindShortcutIsHandledForFocusedMarkdownPreviewPane() throws {
+        let fileURL = try makeTempFile(name: "README.md", contents: "# Title\n\nFind me.\n")
+
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
+        let panel = try XCTUnwrap(
+            workspace.newMarkdownSurface(inPane: paneId, filePath: fileURL.path, focus: true)
+        )
+        defer { panel.close() }
+
+        XCTAssertEqual(workspace.focusedPanelId, panel.id)
+        XCTAssertEqual(panel.displayMode, .preview)
+        XCTAssertTrue(
+            manager.startSearch(),
+            "Cmd+F should be handled (not silently dropped) for a focused markdown preview pane."
+        )
+        XCTAssertEqual(
+            panel.displayMode,
+            .text,
+            "Find in a markdown preview pane should drop into the raw-markdown TextEdit mode that hosts the find bar."
+        )
+    }
+}


### PR DESCRIPTION
Closes #6050
Addresses #6049 (markdown preview panes)

## Root cause
`Cmd+F` is intercepted globally by `KeyEventMonitor` and routed through `TabManager.startSearch()`. That method only handled the focused **terminal** panel (#158) and the focused **browser** panel. Any other focused pane — a file opened as plain text (e.g. `config.toml` → `FilePreviewPanel` text mode) or a markdown preview (`MarkdownPanel`) — fell through and returned `false`, so the keystroke was silently swallowed: no find bar, no feedback.

## Fix
- Add a small `TextFindablePanel` protocol and an `NSTextView.cmuxPresentInlineFindBar()` helper (new file `Sources/Panels/PanelTextFind.swift`). The helper focuses the text view and invokes `performFindPanelAction(_:)` directly, because the global Cmd+F handler swallows the keystroke before AppKit's normal responder-chain routing could reach the text view.
- Route `TabManager.startSearch()` to the focused panel when it conforms to `TextFindablePanel` (after the existing terminal/browser checks):
  - **`FilePreviewPanel`** (text mode): opens the editor's inline find bar. Non-text modes (PDF, image, media, Quick Look) report they don't own find, so the shortcut falls through unchanged (no regression).
  - **`MarkdownPanel`**: claims Cmd+F in either mode. In preview mode it switches to the raw-markdown TextEdit mode — consistent with the existing `applySearchNeedle` global-search path — and opens the find bar once the editor attaches.

The terminal and browser find paths are untouched.

## Tradeoff
For a markdown **preview** pane, Cmd+F drops into the raw-markdown source editor (with the native find bar) rather than searching the rendered WebView. This reuses the panel's existing mode-switch/search machinery and the rock-solid AppKit `NSTextView` find bar, which is reliable across macOS versions — unlike experimental WebView find. Scope is limited to the Cmd+F (start-find) action named in the issue; find-next/find-previous are served by the native find bar's own controls.

## Tests
`cmuxTests/PanelFindShortcutTests.swift` focuses a file-preview text pane and a markdown preview pane and asserts `startSearch()` handles Cmd+F (and that the markdown pane switches into TextEdit mode). Committed red/green:
1. Test-only commit — fails on `main` (`startSearch()` returns `false`).
2. Fix commit — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320784&installation_id=133855650&pr_number=6335&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6335&signature=143854fc7103fb6ee500a99124f4fd6bb1ed42650c807230c98eb4d4675d566e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Cmd+F and follow-up find commands (next/previous/hide) to focused file-preview text and markdown panes so the native inline find bar opens and works consistently. Closes #6050 and addresses #6049.

- **Bug Fixes**
  - Added `TextFindablePanel` and `NSTextView.cmuxPresentInlineFindBar()` (focus + safe deferral until attached).
  - Updated `TabManager.startSearch()` to delegate Cmd+F to the focused `TextFindablePanel`, and route find next/previous/hide to its `NSTextView`.
  - `FilePreviewPanel`/`MarkdownPanel`: text mode presents the inline find bar; non-text modes fall through. Markdown claims Cmd+F in preview, switches to Text mode, tracks a pending find, then opens the find bar when the editor attaches.
  - Added regression tests for file-preview text panes and markdown preview panes.

<sup>Written for commit b89565f765d34eea0add88635a9049c514e95b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

