### PR TITLE
Add broadcast input to all panes in a workspace (iTerm2-style)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6980,8 +6980,9 @@ struct CMUXCLI {
         let (colorOpt, rem3) = parseOption(rem2, name: "--color")
         let (descriptionOpt, rem4) = parseOption(rem3, name: "--description")
         let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+        let (enabledOpt, rem6) = parseOption(rem5, name: "--enabled")
 
-        var positional = rem5
+        var positional = rem6
         let actionRaw: String
         if let actionOpt {
             actionRaw = actionOpt
@@ -7029,6 +7030,17 @@ struct CMUXCLI {
             throw CLIError(message: "workspace-action set-description requires --description <text> (or trailing text)")
         }
 
+        var broadcastEnabled: Bool?
+        if action == "set_broadcast" {
+            let raw = enabledOpt ?? (inferredPositional.isEmpty ? nil : inferredPositional)
+            guard let raw, let parsed = parseBoolString(raw) else {
+                throw CLIError(message: "workspace-action set-broadcast requires --enabled <true|false> (or a trailing true/false)")
+            }
+            broadcastEnabled = parsed
+        } else if enabledOpt != nil {
+            throw CLIError(message: "workspace-action: --enabled only applies to set-broadcast")
+        }
+
         var params: [String: Any] = ["action": action]
         if let windowHandle {
             params["window_id"] = windowHandle
@@ -7044,6 +7056,9 @@ struct CMUXCLI {
         }
         if let description, !description.isEmpty {
             params["description"] = description
+        }
+        if let broadcastEnabled {
+            params["enabled"] = broadcastEnabled
         }
 
         let payload = try client.sendV2(method: "workspace.action", params: params)
@@ -7062,6 +7077,9 @@ struct CMUXCLI {
         }
         if let color = payload["color"] as? String {
             summaryParts.append("color=\(color)")
+        }
+        if let broadcast = payload["broadcast_input"] {
+            summaryParts.append("broadcast_input=\(broadcast)")
         }
         printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: summaryParts.joined(separator: " "))
     }
@@ -14698,6 +14716,7 @@ struct CMUXCLI {
               close-others | close-above | close-below
               mark-read | mark-unread
               set-color | clear-color
+              toggle-broadcast | set-broadcast
 
             Flags:
               --action <name>              Action name (required if not positional)
@@ -14706,6 +14725,7 @@ struct CMUXCLI {
               --title <text>               Title for rename
               --color <name|#hex>          Color for set-color (name or #RRGGBB hex)
               --description <text>         Description for set-description
+              --enabled <true|false>       Broadcast state for set-broadcast
 
             Named colors:
               Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua,
@@ -14721,6 +14741,8 @@ struct CMUXCLI {
               cmux workspace-action --action set-description --description "Ship checklist"
               cmux workspace-action --action set-description $'Ship checklist\n- verify build\n- post notes'
               cmux workspace-action clear-color
+              cmux workspace-action --action toggle-broadcast
+              cmux workspace-action --action set-broadcast --enabled true
             """
         case "tab-action":
             return """

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -96,6 +96,7 @@ extension ShortcutAction {
         case .selectWorkspaceByNumber: return ShortcutStroke(key: "1", command: true)
         case .newSurface: return ShortcutStroke(key: "t", command: true)
         case .toggleTerminalCopyMode: return ShortcutStroke(key: "m", command: true, shift: true)
+        case .toggleWorkspaceInputBroadcast: return ShortcutStroke(key: "b", command: true, shift: true)
         case .focusTextBoxInput: return ShortcutStroke(key: "a", command: true, shift: true)
         case .cycleTextBoxSubmitAction: return ShortcutStroke(key: "\t", shift: true)
         case .attachTextBoxFile: return ShortcutStroke(key: "a", command: true, shift: true, option: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -68,6 +68,8 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case reopenClosedBrowserPanel
     case newSurface
     case toggleTerminalCopyMode
+    /// Toggles iTerm2-style input broadcast to all panes in the focused workspace.
+    case toggleWorkspaceInputBroadcast
     case focusTextBoxInput
     /// Cycles the TextBox submit button to the next configured action.
     case cycleTextBoxSubmitAction
@@ -188,6 +190,7 @@ extension ShortcutAction {
              .editWorkspaceDescription, .closeTab, .closeOtherTabsInPane, .closeWorkspace,
              .newWorkspaceGroup, .groupSelectedWorkspaces, .toggleFocusedWorkspaceGroupCollapsed,
              .reopenClosedBrowserPanel, .newSurface, .toggleTerminalCopyMode,
+             .toggleWorkspaceInputBroadcast,
              .focusTextBoxInput, .cycleTextBoxSubmitAction, .attachTextBoxFile, .sendCtrlFToTerminal,
              .clearScreenKeepScrollback:
             return .navigation
@@ -377,6 +380,7 @@ extension ShortcutAction {
         case .reopenClosedBrowserPanel: return "Reopen Last Closed"
         case .newSurface: return "New Surface"
         case .toggleTerminalCopyMode: return "Toggle Terminal Copy Mode"
+        case .toggleWorkspaceInputBroadcast: return "Broadcast Input to All Panes"
         case .focusTextBoxInput: return "Focus TextBox Input"
         case .cycleTextBoxSubmitAction:
             return String(localized: "shortcut.cycleTextBoxSubmitAction.label", defaultValue: "Cycle TextBox Submit Action")

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -380,7 +380,8 @@ extension ShortcutAction {
         case .reopenClosedBrowserPanel: return "Reopen Last Closed"
         case .newSurface: return "New Surface"
         case .toggleTerminalCopyMode: return "Toggle Terminal Copy Mode"
-        case .toggleWorkspaceInputBroadcast: return "Broadcast Input to All Panes"
+        case .toggleWorkspaceInputBroadcast:
+            return String(localized: "shortcut.toggleWorkspaceInputBroadcast.label", defaultValue: "Broadcast Input to All Panes")
         case .focusTextBoxInput: return "Focus TextBox Input"
         case .cycleTextBoxSubmitAction:
             return String(localized: "shortcut.cycleTextBoxSubmitAction.label", defaultValue: "Cycle TextBox Submit Action")

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -79,6 +79,62 @@ extension TerminalSurface {
         }
     }
 
+    /// Updates the cached workspace-input-broadcast flag for this surface.
+    ///
+    /// Called by the single mutation path (`Workspace.applyInputBroadcastEnabled(_:)`)
+    /// so the desktop `keyDown`/IME/paste hooks can gate on a cheap `Bool` read
+    /// instead of walking the window/workspace tree on every keystroke. See
+    /// ``inputBroadcastEnabled``.
+    @MainActor
+    public func setInputBroadcastEnabled(_ enabled: Bool) {
+        inputBroadcastEnabled = enabled
+    }
+
+    /// Replays a key event captured from another (focused) pane onto this surface
+    /// for workspace input broadcast.
+    ///
+    /// Mirrors the desktop `keyDown` C-string lifetime contract: `text` is bound
+    /// only for the duration of the `ghostty_surface_key` call. Unlike
+    /// ``sendText(_:)`` this does not queue on a cold surface — broadcast only
+    /// targets visible peer panes, which are live.
+    ///
+    /// - Returns: Whether the runtime handled the key (`false` when no live
+    ///   surface is available).
+    @MainActor
+    @discardableResult
+    public func sendMirroredKeyEvent(
+        action: ghostty_input_action_e,
+        keycode: UInt32,
+        mods: ghostty_input_mods_e,
+        consumedMods: ghostty_input_mods_e,
+        unshiftedCodepoint: UInt32,
+        composing: Bool,
+        text: String?
+    ) -> Bool {
+        guard let liveSurface = liveSurfaceForSocketWrite(reason: "broadcast.key") else {
+            return false
+        }
+        guard !ghostty_surface_process_exited(liveSurface) else { return false }
+        hibernationRecorder.recordTerminalInput(workspaceId: tabId, panelId: id)
+
+        var keyEvent = ghostty_input_key_s()
+        keyEvent.action = action
+        keyEvent.keycode = keycode
+        keyEvent.mods = mods
+        keyEvent.consumed_mods = consumedMods
+        keyEvent.unshifted_codepoint = unshiftedCodepoint
+        keyEvent.composing = composing
+
+        if let text, !text.isEmpty {
+            return text.withCString { ptr in
+                keyEvent.text = ptr
+                return ghostty_surface_key(liveSurface, keyEvent)
+            }
+        }
+        keyEvent.text = nil
+        return ghostty_surface_key(liveSurface, keyEvent)
+    }
+
     /// Sends a named key (e.g. `"ctrl-c"`, `"enter"`), queueing on a cold
     /// surface.
     @MainActor

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -97,6 +97,17 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// a surface whose portal is visible.
     var rendererPortalVisible = false
 
+    /// Whether workspace input broadcast is currently enabled for the workspace
+    /// that owns this surface.
+    ///
+    /// This is a derived hot-path cache pushed down by the single mutation path
+    /// (``TabManager`` → `Workspace.applyInputBroadcastEnabled(_:)` →
+    /// ``setInputBroadcastEnabled(_:)``); the authoritative state is the per-window
+    /// `TabManager.broadcastInputWorkspaceIds` set. `keyDown`/IME/paste reads this
+    /// flag to skip the workspace lookup entirely while broadcast is off (the
+    /// common case), so it must stay a single cheap `Bool` read.
+    public internal(set) var inputBroadcastEnabled = false
+
     /// Whether the runtime Ghostty surface exists and has not begun teardown.
     ///
     /// Use this as a quick availability check. Before passing `surface` to

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4842,8 +4842,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Broadcast state is per-window; carry it across the move (detach drops
+        // it from the source window, attach does not restore it on its own).
+        let wasBroadcasting = sourceManager.isBroadcastInputEnabled(for: workspaceId)
         guard let workspace = sourceManager.detachWorkspace(tabId: workspaceId) else { return false }
         destinationManager.attachWorkspace(workspace, at: atIndex, select: focus)
+        if wasBroadcasting {
+            destinationManager.setBroadcastInputEnabled(true, for: workspaceId)
+        }
 
         if focus {
             _ = focusMainWindow(windowId: windowId)
@@ -13463,6 +13469,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             tabManager?.selectPreviousTab()
             return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .toggleWorkspaceInputBroadcast) {
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            let handled = routedManager?.toggleSelectedWorkspaceInputBroadcast() ?? false
+            return handled
         }
 
         if matchConfiguredShortcut(event: event, action: .renameWorkspace) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1795,6 +1795,7 @@ struct ContentView: View {
                         isWorkspaceVisible: presentation.isPanelVisible,
                         isWorkspaceInputActive: isInputActive,
                         rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus,
+                        isInputBroadcastActive: tabManager.isBroadcastInputEnabled(for: tab.id),
                         isFullScreen: isFullScreen,
                         workspacePortalPriority: portalPriority,
                         windowAppearance: appearance,
@@ -12427,6 +12428,7 @@ struct VerticalTabsSidebar: View {
             notificationStore: notificationStore,
             tab: tab,
             index: index,
+            isBroadcasting: tabManager.isBroadcastInputEnabled(for: tab.id),
             workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
                 at: index,
                 workspaceCount: renderContext.workspaceCount
@@ -13273,6 +13275,7 @@ struct TabItemView: View, Equatable {
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
+        lhs.isBroadcasting == rhs.isBroadcasting &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.workspaceShortcutModifierSymbol == rhs.workspaceShortcutModifierSymbol &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
@@ -13311,6 +13314,11 @@ struct TabItemView: View, Equatable {
     @Environment(\.cmuxGlobalFontMagnificationPercent) private var globalFontMagnificationPercent
     let tab: Tab
     let index: Int
+    /// Whether iTerm2-style input broadcast is enabled for this workspace.
+    /// Drives the small broadcast dot on the row. Precomputed from the observed
+    /// `TabManager.broadcastInputWorkspaceIds` by the parent (snapshot-boundary
+    /// rule: a value, not a store reference).
+    let isBroadcasting: Bool
     let workspaceShortcutDigit: Int?
     let workspaceShortcutModifierSymbol: String
     let canCloseWorkspace: Bool
@@ -13771,6 +13779,16 @@ struct TabItemView: View, Equatable {
                         .foregroundColor(.green)
                         .safeHelp(cameraInUseTooltip)
                         .accessibilityLabel(cameraInUseTooltip)
+                }
+
+                if isBroadcasting {
+                    // Small accent dot signalling iTerm2-style input broadcast is
+                    // on for this workspace. Reuses the menu string for its tooltip.
+                    Circle()
+                        .fill(Color(nsColor: .systemOrange))
+                        .frame(width: 7 * fontScale, height: 7 * fontScale)
+                        .padding(.top, 3 * fontScale)
+                        .safeHelp(String(localized: "menu.view.broadcastInput", defaultValue: "Broadcast Input to All Panes"))
                 }
 
                 Text(displayedTitle)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5112,8 +5112,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// Pastes clipboard text as plain text, stripping any rich formatting.
     // Intentionally non-private (like `paste(_:)`): a GhosttyNSView test double in
     // AppDelegateShortcutRoutingTests overrides this, which a `private` IBAction
-    // would break ("method does not override"). SwiftLint's private_action hint
-    // does not apply here.
+    // would break ("method does not override").
+    // swiftlint:disable:next private_action
     @IBAction func pasteAsPlainText(_ sender: Any?) {
         guard prepareSurfaceForPaste(reason: "pasteAsPlainText.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5104,15 +5104,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     @IBAction func paste(_ sender: Any?) {
         guard prepareSurfaceForPaste(reason: "paste.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()
-        _ = performBindingAction("paste_from_clipboard")
+        // Only mirror to peers if the local paste actually fired.
+        guard performBindingAction("paste_from_clipboard") else { return }
         broadcastClipboardPasteIfNeeded()
     }
 
     /// Pastes clipboard text as plain text, stripping any rich formatting.
-    @IBAction func pasteAsPlainText(_ sender: Any?) {
+    @IBAction private func pasteAsPlainText(_ sender: Any?) {
         guard prepareSurfaceForPaste(reason: "pasteAsPlainText.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()
-        _ = performBindingAction("paste_from_clipboard")
+        guard performBindingAction("paste_from_clipboard") else { return }
         broadcastClipboardPasteIfNeeded()
     }
 
@@ -6077,8 +6078,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     /// Mirrors IME/dictation/accessibility-committed text (delivered directly,
-    /// not through the `keyDown` accumulator) onto peer panes as a key event so
-    /// it is encoded identically to the source pane (not bracketed-pasted).
+    /// not through the `keyDown` accumulator) onto peer panes as a key event.
+    /// Byte-faithful for single-line committed text (the dominant case). For the
+    /// rare multiline/control-character commit the source splits LF/CR/Tab/ESC
+    /// into discrete key events while peers receive the text in one event — a
+    /// known minor divergence not worth duplicating the splitter for.
     private func broadcastCommittedTextIfNeeded(_ text: String) {
         guard !text.isEmpty, let surface = terminalSurface, surface.inputBroadcastEnabled else { return }
         surface.owningWorkspace()?.broadcastTerminalInput(
@@ -6165,6 +6169,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         keyEvent.text = nil
         keyEvent.composing = false
         _ = sendGhosttyKey(surface, keyEvent)
+        // Mirror the release so peers using key-release reporting (e.g. the Kitty
+        // keyboard protocol) don't end up with stuck-key state.
+        broadcastKeyIfNeeded(keyEvent, text: nil)
     }
 
     override func flagsChanged(with event: NSEvent) {
@@ -7762,8 +7769,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case .reject:
             return false
         case .insertText(let text):
-            terminalSurface?.sendText(text)
-            broadcastTextIfNeeded(text)
+            // Only mirror to peers when the local surface accepted/queued the text.
+            let delivered = terminalSurface?.sendText(text) ?? false
+            if delivered {
+                broadcastTextIfNeeded(text)
+            }
             return true
         case .fileURLs(let fileURLs):
             let plan = TerminalImageTransferPlanner.plan(
@@ -9103,13 +9113,9 @@ final class GhosttySurfaceScrollView: NSView {
         CATransaction.commit()
     }
 
+    // Callers are all main-actor (updateNSView + portal callbacks), so this sets
+    // the flag directly rather than re-introducing a DispatchQueue trampoline.
     func setBroadcastDot(visible: Bool) {
-        if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in
-                self?.setBroadcastDot(visible: visible)
-            }
-            return
-        }
         guard broadcastDotView.isHidden != !visible else { return }
         broadcastDotView.isHidden = !visible
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5105,6 +5105,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard prepareSurfaceForPaste(reason: "paste.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()
         _ = performBindingAction("paste_from_clipboard")
+        broadcastClipboardPasteIfNeeded()
     }
 
     /// Pastes clipboard text as plain text, stripping any rich formatting.
@@ -5112,6 +5113,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard prepareSurfaceForPaste(reason: "pasteAsPlainText.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()
         _ = performBindingAction("paste_from_clipboard")
+        broadcastClipboardPasteIfNeeded()
     }
 
     private func applyConfiguredMenuShortcut(_ shortcut: StoredShortcut, to item: NSMenuItem) {
@@ -5744,7 +5746,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // If Ghostty handled the key (action/encoding), we're done.
             // If not (e.g. `ignore` keybind), fall through to interpretKeyEvents
             // so the IME gets a chance to process this event.
-            if handled { return }
+            if handled {
+                broadcastKeyIfNeeded(keyEvent, text: text.isEmpty ? nil : text)
+                return
+            }
         }
 
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
@@ -5902,6 +5907,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         extra: "textBytes=\(text.utf8.count)"
                     )
 #endif
+                    broadcastKeyIfNeeded(keyEvent, text: text)
                 } else {
                     keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                     keyEvent.text = nil
@@ -5917,6 +5923,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     #else
                     _ = ghostty_surface_key(surface, keyEvent)
                     #endif
+                    broadcastKeyIfNeeded(keyEvent, text: nil)
                 }
             }
 
@@ -5938,6 +5945,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #else
                 _ = ghostty_surface_key(surface, keyEvent)
 #endif
+                broadcastKeyIfNeeded(keyEvent, text: nil)
             }
         } else {
             // Get the appropriate text for this key event
@@ -5984,6 +5992,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                         extra: "handled=\(handled ? 1 : 0) textBytes=\(text.utf8.count)"
                     )
 #endif
+                    broadcastKeyIfNeeded(keyEvent, text: text)
                 } else {
                     keyEvent.consumed_mods = GHOSTTY_MODS_NONE
                     keyEvent.text = nil
@@ -5999,6 +6008,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     #else
                     _ = ghostty_surface_key(surface, keyEvent)
                     #endif
+                    // The local surface was sent a stripped key (text cleared
+                    // above); mirror exactly that to peers, never the suppressed
+                    // Swift `text` (e.g. Shift+Space, composing fallback).
+                    broadcastKeyIfNeeded(keyEvent, text: nil)
                 }
             } else {
                 keyEvent.consumed_mods = GHOSTTY_MODS_NONE
@@ -6015,6 +6028,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 #else
                 _ = ghostty_surface_key(surface, keyEvent)
                 #endif
+                broadcastKeyIfNeeded(keyEvent, text: nil)
             }
         }
 
@@ -6027,6 +6041,74 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         Self.debugGhosttySurfaceKeyEventObserver?(keyEvent)
 #endif
         return ghostty_surface_key(surface, keyEvent)
+    }
+
+    // MARK: - Input broadcast
+
+    /// Mirrors a key event that was just sent to this surface onto the other
+    /// visible terminal panes when workspace input broadcast is enabled.
+    ///
+    /// Gated on the per-surface `inputBroadcastEnabled` cache so the common
+    /// (broadcast-off) keystroke path costs only a single `Bool` read and never
+    /// walks the window tree. Reads only `keyEvent`'s scalar fields plus the
+    /// in-scope Swift `text` — never `keyEvent.text`, whose C pointer is only
+    /// valid inside the originating `withCString` closure.
+    private func broadcastKeyIfNeeded(_ keyEvent: ghostty_input_key_s, text: String?) {
+        guard let surface = terminalSurface, surface.inputBroadcastEnabled else { return }
+        surface.owningWorkspace()?.broadcastTerminalInput(
+            .key(
+                action: keyEvent.action,
+                keycode: keyEvent.keycode,
+                mods: keyEvent.mods,
+                consumedMods: keyEvent.consumed_mods,
+                unshiftedCodepoint: keyEvent.unshifted_codepoint,
+                composing: keyEvent.composing,
+                text: text
+            ),
+            from: surface.id
+        )
+    }
+
+    /// Mirrors committed paste/drop text onto the other visible terminal panes
+    /// when workspace input broadcast is enabled.
+    private func broadcastTextIfNeeded(_ text: String) {
+        guard !text.isEmpty, let surface = terminalSurface, surface.inputBroadcastEnabled else { return }
+        surface.owningWorkspace()?.broadcastTerminalInput(.text(text), from: surface.id)
+    }
+
+    /// Mirrors IME/dictation/accessibility-committed text (delivered directly,
+    /// not through the `keyDown` accumulator) onto peer panes as a key event so
+    /// it is encoded identically to the source pane (not bracketed-pasted).
+    private func broadcastCommittedTextIfNeeded(_ text: String) {
+        guard !text.isEmpty, let surface = terminalSurface, surface.inputBroadcastEnabled else { return }
+        surface.owningWorkspace()?.broadcastTerminalInput(
+            .key(
+                action: GHOSTTY_ACTION_PRESS,
+                keycode: 0,
+                mods: GHOSTTY_MODS_NONE,
+                consumedMods: GHOSTTY_MODS_NONE,
+                unshiftedCodepoint: 0,
+                composing: false,
+                text: text
+            ),
+            from: surface.id
+        )
+    }
+
+    /// Mirrors a clipboard paste onto peer panes. The local paste goes through
+    /// Ghostty's `paste_from_clipboard` binding, which routes image/file-URL
+    /// clipboards through the image-transfer pipeline (a per-surface side effect,
+    /// possibly a remote upload) rather than typing them into the PTY. So we
+    /// mirror a paste ONLY when it resolves to plain insertable text — exactly
+    /// `TerminalImageTransferPlanner.preparePaste`'s `.insertText` branch (no
+    /// image, no file URLs) — without materializing a temp file on this path.
+    private func broadcastClipboardPasteIfNeeded() {
+        guard let surface = terminalSurface, surface.inputBroadcastEnabled else { return }
+        guard let pasteboard = GhosttyApp.terminalPasteboard.pasteboard(for: GHOSTTY_CLIPBOARD_STANDARD) else { return }
+        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) { return }
+        if pasteboard.canReadObject(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) { return }
+        guard let value = GhosttyApp.terminalPasteboard.stringContents(from: pasteboard), !value.isEmpty else { return }
+        surface.owningWorkspace()?.broadcastTerminalInput(.text(value), from: surface.id)
     }
 
 #if DEBUG
@@ -6109,6 +6191,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.composing = false
             keyEvent.unshifted_codepoint = 0
             _ = sendGhosttyKey(surface, keyEvent)
+            broadcastKeyIfNeeded(keyEvent, text: nil)
         }
 
         let selectionActive = ghostty_surface_has_selection(surface)
@@ -7680,6 +7763,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         case .insertText(let text):
             terminalSurface?.sendText(text)
+            broadcastTextIfNeeded(text)
             return true
         case .fileURLs(let fileURLs):
             let plan = TerminalImageTransferPlanner.plan(
@@ -7939,6 +8023,10 @@ final class GhosttySurfaceScrollView: NSView {
     private let paneDropTargetView = TerminalPaneDropTargetView(frame: .zero)
     private let notificationRingOverlayView: GhosttyFlashOverlayView
     private let notificationRingLayer: CAShapeLayer
+    /// Small dot pinned to the pane's top-right corner while its workspace has
+    /// iTerm2-style input broadcast enabled. Lives on the portal-hosted view so
+    /// it stays visible above the terminal and regardless of the sidebar state.
+    private let broadcastDotView: GhosttyFlashOverlayView
     private let flashOverlayView: GhosttyFlashOverlayView
     private let flashLayer: CAShapeLayer
     var isRightSidebarDockSurface: Bool {
@@ -8192,6 +8280,7 @@ final class GhosttySurfaceScrollView: NSView {
         dropZoneOverlayView = GhosttyFlashOverlayView(frame: .zero)
         notificationRingOverlayView = GhosttyFlashOverlayView(frame: .zero)
         notificationRingLayer = CAShapeLayer()
+        broadcastDotView = GhosttyFlashOverlayView(frame: .zero)
         flashOverlayView = GhosttyFlashOverlayView(frame: .zero)
         flashLayer = CAShapeLayer()
         keyboardCopyModeBadgeContainerView = GhosttyFlashOverlayView(frame: .zero)
@@ -8261,6 +8350,11 @@ final class GhosttySurfaceScrollView: NSView {
         notificationRingOverlayView.layer?.addSublayer(notificationRingLayer)
         notificationRingOverlayView.isHidden = true
         addSubview(notificationRingOverlayView)
+        broadcastDotView.wantsLayer = true
+        broadcastDotView.layer?.backgroundColor = NSColor.systemOrange.cgColor
+        broadcastDotView.autoresizingMask = [.minXMargin, .minYMargin]
+        broadcastDotView.isHidden = true
+        addSubview(broadcastDotView)
         flashOverlayView.wantsLayer = true
         flashOverlayView.layer?.backgroundColor = NSColor.clear.cgColor
         flashOverlayView.layer?.masksToBounds = false
@@ -8681,6 +8775,20 @@ final class GhosttySurfaceScrollView: NSView {
             setDropZoneOverlay(zone: pending)
         }
         _ = setFrameIfNeeded(notificationRingOverlayView, to: bounds)
+        // Pin the broadcast dot to the top-right corner. This view is NOT flipped,
+        // so the top edge is `maxY`.
+        let broadcastDotSize: CGFloat = 8
+        let broadcastDotInset: CGFloat = 6
+        let broadcastDotFrame = CGRect(
+            x: bounds.maxX - broadcastDotSize - broadcastDotInset,
+            y: bounds.maxY - broadcastDotSize - broadcastDotInset,
+            width: broadcastDotSize,
+            height: broadcastDotSize
+        )
+        if broadcastDotView.frame != broadcastDotFrame {
+            broadcastDotView.frame = broadcastDotFrame
+            broadcastDotView.layer?.cornerRadius = broadcastDotSize / 2
+        }
         _ = setFrameIfNeeded(flashOverlayView, to: bounds)
         if let overlay = searchOverlayHostingView {
             _ = setFrameIfNeeded(overlay, to: bounds)
@@ -8993,6 +9101,17 @@ final class GhosttySurfaceScrollView: NSView {
         notificationRingOverlayView.isHidden = targetHidden
         notificationRingLayer.opacity = targetOpacity
         CATransaction.commit()
+    }
+
+    func setBroadcastDot(visible: Bool) {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.setBroadcastDot(visible: visible)
+            }
+            return
+        }
+        guard broadcastDotView.isHidden != !visible else { return }
+        broadcastDotView.isHidden = !visible
     }
 
     private func cancelDeferredSearchOverlayMutation() {
@@ -11704,6 +11823,7 @@ extension GhosttyNSView: NSTextInputClient {
             sanitizedChars,
             preserveLiteralEscape: !isExternalCommittedText
         )
+        broadcastCommittedTextIfNeeded(sanitizedChars)
     }
 
     private func insertBopomofoPreeditText(_ chars: String, replacementRange: NSRange) {
@@ -11745,6 +11865,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
     var portalZPriority: Int = 0
     var showsInactiveOverlay: Bool = false
     var showsUnreadNotificationRing: Bool = false
+    var showsBroadcastDot: Bool = false
     var inactiveOverlayColor: NSColor = .clear
     var inactiveOverlayOpacity: Double = 0
     var searchState: TerminalSurface.SearchState? = nil
@@ -11836,6 +11957,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         var desiredIsActive: Bool = true
         var desiredIsVisibleInUI: Bool = true
         var desiredShowsUnreadNotificationRing: Bool = false
+        var desiredShowsBroadcastDot: Bool = false
         var desiredPortalZPriority: Int = 0
         var lastBoundHostId: ObjectIdentifier?
         var lastPaneDropZone: DropZone?
@@ -11910,6 +12032,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.desiredIsActive = isActive
         coordinator.desiredIsVisibleInUI = isVisibleInUI
         coordinator.desiredShowsUnreadNotificationRing = showsUnreadNotificationRing
+        coordinator.desiredShowsBroadcastDot = showsBroadcastDot
         coordinator.desiredPortalZPriority = portalZPriority
         coordinator.hostedView = hostedView
 #if DEBUG
@@ -11962,6 +12085,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 visible: showsInactiveOverlay
             )
             hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
+            hostedView.setBroadcastDot(visible: showsBroadcastDot)
             hostedView.setSearchOverlay(searchState: searchState)
             hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
         }
@@ -12028,6 +12152,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
                 hostedView.setActive(coordinator.desiredIsActive)
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                hostedView.setBroadcastDot(visible: coordinator.desiredShowsBroadcastDot)
             }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }
@@ -12065,6 +12190,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
                     hostedView.setActive(coordinator.desiredIsActive)
                     hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                    hostedView.setBroadcastDot(visible: coordinator.desiredShowsBroadcastDot)
                 }
                 Self.synchronizePortalGeometry(
                     for: host,
@@ -12169,6 +12295,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         coordinator.desiredIsActive = false
         coordinator.desiredIsVisibleInUI = false
         coordinator.desiredShowsUnreadNotificationRing = false
+        coordinator.desiredShowsBroadcastDot = false
         coordinator.desiredPortalZPriority = 0
         coordinator.lastBoundHostId = nil
         let hostedView = coordinator.hostedView

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5110,7 +5110,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     /// Pastes clipboard text as plain text, stripping any rich formatting.
-    @IBAction private func pasteAsPlainText(_ sender: Any?) {
+    // Intentionally non-private (like `paste(_:)`): a GhosttyNSView test double in
+    // AppDelegateShortcutRoutingTests overrides this, which a `private` IBAction
+    // would break ("method does not override"). SwiftLint's private_action hint
+    // does not apply here.
+    @IBAction func pasteAsPlainText(_ sender: Any?) {
         guard prepareSurfaceForPaste(reason: "pasteAsPlainText.missingSurface") else { return }
         recordDirectAgentHibernationTerminalInput()
         guard performBindingAction("paste_from_clipboard") else { return }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -116,6 +116,7 @@ enum KeyboardShortcutSettings {
         case reopenClosedBrowserPanel
         case newSurface
         case toggleTerminalCopyMode
+        case toggleWorkspaceInputBroadcast
         case focusTextBoxInput, cycleTextBoxSubmitAction, attachTextBoxFile
         case sendCtrlFToTerminal
         case clearScreenKeepScrollback
@@ -238,6 +239,7 @@ enum KeyboardShortcutSettings {
             case .reopenClosedBrowserPanel: return String(localized: "menu.history.reopenLastClosed", defaultValue: "Reopen Last Closed")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
+            case .toggleWorkspaceInputBroadcast: return String(localized: "shortcut.toggleWorkspaceInputBroadcast.label", defaultValue: "Broadcast Input to All Panes")
             case .focusTextBoxInput: return String(localized: "shortcut.focusTextBoxInput.label", defaultValue: "Focus TextBox Input")
             case .cycleTextBoxSubmitAction: return String(localized: "shortcut.cycleTextBoxSubmitAction.label", defaultValue: "Cycle TextBox Submit Action")
             case .attachTextBoxFile: return String(localized: "shortcut.attachTextBoxFile.label", defaultValue: "Attach File to TextBox Input")
@@ -475,6 +477,10 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
+            case .toggleWorkspaceInputBroadcast:
+                // Cmd+Shift+B (B = Broadcast). Distinct from Cmd+B (Toggle Left
+                // Sidebar) and Cmd+Opt+B (Toggle Right Sidebar); no Shift collision.
+                return StoredShortcut(key: "b", command: true, shift: true, option: false, control: false)
             case .focusTextBoxInput: return StoredShortcut(key: "a", command: true, shift: true, option: false, control: false)
             case .cycleTextBoxSubmitAction: return StoredShortcut(key: "\t", command: false, shift: true, option: false, control: false)
             case .attachTextBoxFile: return StoredShortcut(key: "a", command: true, shift: true, option: true, control: false)

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -20,6 +20,7 @@ struct PanelContentView: View {
     let customSidebarTabManager: TabManager?
     let customSidebarUnread: SidebarUnreadModel = TerminalNotificationStore.shared.sidebarUnread
     let hasUnreadNotification: Bool
+    var showsBroadcastDot: Bool = false
     let terminalAgentContext: String
     /// Explicit browser pane-ownership signal for hosts whose panels live outside
     /// the main `Workspace` tree (the Dock). `nil` keeps the main-area behavior.
@@ -51,6 +52,7 @@ struct PanelContentView: View {
                     isSplit: isSplit,
                     appearance: appearance,
                     hasUnreadNotification: hasUnreadNotification,
+                    showsBroadcastDot: showsBroadcastDot,
                     terminalAgentContext: terminalAgentContext,
                     onFocus: onFocus,
                     onResumeAgentHibernation: onResumeAgentHibernation,

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -22,6 +22,7 @@ struct TerminalPanelView: View {
     let isSplit: Bool
     let appearance: PanelAppearance
     let hasUnreadNotification: Bool
+    var showsBroadcastDot: Bool = false
     let terminalAgentContext: String
     let onFocus: () -> Void
     let onResumeAgentHibernation: () -> Void
@@ -74,6 +75,7 @@ struct TerminalPanelView: View {
                 portalZPriority: portalPriority,
                 showsInactiveOverlay: isSplit && !isFocused,
                 showsUnreadNotificationRing: hasUnreadNotification && notificationPaneRingEnabled,
+                showsBroadcastDot: showsBroadcastDot,
                 inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
                 inactiveOverlayOpacity: appearance.unfocusedOverlayOpacity,
                 searchState: panel.searchState,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -229,6 +229,10 @@ class TabManager: ObservableObject {
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var mountedBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
+    /// Workspaces (this window) with iTerm2-style input broadcast enabled.
+    /// Authoritative state; `setBroadcastInputEnabled(_:for:)` is the single
+    /// mutation path and pushes a derived flag down to each workspace's surfaces.
+    @Published private(set) var broadcastInputWorkspaceIds: Set<UUID> = []
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -755,6 +759,35 @@ class TabManager: ObservableObject {
 
     private var selectedWorkspaceTerminalPanels: [TerminalPanel] {
         selectedWorkspace?.panels.values.compactMap { $0 as? TerminalPanel } ?? []
+    }
+
+    // MARK: - Input broadcast
+
+    /// Whether iTerm2-style input broadcast is enabled for `workspaceId`.
+    func isBroadcastInputEnabled(for workspaceId: UUID) -> Bool {
+        broadcastInputWorkspaceIds.contains(workspaceId)
+    }
+
+    /// The single mutation path for input broadcast. Updates the authoritative
+    /// set and pushes the derived per-surface flag down to the workspace so the
+    /// keyDown hot path can gate cheaply. Shared by the View menu, the
+    /// Cmd+Shift+B shortcut, and the `workspace.action` socket/CLI command.
+    func setBroadcastInputEnabled(_ enabled: Bool, for workspaceId: UUID) {
+        if enabled {
+            guard broadcastInputWorkspaceIds.insert(workspaceId).inserted else { return }
+        } else {
+            guard broadcastInputWorkspaceIds.remove(workspaceId) != nil else { return }
+        }
+        tabs.first(where: { $0.id == workspaceId })?.applyInputBroadcastEnabled(enabled)
+    }
+
+    /// Toggles input broadcast for the currently selected workspace.
+    /// - Returns: `true` when a workspace was available to toggle.
+    @discardableResult
+    func toggleSelectedWorkspaceInputBroadcast() -> Bool {
+        guard let workspaceId = selectedWorkspace?.id else { return false }
+        setBroadcastInputEnabled(!isBroadcastInputEnabled(for: workspaceId), for: workspaceId)
+        return true
     }
 
     var isFindVisible: Bool {
@@ -2034,6 +2067,7 @@ class TabManager: ObservableObject {
         }
         workspace.teardownRemoteConnection()
         unwireClosedBrowserTracking(for: workspace)
+        broadcastInputWorkspaceIds.remove(workspace.id)
         browserModel.removeClosedBrowserPanels(forWorkspaceId: workspace.id)
         workspace.owningTabManager = nil
 
@@ -2077,6 +2111,12 @@ class TabManager: ObservableObject {
         // render it as an orphaned indented row with stale grouping state.
         removed.groupId = nil
         unwireClosedBrowserTracking(for: removed)
+        // Broadcast state is per-window. Drop it from this window's set and
+        // reset the surfaces' hot-path flag; the move's destination re-applies
+        // the flag after attach (see AppDelegate/TerminalController move paths),
+        // so a path that forgets to preserve fails safe (broadcast off).
+        broadcastInputWorkspaceIds.remove(removed.id)
+        removed.applyInputBroadcastEnabled(false)
         browserModel.removeClosedBrowserPanels(forWorkspaceId: removed.id)
         removed.owningTabManager = nil
         lastFocusedPanelByTab.removeValue(forKey: removed.id)
@@ -5930,6 +5970,7 @@ extension TabManager {
         workspaceCycleCooldownTask = nil
         isWorkspaceCycleHot = false
         selectionSideEffectsGeneration &+= 1
+        broadcastInputWorkspaceIds.removeAll()
         browserModel.clearRecentlyClosedBrowserPanels()
 
         // Build the new workspace list locally to avoid intermediate @Published

--- a/Sources/TerminalBroadcastInputPayload.swift
+++ b/Sources/TerminalBroadcastInputPayload.swift
@@ -1,0 +1,48 @@
+import CmuxTerminal
+import GhosttyKit
+
+/// A single terminal input event captured from the focused pane so it can be
+/// replayed onto peer panes when workspace input broadcast is enabled.
+///
+/// iTerm2-style broadcast mirrors keystrokes, IME-committed text, pastes, and
+/// file drops from the focused terminal to every other visible terminal pane in
+/// the same workspace. Keyboard/IME input is mirrored as a faithful key event
+/// (``key(action:keycode:mods:consumedMods:unshiftedCodepoint:composing:text:)``)
+/// so control keys, arrows, and modifiers replay exactly; paste/drop are
+/// mirrored as paste-style ``text(_:)`` so bracketed-paste semantics match the
+/// source pane.
+@MainActor
+enum TerminalBroadcastInputPayload {
+    /// A key event mirroring a physical keystroke or IME commit.
+    case key(
+        action: ghostty_input_action_e,
+        keycode: UInt32,
+        mods: ghostty_input_mods_e,
+        consumedMods: ghostty_input_mods_e,
+        unshiftedCodepoint: UInt32,
+        composing: Bool,
+        text: String?
+    )
+
+    /// Committed paste/drop text delivered through the paste path
+    /// (`ghostty_surface_text`, i.e. bracketed paste when the program enables it).
+    case text(String)
+
+    /// Replays this event onto a peer terminal surface.
+    func deliver(to surface: TerminalSurface) {
+        switch self {
+        case let .key(action, keycode, mods, consumedMods, unshiftedCodepoint, composing, text):
+            surface.sendMirroredKeyEvent(
+                action: action,
+                keycode: keycode,
+                mods: mods,
+                consumedMods: consumedMods,
+                unshiftedCodepoint: unshiftedCodepoint,
+                composing: composing,
+                text: text
+            )
+        case let .text(text):
+            surface.sendText(text)
+        }
+    }
+}

--- a/Sources/TerminalController+ControlWorkspaceContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceContext.swift
@@ -176,11 +176,16 @@ extension TerminalController: ControlWorkspaceContext {
         guard let dstTM = AppDelegate.shared?.tabManagerFor(windowId: windowID) else {
             return .windowNotFound
         }
+        // Carry per-window input-broadcast state across the move.
+        let wasBroadcasting = srcTM.isBroadcastInputEnabled(for: workspaceID)
         guard let ws = srcTM.detachWorkspace(tabId: workspaceID) else {
             return .workspaceNotFound
         }
         let focus = v2FocusAllowed(requested: focusRequested)
         dstTM.attachWorkspace(ws, select: focus)
+        if wasBroadcasting {
+            dstTM.setBroadcastInputEnabled(true, for: workspaceID)
+        }
         if focus {
             _ = AppDelegate.shared?.focusMainWindow(windowId: windowID)
             setActiveTabManager(dstTM)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4010,7 +4010,8 @@ class TerminalController {
             "move_up", "move_down", "move_top",
             "close_others", "close_above", "close_below",
             "mark_read", "mark_unread",
-            "set_color", "clear_color"
+            "set_color", "clear_color",
+            "toggle_broadcast", "set_broadcast"
         ]
 
         var result: V2CallResult = .err(code: "invalid_params", message: "Unknown workspace action", data: [
@@ -4178,6 +4179,19 @@ class TerminalController {
             case "clear_color":
                 tabManager.setTabColor(tabId: workspace.id, color: nil)
                 finish(["color": NSNull()])
+
+            case "toggle_broadcast":
+                let enabled = !tabManager.isBroadcastInputEnabled(for: workspace.id)
+                tabManager.setBroadcastInputEnabled(enabled, for: workspace.id)
+                finish(["broadcast_input": enabled])
+
+            case "set_broadcast":
+                guard let enabled = v2Bool(params, "enabled") else {
+                    result = .err(code: "invalid_params", message: "Missing or invalid 'enabled' (expected boolean)", data: nil)
+                    return
+                }
+                tabManager.setBroadcastInputEnabled(enabled, for: workspace.id)
+                finish(["broadcast_input": enabled])
 
             default:
                 result = .err(code: "invalid_params", message: "Unknown workspace action", data: [
@@ -11355,6 +11369,8 @@ class TerminalController {
         var ok = false
         let focus = socketCommandAllowsInAppFocusMutations()
         v2MainSync {
+            let wasBroadcasting = AppDelegate.shared?.tabManagerFor(tabId: wsId)?
+                .isBroadcastInputEnabled(for: wsId) ?? false
             guard let srcTM = AppDelegate.shared?.tabManagerFor(tabId: wsId),
                   let dstTM = AppDelegate.shared?.tabManagerFor(windowId: windowId),
                   let ws = srcTM.detachWorkspace(tabId: wsId) else {
@@ -11362,6 +11378,9 @@ class TerminalController {
                 return
             }
             dstTM.attachWorkspace(ws, select: focus)
+            if wasBroadcasting {
+                dstTM.setBroadcastInputEnabled(true, for: wsId)
+            }
             if focus {
                 _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
                 setActiveTabManager(dstTM)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3677,6 +3677,12 @@ final class Workspace: Identifiable, ObservableObject {
             guard let self, let terminalPanel else { return false }
             return self.resumeAgentHibernation(panelId: terminalPanel.id, focus: focus)
         }
+        // Seed the input-broadcast hot-path cache so a pane created (or
+        // re-attached) while the workspace is broadcasting starts mirroring
+        // immediately. The authoritative state is TabManager's set.
+        terminalPanel.surface.setInputBroadcastEnabled(
+            owningTabManager?.isBroadcastInputEnabled(for: id) ?? false
+        )
     }
 
     private func configureBrowserPanel(_ browserPanel: BrowserPanel) {
@@ -10688,6 +10694,64 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         return visiblePanelIds
+    }
+
+    // MARK: - Input broadcast
+
+    /// Pushes the workspace-level input-broadcast flag down to every terminal
+    /// surface so the `keyDown`/IME/paste hooks can gate on a cheap per-surface
+    /// `Bool`. Called by the single mutation path (`TabManager`).
+    func applyInputBroadcastEnabled(_ enabled: Bool) {
+        for panel in panels.values {
+            (panel as? TerminalPanel)?.surface.setInputBroadcastEnabled(enabled)
+        }
+    }
+
+    /// Replays a captured input event from the focused pane onto every other
+    /// visible terminal pane in this workspace (iTerm2-style broadcast).
+    ///
+    /// Honors the current layout: in split layouts only rendered panes
+    /// (respecting zoom) receive input; in canvas layout each pane's selected
+    /// terminal does. The source pane is always excluded. Browser/non-terminal
+    /// panes are skipped.
+    func broadcastTerminalInput(_ payload: TerminalBroadcastInputPayload, from sourcePanelId: UUID) {
+        for panel in visibleTerminalPanelsForBroadcast(excluding: sourcePanelId) {
+            payload.deliver(to: panel.surface)
+        }
+    }
+
+    /// The visible peer terminal panes that should receive broadcast input,
+    /// excluding the source pane and de-duplicated across panes.
+    ///
+    /// Mirrors `renderedVisiblePanelIdsForCurrentLayout()`'s zoom/canvas logic
+    /// but is intentionally NOT gated on `portalRenderingEnabled` (broadcast
+    /// targets logically-visible panes regardless of portal rendering) and
+    /// resolves directly to `TerminalPanel`s.
+    private func visibleTerminalPanelsForBroadcast(excluding sourcePanelId: UUID) -> [TerminalPanel] {
+        var seen: Set<UUID> = [sourcePanelId]
+        var peers: [TerminalPanel] = []
+
+        func consider(_ panelId: UUID?) {
+            guard let panelId,
+                  seen.insert(panelId).inserted,
+                  let panel = terminalPanel(for: panelId) else { return }
+            peers.append(panel)
+        }
+
+        if layoutMode == .canvas {
+            for pane in canvasModel.layout.panes {
+                consider(pane.selectedPanelId.rawValue)
+            }
+            return peers
+        }
+
+        let renderedPaneIds = bonsplitController.zoomedPaneId.map { [$0] } ?? bonsplitController.allPaneIds
+        for paneId in renderedPaneIds {
+            let selectedTab = bonsplitController.selectedTab(inPane: paneId)
+                ?? bonsplitController.tabs(inPane: paneId).first
+            consider(selectedTab.flatMap { panelIdFromSurfaceId($0.id) })
+        }
+        return peers
     }
 
     func agentHibernationVisiblePanelIdsForCurrentLayout() -> Set<UUID> {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -26,6 +26,7 @@ private struct WorkspacePanelContentHostView: View {
     let windowAppearance: WindowAppearanceSnapshot
     let customSidebarTabManager: TabManager?
     let hasUnreadNotification: Bool
+    let showsBroadcastDot: Bool
     let onFocus: () -> Void
     let onRequestPanelFocus: () -> Void
     let onResumeAgentHibernation: () -> Void
@@ -46,6 +47,7 @@ private struct WorkspacePanelContentHostView: View {
             windowAppearance: windowAppearance,
             customSidebarTabManager: customSidebarTabManager,
             hasUnreadNotification: hasUnreadNotification,
+            showsBroadcastDot: showsBroadcastDot,
             terminalAgentContext: WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace),
             onFocus: onFocus,
             onRequestPanelFocus: onRequestPanelFocus,
@@ -121,6 +123,10 @@ struct WorkspaceContentView: View {
     /// (`isWorkspaceInputActive`) or drag interactivity — only the visual/active
     /// focus state — so the terminal stays visible (via `isSelectedInPane`).
     var rightSidebarOwnsInputFocus: Bool = false
+    /// Whether iTerm2-style input broadcast is enabled for this workspace.
+    /// Drives the per-pane broadcast dot. Sourced from the observed
+    /// `TabManager.broadcastInputWorkspaceIds` in `ContentView`.
+    let isInputBroadcastActive: Bool
     let isFullScreen: Bool
     let workspacePortalPriority: Int
     let windowAppearance: WindowAppearanceSnapshot
@@ -237,6 +243,9 @@ struct WorkspaceContentView: View {
                         isSplit: isSplit,
                         appearance: appearance, windowAppearance: windowAppearance, customSidebarTabManager: workspace.owningTabManager,
                         hasUnreadNotification: showsNotificationRing && !usesWorkspacePaneOverlay,
+                        // Show on every visible pane while broadcast is on (not just
+                        // splits) so the mode stays visible with the sidebar closed.
+                        showsBroadcastDot: isInputBroadcastActive && isVisibleInUI,
                         onFocus: {
                             // Keep bonsplit focus in sync with the AppKit first responder for the
                             // active workspace. This prevents divergence between the blue focused-tab

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1049,6 +1049,17 @@ struct cmuxApp: App {
 
             Divider()
 
+            splitCommandToggle(
+                title: String(localized: "menu.view.broadcastInput", defaultValue: "Broadcast Input to All Panes"),
+                isOn: activeTabManager.selectedWorkspace.map { activeTabManager.isBroadcastInputEnabled(for: $0.id) } ?? false,
+                shortcut: menuShortcut(for: .toggleWorkspaceInputBroadcast)
+            ) {
+                activeTabManager.toggleSelectedWorkspaceInputBroadcast()
+            }
+            .disabled(activeTabManager.selectedWorkspace == nil)
+
+            Divider()
+
             // Numbered workspace selection (9 = last workspace)
             ForEach(1...9, id: \.self) { number in
                 // `menuShortcut(for:)` already returns `.unbound` when the action
@@ -1386,6 +1397,20 @@ struct cmuxApp: App {
                 .keyboardShortcut(key, modifiers: shortcut.eventModifiers)
         } else {
             Button(title, action: action)
+        }
+    }
+
+    /// A menu toggle (renders a checkmark when `isOn`) that conditionally binds a
+    /// keyboard shortcut, mirroring ``splitCommandButton(title:shortcut:action:)``.
+    /// `action` runs on every toggle; the caller drives the authoritative state.
+    @ViewBuilder
+    func splitCommandToggle(title: String, isOn: Bool, shortcut: StoredShortcut, action: @escaping () -> Void) -> some View {
+        let binding = Binding(get: { isOn }, set: { _ in action() })
+        if let key = shortcut.keyEquivalent {
+            Toggle(title, isOn: binding)
+                .keyboardShortcut(key, modifiers: shortcut.eventModifiers)
+        } else {
+            Toggle(title, isOn: binding)
         }
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1047,6 +1047,7 @@
 		C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */; };
 		C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A502000000000000000001 /* TaskManagerWindowController.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
+		BC0ADCA570010000000000F1 /* TerminalBroadcastInputPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC0ADCA570010000000000F2 /* TerminalBroadcastInputPayload.swift */; };
 		E4D1768B7041CDE4F9A084A4 /* TerminalClearScreenKeepScrollbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 		C0DE00000000000000000C42 /* TerminalController+ControlAppFocusContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C41 /* TerminalController+ControlAppFocusContext.swift */; };
@@ -2309,6 +2310,7 @@
 		C7A507000000000000004530 /* TaskManagerViewSnapshotBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerViewSnapshotBoundaryTests.swift; sourceTree = "<group>"; };
 		C7A502000000000000000001 /* TaskManagerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerWindowController.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
+		BC0ADCA570010000000000F2 /* TerminalBroadcastInputPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalBroadcastInputPayload.swift; sourceTree = "<group>"; };
 		F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClearScreenKeepScrollbackTests.swift; sourceTree = "<group>"; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000C41 /* TerminalController+ControlAppFocusContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlAppFocusContext.swift"; sourceTree = "<group>"; };
@@ -3041,6 +3043,7 @@
 				B35750000000000000000001 /* VaultAgentRegistry.swift */,
 				D3284102A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift */,
 				77F5AB36771F1414A95E3330 /* GhosttyKeyModifiers.swift */,
+				BC0ADCA570010000000000F2 /* TerminalBroadcastInputPayload.swift */,
 				C5D0DEC0CF00000000000B1 /* CmuxConfigStore+ConfigStoreReloading.swift */,
 				D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
 				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
@@ -4942,6 +4945,7 @@
 				C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */,
 				C7A506000000000000000002 /* TaskManagerView.swift in Sources */,
 				C7A502000000000000000002 /* TaskManagerWindowController.swift in Sources */,
+				BC0ADCA570010000000000F1 /* TerminalBroadcastInputPayload.swift in Sources */,
 				C0DE00000000000000000C42 /* TerminalController+ControlAppFocusContext.swift in Sources */,
 				C0DE00000000000000000C82 /* TerminalController+ControlBrowserPanelContext.swift in Sources */,
 				CA52E0020000000000000000 /* TerminalController+ControlCanvasContext.swift in Sources */,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3924,3 +3924,49 @@ final class CrossWindowWorkspaceMoveTests: XCTestCase {
         XCTAssertTrue(destination.tabs.contains { $0.id == moving.id })
     }
 }
+
+@MainActor
+final class TabManagerInputBroadcastTests: XCTestCase {
+    func testToggleSelectedWorkspaceInputBroadcastPushesFlagToSurfaces() {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace()
+        manager.selectWorkspace(workspace)
+
+        XCTAssertFalse(manager.isBroadcastInputEnabled(for: workspace.id))
+
+        let terminalSurfaces = workspace.panels.values
+            .compactMap { $0 as? TerminalPanel }
+            .map(\.surface)
+        XCTAssertFalse(terminalSurfaces.isEmpty, "A new workspace should have at least one terminal surface")
+        XCTAssertTrue(terminalSurfaces.allSatisfy { !$0.inputBroadcastEnabled })
+
+        // Single mutation path shared by the menu, the Cmd+Shift+B shortcut, and the CLI.
+        XCTAssertTrue(manager.toggleSelectedWorkspaceInputBroadcast())
+        XCTAssertTrue(manager.isBroadcastInputEnabled(for: workspace.id))
+        XCTAssertTrue(
+            terminalSurfaces.allSatisfy { $0.inputBroadcastEnabled },
+            "Enabling broadcast must push the cached flag down to every terminal surface"
+        )
+
+        XCTAssertTrue(manager.toggleSelectedWorkspaceInputBroadcast())
+        XCTAssertFalse(manager.isBroadcastInputEnabled(for: workspace.id))
+        XCTAssertTrue(
+            terminalSurfaces.allSatisfy { !$0.inputBroadcastEnabled },
+            "Disabling broadcast must clear the cached flag on every terminal surface"
+        )
+    }
+
+    func testClosingBroadcastingWorkspaceClearsBroadcastState() {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace()
+
+        manager.setBroadcastInputEnabled(true, for: workspace.id)
+        XCTAssertTrue(manager.isBroadcastInputEnabled(for: workspace.id))
+
+        manager.closeWorkspace(workspace)
+        XCTAssertFalse(
+            manager.isBroadcastInputEnabled(for: workspace.id),
+            "Closing a workspace must drop it from the broadcast set"
+        )
+    }
+}

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -459,6 +459,25 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         XCTAssertFalse(shortcut.control)
     }
 
+    func testToggleWorkspaceInputBroadcastShortcutDefaultsAndMetadata() {
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.toggleWorkspaceInputBroadcast.label,
+            "Broadcast Input to All Panes"
+        )
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.toggleWorkspaceInputBroadcast.defaultsKey,
+            "shortcut.toggleWorkspaceInputBroadcast"
+        )
+
+        // Cmd+Shift+B (distinct from Cmd+B / Cmd+Opt+B sidebar toggles).
+        let shortcut = KeyboardShortcutSettings.Action.toggleWorkspaceInputBroadcast.defaultShortcut
+        XCTAssertEqual(shortcut.key, "b")
+        XCTAssertTrue(shortcut.command)
+        XCTAssertTrue(shortcut.shift)
+        XCTAssertFalse(shortcut.option)
+        XCTAssertFalse(shortcut.control)
+    }
+
     func testSaveFilePreviewShortcutDefaultsAndMetadata() {
         XCTAssertEqual(KeyboardShortcutSettings.Action.saveFilePreview.label, "Save File Preview")
         XCTAssertEqual(

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -251,6 +251,7 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "closeOtherTabsInPane", combos: [["⌥", "⌘", "T"]], description: { en: "Close other tabs in pane", ja: "ペイン内の他のタブを閉じる" } },
       { id: "reopenClosedBrowserPanel", combos: [["⌘", "⇧", "T"]], description: { en: "Reopen last closed", ja: "最後に閉じた項目を再度開く" } },
       { id: "toggleTerminalCopyMode", combos: [["⌘", "⇧", "M"]], description: { en: "Toggle terminal copy mode", ja: "ターミナルコピーモードを切り替え" } },
+      { id: "toggleWorkspaceInputBroadcast", combos: [["⌘", "⇧", "B"]], description: { en: "Broadcast input to all panes", ja: "すべてのペインに入力をブロードキャスト" } },
       { id: "clearScreenKeepScrollback", combos: [["⌘", "⇧", "K"]], description: { en: "Clear screen (keep scrollback)", ja: "画面をクリア（スクロールバックを保持）" } },
       { id: "focusTextBoxInput", combos: [["⌘", "⇧", "A"]], description: { en: "Switch focus between terminal and TextBox input", ja: "ターミナルとTextBox入力のフォーカスを切り替え" } },
       { id: "cycleTextBoxSubmitAction", combos: [["⇧", "Tab"]], description: { en: "Cycle TextBox submit action", ja: "TextBoxの送信アクションを切り替え" } },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1364,6 +1364,7 @@
               "reopenClosedBrowserPanel",
               "newSurface",
               "toggleTerminalCopyMode",
+              "toggleWorkspaceInputBroadcast",
               "focusTextBoxInput",
               "cycleTextBoxSubmitAction",
               "attachTextBoxFile",


### PR DESCRIPTION
## Summary
Adds an iTerm2-style **broadcast input** mode: when enabled for a workspace, input from the focused terminal pane is mirrored to every other visible terminal pane in that workspace. Reimplements the stale/conflicting #1313 fresh on current `main` (the terminal stack moved into Swift packages since that PR), and adds the extras requested in #2336 (a visual indicator + a CLI command).

Closes #1290
Closes #2336

## What's included
- **Per-workspace toggle** through one shared mutation path (`TabManager.setBroadcastInputEnabled(_:for:)`), reachable from:
  - the View menu — "Broadcast Input to All Panes"
  - a configurable shortcut, default **⌘⇧B** (`toggleWorkspaceInputBroadcast`)
  - the CLI/socket: `cmux workspace-action --action toggle-broadcast` and `--action set-broadcast --enabled <true|false>` (non-focus-stealing)
- **Input mirrored**: keystrokes (incl. control keys, arrows, modifiers via `flagsChanged`), committed IME/dictation text, paste, and text drops.
- **Layout-aware fan-out**: only visible peer panes receive input (respects split zoom and canvas layout); the source pane is always excluded. Paste/drop mirror plain insertable text only — file/image clipboards are a per-surface transfer, not PTY input.
- **Visual indicator** (so the mode is obvious even with the sidebar closed):
  - a small orange dot at the **top-right of each broadcasting pane** (drawn on the portal-hosted AppKit layer, above the terminal)
  - a matching dot on the **workspace's sidebar row** (consistent with how unread state shows in both places)
- **State preserved** when a workspace moves between windows (drag + both socket move paths).
- Localized (`menu.view.broadcastInput`, `shortcut.toggleWorkspaceInputBroadcast.label`) across all 19 catalog locales; shortcut registered in `KeyboardShortcutSettings`, the `CmuxSettings.ShortcutAction` package, `cmux.schema.json`, and the shortcuts docs data.

## Design notes
- The keyDown/IME/paste/drop hooks gate on a cheap per-surface `Bool` (`TerminalSurface.inputBroadcastEnabled`) before doing any work, so the typing hot path is unaffected when broadcast is off. The authoritative state is `TabManager.broadcastInputWorkspaceIds`; `setBroadcastInputEnabled(_:for:)` is the single mutation path and pushes the derived flag down to surfaces.
- Peers receive exactly what the source PTY received: key events replay via a new `TerminalSurface.sendMirroredKeyEvent(...)`, text/paste/drop via `sendText`.

## Testing
- Built and launched locally (Debug, tagged).
- Multi-agent adversarial review of the diff; all flagged issues fixed (notably: suppressed-key text divergence in the keyDown fallback branch, and paste mirroring for file-URL/rich-text clipboards).
- Unit tests: shortcut metadata + `TabManager` broadcast toggle/cleanup behavior.

## Known limitation
- In **canvas** layout, input is broadcast correctly but the pane dot is not shown (canvas terminals bypass the SwiftUI representable that drives it — same gap as the existing unread-notification ring). The sidebar dot still shows. Split layouts show the pane dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784385328&installation_id=133855650&pr_number=6387&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6387&signature=6b95835f376ef22051d583b5d66465bc0d60dc75729e01f0ea77d2238454f873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iTerm2‑style broadcast input. When enabled per workspace, input from the focused terminal pane is mirrored to all other visible panes; includes key press and release to prevent stuck keys.

- **New Features**
  - Per‑workspace toggle via View menu (“Broadcast Input to All Panes”), default Cmd+Shift+B, and CLI: `cmux workspace-action --action toggle-broadcast` or `set-broadcast --enabled <true|false>`; CLI/socket responses include `broadcast_input`.
  - Mirrors keystrokes (press/release, incl. modifiers/arrows), committed IME/dictation text, and plain‑text paste/drops; only if the source pane accepts it; source pane excluded; respects split zoom and canvas visibility.
  - Orange dot indicator on each pane and a matching dot on the workspace’s sidebar row; the pane dot overlays the terminal so it’s visible even with the sidebar closed.
  - Broadcast state is preserved when a workspace moves between windows (drag and both socket move paths).
  - Localized menu/shortcut labels across all catalog locales, including Khmer (`km`).

- **Refactors**
  - Kept `pasteAsPlainText(_:)` non‑private for test doubles and suppressed SwiftLint `private_action`; no behavior change.

Known limitation: in canvas layout, the pane dot is not shown (sidebar dot still shows).

<sup>Written for commit 6da6d883e041a67a7244951cade0a7898f2573b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace input broadcast to mirror eligible keyboard/IME and eligible clipboard text to all visible panes
  * Added per-workspace toggle (**Broadcast Input to All Panes**) with a visual broadcast indicator dot
  * Added default shortcut to toggle the current workspace: **Cmd+Shift+B**
  * Added CLI workspace actions: `toggle-broadcast` and `set-broadcast --enabled <true|false>` (with `broadcast_input` in results)

* **Bug Fixes**
  * Preserve broadcast input state when moving/detaching workspaces between windows

* **Tests**
  * Added unit tests for broadcast toggle propagation and clearing on workspace close

* **Documentation**
  * Updated localization strings, CLI help/examples, and shortcut configuration support for the new action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->