### PR TITLE
Fix OpenCode resume after tui-settings capture

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -124,7 +124,13 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: antigravityPolicy)
         case "opencode":
             var tail = args
-            while let first = tail.first, isOpenCodeInternalArgument(first) { tail.removeFirst() }
+            while let first = tail.first {
+                let normalized = first.replacingOccurrences(of: "\\", with: "/")
+                let isInternalArgument = first == "tui-settings" || (normalized.contains("/$bunfs/") &&
+                    normalized.contains("/src/cli/cmd/tui/worker.js"))
+                guard isInternalArgument else { break }
+                tail.removeFirst()
+            }
             return preserveOptions(tail, policy: openCodePolicy)
         case "rovodev":
             var tail = args
@@ -557,9 +563,4 @@ public enum AgentLaunchSanitizer {
         return String(data: userData, encoding: .utf8)
     }
 
-    private static func isOpenCodeInternalArgument(_ value: String) -> Bool {
-        let normalized = value.replacingOccurrences(of: "\\", with: "/")
-        return value == "tui-settings" || (normalized.contains("/$bunfs/") &&
-            normalized.contains("/src/cli/cmd/tui/worker.js"))
-    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -123,10 +123,9 @@ public enum AgentLaunchSanitizer {
         case "antigravity":
             return preserveOptions(args, policy: antigravityPolicy)
         case "opencode":
-            return preserveOptions(
-                args.filter { !isOpenCodeInternalArgument($0) },
-                policy: openCodePolicy
-            )
+            var tail = args
+            while let first = tail.first, isOpenCodeInternalArgument(first) { tail.removeFirst() }
+            return preserveOptions(tail, policy: openCodePolicy)
         case "rovodev":
             var tail = args
             if tail.first == "rovodev" {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -124,7 +124,7 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: antigravityPolicy)
         case "opencode":
             return preserveOptions(
-                args.filter { !isOpenCodeInternalWorkerArgument($0) },
+                args.filter { !isOpenCodeInternalArgument($0) },
                 policy: openCodePolicy
             )
         case "rovodev":
@@ -558,9 +558,9 @@ public enum AgentLaunchSanitizer {
         return String(data: userData, encoding: .utf8)
     }
 
-    private static func isOpenCodeInternalWorkerArgument(_ value: String) -> Bool {
+    private static func isOpenCodeInternalArgument(_ value: String) -> Bool {
         let normalized = value.replacingOccurrences(of: "\\", with: "/")
-        return normalized.contains("/$bunfs/") &&
-            normalized.contains("/src/cli/cmd/tui/worker.js")
+        return value == "tui-settings" || (normalized.contains("/$bunfs/") &&
+            normalized.contains("/src/cli/cmd/tui/worker.js"))
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -84,6 +84,28 @@ struct AgentResumeArgvTests {
                 ]
             ) == .resolved(["cmux", "omo", "--session", "SID", "--model", "anthropic/claude-sonnet-4-6"])
         )
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "opencode",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: [
+                    "opencode",
+                    "--agent",
+                    "tui-settings",
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                ]
+            ) == [
+                "opencode",
+                "--session",
+                "SID",
+                "--agent",
+                "tui-settings",
+                "--model",
+                "anthropic/claude-sonnet-4-6",
+            ]
+        )
     }
 
     @Test("Captured executable path overrides the fallback executable")

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -55,6 +55,37 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("OpenCode resume drops internal TUI settings selector")
+    func opencodeResumeDropsInternalTUISettingsSelector() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "opencode",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: [
+                    "opencode",
+                    "tui-settings",
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                ]
+            ) == ["opencode", "--session", "SID", "--model", "anthropic/claude-sonnet-4-6"]
+        )
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "omo",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: [
+                    "cmux",
+                    "omo",
+                    "tui-settings",
+                    "--model",
+                    "anthropic/claude-sonnet-4-6",
+                ]
+            ) == .resolved(["cmux", "omo", "--session", "SID", "--model", "anthropic/claude-sonnet-4-6"])
+        )
+    }
+
     @Test("Captured executable path overrides the fallback executable")
     func executablePathOverridesFallback() {
         // Non-claude kinds replay the captured executable path verbatim.


### PR DESCRIPTION
## Summary
- Strip OpenCode's internal `tui-settings` selector from captured resume argv before rebuilding resume commands.
- Keep existing OpenCode worker-path filtering and preserve normal resume flags like `--model`.
- Add a regression covering both direct `opencode` resume and the `omo` wrapper path.

## Tests
- `swift test --package-path Packages/macOS/CMUXAgentLaunch --filter AgentResumeArgvTests` (fails on the test-only commit, passes after the fix)
- `swift test --package-path Packages/macOS/CMUXAgentLaunch`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`

Closes #6395

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784400952&installation_id=133855650&pr_number=6397&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6397&signature=40848b1fe5b811f42cc7f1cac4a77db205d76580166c84a1fbc46d09b9efc265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpenCode resume after capturing TUI settings by dropping the leading internal `tui-settings` selector from captured argv, while preserving it when used as a flag value. Resume commands now rebuild correctly for `opencode` and `omo`, keeping user flags like `--model`.

- **Bug Fixes**
  - In `AgentLaunchSanitizer`, drop only leading internal tokens for `opencode` (`tui-settings` selector or `$bunfs` TUI worker path) by inlining the detection.
  - Preserve normal flags and `--session` injection; keep `"tui-settings"` when passed as `--agent` value. Adds regression tests for direct `opencode` and the `omo` wrapper. Addresses #6395.

<sup>Written for commit 490dd64ed7542c410ae52c9630b3c4e81bd9dc4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode launch argument sanitization to more precisely remove internal configuration arguments, including `tui-settings`, while preserving the correct leading options.

* **Tests**
  * Added unit coverage for resume command construction to ensure internal `tui-settings` is dropped when appropriate, with `--session` and `--model` preserved and `--agent tui-settings` handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->