### PR TITLE
EXPERIMENT: unit tests job on Blacksmith macOS (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,15 +253,12 @@ jobs:
         run: bun run test:db:behavior
 
   tests:
-    # TEMPORARY (2026-06-18): pinned to hosted runners. The self-hosted austin
-    # mac-minis in the MACOS_RUNNER_15 pool cannot broker the XCTest control
-    # session with testmanagerd ("Timed out 120s initiating control session
-    # with daemon" -> Executed 0 tests -> idle-timeout), so this required check
-    # can never go green there. Revert to
-    # `${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}` once the austin
-    # runners are repaired (GUI login session + automation mode + unwedged
-    # testmanagerd). Tracked by the CI-flakiness handoff.
-    runs-on: warp-macos-15-arm64-6x
+    # EXPERIMENT (2026-06-19): try the unit tests on Blacksmith managed macOS.
+    # A live test-e2e run on blacksmith-6vcpu-macos-15 showed testmanagerd DOES
+    # broker the XCTest control session there (the XCUITest ran 61s); it only
+    # failed on app foreground activation, which the unit suite's key-window
+    # tests already self-skip. Validating whether the full unit job goes green.
+    runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 75
     env:
       CMUX_SKIP_ZIG_BUILD: "1"

--- a/.github/workflows/exp-blacksmith-gui-probe.yml
+++ b/.github/workflows/exp-blacksmith-gui-probe.yml
@@ -1,0 +1,52 @@
+name: exp-blacksmith-gui-probe
+
+# Throwaway diagnostic: does a Blacksmith managed macOS runner have a GUI /
+# WindowServer / testmanagerd-capable session, or is it headless? Decides
+# whether the XCTest `tests` job could ever run there. Dispatch-only.
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: macOS runner label to probe
+        type: string
+        default: blacksmith-6vcpu-macos-15
+
+jobs:
+  probe:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 10
+    steps:
+      - name: Probe GUI / WindowServer / automation session
+        run: |
+          set +e
+          echo "=== identity ==="
+          echo "runner.name=${{ runner.name }}"
+          echo "whoami=$(whoami)  id=$(id)"
+          sw_vers
+          echo
+          echo "=== console / login session (root = nobody logged into Aqua) ==="
+          echo "console_user=$(stat -f %Su /dev/console)"
+          echo "managername=$(launchctl managername 2>&1)"
+          echo "gui-domain reachable: $(launchctl print gui/$(id -u) >/dev/null 2>&1 && echo yes || echo NO)"
+          echo
+          echo "=== WindowServer running? (required for any GUI/XCTest app-host) ==="
+          ps -axo pid,user,comm | grep -i '[W]indowServer' || echo "NO WindowServer process"
+          echo "CGSession / loginwindow:"
+          ps -axo user,comm | grep -iE '[l]oginwindow|[A]qua' || echo "  none"
+          echo
+          echo "=== automation mode (the documented headless XCTest unblock) ==="
+          echo "passwordless_sudo: $(sudo -n true 2>/dev/null && echo yes || echo no)"
+          sudo -n automationmodetool enable-automationmode-without-authentication 2>&1 | head -5
+          echo "automationmodetool exit: $?"
+          echo
+          echo "=== SIP ==="
+          csrutil status 2>&1 | head -2
+          echo
+          echo "=== can we open a CG main display? (headless => error/0 displays) ==="
+          /usr/bin/python3 - <<'PY' 2>&1 | head -5 || true
+          import subprocess
+          # CGMainDisplayID via a tiny ObjC-free probe: ioreg for IODisplay
+          out = subprocess.run(["ioreg","-rc","IODisplayConnect"],capture_output=True,text=True).stdout
+          print("IODisplayConnect entries:", out.count("IODisplayConnect"))
+          PY
+          echo "=== DONE: if console_user=root, no WindowServer, and gui-domain NO => headless, XCTest cannot run here ==="


### PR DESCRIPTION
Throwaway experiment to answer: can the slow `tests` job run on Blacksmith managed macOS instead of Warp?

A live `test-e2e` dispatch on `blacksmith-6vcpu-macos-15` proved **testmanagerd brokers the XCTest control session on Blacksmith** (the XCUITest ran for 61s, no 120s control-session timeout). It only failed on `Failed to activate application ... (Running Background)` — foreground activation, which the unit suite's key-window tests already self-skip.

This PR points the `tests` job at `blacksmith-6vcpu-macos-15` to see if the full unit job goes green. Do not merge; informational only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784428423&installation_id=133855650&pr_number=6418&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6418&signature=9adb34f82911672bcce31bcc259c0da9afe8d4e1479a95e17b1ed76a03c116b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes for a labeled experiment; no app or test code changes, though merging would shift where the required macOS unit gate runs.
> 
> **Overview**
> **Throwaway CI experiment** (not intended to merge): the required macOS **`tests`** job now runs on **`blacksmith-6vcpu-macos-15`** instead of **`warp-macos-15-arm64-6x`**, after prior self-hosted Austin runners were timing out on **testmanagerd** control-session setup. Comments document that a live **test-e2e** run on Blacksmith already brokered XCTest successfully; this change checks whether the full **unit** job goes green (foreground-activation failures are expected to be less relevant because key-window tests self-skip).
> 
> Adds **`exp-blacksmith-gui-probe`**, a **workflow_dispatch**-only diagnostic that prints console user, **WindowServer**, **launchctl** GUI domain, **automationmodetool**, SIP, and display probes on a configurable Blacksmith macOS label—meant to decide if XCTest app-host jobs can run there at all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50bcd5aa904fee6d217c9cfa01a5a0676d30b97d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Experiment: run the unit `tests` job on Blacksmith managed macOS to validate stable XCTest control sessions and reduce dependence on Warp. A prior `test-e2e` on `blacksmith-6vcpu-macos-15` showed `testmanagerd` works (61s run), with only foreground activation failures that the unit key-window tests self-skip.

- **Refactors**
  - Point `tests` job in `.github/workflows/ci.yml` to `blacksmith-6vcpu-macos-15`.

- **New Features**
  - Add dispatch-only `exp-blacksmith-gui-probe` workflow to verify GUI/WindowServer, `testmanagerd` readiness, automation mode, SIP, and display presence for a given runner label.

<sup>Written for commit 50bcd5aa904fee6d217c9cfa01a5a0676d30b97d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure and runner configurations to improve development workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->