### PR TITLE
Fix blank SF Symbol controls on macOS 27

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12533,9 +12533,7 @@ private struct SidebarHelpMenuButton: View {
 
     private func helpOptionTrailingIcon(systemName: String, size: CGFloat = 13) -> some View {
         Image(systemName: systemName)
-            .resizable()
-            .scaledToFit()
-            .frame(width: size, height: size)
+            .cmuxSymbolRasterSize(size)
             .foregroundStyle(Color(nsColor: .secondaryLabelColor))
     }
 
@@ -13304,7 +13302,7 @@ struct TabItemView: View, Equatable {
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
                         Image(systemName: "xmark")
-                            .font(.system(size: scaledFontSize(9), weight: .medium))
+                            .cmuxSymbolRasterSize(scaledFontSize(9), weight: .medium)
                             .foregroundColor(activeSecondaryColor(0.7))
                             .frame(width: scaledCloseButtonWidth, height: scaledCloseButtonHitSize, alignment: .center)
                             .contentShape(Rectangle())

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -194,9 +194,7 @@ struct PanelHeaderIconGlyph: View {
 
     var body: some View {
         Image(systemName: systemName)
-            .resizable()
-            .scaledToFit()
-            .frame(width: 13, height: 13)
+            .cmuxSymbolRasterSize(13)
             .frame(width: 20, height: 20, alignment: .center)
             .contentShape(Rectangle())
     }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -67,15 +67,14 @@ enum RenderableSystemSymbol {
 }
 
 extension Image {
-    /// Sizes SF Symbols from an explicit positive frame instead of transient font metrics.
+    /// Keeps a positive symbol frame while avoiding the blank-prone resizable SF Symbol rasterizer.
     func cmuxSymbolRasterSize(
         _ pointSize: CGFloat,
         weight: Font.Weight? = nil,
         alignment: Alignment = .center
     ) -> some View {
         let rasterSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
-        return resizable()
-            .scaledToFit()
+        return font(.system(size: rasterSize))
             .fontWeight(weight)
             .frame(width: rasterSize, height: rasterSize, alignment: alignment)
     }

--- a/Sources/RenderableSystemSymbol.swift
+++ b/Sources/RenderableSystemSymbol.swift
@@ -74,8 +74,8 @@ extension Image {
         alignment: Alignment = .center
     ) -> some View {
         let rasterSize = RenderableSystemSymbol.clampedRasterPointSize(pointSize)
-        return font(.system(size: rasterSize))
-            .fontWeight(weight)
+        let systemFont: Font = weight.map { .system(size: rasterSize, weight: $0) } ?? .system(size: rasterSize)
+        return font(systemFont)
             .frame(width: rasterSize, height: rasterSize, alignment: alignment)
     }
 }


### PR DESCRIPTION
Closes #6388

## Summary
- Stop sizing cmux SF Symbol control glyphs through SwiftUI's `.resizable().scaledToFit()` symbol rasterization path.
- Keep the previous positive-size clamp and explicit frame so the macOS 27 zero-size raster crash fix is preserved.
- Route the sidebar/tab close `xmark`, help-menu trailing icons, and panel header glyphs through the shared `cmuxSymbolRasterSize` helper.

## Hypothesis and fix
The macOS 27.0 beta seed can return a non-nil `NSImage(systemSymbolName:)` while later SwiftUI rasterization draws an empty glyph. The common blank-prone path was cmux's explicit SF Symbol sizing helper, which used `.resizable().scaledToFit()` on `Image(systemName:)`. This PR changes the helper to use a fixed positive point-size font plus an explicit frame instead, avoiding that resizable SF Symbol rasterizer while preserving bounded layout.

## Verification
- Ran `git diff --check`.
- Searched `Sources/` for remaining `Image(systemName:)` + `.resizable().scaledToFit()` patterns; none remain.
- Did not run a local build or tests before PR handoff because #6388 is macOS 27 seed-specific and the requested workflow defers building until after CI is green and explicit launch approval.

I cannot verify the exact blank-glyph symptom on this host: the current machine is macOS 26, and the local cloud-mac provisioning tooling exposes a macOS 26 runner label (`warp-macos-26-arm64-6x`), not macOS 27.0 beta build 26A5353q. A macOS 27 user should verify that toolbar/sidebar/browser control SF Symbol glyphs are visible, especially the hover-only tab/workspace close `xmark`, and that the app still launches without the previous zero-size SF Symbol rasterization crash.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784400486&installation_id=133855650&pr_number=6396&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6396&signature=0ab892332dd67919c864ca45bbbfe8a6dfafe4bfefe264fa573632f51576d1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank SF Symbol controls on macOS 27 by using a fixed point-size system font with an explicit frame instead of the resizable rasterizer. Keeps the positive-size clamp to prevent the previous zero-size raster crash.

- **Bug Fixes**
  - Replaced `.resizable().scaledToFit()` with `.cmuxSymbolRasterSize(...)`, which applies `.font(.system(size:..., weight:...))` and an explicit frame to avoid blank glyphs on macOS 27.
  - Updated sidebar/tab close `xmark`, help-menu trailing icons, and panel header glyphs to use the helper, with weight passed where needed.

<sup>Written for commit 9eacf56902b1fc94b88cbf38ece9cc2dee63729d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sidebar help and workspace row icons to render with consistent SF Symbol sizing.
  * Updated panel header icon rendering for more reliable, crisp symbol display across different icon weights and layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->