### PR TITLE
Fix iOS terminal keyboard gap

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -207,7 +207,8 @@ jobs:
           DEVICE_FAMILY: ${{ matrix.family }}
         run: |
           set -euo pipefail
-          python3 - <<'PY' > /tmp/simulator.env
+          simulator_env="${RUNNER_TEMP:-$PWD}/simulator.env"
+          python3 - <<'PY' > "$simulator_env"
           import json
           import os
           import subprocess
@@ -227,8 +228,8 @@ jobs:
           print(f"SIMULATOR_ID={selected['udid']}")
           print(f"SIMULATOR_NAME={selected['name']}")
           PY
-          cat /tmp/simulator.env
-          cat /tmp/simulator.env >> "$GITHUB_ENV"
+          cat "$simulator_env"
+          cat "$simulator_env" >> "$GITHUB_ENV"
 
       - name: Resolve packages
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.device_family != 'both' && inputs.device_family != matrix.family) }}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -28,9 +28,7 @@ extension MobileShellComposite {
         let immediate = queue.enqueue(delivery)
         terminalOutputQueuesBySurfaceID[surfaceID] = queue
         if let immediate {
-            continuation.yield(
-                MobileTerminalOutputChunk(data: immediate.bytes, streamToken: streamToken)
-            )
+            continuation.yield(outputChunk(for: immediate, streamToken: streamToken))
         }
     }
 
@@ -45,6 +43,17 @@ extension MobileShellComposite {
               terminalOutputStreamTokensBySurfaceID[surfaceID] == streamToken else {
             return
         }
-        continuation.yield(MobileTerminalOutputChunk(data: next.bytes, streamToken: streamToken))
+        continuation.yield(outputChunk(for: next, streamToken: streamToken))
+    }
+
+    private func outputChunk(
+        for delivery: TerminalOutputDelivery,
+        streamToken: UUID
+    ) -> MobileTerminalOutputChunk {
+        MobileTerminalOutputChunk(
+            data: delivery.bytes,
+            streamToken: streamToken,
+            preservesProducerGrid: delivery.preservesProducerGrid
+        )
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9,7 +9,7 @@ public import Foundation
 import Observation
 internal import OSLog
 
-private let mobileShellLog = Logger(
+nonisolated private let mobileShellLog = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
     category: "mobile-shell"
 )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4974,9 +4974,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Report this device's natural terminal grid to the Mac and return the
     /// effective grid the Mac computed (the smallest across all attached
-    /// devices, capped to the Mac pane). The caller pins its libghostty surface
-    /// to that grid so every device renders the same cols×rows with a viewport
-    /// border around the live area (tmux-style shared resize).
+    /// devices, capped to the Mac pane). The caller records the response for
+    /// convergence/diagnostics while keeping the iOS render area full-height.
     public func updateTerminalViewport(
         surfaceID: String,
         columns: Int,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TerminalOutputDelivery.swift
@@ -29,6 +29,15 @@ struct TerminalOutputDelivery: Equatable, Sendable {
             frame.vtPatchBytes()
         }
     }
+
+    var preservesProducerGrid: Bool {
+        switch payload {
+        case .bytes:
+            true
+        case .renderGrid:
+            false
+        }
+    }
 }
 
 /// Backpressure queue for one mounted mobile terminal output stream.

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalOutputDeliveryQueueTests.swift
@@ -8,6 +8,7 @@ import Testing
     let first = TerminalOutputDelivery(bytes: Data("first".utf8), replaceable: false)
 
     #expect(queue.enqueue(first) == first)
+    #expect(first.preservesProducerGrid)
     #expect(queue.pendingCount == 0)
 }
 
@@ -35,10 +36,13 @@ import Testing
     store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: oldChunk.streamToken)
 
     #expect(store.terminalOutputQueuesBySurfaceID[surfaceID]?.pendingCount == 1)
+    #expect(oldChunk.preservesProducerGrid)
+    #expect(currentChunk.preservesProducerGrid)
 
     store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: currentChunk.streamToken)
     let secondChunk = try #require(await currentIterator.next())
     #expect(String(decoding: secondChunk.data, as: UTF8.self) == "new-second")
+    #expect(secondChunk.preservesProducerGrid)
 }
 
 @Test func terminalOutputQueueCoalescesReplaceableViewportFramesBehindBackpressure() {
@@ -88,6 +92,7 @@ import Testing
     let vt = try #require(String(data: delivered.bytes, encoding: .utf8))
     #expect(vt.contains("latest"))
     #expect(!vt.contains("old"))
+    #expect(!delivered.preservesProducerGrid)
 }
 
 @Test func terminalOutputQueuePreservesNonreplaceableBarriers() {

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalOutputSinking.swift
@@ -14,12 +14,22 @@ public import Foundation
 /// propagation is a structured, cancellable `AsyncSequence` instead of a stored
 /// callback.
 public struct MobileTerminalOutputChunk: Sendable {
+    /// VT/PTY bytes to feed into the mounted terminal surface.
     public let data: Data
+    /// Stream generation token used to reject acknowledgements from stale mounts.
     public let streamToken: UUID
+    /// Whether the local emulator must keep the producer's grid before applying
+    /// this chunk.
+    ///
+    /// Legacy raw-byte output is produced by the Mac PTY at the negotiated
+    /// effective grid, so iOS must preserve that grid while applying it. Render-grid
+    /// output is already viewport-shaped state and can fill the local container.
+    public let preservesProducerGrid: Bool
 
-    public init(data: Data, streamToken: UUID) {
+    public init(data: Data, streamToken: UUID, preservesProducerGrid: Bool = false) {
         self.data = data
         self.streamToken = streamToken
+        self.preservesProducerGrid = preservesProducerGrid
     }
 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -137,7 +137,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
                     guard !Task.isCancelled else { return }
                     guard let surfaceView else { return }
-                    await surfaceView.processOutputAndWait(chunk.data)
+                    await surfaceView.processOutputAndWait(
+                        chunk.data,
+                        preservesProducerGrid: chunk.preservesProducerGrid
+                    )
                     store.terminalOutputDidProcess(
                         surfaceID: surfaceID,
                         streamToken: chunk.streamToken

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -265,11 +265,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         }
 
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didResize size: TerminalGridSize) {
-            // Report our natural grid to the Mac and pin our render to the
-            // effective grid it returns (the smallest across every attached
-            // device, capped to the Mac pane). This is the tmux-style shared
-            // resize: the smallest viewport wins and each device letterboxes
-            // its render to match, drawing a border around the live area.
+            // Report our natural grid to the Mac and record the effective grid
+            // it returns (the smallest across every attached device, capped to
+            // the Mac pane). The iOS render area remains full-height locally;
+            // pinch zoom and viewport negotiation only change font/grid
+            // semantics, never the phone view's available height.
             guard size.columns > 0, size.rows > 0 else { return }
             Task { @MainActor [weak self, weak surfaceView] in
                 guard let self, let store = self.store else { return }
@@ -279,12 +279,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     rows: size.rows
                 ) else {
                     // No effective grid came back (RPC timed out or returned
-                    // nil). Left unhandled, the render stays pinned to the prior
-                    // effective grid and looks like a frozen / letterboxed
-                    // terminal even though the main thread is fine. Re-arm the
-                    // report so a transient drop self-heals (bounded inside the
-                    // surface). Logged so the dogfood log still distinguishes
-                    // this from a true main-thread wedge.
+                    // nil). Re-arm the report so a transient drop self-heals
+                    // (bounded inside the surface). Logged so the dogfood log
+                    // still distinguishes this from a true main-thread wedge.
                     MobileDebugLog.anchormux("zoom.viewport.noEffective grid=\(size.columns)x\(size.rows)")
                     surfaceView?.retryViewportReport()
                     return

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPalette.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPalette.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// The fixed Monokai-derived color palette for the mobile terminal surface.
 ///
 /// These match the colors libghostty renders the terminal background/foreground
-/// with, so the SwiftUI chrome around the surface (toolbars, letterbox fill)
+/// with, so the SwiftUI chrome around the surface (toolbars, dock fill)
 /// blends with the live terminal instead of flashing a system color.
 struct TerminalPalette {
     private init() {}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -6,7 +6,7 @@ import GhosttyKit
 import OSLog
 import UIKit
 
-private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface")
+nonisolated private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface")
 
 // lint:allow namespace-enum — file-local DEBUG input-trace logger on the off-limits typing-latency render path; type reshape deferred to the GhosttySurfaceView UI-god-object split wave.
 enum TerminalInputDebugLog {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -93,8 +93,9 @@ protocol TerminalSurfaceHosting: AnyObject {
     func processOutput(_ data: Data)
     func focusInput()
     /// Apply the daemon's effective grid response for diagnostics and viewport
-    /// convergence. iOS still renders at its full local container; a smaller
-    /// effective grid must not shrink or letterbox the phone surface.
+    /// convergence. Render-grid output still renders at the full local
+    /// container; legacy raw-byte output may temporarily preserve this grid so
+    /// the local emulator matches the producer.
     func applyViewSize(cols: Int, rows: Int)
     #if DEBUG
     var onOutputProcessedForTesting: (() -> Void)? { get set }
@@ -802,9 +803,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private static let viewportReportSettleThreshold = 8
     private var lastSnapshotFallbackHTML: String?
     /// Last daemon-authoritative effective grid (min across attached devices).
-    /// Kept for diagnostics and natural-grid reassertion; it does not constrain
-    /// the iOS render layer, which always fills the local container.
+    /// Kept for diagnostics and natural-grid reassertion. It constrains the iOS
+    /// render layer only while applying legacy raw-byte output, where the local
+    /// emulator must match the Mac PTY's producer grid.
     private var effectiveGrid: (cols: Int, rows: Int)?
+    /// True while the stream is applying legacy raw-byte output. Render-grid
+    /// output is viewport-shaped state and must keep filling the local
+    /// container; raw bytes must preserve the effective producer grid.
+    private var rawByteProducerGridPinningEnabled = false
     /// Cached cell metrics derived from the most recent
     /// `ghostty_surface_size` measurement. Used for cursor, hit testing, and
     /// scroll gesture mapping. Zero until the first layout has measured.
@@ -2168,6 +2174,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
+    /// Process terminal output after selecting the geometry policy required by
+    /// that output transport.
+    ///
+    /// - Parameter data: VT or PTY bytes to feed into the surface.
+    /// - Parameter preservesProducerGrid: `true` for legacy raw-byte fallback
+    ///   output that must match the Mac PTY grid; `false` for render-grid output
+    ///   that should fill the local iOS container.
+    public func processOutputAndWait(_ data: Data, preservesProducerGrid: Bool) async {
+        setProducerGridPinningEnabled(preservesProducerGrid)
+        await processOutputAndWait(data)
+    }
+
+    private func setProducerGridPinningEnabled(_ enabled: Bool) {
+        guard rawByteProducerGridPinningEnabled != enabled else { return }
+        rawByteProducerGridPinningEnabled = enabled
+        MobileDebugLog.anchormux("sync.output_grid_mode=\(enabled ? "raw_bytes" : "render_grid")")
+        guard surface != nil else { return }
+        needsGeometrySync = false
+        pendingGeometryReassert = false
+        syncSurfaceGeometry(shouldReassertNaturalSize: !enabled)
+    }
+
     private func processOutput(
         _ data: Data,
         completion: (@MainActor @Sendable () -> Void)?
@@ -2879,16 +2907,62 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return }
         MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
         effectiveGrid = (cols, rows)
-        // Do not recompute geometry here. The effective grid is remote state,
-        // not a local sizing constraint; resizing to it is what created the
-        // keyboard-toolbar dead band. The next real geometry trigger will
-        // reassert the natural grid if this value differs.
+        // Render-grid output treats the effective grid as remote diagnostics
+        // only; resizing to it is what created the keyboard-toolbar dead band.
+        // Raw-byte fallback still needs the local emulator grid to match the
+        // producer, so only that compatibility mode applies the pin.
+        if rawByteProducerGridPinningEnabled {
+            setNeedsGeometrySync(reassertNaturalSize: false)
+        }
+    }
+
+    /// Pure libghostty resize refinement; `nonisolated` so it runs on the
+    /// off-main surface queue (it touches only the passed surface pointer).
+    nonisolated private static func fitSurfaceToGrid(
+        _ surface: ghostty_surface_t,
+        cols: Int,
+        rows: Int,
+        cellPixelSize: CGSize
+    ) -> (requestedW: UInt32, requestedH: UInt32, actual: ghostty_surface_size_s) {
+        let requested = TerminalLetterboxGeometry.gridRequestPixelSize(
+            cols: cols,
+            rows: rows,
+            cellPixelSize: cellPixelSize
+        )
+        var requestedW = requested.width
+        var requestedH = requested.height
+
+        ghostty_surface_set_size(surface, requestedW, requestedH)
+        var actual = ghostty_surface_size(surface)
+
+        // Ghostty's grid calculation subtracts padding and floors partial cells,
+        // so the reverse mapping has to be confirmed against Ghostty itself.
+        // This keeps the raw-byte fallback on the exact daemon grid instead of
+        // occasionally rendering one column short.
+        var steps = 0
+        while steps < 8,
+              Int(actual.columns) < cols || Int(actual.rows) < rows {
+            if Int(actual.columns) < cols {
+                requestedW += 1
+            }
+            if Int(actual.rows) < rows {
+                requestedH += 1
+            }
+            ghostty_surface_set_size(surface, requestedW, requestedH)
+            actual = ghostty_surface_size(surface)
+            steps += 1
+        }
+
+        return (requestedW, requestedH, actual)
     }
 
     /// Result of an off-main geometry pass, handed back to the main actor.
     private struct GeometryResult: Sendable {
         let cellPixelSize: CGSize
         let naturalSize: TerminalGridSize
+        /// Pinned render size in points for raw-byte compatibility; nil means
+        /// fill the local container.
+        let pinnedSize: CGSize?
     }
 
     private func syncSurfaceGeometry(shouldReassertNaturalSize: Bool = true) {
@@ -2935,6 +3009,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let containerH = container.height
         let containerPxW = UInt32(max(1, Int((containerW * scale).rounded(.down))))
         let containerPxH = UInt32(max(1, Int((containerH * scale).rounded(.down))))
+        let pinToProducerGrid = rawByteProducerGridPinningEnabled
+        let eff = pinToProducerGrid ? effectiveGrid : nil
         let pushContentScale = abs(lastAppliedContentScale - scale) > 0.001
         if pushContentScale { lastAppliedContentScale = scale }
 
@@ -2953,13 +3029,36 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 )
             }
 
+            var pinnedSize: CGSize?
+            if let eff,
+               TerminalLetterboxGeometry.producerGridPinnedPointSize(
+                   preservesProducerGrid: pinToProducerGrid,
+                   effective: eff,
+                   measuredColumns: Int(measured.columns),
+                   measuredRows: Int(measured.rows),
+                   cell: cell,
+                   scale: scale,
+                   container: container
+               ) != nil {
+                let fitted = Self.fitSurfaceToGrid(surface, cols: eff.cols, rows: eff.rows, cellPixelSize: cell)
+                let aw = fitted.actual.width_px > 0 ? CGFloat(fitted.actual.width_px) : CGFloat(fitted.requestedW)
+                let ah = fitted.actual.height_px > 0 ? CGFloat(fitted.actual.height_px) : CGFloat(fitted.requestedH)
+                let refined = TerminalLetterboxGeometry.clampPinnedSize(
+                    actualWidthPx: aw,
+                    actualHeightPx: ah,
+                    scale: scale,
+                    container: container
+                )
+                pinnedSize = refined
+            }
+
             let natural = TerminalGridSize(
                 columns: Int(measured.columns),
                 rows: Int(measured.rows),
                 pixelWidth: Int(measured.width_px),
                 pixelHeight: Int(measured.height_px)
             )
-            let result = GeometryResult(cellPixelSize: cell, naturalSize: natural)
+            let result = GeometryResult(cellPixelSize: cell, naturalSize: natural, pinnedSize: pinnedSize)
             DispatchQueue.main.async {
                 self?.applyGeometryResult(
                     result,
@@ -2991,13 +3090,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // and ghostty floors the grid to whole cells, so a container-sized
         // layer is up to ~one cell larger than the surface and EVERY frame is
         // discarded (blank terminal). Using the measured full-container surface
-        // size makes them match so frames present. Left-align + top-anchor; the
-        // toolbar absorbs the small sub-cell remainder below the last row.
+        // size makes them match so frames present. Raw-byte compatibility pins
+        // are already derived from the fitted surface px. Left-align +
+        // top-anchor either way; render-grid output only leaves the small
+        // sub-cell remainder below the last row for the toolbar to absorb.
         let naturalRenderSize = CGSize(
             width: max(1, CGFloat(result.naturalSize.pixelWidth) / scale),
             height: max(1, CGFloat(result.naturalSize.pixelHeight) / scale)
         )
-        let renderRect = CGRect(origin: .zero, size: naturalRenderSize)
+        let renderRect = result.pinnedSize.map { CGRect(origin: .zero, size: $0) }
+            ?? CGRect(origin: .zero, size: naturalRenderSize)
         lastRenderRect = renderRect
         // The docked toolbar's top hugs `lastRenderRect.maxY` (see
         // ``bottomDockFrames()``), so re-seat the whole bottom dock now that the
@@ -3009,10 +3111,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             + "cellPx=\(Int(result.cellPixelSize.width))x\(Int(result.cellPixelSize.height)) "
             + "natural=\(result.naturalSize.columns)x\(result.naturalSize.rows) "
             + "eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil") "
+            + "rawPin=\(rawByteProducerGridPinningEnabled) "
+            + "pinned=\(result.pinnedSize.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil") "
             + "renderRect=\(Int(renderRect.width))x\(Int(renderRect.height))"
         )
         syncRendererLayerFrame(scale: scale, renderRect: renderRect)
-        hideLetterboxBorder()
+        updateLetterboxBorder(
+            renderRect: renderRect,
+            isLetterboxed: rawByteProducerGridPinningEnabled &&
+                (renderRect.width + 0.5 < containerW || renderRect.height + 0.5 < containerH)
+        )
         updateCursorOverlay()
         needsDraw = true
         // Keep drawing for several frames so a frame lands at the final settled
@@ -3068,10 +3176,57 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         CATransaction.commit()
     }
 
-    /// Hide the legacy visible-area border. The iOS terminal no longer
-    /// letterboxes to a smaller effective grid, so no local border should draw.
-    private func hideLetterboxBorder() {
-        letterboxBorderLayer?.isHidden = true
+    /// Add / update a 1-pixel separator border around the raw-byte
+    /// compatibility pinned surface rect. Render-grid output keeps the border
+    /// hidden because that path fills the local container.
+    private func updateLetterboxBorder(renderRect: CGRect, isLetterboxed: Bool) {
+        guard isLetterboxed else {
+            letterboxBorderLayer?.isHidden = true
+            return
+        }
+        let border: CAShapeLayer = {
+            if let existing = letterboxBorderLayer { return existing }
+            let b = CAShapeLayer()
+            b.name = "cmux.letterboxBorder"
+            b.fillColor = UIColor.clear.cgColor
+            b.lineWidth = 1.0
+            b.zPosition = 1000
+            b.isHidden = false
+            b.actions = [
+                "bounds": NSNull(),
+                "frame": NSNull(),
+                "hidden": NSNull(),
+                "opacity": NSNull(),
+                "path": NSNull(),
+                "position": NSNull(),
+                "strokeColor": NSNull(),
+            ]
+            b.isGeometryFlipped = false
+            layer.addSublayer(b)
+            letterboxBorderLayer = b
+            return b
+        }()
+        border.isHidden = false
+        border.strokeColor = UIColor.separator.resolvedColor(with: traitCollection).cgColor
+        border.contentsScale = layer.contentsScale
+        if border.frame != layer.bounds {
+            border.frame = layer.bounds
+        }
+
+        let scale = max(border.contentsScale, 1)
+        let lineWidth = border.lineWidth
+        let alignedRect = CGRect(
+            x: floor(renderRect.minX * scale) / scale,
+            y: floor(renderRect.minY * scale) / scale,
+            width: ceil(renderRect.width * scale) / scale,
+            height: ceil(renderRect.height * scale) / scale
+        )
+        let pathInset = max(lineWidth / 2, 0.5 / scale)
+        let outline = alignedRect.insetBy(dx: pathInset, dy: pathInset)
+        let path = UIBezierPath(rect: outline).cgPath
+        if border.path != path {
+            border.path = path
+        }
     }
 
     private func isGhosttyRendererLayer(_ layer: CALayer) -> Bool {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -92,11 +92,9 @@ protocol TerminalSurfaceHosting: AnyObject {
     var currentGridSize: TerminalGridSize { get }
     func processOutput(_ data: Data)
     func focusInput()
-    /// Apply the daemon's authoritative rendering grid. Unconditional —
-    /// implementations render at exactly cols × rows and letterbox any
-    /// remaining container area. The daemon broadcasts this on every
-    /// attach/resize/detach/open, plus inlined in RPC responses, so
-    /// every attached device converges on the same grid.
+    /// Apply the daemon's effective grid response for diagnostics and viewport
+    /// convergence. iOS still renders at its full local container; a smaller
+    /// effective grid must not shrink or letterbox the phone surface.
     func applyViewSize(cols: Int, rows: Int)
     #if DEBUG
     var onOutputProcessedForTesting: (() -> Void)? { get set }
@@ -546,13 +544,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// per-frame render drains them — the wedge that froze zoom.
     private var pendingFontSize: Float32?
     /// Countdown of quiet frames before the post-zoom geometry resync fires.
-    /// A zoom step changes the cell size, which (when letterbox-pinned to the
-    /// Mac's grid) changes `renderRect` and so reallocates the IOSurface render
-    /// target. Doing that every step thrashed the GPU and wedged
-    /// `render_now`'s synchronous frame wait. Instead each step only applies
-    /// the font (the grid reflows inside the current surface) and arms this
-    /// counter; the display link runs ONE `setNeedsGeometrySync` once zoom goes
-    /// quiet, so the letterbox re-pins a single time. nil = nothing pending.
+    /// A zoom step changes the cell size, which changes the natural rows/cols
+    /// for the same container. Resizing the IOSurface render target on every
+    /// step thrashed the GPU and wedged `render_now`'s synchronous frame wait.
+    /// Instead each step only applies the font and arms this counter; the
+    /// display link runs ONE `setNeedsGeometrySync` once zoom goes quiet, so
+    /// the surface refills the container at the settled font size. nil =
+    /// nothing pending.
     private var zoomSettleFrames: Int?
     private static let zoomSettleFrameThreshold = 6
     /// The transient zoom-control HUD (reset/save/restore-built-in), created
@@ -615,14 +613,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Last time the display-link heartbeat logged (DEBUG diagnostic). The
     /// per-frame callback runs on the main thread, so a steady heartbeat proves
     /// main is alive; if it stops while the screen looks frozen, the main
-    /// thread wedged (vs. an idle terminal or a stuck letterbox pin, where the
+    /// thread wedged (vs. an idle terminal or a stale viewport report, where the
     /// heartbeat keeps ticking). Distinguishes the three on the next dogfood.
     private var lastHeartbeatTime: CFTimeInterval = 0
     /// Time of the most recent applied render-grid output, for the heartbeat's
     /// `sinceOutput` field (ties an idle blank to a stream gap).
     private var lastOutputAppliedTime: CFTimeInterval = 0
     #endif
-    /// Set by any geometry trigger (resize/zoom/keyboard/effective-grid pin);
+    /// Set by any geometry trigger (resize/zoom/keyboard/viewport response);
     /// the display link applies geometry at most once per frame. Coalescing
     /// prevents the fast-zoom geometry storm that thrashed the grid (jumbled
     /// rendering) and saturated the renderer.
@@ -787,12 +785,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var pendingViewportReport: TerminalGridSize?
     private var viewportReportSettleFrames = 0
     /// Bounded retries for the viewport report round-trip. The report goes to
-    /// the Mac, which echoes back the effective grid via `applyViewSize`. If the
-    /// round-trip yields no effective grid (RPC timeout / lost reply), the
-    /// render stays pinned to the prior `effectiveGrid` and looks frozen even
-    /// though the main thread is fine. On a no-effective result we re-arm the
-    /// report (display-link driven, no timers) up to `maxViewportReportRetries`
-    /// so a transient drop self-heals; a confirmed result resets the count.
+    /// the Mac, which echoes back the effective grid via `applyViewSize`. On a
+    /// no-effective result (RPC timeout / lost reply), re-arm the report
+    /// (display-link driven, no timers) up to `maxViewportReportRetries` so a
+    /// transient drop self-heals; a confirmed result resets the count.
     private var viewportReportRetries = 0
     private static let maxViewportReportRetries = 3
     /// Frames of "no zoom in progress" required before the natural grid is
@@ -805,19 +801,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// 120Hz / 0.13s at 60Hz.
     private static let viewportReportSettleThreshold = 8
     private var lastSnapshotFallbackHTML: String?
-    /// Daemon-authoritative effective grid (min across attached devices). When
-    /// set, the Ghostty surface is pinned to this cols×rows inside the
-    /// container so every attached device renders at the same grid. When
-    /// nil, the surface fills the container's natural capacity.
+    /// Last daemon-authoritative effective grid (min across attached devices).
+    /// Kept for diagnostics and natural-grid reassertion; it does not constrain
+    /// the iOS render layer, which always fills the local container.
     private var effectiveGrid: (cols: Int, rows: Int)?
     /// Cached cell metrics derived from the most recent
-    /// `ghostty_surface_size` measurement. Used to translate an effective
-    /// cols×rows pin into a pixel box without re-round-tripping through
-    /// Ghostty. Zero until the first layout has measured.
+    /// `ghostty_surface_size` measurement. Used for cursor, hit testing, and
+    /// scroll gesture mapping. Zero until the first layout has measured.
     private var cellPixelSize: CGSize = .zero
-    /// 1 px separator stroke drawn around the pinned surface rect when the
-    /// container is larger than the render target (i.e., this device is
-    /// not the smallest). Added lazily on first letterbox.
+    /// Legacy 1 px separator stroke for the removed letterbox mode. Kept only
+    /// so an already-created layer can be hidden on upgrade/reload.
     private var letterboxBorderLayer: CAShapeLayer?
     /// Last render rect used for the Ghostty surface inside the host view's
     /// coordinate space. Kept so the border layer can match it without a
@@ -1712,12 +1705,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// The toolbar's button row is bottom-pinned inside its container (see
     /// `TerminalInputTextView.dockedButtonRowHeight`), so the controls always hug the
     /// band's bottom no matter how tall the container is — the round-6 fix for "toolbar
-    /// rides up off the keyboard on a letterbox/resize", kept for free because the
-    /// toolbar never leaves the surface. When there is no composer band, the toolbar's
-    /// TOP floats up to the rendered terminal's bottom (`lastRenderRect.maxY`) to
-    /// absorb the sub-cell remainder (no terminal-background gap above the bar). When
-    /// the composer band is open, the toolbar is exactly its button band and the
-    /// composer below absorbs the layout.
+    /// rides up off the keyboard on resize", kept for free because the toolbar never
+    /// leaves the surface. When there is no composer band, the toolbar's
+    /// TOP floats up only far enough to absorb the rendered grid's sub-cell remainder
+    /// (no terminal-background gap above the bar). When the composer band is open,
+    /// the toolbar is exactly its button band and the composer below absorbs the
+    /// layout.
     ///
     /// While the HIDE button has suppressed the chrome (``chromeHidden``) the dock is
     /// off screen (both frames `.zero`); the grid reservation matches (it reserves 0),
@@ -1747,10 +1740,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // Toolbar top: with a composer band below, the toolbar container is exactly its
         // button band (no slack to absorb — the composer owns the space below). Without
         // a composer, let the top float up to the rendered terminal's bottom so the
-        // container's background fills the sub-cell remainder (libghostty floors the
-        // grid to whole cells and top-anchors the render, so `lastRenderRect.maxY` is at
-        // or above `toolbarReservedTop`). Never drop below `toolbarReservedTop` (that
-        // would re-open the gap) and never go negative.
+        // container's background fills only the sub-cell remainder (libghostty floors
+        // the grid to whole cells and top-anchors the render, so `lastRenderRect.maxY`
+        // is just above `toolbarReservedTop`). Never drop below `toolbarReservedTop`
+        // (that would re-open the gap) and never go negative.
         let toolbarTop: CGFloat
         if effectiveComposerHeight > 0 {
             toolbarTop = max(0, toolbarReservedTop)
@@ -1845,8 +1838,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var pendingScrollLines: Double = 0
     private var pendingScrollCell: (col: Int, row: Int) = (0, 0)
 
-    /// Map a touch point to a grid cell (shared effective grid with the Mac), so
-    /// alt-screen mouse-wheel reports at the cell under the finger.
+    /// Map a touch point to the local grid cell under the finger, so alt-screen
+    /// mouse-wheel reports land at the visible position.
     private func scrollCell(at point: CGPoint) -> (col: Int, row: Int) {
         let scale = max(preferredScreenScale, 1)
         let cellW = max(cellPixelSize.width / scale, 1)
@@ -2599,10 +2592,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // font; the geometry resync is deferred until zoom settles.
         let appliedZoom = applyPendingFontSizeIfNeeded()
         // Post-zoom geometry resync: once no new zoom target has landed for a
-        // few quiet frames, do ONE resize to re-pin the letterbox at the
-        // settled font. This is the single geometry change per zoom gesture
-        // instead of one per step (which thrashed the IOSurface and wedged the
-        // render queue).
+        // few quiet frames, do ONE resize at the settled font. This is the
+        // single geometry change per zoom gesture instead of one per step
+        // (which thrashed the IOSurface and wedged the render queue).
         if !appliedZoom, var frames = zoomSettleFrames {
             frames -= 1
             if frames <= 0 {
@@ -2612,8 +2604,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 zoomSettleFrames = frames
             }
         }
-        // Apply geometry at most once per frame. Every trigger (resize, zoom,
-        // keyboard, effective-grid pin) only marks `needsGeometrySync`, so a
+        // Apply geometry at most once per frame. Every local trigger (resize,
+        // zoom, keyboard) only marks `needsGeometrySync`, so a
         // fast pinch can no longer drive a synchronous per-event storm of
         // set_size calls (the source of the jumbled grid + renderer overload).
         if needsGeometrySync {
@@ -2865,10 +2857,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     /// Re-arm the debounced viewport report after a round-trip returned no
-    /// effective grid, so a transient RPC drop does not leave the render pinned
-    /// to a stale effective grid (the "stuck letterbox" freeze). Bounded and
-    /// display-link driven (the existing settle machinery re-fires it); a
-    /// confirmed `applyViewSize` resets the counter. No-op once the cap is hit.
+    /// effective grid. Bounded and display-link driven (the existing settle
+    /// machinery re-fires it); a confirmed `applyViewSize` resets the counter.
+    /// No-op once the cap is hit.
     public func retryViewportReport() {
         guard viewportReportRetries < Self.maxViewportReportRetries,
               let pending = lastReportedSize, pending.columns > 0, pending.rows > 0 else { return }
@@ -2888,60 +2879,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return }
         MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
         effectiveGrid = (cols, rows)
-        // Mark dirty instead of recomputing synchronously. This breaks the
-        // feedback loop (didResize → updateTerminalViewport RPC → applyViewSize
-        // → syncSurfaceGeometry → didResize …) that, under fast zoom, drove a
-        // storm of set_size calls + viewport RPCs. Geometry now settles once
-        // per frame, and reassert=false avoids re-reporting the unchanged
-        // natural grid back through the round trip.
-        setNeedsGeometrySync(reassertNaturalSize: false)
-    }
-
-    /// Pure libghostty resize refinement; `nonisolated` so it runs on the
-    /// off-main surface queue (it touches only the passed surface pointer).
-    nonisolated private static func fitSurfaceToGrid(
-        _ surface: ghostty_surface_t,
-        cols: Int,
-        rows: Int,
-        cellPixelSize: CGSize
-    ) -> (requestedW: UInt32, requestedH: UInt32, actual: ghostty_surface_size_s) {
-        var requestedW = UInt32(max(1, Int((CGFloat(cols) * cellPixelSize.width).rounded(.down))))
-        var requestedH = UInt32(max(1, Int((CGFloat(rows) * cellPixelSize.height).rounded(.down))))
-
-        ghostty_surface_set_size(surface, requestedW, requestedH)
-        var actual = ghostty_surface_size(surface)
-
-        // Ghostty's grid calculation subtracts padding and floors partial cells,
-        // so the reverse mapping has to be confirmed against Ghostty itself.
-        // This keeps the iOS mirror on the exact daemon grid instead of
-        // occasionally rendering one column short.
-        var steps = 0
-        // Bounded refinement: a few single-pixel nudges are enough to land on
-        // the exact grid. A high cap let a fast-zoom storm run this loop tens
-        // of thousands of times across frames and burn the main thread.
-        while steps < 8,
-              Int(actual.columns) < cols || Int(actual.rows) < rows {
-            if Int(actual.columns) < cols {
-                requestedW += 1
-            }
-            if Int(actual.rows) < rows {
-                requestedH += 1
-            }
-            ghostty_surface_set_size(surface, requestedW, requestedH)
-            actual = ghostty_surface_size(surface)
-            steps += 1
-        }
-
-        return (requestedW, requestedH, actual)
+        // Do not recompute geometry here. The effective grid is remote state,
+        // not a local sizing constraint; resizing to it is what created the
+        // keyboard-toolbar dead band. The next real geometry trigger will
+        // reassert the natural grid if this value differs.
     }
 
     /// Result of an off-main geometry pass, handed back to the main actor.
     private struct GeometryResult: Sendable {
         let cellPixelSize: CGSize
         let naturalSize: TerminalGridSize
-        /// Pinned render size in points when letterboxed to an effective
-        /// grid; nil means fill the container.
-        let pinnedSize: CGSize?
     }
 
     private func syncSurfaceGeometry(shouldReassertNaturalSize: Bool = true) {
@@ -2988,7 +2935,6 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let containerH = container.height
         let containerPxW = UInt32(max(1, Int((containerW * scale).rounded(.down))))
         let containerPxH = UInt32(max(1, Int((containerH * scale).rounded(.down))))
-        let eff = effectiveGrid
         let pushContentScale = abs(lastAppliedContentScale - scale) > 0.001
         if pushContentScale { lastAppliedContentScale = scale }
 
@@ -3007,30 +2953,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 )
             }
 
-            var pinnedSize: CGSize?
-            if let eff, eff.cols > 0, eff.rows > 0, cell.width > 0, cell.height > 0 {
-                let fillsNaturalGrid = eff.cols >= Int(measured.columns) && eff.rows >= Int(measured.rows)
-                let withinOneCell = (Int(measured.columns) - eff.cols) <= 1 && (Int(measured.rows) - eff.rows) <= 1
-                let pinnedW = CGFloat(eff.cols) * cell.width / scale
-                let pinnedH = CGFloat(eff.rows) * cell.height / scale
-                if !fillsNaturalGrid, !withinOneCell, pinnedW + 0.5 < containerW || pinnedH + 0.5 < containerH {
-                    let fitted = Self.fitSurfaceToGrid(surface, cols: eff.cols, rows: eff.rows, cellPixelSize: cell)
-                    let aw = fitted.actual.width_px > 0 ? fitted.actual.width_px : fitted.requestedW
-                    let ah = fitted.actual.height_px > 0 ? fitted.actual.height_px : fitted.requestedH
-                    pinnedSize = CGSize(
-                        width: min(CGFloat(aw) / scale, containerW),
-                        height: min(CGFloat(ah) / scale, containerH)
-                    )
-                }
-            }
-
             let natural = TerminalGridSize(
                 columns: Int(measured.columns),
                 rows: Int(measured.rows),
                 pixelWidth: Int(measured.width_px),
                 pixelHeight: Int(measured.height_px)
             )
-            let result = GeometryResult(cellPixelSize: cell, naturalSize: natural, pinnedSize: pinnedSize)
+            let result = GeometryResult(cellPixelSize: cell, naturalSize: natural)
             DispatchQueue.main.async {
                 self?.applyGeometryResult(
                     result,
@@ -3061,16 +2990,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // present path discards any surface whose size != layer.bounds×scale,
         // and ghostty floors the grid to whole cells, so a container-sized
         // layer is up to ~one cell larger than the surface and EVERY frame is
-        // discarded (blank terminal). Using the measured surface size makes
-        // them match so frames present. Pinned (letterboxed) sizes are already
-        // derived from the fitted surface px. Left-align + top-anchor either
-        // way; any leftover container space is the letterbox margin.
+        // discarded (blank terminal). Using the measured full-container surface
+        // size makes them match so frames present. Left-align + top-anchor; the
+        // toolbar absorbs the small sub-cell remainder below the last row.
         let naturalRenderSize = CGSize(
             width: max(1, CGFloat(result.naturalSize.pixelWidth) / scale),
             height: max(1, CGFloat(result.naturalSize.pixelHeight) / scale)
         )
-        let renderRect = result.pinnedSize.map { CGRect(origin: .zero, size: $0) }
-            ?? CGRect(origin: .zero, size: naturalRenderSize)
+        let renderRect = CGRect(origin: .zero, size: naturalRenderSize)
         lastRenderRect = renderRect
         // The docked toolbar's top hugs `lastRenderRect.maxY` (see
         // ``bottomDockFrames()``), so re-seat the whole bottom dock now that the
@@ -3082,14 +3009,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             + "cellPx=\(Int(result.cellPixelSize.width))x\(Int(result.cellPixelSize.height)) "
             + "natural=\(result.naturalSize.columns)x\(result.naturalSize.rows) "
             + "eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil") "
-            + "pinned=\(result.pinnedSize.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil") "
             + "renderRect=\(Int(renderRect.width))x\(Int(renderRect.height))"
         )
         syncRendererLayerFrame(scale: scale, renderRect: renderRect)
-        updateLetterboxBorder(
-            renderRect: renderRect,
-            isLetterboxed: renderRect.width + 0.5 < containerW || renderRect.height + 0.5 < containerH
-        )
+        hideLetterboxBorder()
         updateCursorOverlay()
         needsDraw = true
         // Keep drawing for several frames so a frame lands at the final settled
@@ -3127,9 +3050,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // next input forces a redraw after the animation finally settled (the
         // "blanked out, typing brought it back" symptom). Disabling implicit
         // actions makes the bounds change land in one step, so a single redraw
-        // presents at the final size immediately. The host layer and letterbox
-        // border already suppress implicit actions; this keeps the render
-        // sublayer consistent.
+        // presents at the final size immediately. The host layer already
+        // suppresses implicit actions; this keeps the render sublayer
+        // consistent.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         layer.contentsScale = scale
@@ -3145,60 +3068,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         CATransaction.commit()
     }
 
-    /// Add / update a 1-pixel separator border around the pinned surface
-    /// rect when the container is larger (this device is not the smallest
-    /// attached to the shared PTY). Smallest-device layouts have
-    /// `isLetterboxed == false` and the border layer is hidden. Uses a
-    /// CAShapeLayer so the stroke doesn't intercept touches / key events.
-    private func updateLetterboxBorder(renderRect: CGRect, isLetterboxed: Bool) {
-        guard isLetterboxed else {
-            letterboxBorderLayer?.isHidden = true
-            return
-        }
-        let border: CAShapeLayer = {
-            if let existing = letterboxBorderLayer { return existing }
-            let b = CAShapeLayer()
-            b.name = "cmux.letterboxBorder"
-            b.fillColor = UIColor.clear.cgColor
-            b.lineWidth = 1.0
-            b.zPosition = 1000 // above the Ghostty renderer layer
-            b.isHidden = false
-            b.actions = [
-                "bounds": NSNull(),
-                "frame": NSNull(),
-                "hidden": NSNull(),
-                "opacity": NSNull(),
-                "path": NSNull(),
-                "position": NSNull(),
-                "strokeColor": NSNull(),
-            ]
-            // Decorative only; let pointer / key events pass through.
-            b.isGeometryFlipped = false
-            layer.addSublayer(b)
-            letterboxBorderLayer = b
-            return b
-        }()
-        border.isHidden = false
-        border.strokeColor = UIColor.separator.resolvedColor(with: traitCollection).cgColor
-        border.contentsScale = layer.contentsScale
-        if border.frame != layer.bounds {
-            border.frame = layer.bounds
-        }
-
-        let scale = max(border.contentsScale, 1)
-        let lineWidth = border.lineWidth
-        let alignedRect = CGRect(
-            x: floor(renderRect.minX * scale) / scale,
-            y: floor(renderRect.minY * scale) / scale,
-            width: ceil(renderRect.width * scale) / scale,
-            height: ceil(renderRect.height * scale) / scale
-        )
-        let pathInset = max(lineWidth / 2, 0.5 / scale)
-        let outline = alignedRect.insetBy(dx: pathInset, dy: pathInset)
-        let path = UIBezierPath(rect: outline).cgPath
-        if border.path != path {
-            border.path = path
-        }
+    /// Hide the legacy visible-area border. The iOS terminal no longer
+    /// letterboxes to a smaller effective grid, so no local border should draw.
+    private func hideLetterboxBorder() {
+        letterboxBorderLayer?.isHidden = true
     }
 
     private func isGhosttyRendererLayer(_ layer: CALayer) -> Bool {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -802,14 +802,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// 120Hz / 0.13s at 60Hz.
     private static let viewportReportSettleThreshold = 8
     private var lastSnapshotFallbackHTML: String?
-    /// Last daemon-authoritative effective grid (min across attached devices).
-    /// Kept for diagnostics and natural-grid reassertion. It constrains the iOS
-    /// render layer only while applying legacy raw-byte output, where the local
-    /// emulator must match the Mac PTY's producer grid.
+    /// Last daemon-authoritative effective grid. Diagnostic for render-grid
+    /// output; a temporary sizing constraint for legacy raw bytes.
     private var effectiveGrid: (cols: Int, rows: Int)?
-    /// True while the stream is applying legacy raw-byte output. Render-grid
-    /// output is viewport-shaped state and must keep filling the local
-    /// container; raw bytes must preserve the effective producer grid.
+    /// True while legacy raw bytes need the local emulator to match the
+    /// producer grid instead of the full local container.
     private var rawByteProducerGridPinningEnabled = false
     /// Cached cell metrics derived from the most recent
     /// `ghostty_surface_size` measurement. Used for cursor, hit testing, and
@@ -2174,13 +2171,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Process terminal output after selecting the geometry policy required by
-    /// that output transport.
-    ///
-    /// - Parameter data: VT or PTY bytes to feed into the surface.
-    /// - Parameter preservesProducerGrid: `true` for legacy raw-byte fallback
-    ///   output that must match the Mac PTY grid; `false` for render-grid output
-    ///   that should fill the local iOS container.
+    /// Process terminal output using the geometry policy required by its
+    /// transport.
     public func processOutputAndWait(_ data: Data, preservesProducerGrid: Bool) async {
         setProducerGridPinningEnabled(preservesProducerGrid)
         await processOutputAndWait(data)
@@ -2884,10 +2876,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
     }
 
-    /// Re-arm the debounced viewport report after a round-trip returned no
-    /// effective grid. Bounded and display-link driven (the existing settle
-    /// machinery re-fires it); a confirmed `applyViewSize` resets the counter.
-    /// No-op once the cap is hit.
+    /// Re-arm a dropped viewport-report round trip. Bounded and display-link
+    /// driven; a confirmed `applyViewSize` resets the counter.
     public func retryViewportReport() {
         guard viewportReportRetries < Self.maxViewportReportRetries,
               let pending = lastReportedSize, pending.columns > 0, pending.rows > 0 else { return }
@@ -2907,17 +2897,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         if effectiveGrid?.cols == cols && effectiveGrid?.rows == rows { return }
         MobileDebugLog.anchormux("zoom.applyViewSize eff=\(effectiveGrid.map { "\($0.cols)x\($0.rows)" } ?? "nil")->\(cols)x\(rows)")
         effectiveGrid = (cols, rows)
-        // Render-grid output treats the effective grid as remote diagnostics
-        // only; resizing to it is what created the keyboard-toolbar dead band.
-        // Raw-byte fallback still needs the local emulator grid to match the
-        // producer, so only that compatibility mode applies the pin.
+        // Only raw-byte fallback resizes to the producer grid. Render-grid
+        // output uses the effective grid for diagnostics/convergence only.
         if rawByteProducerGridPinningEnabled {
             setNeedsGeometrySync(reassertNaturalSize: false)
         }
     }
 
-    /// Pure libghostty resize refinement; `nonisolated` so it runs on the
-    /// off-main surface queue (it touches only the passed surface pointer).
     nonisolated private static func fitSurfaceToGrid(
         _ surface: ghostty_surface_t,
         cols: Int,
@@ -2935,10 +2921,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         ghostty_surface_set_size(surface, requestedW, requestedH)
         var actual = ghostty_surface_size(surface)
 
-        // Ghostty's grid calculation subtracts padding and floors partial cells,
-        // so the reverse mapping has to be confirmed against Ghostty itself.
-        // This keeps the raw-byte fallback on the exact daemon grid instead of
-        // occasionally rendering one column short.
+        // Confirm the reverse pixel mapping against Ghostty; padding/flooring
+        // can otherwise leave the raw-byte fallback one column short.
         var steps = 0
         while steps < 8,
               Int(actual.columns) < cols || Int(actual.rows) < rows {
@@ -2956,12 +2940,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return (requestedW, requestedH, actual)
     }
 
-    /// Result of an off-main geometry pass, handed back to the main actor.
     private struct GeometryResult: Sendable {
         let cellPixelSize: CGSize
         let naturalSize: TerminalGridSize
-        /// Pinned render size in points for raw-byte compatibility; nil means
-        /// fill the local container.
         let pinnedSize: CGSize?
     }
 
@@ -3084,16 +3065,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         if result.cellPixelSize.width > 0, result.cellPixelSize.height > 0 {
             cellPixelSize = result.cellPixelSize
         }
-        // Size the render layer to the EXACT pixel size libghostty rendered
-        // (grid-aligned: cols×cellW × rows×cellH), not the raw container. The
-        // present path discards any surface whose size != layer.bounds×scale,
-        // and ghostty floors the grid to whole cells, so a container-sized
-        // layer is up to ~one cell larger than the surface and EVERY frame is
-        // discarded (blank terminal). Using the measured full-container surface
-        // size makes them match so frames present. Raw-byte compatibility pins
-        // are already derived from the fitted surface px. Left-align +
-        // top-anchor either way; render-grid output only leaves the small
-        // sub-cell remainder below the last row for the toolbar to absorb.
+        // Size the render layer to libghostty's exact grid-aligned pixel size,
+        // not the raw container. The present path discards mismatched surface /
+        // layer sizes; raw-byte pins are already derived from fitted pixels.
         let naturalRenderSize = CGSize(
             width: max(1, CGFloat(result.naturalSize.pixelWidth) / scale),
             height: max(1, CGFloat(result.naturalSize.pixelHeight) / scale)
@@ -3176,9 +3150,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         CATransaction.commit()
     }
 
-    /// Add / update a 1-pixel separator border around the raw-byte
-    /// compatibility pinned surface rect. Render-grid output keeps the border
-    /// hidden because that path fills the local container.
+    /// Draw the 1-pixel separator for raw-byte compatibility pinning only.
     private func updateLetterboxBorder(renderRect: CGRect, isLetterboxed: Bool) {
         guard isLetterboxed else {
             letterboxBorderLayer?.isHidden = true
@@ -3209,9 +3181,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         border.isHidden = false
         border.strokeColor = UIColor.separator.resolvedColor(with: traitCollection).cgColor
         border.contentsScale = layer.contentsScale
-        if border.frame != layer.bounds {
-            border.frame = layer.bounds
-        }
+        if border.frame != layer.bounds { border.frame = layer.bounds }
 
         let scale = max(border.contentsScale, 1)
         let lineWidth = border.lineWidth
@@ -3224,9 +3194,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let pathInset = max(lineWidth / 2, 0.5 / scale)
         let outline = alignedRect.insetBy(dx: pathInset, dy: pathInset)
         let path = UIBezierPath(rect: outline).cgPath
-        if border.path != path {
-            border.path = path
-        }
+        if border.path != path { border.path = path }
     }
 
     private func isGhosttyRendererLayer(_ layer: CALayer) -> Bool {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileZoomStressHarness.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileZoomStressHarness.swift
@@ -11,8 +11,8 @@ import UIKit
 ///   1. Output bytes streaming into `processOutput` (as the Mac does).
 ///   2. The cross-device viewport feedback: `didResize` → an async
 ///      `applyViewSize` echo (mimicking the Mac's `mobile.terminal.viewport`
-///      response), which pins an `effectiveGrid` and drives the
-///      `setSurfaceSizeAtLeastGrid` letterbox-fitting path.
+///      response), which records the remote effective grid without shrinking
+///      the local iOS render area.
 ///   3. Rapid font zoom on a timer.
 ///
 /// Enable with `CMUX_ZOOM_STRESS=1`; see `cmuxApp`. DEBUG-only.
@@ -90,9 +90,9 @@ private struct ZoomStressRepresentable: UIViewRepresentable {
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {}
 
         // (2) Mimic the Mac's viewport response: echo back a slightly smaller
-        // grid asynchronously so an effectiveGrid is pinned and the
-        // letterbox-fitting path runs, exactly like the real app's
-        // didResize → updateTerminalViewport → applyViewSize cascade.
+        // grid asynchronously, exactly like the real app's
+        // didResize → updateTerminalViewport → applyViewSize cascade. The
+        // response must not shrink the local iOS render area.
         //
         // (2b) AND emit a heavy zsh-style prompt-redraw burst on every resize.
         // On a real paired Mac each PTY resize makes zsh redraw its big

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -108,12 +108,11 @@ final class TerminalInputTextView: UITextView {
     /// the composer host. It is the tallest control (the arrow nub,
     /// ``dockedNubSize``) plus ``dockedBottomPadding`` below it. The controls are
     /// pinned to the BOTTOM of this band (minus the padding) instead of the top:
-    /// when the surface-hosted container grows taller than this band (a
-    /// letterbox/resize pushes the rendered terminal's bottom up), the buttons stay
-    /// glued to the keyboard top and only the slack ABOVE them grows, so the
-    /// control row never rides up off the keyboard. In the composer host the frame
-    /// is exactly this height (no slack), so bottom-pinning is identical to
-    /// top-pinning there.
+    /// when the surface-hosted container grows slightly taller than this band
+    /// to absorb the terminal grid's sub-cell remainder, the buttons stay glued
+    /// to the keyboard top and only the slack ABOVE them grows. In the composer
+    /// host the frame is exactly this height (no slack), so bottom-pinning is
+    /// identical to top-pinning there.
     static let dockedButtonRowHeight: CGFloat = dockedNubSize + dockedBottomPadding
     /// Minimum (not fixed) button width. Text buttons (Tab, Esc, ^C, ^D) size to
     /// their intrinsic content width and only floor here so they hug their label
@@ -212,14 +211,13 @@ final class TerminalInputTextView: UITextView {
         // A short fixed-height strip pinned to the container's BOTTOM (minus
         // ``dockedBottomPadding``) that holds the button row. The docked container
         // can be TALLER than this strip, because the host
-        // (`GhosttySurfaceView.bottomDockFrames`) anchors the bar's TOP to the
-        // rendered terminal's bottom and its BOTTOM to the keyboard top, so a
-        // letterbox/resize that pushes the rendered terminal up grows the container
-        // upward. Bottom-pinning the controls keeps them glued to the keyboard top
-        // (the container's bottom edge) with the slack absorbed ABOVE them; a
-        // top-pin would let the controls ride UP off the keyboard whenever the
-        // terminal was letterboxed. `dockedBottomPadding` lifts the strip off the
-        // very bottom edge so the controls have breathing room.
+        // (`GhosttySurfaceView.bottomDockFrames`) anchors the bar's TOP at the
+        // rendered terminal's bottom and its BOTTOM at the keyboard top, so the
+        // container can absorb the small sub-cell remainder below the terminal
+        // grid. Bottom-pinning the controls keeps them glued to the keyboard top
+        // (the container's bottom edge) with that slack absorbed ABOVE them.
+        // `dockedBottomPadding` lifts the strip off the very bottom edge so the
+        // controls have breathing room.
         let buttonRow = UILayoutGuide()
         container.addLayoutGuide(buttonRow)
 

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -162,6 +162,7 @@ public struct TerminalLetterboxGeometry {
     ///   - scale: The screen scale factor.
     ///   - container: The drawable container size in points.
     /// - Returns: Always `nil`; the surface should fill the container.
+    @available(*, deprecated, message: "iOS no longer letterboxes to the daemon effective grid; this always returns nil.")
     public static func pinnedPointSize(
         effective: (cols: Int, rows: Int),
         measuredColumns: Int,

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -1,14 +1,11 @@
 public import CoreGraphics
 import Foundation
 
-/// Pure letterbox-fit math for the terminal surface.
+/// Pure viewport math for the iOS terminal surface.
 ///
 /// Absorbs the pixel arithmetic previously inlined in the iOS surface view's
-/// `syncSurfaceGeometry` and `fitSurfaceToGrid` (the parts that do not call
-/// libghostty): the container pixel size, the request box for an effective
-/// grid pin, and the decision of whether to letterbox and at what point size.
-/// The arithmetic is byte-for-byte identical to the legacy path so the surface
-/// converges on the exact same grid; this layer just makes it testable.
+/// `syncSurfaceGeometry` (the parts that do not call libghostty): the bottom
+/// chrome reservation, keyboard/safe-area occupancy, and pixel/point conversion.
 public struct TerminalLetterboxGeometry {
     private init() {}
 
@@ -133,11 +130,11 @@ public struct TerminalLetterboxGeometry {
         return (w, h)
     }
 
-    /// The initial requested pixel box to fit a `cols × rows` grid.
+    /// Legacy requested pixel box to fit a `cols × rows` grid.
     ///
     /// Floors `cols * cellWidth` / `rows * cellHeight` and clamps to at least 1
-    /// pixel each, matching the start of the legacy `fitSurfaceToGrid` before
-    /// its libghostty refinement loop.
+    /// pixel each, matching the removed effective-grid pinning path. Kept as
+    /// pure arithmetic coverage for callers that need the same conversion.
     ///
     /// - Parameters:
     ///   - cols: The target column count.
@@ -150,13 +147,12 @@ public struct TerminalLetterboxGeometry {
         return (w, h)
     }
 
-    /// Whether the surface should be letterbox-pinned to `effective` inside the
-    /// container, and the candidate pinned point size when it should.
+    /// Legacy effective-grid pinning decision for the iOS render box.
     ///
-    /// Reproduces the legacy guard exactly: skip pinning when the effective grid
-    /// already fills (or is within one cell of) the measured natural grid, or
-    /// when the pinned box would not be meaningfully smaller than the container
-    /// (the `+ 0.5` point tolerance on either axis).
+    /// iOS no longer letterboxes the local terminal to a smaller daemon
+    /// effective grid. The phone still reports its natural grid upstream, but
+    /// the render surface always fills the local container (minus keyboard and
+    /// chrome), so this compatibility helper always returns `nil`.
     ///
     /// - Parameters:
     ///   - effective: The daemon-authoritative `(cols, rows)` grid.
@@ -165,8 +161,7 @@ public struct TerminalLetterboxGeometry {
     ///   - cell: The measured cell size in device pixels.
     ///   - scale: The screen scale factor.
     ///   - container: The drawable container size in points.
-    /// - Returns: `nil` when the surface should fill the container, otherwise
-    ///   the candidate pinned size in points (pre-libghostty-refinement).
+    /// - Returns: Always `nil`; the surface should fill the container.
     public static func pinnedPointSize(
         effective: (cols: Int, rows: Int),
         measuredColumns: Int,
@@ -175,22 +170,12 @@ public struct TerminalLetterboxGeometry {
         scale: CGFloat,
         container: CGSize
     ) -> CGSize? {
-        guard effective.cols > 0, effective.rows > 0, cell.width > 0, cell.height > 0 else { return nil }
-        let fillsNaturalGrid = effective.cols >= measuredColumns && effective.rows >= measuredRows
-        let withinOneCell = (measuredColumns - effective.cols) <= 1 && (measuredRows - effective.rows) <= 1
-        let pinnedW = CGFloat(effective.cols) * cell.width / scale
-        let pinnedH = CGFloat(effective.rows) * cell.height / scale
-        guard !fillsNaturalGrid, !withinOneCell,
-              pinnedW + 0.5 < container.width || pinnedH + 0.5 < container.height else {
-            return nil
-        }
-        return CGSize(width: pinnedW, height: pinnedH)
+        nil
     }
 
-    /// Clamps a libghostty-refined pixel box back into point space, bounded by
-    /// the container.
+    /// Clamps a pixel box back into point space, bounded by the container.
     ///
-    /// Matches the legacy final `pinnedSize` assignment:
+    /// Matches the legacy pinning path's final point conversion:
     /// `min(actualPx / scale, containerPoints)` per axis.
     ///
     /// - Parameters:

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -5,7 +5,8 @@ import Foundation
 ///
 /// Absorbs the pixel arithmetic previously inlined in the iOS surface view's
 /// `syncSurfaceGeometry` (the parts that do not call libghostty): the bottom
-/// chrome reservation, keyboard/safe-area occupancy, and pixel/point conversion.
+/// chrome reservation, keyboard/safe-area occupancy, pixel/point conversion,
+/// and the raw-byte compatibility pinning decision.
 public struct TerminalLetterboxGeometry {
     private init() {}
 
@@ -147,12 +148,13 @@ public struct TerminalLetterboxGeometry {
         return (w, h)
     }
 
-    /// Legacy effective-grid pinning decision for the iOS render box.
+    /// Effective-grid pinning decision for the iOS render box.
     ///
-    /// iOS no longer letterboxes the local terminal to a smaller daemon
-    /// effective grid. The phone still reports its natural grid upstream, but
-    /// the render surface always fills the local container (minus keyboard and
-    /// chrome), so this compatibility helper always returns `nil`.
+    /// Render-grid output should not use this because it can fill the local
+    /// container independently. Legacy raw-byte output still needs it: those
+    /// bytes were produced by the Mac PTY at the negotiated effective grid, so
+    /// the local emulator must temporarily match that grid to keep wrapping,
+    /// cursor addressing, and mouse-cell coordinates aligned.
     ///
     /// - Parameters:
     ///   - effective: The daemon-authoritative `(cols, rows)` grid.
@@ -161,8 +163,8 @@ public struct TerminalLetterboxGeometry {
     ///   - cell: The measured cell size in device pixels.
     ///   - scale: The screen scale factor.
     ///   - container: The drawable container size in points.
-    /// - Returns: Always `nil`; the surface should fill the container.
-    @available(*, deprecated, message: "iOS no longer letterboxes to the daemon effective grid; this always returns nil.")
+    /// - Returns: `nil` when the surface should fill the container, otherwise
+    ///   the candidate pinned size in points (pre-libghostty-refinement).
     public static func pinnedPointSize(
         effective: (cols: Int, rows: Int),
         measuredColumns: Int,
@@ -171,12 +173,54 @@ public struct TerminalLetterboxGeometry {
         scale: CGFloat,
         container: CGSize
     ) -> CGSize? {
-        nil
+        guard effective.cols > 0, effective.rows > 0, cell.width > 0, cell.height > 0 else { return nil }
+        let fillsNaturalGrid = effective.cols >= measuredColumns && effective.rows >= measuredRows
+        let withinOneCell = (measuredColumns - effective.cols) <= 1 && (measuredRows - effective.rows) <= 1
+        let pinnedW = CGFloat(effective.cols) * cell.width / scale
+        let pinnedH = CGFloat(effective.rows) * cell.height / scale
+        guard !fillsNaturalGrid, !withinOneCell,
+              pinnedW + 0.5 < container.width || pinnedH + 0.5 < container.height else {
+            return nil
+        }
+        return CGSize(width: pinnedW, height: pinnedH)
+    }
+
+    /// Effective-grid pinning decision gated by the output transport.
+    ///
+    /// - Parameters:
+    ///   - preservesProducerGrid: Pass `true` for raw-byte fallback output and
+    ///     `false` for render-grid output.
+    ///   - effective: The daemon-authoritative `(cols, rows)` grid.
+    ///   - measuredColumns: The surface's measured natural columns.
+    ///   - measuredRows: The surface's measured natural rows.
+    ///   - cell: The measured cell size in device pixels.
+    ///   - scale: The screen scale factor.
+    ///   - container: The drawable container size in points.
+    /// - Returns: `nil` for render-grid output or when no pin is required,
+    ///   otherwise the raw-byte compatibility pinned size.
+    public static func producerGridPinnedPointSize(
+        preservesProducerGrid: Bool,
+        effective: (cols: Int, rows: Int),
+        measuredColumns: Int,
+        measuredRows: Int,
+        cell: CGSize,
+        scale: CGFloat,
+        container: CGSize
+    ) -> CGSize? {
+        guard preservesProducerGrid else { return nil }
+        return pinnedPointSize(
+            effective: effective,
+            measuredColumns: measuredColumns,
+            measuredRows: measuredRows,
+            cell: cell,
+            scale: scale,
+            container: container
+        )
     }
 
     /// Clamps a pixel box back into point space, bounded by the container.
     ///
-    /// Matches the legacy pinning path's final point conversion:
+    /// Matches the raw-byte compatibility pinning path's final point conversion:
     /// `min(actualPx / scale, containerPoints)` per axis.
     ///
     /// - Parameters:
@@ -185,7 +229,6 @@ public struct TerminalLetterboxGeometry {
     ///   - scale: The screen scale factor.
     ///   - container: The drawable container size in points.
     /// - Returns: The final pinned point size.
-    @available(*, deprecated, message: "iOS no longer letterboxes to the daemon effective grid; this only preserves legacy pixel conversion.")
     public static func clampPinnedSize(
         actualWidthPx: CGFloat,
         actualHeightPx: CGFloat,

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -185,6 +185,7 @@ public struct TerminalLetterboxGeometry {
     ///   - scale: The screen scale factor.
     ///   - container: The drawable container size in points.
     /// - Returns: The final pinned point size.
+    @available(*, deprecated, message: "iOS no longer letterboxes to the daemon effective grid; this only preserves legacy pixel conversion.")
     public static func clampPinnedSize(
         actualWidthPx: CGFloat,
         actualHeightPx: CGFloat,

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -73,63 +73,66 @@ struct TerminalLetterboxGeometryTests {
         #expect(TerminalLetterboxGeometry.cellPixelSize(columns: 80, rows: 24, widthPx: 0, heightPx: 480) == .zero)
     }
 
-    @Test("no pin when effective grid fills the natural grid")
-    func noPinWhenFills() {
-        let pinned = TerminalLetterboxGeometry.pinnedPointSize(
-            effective: (cols: 100, rows: 40),
-            measuredColumns: 100,
-            measuredRows: 40,
-            cell: CGSize(width: 9, height: 18),
-            scale: 3,
-            container: CGSize(width: 402, height: 700)
-        )
-        #expect(pinned == nil)
-    }
-
-    @Test("no pin when effective grid is within one cell of natural")
-    func noPinWithinOneCell() {
-        let pinned = TerminalLetterboxGeometry.pinnedPointSize(
-            effective: (cols: 99, rows: 39),
-            measuredColumns: 100,
-            measuredRows: 40,
-            cell: CGSize(width: 9, height: 18),
-            scale: 3,
-            container: CGSize(width: 402, height: 700)
-        )
-        #expect(pinned == nil)
-    }
-
-    @Test("smaller effective grid does not pin the iOS render box")
-    func smallerEffectiveGridDoesNotPin() {
+    @available(*, deprecated, message: "Exercises deprecated compatibility API.")
+    @Test("effective grid never pins the iOS render box")
+    func effectiveGridNeverPinsIOSRenderBox() {
         // The remote effective grid is a viewport negotiation result, not a
         // sizing constraint for the iOS view. The local render surface must keep
-        // filling the available container so a smaller response cannot leave a
-        // dead band between the terminal and keyboard toolbar.
-        let pinned = TerminalLetterboxGeometry.pinnedPointSize(
-            effective: (cols: 60, rows: 30),
-            measuredColumns: 100,
-            measuredRows: 40,
-            cell: CGSize(width: 9, height: 18),
-            scale: 3,
-            container: CGSize(width: 402, height: 700)
-        )
-        #expect(pinned == nil)
-    }
+        // filling the available container so no response shape can leave a dead
+        // band between the terminal and keyboard toolbar.
+        let cases: [(
+            effective: (cols: Int, rows: Int),
+            measuredColumns: Int,
+            measuredRows: Int,
+            cell: CGSize,
+            scale: CGFloat,
+            container: CGSize
+        )] = [
+            (
+                effective: (cols: 60, rows: 30),
+                measuredColumns: 100,
+                measuredRows: 40,
+                cell: CGSize(width: 9, height: 18),
+                scale: 3,
+                container: CGSize(width: 402, height: 700)
+            ),
+            (
+                effective: (cols: 100, rows: 40),
+                measuredColumns: 100,
+                measuredRows: 40,
+                cell: CGSize(width: 9, height: 18),
+                scale: 3,
+                container: CGSize(width: 402, height: 700)
+            ),
+            (
+                effective: (cols: 99, rows: 39),
+                measuredColumns: 100,
+                measuredRows: 40,
+                cell: CGSize(width: 9, height: 18),
+                scale: 3,
+                container: CGSize(width: 402, height: 700)
+            ),
+            (
+                effective: (cols: 134, rows: 116),
+                measuredColumns: 134,
+                measuredRows: 116,
+                cell: CGSize(width: 9, height: 18),
+                scale: 3,
+                container: CGSize(width: 402, height: 700)
+            ),
+        ]
 
-    @Test("no pin when the pinned box is not meaningfully smaller than the container")
-    func noPinWhenNotSmaller() {
-        // pinnedW = 134*9/3 = 402 == container width, pinnedH = 233*18/3 ≈ 1398 > container.
-        // Both axes fail the (pinned + 0.5 < container) test on width and natural
-        // fills, so confirm a near-equal box does not pin.
-        let pinned = TerminalLetterboxGeometry.pinnedPointSize(
-            effective: (cols: 134, rows: 116),
-            measuredColumns: 134,
-            measuredRows: 116,
-            cell: CGSize(width: 9, height: 18),
-            scale: 3,
-            container: CGSize(width: 402, height: 700)
-        )
-        #expect(pinned == nil)
+        for testCase in cases {
+            let pinned = TerminalLetterboxGeometry.pinnedPointSize(
+                effective: testCase.effective,
+                measuredColumns: testCase.measuredColumns,
+                measuredRows: testCase.measuredRows,
+                cell: testCase.cell,
+                scale: testCase.scale,
+                container: testCase.container
+            )
+            #expect(pinned == nil)
+        }
     }
 
     // MARK: - Keyboard open/closed full-height contract

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -73,66 +73,32 @@ struct TerminalLetterboxGeometryTests {
         #expect(TerminalLetterboxGeometry.cellPixelSize(columns: 80, rows: 24, widthPx: 0, heightPx: 480) == .zero)
     }
 
-    @available(*, deprecated, message: "Exercises deprecated compatibility API.")
-    @Test("effective grid never pins the iOS render box")
-    func effectiveGridNeverPinsIOSRenderBox() {
-        // The remote effective grid is a viewport negotiation result, not a
-        // sizing constraint for the iOS view. The local render surface must keep
-        // filling the available container so no response shape can leave a dead
-        // band between the terminal and keyboard toolbar.
-        let cases: [(
-            effective: (cols: Int, rows: Int),
-            measuredColumns: Int,
-            measuredRows: Int,
-            cell: CGSize,
-            scale: CGFloat,
-            container: CGSize
-        )] = [
-            (
-                effective: (cols: 60, rows: 30),
-                measuredColumns: 100,
-                measuredRows: 40,
-                cell: CGSize(width: 9, height: 18),
-                scale: 3,
-                container: CGSize(width: 402, height: 700)
-            ),
-            (
-                effective: (cols: 100, rows: 40),
-                measuredColumns: 100,
-                measuredRows: 40,
-                cell: CGSize(width: 9, height: 18),
-                scale: 3,
-                container: CGSize(width: 402, height: 700)
-            ),
-            (
-                effective: (cols: 99, rows: 39),
-                measuredColumns: 100,
-                measuredRows: 40,
-                cell: CGSize(width: 9, height: 18),
-                scale: 3,
-                container: CGSize(width: 402, height: 700)
-            ),
-            (
-                effective: (cols: 134, rows: 116),
-                measuredColumns: 134,
-                measuredRows: 116,
-                cell: CGSize(width: 9, height: 18),
-                scale: 3,
-                container: CGSize(width: 402, height: 700)
-            ),
-        ]
+    @Test("render-grid output does not pin to the producer grid")
+    func renderGridOutputDoesNotPinProducerGrid() {
+        let pinned = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: false,
+            effective: (cols: 60, rows: 30),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        #expect(pinned == nil)
+    }
 
-        for testCase in cases {
-            let pinned = TerminalLetterboxGeometry.pinnedPointSize(
-                effective: testCase.effective,
-                measuredColumns: testCase.measuredColumns,
-                measuredRows: testCase.measuredRows,
-                cell: testCase.cell,
-                scale: testCase.scale,
-                container: testCase.container
-            )
-            #expect(pinned == nil)
-        }
+    @Test("raw-byte output pins to a smaller producer grid")
+    func rawByteOutputPinsProducerGrid() {
+        let pinned = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 60, rows: 30),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        #expect(pinned == CGSize(width: 180, height: 180))
     }
 
     // MARK: - Keyboard open/closed full-height contract
@@ -278,7 +244,6 @@ struct TerminalLetterboxGeometryTests {
         #expect(TerminalLetterboxGeometry.resolvedBottomSafeAreaInset(viewInset: 0, windowInset: 0) == 0)
     }
 
-    @available(*, deprecated, message: "Exercises deprecated compatibility API.")
     @Test("clampPinnedSize bounds refined pixels by the container")
     func clampPinned() {
         // refined 540x540 px at scale 3 = 180x180 points, within container.

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -278,6 +278,7 @@ struct TerminalLetterboxGeometryTests {
         #expect(TerminalLetterboxGeometry.resolvedBottomSafeAreaInset(viewInset: 0, windowInset: 0) == 0)
     }
 
+    @available(*, deprecated, message: "Exercises deprecated compatibility API.")
     @Test("clampPinnedSize bounds refined pixels by the container")
     func clampPinned() {
         // refined 540x540 px at scale 3 = 180x180 points, within container.

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -101,6 +101,72 @@ struct TerminalLetterboxGeometryTests {
         #expect(pinned == CGSize(width: 180, height: 180))
     }
 
+    @Test("raw-byte producer-grid pin is nil for invalid metrics")
+    func rawBytePinNilForInvalidMetrics() {
+        let invalidGrid = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 0, rows: 30),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        let invalidCell = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 60, rows: 30),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: .zero,
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        #expect(invalidGrid == nil)
+        #expect(invalidCell == nil)
+    }
+
+    @Test("raw-byte producer-grid pin is nil when the producer grid already fits")
+    func rawBytePinNilWhenProducerGridFitsNaturalGrid() {
+        let pinned = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 100, rows: 40),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        #expect(pinned == nil)
+    }
+
+    @Test("raw-byte producer-grid pin is nil for one-cell drift")
+    func rawBytePinNilForOneCellDrift() {
+        let pinned = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 99, rows: 39),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 402, height: 700)
+        )
+        #expect(pinned == nil)
+    }
+
+    @Test("raw-byte producer-grid pin is nil when the candidate cannot shrink the container")
+    func rawBytePinNilWhenCandidateDoesNotShrinkContainer() {
+        let pinned = TerminalLetterboxGeometry.producerGridPinnedPointSize(
+            preservesProducerGrid: true,
+            effective: (cols: 60, rows: 30),
+            measuredColumns: 100,
+            measuredRows: 40,
+            cell: CGSize(width: 9, height: 18),
+            scale: 3,
+            container: CGSize(width: 100, height: 100)
+        )
+        #expect(pinned == nil)
+    }
+
     // MARK: - Keyboard open/closed full-height contract
 
     // iPhone 16-ish portrait: 402x874 bounds, 34pt home indicator, 44pt toolbar.

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -99,10 +99,12 @@ struct TerminalLetterboxGeometryTests {
         #expect(pinned == nil)
     }
 
-    @Test("pins to a smaller effective grid producing a point-size box")
-    func pinsSmallerGrid() {
-        // effective 60x30, natural 100x40, cell 9x18 px at scale 3.
-        // pinnedW = 60 * 9 / 3 = 180, pinnedH = 30 * 18 / 3 = 180.
+    @Test("smaller effective grid does not pin the iOS render box")
+    func smallerEffectiveGridDoesNotPin() {
+        // The remote effective grid is a viewport negotiation result, not a
+        // sizing constraint for the iOS view. The local render surface must keep
+        // filling the available container so a smaller response cannot leave a
+        // dead band between the terminal and keyboard toolbar.
         let pinned = TerminalLetterboxGeometry.pinnedPointSize(
             effective: (cols: 60, rows: 30),
             measuredColumns: 100,
@@ -111,7 +113,7 @@ struct TerminalLetterboxGeometryTests {
             scale: 3,
             container: CGSize(width: 402, height: 700)
         )
-        #expect(pinned == CGSize(width: 180, height: 180))
+        #expect(pinned == nil)
     }
 
     @Test("no pin when the pinned box is not meaningfully smaller than the container")


### PR DESCRIPTION
## Summary
- Keep the iOS terminal render layer sized from the full local container instead of pinning/letterboxing to the remote effective grid.
- Keep pinch zoom as font-size only; settled zoom resyncs geometry against the full container.
- Add a regression test proving a smaller effective grid does not pin the iOS render box.

## Verification
- `swift test` in `Packages/iOS/CmuxMobileTerminalKit`
- `CMUX_SKIP_ZIG_BUILD=1 ./ios/scripts/reload.sh --tag issue-6357-ios-terminal-keyboard-gap`
- Visual DEBUG zoom-stress harness on iPhone 17 simulator. Real paired terminal was not available locally, so visual verification used `CMUX_ZOOM_STRESS=1` to exercise output + viewport echo + pinch/font-size churn.

## Screenshots
- Before: `/tmp/cmux-issue-6357-screenshots/ios-terminal-keyboard-gap-before.png`
- After: `/tmp/cmux-issue-6357-screenshots/ios-terminal-keyboard-gap-after.png`

Refs #6357

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784332581&installation_id=133855650&pr_number=6367&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6367&signature=d0f909c9d2c632e16aec54e1bc6ae54f15f58f56079a4585a7ea13bc506f6f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS terminal keyboard gap by keeping the surface full‑height for render‑grid output and only pinning to the producer grid for legacy raw bytes. Pinch zoom stays font‑size only with a single post‑zoom resync; viewport echoes retry (bounded), and the toolbar stays bottom‑anchored. Addresses #6357.

- **Bug Fixes**
  - Render fills the local container for render‑grid; raw‑byte compatibility preserves the producer grid and shows the border only when pinned.
  - Zoom adjusts font size per step, then does one settled geometry resync; viewport reports retry (bounded) to self‑heal drops.
  - Docked toolbar stays bottom‑anchored so no gap appears above the keyboard.
  - iOS CI writes simulator env to `$RUNNER_TEMP`; tests assert render‑grid output never pins and raw‑byte output pins only when valid and meaningfully smaller (nil for invalid/one‑cell/unsmaller cases).

- **Refactors**
  - Added `preservesProducerGrid` to `MobileTerminalOutputChunk` and `TerminalOutputDelivery`; `GhosttySurfaceView.processOutputAndWait(_:preservesProducerGrid:)` selects the geometry policy per chunk.
  - Moved viewport math into `TerminalLetterboxGeometry` with `producerGridPinnedPointSize`, `gridRequestPixelSize`, and `clampPinnedSize`; pinning logic is isolated and tested.
  - Marked iOS logger globals `nonisolated`.

<sup>Written for commit fdf514a7a2912a7ecb2df13573103da348ef58e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS terminal zoom/resize reconciliation so the local terminal render stays full-height, using the daemon’s effective grid for diagnostics while reserving grid pinning for legacy raw-byte output.
  * Updated output handling so streamed chunks correctly preserve the producer grid only when appropriate.
* **New Features**
  * Added producer-grid pinning support to the viewport geometry calculations (used when producer-grid preservation is enabled).
* **Refactor**
  * Refined viewport/grid negotiation and letterbox/border behavior to align with the new natural-fill vs raw-byte pinning split.
* **Tests**
  * Expanded geometry and output-queue test coverage around producer-grid preservation and non-pinning scenarios.
* **Documentation**
  * Refreshed inline comments to match the revised zoom/viewport/effective-grid semantics.
* **Chores**
  * Updated iOS simulator test workflow to use a per-runner temp environment file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->