### PR TITLE
remote-tmux: fix mirror buffer truncation on cross-DPI display move

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
@@ -88,7 +88,15 @@ extension TerminalSurface {
         }
         #endif
 
-        if scaleChanged {
+        // Apply the cell-size (set_content_scale) and screen-px (set_size) updates
+        // in an order that never transiently shrinks the grid (= screen_px /
+        // cell_px). Scale-first is fine except on a DPI increase, where the bigger
+        // cell over the not-yet-resized screen collapses the grid and truncates a
+        // manual-IO mirror's buffer — and a DPI move leaves the remote PTY size
+        // unchanged, so nothing repaints it back. Defer the scale past set_size in
+        // that case.
+        let deferScaleUntilResized = scaleChanged && sizeChanged && (xScale > lastXScale || yScale > lastYScale)
+        if scaleChanged && !deferScaleUntilResized {
             ghostty_surface_set_content_scale(surface, xScale, yScale)
             lastXScale = xScale
             lastYScale = yScale
@@ -117,6 +125,14 @@ extension TerminalSurface {
                     writeProcessOutputData(Self.decawmEnableSequence, to: surface)
                 }
             }
+        }
+
+        // Deferred from above on a DPI increase: now that set_size grew the grid,
+        // applying the larger cell only shrinks it back to the final width.
+        if deferScaleUntilResized {
+            ghostty_surface_set_content_scale(surface, xScale, yScale)
+            lastXScale = xScale
+            lastYScale = yScale
         }
 
         // Remote tmux display surfaces: keep the remote tmux client sized to


### PR DESCRIPTION
### Summary
Moving a remote-tmux mirror window between displays with different backing scale factors (e.g. a 2× Retina display ↔ a 1× external display) truncates the mirrored terminal content to a narrow column count. It stays truncated until the window is manually resized — moving *back* to the original display does **not** fix it.

### Root cause
`TerminalSurface.updateSize` applies the two grid-affecting Ghostty calls separately — `ghostty_surface_set_content_scale` (cell size / DPI) and `ghostty_surface_set_size` (screen size in px) — and the terminal grid is `screen_px / cell_px`. On a DPI **increase**, applying the larger new cell while the screen is still at the old pixel size transiently collapses the grid (e.g. 97 → ~48 columns). That shrink discards the columns beyond the new width from the manual-I/O mirror's local buffer. Because a pure DPI move doesn't change the remote tmux pane size, the remote app receives no `SIGWINCH` and never repaints the dropped columns — so the mirror stays narrow until a real resize.

### Fix
Apply the two updates in an order that never shrinks the intermediate grid below the final width: keep the default scale-then-size order (correct in every case except a DPI increase) and, on a DPI increase, defer `set_content_scale` until after `set_size`. DECAWM / refresh handling is unchanged. One file, +17 / −1.

### Testing
Dogfooded: an `ssh-tmux` mirror running a full-screen TUI, moved between 2× and 1× displays in both directions repeatedly — content stays full-width with no manual resize.

### Before / after

**Before (bug):**
<img width="2118" height="1474" alt="broken" src="https://github.com/user-attachments/assets/76fb11c3-f453-4d42-ae54-87bbaf3bb9a0" />

**After (fix):**
<img width="2122" height="1466" alt="fixed" src="https://github.com/user-attachments/assets/f5669960-a719-4005-a900-a22def00d2fa" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784398356&installation_id=133855650&pr_number=6393&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6393&signature=569c5b7ce19d6e2975844245538e0b9c6254f21bfce642e606b4750b93d05f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal rendering when macOS display scaling changes during window resizing, ensuring correct visual sizing when scale and grid dimensions update together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->