### PR TITLE
ci: reload-build runner input as free-form string

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -30,17 +30,12 @@ on:
           - macos
           - ios
       runner:
-        description: macOS runner label to build on
+        description: >-
+          macOS runner label to build on. Blacksmith (blacksmith-6vcpu-macos-26),
+          our self-hosted fleet (cmux-macos-26 / cmux-aws-macos-15), warp, or depot.
         required: false
         default: blacksmith-6vcpu-macos-26
-        type: choice
-        options:
-          - blacksmith-6vcpu-macos-26
-          - blacksmith-6vcpu-macos-15
-          - blacksmith-6vcpu-macos-latest
-          - warp-macos-26-arm64-6x
-          - warp-macos-15-arm64-6x
-          - depot-macos-latest
+        type: string
       nonce:
         description: Opaque marker echoed into run-name so the dispatcher can find this run.
         required: false


### PR DESCRIPTION
Follow-up to #6354. Free-form `runner` input so cloud reload can target Blacksmith or our self-hosted `cmux-macos-26` fleet through one workflow. workflow_dispatch only, `[skip ci]`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784329513&installation_id=133855650&pr_number=6361&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6361&signature=964d4d963196fb8b7ea041a21f4c3a6e25f60e88568c79da308915e3ff42d9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input change for manual dispatch; default runner is unchanged and there is no application or security logic in the diff.
> 
> **Overview**
> The **`reload-build`** workflow’s **`runner`** `workflow_dispatch` input is no longer a fixed dropdown: it is a **free-form string** (default still **`blacksmith-6vcpu-macos-26`**).
> 
> The input description now documents acceptable labels—Blacksmith, self-hosted **`cmux-macos-26`** / **`cmux-aws-macos-15`**, warp, and depot—so cloud reload dispatchers can target either Blacksmith or the cmux Mac fleet through the same workflow without adding every label to a choice list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf145d5a5352c15103e25ef850c7ab940c3b5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the reload-build workflow’s `runner` input to a free-form string so it can target any macOS runner label (e.g., `blacksmith-6vcpu-macos-26`, `cmux-macos-26`, `cmux-aws-macos-15`, Warp, Depot). Keeps default `blacksmith-6vcpu-macos-26` and only applies to `workflow_dispatch`.

<sup>Written for commit fcf145d5a5352c15103e25ef850c7ab940c3b5be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to accept custom runner labels in addition to predefined options, enabling greater flexibility in specifying build execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->