### PR TITLE
ci: add reload-build workflow for cloud reload Blacksmith builder

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -1,0 +1,198 @@
+name: reload-build
+
+# Dispatchable tagged dev-build for the cloud reload scripts' Blacksmith builder.
+#
+# scripts/reload-cloud.sh --builder blacksmith and scripts/reload-cloud-ios.sh
+# --builder blacksmith (in the cmuxterm-hq control repo) dispatch this workflow
+# against an ephemeral branch holding the caller's working tree, then download the
+# produced artifact and install it locally. This is the Blacksmith alternative to
+# SSH-leasing a fleet Mac. It is workflow_dispatch ONLY: nothing here runs on push
+# or pull_request, so it never adds to the heavy CI fan-out.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Dev build tag (becomes cmux DEV <tag> / dev.cmux.ios.<tag>)
+        required: true
+        type: string
+      ref:
+        description: Source ref to build (branch or SHA). Defaults to the dispatch ref.
+        required: false
+        default: ""
+        type: string
+      platform:
+        description: Which artifact to build
+        required: false
+        default: macos
+        type: choice
+        options:
+          - macos
+          - ios
+      runner:
+        description: macOS runner label to build on
+        required: false
+        default: blacksmith-6vcpu-macos-26
+        type: choice
+        options:
+          - blacksmith-6vcpu-macos-26
+          - blacksmith-6vcpu-macos-15
+          - blacksmith-6vcpu-macos-latest
+          - warp-macos-26-arm64-6x
+          - warp-macos-15-arm64-6x
+          - depot-macos-latest
+      nonce:
+        description: Opaque marker echoed into run-name so the dispatcher can find this run.
+        required: false
+        default: ""
+        type: string
+
+# Surface tag/platform/nonce in the run title so the dispatcher can match its run
+# by the nonce it passed (gh workflow run does not return a run id).
+run-name: "reload-build ${{ inputs.tag }} ${{ inputs.platform }} ${{ inputs.nonce }}"
+
+permissions:
+  contents: read
+
+concurrency:
+  # One in-flight build per tag+platform; a newer dispatch supersedes an older one.
+  group: reload-build-${{ inputs.tag }}-${{ inputs.platform }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 60
+    env:
+      # The ghostty CLI helper zig build is skipped; GhosttyKit comes prebuilt.
+      CMUX_SKIP_ZIG_BUILD: "1"
+      SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"
+    steps:
+      - name: Checkout source ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+
+      - name: Start timer
+        id: t0
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort | tail -n 1 || true)"
+            [ -n "$XCODE_APP" ] || { echo "No Xcode.app under /Applications" >&2; exit 1; }
+            XCODE_DIR="$XCODE_APP/Contents/Developer"
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Provision GhosttyKit (macOS)
+        if: ${{ inputs.platform == 'macos' }}
+        run: ./scripts/download-prebuilt-ghosttykit.sh || ./scripts/ensure-ghosttykit.sh
+
+      - name: Mark deps-ready
+        id: t1
+        run: echo "epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      # --- macOS: build the tagged dev app via the same reload.sh the fleet uses ---
+      - name: Build tagged macOS app
+        if: ${{ inputs.platform == 'macos' }}
+        id: build_macos
+        run: |
+          set -euo pipefail
+          ./scripts/reload.sh --tag "${{ inputs.tag }}" --swift-frontend-workaround 2>&1 | tee /tmp/reload.log
+          app_path="$(awk '/^App path:/{getline; sub(/^  /,""); print; exit}' /tmp/reload.log)"
+          [ -n "$app_path" ] && [ -d "$app_path" ] || { echo "could not locate built app" >&2; exit 1; }
+          echo "app_path=$app_path" >> "$GITHUB_OUTPUT"
+          mkdir -p artifact
+          ( cd "$(dirname "$app_path")" && ditto -c -k --sequesterRsrc --keepParent "$(basename "$app_path")" "$GITHUB_WORKSPACE/artifact/app.zip" )
+
+      # --- iOS: build an UNSIGNED debug archive (signed locally by the caller) ---
+      - name: Build unsigned iOS archive
+        if: ${{ inputs.platform == 'ios' }}
+        id: build_ios
+        env:
+          BUILD_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          slug="$(printf '%s' "$BUILD_TAG" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+          bundle_id="dev.cmux.ios.$slug"
+          display_name="cmux DEV $BUILD_TAG"
+
+          # Register the iOS platform if the runner only has macOS provisioned.
+          ios_ready() { xcrun simctl runtime list 2>/dev/null | grep -qiE "iOS [0-9].*\(Ready\)"; }
+          if ! ios_ready; then
+            echo "iOS platform not registered; installing via downloadPlatform iOS"
+            xcodebuild -downloadPlatform iOS 2>&1 | tr '\r' '\n' | grep -ivE 'Preparing to download|registering download' | tail -8 || true
+            ios_ready || { echo "iOS platform still not registered; archive would fail" >&2; exit 1; }
+          fi
+
+          ./scripts/ensure-ghosttykit.sh
+          out="$GITHUB_WORKSPACE/build"
+          mkdir -p "$out"
+          archive="$out/cmux-ios-$slug.xcarchive"
+          rm -rf "$archive"
+          xcodebuild archive \
+            -workspace ios/cmux.xcworkspace \
+            -scheme cmux-ios \
+            -configuration Debug \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$archive" \
+            -derivedDataPath "$RUNNER_TEMP/cmux-ios-dd" \
+            PRODUCT_BUNDLE_IDENTIFIER="$bundle_id" \
+            PRODUCT_DISPLAY_NAME="$display_name" \
+            CMUX_GIT_SHA="$(git rev-parse --short HEAD)" \
+            CMUX_DEV_TAG="$BUILD_TAG" \
+            EXCLUDED_SOURCE_FILE_NAMES=Info.plist \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""
+          [ -d "$archive" ] || { echo "archive not produced: $archive" >&2; exit 1; }
+          mkdir -p artifact
+          ( cd "$out" && ditto -c -k --keepParent "$(basename "$archive")" "$GITHUB_WORKSPACE/artifact/archive.zip" )
+
+      - name: Write timings.json
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifact
+          now=$(date +%s)
+          t0=${{ steps.t0.outputs.epoch }}
+          t1=${{ steps.t1.outputs.epoch || 0 }}
+          cat > artifact/timings.json <<JSON
+          {
+            "tag": "${{ inputs.tag }}",
+            "platform": "${{ inputs.platform }}",
+            "runner": "${{ inputs.runner }}",
+            "ref": "${{ inputs.ref }}",
+            "deps_seconds": $(( t1 > t0 ? t1 - t0 : 0 )),
+            "build_seconds": $(( t1 > 0 ? now - t1 : 0 )),
+            "post_checkout_total_seconds": $(( now - t0 ))
+          }
+          JSON
+          {
+            echo "### reload-build timings"
+            echo ""
+            echo "- runner: \`${{ inputs.runner }}\`"
+            echo "- platform: \`${{ inputs.platform }}\`"
+            echo "- deps: $(( t1 > t0 ? t1 - t0 : 0 ))s"
+            echo "- build: $(( t1 > 0 ? now - t1 : 0 ))s"
+            echo "- post-checkout total: $(( now - t0 ))s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: reload-${{ inputs.tag }}-${{ inputs.platform }}
+          path: artifact/
+          retention-days: 3
+          if-no-files-found: error


### PR DESCRIPTION
Adds `.github/workflows/reload-build.yml`, a `workflow_dispatch`-only build that the cmuxterm-hq cloud reload scripts use as their **Blacksmith** builder alternative to SSH-leasing a fleet Mac.

`scripts/reload-cloud.sh --builder blacksmith` and `scripts/reload-cloud-ios.sh --builder blacksmith` dispatch this workflow against an ephemeral branch holding the caller's working tree, then `gh run download` the artifact and install it locally (macOS: ad-hoc patch + install; iOS: local sign + devicectl install).

- macOS: builds `cmux DEV <tag>.app` via the same `scripts/reload.sh` the fleet uses, zips it.
- iOS: builds an unsigned Debug `.xcarchive` for `dev.cmux.ios.<slug>` (signed locally by the caller).
- `runs-on: ${{ inputs.runner }}`, default `blacksmith-6vcpu-macos-26` (all options are existing actionlint labels).
- Emits per-phase timings (artifact `timings.json` + step summary) for the Blacksmith-vs-fleet comparison.

`workflow_dispatch` only: no `push`/`pull_request` triggers, so it never adds to the heavy CI fan-out. Committed with `[skip ci]` to keep this PR off the paid runners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784328037&installation_id=133855650&pr_number=6354&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6354&signature=e994d65a9badffbb75df0704f980c93f248548e295cbebf83a48eae742160025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with read-only repo permissions and no push/PR triggers; reuses existing build scripts without changing app runtime code.
> 
> **Overview**
> Adds a **`workflow_dispatch`-only** GitHub Actions workflow so cloud reload scripts can build tagged dev artifacts on Blacksmith (or other macOS runners) instead of leasing a fleet Mac.
> 
> Callers pass **tag**, optional **ref**, **platform** (`macos` | `ios`), **runner**, and a **nonce** echoed in `run-name` so the dispatcher can find the run. **Concurrency** cancels in-flight builds for the same tag+platform.
> 
> **macOS** runs `scripts/reload.sh` with the tag, zips the built app. **iOS** produces an **unsigned** Debug `.xcarchive` with `dev.cmux.ios.<slug>` (signing stays local). Shared setup: checkout, Xcode selection, zig install, GhosttyKit provisioning, `CMUX_SKIP_ZIG_BUILD=1`. Outputs **`timings.json`** and a step summary, then uploads a 3-day artifact.
> 
> No `push`/`pull_request` triggers—manual dispatch only, so it does not expand the main CI fan-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9de057017275ae30d3855b2f2d94b3ecab2d5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `reload-build` GitHub Actions workflow to build a tagged dev macOS app or an unsigned iOS archive on `Blacksmith` macOS runners for cloud reload, replacing fleet Mac SSH leases. It’s manual-only (`workflow_dispatch`) and uploads a ready-to-install artifact.

- **New Features**
  - Adds `.github/workflows/reload-build.yml` with inputs: `tag`, `ref`, `platform` (`macos`|`ios`), `runner`, `nonce`.
  - macOS: builds “cmux DEV <tag>.app” via `scripts/reload.sh` and zips it as `app.zip`.
  - iOS: archives unsigned Debug `.xcarchive` for `dev.cmux.ios.<slug>` as `archive.zip`.
  - Uploads `reload-<tag>-<platform>` with `timings.json`; retention 3 days. Concurrency is per tag+platform; run name includes tag/platform/nonce.
  - Default runner `blacksmith-6vcpu-macos-26` (other labels supported).

- **Migration**
  - Trigger via `scripts/reload-cloud.sh --builder blacksmith` or `scripts/reload-cloud-ios.sh --builder blacksmith`.
  - Or dispatch manually with inputs, then use `gh run download` to fetch and install locally.

<sup>Written for commit 4b9de057017275ae30d3855b2f2d94b3ecab2d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new manual build workflow for generating reload-build artifacts on macOS and iOS platforms, with automated timing measurement and artifact preservation policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->