### PR TITLE
Add emacsification of coding agents blog post

### DIFF
--- a/web/app/[locale]/blog/emacsification-of-coding-agents/page.tsx
+++ b/web/app/[locale]/blog/emacsification-of-coding-agents/page.tsx
@@ -1,0 +1,75 @@
+import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "../../../../i18n/seo";
+import { Link } from "../../../../i18n/navigation";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "blog.emacsificationOfCodingAgents",
+  });
+  const rawKeywords = t.raw("metaKeywords");
+  const keywords = Array.isArray(rawKeywords)
+    ? rawKeywords.filter((keyword): keyword is string => typeof keyword === "string")
+    : [];
+
+  return {
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    keywords,
+    openGraph: {
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+      type: "article",
+      publishedTime: "2026-06-19T00:00:00Z",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: t("metaTitle"),
+      description: t("metaDescription"),
+    },
+    alternates: buildAlternates(locale, "/blog/emacsification-of-coding-agents"),
+  };
+}
+
+export default function EmacsificationOfCodingAgentsPage() {
+  const t = useTranslations("blog.posts.emacsificationOfCodingAgents");
+  const tc = useTranslations("common");
+
+  return (
+    <>
+      <div className="mb-8">
+        <Link
+          href="/blog"
+          className="text-sm text-muted hover:text-foreground transition-colors"
+        >
+          &larr; {tc("backToBlog")}
+        </Link>
+      </div>
+
+      <h1>{t("title")}</h1>
+      <time dateTime="2026-06-19" className="text-sm text-muted">
+        {t("date")}
+      </time>
+
+      <p className="mt-6">{t("p1")}</p>
+      <p>{t("p2")}</p>
+      <p>{t("p3")}</p>
+      <p>{t("p4")}</p>
+      <p>
+        {t.rich("p5", {
+          sourceLink: (chunks) => (
+            <a href="https://x.com/lawrencecchen/status/2054882625760956603">
+              {chunks}
+            </a>
+          ),
+        })}
+      </p>
+    </>
+  );
+}

--- a/web/app/[locale]/components/blog-posts.ts
+++ b/web/app/[locale]/components/blog-posts.ts
@@ -1,5 +1,13 @@
 export const blogPosts = [
   {
+    slug: "emacsification-of-coding-agents",
+    key: "emacsificationOfCodingAgents",
+    title: "The Emacsification of Coding Agents",
+    date: "2026-06-19",
+    summary:
+      "Why open, terminal-native agent interfaces let developers compose their own workflows instead of waiting for one IDE to own them.",
+  },
+  {
     slug: "cmux-history",
     key: "cmuxHistory",
     title: "cmux history",

--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -32,6 +32,10 @@ const englishOnlyPages = [
 export const agentReadablePages = [
   { path: "/", title: "Home" },
   { path: "/blog", title: "Blog" },
+  {
+    path: "/blog/emacsification-of-coding-agents",
+    title: "The Emacsification of Coding Agents",
+  },
   { path: "/blog/cmux-history", title: "cmux history" },
   { path: "/blog/cmux-finder", title: "Introducing cmux Finder" },
   { path: "/blog/cmux-vault", title: "cmux Vault" },

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -6,7 +6,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const paths = [
     { path: "", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 1 },
-    { path: "/blog", lastModified: "2026-06-02", changeFrequency: "weekly" as const, priority: 0.8 },
+    { path: "/blog", lastModified: "2026-06-19", changeFrequency: "weekly" as const, priority: 0.8 },
+    { path: "/blog/emacsification-of-coding-agents", lastModified: "2026-06-19", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/cmux-history", lastModified: "2026-06-02", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/cmux-finder", lastModified: "2026-05-22", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/blog/cmux-vault", lastModified: "2026-05-22", changeFrequency: "monthly" as const, priority: 0.7 },

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -308,6 +308,22 @@
     "metaTitle": "Blog",
     "metaDescription": "News and updates from the cmux team",
     "description": "News and updates from the cmux team",
+    "emacsificationOfCodingAgents": {
+      "metaTitle": "The Emacsification of Coding Agents",
+      "metaDescription": "Open, terminal-native agent interfaces let developers compose their own coding workflows instead of waiting for one IDE to own them.",
+      "metaKeywords": [
+        "emacsification of coding agents",
+        "cmux",
+        "AI coding agents",
+        "terminal coding agents",
+        "Claude Code",
+        "Codex",
+        "OpenCode",
+        "Gemini CLI",
+        "agent SDK",
+        "background agents"
+      ]
+    },
     "passkeyAuth": {
       "metaTitle": "Passkey auth in the cmux browser",
       "metaDescription": "cmux v0.64+ supports passkey authentication in browser panes and can import cookies from other browsers with cmux browser import.",
@@ -393,6 +409,16 @@
       "metaDescription": "A native macOS terminal built on Ghostty, designed for running multiple AI coding agents side by side."
     },
     "posts": {
+      "emacsificationOfCodingAgents": {
+        "title": "The Emacsification of Coding Agents",
+        "summary": "Why open, terminal-native agent interfaces let developers compose their own workflows instead of waiting for one IDE to own them.",
+        "date": "June 19, 2026",
+        "p1": "Agent tools are moving into terminals because terminals are the shared interface every provider can support.",
+        "p2": "Claude Code, Codex, OpenCode, Gemini CLI, Aider, and custom SDK agents should not require a different dashboard for every run. The useful layer is a programmable terminal where panes, browsers, notifications, and workspace state are scriptable.",
+        "p3": "That is the emacsification: providers keep interfaces open, developers compose their own workflows, and the best patterns become reusable scripts instead of product lock-in.",
+        "p4": "cmux exists for that world. It stays close to the shell, adds native macOS panes and an embedded browser, and exposes a CLI/socket API so background agents can be launched, watched, resumed, and rearranged by code.",
+        "p5": "Source: <sourceLink>May 14, 2026 tweet</sourceLink>."
+      },
       "passkeyAuth": {
         "title": "Passkey auth in the cmux browser",
         "summary": "cmux's embedded browser supports passkey authentication and can import cookies from other browsers with cmux browser import.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -308,7 +308,33 @@
     "metaTitle": "ブログ",
     "metaDescription": "cmuxチームからのニュースとアップデート",
     "description": "cmuxチームからのニュースとアップデート",
+    "emacsificationOfCodingAgents": {
+      "metaTitle": "コーディングエージェントのEmacs化",
+      "metaDescription": "オープンでターミナルネイティブなエージェントインターフェイスにより、開発者は1つのIDEに任せるのではなく自分のワークフローを組み立てられます。",
+      "metaKeywords": [
+        "コーディングエージェントのEmacs化",
+        "cmux",
+        "AIコーディングエージェント",
+        "ターミナル コーディングエージェント",
+        "Claude Code",
+        "Codex",
+        "OpenCode",
+        "Gemini CLI",
+        "agent SDK",
+        "background agents"
+      ]
+    },
     "posts": {
+      "emacsificationOfCodingAgents": {
+        "title": "コーディングエージェントのEmacs化",
+        "summary": "オープンでターミナルネイティブなエージェントインターフェイスが、1つのIDEに依存しない独自ワークフローを可能にする理由。",
+        "date": "2026年6月19日",
+        "p1": "エージェントツールはターミナルへ向かっています。ターミナルは、どのプロバイダーも対応できる共通インターフェイスだからです。",
+        "p2": "Claude Code、Codex、OpenCode、Gemini CLI、Aider、カスタムSDKエージェントの実行ごとに別々のダッシュボードは必要ありません。役に立つ層は、ペイン、ブラウザ、通知、ワークスペース状態をスクリプトで扱えるプログラマブルなターミナルです。",
+        "p3": "これがEmacs化です。プロバイダーはインターフェイスを開いたままにし、開発者は自分のワークフローを組み立て、良いパターンはプロダクトへのロックインではなく再利用できるスクリプトになります。",
+        "p4": "cmuxはその世界のためにあります。シェルに近いまま、ネイティブmacOSペインと組み込みブラウザを追加し、CLIとsocket APIでバックグラウンドエージェントを起動、監視、再開、並べ替えできるようにします。",
+        "p5": "出典：<sourceLink>2026年5月14日の投稿</sourceLink>。"
+      },
       "cmdShiftU": {
         "title": "Cmd+Shift+U",
         "summary": "Cmd+Shift+Uがcmuxのワークスペース間で完了したエージェントにどうナビゲートするか。",


### PR DESCRIPTION
## Summary
- Add a blog post based on Lawrence's May 14, 2026 emacsification tweet
- Wire the post into the blog index, sitemap, and agent-readable page list
- Add English and Japanese message catalog entries

## Source
- Local tweet capture: `/Users/lawrence/fun/cmuxterm-hq/skills/marketing/data/lawrencecchen-tweets.md`
- Tweet URL: https://x.com/lawrencecchen/status/2054882625760956603
- Excalidraw search found only unrelated iCloud files: `/Users/lawrence/Library/Mobile Documents/com~apple~CloudDocs/Documents/Untitled-2022-01-23-1656.excalidraw` and `/Users/lawrence/Library/Mobile Documents/com~apple~CloudDocs/Documents/lmao.excalidraw`

## Verification
- `jq empty web/messages/en.json && jq empty web/messages/ja.json`
- `bun run lint` (passes with existing warnings)
- `VERCEL_ENV=preview bun run build`

Docs-only change, so no tagged runtime reload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784434369&installation_id=133855650&pr_number=6424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6424&signature=ff5a505750552e2f6fa31fe23b9b7e272d527a2d77db2b4146b1596c3e4dd083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and routing-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a new blog article **The Emacsification of Coding Agents** at `/blog/emacsification-of-coding-agents`, following the same localized Next.js page pattern as other posts (metadata, back link, body from `next-intl`).
> 
> The post is registered as the newest entry in `blogPosts`, included in `agentReadablePages` and the sitemap (with `/blog` `lastModified` bumped to 2026-06-19). **English and Japanese** message catalogs gain SEO meta plus post copy, with a rich-text link to the source tweet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63e1d4bbebe5c00269e2ce0110a766c710f0517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the “The Emacsification of Coding Agents” blog post at /blog/emacsification-of-coding-agents with SEO metadata and translations (en, ja). Wired into the blog index, sitemap, and `agentReadablePages`, with Open Graph/Twitter tags set.

<sup>Written for commit f63e1d4bbebe5c00269e2ce0110a766c710f0517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched a new blog post, "The Emacsification of Coding Agents" (June 19, 2026), now available in English and Japanese. The post has been fully integrated into the blog platform with improved search visibility, better metadata optimization, complete site indexing, and enhanced accessibility features for broader user reach and maximum discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->