### PR TITLE
fix: new workspace in a group honors workspaceInheritWorkingDirectory

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
@@ -115,9 +115,12 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
         return group.id
     }
 
-    /// Create a brand-new workspace inheriting the anchor's cwd, attach it
-    /// to the group, and position it within the group's tabs[] range per
-    /// `placement`. Returns the new workspace.
+    /// Create a brand-new workspace, attach it to the group, and position it
+    /// within the group's tabs[] range per `placement`. The new workspace
+    /// inherits the anchor's cwd only when the host reports working-directory
+    /// inheritance is enabled (`app.workspaceInheritWorkingDirectory`);
+    /// otherwise it falls back to home like ungrouped creation. Returns the
+    /// new workspace.
     @discardableResult
     public func createWorkspaceInGroup(
         groupId: UUID,
@@ -133,11 +136,18 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
         let placement = explicitPlacement
             ?? host.defaultNewWorkspacePlacementInGroup
         guard let group = model.workspaceGroups.first(where: { $0.id == groupId }) else { return nil }
-        let cwd = model.tabs.first(where: { $0.id == group.anchorWorkspaceId })?.currentDirectory
+        // Only adopt the anchor's cwd when the user keeps working-directory
+        // inheritance on. With it off, leave the cwd unset so the new workspace
+        // falls back to home — matching ungrouped new-workspace creation and the
+        // `app.workspaceInheritWorkingDirectory` setting, which group creation
+        // would otherwise silently bypass.
+        let cwd = host.inheritsWorkingDirectoryForNewWorkspaces
+            ? model.tabs.first(where: { $0.id == group.anchorWorkspaceId })?.currentDirectory
+            : nil
         let newWorkspace = host.createWorkspaceForGroup(
             workingDirectory: cwd,
             initialSurface: initialSurface,
-            inheritWorkingDirectory: cwd == nil,
+            inheritWorkingDirectory: host.inheritsWorkingDirectoryForNewWorkspaces && cwd == nil,
             select: select
         )
         model.assignGroup(workspaceId: newWorkspace.id, groupId: groupId)

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupHosting.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupHosting.swift
@@ -71,6 +71,11 @@ public protocol WorkspaceGroupHosting<Tab>: WorkspaceOrderHosting {
     /// The stored global default placement for new in-group workspaces
     /// (legacy settings read of `workspaceGroups.newWorkspacePlacement`).
     var defaultNewWorkspacePlacementInGroup: WorkspaceGroupNewPlacement { get }
+    /// Whether a new in-group workspace should inherit the group anchor's
+    /// working directory (settings read of `app.workspaceInheritWorkingDirectory`).
+    /// When false, in-group creation leaves the cwd unset so the new workspace
+    /// falls back to home, matching ungrouped new-workspace creation.
+    var inheritsWorkingDirectoryForNewWorkspaces: Bool { get }
     /// Normalizes a group icon SF Symbol name (legacy
     /// `RenderableSystemSymbol.normalized(_:)`, app-side catalog).
     func normalizedGroupIconSymbol(_ symbol: String?) -> String?

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -38,6 +38,7 @@ private final class StubGroupHost: WorkspaceGroupHosting {
     var sidebarSelectedWorkspaceIds: Set<UUID> = []
     var localizedAutoGroupNameFormat: String { "Group %lld" }
     var defaultNewWorkspacePlacementInGroup: WorkspaceGroupNewPlacement { .end }
+    var inheritsWorkingDirectoryForNewWorkspaces = true
     private(set) var groupNameChangeCount = 0
 
     init(model: WorkspacesModel<CoordinatorStubTab>) {
@@ -321,5 +322,44 @@ struct WorkspaceCoordinatorTests {
         #expect(model.workspaceGroups[0].anchorWorkspaceId == b.id)
         let memberIds = model.tabs.filter { $0.groupId == groupId }.map(\.id)
         #expect(memberIds.first == b.id)
+    }
+
+    // MARK: New-in-group working directory
+
+    @Test
+    func inGroupCreationInheritsAnchorCwdWhenInheritanceEnabled() throws {
+        let (model, host, groups, _) = makeWorld()
+        let child = CoordinatorStubTab(currentDirectory: "/anchor/project")
+        model.tabs = [child]
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "G",
+            childWorkspaceIds: [child.id],
+            anchorWorkingDirectory: "/anchor/project"
+        ))
+        host.inheritsWorkingDirectoryForNewWorkspaces = true
+
+        let created = try #require(groups.createWorkspaceInGroup(groupId: groupId))
+
+        #expect(created.currentDirectory == "/anchor/project")
+    }
+
+    @Test
+    func inGroupCreationSkipsAnchorCwdWhenInheritanceDisabled() throws {
+        let (model, host, groups, _) = makeWorld()
+        let child = CoordinatorStubTab(currentDirectory: "/anchor/project")
+        model.tabs = [child]
+        let groupId = try #require(groups.createWorkspaceGroup(
+            name: "G",
+            childWorkspaceIds: [child.id],
+            anchorWorkingDirectory: "/anchor/project"
+        ))
+        host.inheritsWorkingDirectoryForNewWorkspaces = false
+
+        let created = try #require(groups.createWorkspaceInGroup(groupId: groupId))
+
+        // With inheritance off, the new in-group workspace must NOT adopt the
+        // anchor's cwd; it falls back to the host default (home), matching
+        // ungrouped new-workspace creation.
+        #expect(created.currentDirectory != "/anchor/project")
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1950,6 +1950,10 @@ class TabManager: ObservableObject {
         settings.value(for: settingsCatalog.workspaceGroups.newWorkspacePlacement)
     }
 
+    var inheritsWorkingDirectoryForNewWorkspaces: Bool {
+        settings.value(for: settingsCatalog.app.workspaceInheritWorkingDirectory)
+    }
+
     func normalizedGroupIconSymbol(_ symbol: String?) -> String? {
         RenderableSystemSymbol.normalized(symbol)
     }

--- a/docs/workspace-groups.md
+++ b/docs/workspace-groups.md
@@ -46,6 +46,8 @@ Hover over a group header to reveal a trailing `+` button. Click to create a new
 
 Pressing `⌘N` while the active workspace is a group anchor or group member also creates the workspace inside that group. The default group placement is **After current**: from a regular group member, the new workspace lands right after the active member; from the anchor/header, it lands at the top of the group.
 
+New in-group workspaces adopt the anchor's cwd only when **Settings → App → Inherit Workspace Working Directory** (`app.workspaceInheritWorkingDirectory`) is on, which is the default. Turn it off and new workspaces — grouped or not — start in your home directory instead.
+
 ## CLI
 
 All group operations are scriptable via `cmux workspace-group <subcommand>`. The hyphenated form ships first; once the broader `cmux workspace <noun>` namespace lands, `cmux workspace group ...` will be the canonical form with the hyphenated form kept as an alias forever.


### PR DESCRIPTION
## Problem

With `app.workspaceInheritWorkingDirectory = false`, a plain (ungrouped) new workspace correctly defaults to **home** (`Workspace.init` resolves an unset cwd to `FileManager.default.homeDirectoryForCurrentUser`). But when the active workspace belongs to a **sidebar group**, every new-workspace entrypoint — `⌘N`, the group header `+`, the command palette, and the `cmux workspace-group new-workspace` CLI/socket call — routes through `WorkspaceGroupCoordinator.createWorkspaceInGroup`, which **unconditionally** seeds the new workspace with the group anchor's cwd.

So a user who explicitly turned inheritance off still lands in the project directory (e.g. `~/Code/cmux`) instead of `~` whenever they're working inside a group. The setting is silently bypassed for grouped creation, and there is no other knob to control it (`workspaceGroups.byCwd` only covers color/icon/placement/contextMenu).

## Fix

Gate the anchor-cwd seeding in `createWorkspaceInGroup` on a new host seam, `inheritsWorkingDirectoryForNewWorkspaces`, backed by the existing `app.workspaceInheritWorkingDirectory` setting (`TabManager` reads it, mirroring `defaultNewWorkspacePlacementInGroup`).

- **Inheritance on (default):** behavior unchanged — new in-group workspaces adopt the anchor's cwd.
- **Inheritance off:** the cwd is left unset, so the new workspace falls back to home, exactly like ungrouped creation.

All entrypoints share the single coordinator path, so the fix applies uniformly (shared-behavior policy).

## Tests

Two-commit red/green per repo policy:

1. `test:` commit adds the regression test + host seam, with the coordinator unchanged → CI red.
2. `fix:` commit gates the coordinator → CI green.

`CmuxWorkspacesTests/WorkspaceCoordinatorTests`:
- `inGroupCreationInheritsAnchorCwdWhenInheritanceEnabled` — guards the default.
- `inGroupCreationSkipsAnchorCwdWhenInheritanceDisabled` — the regression.

## Localization

No new user-facing Swift strings (reuses the existing setting). The only doc touched is `docs/workspace-groups.md`, the English GitHub-hosted markdown the in-app "Open Workspace Groups Docs" button links to; it has no locale variants. The separate localized web docs page and `web/messages/*.json` were not modified.

## Notes

- Scoped to `createWorkspaceInGroup` (new workspace **into** a group). Group **creation** from a selection (`⌘⇧G`) still seeds the anchor from the selected workspaces, which is the intended "group these together" behavior.
- Built locally via `swift build` on `Packages/macOS/CmuxWorkspaces` (full Xcode/Swift Testing not available on this machine; CI runs the test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784335414&installation_id=133855650&pr_number=6373&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6373&signature=b17420c223980f9bfc81f023d23f1f58a77306637b22392deb355395b171139a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes new workspace creation inside sidebar groups to honor `app.workspaceInheritWorkingDirectory`. When inheritance is off, grouped new workspaces start in home, matching ungrouped creation.

- **Bug Fixes**
  - Gate anchor-cwd seeding in `WorkspaceGroupCoordinator.createWorkspaceInGroup` behind `inheritsWorkingDirectoryForNewWorkspaces` (backed by `app.workspaceInheritWorkingDirectory` via `TabManager`).
  - Behavior: On = inherit anchor cwd; Off = leave cwd unset so it falls back to home.
  - Applies to all entrypoints: `⌘N`, group header `+`, command palette, and `cmux workspace-group new-workspace`.
  - Added tests for both modes and updated docs.

<sup>Written for commit 6fa54e4747ba539afca89e8449f7e5b4c7a5a622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * New workspaces created within groups now properly respect the "Inherit Workspace Working Directory" app setting, inheriting the anchor workspace's working directory when enabled (default) or starting in the home directory when disabled.

* **Documentation**
  * Updated workspace groups documentation to clarify when new in-group workspaces inherit the anchor's working directory based on app settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->