### PR TITLE
iOS: unified multi-Mac workspace list (behind unifiedMultiMacEnabled flag)

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+DeeplinkNavigation.swift
@@ -50,13 +50,60 @@ extension CMUXMobileShellStore {
         return workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
     }
 
-    /// The workspace whose terminal list contains `terminalID`, if any.
-    func workspaceID(forTerminalID terminalID: String) -> MobileWorkspacePreview.ID? {
+    /// The workspace (on the active heavy Mac) whose terminal list contains the
+    /// terminal identified by `surfaceKey`, if any.
+    ///
+    /// `surfaceKey` is the Mac-scoped surface key (`"<deviceId>#<terminalID>"`,
+    /// see ``ScopedTerminalID/surfaceKey``); a bare terminal id (no separator)
+    /// is accepted as the unscoped case. Resolution is the multi-Mac routing
+    /// guard: the heavy client only owns the active Mac's surfaces, so a key
+    /// whose `deviceId` is NOT the active Mac's resolves to `nil` — a colliding
+    /// bare terminal id on another Mac can never match the active Mac's
+    /// workspace. The scan still compares the BARE terminal id (the wire id is
+    /// Mac-local); the scope only gates which Mac the key may belong to.
+    func workspaceID(forTerminalID surfaceKey: String) -> MobileWorkspacePreview.ID? {
+        let scoped = ScopedTerminalID(surfaceKey: surfaceKey)
+        // A scoped key for a non-active Mac must not resolve against the heavy
+        // client's workspaces, even if the bare terminal id happens to collide.
+        // An unscoped ("") key predates multi-Mac scoping (single-Mac/preview)
+        // and is allowed to match.
+        if !scoped.deviceId.isEmpty, let activeDeviceID, scoped.deviceId != activeDeviceID {
+            return nil
+        }
+        let bareTerminalID = scoped.terminalID.rawValue
         for workspace in workspaces {
-            if workspace.terminals.contains(where: { $0.id.rawValue == terminalID }) {
+            if workspace.terminals.contains(where: { $0.id.rawValue == bareTerminalID }) {
                 return workspace.id
             }
         }
         return nil
+    }
+
+    /// The bare, Mac-local terminal id to send on the wire for a scoped surface
+    /// key, but ONLY when the key belongs to the active heavy Mac.
+    ///
+    /// Returns `nil` for a key scoped to a non-active Mac (the heavy client
+    /// cannot service it), which makes every wire-bound terminal call
+    /// (`input`, `mouse`, `scroll`, `viewport`, `replay`) a safe no-op rather
+    /// than routing a colliding bare id to the wrong Mac. An unscoped key falls
+    /// through to its bare terminal id for the single-Mac case.
+    func wireTerminalID(forSurfaceKey surfaceKey: String) -> String? {
+        let scoped = ScopedTerminalID(surfaceKey: surfaceKey)
+        if !scoped.deviceId.isEmpty, let activeDeviceID, scoped.deviceId != activeDeviceID {
+            return nil
+        }
+        return scoped.terminalID.rawValue
+    }
+
+    /// The local surface key for a bare wire terminal id arriving from the
+    /// active heavy Mac (a `terminal.bytes` / `terminal.render_grid` event, or a
+    /// replay response). Scoped with ``activeDeviceID`` so the byte-delivery
+    /// dictionaries are keyed identically to the surface the UI registered. When
+    /// there is no active device id (single-Mac/preview), the key is unscoped.
+    func surfaceKeyForActiveMac(wireTerminalID: String) -> String {
+        ScopedTerminalID(
+            deviceId: activeDeviceID ?? "",
+            terminalID: MobileTerminalPreview.ID(rawValue: wireTerminalID)
+        ).surfaceKey
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalScrollDelivery.swift
@@ -63,14 +63,19 @@ extension MobileShellComposite {
     }
 
     private func performTerminalScroll(_ delivery: TerminalScrollDelivery) async {
+        // `delivery.surfaceID` is the Mac-scoped surface key. The bare wire id is
+        // resolved only when the key belongs to the active heavy Mac; a key for
+        // another Mac yields nil here so the scroll is dropped rather than routed
+        // to the wrong Mac.
         guard let client = remoteClient,
-              let workspaceID = workspaceID(forTerminalID: delivery.surfaceID) else {
+              let workspaceID = workspaceID(forTerminalID: delivery.surfaceID),
+              let wireSurfaceID = wireTerminalID(forSurfaceKey: delivery.surfaceID) else {
             return
         }
         do {
             var params: [String: Any] = [
                 "workspace_id": workspaceID.rawValue,
-                "surface_id": delivery.surfaceID,
+                "surface_id": wireSurfaceID,
                 "client_id": clientID,
                 "delta_lines": delivery.lines,
                 "col": delivery.col,
@@ -89,9 +94,11 @@ extension MobileShellComposite {
                   remoteClient === client else {
                 return
             }
+            // The Mac echoes the BARE wire surface id; compare on the wire id, and
+            // `deliverAuthoritativeTerminalRenderGrid` re-scopes for delivery.
             guard let payload = try? MobileTerminalReplayResponse.decode(data),
                   let renderGrid = payload.renderGrid,
-                  renderGrid.surfaceID == delivery.surfaceID else {
+                  renderGrid.surfaceID == wireSurfaceID else {
                 return
             }
             deliverAuthoritativeTerminalRenderGrid(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -296,6 +296,39 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return lhs.id.rawValue < rhs.id.rawValue
         }
     }
+
+    /// A `deviceId -> human display name` map for resolving the per-row Mac chip
+    /// label in the unified list, returned as an immutable value snapshot so no
+    /// `@Observable` store crosses the `List` boundary.
+    ///
+    /// Sources, most-authoritative last (later writes win): the registry's
+    /// `RegistryDevice.title`, then each paired Mac's `displayName`, then the
+    /// active Mac's live ``connectedHostName`` (the freshest, user-visible name
+    /// for the Mac actually connected). A device whose name is unknown is simply
+    /// absent from the map; the chip then falls back to the short device id at
+    /// the view layer. Always non-empty values; empty/whitespace names are
+    /// skipped so they cannot shadow a better source.
+    public var unifiedDeviceNames: [String: String] {
+        var names: [String: String] = [:]
+        func record(_ deviceID: String, _ name: String?) {
+            guard !deviceID.isEmpty else { return }
+            guard let name else { return }
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            names[deviceID] = trimmed
+        }
+        for device in registryDevices {
+            record(device.deviceId, device.displayName)
+        }
+        for mac in pairedMacs {
+            record(mac.macDeviceID, mac.displayName)
+        }
+        if let activeDeviceID {
+            record(activeDeviceID, connectedHostName)
+        }
+        return names
+    }
+
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups (or is old enough not to emit them). Drives the collapsible group
     /// sections in the workspace list.
@@ -464,6 +497,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public var selectedWorkspaceID: MobileWorkspacePreview.ID? {
         didSet {
             syncSelectedTerminalForWorkspace()
+        }
+    }
+
+    /// The current selection scoped to the owning Mac, for the unified list's
+    /// scoped navigation.
+    ///
+    /// P2 (unified list UI) threads selection through ``ScopedWorkspaceID`` so the
+    /// list and navigation stack are keyed on `(deviceId, workspaceID)` and two
+    /// Macs with colliding bare workspace ids stay distinguishable. The store's
+    /// authoritative selection is still the bare ``selectedWorkspaceID`` targeting
+    /// the heavy client; the `deviceId` carried here is the active Mac's
+    /// ``activeDeviceID`` (or `""` when unscoped). Cross-Mac heavy-attach routing
+    /// from a scoped selection lands in P3; until then setting a non-active Mac's
+    /// scope only updates the bare workspace id against the active client.
+    public var scopedSelectedWorkspaceID: ScopedWorkspaceID? {
+        get {
+            guard let selectedWorkspaceID else { return nil }
+            return ScopedWorkspaceID(deviceId: activeDeviceID ?? "", workspaceID: selectedWorkspaceID)
+        }
+        set {
+            selectedWorkspaceID = newValue?.workspaceID
         }
     }
     /// The terminal whose surface (and composer draft) is currently shown.
@@ -5743,6 +5797,24 @@ extension MobileShellComposite {
     /// live subscription, so unified-list presence gating can be exercised.
     public func debugApplyPresence(_ update: PresenceUpdate) {
         presenceMap.apply(update)
+    }
+
+    /// Test-only seam to set the live host name without a real connect, so the
+    /// ``unifiedDeviceNames`` active-Mac source can be exercised.
+    public func debugSetConnectedHostName(_ name: String) {
+        connectedHostName = name
+    }
+
+    /// Test-only seam to seed paired Macs without persistence, so
+    /// ``unifiedDeviceNames`` resolution can be exercised.
+    public func debugSetPairedMacs(_ macs: [MobilePairedMac]) {
+        pairedMacs = macs
+    }
+
+    /// Test-only seam to seed registry devices without a registry fetch, so
+    /// ``unifiedDeviceNames`` resolution can be exercised.
+    public func debugSetRegistryDevices(_ devices: [RegistryDevice]) {
+        registryDevices = devices
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -280,6 +280,75 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return Self.orderedForUnifiedList(merged)
     }
 
+    /// The online, non-active Macs the aggregator should fetch workspace lists
+    /// from for the unified list, derived from ``deviceTreeDevices`` (registry,
+    /// else locally paired Macs) gated by ``presenceMap`` online state.
+    ///
+    /// A device is included when: it is not the active heavy Mac; presence
+    /// reports it online (a device the presence service has never seen is
+    /// excluded, mirroring the merge in ``unifiedWorkspaces``); and it advertises
+    /// a dialable, Stack-auth-trusted route. The chosen instance is the
+    /// most-recently-seen reachable one, matching ``reconnectableInstance``.
+    /// Empty while the flag is off so the aggregator stays inert.
+    var unifiedAggregatorTargets: [MultiMacWorkspaceAggregator.Target] {
+        guard unifiedMultiMacEnabled else { return [] }
+        let supportedKinds = runtime?.supportedRouteKinds ?? []
+        var targets: [MultiMacWorkspaceAggregator.Target] = []
+        for device in deviceTreeDevices {
+            guard !device.deviceId.isEmpty else { continue }
+            // The active Mac is served by the heavy client; never list it here.
+            if let activeDeviceID, device.deviceId == activeDeviceID { continue }
+            // Presence gating, same rule as the unified merge: only an online
+            // device contributes; an unknown (nil summary) device does not.
+            guard presenceMap.deviceSummary(deviceId: device.deviceId)?.online == true else { continue }
+            // Pick the freshest reachable, Stack-auth-trusted instance/route.
+            let candidates = device.instances.compactMap { instance -> (RegistryAppInstance, CmxAttachRoute)? in
+                guard let route = Self.firstStackAuthReconnectRoute(
+                    instance.routes,
+                    supportedKinds: supportedKinds
+                ) else { return nil }
+                return (instance, route)
+            }
+            guard let chosen = candidates.max(by: { $0.0.lastSeenAt < $1.0.lastSeenAt }) ?? candidates.first else {
+                continue
+            }
+            let route = chosen.1
+            targets.append(
+                MultiMacWorkspaceAggregator.Target(
+                    deviceId: device.deviceId,
+                    displayName: device.displayName ?? device.deviceId,
+                    route: route
+                )
+            )
+        }
+        return targets
+    }
+
+    /// Refresh the unified multi-Mac aggregator's per-device workspace slices
+    /// from the current online, non-active Macs, and prune any device that is no
+    /// longer a live target (went offline, or became the active heavy Mac).
+    ///
+    /// This is the single production driver for the aggregator: the connect /
+    /// activation completion, presence events, and pull-to-refresh all funnel
+    /// through it. A no-op while the flag is off (``unifiedAggregatorTargets`` is
+    /// empty), so FLAG OFF never opens a list client.
+    public func refreshUnifiedAggregator() async {
+        guard unifiedMultiMacEnabled else { return }
+        await multiMacAggregator.refresh(targets: unifiedAggregatorTargets)
+    }
+
+    /// Fire-and-forget kick for the aggregator from a hot path (heavy connect
+    /// completion, presence event) that must not block on N list RPCs. Coalesces
+    /// onto the single in-flight refresh task; a no-op while the flag is off.
+    private func kickUnifiedAggregatorRefresh() {
+        guard unifiedMultiMacEnabled else { return }
+        if let existing = unifiedAggregatorRefreshTask, !existing.isCancelled { return }
+        unifiedAggregatorRefreshTask = Task { @MainActor [weak self] in
+            defer { self?.unifiedAggregatorRefreshTask = nil }
+            await self?.refreshUnifiedAggregator()
+        }
+    }
+
     /// Order the unified list: pinned workspaces first, then by `lastActivityAt`
     /// descending (most recent first), with a stable id tiebreak so the order
     /// is deterministic across Macs and refreshes. Workspaces with no
@@ -781,6 +850,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// event-driven ``workspaceListRefreshTask`` cancel/restart can never truncate
     /// the spinner the pull is awaiting. Rapid pulls coalesce onto this single task.
     private var pullToRefreshTask: Task<Void, Never>?
+    /// Non-blocking driver for the unified multi-Mac aggregator (other Macs'
+    /// workspace lists). Connect/activation completion and presence events kick
+    /// this so the heavy path is never blocked on N list RPCs; rapid kicks
+    /// coalesce onto the single in-flight task. Cancelled on sign-out/deinit.
+    private var unifiedAggregatorRefreshTask: Task<Void, Never>?
     private var createWorkspaceTaskID: UUID?
     private var createTerminalTaskID: UUID?
     private var connectionGeneration: UUID
@@ -945,6 +1019,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         createTerminalTask?.cancel()
         workspaceListRefreshTask?.cancel()
         pullToRefreshTask?.cancel()
+        unifiedAggregatorRefreshTask?.cancel()
         if let remoteClient {
             Task { await remoteClient.disconnect() }
         }
@@ -1046,6 +1121,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // next account never sees the previous user's other Macs' workspaces.
         activeDeviceID = nil
         activatingDeviceID = nil
+        unifiedAggregatorRefreshTask?.cancel()
+        unifiedAggregatorRefreshTask = nil
         multiMacAggregator.reset()
         // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
         // the forget path. On a real account switch the next reconnect's no-mac
@@ -1821,6 +1898,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private func applyPresenceUpdate(_ update: PresenceUpdate) {
         presenceMap.apply(update)
+        // A presence change can bring another Mac online (it should now appear in
+        // the unified list) or take one offline (its slice must be pruned). Kick
+        // the aggregator so the unified list tracks live presence. No-op while the
+        // flag is off; coalesces with any in-flight refresh.
+        kickUnifiedAggregatorRefresh()
         switch update {
         case .routes(let instance), .online(let instance):
             // Both events can carry fresh attach routes (online = a host that
@@ -2082,6 +2164,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
             return
         }
+        // Bind the heavy connection to the KNOWN cross-Mac target. The heavy
+        // `connect()` already set `activeDeviceID` from `connectedMacDeviceID`,
+        // but on a synthetic `manual-…` ticket (a route lacking
+        // `mobile.attach_ticket.create`) that heuristic resolves to the
+        // PREVIOUSLY-active Mac, because the new target is not yet marked active
+        // in the paired-Mac store (that upsert happens below, after this connect
+        // returned). The registry path has the real device id in hand, so bind
+        // it directly instead of relying on the heuristic — this is what
+        // `activateMac`/`selectScopedWorkspace`'s `activeDeviceID == target`
+        // guard and the aggregator's slice attribution both depend on. Skip
+        // synthetic `manual-` ids, which carry no real device identity.
+        if !device.deviceId.hasPrefix("manual-") {
+            activeDeviceID = device.deviceId
+        }
         if let pairedMacStore, !device.deviceId.hasPrefix("manual-") {
             do {
                 try await pairedMacStore.upsert(
@@ -2100,6 +2196,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         await loadPairedMacs()
         await loadRegistryDevices()
+        // The active heavy Mac just changed: re-derive the aggregator targets so
+        // the newly-active Mac is pruned from the slices (it is served by the
+        // heavy client now) and the previously-active Mac is fetched as a target.
+        await refreshUnifiedAggregator()
     }
 
     /// Reload ``pairedMacs`` from the store, scoped to the signed-in Stack user.
@@ -2206,6 +2306,27 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             if case let .hostPort(host, port) = route.endpoint {
                 return (host, port)
             }
+        }
+        return nil
+    }
+
+    /// The first route, in reconnect-preference order, that this build can dial
+    /// AND that is trusted to carry the Stack-account token (so a Stack-authed
+    /// `mobile.workspace.list` over it can authorize). Used to build the
+    /// aggregator's per-Mac list-client targets. Returns `nil` when no such
+    /// route exists, so an untrusted-only Mac contributes no aggregator slice.
+    static func firstStackAuthReconnectRoute(
+        _ routes: [CmxAttachRoute],
+        supportedKinds: [CmxAttachTransportKind]
+    ) -> CmxAttachRoute? {
+        let supportedKinds = Set(supportedKinds)
+        for route in routes.sorted(by: routeSortsBefore) {
+            if !supportedKinds.isEmpty, !supportedKinds.contains(route.kind) {
+                continue
+            }
+            guard case .hostPort = route.endpoint else { continue }
+            guard MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) else { continue }
+            return route
         }
         return nil
     }
@@ -3683,6 +3804,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     applyRemoteWorkspaceList(response, preferActiveTicketTarget: workspaceListRequest.preferActiveTicketTarget)
                     syncSelectedTerminalForWorkspace()
                     markMacConnectionHealthy()
+                    // Now that the active Mac is bound, populate the unified list
+                    // with the OTHER online Macs' workspaces. Fire-and-forget so
+                    // the heavy connect return is not blocked on N list RPCs.
+                    kickUnifiedAggregatorRefresh()
                     diagnosticLog?.record(DiagnosticEvent(.pairOk))
                     if workspaceListRequest.isScoped {
                         scheduleFullWorkspaceListRefreshIfAvailable(
@@ -5627,17 +5752,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// `mobile.workspace.list` calls. Returns immediately when not connected, so an
     /// offline pull cannot hang the spinner on a transport timeout.
     public func refreshWorkspaces() async {
-        guard connectionState == .connected, remoteClient != nil else { return }
-        if let inFlight = pullToRefreshTask {
-            await inFlight.value
-            return
+        // Pull-to-refresh also re-syncs the OTHER online Macs' lists (flag on),
+        // so a pull updates the whole unified list, not just the active Mac.
+        // Awaited alongside the active-Mac reload so the spinner reflects both.
+        async let aggregatorRefresh: Void = refreshUnifiedAggregator()
+        if connectionState == .connected, remoteClient != nil {
+            if let inFlight = pullToRefreshTask {
+                await inFlight.value
+            } else {
+                let task = Task { @MainActor [weak self] in
+                    defer { self?.pullToRefreshTask = nil }
+                    await self?.reloadWorkspaceListFromMac()
+                }
+                pullToRefreshTask = task
+                await task.value
+            }
         }
-        let task = Task { @MainActor [weak self] in
-            defer { self?.pullToRefreshTask = nil }
-            await self?.reloadWorkspaceListFromMac()
-        }
-        pullToRefreshTask = task
-        await task.value
+        await aggregatorRefresh
     }
 
     private func stopTerminalRefreshPolling() {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -202,6 +202,100 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Bumped on every ``workspaces`` mutation: a cheap "lists may have
     /// changed" signal (e.g. for retrying a parked notification deep link).
     public private(set) var workspaceTopologyVersion: UInt64 = 0
+
+    /// The cmux device UUID of the Mac the heavy connection is bound to.
+    ///
+    /// Set on every successful heavy ``connect(ticket:allowsStackAuthFallback:)``
+    /// from the active ticket's resolved real device id, and cleared when the
+    /// connection context is torn down. Every preview the heavy client reports
+    /// is tagged with this in ``applyRemoteWorkspaceList`` so the unified list
+    /// can tell the active Mac's workspaces apart from the aggregator's slices.
+    /// `nil` while disconnected or when no real device id can be correlated.
+    public private(set) var activeDeviceID: String?
+
+    /// The lightweight aggregator that fetches *other* online Macs' workspace
+    /// lists for the unified multi-Mac list. Inert (never refreshed) while the
+    /// ``unifiedMultiMacEnabled`` flag is off, so FLAG OFF stays byte-identical
+    /// to single-Mac behavior.
+    public let multiMacAggregator: MultiMacWorkspaceAggregator
+
+    /// Whether the unified multi-Mac workspace list is enabled for this process
+    /// (see ``MobileUnifiedMultiMacFlag``). Resolved once at init so a single
+    /// run has one consistent answer.
+    public let unifiedMultiMacEnabled: Bool
+
+    /// The workspaces shown in the (unified) list.
+    ///
+    /// FLAG OFF: byte-identical to ``workspaces`` with each entry tagged with
+    /// ``activeDeviceID`` — the aggregator is never consulted, so this is the
+    /// single connected Mac's list exactly as today.
+    ///
+    /// FLAG ON: the heavy client's live ``workspaces`` (tagged
+    /// ``activeDeviceID``) merged with the aggregator's per-device slices,
+    /// gated by ``presenceMap`` online state (a device whose presence says it
+    /// is offline contributes nothing), ordered pinned-first then
+    /// `lastActivityAt` descending.
+    public var unifiedWorkspaces: [MobileWorkspacePreview] {
+        let active = workspaces.map { workspace -> MobileWorkspacePreview in
+            guard let activeDeviceID, workspace.deviceId.isEmpty else { return workspace }
+            var tagged = workspace
+            tagged.deviceId = activeDeviceID
+            tagged.terminals = tagged.terminals.map { terminal in
+                guard terminal.deviceId.isEmpty else { return terminal }
+                var terminal = terminal
+                terminal.deviceId = activeDeviceID
+                return terminal
+            }
+            return tagged
+        }
+        guard unifiedMultiMacEnabled else { return active }
+
+        var merged = active
+        for (deviceID, slice) in multiMacAggregator.perDeviceWorkspaces {
+            // The active Mac is served by the heavy client above; never
+            // double-list it from a stale aggregator slice.
+            if let activeDeviceID, deviceID == activeDeviceID { continue }
+            // Presence gating: only an online device contributes. A device the
+            // presence service has never seen (nil summary) is treated as not
+            // online for the unified list (it is reachable only through an
+            // explicit reconnect, not a passive merge).
+            guard presenceMap.deviceSummary(deviceId: deviceID)?.online == true else { continue }
+            merged.append(contentsOf: slice)
+        }
+        return Self.orderedForUnifiedList(merged)
+    }
+
+    /// Order the unified list: pinned workspaces first, then by `lastActivityAt`
+    /// descending (most recent first), with a stable id tiebreak so the order
+    /// is deterministic across Macs and refreshes. Workspaces with no
+    /// `lastActivityAt` sort after those that have one.
+    static func orderedForUnifiedList(
+        _ workspaces: [MobileWorkspacePreview]
+    ) -> [MobileWorkspacePreview] {
+        workspaces.sorted { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned {
+                return lhs.isPinned && !rhs.isPinned
+            }
+            let lhsActivity = lhs.lastActivityAt
+            let rhsActivity = rhs.lastActivityAt
+            switch (lhsActivity, rhsActivity) {
+            case let (l?, r?) where l != r:
+                return l > r
+            case (.some, .none):
+                return true
+            case (.none, .some):
+                return false
+            default:
+                break
+            }
+            // Deterministic tiebreak: device id, then workspace id, so two Macs
+            // with colliding bare ids still sort stably.
+            if lhs.deviceId != rhs.deviceId {
+                return lhs.deviceId < rhs.deviceId
+            }
+            return lhs.id.rawValue < rhs.id.rawValue
+        }
+    }
     /// The Mac's workspace groups, in section order. Empty when the Mac reports no
     /// groups (or is old enough not to emit them). Drives the collapsible group
     /// sections in the workspace list.
@@ -662,10 +756,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         diagnosticLog: DiagnosticLog? = nil,
         feedbackEmailSubmitter: (any MobileFeedbackEmailSubmitting)? = nil,
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
-        draftStore: (any TerminalDraftStoring)? = nil
+        draftStore: (any TerminalDraftStoring)? = nil,
+        unifiedMultiMacEnabled: Bool? = nil
     ) {
         self.runtime = runtime
         self.draftStore = draftStore
+        let unifiedFlag = unifiedMultiMacEnabled ?? MobileUnifiedMultiMacFlag.isEnabled()
+        self.unifiedMultiMacEnabled = unifiedFlag
+        self.multiMacAggregator = MultiMacWorkspaceAggregator(runtime: runtime)
         self.pairedMacStore = pairedMacStore
         self.deviceRegistry = deviceRegistry
         self.presence = presence
@@ -748,11 +846,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
-    public static func preview(runtime: (any MobileSyncRuntime)? = nil) -> CMUXMobileShellStore {
+    public static func preview(
+        runtime: (any MobileSyncRuntime)? = nil,
+        unifiedMultiMacEnabled: Bool? = nil
+    ) -> CMUXMobileShellStore {
         CMUXMobileShellStore(
             runtime: runtime,
             workspaces: PreviewMobileHost.workspaces,
-            deliveredNotificationClearer: NoopDeliveredNotificationClearer()
+            deliveredNotificationClearer: NoopDeliveredNotificationClearer(),
+            unifiedMultiMacEnabled: unifiedMultiMacEnabled
         )
     }
 
@@ -836,6 +938,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Likewise drop the registry-backed device tree so a shared device never
         // shows the previous user's team devices after sign-out.
         registryDevices = []
+        // Drop the unified multi-Mac slices and the active-device binding so the
+        // next account never sees the previous user's other Macs' workspaces.
+        activeDeviceID = nil
+        multiMacAggregator.reset()
         // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
         // the forget path. On a real account switch the next reconnect's no-mac
         // branch clears the hint. Bump the reconnect generation so any in-flight
@@ -2456,6 +2562,52 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
     }
 
+    /// Build a short-lived RPC client for a single (deviceId, host, port)
+    /// target, used by ``MultiMacWorkspaceAggregator`` to fetch one *other*
+    /// Mac's `mobile.workspace.list` and then idle.
+    ///
+    /// This factors out only the lightweight client-construction the heavy
+    /// ``connect(ticket:allowsStackAuthFallback:)`` path also performs — a
+    /// synthetic mac-scoped ticket plus a route-appropriate Stack-auth policy —
+    /// without any of connect's destructive session work (it does not touch
+    /// `remoteClient`, the render-grid stream, the liveness watchdog, terminal
+    /// byte streams, or any persisted paired-Mac state). The ticket carries no
+    /// attach token, so the workspace-list request authorizes purely through
+    /// the Stack account token on trusted routes, exactly as the heavy connect's
+    /// `workspace.list` does.
+    /// - Parameters:
+    ///   - runtime: The DI runtime supplying transport/timeouts/clock.
+    ///   - deviceId: The target Mac's cmux device UUID, stamped on the ticket so
+    ///     a later identity check can correlate it.
+    ///   - displayName: A human label for the synthetic ticket.
+    ///   - route: The attach route to dial.
+    /// - Returns: A ready-to-use client, or `nil` when the route is not
+    ///   Stack-auth trusted (a `mobile.workspace.list` over it could never
+    ///   authorize, so there is no point opening a transport).
+    static func makeMacListClient(
+        runtime: any MobileSyncRuntime,
+        deviceId: String,
+        displayName: String,
+        route: CmxAttachRoute
+    ) -> MobileCoreRPCClient? {
+        guard MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) else {
+            return nil
+        }
+        guard let ticket = try? manualHostTicket(
+            displayName: displayName,
+            macDeviceID: deviceId,
+            route: route
+        ) else {
+            return nil
+        }
+        return MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+    }
+
     private func requestManualAttachTicket(
         route: CmxAttachRoute,
         displayName: String
@@ -3350,9 +3502,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     }
                     clearPairingError()
                     await persistPairedMacFromTicket(ticket)
+                    connectionState = .connected
+                    // Bind the heavy connection to its real device id so the
+                    // unified list tags this Mac's workspaces and the aggregator
+                    // never double-lists it. `connectedMacDeviceID` resolves the
+                    // ticket id (or the active paired Mac for manual tickets), and
+                    // requires `.connected`, so it is read after the state flip.
+                    activeDeviceID = connectedMacDeviceID
                     applyRemoteWorkspaceList(response, preferActiveTicketTarget: workspaceListRequest.preferActiveTicketTarget)
                     syncSelectedTerminalForWorkspace()
-                    connectionState = .connected
                     markMacConnectionHealthy()
                     diagnosticLog?.record(DiagnosticEvent(.pairOk))
                     if workspaceListRequest.isScoped {
@@ -3510,6 +3668,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func clearActiveConnectionContext() {
         activeTicket = nil
         activeRoute = nil
+        activeDeviceID = nil
         connectedHostName = ""
     }
 
@@ -5339,8 +5498,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func remoteWorkspacesPreservingSnapshots(
         from response: MobileSyncWorkspaceListResponse
     ) -> [MobileWorkspacePreview] {
-        response.workspaces.map { remoteWorkspace in
+        // Every workspace the heavy client reports belongs to the active Mac,
+        // so stamp `activeDeviceID` onto it (and its terminals) here. This is
+        // the single point the active Mac's previews are tagged; the unified
+        // list relies on it to tell the active Mac apart from aggregator slices
+        // and to scope selection/routing. When `activeDeviceID` is nil (preview
+        // host, or a manual ticket with no correlatable device id) the tag stays
+        // empty, which is the unscoped/single-Mac case.
+        let deviceID = activeDeviceID ?? ""
+        return response.workspaces.map { remoteWorkspace in
             var workspace = MobileWorkspacePreview(remote: remoteWorkspace)
+            workspace.deviceId = deviceID
+            workspace.terminals = workspace.terminals.map { remoteTerminal in
+                var terminal = remoteTerminal
+                terminal.deviceId = deviceID
+                return terminal
+            }
             guard let existingWorkspace = workspaces.first(where: { $0.id == workspace.id }) else {
                 return workspace
             }
@@ -5556,3 +5729,20 @@ private extension MobileShellComposite {
         return ""
     }
 }
+
+#if DEBUG
+extension MobileShellComposite {
+    /// Test-only seam to bind the active heavy-connection device id without a
+    /// real connect, so the ``unifiedWorkspaces`` merge can be exercised in
+    /// isolation.
+    public func debugSetActiveDeviceID(_ deviceID: String?) {
+        activeDeviceID = deviceID
+    }
+
+    /// Test-only seam to apply a presence update to ``presenceMap`` without a
+    /// live subscription, so unified-list presence gating can be exercised.
+    public func debugApplyPresence(_ update: PresenceUpdate) {
+        presenceMap.apply(update)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -939,7 +939,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) {
         self.runtime = runtime
         self.draftStore = draftStore
-        let unifiedFlag = unifiedMultiMacEnabled ?? MobileUnifiedMultiMacFlag.isEnabled()
+        let unifiedFlag = unifiedMultiMacEnabled ?? MobileUnifiedMultiMacFlag().isEnabled
         self.unifiedMultiMacEnabled = unifiedFlag
         self.multiMacAggregator = MultiMacWorkspaceAggregator(runtime: runtime)
         self.pairedMacStore = pairedMacStore

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -87,6 +87,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // down (and blank the map) the moment the user signs out so a
             // shared device never renders the previous account's devices.
             evaluatePresenceSubscription()
+            // Discover online Macs from the registry without waiting for a heavy
+            // connection so a freshly signed-in phone lists them straight away.
+            // Reset the discovery gate on sign-out so the next account starts
+            // from a clean "still determining" state. No-op while the flag is off.
+            if isSignedIn {
+                kickUnifiedRegistryDiscovery()
+            } else {
+                hasCompletedInitialUnifiedDiscovery = false
+            }
         }
     }
     public private(set) var connectionState: MobileConnectionState {
@@ -228,6 +237,35 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return activatingDeviceID == deviceId
     }
 
+    /// Whether the first post-sign-in unified discovery pass (registry load +
+    /// aggregator refresh) has completed at least once this session. Drives the
+    /// root view's "discovering devices" spinner so a freshly signed-in phone
+    /// shows a neutral determining state instead of flashing the add-device
+    /// screen before the registry has been consulted. Reset on sign-out. Always
+    /// `false`-irrelevant while the flag is off (the root view ignores it then).
+    public private(set) var hasCompletedInitialUnifiedDiscovery: Bool = false
+
+    /// FLAG ON: the unified list has at least one discovered workspace (from the
+    /// heavy client and/or the aggregator's online-Mac slices), so the root view
+    /// should show the unified workspace list even with no heavy connection.
+    /// FLAG OFF: always `false`, so routing falls back to the connection-gated
+    /// path unchanged.
+    public var shouldShowUnifiedWorkspaceList: Bool {
+        unifiedMultiMacEnabled && !unifiedWorkspaces.isEmpty
+    }
+
+    /// FLAG ON: signed in but the first registry+aggregator discovery pass has
+    /// not finished and nothing is listed yet, so the root view shows a neutral
+    /// determining spinner rather than the add-device screen. FLAG OFF: always
+    /// `false`. Once discovery completes with no online Macs, this is `false` and
+    /// the add-device screen shows as before.
+    public var isDiscoveringUnifiedMacs: Bool {
+        unifiedMultiMacEnabled
+            && isSignedIn
+            && !hasCompletedInitialUnifiedDiscovery
+            && unifiedWorkspaces.isEmpty
+    }
+
     /// The lightweight aggregator that fetches *other* online Macs' workspace
     /// lists for the unified multi-Mac list. Inert (never refreshed) while the
     /// ``unifiedMultiMacEnabled`` flag is off, so FLAG OFF stays byte-identical
@@ -346,6 +384,28 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         unifiedAggregatorRefreshTask = Task { @MainActor [weak self] in
             defer { self?.unifiedAggregatorRefreshTask = nil }
             await self?.refreshUnifiedAggregator()
+        }
+    }
+
+    /// Discover and list the user's online Macs from the team registry with NO
+    /// heavy connection: load ``registryDevices`` (the aggregator's target
+    /// source, otherwise only populated after a heavy connect) then refresh the
+    /// aggregator. This is what lets a freshly signed-in phone — never paired,
+    /// no stored Mac — populate the unified list straight from the registry +
+    /// presence instead of dead-ending on the add-device screen.
+    ///
+    /// Called on the sign-in edge and on foreground. A no-op while the flag is
+    /// off, so FLAG OFF never loads the registry pre-connection and behaves
+    /// exactly as before. Marks ``hasCompletedInitialUnifiedDiscovery`` once the
+    /// first pass finishes so the root view can distinguish "still discovering"
+    /// (neutral spinner) from "discovered, genuinely no Macs" (add-device).
+    private func kickUnifiedRegistryDiscovery() {
+        guard unifiedMultiMacEnabled, isSignedIn else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.loadRegistryDevices()
+            await self.refreshUnifiedAggregator()
+            self.hasCompletedInitialUnifiedDiscovery = true
         }
     }
 
@@ -1124,6 +1184,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         unifiedAggregatorRefreshTask?.cancel()
         unifiedAggregatorRefreshTask = nil
         multiMacAggregator.reset()
+        // The next account must re-discover from a clean "still determining"
+        // state rather than inheriting this session's completed-discovery gate.
+        hasCompletedInitialUnifiedDiscovery = false
         // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
         // the forget path. On a real account switch the next reconnect's no-mac
         // branch clears the hint. Bump the reconnect generation so any in-flight
@@ -1155,6 +1218,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Covers stores constructed already-signed-in (no isSignedIn edge) and
         // restarts a subscription torn down while backgrounded.
         evaluatePresenceSubscription()
+        // Re-discover online Macs on foreground: covers a store constructed
+        // already-signed-in (no isSignedIn edge fired) and refreshes the unified
+        // list after time in the background. No-op while the flag is off.
+        kickUnifiedRegistryDiscovery()
         resyncTerminalOutput(reason: "foreground", restartEventStream: true)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -213,6 +213,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// `nil` while disconnected or when no real device id can be correlated.
     public private(set) var activeDeviceID: String?
 
+    /// The cmux device id the unified list is currently switching the heavy
+    /// connection to, while that destructive ``activateMac(deviceId:)`` is in
+    /// flight. `nil` when no cross-Mac activation is running. Drives the per-row
+    /// "connecting…" state in the unified list so the tapped Mac's rows show
+    /// progress without disturbing the others (still served by the aggregator).
+    public private(set) var activatingDeviceID: String?
+
+    /// Whether the unified list should show a per-row "connecting" state for a
+    /// workspace, i.e. its owning Mac is the one currently being activated.
+    /// - Parameter deviceId: The workspace row's owning Mac device id.
+    public func isActivatingMac(deviceId: String) -> Bool {
+        guard let activatingDeviceID, !deviceId.isEmpty else { return false }
+        return activatingDeviceID == deviceId
+    }
+
     /// The lightweight aggregator that fetches *other* online Macs' workspace
     /// lists for the unified multi-Mac list. Inert (never refreshed) while the
     /// ``unifiedMultiMacEnabled`` flag is off, so FLAG OFF stays byte-identical
@@ -503,14 +518,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// The current selection scoped to the owning Mac, for the unified list's
     /// scoped navigation.
     ///
-    /// P2 (unified list UI) threads selection through ``ScopedWorkspaceID`` so the
-    /// list and navigation stack are keyed on `(deviceId, workspaceID)` and two
-    /// Macs with colliding bare workspace ids stay distinguishable. The store's
-    /// authoritative selection is still the bare ``selectedWorkspaceID`` targeting
-    /// the heavy client; the `deviceId` carried here is the active Mac's
-    /// ``activeDeviceID`` (or `""` when unscoped). Cross-Mac heavy-attach routing
-    /// from a scoped selection lands in P3; until then setting a non-active Mac's
-    /// scope only updates the bare workspace id against the active client.
+    /// Selection threads through ``ScopedWorkspaceID`` so the list and navigation
+    /// stack are keyed on `(deviceId, workspaceID)` and two Macs with colliding
+    /// bare workspace ids stay distinguishable. The store's authoritative
+    /// selection is still the bare ``selectedWorkspaceID`` targeting the heavy
+    /// client; the `deviceId` carried here is the active Mac's ``activeDeviceID``
+    /// (or `""` when unscoped).
+    ///
+    /// This accessor only updates the bare selection against the CURRENTLY active
+    /// client. Selecting a workspace on a different Mac (the lazy heavy-attach)
+    /// goes through ``selectScopedWorkspace(_:)``, which first switches the heavy
+    /// connection with ``activateMac(deviceId:)``. A plain set of a non-active
+    /// scope therefore just records the bare id (used for split-detail and
+    /// navigation-path bookkeeping) without re-routing the connection.
     public var scopedSelectedWorkspaceID: ScopedWorkspaceID? {
         get {
             guard let selectedWorkspaceID else { return nil }
@@ -519,6 +539,36 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         set {
             selectedWorkspaceID = newValue?.workspaceID
         }
+    }
+
+    /// Open a scoped workspace from the unified list, switching the heavy
+    /// connection to its owning Mac first when that Mac is not already active.
+    ///
+    /// This is the lazy heavy-attach entrypoint: when the tapped workspace's
+    /// `deviceId` differs from ``activeDeviceID`` (and is non-empty), the heavy
+    /// client is switched with ``activateMac(deviceId:)`` before the selection
+    /// lands, so the terminal that mounts streams from the correct Mac. After the
+    /// switch the bare ``selectedWorkspaceID`` is set to the tapped workspace id,
+    /// which now targets the freshly-activated client. When the Mac is already
+    /// active (the common case, and the only case when the flag is off / single
+    /// Mac) this is just a bare selection with no connection churn.
+    ///
+    /// The other online Macs' rows remain in ``unifiedWorkspaces`` throughout
+    /// (the aggregator keeps their slices); only the heavy stream moves.
+    /// - Parameter scopedID: The scoped identity of the workspace to open.
+    public func selectScopedWorkspace(_ scopedID: ScopedWorkspaceID) async {
+        let targetDeviceID = scopedID.deviceId
+        let crossesMac = !targetDeviceID.isEmpty
+            && activeDeviceID != nil
+            && targetDeviceID != activeDeviceID
+        if crossesMac {
+            await activateMac(deviceId: targetDeviceID)
+            // Activation failed (still on the previous Mac): do not select a
+            // workspace id that does not exist on the active client. The row
+            // stays where it was and the connection error surfaces normally.
+            guard activeDeviceID == targetDeviceID else { return }
+        }
+        selectedWorkspaceID = scopedID.workspaceID
     }
     /// The terminal whose surface (and composer draft) is currently shown.
     ///
@@ -995,6 +1045,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Drop the unified multi-Mac slices and the active-device binding so the
         // next account never sees the previous user's other Macs' workspaces.
         activeDeviceID = nil
+        activatingDeviceID = nil
         multiMacAggregator.reset()
         // Reset the in-memory restoring flags; hasKnownPairedMac stays driven by
         // the forget path. On a real account switch the next reconnect's no-mac
@@ -1036,7 +1087,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// render-grid mirrors any resulting change back. Fire-and-forget.
     public func clickTerminal(surfaceID: String, col: Int, row: Int) async {
         guard let client = remoteClient,
-              let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+              let workspaceID = workspaceID(forTerminalID: surfaceID),
+              let wireSurfaceID = wireTerminalID(forSurfaceKey: surfaceID) else {
             return
         }
         do {
@@ -1044,7 +1096,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 method: "mobile.terminal.mouse",
                 params: [
                     "workspace_id": workspaceID.rawValue,
-                    "surface_id": surfaceID,
+                    "surface_id": wireSurfaceID,
                     "client_id": clientID,
                     "col": col,
                     "row": row,
@@ -1906,6 +1958,65 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 "presence route upsert failed: \(String(describing: error), privacy: .public)"
             )
         }
+    }
+
+    /// Switch the heavy connection to `deviceId` for the unified multi-Mac list.
+    ///
+    /// Opening a workspace whose owning Mac is not the active heavy Mac calls
+    /// this. It is the unified-list counterpart to the device tree's tap-to-open:
+    /// it resolves an online, reconnectable app instance for `deviceId` from the
+    /// registry/paired-Mac tree and routes through the SAME destructive
+    /// ``connectToRegistryInstance(device:instance:)`` path, which replaces the
+    /// live client and re-binds ``activeDeviceID``. The OTHER Macs' rows stay in
+    /// the list (served by the aggregator); only the heavy stream moves.
+    ///
+    /// While the connect is in flight, ``activatingDeviceID`` is set to `deviceId`
+    /// so the tapped Mac's rows can show a per-row connecting state; it is cleared
+    /// in a `defer` regardless of outcome. A no-op when already active on
+    /// `deviceId`, when `deviceId` is empty/unknown, or when no reachable online
+    /// instance exists (the row then simply does not switch). Failure isolation
+    /// and rollback to the previously-active Mac are inherited from
+    /// ``connectToRegistryInstance(device:instance:)``.
+    /// - Parameter deviceId: The cmux device id of the Mac to make active.
+    public func activateMac(deviceId: String) async {
+        guard !deviceId.isEmpty else { return }
+        // Already the active heavy Mac: nothing to switch.
+        if connectionState == .connected, activeDeviceID == deviceId { return }
+        guard let (device, instance) = reconnectableInstance(forDeviceID: deviceId) else {
+            mobileShellLog.error(
+                "activateMac: no reconnectable instance device=\(deviceId, privacy: .public)"
+            )
+            return
+        }
+        activatingDeviceID = deviceId
+        defer { activatingDeviceID = nil }
+        await connectToRegistryInstance(device: device, instance: instance)
+    }
+
+    /// Resolve the device + the app instance to dial for a cross-Mac activation.
+    ///
+    /// Sourced from ``deviceTreeDevices`` (registry, else locally paired Macs) so
+    /// it works with the cloud registry down. Picks the first instance that
+    /// advertises a route this build can reconnect to, preferring instances the
+    /// presence service reports online — but a device with no presence record
+    /// still yields its first route-bearing instance, since the registry carries
+    /// the route and presence may simply lack a sample. Returns `nil` when the
+    /// device is unknown or has no reconnectable instance.
+    private func reconnectableInstance(
+        forDeviceID deviceId: String
+    ) -> (RegistryDevice, RegistryAppInstance)? {
+        guard let device = deviceTreeDevices.first(where: { $0.deviceId == deviceId }) else {
+            return nil
+        }
+        let supportedKinds = runtime?.supportedRouteKinds ?? []
+        let reachable = device.instances.filter { instance in
+            Self.firstReconnectHostPortRoute(instance.routes, supportedKinds: supportedKinds) != nil
+        }
+        guard !reachable.isEmpty else { return nil }
+        // Prefer the most-recently-seen reachable instance, so a live tag wins
+        // over a stale one on a multi-tag Mac.
+        let chosen = reachable.max(by: { $0.lastSeenAt < $1.lastSeenAt }) ?? reachable[0]
+        return (device, chosen)
     }
 
     /// Connect the live session to a specific registry app instance (a tag on a
@@ -3442,11 +3553,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let text = String(data: data, encoding: .utf8) else {
             return
         }
+        // `surfaceID` is the Mac-scoped surface key. The bare wire terminal id is
+        // resolved only when the key belongs to the active heavy Mac; a key for
+        // another Mac (with a possibly-colliding bare id) yields nil here and the
+        // input is dropped rather than routed to the wrong Mac. The workspace
+        // scan compares the bare id against the active Mac's workspaces.
+        guard let wireTerminalID = wireTerminalID(forSurfaceKey: surfaceID) else { return }
         let workspaceCandidate = workspaces.first(where: { workspace in
-            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
+            workspace.terminals.contains(where: { $0.id.rawValue == wireTerminalID })
         })
         guard let workspace = workspaceCandidate else { return }
-        let terminalID = MobileTerminalPreview.ID(rawValue: surfaceID)
+        let terminalID = MobileTerminalPreview.ID(rawValue: wireTerminalID)
         await submitTerminalRawInput(text, workspaceID: workspace.id, terminalID: terminalID)
     }
 
@@ -4332,7 +4449,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 )
             )
             guard isCurrentRemoteOperation(client: client, generation: generation) else { return }
-            handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+            // The byte-delivery dicts are keyed on the active-Mac-scoped surface
+            // key; `terminalID` is the active Mac's bare wire id, so scope it.
+            handleTerminalInputResponse(
+                responseData,
+                surfaceID: surfaceKeyForActiveMac(wireTerminalID: terminalID.rawValue)
+            )
         } catch {
             guard generation == connectionGeneration else { return }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
@@ -4407,7 +4529,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // returning failure here would keep the composer draft and a retry
             // would paste the same block twice.
             if isCurrentRemoteOperation(client: client, generation: generation) {
-                handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+                handleTerminalInputResponse(
+                    responseData,
+                    surfaceID: surfaceKeyForActiveMac(wireTerminalID: terminalID.rawValue)
+                )
             }
             return true
         } catch {
@@ -4503,7 +4628,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // bookkeeping is generation-guarded), so a retry does not re-send the
             // same image.
             if isCurrentRemoteOperation(client: client, generation: generation) {
-                handleTerminalInputResponse(responseData, surfaceID: terminalID.rawValue)
+                handleTerminalInputResponse(
+                    responseData,
+                    surfaceID: surfaceKeyForActiveMac(wireTerminalID: terminalID.rawValue)
+                )
             }
             return true
         } catch {
@@ -5107,24 +5235,32 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
     }
 
+    /// Deliver an authoritative render-grid frame from the active Mac.
+    ///
+    /// `renderGrid.surfaceID` is the BARE wire surface id; the local sink/dicts
+    /// are keyed on the active-Mac-scoped surface key, so the bare id is scoped
+    /// once here and every dictionary op + delivery uses the scoped key.
+    /// `expectedSurfaceID`, when present, is the SCOPED key the caller is
+    /// delivering for (e.g. a scroll prefetch), matched against the scoped key.
     func deliverAuthoritativeTerminalRenderGrid(
         _ renderGrid: MobileTerminalRenderGridFrame,
         expectedSurfaceID: String? = nil,
         source: String
     ) {
-        guard expectedSurfaceID == nil || renderGrid.surfaceID == expectedSurfaceID,
-              hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
+        let surfaceKey = surfaceKeyForActiveMac(wireTerminalID: renderGrid.surfaceID)
+        guard expectedSurfaceID == nil || surfaceKey == expectedSurfaceID,
+              hasTerminalOutputSink(surfaceID: surfaceKey) else {
             return
         }
-        if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[renderGrid.surfaceID],
+        if let deliveredSeq = deliveredTerminalByteEndSeqBySurfaceID[surfaceKey],
            deliveredSeq > renderGrid.stateSeq {
             MobileDebugLog.anchormux(
-                "sync.render_grid_stale source=\(source) surface=\(renderGrid.surfaceID) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
+                "sync.render_grid_stale source=\(source) surface=\(surfaceKey) delivered=\(deliveredSeq) frame=\(renderGrid.stateSeq)"
             )
             return
         }
-        markTerminalBytesDelivered(surfaceID: renderGrid.surfaceID, endSeq: renderGrid.stateSeq)
-        deliverTerminalRenderGrid(renderGrid, surfaceID: renderGrid.surfaceID)
+        markTerminalBytesDelivered(surfaceID: surfaceKey, endSeq: renderGrid.stateSeq)
+        deliverTerminalRenderGrid(renderGrid, surfaceID: surfaceKey)
     }
 
     private static func terminalSnapshotReplacementBytes(_ snapshotBytes: Data) -> Data {
@@ -5197,7 +5333,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ) async -> (columns: Int, rows: Int)? {
         guard columns > 0, rows > 0,
               let client = remoteClient,
-              let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+              let workspaceID = workspaceID(forTerminalID: surfaceID),
+              let wireSurfaceID = wireTerminalID(forSurfaceKey: surfaceID) else {
             return nil
         }
         do {
@@ -5205,7 +5342,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 method: "mobile.terminal.viewport",
                 params: [
                     "workspace_id": workspaceID.rawValue,
-                    "surface_id": surfaceID,
+                    "surface_id": wireSurfaceID,
                     "client_id": clientID,
                     "viewport_columns": columns,
                     "viewport_rows": rows,
@@ -5228,7 +5365,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// detach). Fire-and-forget; the Mac also clears on connection close.
     public func clearTerminalViewport(surfaceID: String) {
         guard let client = remoteClient,
-              let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+              let workspaceID = workspaceID(forTerminalID: surfaceID),
+              let wireSurfaceID = wireTerminalID(forSurfaceKey: surfaceID) else {
             return
         }
         let id = clientID
@@ -5237,7 +5375,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 method: "mobile.terminal.viewport",
                 params: [
                     "workspace_id": workspaceID.rawValue,
-                    "surface_id": surfaceID,
+                    "surface_id": wireSurfaceID,
                     "client_id": id,
                     "clear": true,
                 ]
@@ -5259,7 +5397,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             #endif
             return
         }
-        guard let workspaceID = workspaceID(forTerminalID: surfaceID) else {
+        guard let workspaceID = workspaceID(forTerminalID: surfaceID),
+              let wireSurfaceID = wireTerminalID(forSurfaceKey: surfaceID) else {
             #if DEBUG
             mobileShellLog.error("CMUX_REPLAY skip surface=\(surfaceID, privacy: .public) reason=workspace_not_found")
             #endif
@@ -5280,7 +5419,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     method: "mobile.terminal.replay",
                     params: [
                         "workspace_id": workspaceID.rawValue,
-                        "surface_id": surfaceID,
+                        "surface_id": wireSurfaceID,
                     ]
                 )
                 let data = try await client.sendRequest(request)
@@ -5289,7 +5428,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 let bytes = payload?.dataBase64.flatMap { Data(base64Encoded: $0) }
                 let snapshotBytes = payload?.snapshotBase64.flatMap { Data(base64Encoded: $0) }
                 let decodedRenderGrid = payload?.renderGrid
-                let renderGrid = decodedRenderGrid?.surfaceID == surfaceID ? decodedRenderGrid : nil
+                // The Mac echoes the BARE wire surface id; the local sink/dicts
+                // are keyed on the scoped `surfaceID`, so match the response on
+                // the wire id and deliver under the scoped key.
+                let renderGrid = decodedRenderGrid?.surfaceID == wireSurfaceID ? decodedRenderGrid : nil
                 let replaySeq = renderGrid?.stateSeq ?? payload?.sequence
                 #if DEBUG
                 let seq = replaySeq ?? 0
@@ -5344,8 +5486,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // The frame may arrive nested under `render_grid` or as the bare payload;
         // try the wrapper first, then fall back to decoding the whole payload.
         let renderGridDTO = try? MobileTerminalRenderGridEvent.decode(json)
+        // The frame carries the BARE wire surface id; the sink is keyed on the
+        // active-Mac-scoped key, so scope before the sink check.
         guard let renderGrid = renderGridDTO?.frame ?? (try? MobileTerminalRenderGridFrame.decode(json)),
-              hasTerminalOutputSink(surfaceID: renderGrid.surfaceID) else {
+              hasTerminalOutputSink(surfaceID: surfaceKeyForActiveMac(wireTerminalID: renderGrid.surfaceID)) else {
             return
         }
         #if DEBUG
@@ -5387,7 +5531,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         else {
             return
         }
-        let surfaceID = payload.surfaceID
+        // The Mac's event carries the BARE wire surface id; the local sink/dicts
+        // are keyed on the active-Mac-scoped surface key, so scope it here before
+        // any dictionary lookup so bytes land on the correct Mac's surface.
+        let surfaceID = surfaceKeyForActiveMac(wireTerminalID: payload.surfaceID)
         let bytes = payload.bytes
         #if DEBUG
         let debugSeq = payload.sequence ?? 0
@@ -5815,6 +5962,44 @@ extension MobileShellComposite {
     /// ``unifiedDeviceNames`` resolution can be exercised.
     public func debugSetRegistryDevices(_ devices: [RegistryDevice]) {
         registryDevices = devices
+    }
+
+    /// Test-only seam mirroring an inbound `terminal.render_grid` event from the
+    /// active heavy Mac, which carries the BARE wire surface id. Routes through
+    /// the same ``deliverAuthoritativeTerminalRenderGrid(_:expectedSurfaceID:source:)``
+    /// production uses, so the scoped-key delivery (and the cross-Mac collision
+    /// guard) is exercised end-to-end without a live transport.
+    /// - Parameters:
+    ///   - wireSurfaceID: The bare, Mac-local terminal id the Mac echoes.
+    ///   - seq: The frame's state sequence.
+    ///   - text: The plain-text rows to render.
+    public func debugDeliverActiveMacRenderGrid(
+        wireSurfaceID: String,
+        seq: UInt64,
+        text: String
+    ) {
+        guard let frame = try? MobileTerminalRenderGridFrame.fromPlainRows(
+            surfaceID: wireSurfaceID,
+            stateSeq: seq,
+            columns: 16,
+            rows: 4,
+            text: text
+        ) else { return }
+        deliverAuthoritativeTerminalRenderGrid(frame, source: "debug")
+    }
+
+    /// Test-only seam exposing the keys currently registered in the output-sink
+    /// map (the scoped surface keys), so a collision test can assert which Mac's
+    /// surface received bytes without reaching into private state.
+    public var debugRegisteredSurfaceKeys: Set<String> {
+        Set(terminalByteContinuationsBySurfaceID.keys)
+    }
+
+    /// Test-only seam exposing the delivered end-sequence recorded for a scoped
+    /// surface key, so a collision test can prove a render grid landed on the
+    /// correct Mac's surface (and not the colliding one).
+    public func debugDeliveredEndSeq(forSurfaceKey surfaceKey: String) -> UInt64? {
+        deliveredTerminalByteEndSeqBySurfaceID[surfaceKey]
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileUnifiedMultiMacFlag.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileUnifiedMultiMacFlag.swift
@@ -1,0 +1,75 @@
+public import Foundation
+
+/// Resolves whether the unified multi-Mac workspace list is enabled for this
+/// process.
+///
+/// The unified list discovers every online Mac from the registry and merges all
+/// of their workspaces into one list (see the P1–P3 plan). It is ON by default
+/// on Debug builds (so it dogfoods automatically) and OFF on Release until it
+/// has shipped, with a `UserDefaults` override either way so a tagged build or a
+/// QA device can force the state without a rebuild.
+///
+/// FLAG OFF must be byte-identical to today's single-Mac behavior: the
+/// aggregator stays inactive and ``MobileShellComposite/unifiedWorkspaces``
+/// equals the heavy client's ``MobileShellComposite/workspaces`` tagged with the
+/// active Mac's device id.
+///
+/// This mirrors ``PresenceClient/resolvedServiceBaseURL(environment:defaults:isDebugBuild:)``:
+/// the resolution itself is parameterized so it is testable on any build.
+public enum MobileUnifiedMultiMacFlag {
+    /// Env override, for tagged dev builds and CI.
+    public static let enabledEnvKey = "CMUX_UNIFIED_MULTI_MAC"
+    /// UserDefaults override, for QA/dogfood devices.
+    public static let enabledDefaultsKey = "unifiedMultiMacEnabled"
+
+    /// Whether the unified multi-Mac list is enabled for this process.
+    ///
+    /// An explicit override (env first, then defaults) wins in either
+    /// direction; absent any override the value is the build default (Debug on,
+    /// Release off).
+    /// - Parameters:
+    ///   - environment: Process environment. Injected for testability.
+    ///   - defaults: User defaults. Injected for testability.
+    ///   - isDebugBuild: Whether this is a Debug build. Injected for testability.
+    public static func isEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        isDebugBuild: Bool = MobileUnifiedMultiMacFlag.isDebugBuild
+    ) -> Bool {
+        if let override = booleanOverride(environment[enabledEnvKey]) {
+            return override
+        }
+        if defaults.object(forKey: enabledDefaultsKey) != nil {
+            return defaults.bool(forKey: enabledDefaultsKey)
+        }
+        return isDebugBuild
+    }
+
+    /// Parse an env-string override into a tri-state: `nil` when unset/blank,
+    /// otherwise the parsed boolean. Accepts `1/0`, `true/false`, `yes/no`,
+    /// `on/off` (case-insensitive).
+    private static func booleanOverride(_ rawValue: String?) -> Bool? {
+        guard let trimmed = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        switch trimmed.lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+
+    /// Whether this is a Debug build (compile-time; parameterized above so the
+    /// resolution itself is testable on any build).
+    public static var isDebugBuild: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileUnifiedMultiMacFlag.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileUnifiedMultiMacFlag.swift
@@ -16,7 +16,7 @@ public import Foundation
 ///
 /// This mirrors ``PresenceClient/resolvedServiceBaseURL(environment:defaults:isDebugBuild:)``:
 /// the resolution itself is parameterized so it is testable on any build.
-public enum MobileUnifiedMultiMacFlag {
+public struct MobileUnifiedMultiMacFlag {
     /// Env override, for tagged dev builds and CI.
     public static let enabledEnvKey = "CMUX_UNIFIED_MULTI_MAC"
     /// UserDefaults override, for QA/dogfood devices.
@@ -27,22 +27,31 @@ public enum MobileUnifiedMultiMacFlag {
     /// An explicit override (env first, then defaults) wins in either
     /// direction; absent any override the value is the build default (Debug on,
     /// Release off).
+    public let isEnabled: Bool
+
+    /// Resolves the flag for this process.
+    ///
+    /// An explicit override (env first, then defaults) wins in either
+    /// direction; absent any override the value is the build default (Debug on,
+    /// Release off). The resolution happens here so we store the resolved
+    /// `Bool` rather than a `UserDefaults`/environment reference (avoids
+    /// `Sendable` issues).
     /// - Parameters:
     ///   - environment: Process environment. Injected for testability.
     ///   - defaults: User defaults. Injected for testability.
     ///   - isDebugBuild: Whether this is a Debug build. Injected for testability.
-    public static func isEnabled(
+    public init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard,
-        isDebugBuild: Bool = MobileUnifiedMultiMacFlag.isDebugBuild
-    ) -> Bool {
-        if let override = booleanOverride(environment[enabledEnvKey]) {
-            return override
+        isDebugBuild: Bool = MobileUnifiedMultiMacFlag.currentIsDebugBuild
+    ) {
+        if let override = MobileUnifiedMultiMacFlag.booleanOverride(environment[MobileUnifiedMultiMacFlag.enabledEnvKey]) {
+            isEnabled = override
+        } else if defaults.object(forKey: MobileUnifiedMultiMacFlag.enabledDefaultsKey) != nil {
+            isEnabled = defaults.bool(forKey: MobileUnifiedMultiMacFlag.enabledDefaultsKey)
+        } else {
+            isEnabled = isDebugBuild
         }
-        if defaults.object(forKey: enabledDefaultsKey) != nil {
-            return defaults.bool(forKey: enabledDefaultsKey)
-        }
-        return isDebugBuild
     }
 
     /// Parse an env-string override into a tri-state: `nil` when unset/blank,
@@ -65,7 +74,7 @@ public enum MobileUnifiedMultiMacFlag {
 
     /// Whether this is a Debug build (compile-time; parameterized above so the
     /// resolution itself is testable on any build).
-    public static var isDebugBuild: Bool {
+    public static var currentIsDebugBuild: Bool {
         #if DEBUG
         return true
         #else

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MultiMacWorkspaceAggregator.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MultiMacWorkspaceAggregator.swift
@@ -1,0 +1,208 @@
+public import CMUXMobileCore
+public import CmuxMobileRPC
+public import CmuxMobileShellModel
+public import Foundation
+import Observation
+internal import OSLog
+
+private let aggregatorLog = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "dev.cmux.ios",
+    category: "multi-mac-aggregator"
+)
+
+/// Fetches the workspace lists of the user's *other* online Macs and exposes
+/// them as per-device slices for the unified multi-Mac list.
+///
+/// The phone keeps one "heavy" connection (render-grid stream, liveness
+/// watchdog, terminal byte streams) to the Mac whose terminal is on screen —
+/// that lives in ``MobileShellComposite``. This aggregator is the lightweight
+/// counterpart: for every *other* online Mac it opens a short-lived
+/// ``MobileCoreRPCClient`` (built by
+/// ``MobileShellComposite/makeMacListClient(runtime:deviceId:displayName:route:)``),
+/// pulls `mobile.workspace.list` once, tags the returned previews with the
+/// owning Mac's `deviceId`, and lets the client idle. It owns NO render
+/// streams, watchdogs, or terminal input; it is read-only workspace metadata.
+///
+/// Failure isolation is a hard requirement: one Mac being unreachable records
+/// an error for *that* device only and must never blank another device's
+/// already-fetched slice. Per-device refreshes coalesce so overlapping calls
+/// (a presence event landing while a pull-to-refresh is in flight) reuse the
+/// single in-flight fetch instead of stacking duplicate RPCs.
+@MainActor
+@Observable
+public final class MultiMacWorkspaceAggregator {
+    /// One online Mac the aggregator should fetch from. The active (heavy)
+    /// Mac is intentionally excluded by the caller, so every target here gets a
+    /// short-lived list client.
+    public struct Target: Sendable, Equatable {
+        /// The Mac's cmux device UUID, stamped onto every fetched preview.
+        public var deviceId: String
+        /// A human label for the synthetic list-client ticket.
+        public var displayName: String
+        /// The attach route to dial for the one-shot workspace-list fetch.
+        public var route: CmxAttachRoute
+
+        public init(deviceId: String, displayName: String, route: CmxAttachRoute) {
+            self.deviceId = deviceId
+            self.displayName = displayName
+            self.route = route
+        }
+    }
+
+    /// The latest workspace slice fetched per device, keyed by `deviceId`.
+    /// Every preview in a slice is tagged with that device's id. A device with
+    /// an in-flight first fetch simply has no entry yet.
+    public private(set) var perDeviceWorkspaces: [String: [MobileWorkspacePreview]] = [:]
+
+    /// The latest fetch error per device, keyed by `deviceId`. Set when a
+    /// device's fetch fails and cleared on its next success. Isolated per
+    /// device so one Mac's failure never affects another's slice.
+    public private(set) var perDeviceError: [String: any Error] = [:]
+
+    private let runtime: (any MobileSyncRuntime)?
+    /// In-flight fetch task per device, so overlapping refreshes coalesce onto
+    /// one RPC rather than stacking duplicates.
+    private var inFlight: [String: Task<Void, Never>] = [:]
+
+    /// - Parameter runtime: The DI runtime. `nil` in previews/tests with no
+    ///   transport, where every refresh is a no-op.
+    public init(runtime: (any MobileSyncRuntime)?) {
+        self.runtime = runtime
+    }
+
+    /// Refresh every target's slice, coalescing per-device, and prune slices
+    /// for devices no longer in `targets` (a Mac that went offline or is now
+    /// the active heavy connection).
+    ///
+    /// Returns after every per-device fetch this call started (or joined) has
+    /// settled, so a pull-to-refresh can await real completion.
+    /// - Parameter targets: The online, non-active Macs to fetch from.
+    public func refresh(targets: [Target]) async {
+        let liveDeviceIDs = Set(targets.map(\.deviceId))
+        pruneDevices(absentFrom: liveDeviceIDs)
+
+        await withTaskGroup(of: Void.self) { group in
+            for target in targets {
+                let task = refreshTask(for: target)
+                group.addTask { await task.value }
+            }
+            await group.waitForAll()
+        }
+    }
+
+    /// Drop all per-device state and cancel in-flight fetches (sign-out, or the
+    /// flag turning off). Leaves the aggregator inert until the next refresh.
+    public func reset() {
+        for task in inFlight.values {
+            task.cancel()
+        }
+        inFlight = [:]
+        perDeviceWorkspaces = [:]
+        perDeviceError = [:]
+    }
+
+    /// Workspaces fetched for one device, already tagged with its id. Empty
+    /// when the device has no slice yet (first fetch in flight, or it failed
+    /// before ever succeeding).
+    public func workspaces(forDeviceID deviceID: String) -> [MobileWorkspacePreview] {
+        perDeviceWorkspaces[deviceID] ?? []
+    }
+
+    // MARK: - Internals
+
+    /// Remove slices and errors for devices not in `liveDeviceIDs`, and cancel
+    /// any of their in-flight fetches. A device drops out when it goes offline
+    /// or becomes the active heavy connection (the composite stops listing it
+    /// as a target).
+    private func pruneDevices(absentFrom liveDeviceIDs: Set<String>) {
+        for deviceID in perDeviceWorkspaces.keys where !liveDeviceIDs.contains(deviceID) {
+            perDeviceWorkspaces.removeValue(forKey: deviceID)
+        }
+        for deviceID in perDeviceError.keys where !liveDeviceIDs.contains(deviceID) {
+            perDeviceError.removeValue(forKey: deviceID)
+        }
+        for deviceID in inFlight.keys where !liveDeviceIDs.contains(deviceID) {
+            inFlight[deviceID]?.cancel()
+            inFlight.removeValue(forKey: deviceID)
+        }
+    }
+
+    /// The coalesced fetch task for a target: reuse the in-flight one when a
+    /// fetch for this device is already running, otherwise start one.
+    private func refreshTask(for target: Target) -> Task<Void, Never> {
+        if let existing = inFlight[target.deviceId] {
+            return existing
+        }
+        let task = Task { @MainActor [weak self] in
+            await self?.performFetch(target)
+            self?.inFlight.removeValue(forKey: target.deviceId)
+        }
+        inFlight[target.deviceId] = task
+        return task
+    }
+
+    /// Fetch one device's `mobile.workspace.list` over a short-lived client and
+    /// store the tagged slice, or record the error. Never throws and never
+    /// touches another device's state.
+    private func performFetch(_ target: Target) async {
+        guard let runtime else { return }
+        guard let client = MobileShellComposite.makeMacListClient(
+            runtime: runtime,
+            deviceId: target.deviceId,
+            displayName: target.displayName,
+            route: target.route
+        ) else {
+            // No dialable Stack-auth route: a no-op that leaves any prior slice
+            // intact rather than blanking it.
+            aggregatorLog.debug(
+                "no list-client route device=\(target.deviceId, privacy: .public)"
+            )
+            return
+        }
+        defer { Task { await client.disconnect() } }
+
+        do {
+            let request = try MobileCoreRPCClient.requestData(
+                method: "mobile.workspace.list",
+                params: [:]
+            )
+            let data = try await client.sendRequest(
+                request,
+                timeoutNanoseconds: runtime.pairingRequestTimeoutNanoseconds
+            )
+            if Task.isCancelled { return }
+            let response = try MobileSyncWorkspaceListResponse.decode(data)
+            let tagged = response.workspaces.map { remote in
+                var workspace = MobileWorkspacePreview(remote: remote)
+                workspace.deviceId = target.deviceId
+                workspace.terminals = workspace.terminals.map { terminal in
+                    var terminal = terminal
+                    terminal.deviceId = target.deviceId
+                    return terminal
+                }
+                return workspace
+            }
+            perDeviceWorkspaces[target.deviceId] = tagged
+            perDeviceError.removeValue(forKey: target.deviceId)
+        } catch {
+            if Task.isCancelled { return }
+            // Isolate the failure to this device. A previously-fetched slice is
+            // left untouched so a transient blip does not blank a working Mac.
+            perDeviceError[target.deviceId] = error
+            aggregatorLog.error(
+                "workspace.list fetch failed device=\(target.deviceId, privacy: .public): \(String(describing: error), privacy: .private)"
+            )
+        }
+    }
+}
+
+#if DEBUG
+extension MultiMacWorkspaceAggregator {
+    /// Test-only seam to seed a per-device slice (already tagged by the caller)
+    /// without a live fetch, so the composite's merge/gating can be tested in
+    /// isolation from the transport.
+    public func debugSetSlice(deviceID: String, workspaces: [MobileWorkspacePreview]) {
+        perDeviceWorkspaces[deviceID] = workspaces
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CrossMacActivationBindingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/CrossMacActivationBindingTests.swift
@@ -1,0 +1,110 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Regression guard for the cross-Mac activation `activeDeviceID` binding on the
+/// SYNTHETIC-ticket path.
+///
+/// `activeDeviceID` is the linchpin of the multi-Mac scoping scheme: it selects
+/// which client a scoped surface key may route to, tags every active-Mac
+/// preview, and drives `selectScopedWorkspace`'s `activeDeviceID == target`
+/// guard. The bug: after the heavy connect switched to Mac B, the connect path
+/// derived `activeDeviceID` from `connectedMacDeviceID`, which on a `manual-…`
+/// synthetic ticket (a route lacking `mobile.attach_ticket.create`) resolves to
+/// the PREVIOUSLY-active Mac (or nil) because B is not yet marked active in the
+/// paired-Mac store. The fix binds `activeDeviceID` to the KNOWN target device
+/// id in `connectToRegistryInstance`, matching the aggregator's slice
+/// attribution.
+///
+/// These tests drive the real connect path (no `debugSetActiveDeviceID`), with a
+/// host router whose `mobile.attach_ticket.create` fails method-not-found so the
+/// connect mints a synthetic `manual-…` ticket exactly as a route without that
+/// RPC does in production.
+@MainActor
+@Suite struct CrossMacActivationBindingTests {
+    private func loopbackRoute(port: Int) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "debug_loopback_\(port)",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: port)
+        )
+    }
+
+    private func onlineUpdate(deviceId: String) -> PresenceUpdate {
+        .online(PresenceInstance(
+            deviceId: deviceId,
+            tag: "default",
+            platform: "mac",
+            online: true,
+            lastSeenAt: 0
+        ))
+    }
+
+    private func registryDeviceB(port: Int) throws -> RegistryDevice {
+        RegistryDevice(
+            deviceId: "mac-b",
+            platform: "mac",
+            displayName: "Mac B",
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            instances: [
+                RegistryAppInstance(
+                    tag: "default",
+                    routes: [try loopbackRoute(port: port)],
+                    lastSeenAt: Date(timeIntervalSince1970: 0)
+                )
+            ]
+        )
+    }
+
+    /// After activating Mac B over a synthetic-ticket route, `activeDeviceID`
+    /// must bind to B (the known target), not stay on the previously-active A.
+    @Test func crossMacActivateBindsActiveDeviceToKnownTarget() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        await router.setFailAttachTicketCreate(true)
+        let box = TransportBox()
+        let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+        // The first heavy connect binds the active device to the real ticket id.
+        #expect(store.activeDeviceID == "test-mac")
+
+        store.debugSetRegistryDevices([try registryDeviceB(port: 56601)])
+        store.debugApplyPresence(onlineUpdate(deviceId: "mac-b"))
+
+        await store.activateMac(deviceId: "mac-b")
+
+        // The heavy connection switched to B over a synthetic manual ticket
+        // (no `attach_ticket.create`); the active binding must be B, not A.
+        #expect(store.activeDeviceID == "mac-b")
+        #expect(store.activeDeviceID != "test-mac")
+
+        await router.releaseAllHeld()
+    }
+
+    /// `selectScopedWorkspace` on a non-active Mac's row must open the workspace
+    /// (set `selectedWorkspaceID`) once the heavy connection switches — the guard
+    /// `activeDeviceID == target` must pass on the synthetic path.
+    @Test func selectScopedWorkspaceOnOtherMacOpensAfterSwitch() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        await router.setFailAttachTicketCreate(true)
+        let box = TransportBox()
+        let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+        #expect(store.activeDeviceID == "test-mac")
+
+        store.debugSetRegistryDevices([try registryDeviceB(port: 56602)])
+        store.debugApplyPresence(onlineUpdate(deviceId: "mac-b"))
+
+        await store.selectScopedWorkspace(
+            ScopedWorkspaceID(deviceId: "mac-b", workspaceID: "live-workspace")
+        )
+
+        // The guard passed (active is now B), so the bare selection landed.
+        #expect(store.activeDeviceID == "mac-b")
+        #expect(store.selectedWorkspaceID == "live-workspace")
+
+        await router.releaseAllHeld()
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -66,9 +66,20 @@ actor LivenessHostRouter {
     private var hasActiveSubscription = false
     private var heldContinuations: [CheckedContinuation<Void, Never>] = []
     private var capabilities = ["events.v1", "terminal.render_grid.v1", "terminal.replay.v1"]
+    /// When true, `mobile.attach_ticket.create` is answered with a
+    /// method-not-found error, so the client falls back to a synthetic
+    /// `manual-…` ticket — modeling a route/host without that RPC. Used by the
+    /// cross-Mac activation binding regression test.
+    private var failAttachTicketCreate = false
 
     func record(method: String?, topics: [String]?) {
         recorded.append(RecordedRequest(method: method, topics: topics))
+    }
+
+    /// Make `mobile.attach_ticket.create` fail with method-not-found so the
+    /// client mints a synthetic manual ticket (the synthetic-ticket path).
+    func setFailAttachTicketCreate(_ fail: Bool) {
+        failAttachTicketCreate = fail
     }
 
     func count(of method: String) -> Int {
@@ -118,6 +129,12 @@ actor LivenessHostRouter {
 
     func response(method: String?, id: String?) async -> Data? {
         switch method {
+        case "mobile.attach_ticket.create" where failAttachTicketCreate:
+            return try? Self.errorFrame(
+                id: id,
+                message: "method not found",
+                code: "method_not_found"
+            )
         case "workspace.list", "mobile.workspace.list":
             return try? Self.resultFrame(id: id, result: [
                 "workspaces": [
@@ -183,11 +200,15 @@ actor LivenessHostRouter {
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
     }
 
-    private static func errorFrame(id: String?, message: String) throws -> Data {
+    private static func errorFrame(id: String?, message: String, code: String? = nil) throws -> Data {
+        var error: [String: Any] = ["message": message]
+        if let code {
+            error["code"] = code
+        }
         let envelope: [String: Any] = [
             "id": id ?? UUID().uuidString,
             "ok": false,
-            "error": ["message": message],
+            "error": error,
         ]
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileUnifiedMultiMacFlagTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileUnifiedMultiMacFlagTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Resolution tests for ``MobileUnifiedMultiMacFlag``: build default, env
+/// override, and UserDefaults override, mirroring the presence-service URL
+/// resolution pattern.
+@Suite struct MobileUnifiedMultiMacFlagTests {
+    private func emptyDefaults() -> UserDefaults {
+        let suite = "unified-flag-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test func defaultsToBuildTypeWhenNoOverride() {
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: [:], defaults: emptyDefaults(), isDebugBuild: true
+        ) == true)
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: [:], defaults: emptyDefaults(), isDebugBuild: false
+        ) == false)
+    }
+
+    @Test func envOverrideWinsBothDirections() {
+        // Force ON on a release build.
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: ["CMUX_UNIFIED_MULTI_MAC": "1"],
+            defaults: emptyDefaults(),
+            isDebugBuild: false
+        ) == true)
+        // Force OFF on a debug build.
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: ["CMUX_UNIFIED_MULTI_MAC": "false"],
+            defaults: emptyDefaults(),
+            isDebugBuild: true
+        ) == false)
+    }
+
+    @Test func defaultsOverrideWinsOverBuildType() {
+        let on = emptyDefaults()
+        on.set(true, forKey: "unifiedMultiMacEnabled")
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: [:], defaults: on, isDebugBuild: false
+        ) == true)
+
+        let off = emptyDefaults()
+        off.set(false, forKey: "unifiedMultiMacEnabled")
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: [:], defaults: off, isDebugBuild: true
+        ) == false)
+    }
+
+    @Test func envOverrideBeatsDefaultsOverride() {
+        let defaults = emptyDefaults()
+        defaults.set(false, forKey: "unifiedMultiMacEnabled")
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: ["CMUX_UNIFIED_MULTI_MAC": "on"],
+            defaults: defaults,
+            isDebugBuild: false
+        ) == true)
+    }
+
+    @Test func blankEnvIsIgnored() {
+        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+            environment: ["CMUX_UNIFIED_MULTI_MAC": "  "],
+            defaults: emptyDefaults(),
+            isDebugBuild: false
+        ) == false)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileUnifiedMultiMacFlagTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileUnifiedMultiMacFlagTests.swift
@@ -14,58 +14,58 @@ import Testing
     }
 
     @Test func defaultsToBuildTypeWhenNoOverride() {
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: [:], defaults: emptyDefaults(), isDebugBuild: true
-        ) == true)
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        ).isEnabled == true)
+        #expect(MobileUnifiedMultiMacFlag(
             environment: [:], defaults: emptyDefaults(), isDebugBuild: false
-        ) == false)
+        ).isEnabled == false)
     }
 
     @Test func envOverrideWinsBothDirections() {
         // Force ON on a release build.
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: ["CMUX_UNIFIED_MULTI_MAC": "1"],
             defaults: emptyDefaults(),
             isDebugBuild: false
-        ) == true)
+        ).isEnabled == true)
         // Force OFF on a debug build.
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: ["CMUX_UNIFIED_MULTI_MAC": "false"],
             defaults: emptyDefaults(),
             isDebugBuild: true
-        ) == false)
+        ).isEnabled == false)
     }
 
     @Test func defaultsOverrideWinsOverBuildType() {
         let on = emptyDefaults()
         on.set(true, forKey: "unifiedMultiMacEnabled")
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: [:], defaults: on, isDebugBuild: false
-        ) == true)
+        ).isEnabled == true)
 
         let off = emptyDefaults()
         off.set(false, forKey: "unifiedMultiMacEnabled")
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: [:], defaults: off, isDebugBuild: true
-        ) == false)
+        ).isEnabled == false)
     }
 
     @Test func envOverrideBeatsDefaultsOverride() {
         let defaults = emptyDefaults()
         defaults.set(false, forKey: "unifiedMultiMacEnabled")
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: ["CMUX_UNIFIED_MULTI_MAC": "on"],
             defaults: defaults,
             isDebugBuild: false
-        ) == true)
+        ).isEnabled == true)
     }
 
     @Test func blankEnvIsIgnored() {
-        #expect(MobileUnifiedMultiMacFlag.isEnabled(
+        #expect(MobileUnifiedMultiMacFlag(
             environment: ["CMUX_UNIFIED_MULTI_MAC": "  "],
             defaults: emptyDefaults(),
             isDebugBuild: false
-        ) == false)
+        ).isEnabled == false)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MultiMacWorkspaceAggregatorTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MultiMacWorkspaceAggregatorTestSupport.swift
@@ -1,0 +1,179 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import Foundation
+@testable import CmuxMobileShell
+
+// Test doubles for MultiMacWorkspaceAggregatorTests: a runtime whose transport
+// factory routes each connection to a per-port scripted Mac, so several Macs
+// (distinguished by loopback port) can be fetched at once, including two Macs
+// returning identical bare workspace/terminal ids to exercise the collision
+// invariant.
+
+/// One scripted Mac's `mobile.workspace.list` answer, plus optional forced
+/// failure to model an unreachable/erroring host.
+struct ScriptedMacList: Sendable {
+    /// Bare workspace ids the Mac reports (each gets one terminal id
+    /// `<workspaceID>-t`). Kept Mac-local on purpose so two Macs can collide.
+    var workspaceIDs: [String]
+    /// When true, every request errors, modeling a host that fails to answer.
+    var fails: Bool
+
+    init(workspaceIDs: [String], fails: Bool = false) {
+        self.workspaceIDs = workspaceIDs
+        self.fails = fails
+    }
+}
+
+/// Maps loopback port -> scripted Mac. The aggregator opens one client per
+/// target; each target uses a distinct port, so the port identifies the Mac.
+actor MultiMacScriptedHosts {
+    private var byPort: [Int: ScriptedMacList]
+
+    init(byPort: [Int: ScriptedMacList]) {
+        self.byPort = byPort
+    }
+
+    func setList(port: Int, list: ScriptedMacList) {
+        byPort[port] = list
+    }
+
+    func response(port: Int, method: String?, id: String?) -> Data? {
+        guard let mac = byPort[port] else {
+            return try? Self.errorFrame(id: id, message: "no scripted host for port \(port)")
+        }
+        switch method {
+        case "mobile.workspace.list", "workspace.list":
+            if mac.fails {
+                return try? Self.errorFrame(id: id, message: "scripted failure")
+            }
+            let workspaces = mac.workspaceIDs.map { workspaceID -> [String: Any] in
+                [
+                    "id": workspaceID,
+                    "title": "WS \(workspaceID)",
+                    "is_selected": false,
+                    "terminals": [
+                        [
+                            "id": "\(workspaceID)-t",
+                            "title": "Terminal",
+                            "is_ready": true,
+                            "is_focused": false,
+                        ],
+                    ],
+                ]
+            }
+            return try? Self.resultFrame(id: id, result: ["workspaces": workspaces])
+        default:
+            return try? Self.errorFrame(id: id, message: "unexpected method \(method ?? "nil")")
+        }
+    }
+
+    private static func resultFrame(id: String?, result: [String: Any]) throws -> Data {
+        let envelope: [String: Any] = [
+            "id": id ?? UUID().uuidString,
+            "ok": true,
+            "result": result,
+        ]
+        return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+    }
+
+    private static func errorFrame(id: String?, message: String) throws -> Data {
+        let envelope: [String: Any] = [
+            "id": id ?? UUID().uuidString,
+            "ok": false,
+            "error": ["message": message],
+        ]
+        return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
+    }
+}
+
+struct MultiMacRuntime: MobileSyncRuntime {
+    var transportFactory: any CmxByteTransportFactory
+    var stackAccessTokenProvider: @Sendable () async throws -> String = { "test-stack-token" }
+    var stackAccessTokenForceRefresher: @Sendable () async throws -> String = { "test-stack-token" }
+    var rpcRequestTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
+    var now: @Sendable () -> Date = { Date() }
+    var supportedRouteKinds: [CmxAttachTransportKind] = [.debugLoopback]
+    var pairingRequestTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
+    var supportsServerPushEvents: Bool = true
+    var livenessProbeTimeoutNanoseconds: UInt64 = 200_000_000
+}
+
+struct MultiMacTransportFactory: CmxByteTransportFactory {
+    let hosts: MultiMacScriptedHosts
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        guard case let .hostPort(_, port) = route.endpoint else {
+            throw MobileShellConnectionError.connectionClosed
+        }
+        return MultiMacTransport(hosts: hosts, port: port)
+    }
+}
+
+actor MultiMacTransport: CmxByteTransport {
+    private let hosts: MultiMacScriptedHosts
+    private let port: Int
+    private var pendingFrames: [Data] = []
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var isClosed = false
+
+    init(hosts: MultiMacScriptedHosts, port: Int) {
+        self.hosts = hosts
+        self.port = port
+    }
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if !pendingFrames.isEmpty {
+            return pendingFrames.removeFirst()
+        }
+        if isClosed {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            receiveWaiters.append(continuation)
+        }
+    }
+
+    func send(_ data: Data) async throws {
+        var buffer = data
+        let payloads = try MobileSyncFrameCodec.decodeFrames(from: &buffer)
+        for payload in payloads {
+            let parsed = (try? JSONSerialization.jsonObject(with: payload)) as? [String: Any]
+            let method = parsed?["method"] as? String
+            let id = parsed?["id"] as? String
+            Task { [hosts, port, weak self] in
+                guard let response = await hosts.response(port: port, method: method, id: id) else {
+                    return
+                }
+                await self?.deliver(response)
+            }
+        }
+    }
+
+    func close() async {
+        isClosed = true
+        let waiters = receiveWaiters
+        receiveWaiters = []
+        for waiter in waiters {
+            waiter.resume(returning: nil)
+        }
+    }
+
+    func deliver(_ frame: Data) {
+        if receiveWaiters.isEmpty {
+            pendingFrames.append(frame)
+            return
+        }
+        let waiter = receiveWaiters.removeFirst()
+        waiter.resume(returning: frame)
+    }
+}
+
+func loopbackRoute(port: Int) throws -> CmxAttachRoute {
+    try CmxAttachRoute(
+        id: "debug_loopback",
+        kind: .debugLoopback,
+        endpoint: .hostPort(host: "127.0.0.1", port: port)
+    )
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MultiMacWorkspaceAggregatorTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MultiMacWorkspaceAggregatorTests.swift
@@ -1,0 +1,165 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``MultiMacWorkspaceAggregator``: it fetches each online
+/// Mac's `mobile.workspace.list` over a short-lived client, tags every preview
+/// with the owning Mac's `deviceId`, isolates one Mac's failure from the others,
+/// and prunes devices that leave the target set.
+@MainActor
+@Suite struct MultiMacWorkspaceAggregatorTests {
+    @Test func tagsEachSliceWithItsDeviceID() async throws {
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7001: ScriptedMacList(workspaceIDs: ["ws-a"]),
+            7002: ScriptedMacList(workspaceIDs: ["ws-b"]),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-1", displayName: "Mac One", route: try loopbackRoute(port: 7001)),
+            .init(deviceId: "mac-2", displayName: "Mac Two", route: try loopbackRoute(port: 7002)),
+        ])
+
+        let mac1 = aggregator.workspaces(forDeviceID: "mac-1")
+        let mac2 = aggregator.workspaces(forDeviceID: "mac-2")
+        #expect(mac1.map(\.id.rawValue) == ["ws-a"])
+        #expect(mac2.map(\.id.rawValue) == ["ws-b"])
+        // Every fetched preview — and its terminals — carry the owning device id.
+        #expect(mac1.allSatisfy { $0.deviceId == "mac-1" })
+        #expect(mac1.flatMap(\.terminals).allSatisfy { $0.deviceId == "mac-1" })
+        #expect(mac2.allSatisfy { $0.deviceId == "mac-2" })
+        #expect(mac2.flatMap(\.terminals).allSatisfy { $0.deviceId == "mac-2" })
+        #expect(aggregator.perDeviceError.isEmpty)
+    }
+
+    @Test func scopedIDsResolveIndependentlyWhenBareIDsCollide() async throws {
+        // Two Macs report the SAME bare workspace and terminal id strings. The
+        // scoped identity (deviceId + id) must keep them distinct so selection
+        // and routing can target the correct Mac.
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7101: ScriptedMacList(workspaceIDs: ["workspace-1"]),
+            7102: ScriptedMacList(workspaceIDs: ["workspace-1"]),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-A", displayName: "A", route: try loopbackRoute(port: 7101)),
+            .init(deviceId: "mac-B", displayName: "B", route: try loopbackRoute(port: 7102)),
+        ])
+
+        let a = try #require(aggregator.workspaces(forDeviceID: "mac-A").first)
+        let b = try #require(aggregator.workspaces(forDeviceID: "mac-B").first)
+        // Bare ids collide on purpose...
+        #expect(a.id == b.id)
+        #expect(a.terminals.first?.id == b.terminals.first?.id)
+        // ...but the scoped identities are distinct and route to the right Mac.
+        #expect(ScopedWorkspaceID(a) != ScopedWorkspaceID(b))
+        #expect(ScopedWorkspaceID(a).deviceId == "mac-A")
+        #expect(ScopedWorkspaceID(b).deviceId == "mac-B")
+        let aTerminal = try #require(a.terminals.first)
+        let bTerminal = try #require(b.terminals.first)
+        #expect(ScopedTerminalID(aTerminal) != ScopedTerminalID(bTerminal))
+        #expect(ScopedTerminalID(aTerminal).deviceId == "mac-A")
+        #expect(ScopedTerminalID(bTerminal).deviceId == "mac-B")
+    }
+
+    @Test func oneMacFailureDoesNotBlankOthers() async throws {
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7201: ScriptedMacList(workspaceIDs: ["ok-1"]),
+            7202: ScriptedMacList(workspaceIDs: [], fails: true),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+
+        await aggregator.refresh(targets: [
+            .init(deviceId: "good", displayName: "Good", route: try loopbackRoute(port: 7201)),
+            .init(deviceId: "bad", displayName: "Bad", route: try loopbackRoute(port: 7202)),
+        ])
+
+        // The healthy Mac's slice is present; the failing one records an error
+        // and contributes no slice.
+        #expect(aggregator.workspaces(forDeviceID: "good").map(\.id.rawValue) == ["ok-1"])
+        #expect(aggregator.workspaces(forDeviceID: "bad").isEmpty)
+        #expect(aggregator.perDeviceError["bad"] != nil)
+        #expect(aggregator.perDeviceError["good"] == nil)
+    }
+
+    @Test func transientFailureLeavesPriorSliceIntact() async throws {
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7301: ScriptedMacList(workspaceIDs: ["ws-x"]),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+        let target = MultiMacWorkspaceAggregator.Target(
+            deviceId: "mac",
+            displayName: "Mac",
+            route: try loopbackRoute(port: 7301)
+        )
+
+        await aggregator.refresh(targets: [target])
+        #expect(aggregator.workspaces(forDeviceID: "mac").map(\.id.rawValue) == ["ws-x"])
+
+        // The Mac now fails. A refresh records the error but must NOT blank the
+        // last-known-good slice.
+        await hosts.setList(port: 7301, list: ScriptedMacList(workspaceIDs: [], fails: true))
+        await aggregator.refresh(targets: [target])
+        #expect(aggregator.perDeviceError["mac"] != nil)
+        #expect(aggregator.workspaces(forDeviceID: "mac").map(\.id.rawValue) == ["ws-x"])
+    }
+
+    @Test func prunesDevicesThatLeaveTargetSet() async throws {
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7401: ScriptedMacList(workspaceIDs: ["ws-1"]),
+            7402: ScriptedMacList(workspaceIDs: ["ws-2"]),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-1", displayName: "1", route: try loopbackRoute(port: 7401)),
+            .init(deviceId: "mac-2", displayName: "2", route: try loopbackRoute(port: 7402)),
+        ])
+        #expect(aggregator.workspaces(forDeviceID: "mac-1").isEmpty == false)
+        #expect(aggregator.workspaces(forDeviceID: "mac-2").isEmpty == false)
+
+        // mac-2 leaves the target set (went offline / became active). Its slice
+        // is pruned; mac-1 stays.
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-1", displayName: "1", route: try loopbackRoute(port: 7401)),
+        ])
+        #expect(aggregator.workspaces(forDeviceID: "mac-1").isEmpty == false)
+        #expect(aggregator.workspaces(forDeviceID: "mac-2").isEmpty)
+        #expect(aggregator.perDeviceWorkspaces["mac-2"] == nil)
+    }
+
+    @Test func resetClearsAllState() async throws {
+        let hosts = MultiMacScriptedHosts(byPort: [
+            7501: ScriptedMacList(workspaceIDs: ["ws-1"]),
+        ])
+        let runtime = MultiMacRuntime(transportFactory: MultiMacTransportFactory(hosts: hosts))
+        let aggregator = MultiMacWorkspaceAggregator(runtime: runtime)
+
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-1", displayName: "1", route: try loopbackRoute(port: 7501)),
+        ])
+        #expect(aggregator.perDeviceWorkspaces.isEmpty == false)
+
+        aggregator.reset()
+        #expect(aggregator.perDeviceWorkspaces.isEmpty)
+        #expect(aggregator.perDeviceError.isEmpty)
+    }
+
+    @Test func nilRuntimeIsInert() async throws {
+        let aggregator = MultiMacWorkspaceAggregator(runtime: nil)
+        await aggregator.refresh(targets: [
+            .init(deviceId: "mac-1", displayName: "1", route: try loopbackRoute(port: 7601)),
+        ])
+        #expect(aggregator.perDeviceWorkspaces.isEmpty)
+        #expect(aggregator.perDeviceError.isEmpty)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ScopedSurfaceRoutingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ScopedSurfaceRoutingTests.swift
@@ -1,0 +1,189 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// The P3 red/green guard: two Macs reporting the SAME bare workspace/terminal
+/// id strings must route selection, terminal input, and render-grid byte
+/// delivery to the correct Mac. The structural fix is the Mac-scoped surface
+/// key (`"<deviceId>#<terminalID>"`); these tests prove a colliding bare id on a
+/// non-active Mac can never steal the active Mac's surface, and that the
+/// single-Mac (unscoped) case still resolves.
+@MainActor
+@Suite struct ScopedSurfaceRoutingTests {
+    private func terminal(_ id: String, deviceId: String) -> MobileTerminalPreview {
+        MobileTerminalPreview(id: .init(rawValue: id), deviceId: deviceId, name: "T")
+    }
+
+    private func workspace(
+        id: String,
+        deviceId: String,
+        terminalID: String
+    ) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            deviceId: deviceId,
+            name: "WS \(id)",
+            terminals: [terminal(terminalID, deviceId: deviceId)]
+        )
+    }
+
+    /// Mount an output sink for a scoped surface key and collect what it
+    /// receives, mirroring how the terminal surface attaches in production.
+    private func mountSink(
+        _ store: MobileShellComposite,
+        surfaceKey: String,
+        into bag: ChunkBag
+    ) -> Task<Void, Never> {
+        Task { @MainActor in
+            for await chunk in store.terminalOutputStream(surfaceID: surfaceKey) {
+                bag.append(chunk.data)
+                store.terminalOutputDidProcess(surfaceID: surfaceKey, streamToken: chunk.streamToken)
+            }
+        }
+    }
+
+    @MainActor
+    final class ChunkBag {
+        private(set) var count = 0
+        func append(_ data: Data) { count += data.isEmpty ? 0 : 1 }
+    }
+
+    // MARK: - Render-grid byte delivery routing
+
+    @Test func renderGridBytesRouteOnlyToActiveMacSurface() async throws {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        // Both Macs use the SAME bare terminal id "term-1".
+        store.debugSetActiveDeviceID("mac-A")
+
+        let keyA = ScopedTerminalID(deviceId: "mac-A", terminalID: .init(rawValue: "term-1")).surfaceKey
+        let keyB = ScopedTerminalID(deviceId: "mac-B", terminalID: .init(rawValue: "term-1")).surfaceKey
+        #expect(keyA != keyB, "colliding bare ids must produce distinct scoped keys")
+
+        let bagA = ChunkBag()
+        let bagB = ChunkBag()
+        let taskA = mountSink(store, surfaceKey: keyA, into: bagA)
+        let taskB = mountSink(store, surfaceKey: keyB, into: bagB)
+        defer { taskA.cancel(); taskB.cancel() }
+
+        // Let both sinks register.
+        _ = try await pollUntil { store.debugRegisteredSurfaceKeys.isSuperset(of: [keyA, keyB]) }
+
+        // A render-grid event from the active Mac echoes the BARE wire id "term-1".
+        store.debugDeliverActiveMacRenderGrid(wireSurfaceID: "term-1", seq: 42, text: "hello")
+
+        // Only the active Mac's scoped surface recorded the frame; the colliding
+        // non-active surface saw nothing.
+        #expect(store.debugDeliveredEndSeq(forSurfaceKey: keyA) == 42)
+        #expect(store.debugDeliveredEndSeq(forSurfaceKey: keyB) == nil)
+
+        _ = try await pollUntil { bagA.count >= 1 }
+        #expect(bagA.count >= 1)
+        #expect(bagB.count == 0)
+    }
+
+    // MARK: - Input / wire routing
+
+    @Test func wireTerminalResolvesOnlyForActiveMacKey() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "mac-A", terminalID: "term-1")]
+        store.debugSetActiveDeviceID("mac-A")
+
+        let keyActive = ScopedTerminalID(deviceId: "mac-A", terminalID: .init(rawValue: "term-1")).surfaceKey
+        let keyOther = ScopedTerminalID(deviceId: "mac-B", terminalID: .init(rawValue: "term-1")).surfaceKey
+
+        // The active Mac's key resolves to the bare wire id and the active
+        // workspace; the colliding non-active Mac's key resolves to neither, so
+        // input/scroll/viewport against it is a safe no-op instead of routing to
+        // the wrong Mac.
+        #expect(store.wireTerminalID(forSurfaceKey: keyActive) == "term-1")
+        #expect(store.workspaceID(forTerminalID: keyActive)?.rawValue == "ws-1")
+        #expect(store.wireTerminalID(forSurfaceKey: keyOther) == nil)
+        #expect(store.workspaceID(forTerminalID: keyOther) == nil)
+    }
+
+    @Test func collidingBareIdInputLandsOnActiveMacOnly() async {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "mac-A", terminalID: "term-1")]
+        store.debugSetActiveDeviceID("mac-A")
+
+        let keyOther = ScopedTerminalID(deviceId: "mac-B", terminalID: .init(rawValue: "term-1")).surfaceKey
+        // Submitting input for the OTHER Mac's surface (same bare id) must not
+        // resolve a workspace on the active client. With no transport it cannot
+        // assert the wire, but the routing guard (wireTerminalID == nil) is the
+        // hard invariant proved above; here we additionally confirm the input
+        // path early-outs without crashing for the wrong-Mac key.
+        await store.submitTerminalRawInput(Data("x".utf8), surfaceID: keyOther)
+        #expect(store.wireTerminalID(forSurfaceKey: keyOther) == nil)
+    }
+
+    // MARK: - Single-Mac (unscoped) parity
+
+    @Test func unscopedKeyResolvesForSingleMac() async throws {
+        // No active device id (manual ticket / single-Mac): the key is unscoped
+        // ("#term-1") and must still resolve to the wire id and the workspace,
+        // and render-grid bytes must still land.
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "", terminalID: "term-1")]
+
+        let key = ScopedTerminalID(deviceId: "", terminalID: .init(rawValue: "term-1")).surfaceKey
+        #expect(store.wireTerminalID(forSurfaceKey: key) == "term-1")
+        #expect(store.workspaceID(forTerminalID: key)?.rawValue == "ws-1")
+
+        let bag = ChunkBag()
+        let task = mountSink(store, surfaceKey: key, into: bag)
+        defer { task.cancel() }
+        _ = try await pollUntil { store.debugRegisteredSurfaceKeys.contains(key) }
+
+        store.debugDeliverActiveMacRenderGrid(wireSurfaceID: "term-1", seq: 7, text: "ok")
+        #expect(store.debugDeliveredEndSeq(forSurfaceKey: key) == 7)
+    }
+
+    // MARK: - Lazy heavy-attach selection
+
+    @Test func selectingActiveMacScopeLandsSelectionWithoutActivation() async {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "mac-A", terminalID: "term-1")]
+        store.debugSetActiveDeviceID("mac-A")
+
+        await store.selectScopedWorkspace(
+            ScopedWorkspaceID(deviceId: "mac-A", workspaceID: "ws-1")
+        )
+        // Same Mac: the bare selection lands and no activation ran.
+        #expect(store.selectedWorkspaceID == "ws-1")
+        #expect(store.activatingDeviceID == nil)
+    }
+
+    @Test func selectingUnreachableOtherMacDoesNotChangeSelection() async {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "mac-A", terminalID: "term-1")]
+        store.debugSetActiveDeviceID("mac-A")
+        store.selectedWorkspaceID = "ws-1"
+
+        // mac-B is not in the registry/paired tree, so activateMac cannot resolve
+        // a route: the heavy connection stays on mac-A and the selection is NOT
+        // moved to a workspace id that does not exist on the active client.
+        await store.selectScopedWorkspace(
+            ScopedWorkspaceID(deviceId: "mac-B", workspaceID: "ws-9")
+        )
+        #expect(store.activeDeviceID == "mac-A")
+        #expect(store.selectedWorkspaceID == "ws-1")
+        #expect(store.activatingDeviceID == nil)
+    }
+
+    // MARK: - Flag-off parity
+
+    @Test func flagOffUsesUnscopedSurfaceRouting() {
+        // Flag off: the active Mac is still tagged (its real device id), but the
+        // surface key the UI builds for a flag-off single-Mac is unscoped because
+        // the workspace's deviceId is "" until the unified merge tags it. The
+        // wire resolution must remain bare-id identical to today.
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: false)
+        store.workspaces = [workspace(id: "ws-1", deviceId: "", terminalID: "term-1")]
+
+        let key = ScopedTerminalID(deviceId: "", terminalID: .init(rawValue: "term-1")).surfaceKey
+        #expect(store.wireTerminalID(forSurfaceKey: key) == "term-1")
+        #expect(store.workspaceID(forTerminalID: key)?.rawValue == "ws-1")
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedAggregatorTargetsTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedAggregatorTargetsTests.swift
@@ -1,0 +1,101 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for the production driver that feeds
+/// ``MultiMacWorkspaceAggregator``: ``MobileShellComposite/unifiedAggregatorTargets``.
+///
+/// Before the fix, the aggregator's `refresh(targets:)` was never called outside
+/// tests, so the unified list only ever showed the active Mac. The targets
+/// property is the seam that turns the registry + presence into the set of
+/// OTHER online Macs the aggregator fetches; these tests pin its gating:
+/// flag-off ⇒ empty; the active Mac and offline/unknown devices are excluded;
+/// only route-bearing, Stack-auth-trusted devices contribute.
+@MainActor
+@Suite struct UnifiedAggregatorTargetsTests {
+    private func loopbackRoute(port: Int) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "debug_loopback_\(port)",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: port)
+        )
+    }
+
+    private func device(_ id: String, name: String?, port: Int?) throws -> RegistryDevice {
+        RegistryDevice(
+            deviceId: id,
+            platform: "mac",
+            displayName: name,
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            instances: port.map { p in
+                [RegistryAppInstance(
+                    tag: "default",
+                    routes: [try! loopbackRoute(port: p)],
+                    lastSeenAt: Date(timeIntervalSince1970: 0)
+                )]
+            } ?? []
+        )
+    }
+
+    private func online(_ deviceId: String) -> PresenceUpdate {
+        .online(PresenceInstance(
+            deviceId: deviceId,
+            tag: "default",
+            platform: "mac",
+            online: true,
+            lastSeenAt: 0
+        ))
+    }
+
+    private func offline(_ deviceId: String) -> PresenceUpdate {
+        .offline(
+            PresenceInstance(
+                deviceId: deviceId,
+                tag: "default",
+                platform: "mac",
+                online: false,
+                lastSeenAt: 0
+            ),
+            reason: .timeout
+        )
+    }
+
+    @Test func flagOffYieldsNoTargets() throws {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: false)
+        store.debugSetActiveDeviceID("mac-a")
+        store.debugSetRegistryDevices([try device("mac-b", name: "B", port: 56610)])
+        store.debugApplyPresence(online("mac-b"))
+        #expect(store.unifiedAggregatorTargets.isEmpty)
+    }
+
+    @Test func excludesActiveOfflineAndUnknownDevices() throws {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-a")
+        store.debugSetRegistryDevices([
+            try device("mac-a", name: "Active", port: 56611),   // active: excluded
+            try device("mac-b", name: "Online B", port: 56612), // online + route: included
+            try device("mac-c", name: "Offline C", port: 56613), // offline: excluded
+            try device("mac-d", name: "Unknown D", port: 56614), // no presence: excluded
+        ])
+        store.debugApplyPresence(online("mac-a"))
+        store.debugApplyPresence(online("mac-b"))
+        store.debugApplyPresence(offline("mac-c"))
+        // mac-d gets no presence update at all.
+
+        let targets = store.unifiedAggregatorTargets
+        #expect(targets.map(\.deviceId).sorted() == ["mac-b"])
+        #expect(targets.first?.displayName == "Online B")
+    }
+
+    @Test func excludesOnlineDeviceWithNoReachableRoute() throws {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-a")
+        // Online, but advertises no routes: cannot be dialed, so contributes no
+        // target (and the aggregator must not be asked to fetch from it).
+        store.debugSetRegistryDevices([try device("mac-b", name: "No Route", port: nil)])
+        store.debugApplyPresence(online("mac-b"))
+        #expect(store.unifiedAggregatorTargets.isEmpty)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedListSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedListSelectionTests.swift
@@ -1,0 +1,99 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for the P2 (unified list UI) store seams: scoped selection
+/// round-trips through the bare authoritative selection, and the per-row Mac
+/// chip name map resolves from registry/paired/live sources.
+@MainActor
+@Suite struct UnifiedListSelectionTests {
+    private func pairedMac(_ deviceID: String, name: String?) -> MobilePairedMac {
+        MobilePairedMac(
+            macDeviceID: deviceID,
+            displayName: name,
+            routes: [],
+            createdAt: Date(timeIntervalSince1970: 0),
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            isActive: false,
+            stackUserID: nil
+        )
+    }
+
+    private func registryDevice(_ deviceID: String, name: String?) -> RegistryDevice {
+        RegistryDevice(
+            deviceId: deviceID,
+            platform: "mac",
+            displayName: name,
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            instances: []
+        )
+    }
+
+    @Test func scopedSelectionCarriesActiveDeviceIDAndWritesBareID() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-active")
+
+        store.scopedSelectedWorkspaceID = ScopedWorkspaceID(deviceId: "mac-active", workspaceID: "ws-1")
+
+        // The store's authoritative selection stays the bare wire id.
+        #expect(store.selectedWorkspaceID == "ws-1")
+        // Reading back re-scopes with the active device id.
+        #expect(store.scopedSelectedWorkspaceID == ScopedWorkspaceID(deviceId: "mac-active", workspaceID: "ws-1"))
+    }
+
+    @Test func scopedSelectionNilClearsBareSelection() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-active")
+        store.scopedSelectedWorkspaceID = ScopedWorkspaceID(workspaceID: "ws-1")
+        #expect(store.selectedWorkspaceID != nil)
+
+        store.scopedSelectedWorkspaceID = nil
+        #expect(store.selectedWorkspaceID == nil)
+        #expect(store.scopedSelectedWorkspaceID == nil)
+    }
+
+    @Test func nilActiveDeviceYieldsUnscopedSelection() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        // No active device id (manual ticket / preview): selection is unscoped.
+        store.scopedSelectedWorkspaceID = ScopedWorkspaceID(workspaceID: "ws-1")
+        #expect(store.scopedSelectedWorkspaceID == ScopedWorkspaceID(deviceId: "", workspaceID: "ws-1"))
+    }
+
+    @Test func deviceNamesResolveActiveHostOverPairedAndRegistry() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-active")
+        store.debugSetConnectedHostName("Live Studio")
+        // The active Mac also appears (staler) in the registry and paired list;
+        // the live connected host name must win for the active device.
+        store.debugSetRegistryDevices([
+            registryDevice("mac-active", name: "Registry Studio"),
+            registryDevice("mac-2", name: "Registry Two"),
+        ])
+        store.debugSetPairedMacs([
+            pairedMac("mac-active", name: "Paired Studio"),
+            pairedMac("mac-3", name: "Paired Three"),
+        ])
+
+        let names = store.unifiedDeviceNames
+        #expect(names["mac-active"] == "Live Studio")
+        #expect(names["mac-2"] == "Registry Two")
+        #expect(names["mac-3"] == "Paired Three")
+    }
+
+    @Test func deviceNamesSkipEmptyAndUnknown() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.debugSetActiveDeviceID("mac-active")
+        // A blank live host name must not shadow a better source for the active
+        // device; an empty device id is never recorded.
+        store.debugSetConnectedHostName("   ")
+        store.debugSetRegistryDevices([registryDevice("mac-active", name: "Registry Studio")])
+        store.debugSetPairedMacs([pairedMac("", name: "No Device")])
+
+        let names = store.unifiedDeviceNames
+        #expect(names["mac-active"] == "Registry Studio")
+        #expect(names[""] == nil)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedRootRoutingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedRootRoutingTests.swift
@@ -1,0 +1,94 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for the root-view routing seams that fix the "signed in but
+/// stuck on Add device" bug: ``MobileShellComposite/shouldShowUnifiedWorkspaceList``
+/// and ``MobileShellComposite/isDiscoveringUnifiedMacs``.
+///
+/// The bug: a freshly signed-in phone with a discoverable online Mac dead-ended
+/// on the add-device screen because the root view only showed the workspace list
+/// when `connectionState == .connected`. These predicates let the unified list
+/// render from the registry/aggregator with NO heavy connection, so signing in
+/// lands on the list instead of add-device.
+@MainActor
+@Suite struct UnifiedRootRoutingTests {
+    private func makeWorkspace(id: String, deviceId: String = "") -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            deviceId: deviceId,
+            name: "WS \(id)",
+            isPinned: false,
+            lastActivityAt: nil,
+            terminals: [MobileTerminalPreview(id: .init(rawValue: "\(id)-t"), deviceId: deviceId, name: "T")]
+        )
+    }
+
+    private func onlineInstance(_ deviceId: String) -> PresenceInstance {
+        PresenceInstance(deviceId: deviceId, tag: "default", platform: "mac", online: true, lastSeenAt: 1000)
+    }
+
+    /// The core fix: a discovered online Mac contributes a slice through the
+    /// aggregator with NO active heavy connection (no `activeDeviceID`, no live
+    /// `workspaces`), and that alone makes the unified list show — the state that
+    /// previously fell through to the add-device screen.
+    @Test func discoveredOnlineMacShowsListWithoutHeavyConnection() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        // No heavy connection: clear the preview placeholder workspaces and leave
+        // activeDeviceID nil.
+        store.workspaces = []
+        store.debugApplyPresence(.online(onlineInstance("mac-b")))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-b",
+            workspaces: [makeWorkspace(id: "ws-b", deviceId: "mac-b")]
+        )
+
+        #expect(store.activeDeviceID == nil)
+        #expect(!store.unifiedWorkspaces.isEmpty)
+        #expect(store.shouldShowUnifiedWorkspaceList)
+        // With something to show, the determining spinner must not be requested.
+        #expect(!store.isDiscoveringUnifiedMacs)
+    }
+
+    /// FLAG OFF parity: even with workspaces present, the unified routing gate is
+    /// inert, so routing falls back to the connection-gated path unchanged.
+    @Test func flagOffNeverShowsUnifiedListOrSpinner() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: false)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        store.debugSetActiveDeviceID("mac-active")
+
+        #expect(!store.shouldShowUnifiedWorkspaceList)
+        #expect(!store.isDiscoveringUnifiedMacs)
+    }
+
+    /// Flag on but nothing discovered yet (no live workspaces, no online slices):
+    /// the list gate is false, so routing relies on the determining spinner /
+    /// add-device fallback rather than showing an empty list.
+    @Test func emptyDiscoveryDoesNotShowList() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = []
+
+        #expect(store.unifiedWorkspaces.isEmpty)
+        #expect(!store.shouldShowUnifiedWorkspaceList)
+    }
+
+    /// An offline discovered Mac is gated out of the unified list, so it does not
+    /// trip the list gate — the same presence rule the merge enforces.
+    @Test func offlineDiscoveredMacDoesNotShowList() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = []
+        store.debugApplyPresence(.offline(
+            PresenceInstance(deviceId: "mac-b", tag: "default", platform: "mac", online: false, lastSeenAt: 1000),
+            reason: .timeout
+        ))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-b",
+            workspaces: [makeWorkspace(id: "ws-b", deviceId: "mac-b")]
+        )
+
+        #expect(store.unifiedWorkspaces.isEmpty)
+        #expect(!store.shouldShowUnifiedWorkspaceList)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedWorkspacesMergeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/UnifiedWorkspacesMergeTests.swift
@@ -1,0 +1,162 @@
+import CMUXMobileCore
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Behavior tests for ``MobileShellComposite/unifiedWorkspaces``: the flag-gated
+/// merge of the active Mac's live workspaces with the aggregator's per-device
+/// slices, presence gating, ordering, and FLAG OFF parity.
+@MainActor
+@Suite struct UnifiedWorkspacesMergeTests {
+    private func makeWorkspace(
+        id: String,
+        deviceId: String = "",
+        isPinned: Bool = false,
+        lastActivityAt: Date? = nil
+    ) -> MobileWorkspacePreview {
+        MobileWorkspacePreview(
+            id: .init(rawValue: id),
+            deviceId: deviceId,
+            name: "WS \(id)",
+            isPinned: isPinned,
+            lastActivityAt: lastActivityAt,
+            terminals: [MobileTerminalPreview(id: .init(rawValue: "\(id)-t"), deviceId: deviceId, name: "T")]
+        )
+    }
+
+    private func onlineInstance(_ deviceId: String) -> PresenceInstance {
+        PresenceInstance(deviceId: deviceId, tag: "default", platform: "mac", online: true, lastSeenAt: 1000)
+    }
+
+    private func offlineInstance(_ deviceId: String) -> PresenceInstance {
+        PresenceInstance(deviceId: deviceId, tag: "default", platform: "mac", online: false, lastSeenAt: 1000)
+    }
+
+    @Test func mergesActiveAndAggregatorSlicesWhenOnline() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        store.debugSetActiveDeviceID("mac-active")
+        // Two other online Macs each contribute a slice.
+        store.debugApplyPresence(.online(onlineInstance("mac-2")))
+        store.debugApplyPresence(.online(onlineInstance("mac-3")))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-2",
+            workspaces: [makeWorkspace(id: "ws-2", deviceId: "mac-2")]
+        )
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-3",
+            workspaces: [makeWorkspace(id: "ws-3", deviceId: "mac-3")]
+        )
+
+        let unified = store.unifiedWorkspaces
+        let ids = Set(unified.map(\.id.rawValue))
+        #expect(ids == ["live-1", "ws-2", "ws-3"])
+        // The active Mac's workspace is tagged with the active device id.
+        let live = unified.first { $0.id.rawValue == "live-1" }
+        #expect(live?.deviceId == "mac-active")
+        #expect(live?.terminals.first?.deviceId == "mac-active")
+    }
+
+    @Test func offlineDeviceSlicesAreGatedOut() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        store.debugSetActiveDeviceID("mac-active")
+        // mac-2 is online, mac-3 is offline. Only mac-2 contributes.
+        store.debugApplyPresence(.online(onlineInstance("mac-2")))
+        store.debugApplyPresence(.offline(offlineInstance("mac-3"), reason: .timeout))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-2",
+            workspaces: [makeWorkspace(id: "ws-2", deviceId: "mac-2")]
+        )
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-3",
+            workspaces: [makeWorkspace(id: "ws-3", deviceId: "mac-3")]
+        )
+
+        let ids = Set(store.unifiedWorkspaces.map(\.id.rawValue))
+        #expect(ids == ["live-1", "ws-2"])
+    }
+
+    @Test func unknownPresenceDeviceIsGatedOut() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        store.debugSetActiveDeviceID("mac-active")
+        // No presence ever seen for mac-2: it must not passively merge.
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-2",
+            workspaces: [makeWorkspace(id: "ws-2", deviceId: "mac-2")]
+        )
+
+        let ids = Set(store.unifiedWorkspaces.map(\.id.rawValue))
+        #expect(ids == ["live-1"])
+    }
+
+    @Test func staleActiveDeviceSliceIsNeverDoubleListed() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: true)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        store.debugSetActiveDeviceID("mac-active")
+        // A stale slice for the active device (e.g. fetched before it became
+        // active) must not produce a duplicate list entry.
+        store.debugApplyPresence(.online(onlineInstance("mac-active")))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-active",
+            workspaces: [makeWorkspace(id: "live-1", deviceId: "mac-active")]
+        )
+
+        #expect(store.unifiedWorkspaces.map(\.id.rawValue) == ["live-1"])
+    }
+
+    @Test func ordersPinnedFirstThenLastActivityDescending() {
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        let workspaces = [
+            makeWorkspace(id: "old", deviceId: "m1", lastActivityAt: base),
+            makeWorkspace(id: "pinned-old", deviceId: "m1", isPinned: true, lastActivityAt: base),
+            makeWorkspace(id: "new", deviceId: "m2", lastActivityAt: base.addingTimeInterval(100)),
+            makeWorkspace(id: "pinned-new", deviceId: "m2", isPinned: true, lastActivityAt: base.addingTimeInterval(100)),
+            makeWorkspace(id: "no-activity", deviceId: "m2", lastActivityAt: nil),
+        ]
+
+        let ordered = MobileShellComposite.orderedForUnifiedList(workspaces).map(\.id.rawValue)
+        // Pinned first (newest pinned before older pinned), then unpinned by
+        // recency, then no-activity last.
+        #expect(ordered == ["pinned-new", "pinned-old", "new", "old", "no-activity"])
+    }
+
+    @Test func flagOffIsByteIdenticalToTaggedActiveWorkspaces() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: false)
+        store.workspaces = [makeWorkspace(id: "live-1"), makeWorkspace(id: "live-2")]
+        store.debugSetActiveDeviceID("mac-active")
+        // Even with online Macs and aggregator slices present, FLAG OFF must
+        // ignore them entirely.
+        store.debugApplyPresence(.online(onlineInstance("mac-2")))
+        store.multiMacAggregator.debugSetSlice(
+            deviceID: "mac-2",
+            workspaces: [makeWorkspace(id: "ws-2", deviceId: "mac-2")]
+        )
+
+        // unifiedWorkspaces == workspaces tagged with activeDeviceID, in the
+        // same order, and nothing from the aggregator.
+        let expected = store.workspaces.map { workspace -> MobileWorkspacePreview in
+            var tagged = workspace
+            tagged.deviceId = "mac-active"
+            tagged.terminals = tagged.terminals.map { terminal in
+                var terminal = terminal
+                terminal.deviceId = "mac-active"
+                return terminal
+            }
+            return tagged
+        }
+        #expect(store.unifiedWorkspaces == expected)
+        #expect(store.unifiedWorkspaces.map(\.id.rawValue) == ["live-1", "live-2"])
+    }
+
+    @Test func flagOffWithNilActiveDeviceLeavesWorkspacesUntouched() {
+        let store = MobileShellComposite.preview(unifiedMultiMacEnabled: false)
+        store.workspaces = [makeWorkspace(id: "live-1")]
+        // No active device id (preview / manual ticket): the list equals
+        // workspaces exactly, unscoped.
+        #expect(store.unifiedWorkspaces == store.workspaces)
+        #expect(store.unifiedWorkspaces.first?.deviceId == "")
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalPreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalPreview.swift
@@ -25,6 +25,13 @@ public struct MobileTerminalPreview: Identifiable, Equatable, Sendable {
 
     /// The terminal's stable identifier.
     public var id: ID
+    /// The cmux device UUID of the Mac that owns this terminal, matching the
+    /// owning ``MobileWorkspacePreview/deviceId``. Empty (`""`) means
+    /// "unscoped" — the single-Mac legacy behavior. In the unified multi-Mac
+    /// list this is stamped with the owning Mac's id so two Macs with colliding
+    /// bare terminal ids stay distinguishable; the wire id (``id``) stays
+    /// Mac-local and `deviceId` selects which client byte input is routed to.
+    public var deviceId: String
     /// The terminal's user-facing display name.
     public var name: String
     /// Whether the terminal surface is ready to receive input and render output.
@@ -37,18 +44,23 @@ public struct MobileTerminalPreview: Identifiable, Equatable, Sendable {
     /// Creates a terminal preview.
     /// - Parameters:
     ///   - id: The terminal's stable identifier.
+    ///   - deviceId: The owning Mac's cmux device UUID. Defaults to `""`
+    ///     (unscoped / single-Mac), so existing construction and tests compile
+    ///     unchanged.
     ///   - name: The terminal's user-facing display name.
     ///   - isReady: Whether the terminal surface is ready. Defaults to `true`.
     ///   - isFocused: Whether the terminal currently holds focus. Defaults to `false`.
     ///   - viewportFit: The negotiated viewport fit, if any. Defaults to `nil`.
     public init(
         id: ID,
+        deviceId: String = "",
         name: String,
         isReady: Bool = true,
         isFocused: Bool = false,
         viewportFit: MobileTerminalViewportFit? = nil
     ) {
         self.id = id
+        self.deviceId = deviceId
         self.name = name
         self.isReady = isReady
         self.isFocused = isFocused

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -27,6 +27,15 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
 
     /// The workspace's stable identifier.
     public var id: ID
+    /// The cmux device UUID of the Mac that owns this workspace, matching
+    /// ``RegistryDevice``/``CmxAttachTicket`` `macDeviceID`. Empty (`""`) means
+    /// "unscoped" — the single-Mac legacy behavior, where workspace ids are
+    /// already unambiguous because only one Mac is ever in the list. In the
+    /// unified multi-Mac list this is stamped with the owning Mac's id so two
+    /// Macs with colliding bare workspace ids are still distinguishable; the
+    /// wire id (``id``) stays Mac-local and `deviceId` selects which client a
+    /// request is routed to.
+    public var deviceId: String
     /// The Mac window that owns this workspace, when reported by the paired Mac.
     public var windowID: String?
     /// The workspace's user-facing display name.
@@ -60,6 +69,9 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// Creates a workspace preview.
     /// - Parameters:
     ///   - id: The workspace's stable identifier.
+    ///   - deviceId: The owning Mac's cmux device UUID. Defaults to `""`
+    ///     (unscoped / single-Mac), so existing construction and tests compile
+    ///     unchanged.
     ///   - windowID: The owning Mac window identifier, when known.
     ///   - name: The workspace's user-facing display name.
     ///   - isPinned: Whether the workspace is pinned on the Mac. Defaults to `false`.
@@ -71,6 +83,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     ///   - terminals: The terminals contained in the workspace, in display order.
     public init(
         id: ID,
+        deviceId: String = "",
         windowID: String? = nil,
         name: String,
         isPinned: Bool = false,
@@ -82,6 +95,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
         terminals: [MobileTerminalPreview]
     ) {
         self.id = id
+        self.deviceId = deviceId
         self.windowID = windowID
         self.name = name
         self.isPinned = isPinned

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedTerminalID.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedTerminalID.swift
@@ -1,0 +1,34 @@
+/// A terminal identity that is unambiguous across multiple Macs.
+///
+/// Bare ``MobileTerminalPreview/ID`` strings are Mac-local: two Macs can both
+/// report `"terminal-1"`. The render-grid byte-delivery and input paths must
+/// route to the Mac that actually owns the terminal, so the scoped selection
+/// and (in a later phase) the surface key are keyed on this pair.
+///
+/// Invariant: ``terminalID`` stays Mac-local (the wire id sent to that Mac's
+/// RPC client) and ``deviceId`` only selects which client to send to — the two
+/// are never crossed.
+public struct ScopedTerminalID: Hashable, Sendable, Codable {
+    /// The owning Mac's cmux device UUID (matches
+    /// ``MobileTerminalPreview/deviceId``). `""` is the unscoped/single-Mac
+    /// case.
+    public var deviceId: String
+    /// The Mac-local terminal identifier (the wire id).
+    public var terminalID: MobileTerminalPreview.ID
+
+    /// Creates a scoped terminal identity.
+    /// - Parameters:
+    ///   - deviceId: The owning Mac's cmux device UUID. Defaults to `""`.
+    ///   - terminalID: The Mac-local terminal identifier.
+    public init(deviceId: String = "", terminalID: MobileTerminalPreview.ID) {
+        self.deviceId = deviceId
+        self.terminalID = terminalID
+    }
+
+    /// The scoped identity for a terminal preview, taking its `deviceId` and
+    /// `id` together.
+    /// - Parameter terminal: The terminal whose scoped identity is wanted.
+    public init(_ terminal: MobileTerminalPreview) {
+        self.init(deviceId: terminal.deviceId, terminalID: terminal.id)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedTerminalID.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedTerminalID.swift
@@ -31,4 +31,42 @@ public struct ScopedTerminalID: Hashable, Sendable, Codable {
     public init(_ terminal: MobileTerminalPreview) {
         self.init(deviceId: terminal.deviceId, terminalID: terminal.id)
     }
+
+    /// The separator between the device id and the Mac-local terminal id in an
+    /// encoded ``surfaceKey``. `#` never appears in a cmux device UUID or a
+    /// panel/terminal id, so the split is unambiguous; the first occurrence
+    /// splits, and a terminal id that somehow contained one would keep its tail
+    /// intact.
+    public static let surfaceKeySeparator: Character = "#"
+
+    /// The opaque, Mac-disambiguated surface key used as the dictionary key in
+    /// the composite's `*BySurfaceID` byte-delivery maps and as the surface
+    /// identity the terminal kit holds (`hostSurfaceID`, the output stream key).
+    ///
+    /// Encoded as `"<deviceId>#<terminalID>"`. Two Macs reporting the same bare
+    /// `terminalID` therefore produce distinct surface keys, so render-grid
+    /// bytes and input can never route to the wrong Mac's surface. The wire id
+    /// sent to a Mac's RPC stays the bare ``terminalID`` — only the local key is
+    /// scoped. An unscoped (`""`) device id yields `"#<terminalID>"`, which is
+    /// still a stable distinct key for the single-Mac/preview case.
+    public var surfaceKey: String {
+        "\(deviceId)\(Self.surfaceKeySeparator)\(terminalID.rawValue)"
+    }
+
+    /// Decode a ``surfaceKey`` back into its `(deviceId, terminalID)` pair.
+    ///
+    /// Splits on the FIRST ``surfaceKeySeparator`` so a device id is recovered
+    /// exactly and any separator in the (Mac-local) terminal tail is preserved.
+    /// A string with no separator is treated as an unscoped bare terminal id
+    /// (`deviceId == ""`), so legacy/bare keys still resolve.
+    /// - Parameter surfaceKey: An encoded surface key (or a bare terminal id).
+    public init(surfaceKey: String) {
+        guard let separatorIndex = surfaceKey.firstIndex(of: Self.surfaceKeySeparator) else {
+            self.init(deviceId: "", terminalID: MobileTerminalPreview.ID(rawValue: surfaceKey))
+            return
+        }
+        let deviceId = String(surfaceKey[surfaceKey.startIndex..<separatorIndex])
+        let terminalID = String(surfaceKey[surfaceKey.index(after: separatorIndex)...])
+        self.init(deviceId: deviceId, terminalID: MobileTerminalPreview.ID(rawValue: terminalID))
+    }
 }

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedWorkspaceID.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/ScopedWorkspaceID.swift
@@ -1,0 +1,34 @@
+/// A workspace identity that is unambiguous across multiple Macs.
+///
+/// Bare ``MobileWorkspacePreview/ID`` strings are Mac-local: two Macs can both
+/// report `"workspace-1"`. In the unified multi-Mac list the selection and any
+/// routed request must know *which* Mac a workspace belongs to, so the
+/// composite's scoped selection is keyed on this pair rather than the bare id.
+///
+/// Invariant: ``workspaceID`` stays Mac-local (it is the wire id sent to that
+/// Mac's RPC client) and ``deviceId`` only selects which client to send to —
+/// the two are never crossed or concatenated into the wire id.
+public struct ScopedWorkspaceID: Hashable, Sendable, Codable {
+    /// The owning Mac's cmux device UUID (matches
+    /// ``MobileWorkspacePreview/deviceId``). `""` is the unscoped/single-Mac
+    /// case.
+    public var deviceId: String
+    /// The Mac-local workspace identifier (the wire id).
+    public var workspaceID: MobileWorkspacePreview.ID
+
+    /// Creates a scoped workspace identity.
+    /// - Parameters:
+    ///   - deviceId: The owning Mac's cmux device UUID. Defaults to `""`.
+    ///   - workspaceID: The Mac-local workspace identifier.
+    public init(deviceId: String = "", workspaceID: MobileWorkspacePreview.ID) {
+        self.deviceId = deviceId
+        self.workspaceID = workspaceID
+    }
+
+    /// The scoped identity for a workspace preview, taking its `deviceId` and
+    /// `id` together.
+    /// - Parameter workspace: The workspace whose scoped identity is wanted.
+    public init(_ workspace: MobileWorkspacePreview) {
+        self.init(deviceId: workspace.deviceId, workspaceID: workspace.id)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/ScopedIDTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/ScopedIDTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShellModel
+
+/// Tests for the multi-Mac scoping value types: bare ids stay Mac-local while
+/// the scoped identities (`deviceId` + bare id) disambiguate two Macs that
+/// happen to report the same string.
+@Suite struct ScopedIDTests {
+    @Test func collidingBareWorkspaceIDsResolveIndependently() {
+        // Two Macs both report bare workspace id "workspace-1".
+        let macA = MobileWorkspacePreview(
+            id: "workspace-1",
+            deviceId: "mac-A",
+            name: "A",
+            terminals: []
+        )
+        let macB = MobileWorkspacePreview(
+            id: "workspace-1",
+            deviceId: "mac-B",
+            name: "B",
+            terminals: []
+        )
+
+        // The bare ids collide...
+        #expect(macA.id == macB.id)
+        // ...but the scoped ids are distinct and carry the wire id unchanged.
+        let scopedA = ScopedWorkspaceID(macA)
+        let scopedB = ScopedWorkspaceID(macB)
+        #expect(scopedA != scopedB)
+        #expect(scopedA.deviceId == "mac-A")
+        #expect(scopedB.deviceId == "mac-B")
+        #expect(scopedA.workspaceID == "workspace-1")
+        #expect(scopedB.workspaceID == "workspace-1")
+        // Usable as dictionary keys without collapsing.
+        let routing: [ScopedWorkspaceID: String] = [scopedA: "A", scopedB: "B"]
+        #expect(routing[scopedA] == "A")
+        #expect(routing[scopedB] == "B")
+    }
+
+    @Test func collidingBareTerminalIDsResolveIndependently() {
+        let a = MobileTerminalPreview(id: "terminal-1", deviceId: "mac-A", name: "A")
+        let b = MobileTerminalPreview(id: "terminal-1", deviceId: "mac-B", name: "B")
+        #expect(a.id == b.id)
+        let scopedA = ScopedTerminalID(a)
+        let scopedB = ScopedTerminalID(b)
+        #expect(scopedA != scopedB)
+        #expect(scopedA.terminalID == "terminal-1")
+        #expect(scopedB.terminalID == "terminal-1")
+        let routing: [ScopedTerminalID: String] = [scopedA: "A", scopedB: "B"]
+        #expect(routing[scopedA] == "A")
+        #expect(routing[scopedB] == "B")
+    }
+
+    @Test func scopedIDsRoundTripThroughCodable() throws {
+        let scoped = ScopedWorkspaceID(deviceId: "mac-X", workspaceID: "workspace-7")
+        let data = try JSONEncoder().encode(scoped)
+        let decoded = try JSONDecoder().decode(ScopedWorkspaceID.self, from: data)
+        #expect(decoded == scoped)
+
+        let scopedTerminal = ScopedTerminalID(deviceId: "mac-Y", terminalID: "terminal-9")
+        let terminalData = try JSONEncoder().encode(scopedTerminal)
+        let decodedTerminal = try JSONDecoder().decode(ScopedTerminalID.self, from: terminalData)
+        #expect(decodedTerminal == scopedTerminal)
+    }
+
+    @Test func deviceIDDefaultsToEmptyForLegacyConstruction() {
+        // Construction without deviceId compiles and yields the unscoped case,
+        // keeping single-Mac call sites and tests unchanged.
+        let workspace = MobileWorkspacePreview(id: "w", name: "W", terminals: [])
+        let terminal = MobileTerminalPreview(id: "t", name: "T")
+        #expect(workspace.deviceId == "")
+        #expect(terminal.deviceId == "")
+        #expect(ScopedWorkspaceID(workspace).deviceId == "")
+        #expect(ScopedTerminalID(terminal).deviceId == "")
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -179,6 +179,19 @@ struct CMUXMobileRootView: View {
             // paired-but-offline user (who can reach here after a failed
             // reconnect) is excluded by the gate and falls through to pairing.
             onboardingFlow
+        } else if store.shouldShowUnifiedWorkspaceList {
+            // FLAG ON: the registry/aggregator discovered online Macs, so show
+            // the unified list even with no heavy connection. Tapping a row
+            // lazy-attaches that Mac (see `selectScopedWorkspace`). This is what
+            // closes the loop for a freshly signed-in phone: sign in -> online
+            // Macs appear -> tap to connect, no QR / add-device dead end.
+            WorkspaceShellView(store: store, signOut: signOut)
+        } else if store.isDiscoveringUnifiedMacs {
+            // FLAG ON: signed in, first registry+aggregator discovery pass not
+            // finished and nothing listed yet. Show a neutral determining
+            // spinner so the add-device screen does not flash before the
+            // registry has been consulted.
+            MobilePairedMacDeterminingView()
         } else if store.connectionState != .connected {
             DisconnectedWorkspaceShellView(
                 hasKnownPairedMac: store.hasKnownPairedMac,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -23,8 +23,9 @@ import SwiftUI
 /// lives here at the boundary; below it everything is values.
 struct DeviceTreeView: View {
     @Bindable var store: CMUXMobileShellStore
-    /// Open a workspace (the existing tap-to-open path). Forwarded from the shell.
-    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    /// Open a workspace (the existing tap-to-open path), scoped to its owning Mac.
+    /// Forwarded from the shell.
+    let selectWorkspace: (ScopedWorkspaceID) -> Void
     @Environment(\.dismiss) private var dismiss
     /// Display preferences (title wrapping, preview line count) shared with the
     /// flat workspace list, read here at the snapshot boundary and passed down
@@ -212,8 +213,8 @@ struct DeviceTreeView: View {
                         navigationStyle: .sidebar,
                         wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
                         previewLineLimit: displaySettings.workspacePreviewLineCount,
-                        selectWorkspace: { id in
-                            selectWorkspace(id)
+                        selectWorkspace: { scopedID in
+                            selectWorkspace(scopedID)
                             dismiss()
                         },
                         renameWorkspace: nil,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -23,7 +23,16 @@ import UIKit
 /// field-grow pushes only the terminal up. There is no toolbar handoff and no second
 /// layout system reaching into the surface's bottom math.
 struct GhosttySurfaceRepresentable: UIViewRepresentable {
+    /// The Mac-scoped surface key (`"<deviceId>#<terminalID>"`). Drives the byte
+    /// sink, raw input, viewport/scroll/click routing, and the surface's
+    /// `hostSurfaceID`, so render-grid bytes and input never cross to another
+    /// Mac that reuses the same bare terminal id.
     let surfaceID: String
+    /// The bare, Mac-local terminal id. Used only for the per-terminal composer /
+    /// draft / autofocus store maps, which persist drafts by bare id and must not
+    /// re-key under the unified multi-Mac flag (a scoped key would orphan saved
+    /// drafts on upgrade).
+    let terminalID: String
     let store: CMUXMobileShellStore
     let fontSize: Float32
     /// Whether the mounted surface should grab the keyboard when it attaches to
@@ -38,7 +47,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     var isComposerActive: Bool = false
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(surfaceID: surfaceID, store: store)
+        Coordinator(surfaceID: surfaceID, terminalID: terminalID, store: store)
     }
 
     func makeUIView(context: Context) -> UIView {
@@ -103,7 +112,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, GhosttySurfaceViewDelegate {
+        /// Scoped surface key for byte/input routing and surface identity.
         let surfaceID: String
+        /// Bare terminal id for the per-terminal composer/draft/autofocus maps.
+        let terminalID: String
         weak var store: CMUXMobileShellStore?
         weak var surfaceView: GhosttySurfaceView?
         private var outputTask: Task<Void, Never>?
@@ -119,8 +131,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// the meantime.
         private var composerMountGeneration = 0
 
-        init(surfaceID: String, store: CMUXMobileShellStore) {
+        init(surfaceID: String, terminalID: String, store: CMUXMobileShellStore) {
             self.surfaceID = surfaceID
+            self.terminalID = terminalID
             self.store = store
             super.init()
         }
@@ -194,7 +207,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// sizes the surface band.
         @MainActor
         private func makeComposerController(store: CMUXMobileShellStore) -> UIHostingController<TerminalComposerView> {
-            let view = TerminalComposerView(store: store, terminalID: surfaceID) { [weak self] in
+            let view = TerminalComposerView(store: store, terminalID: terminalID) { [weak self] in
                 // Content changed (a line added/removed, or cleared after send): live
                 // grows/shrinks animate. `setComposerBandHeight` is idempotent on
                 // unchanged heights, so a no-op change is harmless.
@@ -328,8 +341,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // presents/dismisses the iMessage-style composer. The reveal-and-focus
             // case routes through `...DidRequestComposerFocus` instead, so this never
             // closes a still-presented-but-suppressed composer.
-            Task { @MainActor [weak store, surfaceID] in
-                store?.toggleComposer(forTerminalID: surfaceID)
+            Task { @MainActor [weak store, terminalID] in
+                store?.toggleComposer(forTerminalID: terminalID)
             }
         }
 
@@ -338,8 +351,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // re-focused, without dismissing it — the reveal-after-hide and
             // present-while-suppressed paths. Ensure-present + bump the focus token the
             // composer view observes, so the draft and its focus return together.
-            Task { @MainActor [weak store, surfaceID] in
-                store?.presentAndFocusComposer(forTerminalID: surfaceID)
+            Task { @MainActor [weak store, terminalID] in
+                store?.presentAndFocusComposer(forTerminalID: terminalID)
             }
         }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import CmuxAuthRuntime
 import CmuxMobileShell
+import CmuxMobileShellModel
 import CmuxMobileSupport
 import CmuxMobileWorkspace
 import SwiftUI
@@ -19,9 +20,14 @@ struct MobileSettingsView: View {
     /// The shell store, used to drive the multi-Mac switcher. `nil` in previews,
     /// where the "Switch Mac" entry is hidden.
     var store: CMUXMobileShellStore?
+    /// Open a workspace from the device tree ("Manage devices"), forwarded from
+    /// the workspace list so opening a workspace there dismisses Settings and the
+    /// device sheet and reveals it. `nil` (previews) hides the entry.
+    var selectWorkspace: ((ScopedWorkspaceID) -> Void)?
 
     @Environment(\.dismiss) private var dismiss
     @State private var showingShortcuts = false
+    @State private var showingDeviceTree = false
     /// Mirrors ``MobilePushCoordinator/isEnabled`` so the toggle's label/icon
     /// update after the async enable/disable. The coordinator exposes
     /// `isEnabled` as a non-observable `UserDefaults` read, so reading it
@@ -91,6 +97,17 @@ struct MobileSettingsView: View {
                                 )
                             }
                             .accessibilityIdentifier("MobileSettingsSwitchMac")
+                        }
+                        if store != nil, selectWorkspace != nil {
+                            Button {
+                                showingDeviceTree = true
+                            } label: {
+                                Label(
+                                    L10n.string("mobile.settings.manageDevices", defaultValue: "Manage Devices"),
+                                    systemImage: "rectangle.stack"
+                                )
+                            }
+                            .accessibilityIdentifier("MobileSettingsManageDevices")
                         }
                         if let rescanQR {
                             Button {
@@ -231,6 +248,18 @@ struct MobileSettingsView: View {
             .sheet(isPresented: $showingHostPicker) {
                 if let store {
                     MobileHostPickerView(store: store)
+                }
+            }
+            .sheet(isPresented: $showingDeviceTree) {
+                if let store, let selectWorkspace {
+                    DeviceTreeView(store: store) { scopedID in
+                        // Open the workspace, then dismiss the device sheet and
+                        // Settings so the user lands on the opened workspace
+                        // instead of behind two stacked sheets.
+                        selectWorkspace(scopedID)
+                        showingDeviceTree = false
+                        dismiss()
+                    }
                 }
             }
             .sheet(isPresented: $showingOnboarding) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -64,6 +64,17 @@ struct WorkspaceDetailView: View {
         workspace.terminals.first { $0.id == store.selectedTerminalID } ?? workspace.terminals.first
     }
 
+    /// The Mac-scoped surface key for the selected terminal
+    /// (`"<deviceId>#<terminalID>"`, see ``ScopedTerminalID/surfaceKey``). This is
+    /// the opaque identity the terminal surface holds and the composite keys its
+    /// byte-delivery maps on, so two Macs reporting the same bare terminal id can
+    /// never cross-route render-grid bytes or input. Flag off / single-Mac ⇒ the
+    /// terminal's `deviceId` is `""` (or the lone active Mac), so the key is still
+    /// a stable per-terminal identity and behavior is unchanged.
+    private var selectedTerminalSurfaceKey: String? {
+        selectedTerminal.map { ScopedTerminalID($0).surfaceKey }
+    }
+
     /// The active browser surface for this workspace, when a browser pane is open.
     private var activeBrowser: BrowserSurfaceState? {
         browserStore.activeBrowser(for: workspace.id.rawValue)
@@ -271,9 +282,16 @@ struct WorkspaceDetailView: View {
         // dogfood iosfin no longer fight for the same screen edge.
         Group {
             #if os(iOS)
-            if let terminalID = selectedTerminal?.id.rawValue {
+            if let terminalID = selectedTerminal?.id.rawValue,
+               let surfaceKey = selectedTerminalSurfaceKey {
                 GhosttySurfaceRepresentable(
-                    surfaceID: terminalID,
+                    // `surfaceID` is the Mac-scoped surface key driving byte
+                    // delivery, input, and surface identity; `terminalID` stays
+                    // the bare id for the per-terminal composer/draft/autofocus
+                    // maps (which persist drafts by bare id and must not change
+                    // key under the flag).
+                    surfaceID: surfaceKey,
+                    terminalID: terminalID,
                     store: store,
                     fontSize: MobileTerminalFontPreference.defaultSize,
                     // While the composer is presented the terminal input proxy
@@ -288,13 +306,15 @@ struct WorkspaceDetailView: View {
                         && !store.isComposerPresented,
                     isComposerActive: store.isComposerPresented
                 )
-                // Identity must track the selected terminal. The representable's
-                // coordinator binds its byte sink to the surfaceID at make time and
-                // `updateUIView` is a no-op, so without a per-terminal id SwiftUI
-                // reuses the first terminal's surface and the dropdown never switches.
-                // Keying on terminalID tears down the old surface (unregistering its
-                // sink via dismantleUIView) and builds the newly-selected one.
-                .id(terminalID)
+                // Identity must track the selected terminal AND its owning Mac.
+                // The representable's coordinator binds its byte sink to the
+                // surfaceID at make time and `updateUIView` is a no-op, so without
+                // a per-surface id SwiftUI reuses the first terminal's surface and
+                // the dropdown never switches. Keying on the SCOPED surface key
+                // also tears down + rebuilds the surface when the active Mac
+                // switches to one whose bare terminal id collides, so the new
+                // Mac's sink is registered under its own scoped key.
+                .id(surfaceKey)
                 .onAppear {
                     store.consumeTerminalAutoFocusSuppression(for: terminalID)
                 }
@@ -528,7 +548,10 @@ struct WorkspaceDetailView: View {
     /// Opens the "View as Text" sheet: the terminal's content as selectable
     /// plain text, because the render surface itself has no copy affordance.
     private func openTextSheetFromMenu() {
-        textSheetSurfaceID = selectedTerminal?.id.rawValue
+        // The surface registers under the scoped surface key (`hostSurfaceID`),
+        // so the "View as Text" lookup must use that same key to resolve the
+        // live libghostty surface.
+        textSheetSurfaceID = selectedTerminalSurfaceKey
         isTextSheetPresented = true
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -19,8 +19,12 @@ struct WorkspaceGroupHeaderRow: View {
     let navigationStyle: WorkspaceNavigationStyle
     /// Whether the anchor workspace is the current selection (sidebar style only).
     let isAnchorSelected: Bool
+    /// The anchor workspace's scoped identity (its bare id paired with the owning
+    /// Mac's device id). Groups render only in the single-Mac (flag-off)
+    /// presentation, so this is the active Mac's scope.
+    let anchorScopedID: ScopedWorkspaceID
     /// Select (and, in push style, navigate to) the anchor workspace.
-    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    let selectWorkspace: (ScopedWorkspaceID) -> Void
     /// Toggle the group's collapsed state on the Mac. When `nil` (previews, or a
     /// Mac without the groups capability), the chevron renders without a tap
     /// action.
@@ -87,12 +91,12 @@ struct WorkspaceGroupHeaderRow: View {
     private var anchorTarget: some View {
         switch navigationStyle {
         case .push:
-            NavigationLink(value: group.anchorWorkspaceID) {
+            NavigationLink(value: anchorScopedID) {
                 nameLabel
             }
         case .sidebar:
             Button {
-                selectWorkspace(group.anchorWorkspaceID)
+                selectWorkspace(anchorScopedID)
             } label: {
                 nameLabel
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -77,6 +77,10 @@ struct WorkspaceListView: View {
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
+    /// Whether the flag-off top-left device-tree picker sheet is presented. Used
+    /// only in single-Mac mode (`!showsMacChips`); in unified multi-Mac mode the
+    /// device tree is demoted into Settings ("Manage Devices") instead.
+    @State private var showingDeviceTree = false
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State private var filter: MobileWorkspaceListFilter = .all
@@ -175,6 +179,15 @@ struct WorkspaceListView: View {
             ToolbarItem(placement: .topBarLeading) {
                 settingsMenu
             }
+            // Single-Mac (flag-off) parity: keep the prominent top-left device
+            // picker exactly as today. The unified multi-Mac list (flag on)
+            // demotes the tree into Settings ("Manage Devices") instead, since the
+            // unified workspace list is the primary navigation there.
+            if !showsMacChips, store != nil {
+                ToolbarItem(placement: .topBarLeading) {
+                    devicesButton
+                }
+            }
             ToolbarItemGroup(placement: .topBarTrailing) {
                 WorkspaceListFilterMenu(filter: $filter)
                 newWorkspaceButton
@@ -192,21 +205,47 @@ struct WorkspaceListView: View {
             TerminalShortcutsSettingsView()
         }
         .sheet(isPresented: $showingSettings) {
-            // The device tree ("Manage devices") now lives inside Settings rather
-            // than a top-left toolbar button: it is a secondary management surface,
-            // not the primary navigation (the unified workspace list is). The
-            // workspace-select closure is forwarded so opening a workspace from the
-            // tree dismisses Settings and the device sheet and reveals it.
+            // In unified multi-Mac mode the device tree ("Manage Devices") lives
+            // inside Settings rather than a top-left toolbar button: it is a
+            // secondary management surface, not the primary navigation (the
+            // unified workspace list is). The workspace-select closure is
+            // forwarded so opening a workspace from the tree dismisses Settings
+            // and the device sheet and reveals it. In single-Mac (flag-off) mode
+            // the tree stays a top-left toolbar button (see below), so
+            // `selectWorkspace` is NOT forwarded and the "Manage Devices" Settings
+            // entry stays hidden — Settings matches today exactly.
             MobileSettingsView(
                 connectedHostName: host,
                 rescanQR: rescanQR,
                 signOut: signOut,
                 store: store,
-                selectWorkspace: selectWorkspace
+                selectWorkspace: showsMacChips ? selectWorkspace : nil
             )
+        }
+        // Single-Mac (flag-off) parity: present the device tree at the
+        // workspace-list level (a single sheet, not nested under Settings), so
+        // selecting a workspace dismisses straight back to the workspace shell and
+        // reveals the opened workspace rather than leaving a parent sheet covering
+        // it. Suppressed in unified multi-Mac mode, where the tree is in Settings.
+        .sheet(isPresented: $showingDeviceTree) {
+            if let store, !showsMacChips {
+                DeviceTreeView(store: store, selectWorkspace: selectWorkspace)
+            }
         }
         #endif
     }
+
+    #if os(iOS)
+    private var devicesButton: some View {
+        Button {
+            showingDeviceTree = true
+        } label: {
+            Image(systemName: "rectangle.stack")
+        }
+        .accessibilityLabel(L10n.string("mobile.settings.devices", defaultValue: "Devices"))
+        .accessibilityIdentifier("MobileWorkspaceDevicesButton")
+    }
+    #endif
 
     /// Flat presentation: a pinned-first list with no group headers. Used when the
     /// Mac has no groups (or lacks the capability) or while searching.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -24,6 +24,12 @@ struct WorkspaceListView: View {
     /// presentation, i.e. the unified multi-Mac mode. `false` (the default)
     /// preserves the single-Mac look exactly: no chips, and group sections honored.
     var showsMacChips: Bool = false
+    /// The device id of the Mac whose heavy connection is currently being
+    /// switched to (via `activateMac`), so its rows show a per-row connecting
+    /// state in the unified list. `nil` when no cross-Mac activation is running.
+    /// Passed as a value snapshot so no `@Observable` store crosses the `List`
+    /// boundary.
+    var activatingDeviceID: String? = nil
     let host: String
     let connectionStatus: MobileMacConnectionStatus
     let navigationStyle: WorkspaceNavigationStyle
@@ -71,7 +77,6 @@ struct WorkspaceListView: View {
     @State private var searchText = ""
     @State private var showingShortcutsSettings = false
     @State private var showingSettings = false
-    @State private var showingDeviceTree = false
     /// The active row filter (All / Unread), shared-model state behind the
     /// toolbar ``WorkspaceListFilterMenu``. Session-transient like a search.
     @State private var filter: MobileWorkspaceListFilter = .all
@@ -170,11 +175,6 @@ struct WorkspaceListView: View {
             ToolbarItem(placement: .topBarLeading) {
                 settingsMenu
             }
-            if store != nil {
-                ToolbarItem(placement: .topBarLeading) {
-                    devicesButton
-                }
-            }
             ToolbarItemGroup(placement: .topBarTrailing) {
                 WorkspaceListFilterMenu(filter: $filter)
                 newWorkspaceButton
@@ -192,36 +192,21 @@ struct WorkspaceListView: View {
             TerminalShortcutsSettingsView()
         }
         .sheet(isPresented: $showingSettings) {
+            // The device tree ("Manage devices") now lives inside Settings rather
+            // than a top-left toolbar button: it is a secondary management surface,
+            // not the primary navigation (the unified workspace list is). The
+            // workspace-select closure is forwarded so opening a workspace from the
+            // tree dismisses Settings and the device sheet and reveals it.
             MobileSettingsView(
                 connectedHostName: host,
                 rescanQR: rescanQR,
                 signOut: signOut,
-                store: store
+                store: store,
+                selectWorkspace: selectWorkspace
             )
-        }
-        // Present the device tree at the workspace-list level (a single sheet,
-        // not nested under Settings), so selecting a workspace dismisses straight
-        // back to the workspace shell and reveals the opened workspace rather than
-        // leaving a parent sheet covering it.
-        .sheet(isPresented: $showingDeviceTree) {
-            if let store {
-                DeviceTreeView(store: store, selectWorkspace: selectWorkspace)
-            }
         }
         #endif
     }
-
-    #if os(iOS)
-    private var devicesButton: some View {
-        Button {
-            showingDeviceTree = true
-        } label: {
-            Image(systemName: "rectangle.stack")
-        }
-        .accessibilityLabel(L10n.string("mobile.settings.devices", defaultValue: "Devices"))
-        .accessibilityIdentifier("MobileWorkspaceDevicesButton")
-    }
-    #endif
 
     /// Flat presentation: a pinned-first list with no group headers. Used when the
     /// Mac has no groups (or lacks the capability) or while searching.
@@ -279,6 +264,9 @@ struct WorkspaceListView: View {
             macChipName: showsMacChips
                 ? WorkspaceMacChip.label(forDeviceID: workspace.deviceId, names: deviceNames)
                 : nil,
+            isConnecting: showsMacChips
+                && !workspace.deviceId.isEmpty
+                && activatingDeviceID == workspace.deviceId,
             selectWorkspace: selectWorkspace,
             renameWorkspace: renameWorkspace,
             setPinned: setPinned,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -14,7 +14,16 @@ struct WorkspaceListView: View {
     /// groups; the list then renders flat. Passed as value snapshots so no
     /// `@Observable` store crosses the `List` boundary.
     var groups: [MobileWorkspaceGroupPreview] = []
-    let selectedWorkspaceID: MobileWorkspacePreview.ID?
+    let selectedWorkspaceID: ScopedWorkspaceID?
+    /// `deviceId -> Mac display name` map for resolving each row's Mac chip in the
+    /// unified multi-Mac list. Passed as an immutable value snapshot so no
+    /// `@Observable` store crosses the `List` boundary. Empty (the default) in the
+    /// single-Mac / preview case.
+    var deviceNames: [String: String] = [:]
+    /// Whether to render the per-row Mac chip and force flat (ungrouped)
+    /// presentation, i.e. the unified multi-Mac mode. `false` (the default)
+    /// preserves the single-Mac look exactly: no chips, and group sections honored.
+    var showsMacChips: Bool = false
     let host: String
     let connectionStatus: MobileMacConnectionStatus
     let navigationStyle: WorkspaceNavigationStyle
@@ -25,7 +34,7 @@ struct WorkspaceListView: View {
     /// How many lines each row's activity preview shows (1 or 2). Passed in as
     /// a value snapshot so no `@Observable` store crosses the `List` boundary.
     var previewLineLimit: Int = MobileDisplaySettings.defaultWorkspacePreviewLineCount
-    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    let selectWorkspace: (ScopedWorkspaceID) -> Void
     let createWorkspace: () -> Void
     /// Pull-to-refresh action. Awaits the real workspace-list re-sync from the
     /// paired Mac so the system refresh spinner reflects actual completion (and
@@ -86,7 +95,12 @@ struct WorkspaceListView: View {
     /// group is acceptable while filtering. An active row filter (Unread)
     /// flattens the same way, for the same reason.
     private var rendersGroupedSections: Bool {
-        !groups.isEmpty && trimmedQuery.isEmpty && !filter.isActive
+        // The unified multi-Mac list is always flat: group sections are a
+        // single-Mac sidebar concept and do not compose across Macs (two Macs can
+        // have unrelated groups), so chips replace grouping as the per-row Mac
+        // dimension. Flag off ⇒ `showsMacChips` is false and grouping is honored
+        // exactly as before.
+        !showsMacChips && !groups.isEmpty && trimmedQuery.isEmpty && !filter.isActive
     }
 
     private func matchesQuery(_ workspace: MobileWorkspacePreview, query: String) -> Bool {
@@ -230,7 +244,8 @@ struct WorkspaceListView: View {
                     hasUnread: hasUnread,
                     navigationStyle: navigationStyle,
                     isAnchorSelected: navigationStyle == .sidebar
-                        && selectedWorkspaceID == group.anchorWorkspaceID,
+                        && selectedWorkspaceID?.workspaceID == group.anchorWorkspaceID,
+                    anchorScopedID: anchorScopedID(for: group),
                     selectWorkspace: selectWorkspace,
                     toggleCollapsed: toggleGroupCollapsed
                 )
@@ -242,15 +257,28 @@ struct WorkspaceListView: View {
         }
     }
 
+    /// The scoped identity of a group's anchor workspace. Groups render only in
+    /// the single-Mac (flag-off) presentation, so the anchor's `deviceId` is
+    /// resolved from the matching workspace in ``workspaces`` (the active Mac),
+    /// falling back to unscoped (`""`) if the anchor is not present.
+    private func anchorScopedID(for group: MobileWorkspaceGroupPreview) -> ScopedWorkspaceID {
+        let deviceId = workspaces.first { $0.id == group.anchorWorkspaceID }?.deviceId ?? ""
+        return ScopedWorkspaceID(deviceId: deviceId, workspaceID: group.anchorWorkspaceID)
+    }
+
     @ViewBuilder
     private func workspaceRow(_ workspace: MobileWorkspacePreview, indented: Bool) -> some View {
         WorkspaceNavigationRow(
             workspace: workspace,
             connectionStatus: connectionStatus,
-            isSelected: navigationStyle == .sidebar && selectedWorkspaceID == workspace.id,
+            isSelected: navigationStyle == .sidebar
+                && selectedWorkspaceID == ScopedWorkspaceID(workspace),
             navigationStyle: navigationStyle,
             wrapWorkspaceTitles: wrapWorkspaceTitles,
             previewLineLimit: previewLineLimit,
+            macChipName: showsMacChips
+                ? WorkspaceMacChip.label(forDeviceID: workspace.deviceId, names: deviceNames)
+                : nil,
             selectWorkspace: selectWorkspace,
             renameWorkspace: renameWorkspace,
             setPinned: setPinned,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacChip.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacChip.swift
@@ -1,0 +1,53 @@
+import CmuxMobileSupport
+import SwiftUI
+
+/// A small per-row "Mac" chip shown in the unified multi-Mac workspace list,
+/// labeling which Mac owns the workspace. The Mac is a secondary dimension of a
+/// flat list (not a navigation mode), so the chip is compact and unobtrusive.
+///
+/// Pure value view: it takes only the resolved label string, so it stays below
+/// the `List` snapshot boundary without referencing any store.
+struct WorkspaceMacChip: View {
+    /// The resolved Mac display name (already non-empty; the caller falls back to
+    /// a short device id when no friendly name is known).
+    let name: String
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "desktopcomputer")
+                .font(.system(size: 9, weight: .semibold))
+                .accessibilityHidden(true)
+            Text(name)
+                .font(.system(size: 11, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color.primary.opacity(0.08))
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            String(
+                format: L10n.string("mobile.workspace.macChip.a11y", defaultValue: "On %@"),
+                name
+            )
+        )
+    }
+
+    /// Resolve a chip label for a workspace's owning Mac.
+    ///
+    /// Returns the friendly device name when known, otherwise the short device id
+    /// (first 8 chars, matching ``RegistryDevice/title``). Returns `nil` for an
+    /// empty/unscoped `deviceId` so a single-Mac (unscoped) row shows no chip.
+    static func label(forDeviceID deviceID: String, names: [String: String]) -> String? {
+        guard !deviceID.isEmpty else { return nil }
+        if let name = names[deviceID], !name.isEmpty {
+            return name
+        }
+        return String(deviceID.prefix(8))
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -11,7 +11,10 @@ struct WorkspaceNavigationRow: View {
     /// How many lines the activity preview shows (1 or 2), forwarded to the
     /// shared ``WorkspaceRow``.
     var previewLineLimit: Int = MobileDisplaySettings.defaultWorkspacePreviewLineCount
-    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    /// The owning-Mac chip label, when this row is part of the unified multi-Mac
+    /// list. `nil` (the default) hides the chip, preserving the single-Mac look.
+    var macChipName: String? = nil
+    let selectWorkspace: (ScopedWorkspaceID) -> Void
     /// Rename the workspace on the Mac. When `nil` (e.g. previews) the rename
     /// affordance is hidden.
     var renameWorkspace: ((MobileWorkspacePreview.ID, String) -> Void)? = nil
@@ -92,12 +95,12 @@ struct WorkspaceNavigationRow: View {
     private var rowTarget: some View {
         switch navigationStyle {
         case .push:
-            NavigationLink(value: workspace.id) {
+            NavigationLink(value: ScopedWorkspaceID(workspace)) {
                 rowLabel
             }
         case .sidebar:
             Button {
-                selectWorkspace(workspace.id)
+                selectWorkspace(ScopedWorkspaceID(workspace))
             } label: {
                 rowLabel
             }
@@ -111,7 +114,8 @@ struct WorkspaceNavigationRow: View {
             connectionStatus: connectionStatus,
             isSelected: navigationStyle == .sidebar && isSelected,
             wrapWorkspaceTitles: wrapWorkspaceTitles,
-            previewLineLimit: previewLineLimit
+            previewLineLimit: previewLineLimit,
+            macChipName: macChipName
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceNavigationRow.swift
@@ -14,6 +14,10 @@ struct WorkspaceNavigationRow: View {
     /// The owning-Mac chip label, when this row is part of the unified multi-Mac
     /// list. `nil` (the default) hides the chip, preserving the single-Mac look.
     var macChipName: String? = nil
+    /// Whether this row's owning Mac is currently being switched to (the
+    /// destructive `activateMac` heavy-attach is in flight). Shows a small
+    /// spinner beside the chip; `false` (the default) renders the chip as-is.
+    var isConnecting: Bool = false
     let selectWorkspace: (ScopedWorkspaceID) -> Void
     /// Rename the workspace on the Mac. When `nil` (e.g. previews) the rename
     /// affordance is hidden.
@@ -115,7 +119,8 @@ struct WorkspaceNavigationRow: View {
             isSelected: navigationStyle == .sidebar && isSelected,
             wrapWorkspaceTitles: wrapWorkspaceTitles,
             previewLineLimit: previewLineLimit,
-            macChipName: macChipName
+            macChipName: macChipName,
+            isConnecting: isConnecting
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -13,6 +13,9 @@ struct WorkspaceRow: View {
     /// "Preview Lines" setting; 2 is the default). Space is reserved so rows
     /// with short previews keep the same height as their neighbors.
     var previewLineLimit: Int = MobileDisplaySettings.defaultWorkspacePreviewLineCount
+    /// The owning-Mac chip label in the unified multi-Mac list. `nil` hides the
+    /// chip, preserving the single-Mac row layout exactly.
+    var macChipName: String? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -60,6 +63,11 @@ struct WorkspaceRow: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+
+                    if let macChipName {
+                        Spacer(minLength: 8)
+                        WorkspaceMacChip(name: macChipName)
+                    }
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -16,6 +16,10 @@ struct WorkspaceRow: View {
     /// The owning-Mac chip label in the unified multi-Mac list. `nil` hides the
     /// chip, preserving the single-Mac row layout exactly.
     var macChipName: String? = nil
+    /// Whether this row's owning Mac's heavy connection is being switched to
+    /// (the lazy `activateMac` is in flight). Shows a small spinner beside the
+    /// chip; `false` (the default) renders the chip unchanged.
+    var isConnecting: Bool = false
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -66,6 +70,14 @@ struct WorkspaceRow: View {
 
                     if let macChipName {
                         Spacer(minLength: 8)
+                        if isConnecting {
+                            ProgressView()
+                                .controlSize(.mini)
+                                .accessibilityLabel(L10n.string(
+                                    "mobile.workspace.macChip.connecting.a11y",
+                                    defaultValue: "Connecting"
+                                ))
+                        }
                         WorkspaceMacChip(name: macChipName)
                     }
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -13,8 +13,12 @@ struct WorkspaceShellView: View {
     @Bindable var store: CMUXMobileShellStore
     let signOut: () -> Void
     @Environment(MobileDisplaySettings.self) private var displaySettings
-    @State private var compactNavigationPath: [MobileWorkspacePreview.ID] = []
-    @State private var pendingCompactCreateNavigationWorkspaceIDs: Set<MobileWorkspacePreview.ID>?
+    /// The compact-stack navigation path, keyed on ``ScopedWorkspaceID`` so a
+    /// pushed workspace is unambiguous across Macs in the unified list. Flag off ⇒
+    /// every scope's `deviceId` is the single active Mac (or `""`), so this
+    /// behaves exactly like the previous bare-id path.
+    @State private var compactNavigationPath: [ScopedWorkspaceID] = []
+    @State private var pendingCompactCreateNavigationWorkspaceIDs: Set<ScopedWorkspaceID>?
     @State private var hasPresentedSplitDetail = false
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .automatic
     #if os(iOS)
@@ -42,10 +46,10 @@ struct WorkspaceShellView: View {
             }
         }
         .onChange(of: usesCompactStack) { _, isCompact in
-            guard isCompact, hasPresentedSplitDetail, let selectedWorkspaceID = store.selectedWorkspaceID else {
+            guard isCompact, hasPresentedSplitDetail, let scopedID = store.scopedSelectedWorkspaceID else {
                 return
             }
-            compactNavigationPath = [selectedWorkspaceID]
+            compactNavigationPath = [scopedID]
         }
         // A notification-tap deep link must actually navigate, not just mark a
         // selection: on the compact stack an empty path ignores selection
@@ -69,9 +73,11 @@ struct WorkspaceShellView: View {
     private var stackLayout: some View {
         NavigationStack(path: $compactNavigationPath) {
             WorkspaceListView(
-                workspaces: store.workspaces,
+                workspaces: store.unifiedWorkspaces,
                 groups: store.workspaceGroups,
-                selectedWorkspaceID: store.selectedWorkspaceID,
+                selectedWorkspaceID: store.scopedSelectedWorkspaceID,
+                deviceNames: store.unifiedDeviceNames,
+                showsMacChips: store.unifiedMultiMacEnabled,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .push,
@@ -89,14 +95,14 @@ struct WorkspaceShellView: View {
                 closeWorkspace: closeWorkspaceClosure,
                 toggleGroupCollapsed: toggleGroupCollapsedClosure
             )
-            .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
-                workspaceDestination(for: workspaceID, createWorkspace: createWorkspaceInCompactStack)
+            .navigationDestination(for: ScopedWorkspaceID.self) { scopedID in
+                workspaceDestination(for: scopedID.workspaceID, createWorkspace: createWorkspaceInCompactStack)
             }
         }
-        .onChange(of: store.selectedWorkspaceID) { _, selectedWorkspaceID in
+        .onChange(of: store.scopedSelectedWorkspaceID) { _, scopedID in
             if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
                 currentPath: compactNavigationPath,
-                selectedWorkspaceID: selectedWorkspaceID,
+                selectedWorkspaceID: scopedID,
                 existingWorkspaceIDs: pendingCompactCreateNavigationWorkspaceIDs
             ) {
                 pendingCompactCreateNavigationWorkspaceIDs = nil
@@ -106,22 +112,23 @@ struct WorkspaceShellView: View {
             }
             compactNavigationPath = WorkspaceShellCompactNavigationPolicy.pathForSelectionChange(
                 currentPath: compactNavigationPath,
-                selectedWorkspaceID: selectedWorkspaceID
+                selectedWorkspaceID: scopedID
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onChange(of: compactNavigationPath) { _, path in
-            guard let selectedWorkspaceID = path.last else {
+            guard let scopedID = path.last else {
                 return
             }
             pendingCompactCreateNavigationWorkspaceIDs = nil
-            guard store.selectedWorkspaceID != selectedWorkspaceID else {
+            guard store.scopedSelectedWorkspaceID != scopedID else {
                 return
             }
-            store.selectedWorkspaceID = selectedWorkspaceID
+            store.scopedSelectedWorkspaceID = scopedID
         }
-        .onChange(of: store.workspaces.map(\.id)) { _, workspaceIDs in
-            compactNavigationPath.removeAll { !workspaceIDs.contains($0) }
+        .onChange(of: store.unifiedWorkspaces.map { ScopedWorkspaceID($0) }) { _, scopedIDs in
+            let valid = Set(scopedIDs)
+            compactNavigationPath.removeAll { !valid.contains($0) }
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
         .onAppear {
@@ -132,9 +139,11 @@ struct WorkspaceShellView: View {
     private var splitLayout: some View {
         NavigationSplitView(columnVisibility: $splitColumnVisibility) {
             WorkspaceListView(
-                workspaces: store.workspaces,
+                workspaces: store.unifiedWorkspaces,
                 groups: store.workspaceGroups,
-                selectedWorkspaceID: store.selectedWorkspaceID,
+                selectedWorkspaceID: store.scopedSelectedWorkspaceID,
+                deviceNames: store.unifiedDeviceNames,
+                showsMacChips: store.unifiedMultiMacEnabled,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .sidebar,
@@ -174,16 +183,23 @@ struct WorkspaceShellView: View {
         guard store.deeplinkWorkspaceNavigationRequest != nil else { return }
         guard let workspaceID = store.consumeDeeplinkWorkspaceNavigationRequest() else { return }
         guard usesCompactStack else { return }
-        if compactNavigationPath.last != workspaceID {
-            compactNavigationPath = [workspaceID]
+        // A deep link targets the active Mac's workspace (push notifications come
+        // from the connected Mac), so scope it with the active device id.
+        let scopedID = ScopedWorkspaceID(deviceId: store.activeDeviceID ?? "", workspaceID: workspaceID)
+        if compactNavigationPath.last != scopedID {
+            compactNavigationPath = [scopedID]
         }
     }
 
-    private func selectWorkspace(_ id: MobileWorkspacePreview.ID) {
+    private func selectWorkspace(_ scopedID: ScopedWorkspaceID) {
         pendingCompactCreateNavigationWorkspaceIDs = nil
-        store.selectedWorkspaceID = id
-        if usesCompactStack, compactNavigationPath.last != id {
-            compactNavigationPath = [id]
+        // P2 keeps the store's authoritative selection on the bare workspace id
+        // against the heavy client; cross-Mac heavy-attach from a non-active scope
+        // lands in P3. The scope is preserved in the navigation path so the pushed
+        // workspace stays unambiguous across Macs.
+        store.scopedSelectedWorkspaceID = scopedID
+        if usesCompactStack, compactNavigationPath.last != scopedID {
+            compactNavigationPath = [scopedID]
         }
     }
 
@@ -239,12 +255,12 @@ struct WorkspaceShellView: View {
     }
 
     private func createWorkspaceInCompactStack() {
-        let existingWorkspaceIDs = Set(store.workspaces.map(\.id))
+        let existingWorkspaceIDs = Set(store.unifiedWorkspaces.map { ScopedWorkspaceID($0) })
         pendingCompactCreateNavigationWorkspaceIDs = existingWorkspaceIDs
         store.createWorkspace()
         if let createdPath = WorkspaceShellCompactNavigationPolicy.pathForCreatedWorkspaceSelection(
             currentPath: compactNavigationPath,
-            selectedWorkspaceID: store.selectedWorkspaceID,
+            selectedWorkspaceID: store.scopedSelectedWorkspaceID,
             existingWorkspaceIDs: existingWorkspaceIDs
         ) {
             pendingCompactCreateNavigationWorkspaceIDs = nil
@@ -256,11 +272,11 @@ struct WorkspaceShellView: View {
         #if DEBUG
         guard ProcessInfo.processInfo.environment["CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE"] == "1",
               compactNavigationPath.isEmpty,
-              let selectedWorkspaceID = store.selectedWorkspaceID,
-              store.workspaces.contains(where: { $0.id == selectedWorkspaceID }) else {
+              let scopedID = store.scopedSelectedWorkspaceID,
+              store.unifiedWorkspaces.contains(where: { ScopedWorkspaceID($0) == scopedID }) else {
             return
         }
-        compactNavigationPath = [selectedWorkspaceID]
+        compactNavigationPath = [scopedID]
         #endif
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -78,6 +78,7 @@ struct WorkspaceShellView: View {
                 selectedWorkspaceID: store.scopedSelectedWorkspaceID,
                 deviceNames: store.unifiedDeviceNames,
                 showsMacChips: store.unifiedMultiMacEnabled,
+                activatingDeviceID: store.activatingDeviceID,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .push,
@@ -144,6 +145,7 @@ struct WorkspaceShellView: View {
                 selectedWorkspaceID: store.scopedSelectedWorkspaceID,
                 deviceNames: store.unifiedDeviceNames,
                 showsMacChips: store.unifiedMultiMacEnabled,
+                activatingDeviceID: store.activatingDeviceID,
                 host: store.connectedHostName,
                 connectionStatus: store.macConnectionStatus,
                 navigationStyle: .sidebar,
@@ -193,11 +195,23 @@ struct WorkspaceShellView: View {
 
     private func selectWorkspace(_ scopedID: ScopedWorkspaceID) {
         pendingCompactCreateNavigationWorkspaceIDs = nil
-        // P2 keeps the store's authoritative selection on the bare workspace id
-        // against the heavy client; cross-Mac heavy-attach from a non-active scope
-        // lands in P3. The scope is preserved in the navigation path so the pushed
-        // workspace stays unambiguous across Macs.
-        store.scopedSelectedWorkspaceID = scopedID
+        // Lazy heavy-attach: when the tapped workspace's Mac is not the active
+        // heavy connection, `selectScopedWorkspace` switches the heavy client to
+        // it (via `activateMac`) before landing the bare selection, so the
+        // terminal that mounts streams from the correct Mac. When the Mac is
+        // already active (single-Mac, flag off, or re-tapping the live Mac) it is
+        // just a bare selection with no connection churn.
+        //
+        // The navigation push is keyed on the SCOPED id and happens immediately so
+        // the detail screen presents without waiting on the connect round-trip;
+        // the detail container resolves the concrete workspace once the activated
+        // Mac's `workspaces` arrive. A failed activation leaves the bare selection
+        // unchanged inside the store, and the navigation push surfaces the
+        // connection status/error in the detail chrome.
+        let store = store
+        Task { @MainActor in
+            await store.selectScopedWorkspace(scopedID)
+        }
         if usesCompactStack, compactNavigationPath.last != scopedID {
             compactNavigationPath = [scopedID]
         }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1854,6 +1854,23 @@
         }
       }
     },
+    "mobile.settings.manageDevices": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Devices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイスを管理"
+          }
+        }
+      }
+    },
     "mobile.settings.display": {
       "extractionState": "manual",
       "localizations": {
@@ -3686,6 +3703,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ 上"
+          }
+        }
+      }
+    },
+    "mobile.workspace.macChip.connecting.a11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続中"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3673,6 +3673,23 @@
         }
       }
     },
+    "mobile.workspace.macChip.a11y": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上"
+          }
+        }
+      }
+    },
     "mobile.workspace.markRead": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Unified multi-Mac workspace list (iOS)

After sign-in the phone discovers every online Mac from the device registry (LAN/Tailnet) and merges all of their workspaces into **one flat list** with a per-row Mac chip. The top-left tree-picker stops being primary navigation and moves under Settings as "Manage Devices." No QR; sign-in stays required.

All of this is **behind the `unifiedMultiMacEnabled` flag** (`MobileUnifiedMultiMacFlag`): ON by default on Debug, OFF on Release, with env (`CMUX_UNIFIED_MULTI_MAC`) and `UserDefaults` overrides. **Flag OFF is byte-identical to today's single-Mac behavior** — the aggregator stays inactive and `unifiedWorkspaces` equals the heavy client's `workspaces` tagged with the active Mac's device id.

### Connection model
One heavy active `remoteClient` (render-grid stream, watchdog, terminal bytes) for the on-screen Mac, plus a new `@MainActor MultiMacWorkspaceAggregator` that owns short-lived per-Mac "list clients" used only to fetch `mobile.workspace.list` metadata on a slow cadence, then idled. On the wire: one heavy stream + transient list RPCs; the UI shows all Macs. Non-active rows refresh periodically and on presence events / pull-to-refresh, not live.

### Identity scoping
Workspace/terminal IDs are bare per-Mac strings that can collide across Macs. Fixed structurally:
- `deviceId` added to `MobileWorkspacePreview` / `MobileTerminalPreview` (defaulted in init).
- New `ScopedWorkspaceID` / `ScopedTerminalID`; the store's selection becomes scoped.
- The terminal surface key (input + `*BySurfaceID` byte-delivery dicts) is now scoped (`<deviceId>#<terminalID>`) so render-grid bytes/input never route to the wrong Mac.
- Invariant: the wire id stays Mac-local; `deviceId` selects which client to send to; they're never crossed.

### Phasing (all landed on this branch)
- **P1** — plumbing: `deviceId`, scoped IDs, aggregator, `unifiedWorkspaces` (flag-gated, no UI change).
- **P2** — unified list UI: `WorkspaceListView` / `WorkspaceShellView` consume `unifiedWorkspaces` + scoped selection + Mac chips.
- **P3** — lazy heavy-attach routing on opening a non-active Mac's workspace, scoped surfaceID through the terminal kit, tree-picker demoted to Settings.

### Tests
`MultiMacWorkspaceAggregatorTests`, `UnifiedWorkspacesMergeTests`, `UnifiedListSelectionTests`, `UnifiedAggregatorTargetsTests`, `ScopedSurfaceRoutingTests`, `CrossMacActivationBindingTests`, `ScopedIDTests`, `MobileUnifiedMultiMacFlagTests` — covering merge of active + N slices, presence online/offline gating, one Mac's fetch failure not blanking others, the scoped-ID collision/routing guard, and ordering (pinned → lastActivityAt across Macs).

Draft: iOS unit/simulator tests dispatched on GitHub Actions; not yet dogfooded on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784332916&installation_id=133855650&pr_number=6369&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6369&signature=d8a3944af99209b8c609e5574fa2fd0de527cf0fdfed89f547c7c82f24dd3071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies iOS into a single, flat workspace list across all online Macs with per‑row Mac chips and safe, scoped terminal routing. The list now appears right after sign‑in without a heavy connection by discovering online Macs from the registry. All changes are behind `unifiedMultiMacEnabled` (Debug ON, Release OFF; env `CMUX_UNIFIED_MULTI_MAC` and `UserDefaults` overrides); flag OFF is identical to today.

- **New Features**
  - Unified list: merges the active Mac with other online Macs into `MobileShellComposite.unifiedWorkspaces`; shows compact Mac chips; “Device Tree” moves to Settings as “Manage Devices.”
  - Scoped identities: `deviceId` added to previews; new `ScopedWorkspaceID` and `ScopedTerminalID`; terminal surface key is `"<deviceId>#<terminalID>"` so bytes/input never cross Macs; selection uses scoped IDs.
  - Cross‑Mac open: opening a workspace on another Mac lazily switches the heavy connection, then selects the workspace; non‑active rows refresh on cadence/presence/pull‑to‑refresh.
  - Aggregator: `MultiMacWorkspaceAggregator` uses short‑lived clients to fetch other Macs’ `mobile.workspace.list`, tags with `deviceId`, isolates per‑Mac failures, and merges slices behind presence gating.
  - Sign‑in discovery and routing: `kickUnifiedRegistryDiscovery()` loads the registry on sign‑in/foreground; the root view shows the unified list without a heavy connection when Macs are found, or a neutral spinner while the first pass completes.

- **Bug Fixes**
  - Fixed `activeDeviceID` binding on the synthetic‑ticket path so cross‑Mac activation uses the intended target.
  - Wired `unifiedAggregatorTargets` and refresh triggers (heavy connect, activation, presence, pull‑to‑refresh); cancels on sign‑out; no‑op when the flag is off.
  - Restored flag‑off parity for the Devices toolbar button and sheet; unified “Manage Devices” entry shows only when the flag is on.
  - Converted `MobileUnifiedMultiMacFlag` to an instantiable struct with the same resolution semantics (env → `UserDefaults` → build default) to satisfy package conventions.

<sup>Written for commit dbf51707d0e21ba0e3813c44d33fb960722eb09e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

