### PR TITLE
Fix notification jump focus for nested tabs

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3397,12 +3397,9 @@ class TabManager: ObservableObject {
             return false
         }
         let requestedPanelId = surfaceId.flatMap { panelId(forSurfaceOrPanelId: $0, in: tab) }
-        if let requestedSurfaceId = surfaceId, requestedPanelId == nil {
+        if let surfaceId, requestedPanelId == nil {
 #if DEBUG
-            cmuxDebugLog(
-                "notification.focus.fail tab=\(tabId.uuidString.prefix(5)) " +
-                "panel=\(requestedSurfaceId.uuidString.prefix(5)) reason=missingPanel"
-            )
+            cmuxDebugLog("notification.focus.fail tab=\(tabId.uuidString.prefix(5)) panel=\(surfaceId.uuidString.prefix(5)) reason=missingPanel")
 #endif
             return false
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3396,16 +3396,17 @@ class TabManager: ObservableObject {
 #endif
             return false
         }
-        if let surfaceId, tab.panels[surfaceId] == nil {
+        let requestedPanelId = surfaceId.flatMap { panelId(forSurfaceOrPanelId: $0, in: tab) }
+        if let requestedSurfaceId = surfaceId, requestedPanelId == nil {
 #if DEBUG
             cmuxDebugLog(
                 "notification.focus.fail tab=\(tabId.uuidString.prefix(5)) " +
-                "panel=\(surfaceId.uuidString.prefix(5)) reason=missingPanel"
+                "panel=\(requestedSurfaceId.uuidString.prefix(5)) reason=missingPanel"
             )
 #endif
             return false
         }
-        let desiredPanelId = surfaceId ?? tab.focusedPanelId
+        let desiredPanelId = requestedPanelId ?? tab.focusedPanelId
 #if DEBUG
         if let desiredPanelId {
             AppDelegate.shared?.armJumpUnreadFocusRecord(tabId: tabId, surfaceId: desiredPanelId)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -768,6 +768,7 @@
 		C5B6A10000000000000000B1 /* TabManager+SidebarGitHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B6A10000000000000000B2 /* TabManager+SidebarGitHosting.swift */; };
 		604500100000000000000007 /* TabManager+WindowTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604500100000000000000008 /* TabManager+WindowTitle.swift */; };
 		A5001003 /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001013 /* TabManager.swift */; };
+		C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */; };
 		2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
@@ -1720,6 +1721,7 @@
 		C5B6A10000000000000000B2 /* TabManager+SidebarGitHosting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+SidebarGitHosting.swift"; sourceTree = "<group>"; };
 		604500100000000000000008 /* TabManager+WindowTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+WindowTitle.swift"; sourceTree = "<group>"; };
 		A5001013 /* TabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
+		C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerNotificationFocusRegressionTests.swift; sourceTree = "<group>"; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
@@ -2903,6 +2905,7 @@
 				596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */,
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
+				C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 				C0793DC7D7B61CF54886EC36 /* RemoteTmuxControlParserTests.swift */,
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
@@ -4255,6 +4258,7 @@
 				62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
 				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
+				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,

--- a/cmuxTests/TabManagerNotificationFocusRegressionTests.swift
+++ b/cmuxTests/TabManagerNotificationFocusRegressionTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct TabManagerNotificationFocusRegressionTests {
+    @Test
+    func focusTabFromNotificationAcceptsBonsplitSurfaceIdForNestedTabNotification() async throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let firstPanelId = try #require(workspace.focusedPanelId)
+        let paneId = try #require(workspace.bonsplitController.focusedPaneId)
+        _ = workspace.newTerminalSurface(inPane: paneId, focus: false)
+        let thirdPanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let thirdSurfaceId = try #require(workspace.surfaceIdFromPanelId(thirdPanel.id)?.uuid)
+
+        workspace.focusPanel(firstPanelId)
+        #expect(workspace.focusedPanelId == firstPanelId)
+        #expect(manager.focusTabFromNotification(workspace.id, surfaceId: thirdSurfaceId))
+        await drainMainQueue()
+        await drainMainQueue()
+
+        #expect(workspace.focusedPanelId == thirdPanel.id)
+        #expect(workspace.bonsplitController.selectedTab(inPane: paneId)?.id.uuid == thirdSurfaceId)
+    }
+
+    private func drainMainQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+}

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2219,6 +2219,29 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertEqual(workspace.focusedPanelId, rightPanel.id, "Expected notification target panel to be focused")
     }
 
+    func testFocusTabFromNotificationAcceptsBonsplitSurfaceIdForNestedTabNotification() throws {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let paneId = workspace.bonsplitController.focusedPaneId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+        _ = workspace.newTerminalSurface(inPane: paneId, focus: false)
+        let thirdPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let thirdSurfaceId = try XCTUnwrap(workspace.surfaceIdFromPanelId(thirdPanel.id)?.uuid)
+
+        workspace.focusPanel(firstPanelId)
+        XCTAssertEqual(workspace.focusedPanelId, firstPanelId)
+
+        XCTAssertTrue(manager.focusTabFromNotification(workspace.id, surfaceId: thirdSurfaceId))
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(workspace.focusedPanelId, thirdPanel.id)
+        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id.uuid, thirdSurfaceId)
+    }
+
     func testFocusTabFromNotificationReturnsFalseForMissingPanel() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace else {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2219,29 +2219,6 @@ final class TabManagerNotificationFocusTests: XCTestCase {
         XCTAssertEqual(workspace.focusedPanelId, rightPanel.id, "Expected notification target panel to be focused")
     }
 
-    func testFocusTabFromNotificationAcceptsBonsplitSurfaceIdForNestedTabNotification() throws {
-        let manager = TabManager()
-        guard let workspace = manager.selectedWorkspace,
-              let firstPanelId = workspace.focusedPanelId,
-              let paneId = workspace.bonsplitController.focusedPaneId else {
-            XCTFail("Expected selected workspace with focused panel")
-            return
-        }
-        _ = workspace.newTerminalSurface(inPane: paneId, focus: false)
-        let thirdPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
-        let thirdSurfaceId = try XCTUnwrap(workspace.surfaceIdFromPanelId(thirdPanel.id)?.uuid)
-
-        workspace.focusPanel(firstPanelId)
-        XCTAssertEqual(workspace.focusedPanelId, firstPanelId)
-
-        XCTAssertTrue(manager.focusTabFromNotification(workspace.id, surfaceId: thirdSurfaceId))
-        drainMainQueue()
-        drainMainQueue()
-
-        XCTAssertEqual(workspace.focusedPanelId, thirdPanel.id)
-        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id.uuid, thirdSurfaceId)
-    }
-
     func testFocusTabFromNotificationReturnsFalseForMissingPanel() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace else {


### PR DESCRIPTION
Summary
- Add a regression test for notification focus when the notification target is a Bonsplit nested tab UUID.
- Normalize notification focus targets in TabManager so panel UUIDs and Bonsplit tab UUIDs both resolve to the intended panel before focusing.

Testing
- RED before fix: xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-notiftab-test -only-testing:cmuxTests/TabManagerNotificationFocusTests/testFocusTabFromNotificationAcceptsBonsplitSurfaceIdForNestedTabNotification\n- PASS after fix: same focused test\n- PASS: xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-notiftab-test -only-testing:cmuxTests/TabManagerNotificationFocusTests\n- PASS: ./scripts/reload-cloud.sh --tag nftab\n- PASS preflight: launched tagged app, created a workspace with three nested terminal tabs, queued a third-tab notification, jumped from another workspace, verified selectedTabId and selected surface are the third tab, captured screenshot /var/folders/rr/vmfx6xh12dz2tlvgtmyvjmf80000gn/T/cmux-screenshots/nftab-preflight_2026-06-19T02-06-44Z_2A401BF6.png\n\nLocalization\n- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784426849&installation_id=133855650&pr_number=6416&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6416&signature=0013eb52747846d1cbfdc26c6f611f2c985ec74936278f9e92de8de1dd3912a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to notification focus resolution aligned with existing `focusTab` behavior; test-only addition otherwise.
> 
> **Overview**
> Fixes **notification jump-to-unread** when the target is a **nested Bonsplit tab** whose UUID is a surface/tab id, not a panel key in `tab.panels`.
> 
> `focusTabFromNotification` now resolves the optional `surfaceId` through **`panelId(forSurfaceOrPanelId:in:)`** (same normalization as `focusTab`), treats a provided id as missing only when that lookup fails, and focuses using the **resolved panel id** instead of passing the raw surface UUID through.
> 
> Adds **`TabManagerNotificationFocusRegressionTests`** to assert that focusing by a third nested tab’s surface UUID selects the correct panel and Bonsplit selected tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d351715f7b9e284cfac9ee271641ae7c8f5729c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes notification jump focus when a notification targets a nested Bonsplit tab. Surface/tab IDs now resolve to the owning panel before focusing, so the right panel is selected consistently.

- **Bug Fixes**
  - Normalize notification focus targets in TabManager by resolving surface IDs to panel IDs before focus.
  - Add a Swift Testing regression test (TabManagerNotificationFocusRegressionTests) to ensure Bonsplit surface tab UUIDs select the correct panel.

<sup>Written for commit 0d351715f7b9e284cfac9ee271641ae7c8f5729c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab focus handling triggered from notifications, enhancing workspace panel identification and navigation.

* **Tests**
  * Added regression test coverage for notification-triggered tab focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->