### PR TITLE
Support Cmd+F (Find) in Markdown panels (#6049)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -15,7 +15,7 @@
 7221	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6223	cmuxTests/GhosttyConfigTests.swift
-6154	Sources/TabManager.swift
+6177	Sources/TabManager.swift
 6153	CLI/cmux_open.swift
 6074	Sources/TextBoxInput.swift
 5925	cmuxTests/TerminalAndGhosttyTests.swift
@@ -56,7 +56,7 @@
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
-1622	cmuxTests/MarkdownPanelTests.swift
+1647	cmuxTests/MarkdownPanelTests.swift
 1560	cmuxTests/TextBoxMentionCompletionTests.swift
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1512	cmuxTests/RestorableAgentSessionIndexTests.swift
@@ -200,6 +200,7 @@
 527	CLI/CLISocketPathResolver.swift
 527	Packages/macOS/CmuxSocketControl/Sources/CmuxSocketControl/SocketControlSettings.swift
 524	CLI/CMUXCLI+AutoNaming.swift
+523	Sources/Panels/MarkdownPanel.swift
 522	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
 520	CLI/CMUXCLI+AmpExtension.swift
 520	cmuxTests/MainWindowVisibilityControllerTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -56,7 +56,7 @@
 1695	cmuxTests/WorkspacePullRequestSidebarTests.swift
 1677	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1652	cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
-1574	cmuxTests/MarkdownPanelTests.swift
+1622	cmuxTests/MarkdownPanelTests.swift
 1560	cmuxTests/TextBoxMentionCompletionTests.swift
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1512	cmuxTests/RestorableAgentSessionIndexTests.swift

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -82,6 +82,10 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     private var saveGeneration: Int = 0
     private var activeSaveGeneration: Int?
     private var pendingSearchNeedle: String?
+    /// Set when a Cmd+F find was requested before the text editor's `NSTextView`
+    /// was mounted (e.g. the panel was in preview mode). Applied once the text
+    /// view attaches to a window via ``focus()`` / ``retryPendingFocus()``.
+    private var pendingFindRequest: Bool = false
     private weak var textView: NSTextView?
     private var isClosed: Bool = false
     // NotificationCenter token; removal is thread-safe so deinit can drop it.
@@ -235,6 +239,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         guard displayMode == .text else { return }
         _ = textView?.window?.makeFirstResponder(textView)
         applyPendingSearchNeedleIfPossible()
+        applyPendingFindIfPossible()
     }
 
     func unfocus() {
@@ -416,6 +421,72 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         textView.setSelectedRange(range)
         textView.scrollRangeToVisible(range)
         pendingSearchNeedle = nil
+    }
+
+    // MARK: - Find (Cmd+F)
+
+    /// Opens the native macOS find bar for this panel in response to the global
+    /// `find` action (Cmd+F). The find bar lives on the text-editor `NSTextView`
+    /// (which already has `usesFindPanel == true`), so a preview-mode panel first
+    /// switches to text mode — `WKWebView` exposes no native find UI on macOS.
+    /// Returns `true` because the request is always handled (immediately, or
+    /// deferred until the text view mounts).
+    @discardableResult
+    func startFind() -> Bool {
+        switch displayMode {
+        case .text:
+            return presentFindBar()
+        case .preview:
+            // Defer the find-bar presentation until the text editor mounts and
+            // attaches its NSTextView (focus()/retryPendingFocus()).
+            pendingFindRequest = true
+            setDisplayMode(.text)
+            return true
+        }
+    }
+
+    /// Advances to the next find match. No-op when the find bar is not active.
+    func findNext() {
+        textView?.performTextFinderAction(Self.findActionSender(.nextMatch))
+    }
+
+    /// Returns to the previous find match. No-op when the find bar is not active.
+    func findPrevious() {
+        textView?.performTextFinderAction(Self.findActionSender(.previousMatch))
+    }
+
+    /// Hides the native find bar. No-op when the find bar is not active.
+    func hideFind() {
+        pendingFindRequest = false
+        textView?.performTextFinderAction(Self.findActionSender(.hideFindInterface))
+    }
+
+    @discardableResult
+    private func presentFindBar() -> Bool {
+        guard let textView else {
+            // Text view not mounted yet; apply once it attaches.
+            pendingFindRequest = true
+            return true
+        }
+        pendingFindRequest = false
+        textView.window?.makeFirstResponder(textView)
+        textView.performTextFinderAction(Self.findActionSender(.showFindInterface))
+        return true
+    }
+
+    private func applyPendingFindIfPossible() {
+        guard pendingFindRequest, let textView, textView.window != nil else { return }
+        pendingFindRequest = false
+        textView.window?.makeFirstResponder(textView)
+        textView.performTextFinderAction(Self.findActionSender(.showFindInterface))
+    }
+
+    /// Builds a menu-item sender carrying the `NSTextFinder.Action` tag that
+    /// `NSTextView.performTextFinderAction(_:)` reads to pick the find action.
+    private static func findActionSender(_ action: NSTextFinder.Action) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        return item
     }
 
     // MARK: - File watcher

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -826,9 +826,14 @@ class TabManager: ObservableObject {
 #endif
             return handled
         }
-        guard let browserPanel = focusedBrowserPanel else { return false }
-        browserPanel.startFind()
-        return browserPanel.searchState != nil
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.startFind()
+            return browserPanel.searchState != nil
+        }
+        if let markdownPanel = focusedMarkdownPanelForFind {
+            return markdownPanel.startFind()
+        }
+        return false
     }
 
     func searchSelection() {
@@ -851,8 +856,11 @@ class TabManager: ObservableObject {
             _ = panel.performBindingAction("search:next")
             return
         }
-
-        focusedBrowserPanel?.findNext()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.findNext()
+            return
+        }
+        focusedMarkdownPanelForFind?.findNext()
     }
 
     func findPrevious() {
@@ -860,8 +868,11 @@ class TabManager: ObservableObject {
             _ = panel.performBindingAction("search:previous")
             return
         }
-
-        focusedBrowserPanel?.findPrevious()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.findPrevious()
+            return
+        }
+        focusedMarkdownPanelForFind?.findPrevious()
     }
 
     @discardableResult
@@ -941,8 +952,11 @@ class TabManager: ObservableObject {
             panel.searchState = nil
             return
         }
-
-        focusedBrowserPanel?.hideFind()
+        if let browserPanel = focusedBrowserPanel {
+            browserPanel.hideFind()
+            return
+        }
+        focusedMarkdownPanelForFind?.hideFind()
     }
 
     func makeWorkspaceForCreation(
@@ -2910,6 +2924,15 @@ class TabManager: ObservableObject {
               let panel = tab.panels[panelId] as? MarkdownPanel,
               panel.displayMode == .preview else { return nil }
         return panel
+    }
+
+    /// Returns the focused panel if it's a MarkdownPanel, in any display mode.
+    /// Used for find (Cmd+F) routing, which is valid in both preview and text
+    /// modes (unlike zoom, which only applies to the preview WKWebView).
+    var focusedMarkdownPanelForFind: MarkdownPanel? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? MarkdownPanel
     }
 
     @discardableResult

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -195,6 +195,54 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(panel.fontFamily, "Avenir Next")
     }
 
+    // Regression for https://github.com/manaflow-ai/cmux/issues/6049:
+    // TabManager.startSearch() ignored MarkdownPanel entirely, so the global
+    // find action (Cmd+F) returned false (unhandled, silently dropped) when a
+    // Markdown panel was focused. Pressing Cmd+F must be handled and surface a
+    // find bar; for a preview-mode panel that means switching to text mode,
+    // because WKWebView has no native find UI on macOS.
+    func testStartSearchRoutesToFocusedMarkdownPanel() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-find-routing-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            try? fileManager.removeItem(at: directoryURL)
+        }
+
+        let fileURL = directoryURL.appendingPathComponent("README.md")
+        try "# Title\n\nBody.\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: true, eagerLoadTerminal: false)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let result = TerminalController.shared.v2FileOpen(params: [
+            "paths": [fileURL.path],
+            "workspace_id": workspace.id.uuidString,
+            "pane_id": pane.id.uuidString,
+            "focus": true
+        ])
+
+        guard case .ok(let rawPayload) = result,
+              let payload = rawPayload as? [String: Any],
+              let openedPanelIdString = payload["surface_id"] as? String,
+              let openedPanelId = UUID(uuidString: openedPanelIdString) else {
+            XCTFail("Expected file.open to succeed for markdown, got \(result)")
+            return
+        }
+
+        XCTAssertEqual(workspace.focusedPanelId, openedPanelId)
+        let panel = try XCTUnwrap(workspace.markdownPanel(for: openedPanelId))
+        XCTAssertEqual(panel.displayMode, .preview)
+
+        // The crux: the global find action must be handled (not silently dropped).
+        XCTAssertTrue(manager.startSearch())
+        XCTAssertEqual(panel.displayMode, .text)
+    }
+
     func testFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel() throws {
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -237,9 +237,34 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(workspace.focusedPanelId, openedPanelId)
         let panel = try XCTUnwrap(workspace.markdownPanel(for: openedPanelId))
         XCTAssertEqual(panel.displayMode, .preview)
+        XCTAssertNotNil(manager.focusedMarkdownPanelForFind)
 
         // The crux: the global find action must be handled (not silently dropped).
         XCTAssertTrue(manager.startSearch())
+        XCTAssertEqual(panel.displayMode, .text)
+    }
+
+    // Companion to the routing test: a preview-mode panel handles startFind() by
+    // switching to text mode so the native NSTextView find bar can be presented.
+    func testMarkdownStartFindSwitchesPreviewToTextMode() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-find-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("README.md")
+        try "# Title\n\nNeedle body.\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? fileManager.removeItem(at: directoryURL) }
+
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: fileURL.path)
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.displayMode, .preview)
+        // The request is always handled; preview mode flips to text so the native
+        // find bar (NSTextView, usesFindPanel == true) can be presented.
+        XCTAssertTrue(panel.startFind())
+        XCTAssertEqual(panel.displayMode, .text)
+        // A second invocation while already in text mode is still handled.
+        XCTAssertTrue(panel.startFind())
         XCTAssertEqual(panel.displayMode, .text)
     }
 


### PR DESCRIPTION
Closes #6049

## Problem
When a Markdown panel is focused, pressing **Cmd+F** does nothing. cmux intercepts the global `find` action and routes it through `TabManager.startSearch()`, which only checked `selectedTerminalPanel` and `focusedBrowserPanel` — `MarkdownPanel` was ignored, so the action was silently dropped.

## Root cause / correction to the issue's proposal
The issue (and the community PR #6054) proposed targeting the preview `WKWebView` with `performFindPanelAction:`. I verified empirically on macOS 26.4 that **`WKWebView` responds to neither `performFindPanelAction:` nor `performTextFinderAction:`** (only the private `_findString:options:maxCount:`), so that approach is a no-op — there is no native find-bar UI on a macOS `WKWebView`.

```
performFindPanelAction:  -> false
performTextFinderAction: -> false
NSTextView performTextFinderAction: true
```

## Fix
Route the find action to the focused Markdown panel and present the **native AppKit find bar**, which lives on the text-editor `NSTextView` (already configured with `usesFindPanel == true`):

- `MarkdownPanel`: add `startFind()` / `findNext()` / `findPrevious()` / `hideFind()`. Because the preview `WKWebView` has no native find UI, a **preview-mode** panel switches to **text mode** and defers presenting the find bar until the `NSTextView` attaches to a window (mirrors the existing `pendingSearchNeedle` deferral). Text mode presents the bar immediately.
- `TabManager`: add `focusedMarkdownPanelForFind` (any display mode, unlike the preview-only `focusedMarkdownPanel` used for zoom) and route `startSearch` / `findNext` / `findPrevious` / `hideFind` to it after the terminal and browser checks. Single shared mutation path — no per-entrypoint duplication.

## Tradeoff
Cmd+F in **preview** mode flips the panel to the **source/text** view to use the native find bar (same words, fully native, works on all macOS versions). This matches the issue's stated intent ("native macOS search bar without a custom SwiftUI overlay"). A richer in-rendered-preview find overlay (WKWebView `find(_:configuration:)` + custom bar, à la the browser panel) is larger and tracked separately under #6050.

## Localization
No new user-facing strings — the native macOS find bar is system-localized, and the `find` / `findNext` / `findPrevious` / `hideFind` menu entries already exist.

## Tests (two-commit red/green)
1. `c598b6c` — adds `testStartSearchRoutesToFocusedMarkdownPanel` (fails: `startSearch()` returns false / panel stays in preview).
2. `70ad924` — the fix; the test goes green, plus `testMarkdownStartFindSwitchesPreviewToTextMode`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784320881&installation_id=133855650&pr_number=6336&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6336&signature=88a84a18bb5f9f74eb75ea4ccc5e4a1d7c2eeb479e5e57887a5c6ded39944222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Cmd+F in Markdown panels by routing find actions to the focused panel and showing the native macOS find bar; preview mode switches to text mode to display it. Fixes #6049.

- **Bug Fixes**
  - Route Cmd+F/Find Next/Previous/Hide to the focused Markdown panel; preview panels flip to text and defer until the `NSTextView` mounts.
  - Added regression tests for routing and preview-to-text behavior.

<sup>Written for commit 1509ed14e61bbed26f001e15889e00ae39eb3ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

