### PR TITLE
ci: self-heal resolve clears whole .ci-source-packages on incomplete artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,11 +367,11 @@ jobs:
               # .ci-source-packages can make resolve report success without the
               # binary artifacts (Sparkle/Sentry) actually present, which then
               # fails the build. Verify they materialized; if not, clear and retry.
-              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && ls -d "$SOURCE_PACKAGES_DIR"/artifacts/sentry-cocoa/*/*.xcframework >/dev/null 2>&1; then
+              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && [ -d "$SOURCE_PACKAGES_DIR/artifacts/sentry-cocoa/Sentry/Sentry.xcframework" ]; then
                 exit 0
               fi
               echo "Resolve succeeded but binary artifacts are missing (stale cache); clearing and retrying" >&2
-              rm -rf "$SOURCE_PACKAGES_DIR/artifacts"
+              rm -rf "$SOURCE_PACKAGES_DIR"  # whole dir — resolve will not re-materialize artifacts into a partial tree
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "Failed to resolve Swift packages after 3 attempts" >&2
@@ -792,11 +792,11 @@ jobs:
               # .ci-source-packages can make resolve report success without the
               # binary artifacts (Sparkle/Sentry) actually present, which then
               # fails the build. Verify they materialized; if not, clear and retry.
-              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && ls -d "$SOURCE_PACKAGES_DIR"/artifacts/sentry-cocoa/*/*.xcframework >/dev/null 2>&1; then
+              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && [ -d "$SOURCE_PACKAGES_DIR/artifacts/sentry-cocoa/Sentry/Sentry.xcframework" ]; then
                 exit 0
               fi
               echo "Resolve succeeded but binary artifacts are missing (stale cache); clearing and retrying" >&2
-              rm -rf "$SOURCE_PACKAGES_DIR/artifacts"
+              rm -rf "$SOURCE_PACKAGES_DIR"  # whole dir — resolve will not re-materialize artifacts into a partial tree
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "Failed to resolve Swift packages after 3 attempts" >&2
@@ -1288,11 +1288,11 @@ jobs:
               # .ci-source-packages can make resolve report success without the
               # binary artifacts (Sparkle/Sentry) actually present, which then
               # fails the build. Verify they materialized; if not, clear and retry.
-              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && ls -d "$SOURCE_PACKAGES_DIR"/artifacts/sentry-cocoa/*/*.xcframework >/dev/null 2>&1; then
+              if [ -d "$SOURCE_PACKAGES_DIR/artifacts/sparkle/Sparkle/Sparkle.xcframework" ] && [ -d "$SOURCE_PACKAGES_DIR/artifacts/sentry-cocoa/Sentry/Sentry.xcframework" ]; then
                 exit 0
               fi
               echo "Resolve succeeded but binary artifacts are missing (stale cache); clearing and retrying" >&2
-              rm -rf "$SOURCE_PACKAGES_DIR/artifacts"
+              rm -rf "$SOURCE_PACKAGES_DIR"  # whole dir — resolve will not re-materialize artifacts into a partial tree
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "Failed to resolve Swift packages after 3 attempts" >&2


### PR DESCRIPTION
Fixes intermittent 'no XCFramework found (Sparkle/Sentry)' on main: incomplete restored Swift-package cache passed the old loose verify, and clearing only artifacts didn't re-materialize them. Now verifies the exact required frameworks and clears the whole .ci-source-packages on miss so the retry does a full clean resolve.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784415141&installation_id=133855650&pr_number=6403&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6403&signature=178a118a1f0d4e86341e9b415a448ac4ba7ef6d964537c12d865d06fe70d0e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to cache validation and cleanup; no app, auth, or release logic touched.
> 
> **Overview**
> **Tightens the Swift package resolve self-heal step** used after restoring `.ci-source-packages` in the macOS CI jobs (`tests`, `tests-build-and-lag`, `ui-regressions`).
> 
> After `xcodebuild -resolvePackageDependencies`, the post-resolve check now requires **exact** Sparkle and Sentry binary paths (`Sparkle.xcframework` and `Sentry/Sentry.xcframework`) instead of a loose glob for any Sentry xcframework under `sentry-cocoa`. That closes the gap where a partial or stale cache could still pass verification and later fail with missing XCFramework errors.
> 
> When verification fails, the retry path **deletes the entire** `.ci-source-packages` directory (not only `artifacts/`), so the next attempt does a full clean resolve instead of leaving a partial tree that Xcode would not fully repopulate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb3f84c6ab78dfa232ca3185174616ecc5e057c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents intermittent "no XCFramework found" CI failures by validating the exact `Sparkle` and `Sentry` artifacts and, if missing, clearing the entire `.ci-source-packages` to force a clean SwiftPM resolve.

- **Bug Fixes**
  - Verify `artifacts/sparkle/Sparkle/Sparkle.xcframework` and `artifacts/sentry-cocoa/Sentry/Sentry.xcframework` instead of using a loose wildcard match.
  - On a miss, remove the whole `.ci-source-packages` directory (not just `artifacts`) so the retry re-materializes all required binaries.

<sup>Written for commit 9cb3f84c6ab78dfa232ca3185174616ecc5e057c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline reliability by strengthening package dependency cache validation and recovery mechanisms. The build system now explicitly verifies that required dependencies are properly obtained and automatically detects and clears corrupted cache entries, retrying the resolution process. This prevents intermittent build failures and enhances overall development workflow stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->