### PR TITLE
ios: mark workspace read/unread from terminal menu; chat button top-level

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -123,7 +123,7 @@
 746	Sources/App/MenuBarExtraController.swift
 738	Packages/macOS/CMUXProjectModel/Sources/CMUXProjectModel/XcodeProjectAdapter.swift
 736	Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
-726	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+757	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
 726	cmuxTests/CLICodexHookTimeoutRegressionTests.swift
 725	Sources/RightSidebarPanelView.swift
 722	Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Store/ChatConversationStore.swift

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -152,8 +152,11 @@ struct WorkspaceDetailView: View {
         .mobileTerminalNavigationChrome()
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
+                // Agent-chat toggle stays a top-level button (shown only when the
+                // visible tab has a session), sitting where New Workspace used to
+                // be — next to the terminal picker. New Workspace moved into the
+                // picker menu.
                 chatToggleButton
-                newWorkspaceToolbarButton
                 terminalPickerToolbarButton
             }
         }
@@ -249,8 +252,11 @@ struct WorkspaceDetailView: View {
         .mobileTerminalNavigationChrome()
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
+                // Agent-chat toggle stays a top-level button (shown only when the
+                // visible tab has a session), sitting where New Workspace used to
+                // be — next to the terminal picker. New Workspace moved into the
+                // picker menu.
                 chatToggleButton
-                newWorkspaceToolbarButton
                 terminalPickerToolbarButton
             }
         }
@@ -362,8 +368,11 @@ struct WorkspaceDetailView: View {
         .toolbar {
             #if os(iOS)
             ToolbarItemGroup(placement: .topBarTrailing) {
+                // Agent-chat toggle stays a top-level button (shown only when the
+                // visible tab has a session), sitting where New Workspace used to
+                // be — next to the terminal picker. New Workspace moved into the
+                // picker menu.
                 chatToggleButton
-                newWorkspaceToolbarButton
                 terminalPickerToolbarButton
             }
             #else
@@ -462,6 +471,23 @@ struct WorkspaceDetailView: View {
                 )
             }
             .accessibilityIdentifier("MobileNewBrowserMenuItem")
+        }
+
+        // Mark the current workspace read/unread from the terminal-icon menu,
+        // mirroring the workspace list's swipe action. Only when the Mac supports
+        // read-state actions, so it stays hidden on older Macs.
+        if store.supportsWorkspaceReadStateActions {
+            Section {
+                Button(action: toggleWorkspaceReadStateFromMenu) {
+                    Label(
+                        workspace.hasUnread
+                            ? L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")
+                            : L10n.string("mobile.workspace.markUnread", defaultValue: "Mark as Unread"),
+                        systemImage: workspace.hasUnread ? "envelope.open" : "envelope.badge"
+                    )
+                }
+                .accessibilityIdentifier("MobileWorkspaceMarkReadStateMenuItem")
+            }
         }
 
         if closeWorkspace != nil {
@@ -684,6 +710,17 @@ struct WorkspaceDetailView: View {
 
     private func confirmCloseWorkspaceFromMenu() {
         closeWorkspace?(workspace.id)
+    }
+
+    /// Toggle the current workspace's read state on the Mac from the picker menu.
+    /// Flips relative to the workspace's current `hasUnread`; the authoritative
+    /// list re-sync inside `setWorkspaceUnread` reconciles the row + back-button
+    /// count.
+    private func toggleWorkspaceReadStateFromMenu() {
+        let store = store
+        let id = workspace.id
+        let markUnread = !workspace.hasUnread
+        Task { await store.setWorkspaceUnread(id: id, markUnread) }
     }
 
     private func createTerminalFromToolbar() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -152,10 +152,8 @@ struct WorkspaceDetailView: View {
         .mobileTerminalNavigationChrome()
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                // Agent-chat toggle stays a top-level button (shown only when the
-                // visible tab has a session), sitting where New Workspace used to
-                // be — next to the terminal picker. New Workspace moved into the
-                // picker menu.
+                // Chat toggle stays top-level next to the picker (where New
+                // Workspace was); New Workspace moved into the picker menu.
                 chatToggleButton
                 terminalPickerToolbarButton
             }
@@ -252,10 +250,8 @@ struct WorkspaceDetailView: View {
         .mobileTerminalNavigationChrome()
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
-                // Agent-chat toggle stays a top-level button (shown only when the
-                // visible tab has a session), sitting where New Workspace used to
-                // be — next to the terminal picker. New Workspace moved into the
-                // picker menu.
+                // Chat toggle stays top-level next to the picker (where New
+                // Workspace was); New Workspace moved into the picker menu.
                 chatToggleButton
                 terminalPickerToolbarButton
             }
@@ -368,10 +364,8 @@ struct WorkspaceDetailView: View {
         .toolbar {
             #if os(iOS)
             ToolbarItemGroup(placement: .topBarTrailing) {
-                // Agent-chat toggle stays a top-level button (shown only when the
-                // visible tab has a session), sitting where New Workspace used to
-                // be — next to the terminal picker. New Workspace moved into the
-                // picker menu.
+                // Chat toggle stays top-level next to the picker (where New
+                // Workspace was); New Workspace moved into the picker menu.
                 chatToggleButton
                 terminalPickerToolbarButton
             }


### PR DESCRIPTION
## What

- Add a **Mark as Read / Mark as Unread** row to the terminal-icon picker menu (top-right) on the workspace detail, so you can flip a workspace's read state without going back to the list. Mirrors the workspace list's swipe action.
- **Remove the dedicated New Workspace top-bar button** — it stays available in the picker menu.
- The **agent-chat toggle remains a top-level button** in the freed slot (next to the terminal picker), shown only when the visible tab has an agent session.

## How

- `terminalPickerMenuContent`: new section with a single toggle row that reads "Mark as Read" when the workspace is unread and "Mark as Unread" otherwise (`envelope.open` / `envelope.badge`). Action calls `store.setWorkspaceUnread(id:, !hasUnread)`, which sends the mutation to the Mac and re-syncs the authoritative list. Gated on `store.supportsWorkspaceReadStateActions` so it's hidden on older Macs.
- The three trailing toolbars (terminal / chat / browser) drop `newWorkspaceToolbarButton`, leaving `[chatToggleButton, terminalPickerToolbarButton]`.

Reuses existing localized strings `mobile.workspace.markRead` / `mobile.workspace.markUnread` (en + ja already present); no new user-facing strings.

Builds on the unread-count work (https://github.com/manaflow-ai/cmux/pull/6350): opening a workspace marks it read, and this gives an explicit re-flag-as-unread path.

## Verification

- iOS device build (`dev.cmux.ios.mkunrd`) + macOS app on the same tag.
- Dogfood: in a workspace, open the terminal-icon menu → "Mark as Unread"; go back, the workspace shows unread (and the back-button count reflects it). Re-open and it flips to "Mark as Read".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784329557&installation_id=133855650&pr_number=6362&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6362&signature=35bafb56b0c1d56a8584a9b7c9a76ce180bd338e0ad0423d362fba466dfc5476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS toolbar and menu wiring reusing existing `setWorkspaceUnread` and capability gating; no auth or data-model changes.
> 
> **Overview**
> On **workspace detail** (terminal, chat, and browser chrome), the top bar no longer shows **New Workspace**; that action stays in the **terminal picker** menu. The **agent chat** toggle remains a top-level trailing button next to the picker.
> 
> The terminal picker menu gains **Mark as Read** / **Mark as Unread** for the current workspace (same behavior as the list swipe), shown only when `supportsWorkspaceReadStateActions` is true. It calls `setWorkspaceUnread` on the Mac and re-syncs list state.
> 
> The Swift file-length budget for `WorkspaceDetailView.swift` is bumped to match the added lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd056a119ce43bef491212d82cc3232fb26cd295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Mark as Read/Unread action to the terminal-icon picker on workspace detail so you can change a workspace’s read state without leaving the view. The New Workspace top-bar button is removed; the agent-chat toggle stays top-level next to the terminal picker when an agent session is present.

- **New Features**
  - Terminal picker adds a state-aware “Mark as Read/Mark as Unread” with icons; calls `setWorkspaceUnread`; shown only when `supportsWorkspaceReadStateActions` is true.
  - Top bar update: remove New Workspace button (now in the picker menu); keep the chat toggle as a top-level button.

- **Refactors**
  - Shortened duplicate toolbar comments and raised `WorkspaceDetailView.swift` length budget in `.github/swift-file-length-budget.tsv` to 757.

<sup>Written for commit bd056a119ce43bef491212d82cc3232fb26cd295. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **Mark as Read / Mark as Unread** option to the terminal picker menu for managing workspace read state.

* **UI Improvements**
  * Updated the workspace detail toolbar layout by moving the **New Workspace** action out of the top-right toolbar area to improve navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->