### PR TITLE
Refresh app chrome on OS appearance switch (#6385)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1273,6 +1273,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         AppIconLaunchState.markDidFinishLaunching()
         AppearanceSettingsUserDefaultsObserver.shared.startObserving()
+        // Bridge OS-driven appearance switches (scheduled Auto Light↔Dark) into
+        // the chrome-refresh path so the sidebar/titlebar re-resolve colors live
+        // instead of staying stale until a tab switch (#6385).
+        SystemAppearanceObserver.shared.startObserving()
         BrowserSystemProxyWatcher.shared.startObserving()
         if isRunningUnderXCTest {
             NSApp.setActivationPolicy(.regular)

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -309,6 +309,81 @@ final class AppearanceSettingsUserDefaultsObserver {
     }
 }
 
+extension Notification.Name {
+    /// Posted on the main thread whenever the system's effective appearance
+    /// changes (e.g. a macOS scheduled "Auto" Light↔Dark switch). Distinct from
+    /// the cmux appearance *setting* change tracked by
+    /// `AppearanceSettingsUserDefaultsObserver`: this fires when the OS — not the
+    /// user's cmux preference — flips appearance. See #6385.
+    static let systemAppearanceDidChange = Notification.Name("systemAppearanceDidChange")
+}
+
+/// Bridges OS-driven appearance switches into the app's chrome-refresh path.
+///
+/// When macOS flips appearance on a schedule (System Settings → Appearance →
+/// Auto), `NSApp.effectiveAppearance` updates and the terminal re-themes itself,
+/// but cmux's own chrome (sidebar text, titlebar) caches a color-scheme snapshot
+/// that is only invalidated by unrelated events — so it stays stale until a tab
+/// switch forces a re-render (#6385). This observer watches
+/// `NSApp.effectiveAppearance` and posts `.systemAppearanceDidChange`, which
+/// `ContentView` turns into a `scheduleTitlebarThemeRefresh(...)` — the same
+/// invalidation a tab switch triggers, just automatically.
+///
+/// It is intentionally separate from `AppIconAppearanceObserver`, which observes
+/// the same key path but is torn down whenever the app icon isn't in automatic
+/// mode, so it cannot be relied upon to refresh app chrome.
+final class SystemAppearanceObserver {
+    struct Environment {
+        let startEffectiveAppearanceObservation: (@escaping () -> Void) -> EffectiveAppearanceObservation?
+        let postNotification: () -> Void
+
+        static func live(notificationCenter: NotificationCenter = .default) -> Environment {
+            Environment(
+                startEffectiveAppearanceObservation: { handler in
+                    guard let app = NSApp else { return nil }
+                    return app.observe(\.effectiveAppearance, options: []) { _, _ in
+                        DispatchQueue.main.async {
+                            handler()
+                        }
+                    }
+                },
+                postNotification: {
+                    notificationCenter.post(name: .systemAppearanceDidChange, object: nil)
+                }
+            )
+        }
+    }
+
+    static let shared = SystemAppearanceObserver()
+
+    private let environment: Environment
+    private var observation: EffectiveAppearanceObservation?
+
+    init(environment: Environment = .live()) {
+        self.environment = environment
+    }
+
+    deinit {
+        stopObserving()
+    }
+
+    /// Begin observing `NSApp.effectiveAppearance`. Start this once launch has
+    /// completed (past the macOS Tahoe `App.init()` crash window for touching
+    /// `effectiveAppearance`). Idempotent.
+    func startObserving() {
+        guard observation == nil else { return }
+        observation = environment.startEffectiveAppearanceObservation { [weak self] in
+            guard let self, self.observation != nil else { return }
+            self.environment.postNotification()
+        }
+    }
+
+    func stopObserving() {
+        observation?.invalidate()
+        observation = nil
+    }
+}
+
 private struct AppearanceColorSchemeModifier: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     let rawValue: String?

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2666,6 +2666,14 @@ struct ContentView: View {
             )
         })
 
+        // A macOS scheduled Auto Light↔Dark switch updates NSApp.effectiveAppearance
+        // but does not bump titlebarThemeGeneration, so the cached sidebar color
+        // scheme stays stale until an unrelated event forces a re-render. Bridge the
+        // OS appearance change into the same refresh path a tab switch uses (#6385).
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .systemAppearanceDidChange)) { _ in
+            scheduleTitlebarThemeRefresh(reason: "systemAppearanceChanged")
+        })
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidFocusTab)) { _ in
             sidebarSelectionState.selection = .tabs
             scheduleTitlebarTextRefresh()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4325,16 +4325,16 @@ enum AppIconSettings {
     }
 }
 
-protocol AppIconAppearanceObservation: AnyObject {
+protocol EffectiveAppearanceObservation: AnyObject {
     func invalidate()
 }
 
-extension NSKeyValueObservation: AppIconAppearanceObservation {}
+extension NSKeyValueObservation: EffectiveAppearanceObservation {}
 
 final class AppIconAppearanceObserver: NSObject {
     struct Environment {
         let isApplicationFinishedLaunching: () -> Bool
-        let startEffectiveAppearanceObservation: (@escaping () -> Void) -> AppIconAppearanceObservation?
+        let startEffectiveAppearanceObservation: (@escaping () -> Void) -> EffectiveAppearanceObservation?
         let addDidFinishLaunchingObserver: (@escaping () -> Void) -> NSObjectProtocol
         let removeObserver: (NSObjectProtocol) -> Void
         let currentAppearanceIsDark: () -> Bool?
@@ -4382,7 +4382,7 @@ final class AppIconAppearanceObserver: NSObject {
 
     static let shared = AppIconAppearanceObserver()
     private let environment: Environment
-    private var observation: AppIconAppearanceObservation?
+    private var observation: EffectiveAppearanceObservation?
     private var launchObserver: NSObjectProtocol?
     private var hasDeferredStartPending = false
     private var lastAppliedImageName: String?

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -536,6 +536,91 @@ final class AppearanceSettingsTests: XCTestCase {
         XCTAssertEqual(synchronizedSource, "test.defaultsObserver")
     }
 
+    // MARK: - SystemAppearanceObserver (#6385)
+
+    private final class FakeEffectiveAppearanceObservation: EffectiveAppearanceObservation {
+        private(set) var invalidateCount = 0
+        func invalidate() { invalidateCount += 1 }
+    }
+
+    func testSystemAppearanceObserverPostsNotificationWhenEffectiveAppearanceChanges() {
+        var capturedHandler: (() -> Void)?
+        var postCount = 0
+        let observation = FakeEffectiveAppearanceObservation()
+
+        let observer = SystemAppearanceObserver(
+            environment: .init(
+                startEffectiveAppearanceObservation: { handler in
+                    capturedHandler = handler
+                    return observation
+                },
+                postNotification: { postCount += 1 }
+            )
+        )
+
+        observer.startObserving()
+        XCTAssertNotNil(capturedHandler, "startObserving should register an effective-appearance observation")
+        XCTAssertEqual(postCount, 0, "Observation start alone must not post a refresh")
+
+        // Simulate macOS flipping NSApp.effectiveAppearance (scheduled Auto switch).
+        capturedHandler?()
+        XCTAssertEqual(postCount, 1, "An effective-appearance change must post .systemAppearanceDidChange")
+
+        capturedHandler?()
+        XCTAssertEqual(postCount, 2, "Each subsequent appearance change must post again")
+    }
+
+    func testSystemAppearanceObserverStartIsIdempotent() {
+        var startCount = 0
+        let observer = SystemAppearanceObserver(
+            environment: .init(
+                startEffectiveAppearanceObservation: { _ in
+                    startCount += 1
+                    return FakeEffectiveAppearanceObservation()
+                },
+                postNotification: {}
+            )
+        )
+
+        observer.startObserving()
+        observer.startObserving()
+        XCTAssertEqual(startCount, 1, "Repeated startObserving must not register duplicate observations")
+    }
+
+    func testSystemAppearanceObserverStopInvalidatesAndSilencesFurtherChanges() {
+        var capturedHandler: (() -> Void)?
+        var postCount = 0
+        let observation = FakeEffectiveAppearanceObservation()
+
+        let observer = SystemAppearanceObserver(
+            environment: .init(
+                startEffectiveAppearanceObservation: { handler in
+                    capturedHandler = handler
+                    return observation
+                },
+                postNotification: { postCount += 1 }
+            )
+        )
+
+        observer.startObserving()
+        observer.stopObserving()
+        XCTAssertEqual(observation.invalidateCount, 1, "stopObserving must invalidate the KVO observation")
+
+        // A late KVO callback after teardown must not post a refresh.
+        capturedHandler?()
+        XCTAssertEqual(postCount, 0, "No refresh should be posted once the observer is stopped")
+    }
+
+    func testLiveSystemAppearanceObserverPostsToInjectedNotificationCenter() {
+        let notificationCenter = NotificationCenter()
+        let expectation = expectation(forNotification: .systemAppearanceDidChange, object: nil, notificationCenter: notificationCenter)
+
+        let environment = SystemAppearanceObserver.Environment.live(notificationCenter: notificationCenter)
+        environment.postNotification()
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     private func withTemporaryAppearanceDefaults(
         appearanceMode: String,
         appleInterfaceStyle: String?,

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -564,7 +564,7 @@ final class NotificationsPopoverAnchorPolicyTests: XCTestCase {
 }
 
 final class AppIconAppearanceObserverTests: XCTestCase {
-    private final class ObservationToken: AppIconAppearanceObservation {
+    private final class ObservationToken: EffectiveAppearanceObservation {
         private(set) var invalidateCallCount = 0
 
         func invalidate() {


### PR DESCRIPTION
## Summary

Fixes #6385 — when macOS switches appearance on a schedule (System Settings → Appearance → **Auto**, e.g. Light by day, Dark at night), cmux's own UI chrome (most visibly the **sidebar text**) stayed in the pre-switch color — black text on a now-dark sidebar — until an unrelated event forced a re-render. Switching tabs fixed it, which was the tell.

## Root cause

The terminal re-themes itself on an OS appearance change, but cmux freezes the sidebar/titlebar color scheme into `windowAppearanceSnapshot`, which only recomputes when the `@State` counter `titlebarThemeGeneration` is bumped by `scheduleTitlebarThemeRefresh(...)`. That refresh is driven by `.ghosttyDefaultBackgroundDidChange` and workspace/focus notifications — **nothing bumped it when `NSApp.effectiveAppearance` changed**. So the OS flipped appearance, the cached snapshot was never invalidated, and the chrome stayed stale until a tab switch (or resize) happened to force a `body` re-evaluation.

The only existing observers of `NSApp.effectiveAppearance` (`AppIconAppearanceObserver`, Dock-tile plugin) drive the app icon and are torn down when the icon isn't in automatic mode, so they can't be relied upon to refresh chrome.

## Fix

- Add an always-on `SystemAppearanceObserver` (`Sources/AppearanceSettings.swift`) that KVO-observes `NSApp.effectiveAppearance` and posts a new `.systemAppearanceDidChange` notification on the main thread.
- Start it once from `applicationDidFinishLaunching` (past the macOS Tahoe `App.init()` crash window for touching `effectiveAppearance`), alongside the existing `AppearanceSettingsUserDefaultsObserver`.
- In `ContentView`, observe `.systemAppearanceDidChange` with the same `.onReceive` pattern already used for `.ghosttyDefaultBackgroundDidChange` and call `scheduleTitlebarThemeRefresh(reason: "systemAppearanceChanged")` — reusing the proven `titlebarThemeGeneration` invalidation path. This mirrors what a tab switch already does, just automatically on the appearance change.
- Generalize the icon observer's `AppIconAppearanceObservation` protocol to `EffectiveAppearanceObservation` so both observers share the same testable seam.

This touches no color math and stays out of the typing-latency-sensitive view code — it only invalidates a cached snapshot the same way existing event handlers already do.

## Tests

Adds regression coverage in `cmuxTests/AppearanceSettingsTests.swift` (an already-wired test file) for `SystemAppearanceObserver`:

- posts `.systemAppearanceDidChange` on each effective-appearance change (and **not** merely on start);
- `startObserving()` is idempotent (no duplicate observations);
- `stopObserving()` invalidates the KVO observation and silences late callbacks;
- the live `Environment` posts to the injected `NotificationCenter`.

> **Note on the two-commit red/green convention:** it doesn't apply cleanly here because the regression tests reference the new `SystemAppearanceObserver` type, so a "test-only" first commit wouldn't compile (it'd be a build error, not a failing assertion). The tests are unit-level coverage of the new invalidation seam rather than a behavioral repro of the stale snapshot, which lives in SwiftUI view internals.

## Localization

No user-facing strings changed (internal observer + notification wiring only), so no `Localizable.xcstrings` / web message-catalog updates are required.

## Verification

⚠️ I could not run a local Xcode build — this environment only has Command Line Tools (no `Xcode.app`), so `xcodebuild`/`reload.sh` are unavailable. The change deliberately mirrors the existing `AppIconAppearanceObserver` / `AppearanceSettingsUserDefaultsObserver` patterns (same KVO-on-`effectiveAppearance`, same injectable `Environment`, same `static let shared` + `startObserving()` lifecycle) which already compile under this repo's Swift 6 config. CI build/test should confirm compilation, and a maintainer with the scheduled-Auto repro can confirm the sidebar now re-colors live without a tab switch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784388976&installation_id=133855650&pr_number=6390&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6390&signature=28715e71ccb027a59fb531636070ecedef36f15c4070d76199b07febcbef8044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6385 by refreshing app chrome when macOS switches between Light and Dark automatically. Sidebar and titlebar colors now update immediately without needing a tab switch.

- Bug Fixes
  - Added always-on `SystemAppearanceObserver` that watches `NSApp.effectiveAppearance` and posts `.systemAppearanceDidChange`.
  - Started the observer after launch; `ContentView` listens and calls `scheduleTitlebarThemeRefresh("systemAppearanceChanged")`.
  - Only invalidates the cached snapshot; no color math or rendering changes.

- Refactors
  - Generalized `AppIconAppearanceObservation` to `EffectiveAppearanceObservation` and updated usages.

<sup>Written for commit ea4a8e644b488d5a7800a233f1f1e46fcca5ba69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar and titlebar colors now update immediately when your system appearance changes between light and dark mode, instead of waiting for a tab switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->