### PR TITLE
Guard PostHog flush against shutdown stalls

### DIFF
--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -163,7 +163,7 @@ struct PostHogAnalyticsPropertiesTests {
         let flushReturned = DispatchSemaphore(value: 0)
         let flushRanOnMainThread = DispatchSemaphore(value: 0)
         let flushRanOffMainThread = DispatchSemaphore(value: 0)
-        let callerReturnedPromptly = DispatchSemaphore(value: 0)
+        let callerReturned = DispatchSemaphore(value: 0)
         let analytics = PostHogAnalytics.makeForTesting(
             workQueue: DispatchQueue(label: "com.cmux.tests.posthog.analytics"),
             didStart: true,
@@ -183,12 +183,8 @@ struct PostHogAnalyticsPropertiesTests {
         )
 
         let trackActiveOnMainThread = {
-            let start = DispatchTime.now().uptimeNanoseconds
             analytics.trackActive(reason: "didBecomeActive")
-            let elapsedSeconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
-            if elapsedSeconds < 0.25 {
-                callerReturnedPromptly.signal()
-            }
+            callerReturned.signal()
         }
 
         if Thread.isMainThread {
@@ -197,7 +193,7 @@ struct PostHogAnalyticsPropertiesTests {
             DispatchQueue.main.async(execute: trackActiveOnMainThread)
         }
 
-        #expect(callerReturnedPromptly.wait(timeout: .now() + .seconds(1)) == .success)
+        #expect(callerReturned.wait(timeout: .now() + .seconds(1)) == .success)
         #expect(flushStarted.wait(timeout: .now() + .seconds(1)) == .success)
         #expect(flushRanOffMainThread.wait(timeout: .now() + .seconds(1)) == .success)
         #expect(flushRanOnMainThread.wait(timeout: .now() + .milliseconds(50)) == .timedOut)

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -142,5 +142,72 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(hourlyEvent.properties["hour_utc"] as? String == "2026-02-21T14")
         #expect(hourlyEvent.properties["reason"] as? String == "didBecomeActive")
     }
+
+    @Test
+    func activeFlushDoesNotBlockMainThreadWhenSDKFlushBlocks() throws {
+        let suiteName = "cmux.posthog.analytics.tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let fixedDate = try #require(Calendar(identifier: .iso8601).date(from: DateComponents(
+            timeZone: TimeZone(secondsFromGMT: 0),
+            year: 2026,
+            month: 2,
+            day: 21,
+            hour: 14
+        )))
+        let flushStarted = DispatchSemaphore(value: 0)
+        let flushCanReturn = DispatchSemaphore(value: 0)
+        let flushReturned = DispatchSemaphore(value: 0)
+        let flushRanOnMainThread = DispatchSemaphore(value: 0)
+        let flushRanOffMainThread = DispatchSemaphore(value: 0)
+        let callerReturnedPromptly = DispatchSemaphore(value: 0)
+        let callerReturnedSlowly = DispatchSemaphore(value: 0)
+        let analytics = PostHogAnalytics.makeForTesting(
+            workQueue: DispatchQueue(label: "com.cmux.tests.posthog.analytics"),
+            didStart: true,
+            userDefaults: defaults,
+            now: { fixedDate },
+            capturePostHog: { _, _ in },
+            flushPostHog: {
+                if Thread.isMainThread {
+                    flushRanOnMainThread.signal()
+                } else {
+                    flushRanOffMainThread.signal()
+                }
+                flushStarted.signal()
+                _ = flushCanReturn.wait(timeout: .now() + .seconds(1))
+                flushReturned.signal()
+            }
+        )
+
+        let trackActiveOnMainThread = {
+            let start = DispatchTime.now().uptimeNanoseconds
+            analytics.trackActive(reason: "didBecomeActive")
+            let elapsedSeconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
+            if elapsedSeconds < 0.25 {
+                callerReturnedPromptly.signal()
+            } else {
+                callerReturnedSlowly.signal()
+            }
+        }
+
+        if Thread.isMainThread {
+            trackActiveOnMainThread()
+        } else {
+            DispatchQueue.main.async(execute: trackActiveOnMainThread)
+        }
+
+        #expect(callerReturnedPromptly.wait(timeout: .now() + .seconds(1)) == .success)
+        #expect(callerReturnedSlowly.wait(timeout: .now() + .milliseconds(50)) == .timedOut)
+        #expect(flushStarted.wait(timeout: .now() + .seconds(1)) == .success)
+        #expect(flushRanOffMainThread.wait(timeout: .now() + .seconds(1)) == .success)
+        #expect(flushRanOnMainThread.wait(timeout: .now() + .milliseconds(50)) == .timedOut)
+        #expect(flushReturned.wait(timeout: .now() + .milliseconds(50)) == .timedOut)
+        flushCanReturn.signal()
+        #expect(flushReturned.wait(timeout: .now() + .seconds(1)) == .success)
+    }
 }
 #endif

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -164,7 +164,6 @@ struct PostHogAnalyticsPropertiesTests {
         let flushRanOnMainThread = DispatchSemaphore(value: 0)
         let flushRanOffMainThread = DispatchSemaphore(value: 0)
         let callerReturnedPromptly = DispatchSemaphore(value: 0)
-        let callerReturnedSlowly = DispatchSemaphore(value: 0)
         let analytics = PostHogAnalytics.makeForTesting(
             workQueue: DispatchQueue(label: "com.cmux.tests.posthog.analytics"),
             didStart: true,
@@ -178,7 +177,7 @@ struct PostHogAnalyticsPropertiesTests {
                     flushRanOffMainThread.signal()
                 }
                 flushStarted.signal()
-                _ = flushCanReturn.wait(timeout: .now() + .seconds(1))
+                _ = flushCanReturn.wait(timeout: .now() + .seconds(5))
                 flushReturned.signal()
             }
         )
@@ -189,8 +188,6 @@ struct PostHogAnalyticsPropertiesTests {
             let elapsedSeconds = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000
             if elapsedSeconds < 0.25 {
                 callerReturnedPromptly.signal()
-            } else {
-                callerReturnedSlowly.signal()
             }
         }
 
@@ -201,7 +198,6 @@ struct PostHogAnalyticsPropertiesTests {
         }
 
         #expect(callerReturnedPromptly.wait(timeout: .now() + .seconds(1)) == .success)
-        #expect(callerReturnedSlowly.wait(timeout: .now() + .milliseconds(50)) == .timedOut)
         #expect(flushStarted.wait(timeout: .now() + .seconds(1)) == .success)
         #expect(flushRanOffMainThread.wait(timeout: .now() + .seconds(1)) == .success)
         #expect(flushRanOnMainThread.wait(timeout: .now() + .milliseconds(50)) == .timedOut)


### PR DESCRIPTION

Fixes #6415

## Summary

- Verified the v0.64.16 stack trace against the tag: `applicationWillTerminate(_:)` called `PostHogAnalytics.shared.flush()`, and that method used a synchronous `workQueue.sync` before invoking `PostHogSDK.shared.flush()`.
- Verified current main no longer has that production shutdown path: `applicationWillTerminate(_:)` does not call PostHog, `PostHogAnalytics` no longer exposes a public `flush()`, and all current wrapper flush calls run through `dispatchAsyncOnWorkQueue`.
- Checked the resolved PostHog iOS SDK 3.41.0 source: `captureApplicationLifecycleEvents = false` means the SDK does not install its macOS lifecycle integration, and `PostHogSDK.flush()` delegates to queue work asynchronously rather than doing synchronous network I/O on the caller.
- Added a regression guard only: a blocking injected `flushPostHog` must not block a main-thread `trackActive` caller, must start on the analytics work queue, and must remain fire-and-forget from the caller perspective.

## Current-main finding

The user-visible v0.64.16 production bug appears already fixed on current main by #6232 / `3041a8eec` (`Avoid PostHog flush deadlock during quit`). This PR does not fabricate another production behavior change; it adds focused coverage so future changes do not reintroduce a main-thread blocking analytics flush path.

## Tests

- `./scripts/lint-pbxproj-test-wiring.sh`
- Not run: local xcodebuild/test/reload actions, per issue instructions forbidding builds and local xcodebuild test actions before CI/dogfood handoff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784427639&installation_id=133855650&pr_number=6417&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6417&signature=f6a0b9637b30b26ee95eea987bd1cec2c47a97469cf0875378de03f14913fa10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to ensure a PostHog flush triggered by trackActive never blocks the main thread, even if the SDK flush stalls, guarding against the shutdown hang in #6415. Make the guard causal by asserting the caller returns quickly, the flush starts promptly off the main thread, and completion waits until explicitly released to prove fire-and-forget behavior.

<sup>Written for commit ec29b6ab95a2f2202a3225498f5ded16dd62db6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new serialized analytics test to ensure active tracking stays responsive even when analytics flushing is blocked.
  * Verifies the call returns promptly, flushing begins right away, flushing runs off the main thread, and completion is deferred until flushing is unblocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->