### PR TITLE
feat: add tab sidebar position setting (left / right)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to cmux are documented here.
 ## [0.64.16] - 2026-06-15
 
 ### Added
+- Tab sidebar position setting: move the vertical tab list to the left or right side of the window ([#6389](https://github.com/manaflow-ai/cmux/pull/6389))
 - Opt-in AI auto-naming of workspaces and tabs from your agent conversations ([#5547](https://github.com/manaflow-ai/cmux/pull/5547)) -- thanks @mvanhorn!
 - Per-workspace environment variables inherited by every shell in the workspace ([#6116](https://github.com/manaflow-ai/cmux/pull/6116))
 - Configurable file explorer double-click action: preview, default editor, or preferred editor ([#5827](https://github.com/manaflow-ai/cmux/pull/5827))

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarAppearanceCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarAppearanceCatalogSection.swift
@@ -68,5 +68,11 @@ public struct SidebarAppearanceCatalogSection: SettingCatalogSection {
         userDefaultsKey: "sidebarState"
     )
 
+    public let side = DefaultsKey<SidebarSideOption>(
+        id: "sidebarAppearance.side",
+        defaultValue: .left,
+        userDefaultsKey: "sidebarSide"
+    )
+
     public init() {}
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/SidebarSideOption.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/SidebarSideOption.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Which side of the window the vertical tab sidebar appears on.
+public enum SidebarSideOption: String, CaseIterable, Sendable, SettingCodable {
+    case left
+    case right
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
@@ -34,6 +34,7 @@ public struct SidebarSection: View {
     @State private var showLog: DefaultsValueModel<Bool>
     @State private var showProgress: DefaultsValueModel<Bool>
     @State private var showMetadata: DefaultsValueModel<Bool>
+    @State private var sidebarSide: DefaultsValueModel<SidebarSideOption>
     @State private var rightMaxWidth: DefaultsValueModel<Double>
     @State private var rememberedRightMaxWidth: DefaultsValueModel<Double>
 
@@ -60,6 +61,7 @@ public struct SidebarSection: View {
         _showLog = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.showLog))
         _showProgress = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.showProgress))
         _showMetadata = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.showCustomMetadata))
+        _sidebarSide = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebarAppearance.side))
         _rightMaxWidth = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.rightMaxWidth))
         _rememberedRightMaxWidth = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.sidebar.rememberedRightMaxWidth))
     }
@@ -169,6 +171,20 @@ public struct SidebarSection: View {
     @ViewBuilder
     private var mainCard: some View {
         SettingsCard {
+            SettingsCardRow(
+                configurationReview: .json("sidebarAppearance.side"),
+                String(localized: "settings.sidebarAppearance.side", defaultValue: "Tab Sidebar Position"),
+                subtitle: String(localized: "settings.sidebarAppearance.side.subtitle", defaultValue: "Choose which side the workspace tab list appears on.")
+            ) {
+                Picker("", selection: Binding(get: { sidebarSide.current }, set: { sidebarSide.set($0) })) {
+                    Text(String(localized: "settings.sidebarAppearance.side.left", defaultValue: "Left")).tag(SidebarSideOption.left)
+                    Text(String(localized: "settings.sidebarAppearance.side.right", defaultValue: "Right")).tag(SidebarSideOption.right)
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+            }
+            SettingsCardDivider()
+
             SettingsCardRow(
                 configurationReview: .json("sidebarAppearance.matchTerminalBackground"),
                 String(localized: "settings.sidebarAppearance.matchTerminalBackground", defaultValue: "Match Terminal Background"),

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1266,13 +1266,14 @@ struct ContentView: View {
     ) {
         switch handle {
         case .divider:
+            let dragSign: CGFloat = isSidebarOnRight ? -1 : 1
             return (
                 currentWidth: sidebarWidth,
                 captureStart: { sidebarDragStartWidth = sidebarWidth },
                 updateWidth: { translation in
                     let startWidth = sidebarDragStartWidth ?? sidebarWidth
                     let nextWidth = Self.clampedSidebarWidth(
-                        startWidth + translation,
+                        startWidth + dragSign * translation,
                         maximumWidth: maxSidebarWidth(availableWidth: availableWidth),
                         minimumWidth: minimumSidebarWidth
                     )
@@ -1460,9 +1461,17 @@ struct ContentView: View {
 
     private func dividerBandContains(pointInContent point: NSPoint, contentBounds: NSRect) -> Bool {
         guard point.y >= contentBounds.minY, point.y <= contentBounds.maxY else { return false }
-        if sidebarState.isVisible,
-           SidebarResizeInteraction.Edge.leading.hitRange(dividerX: sidebarWidth).contains(point.x) {
-            return true
+        if sidebarState.isVisible {
+            if isSidebarOnRight {
+                let sidebarDividerX = contentBounds.maxX - sidebarWidth
+                if SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: sidebarDividerX).contains(point.x) {
+                    return true
+                }
+            } else {
+                if SidebarResizeInteraction.Edge.leading.hitRange(dividerX: sidebarWidth).contains(point.x) {
+                    return true
+                }
+            }
         }
 
         let rightDividerX = contentBounds.maxX - rightSidebarWidth
@@ -1668,12 +1677,21 @@ struct ContentView: View {
     }
 
     private var sidebarResizerOverlay: some View {
-        placedSidebarResizerOverlay(
-            handle: .divider,
-            edge: .leading,
-            accessibilityIdentifier: "SidebarResizer",
-            dividerX: { totalWidth in min(max(sidebarWidth, 0), totalWidth) }
-        )
+        if isSidebarOnRight {
+            placedSidebarResizerOverlay(
+                handle: .divider,
+                edge: .trailing,
+                accessibilityIdentifier: "SidebarResizer",
+                dividerX: { totalWidth in totalWidth - min(max(sidebarWidth, 0), totalWidth) }
+            )
+        } else {
+            placedSidebarResizerOverlay(
+                handle: .divider,
+                edge: .leading,
+                accessibilityIdentifier: "SidebarResizer",
+                dividerX: { totalWidth in min(max(sidebarWidth, 0), totalWidth) }
+            )
+        }
     }
 
     private var rightSidebarResizerOverlay: some View {
@@ -1703,7 +1721,7 @@ struct ContentView: View {
             selectedTabIds: $selectedTabIds, lastSidebarSelectionIndex: $lastSidebarSelectionIndex, sidebarRenderWorkerClient: $sidebarRenderWorkerClient
         )
         .frame(width: sidebarWidth)
-        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxHeight: .infinity, alignment: isSidebarOnRight ? .topTrailing : .topLeading)
     }
 
     /// Native titlebar inset reported by AppKit. Standard mode follows cmux's visual chrome;
@@ -1897,7 +1915,8 @@ struct ContentView: View {
     }
 
     private func sidebarPanelWithBackdrop(appearance: WindowAppearanceSnapshot) -> some View {
-        sidebarPanelContainer(width: sidebarWidth, alignment: .leading, role: .leftSidebar, appearance: appearance) {
+        let alignment: Alignment = isSidebarOnRight ? .trailing : .leading
+        return sidebarPanelContainer(width: sidebarWidth, alignment: alignment, role: .leftSidebar, appearance: appearance) {
             sidebarView
         }
     }
@@ -1981,6 +2000,9 @@ struct ContentView: View {
     @AppStorage("sidebarState") private var sidebarStateSetting = SidebarStateOption.followWindow.rawValue
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
+    @AppStorage("sidebarSide") private var sidebarSide = SidebarSideOption.left.rawValue
+
+    private var isSidebarOnRight: Bool { sidebarSide == SidebarSideOption.right.rawValue }
 
     // Background glass settings
     @AppStorage("bgGlassTintHex") private var bgGlassTintHex = "#000000"
@@ -2079,10 +2101,12 @@ struct ContentView: View {
 
     private func customTitlebar(appearance: WindowAppearanceSnapshot) -> some View {
         let titlebarContentHeight = max(1, WindowChromeMetrics.appTitlebarHeight - 2)
+        // When the sidebar is on the right it doesn't block the traffic lights,
+        // so pass isSidebarVisible: false to avoid adding unnecessary leading padding.
         let leadingPadding = Self.customTitlebarLeadingPadding(
             isFullScreen: isFullScreen,
-            isSidebarVisible: sidebarState.isVisible,
-            sidebarWidth: sidebarWidth,
+            isSidebarVisible: isSidebarOnRight ? false : sidebarState.isVisible,
+            sidebarWidth: isSidebarOnRight ? 0 : sidebarWidth,
             minimumSidebarWidth: minimumSidebarWidth,
             titlebarLeadingInset: titlebarLeadingInset
         )
@@ -2139,7 +2163,10 @@ struct ContentView: View {
                 refreshNotificationName: .ghosttyDefaultBackgroundDidChange,
                 backgroundColorProvider: { GhosttyBackgroundTheme.currentColor() }
             )
-                .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
+                .padding(
+                    isSidebarOnRight ? .trailing : .leading,
+                    sidebarState.isVisible ? sidebarWidth : 0
+                )
         }
     }
 
@@ -2166,8 +2193,8 @@ struct ContentView: View {
                     // snaps without animation (`.transaction { $0.animation = nil }`), so we match
                     // that here — otherwise this inset could animate out of step with the panel on
                     // toggle and momentarily expose (or re-cover) the mode bar mid-transition.
-                    .padding(.trailing, rightSidebarWidth)
-                    .animation(nil, value: rightSidebarWidth)
+                    .padding(.trailing, rightSidebarWidth + (isSidebarOnRight && sidebarState.isVisible ? sidebarWidth : 0))
+                    .animation(nil, value: rightSidebarWidth + (isSidebarOnRight && sidebarState.isVisible ? sidebarWidth : 0))
             }
             .overlay(alignment: .topLeading) {
                 if let placement = Self.fullscreenControlsPlacement(
@@ -2442,38 +2469,69 @@ struct ContentView: View {
         let useWithinWindow = sidebarBlendMode == SidebarBlendModeOption.withinWindow.rawValue
             && !sidebarMatchTerminalBackground
         if useWithinWindow {
-            // Overlay mode keeps the left sidebar on top, but the right
-            // sidebar stays in an HStack so terminal rows are clipped before
-            // the sidebar backdrop samples the window.
-            layout = AnyView(
-                ZStack(alignment: .leading) {
-                    HStack(spacing: 0) {
-                        terminalContentWithSidebarDropOverlay(appearance: appearance)
-                            .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .layoutPriority(1)
-                        rightSidebarPanelWithBackdrop(appearance: appearance)
+            if isSidebarOnRight {
+                // Right-side overlay mode: push terminal+file-explorer left, overlay tab
+                // sidebar on the trailing edge.
+                layout = AnyView(
+                    ZStack(alignment: .trailing) {
+                        HStack(spacing: 0) {
+                            terminalContentWithSidebarDropOverlay(appearance: appearance)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .layoutPriority(1)
+                            rightSidebarPanelWithBackdrop(appearance: appearance)
+                        }
+                        .padding(.trailing, sidebarState.isVisible ? sidebarWidth : 0)
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                    if sidebarState.isVisible {
-                        sidebarPanelWithBackdrop(appearance: appearance)
+                )
+            } else {
+                // Overlay mode keeps the left sidebar on top, but the right
+                // sidebar stays in an HStack so terminal rows are clipped before
+                // the sidebar backdrop samples the window.
+                layout = AnyView(
+                    ZStack(alignment: .leading) {
+                        HStack(spacing: 0) {
+                            terminalContentWithSidebarDropOverlay(appearance: appearance)
+                                .padding(.leading, sidebarState.isVisible ? sidebarWidth : 0)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                                .layoutPriority(1)
+                            rightSidebarPanelWithBackdrop(appearance: appearance)
+                        }
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                }
-            )
+                )
+            }
         } else {
-            // Standard HStack mode for behindWindow blur
-            layout = AnyView(
-                HStack(spacing: 0) {
-                    if sidebarState.isVisible {
-                        sidebarPanelWithBackdrop(appearance: appearance)
+            if isSidebarOnRight {
+                // Standard HStack mode, tab sidebar on trailing edge
+                layout = AnyView(
+                    HStack(spacing: 0) {
+                        terminalContentWithRightSidebarPanel(appearance: appearance)
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
                     }
-                    terminalContentWithRightSidebarPanel(appearance: appearance)
-                }
-            )
+                )
+            } else {
+                // Standard HStack mode for behindWindow blur
+                layout = AnyView(
+                    HStack(spacing: 0) {
+                        if sidebarState.isVisible {
+                            sidebarPanelWithBackdrop(appearance: appearance)
+                        }
+                        terminalContentWithRightSidebarPanel(appearance: appearance)
+                    }
+                )
+            }
         }
 
         return AnyView(
             layout
-                .overlay(alignment: .leading) {
+                .overlay(alignment: isSidebarOnRight ? .trailing : .leading) {
                     if sidebarState.isVisible {
                         sidebarResizerOverlay
                             .zIndex(1000)

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -859,6 +859,12 @@
           "maximum": 1,
           "default": 0.03,
           "description": "Sidebar tint opacity from 0 to 1. Note: this only controls the sidebar tint, not terminal/window transparency. For terminal background transparency or blur, set `background-opacity` and `background-blur` in `~/.config/ghostty/config` and run `cmux reload-config`."
+        },
+        "side": {
+          "type": "string",
+          "enum": ["left", "right"],
+          "default": "left",
+          "description": "Which side of the window the workspace tab sidebar appears on."
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds a "Tab Sidebar Position" picker to Settings > Sidebar that lets users move
the vertical tab list to the left (default) or right side of the window. The
setting is persisted via UserDefaults and configurable in cmux.json as
`sidebarAppearance.side`.

## Changes

- `SidebarSideOption.swift` - new enum (`left` | `right`) with `SettingCodable` conformance
- `SidebarAppearanceCatalogSection.swift` - adds `sidebarAppearance.side` catalog key
- `SidebarSection.swift` - adds picker row at top of the Sidebar settings card
- `ContentView.swift` - layout branches for right-side mode: resizer drag direction,
  hit-test edge, divider position, frame/container alignment, HStack order, titlebar
  chrome border gap, and leading padding all flip correctly
- `Localizable.xcstrings` - en + ja keys for the picker label and both options
- `cmux.schema.json` - `sidebarAppearance.side` string property (`"left"` | `"right"`)

## Testing

No automated tests added. The layout branches in ContentView involve SwiftUI
view composition that is not currently covered by unit tests in this area.
Verified manually: toggled the picker between Left and Right, confirmed sidebar
moves, resize handle appears on the correct edge, dragging works, titlebar chrome
gap follows the active side, and toggling back to Left restores the original layout.
Both overlay (within-window) and standard blend modes were tested.


https://github.com/user-attachments/assets/c1554f2c-6f6e-4047-838d-cb5db06c37a5



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784386358&installation_id=133855650&pr_number=6389&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6389&signature=1e25deba5e24ba885e08a519f26a48868e581a7735cda8f915e4612c70c99789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Tab Sidebar Position setting to reposition the vertical tab list to either the left or right side of the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->