### PR TITLE
ci: reload-build use per-run log path

### DIFF
--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -104,8 +104,11 @@ jobs:
         id: build_macos
         run: |
           set -euo pipefail
-          ./scripts/reload.sh --tag "${{ inputs.tag }}" --swift-frontend-workaround 2>&1 | tee /tmp/reload.log
-          app_path="$(awk '/^App path:/{getline; sub(/^  /,""); print; exit}' /tmp/reload.log)"
+          # Per-run log path: /tmp/reload.log collides across tenants on the
+          # multi-tenant self-hosted fleet Macs (tee: Permission denied).
+          log="$RUNNER_TEMP/reload.log"
+          ./scripts/reload.sh --tag "${{ inputs.tag }}" --swift-frontend-workaround 2>&1 | tee "$log"
+          app_path="$(awk '/^App path:/{getline; sub(/^  /,""); print; exit}' "$log")"
           [ -n "$app_path" ] && [ -d "$app_path" ] || { echo "could not locate built app" >&2; exit 1; }
           echo "app_path=$app_path" >> "$GITHUB_OUTPUT"
           mkdir -p artifact


### PR DESCRIPTION
Use `$RUNNER_TEMP/reload.log` instead of hardcoded `/tmp/reload.log`, which collides across tenants on multi-tenant self-hosted fleet Macs. workflow_dispatch only, `[skip ci]`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784330737&installation_id=133855650&pr_number=6363&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6363&signature=eb9a2ec423b0b7413c9496e489f2f6df0a551536f25fb6511fcf924d906be1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to log file location; no product code or secrets handling.
> 
> **Overview**
> Fixes **reload-build** macOS jobs failing on shared self-hosted fleet Macs when multiple runs try to write the same log file.
> 
> The **Build tagged macOS app** step now tees `reload.sh` output to **`$RUNNER_TEMP/reload.log`** instead of **`/tmp/reload.log`**, and parses the built app path from that per-run file. A short comment documents the tenant collision that caused `tee: Permission denied`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2327fc38528b57d446f9eacb8d3dc2c0adb349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a per-run log path in the reload-build workflow to avoid collisions on multi-tenant self-hosted macOS runners. Logs now write to `$RUNNER_TEMP/reload.log`, and the parser reads from it, fixing intermittent tee: Permission denied errors and failed app path extraction.

<sup>Written for commit 7d2327fc38528b57d446f9eacb8d3dc2c0adb349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build reliability on self-hosted infrastructure by enhancing build log handling to prevent conflicts during concurrent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->