### PR TITLE
Show drop line when dragging tabs into workspaces

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarTabDropIndicatorPredicate.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SidebarDrop/SidebarTabDropIndicatorPredicate.swift
@@ -9,9 +9,11 @@ public struct SidebarTabDropIndicatorPredicate {
         forTabId tabId: UUID,
         draggedTabId: UUID?,
         dropIndicator: SidebarDropIndicator?,
-        tabIds: [UUID]
+        tabIds: [UUID],
+        isExternalDragActive: Bool = false
     ) -> Bool {
-        guard draggedTabId != nil, let indicator = dropIndicator else { return false }
+        guard draggedTabId != nil || isExternalDragActive,
+              let indicator = dropIndicator else { return false }
         if indicator.tabId == tabId && indicator.edge == .top {
             return true
         }
@@ -31,9 +33,11 @@ public struct SidebarTabDropIndicatorPredicate {
     public func emptyAreaTopVisible(
         draggedTabId: UUID?,
         dropIndicator: SidebarDropIndicator?,
-        lastTabId: UUID?
+        lastTabId: UUID?,
+        isExternalDragActive: Bool = false
     ) -> Bool {
-        guard draggedTabId != nil, let indicator = dropIndicator else { return false }
+        guard draggedTabId != nil || isExternalDragActive,
+              let indicator = dropIndicator else { return false }
         if indicator.tabId == nil {
             return true
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10208,15 +10208,12 @@ struct VerticalTabsSidebar: View {
     /// indicator from a value snapshot without holding a `SidebarDragState`
     /// reference (snapshot-boundary rule). Delegates to a pure predicate so
     /// the logic is unit-testable in isolation from view state.
-    private func emptyAreaTopDropIndicatorVisible() -> Bool {
-        let reorderIds = tabManager.sidebarReorderWorkspaceIds(
-            forDraggedWorkspaceId: dragState.draggedTabId,
-            usesTopLevelRows: dragState.dropIndicatorUsesTopLevelRows
-        )
+    private func emptyAreaTopDropIndicatorVisible(renderContext: WorkspaceListRenderContext) -> Bool {
         return SidebarTabDropIndicatorPredicate().emptyAreaTopVisible(
             draggedTabId: dragState.draggedTabId,
             dropIndicator: dragState.dropIndicator,
-            lastTabId: reorderIds.last
+            lastTabId: renderContext.dropIndicatorRowIds.last,
+            isExternalDragActive: renderContext.isExternalWorkspaceDropActive
         )
     }
 
@@ -10345,6 +10342,10 @@ struct VerticalTabsSidebar: View {
         let tabIds: [UUID]
         /// Drag-scope row ids shared by every visible row for this render pass.
         let sidebarReorderIds: [UUID]
+        /// Row ids used to render a current drop indicator. Sidebar workspace
+        /// drags use reorder scope; external Bonsplit tab drags use visible rows.
+        let dropIndicatorRowIds: [UUID]
+        let isExternalWorkspaceDropActive: Bool
         let workspaceCount: Int
         let canCloseWorkspace: Bool
         let workspaceNumberShortcut: StoredShortcut
@@ -10403,10 +10404,14 @@ struct VerticalTabsSidebar: View {
                 usesTopLevelRows: dragState.dropIndicatorUsesTopLevelRows
             )
         } ?? []
+        let isExternalWorkspaceDropActive = draggedSidebarTabId == nil && isBonsplitWorkspaceDropTargetCollectionActive
+        let dropIndicatorRowIds = draggedSidebarTabId == nil ? visibleWorkspaceRowIds : sidebarReorderIds
         let renderContext = WorkspaceListRenderContext(
             tabs: tabs,
             tabIds: tabs.map(\.id),
             sidebarReorderIds: sidebarReorderIds,
+            dropIndicatorRowIds: dropIndicatorRowIds,
+            isExternalWorkspaceDropActive: isExternalWorkspaceDropActive,
             workspaceCount: workspaceCount,
             canCloseWorkspace: canCloseWorkspace,
             workspaceNumberShortcut: workspaceNumberShortcut,
@@ -10822,7 +10827,7 @@ struct VerticalTabsSidebar: View {
                             selectedTabIds: $selectedTabIds,
                             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                             dragAutoScrollController: dragAutoScrollController,
-                            topDropIndicatorVisible: emptyAreaTopDropIndicatorVisible(),
+                            topDropIndicatorVisible: emptyAreaTopDropIndicatorVisible(renderContext: renderContext),
                             tabDropDelegate: emptyAreaTabDropDelegate(renderContext: renderContext),
                             bonsplitDropIndicator: dropIndicatorBinding
                         )
@@ -11841,7 +11846,7 @@ struct VerticalTabsSidebar: View {
         // #5845; regressed by #6033). Drop/tap = background; indicator on rows.
         workspaceRows(renderContext: renderContext)
             .overlay(alignment: .bottom) {
-                if emptyAreaTopDropIndicatorVisible() {
+                if emptyAreaTopDropIndicatorVisible(renderContext: renderContext) {
                     Rectangle()
                         .fill(cmuxAccentColor())
                         .frame(height: 2)
@@ -12080,12 +12085,12 @@ struct VerticalTabsSidebar: View {
         // Equatable conformance ignores closures, so rows whose snapshot is
         // unchanged skip re-render when drag state moves.
         let isBeingDragged = dragState.draggedTabId == tab.id
-        let sidebarReorderIds = renderContext.sidebarReorderIds
         let topDropIndicatorVisible = SidebarTabDropIndicatorPredicate().topVisible(
             forTabId: tab.id,
             draggedTabId: dragState.draggedTabId,
             dropIndicator: dragState.dropIndicator,
-            tabIds: sidebarReorderIds
+            tabIds: renderContext.dropIndicatorRowIds,
+            isExternalDragActive: renderContext.isExternalWorkspaceDropActive
         )
         let onDragStart: () -> NSItemProvider = { [tabId = tab.id] in
             #if DEBUG

--- a/Sources/Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift
+++ b/Sources/Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift
@@ -13,6 +13,7 @@ struct SidebarBonsplitTabWorkspaceDropOverlay: NSViewRepresentable {
             self.targets = targets
             guard !targets.isEmpty else { return }
             DispatchQueue.main.async { [weak view] in
+                view?.refreshDropIndicatorFromCurrentDrag()
                 view?.performPendingDropIfPossible()
             }
         }
@@ -120,6 +121,11 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
         let transfer: BonsplitTabDragPayload.Transfer
     }
 
+    private struct CurrentDrag {
+        let point: CGPoint
+        let transfer: BonsplitTabDragPayload.Transfer
+    }
+
     var targetBridge: SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge?
     var canPerformAction: (SidebarDropPlanner.WorkspaceDropAction, BonsplitTabDragPayload.Transfer) -> Bool = { _, _ in false }
     var updateAutoscroll: () -> Void = {}
@@ -130,6 +136,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
     private var isRequestingWorkspaceDropTargets = false
     private var workspaceDropTargetRequestId: UInt64 = 0
     private var pendingDrop: PendingDrop?
+    private var currentDrag: CurrentDrag?
     private var targets: [SidebarDropPlanner.WorkspaceDropTarget] {
         targetBridge?.targets ?? []
     }
@@ -161,6 +168,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
     }
 
     override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+        currentDrag = nil
         guard pendingDrop == nil else {
             completeOrClearPendingDropAfterDragTeardown()
             setDropIndicator(nil)
@@ -189,6 +197,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
         let action = action(for: sender)
         if let action, let transfer = acceptedTransfer(sender, action: action) {
             let moved = perform(action: action, transfer: transfer)
+            currentDrag = nil
             pendingDrop = nil
             updateWorkspaceDropTargetCollection(sender, isActive: false)
             setDropIndicator(nil)
@@ -214,6 +223,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
         }
 
         updateWorkspaceDropTargetCollection(sender, isActive: false)
+        currentDrag = nil
         setDropIndicator(nil)
 #if DEBUG
         dlog(
@@ -254,8 +264,24 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
 #endif
     }
 
+    func refreshDropIndicatorFromCurrentDrag() {
+        guard let currentDrag,
+              isRequestingWorkspaceDropTargets,
+              !targets.isEmpty else {
+            return
+        }
+        guard let action = SidebarDropPlanner().workspaceAction(for: currentDrag.point, targets: targets),
+              canPerformAction(action, currentDrag.transfer) else {
+            setDropIndicator(nil)
+            return
+        }
+        updateAutoscroll()
+        setDropIndicator(for: action)
+    }
+
     func clearPendingDrop() {
         pendingDrop = nil
+        currentDrag = nil
         isRequestingWorkspaceDropTargets = false
         workspaceDropTargetRequestId &+= 1
     }
@@ -278,6 +304,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
     }
 
     override func concludeDragOperation(_ sender: (any NSDraggingInfo)?) {
+        currentDrag = nil
         guard pendingDrop == nil else {
             completeOrClearPendingDropAfterDragTeardown()
             setDropIndicator(nil)
@@ -292,16 +319,25 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
 
     private func updateDrag(_ sender: any NSDraggingInfo, phase: String) -> NSDragOperation {
         let action = action(for: sender)
+        guard let transfer = BonsplitTabDragPayload.transfer(from: sender.draggingPasteboard) else {
+            currentDrag = nil
+            setDropIndicator(nil)
+#if DEBUG
+            dlog("sidebar.workspaceDropOverlay.\(phase) accepted=0 clear=1 reason=missingTransfer")
+#endif
+            return []
+        }
+        currentDrag = CurrentDrag(point: localPoint(sender), transfer: transfer)
         if isRequestingWorkspaceDropTargets,
            targets.isEmpty,
-           BonsplitTabDragPayload.transfer(from: sender.draggingPasteboard) != nil {
+           BonsplitTabDragPayload.canRouteWorkspaceDrop(pasteboardTypes: sender.draggingPasteboard.types) {
             setDropIndicator(nil)
 #if DEBUG
             dlog("sidebar.workspaceDropOverlay.\(phase) accepted=1 pendingTargets=1")
 #endif
             return .move
         }
-        guard acceptedTransfer(sender, action: action) != nil, let action else {
+        guard let action, canPerformAction(action, transfer) else {
             setDropIndicator(nil)
 #if DEBUG
             dlog(
@@ -313,12 +349,7 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
         }
 
         updateAutoscroll()
-        switch action {
-        case .newWorkspace(_, let indicator):
-            setDropIndicator(indicator)
-        case .existingWorkspace:
-            setDropIndicator(nil)
-        }
+        setDropIndicator(for: action)
 
 #if DEBUG
         dlog(
@@ -327,6 +358,15 @@ final class SidebarBonsplitTabWorkspaceDropView: NSView {
         )
 #endif
         return .move
+    }
+
+    private func setDropIndicator(for action: SidebarDropPlanner.WorkspaceDropAction) {
+        switch action {
+        case .newWorkspace(_, let indicator):
+            setDropIndicator(indicator)
+        case .existingWorkspace:
+            setDropIndicator(nil)
+        }
     }
 
     private func completeOrClearPendingDropAfterDragTeardown() {

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -43,7 +43,8 @@ extension VerticalTabsSidebar {
             forTabId: group.anchorWorkspaceId,
             draggedTabId: dragState.draggedTabId,
             dropIndicator: dragState.dropIndicator,
-            tabIds: renderContext.sidebarReorderIds
+            tabIds: renderContext.dropIndicatorRowIds,
+            isExternalDragActive: renderContext.isExternalWorkspaceDropActive
         )
         let onDragStart: () -> NSItemProvider = { [anchorId = group.anchorWorkspaceId] in
             #if DEBUG

--- a/cmuxTests/SidebarTabDropIndicatorPredicateTests.swift
+++ b/cmuxTests/SidebarTabDropIndicatorPredicateTests.swift
@@ -53,6 +53,19 @@ final class SidebarTabDropIndicatorPredicateTopVisibleTests: XCTestCase {
         )
     }
 
+    func testReturnsTrueForExternalDragWhenIndicatorTargetsThisRowTopEdge() {
+        let rowId = UUID()
+        XCTAssertTrue(
+            SidebarTabDropIndicatorPredicate().topVisible(
+                forTabId: rowId,
+                draggedTabId: nil,
+                dropIndicator: SidebarDropIndicator(tabId: rowId, edge: .top),
+                tabIds: [rowId],
+                isExternalDragActive: true
+            )
+        )
+    }
+
     func testReturnsFalseWhenIndicatorTargetsThisRowBottomEdge() {
         let rowId = UUID()
         let draggedId = UUID()
@@ -81,6 +94,20 @@ final class SidebarTabDropIndicatorPredicateTopVisibleTests: XCTestCase {
                 draggedTabId: draggedId,
                 dropIndicator: SidebarDropIndicator(tabId: firstId, edge: .bottom),
                 tabIds: [firstId, middleId, draggedId]
+            )
+        )
+    }
+
+    func testReturnsTrueForExternalDragWhenIndicatorTargetsPreviousRowBottomEdge() {
+        let firstId = UUID()
+        let secondId = UUID()
+        XCTAssertTrue(
+            SidebarTabDropIndicatorPredicate().topVisible(
+                forTabId: secondId,
+                draggedTabId: nil,
+                dropIndicator: SidebarDropIndicator(tabId: firstId, edge: .bottom),
+                tabIds: [firstId, secondId],
+                isExternalDragActive: true
             )
         )
     }
@@ -162,6 +189,17 @@ final class SidebarTabDropIndicatorPredicateEmptyAreaTests: XCTestCase {
                 draggedTabId: UUID(),
                 dropIndicator: SidebarDropIndicator(tabId: nil, edge: .top),
                 lastTabId: UUID()
+            )
+        )
+    }
+
+    func testReturnsTrueForExternalDragWhenIndicatorTargetsEndOfList() {
+        XCTAssertTrue(
+            SidebarTabDropIndicatorPredicate().emptyAreaTopVisible(
+                draggedTabId: nil,
+                dropIndicator: SidebarDropIndicator(tabId: nil, edge: .bottom),
+                lastTabId: UUID(),
+                isExternalDragActive: true
             )
         )
     }


### PR DESCRIPTION
Summary
- Allow sidebar drop indicators to render during external Bonsplit tab drags into vertical tab workspaces.
- Use visible workspace row ids for external drop targets, while preserving sidebar reorder ids for workspace reordering.
- Refresh the AppKit workspace-drop overlay indicator when async sidebar target frames arrive.

Testing
- xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-vtdi -only-testing:cmuxTests/SidebarTabDropIndicatorPredicateTopVisibleTests -only-testing:cmuxTests/SidebarTabDropIndicatorPredicateEmptyAreaTests
- ./scripts/reload-cloud.sh --tag dragln
- Launched tagged app via /tmp/cmux-debug-dragln.sock and captured sidebar drop line with debug.sidebar.simulate_drag. Exact native Bonsplit tab mouse drag is not exposed through the debug socket, so it still needs dogfood.

Related task
- User report: blue line does not appear when dragging a tab into vertical tab workspaces.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784435641&installation_id=133855650&pr_number=6427&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6427&signature=0dfbfccd6b57b62333a7ba888e2561bc18cfc07cca61d0044971b0f7f7dda894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches drag-and-drop UI and insertion-index logic for workspace moves, but changes are scoped to indicator visibility and overlay refresh with new unit tests; dogfood on real Bonsplit mouse drags is still pending.
> 
> **Overview**
> Fixes the missing **blue insertion line** when dragging a Bonsplit tab onto the vertical-tab workspace sidebar. Indicators used to require an in-sidebar `draggedTabId`, so external AppKit drags never satisfied the predicate even when `dropIndicator` was set.
> 
> `SidebarTabDropIndicatorPredicate` now accepts **`isExternalDragActive`** so row and empty-area top indicators can show without a sidebar reorder drag. `WorkspaceListRenderContext` carries **`dropIndicatorRowIds`** (visible workspace rows for external drops, reorder scope for sidebar drags) and **`isExternalWorkspaceDropActive`**, wired from `isBonsplitWorkspaceDropTargetCollectionActive` when no sidebar tab is being dragged.
> 
> The AppKit **`SidebarBonsplitTabWorkspaceDropOverlay`** keeps the current drag point/transfer, calls **`refreshDropIndicatorFromCurrentDrag`** when async workspace target frames land, and tightens drag updates so indicators are set consistently for new-workspace targets. Unit tests cover external-drag branches on the predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da3785286ea6ebd6c6531bf34f784a08cbdf56d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the blue drop line when dragging external Bonsplit tabs into vertical tab workspaces. Fixes the user report where the indicator didn’t appear.

- **Bug Fixes**
  - Display the drop line for external drags by using visible workspace row ids and a new `isExternalDragActive` path; keep sidebar reorder ids for internal reordering.
  - Refresh the workspace-drop overlay when async target frames arrive by tracking the current drag and recalculating the indicator.
  - Correct empty-area and end-of-list cases for external drags; added unit tests for `topVisible` and `emptyAreaTopVisible`.

<sup>Written for commit da3785286ea6ebd6c6531bf34f784a08cbdf56d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

