### PR TITLE
Support Finder-style custom sidebar columns

### DIFF
--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarContextSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarContextSnapshot.swift
@@ -6,7 +6,7 @@ public import Foundation
 /// and the current wall-clock instant on each `TimelineView` tick. The
 /// data-context builder maps it to the top-level interpreter dictionary
 /// (`workspaces`, `workspaceCount`, `selectedTitle`, `selectedId`,
-/// `unreadTotal`, `clock`).
+/// `unreadTotal`, `recents`, `recentCount`, `clock`).
 public struct CustomSidebarContextSnapshot: Sendable, Equatable {
     /// The ordered workspaces shown in the sidebar.
     public let workspaces: [CustomSidebarWorkspaceSnapshot]
@@ -17,6 +17,8 @@ public struct CustomSidebarContextSnapshot: Sendable, Equatable {
     public let selectedWorkspaceTitle: String
     /// The total unread count across all workspaces (`unreadTotal`).
     public let totalUnreadCount: Int
+    /// Recent focus-history targets, newest first (`recents`).
+    public let recentFocus: [CustomSidebarRecentFocusSnapshot]
     /// The wall-clock instant the `clock` object is derived from.
     public let now: Date
 
@@ -26,12 +28,14 @@ public struct CustomSidebarContextSnapshot: Sendable, Equatable {
         selectedWorkspaceId: UUID?,
         selectedWorkspaceTitle: String,
         totalUnreadCount: Int,
+        recentFocus: [CustomSidebarRecentFocusSnapshot] = [],
         now: Date
     ) {
         self.workspaces = workspaces
         self.selectedWorkspaceId = selectedWorkspaceId
         self.selectedWorkspaceTitle = selectedWorkspaceTitle
         self.totalUnreadCount = totalUnreadCount
+        self.recentFocus = recentFocus
         self.now = now
     }
 }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
@@ -28,9 +28,10 @@ public struct CustomSidebarDataContextBuilder {
     ///
     /// Mirrors the original `customSidebarDataContext(now:)` output exactly:
     /// `workspaces`, `workspaceCount`, `selectedTitle`, `selectedId`,
-    /// `unreadTotal`, and `clock`.
+    /// `unreadTotal`, `recents`, `recentCount`, and `clock`.
     public func dataContext(for snapshot: CustomSidebarContextSnapshot) -> [String: SwiftValue] {
         let workspaces: [SwiftValue] = snapshot.workspaces.map(workspaceValue(_:))
+        let recents: [SwiftValue] = snapshot.recentFocus.map(recentFocusValue(_:))
         let components = calendar.dateComponents(
             [.hour, .minute, .second, .weekday],
             from: snapshot.now
@@ -52,6 +53,8 @@ public struct CustomSidebarDataContextBuilder {
             "selectedTitle": .string(snapshot.selectedWorkspaceTitle),
             "selectedId": .string(snapshot.selectedWorkspaceId?.uuidString ?? ""),
             "unreadTotal": .int(snapshot.totalUnreadCount),
+            "recents": .array(recents),
+            "recentCount": .int(snapshot.recentFocus.count),
             "clock": clock,
         ]
     }
@@ -120,6 +123,7 @@ public struct CustomSidebarDataContextBuilder {
         var surfaceFields: [String: SwiftValue] = [
             "id": .string(surface.panelId.uuidString),
             "title": .string(surface.title),
+            "kind": .string(surface.kind),
             "focused": .bool(surface.isFocused),
             "pinned": .bool(surface.isPinned),
         ]
@@ -134,5 +138,22 @@ public struct CustomSidebarDataContextBuilder {
             surfaceFields["ports"] = .array(surface.listeningPorts.map { .int($0) })
         }
         return .object(surfaceFields)
+    }
+
+    /// Projects one focus-history item into the interpreter value tree.
+    public func recentFocusValue(_ recent: CustomSidebarRecentFocusSnapshot) -> SwiftValue {
+        var fields: [String: SwiftValue] = [
+            "workspaceId": .string(recent.workspaceId.uuidString),
+            "workspaceTitle": .string(recent.workspaceTitle),
+            "position": .string(recent.position),
+            "focusedAt": .int(Int(recent.focusedAt.timeIntervalSince1970)),
+        ]
+        if let panelId = recent.panelId {
+            fields["panelId"] = .string(panelId.uuidString)
+        }
+        if let panelTitle = recent.panelTitle, !panelTitle.isEmpty {
+            fields["panelTitle"] = .string(panelTitle)
+        }
+        return .object(fields)
     }
 }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarRecentFocusSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarRecentFocusSnapshot.swift
@@ -1,0 +1,35 @@
+public import Foundation
+
+/// One recently focused workspace/panel exposed to interpreted custom
+/// sidebars as a `recents` row.
+public struct CustomSidebarRecentFocusSnapshot: Sendable, Equatable {
+    /// The workspace that was focused.
+    public let workspaceId: UUID
+    /// The focused panel inside the workspace, when known.
+    public let panelId: UUID?
+    /// The workspace's display title at snapshot time.
+    public let workspaceTitle: String
+    /// The panel's display title at snapshot time, when known.
+    public let panelTitle: String?
+    /// Whether this item is older or newer than the current focus-history
+    /// position.
+    public let position: String
+    /// When this focus target was focused.
+    public let focusedAt: Date
+
+    public init(
+        workspaceId: UUID,
+        panelId: UUID?,
+        workspaceTitle: String,
+        panelTitle: String?,
+        position: String,
+        focusedAt: Date
+    ) {
+        self.workspaceId = workspaceId
+        self.panelId = panelId
+        self.workspaceTitle = workspaceTitle
+        self.panelTitle = panelTitle
+        self.position = position
+        self.focusedAt = focusedAt
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarSurfaceSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarSurfaceSnapshot.swift
@@ -12,6 +12,8 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
     public let panelId: UUID
     /// The surface title (`tabs[i].title`).
     public let title: String
+    /// The surface kind (`tabs[i].kind`), e.g. terminal/browser/markdown.
+    public let kind: String
     /// Whether this surface is the workspace's focused panel (`tabs[i].focused`).
     public let isFocused: Bool
     /// Whether the surface's panel is pinned (`tabs[i].pinned`).
@@ -31,6 +33,7 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
     public init(
         panelId: UUID,
         title: String,
+        kind: String,
         isFocused: Bool,
         isPinned: Bool,
         directory: String?,
@@ -40,6 +43,7 @@ public struct CustomSidebarSurfaceSnapshot: Sendable, Equatable {
     ) {
         self.panelId = panelId
         self.title = title
+        self.kind = kind
         self.isFocused = isFocused
         self.isPinned = isPinned
         self.directory = directory

--- a/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
+++ b/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
@@ -16,6 +16,7 @@ struct CustomSidebarDataContextBuilderTests {
         CustomSidebarSurfaceSnapshot(
             panelId: id,
             title: "shell",
+            kind: "terminal",
             isFocused: false,
             isPinned: false,
             directory: nil,
@@ -114,6 +115,51 @@ struct CustomSidebarDataContextBuilderTests {
         #expect(clock?.member("time") == .string("01:02:03"))
         #expect(clock?.member("weekday") == .int(5))
         #expect(clock?.member("epoch") == .int(3723))
+    }
+
+    @Test("Recent focus history is exposed as top-level recents")
+    func recentFocusHistory() {
+        let builder = CustomSidebarDataContextBuilder(calendar: fixedCalendar())
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let snapshot = CustomSidebarContextSnapshot(
+            workspaces: [],
+            selectedWorkspaceId: nil,
+            selectedWorkspaceTitle: "",
+            totalUnreadCount: 0,
+            recentFocus: [
+                CustomSidebarRecentFocusSnapshot(
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    workspaceTitle: "cmux",
+                    panelTitle: "agent",
+                    position: "older",
+                    focusedAt: Date(timeIntervalSince1970: 123)
+                ),
+                CustomSidebarRecentFocusSnapshot(
+                    workspaceId: workspaceId,
+                    panelId: nil,
+                    workspaceTitle: "docs",
+                    panelTitle: nil,
+                    position: "newer",
+                    focusedAt: Date(timeIntervalSince1970: 456)
+                ),
+            ],
+            now: Date(timeIntervalSince1970: 0)
+        )
+
+        let context = builder.dataContext(for: snapshot)
+        let recents = context["recents"]?.iterationValues
+
+        #expect(context["recentCount"] == .int(2))
+        #expect(recents?.first?.member("workspaceId") == .string(workspaceId.uuidString))
+        #expect(recents?.first?.member("panelId") == .string(panelId.uuidString))
+        #expect(recents?.first?.member("workspaceTitle") == .string("cmux"))
+        #expect(recents?.first?.member("panelTitle") == .string("agent"))
+        #expect(recents?.first?.member("position") == .string("older"))
+        #expect(recents?.first?.member("focusedAt") == .int(123))
+        #expect(recents?.last?.member("panelId") == nil)
+        #expect(recents?.last?.member("panelTitle") == nil)
     }
 
     @Test("Workspace always-present fields map straight through")
@@ -284,6 +330,7 @@ struct CustomSidebarDataContextBuilderTests {
         let enriched = CustomSidebarSurfaceSnapshot(
             panelId: id,
             title: "editor",
+            kind: "browser",
             isFocused: true,
             isPinned: true,
             directory: "/src",
@@ -296,6 +343,7 @@ struct CustomSidebarDataContextBuilderTests {
 
         #expect(value.member("id") == .string(id.uuidString))
         #expect(value.member("title") == .string("editor"))
+        #expect(value.member("kind") == .string("browser"))
         #expect(value.member("focused") == .bool(true))
         #expect(value.member("pinned") == .bool(true))
         #expect(value.member("directory") == .string("/src"))

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -39,14 +39,13 @@ import Testing
     @Test func parsesHSplitViewColumns() {
         let node = interp.evaluate("""
         HSplitView {
-            VStack { Text("left") }
-            VStack { Text("right") }
+            VStack { Text("left") }; VStack { Text("right") }; VStack { Text("deep") }; VStack { Text("info") }
         }
         """)
         #expect(node?.kind == .hsplit)
-        #expect(node?.children.count == 2)
+        #expect(node?.children.count == 4)
         #expect(node?.children.first?.kind == .vstack)
-        #expect(node?.children.last?.children.first?.text == "right")
+        #expect(node?.children.last?.children.first?.text == "info")
     }
 
     @Test func parsesShapesAndLabeledFrameAndBackground() {

--- a/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/ResizableHSplit.swift
+++ b/Packages/macOS/CmuxSwiftRenderUI/Sources/CmuxSwiftRenderUI/Rendering/ResizableHSplit.swift
@@ -2,11 +2,11 @@ import AppKit
 import CmuxSwiftRender
 import SwiftUI
 
-/// A two-column horizontally resizable split with a draggable divider.
+/// A horizontally split sidebar root.
 ///
-/// The split fraction is persisted in `@AppStorage` so it survives the sidebar
-/// re-interpreting its source (which happens on every workspace change) and
-/// across launches. Each column scrolls independently.
+/// Two children keep the original draggable split. Three or more children render
+/// as Finder-style fixed-width columns inside a horizontal scroll view. In both
+/// modes each column scrolls independently.
 struct ResizableHSplit: View {
     let columns: [RenderNode]
 
@@ -15,9 +15,18 @@ struct ResizableHSplit: View {
     @Environment(\.customSidebarContentInsets) private var contentInsets
 
     private let minColumnWidth: CGFloat = 80
+    private let maxFinderColumnWidth: CGFloat = 168
     private let handleWidth: CGFloat = 10
 
     var body: some View {
+        if columns.count > 2 {
+            multiColumnBody
+        } else {
+            twoColumnBody
+        }
+    }
+
+    private var twoColumnBody: some View {
         GeometryReader { geo in
             let total = max(geo.size.width, 1)
             let lowerBound = Double(minColumnWidth / total)
@@ -30,6 +39,29 @@ struct ResizableHSplit: View {
                 divider(total: total)
                 column(columns.count > 1 ? columns[1] : nil)
                     .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var multiColumnBody: some View {
+        GeometryReader { geo in
+            let visibleColumns = CGFloat(min(columns.count, 3))
+            let dividerWidth = CGFloat(max(columns.count - 1, 0))
+            let columnWidth = min(
+                maxFinderColumnWidth,
+                max(minColumnWidth, floor((geo.size.width - dividerWidth) / visibleColumns))
+            )
+            ScrollView(.horizontal) {
+                HStack(spacing: 0) {
+                    ForEach(columns.indices, id: \.self) { index in
+                        if index > columns.startIndex {
+                            Divider()
+                        }
+                        column(columns[index])
+                            .frame(width: columnWidth)
+                    }
+                }
+                .frame(height: geo.size.height)
             }
         }
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10076,8 +10076,7 @@ struct VerticalTabsSidebar: View {
     /// Live, read-only projection of workspace state handed to custom
     /// sidebars so interpreted Swift can bind to it (e.g.
     /// `ForEach(workspaces) { w in Text(w.title) }`) and re-render when it
-    /// changes. A value snapshot built fresh each render, never the store
-    /// itself, so it respects the sidebar snapshot-boundary rule.
+    /// changes. A fresh value snapshot respects the sidebar snapshot-boundary rule.
     private func customSidebarDataContext(now: Date) -> [String: SwiftValue] {
         let selectedId = tabManager.selectedTabId
         let workspaces = tabManager.tabs.enumerated().map { index, workspace in
@@ -10089,6 +10088,7 @@ struct VerticalTabsSidebar: View {
             selectedWorkspaceId: selectedId,
             selectedWorkspaceTitle: selectedWorkspace?.customTitle ?? selectedWorkspace?.title ?? "",
             totalUnreadCount: sidebarUnread.totalUnreadCount,
+            recentFocus: customSidebarRecentFocusSnapshots(),
             now: now
         )
         return CustomSidebarDataContextBuilder().dataContext(for: snapshot)
@@ -10147,7 +10147,7 @@ struct VerticalTabsSidebar: View {
                 surfaces.append(
                     CustomSidebarSurfaceSnapshot(
                         panelId: panelId,
-                        title: tab.title,
+                        title: tab.title, kind: workspace.panels[panelId]?.panelType.rawValue ?? "terminal",
                         isFocused: panelId == focusedPanelId,
                         isPinned: workspace.pinnedPanelIds.contains(panelId),
                         directory: workspace.panelDirectories[panelId],

--- a/Sources/VerticalTabsSidebar+CustomSidebarRecents.swift
+++ b/Sources/VerticalTabsSidebar+CustomSidebarRecents.swift
@@ -1,0 +1,22 @@
+import CmuxSidebar
+import CmuxWorkspaces
+
+extension VerticalTabsSidebar {
+    /// Projects the window focus-history stack into custom-sidebar rows.
+    func customSidebarRecentFocusSnapshots() -> [CustomSidebarRecentFocusSnapshot] {
+        let back = tabManager.focusHistoryMenuSnapshot(direction: .back, maxItemCount: nil)
+        let forward = tabManager.focusHistoryMenuSnapshot(direction: .forward, maxItemCount: nil)
+        return FocusHistoryMenuSnapshot.recentlyFocused(back: back, forward: forward, maxItemCount: 16)
+            .items
+            .map { item in
+                CustomSidebarRecentFocusSnapshot(
+                    workspaceId: item.entry.workspaceId,
+                    panelId: tabManager.focusHistoryNavigation.resolvedFocusHistoryPanelId(for: item.entry),
+                    workspaceTitle: item.workspaceTitle,
+                    panelTitle: item.panelTitle,
+                    position: item.position == .older ? "older" : "newer",
+                    focusedAt: item.focusedAt
+                )
+            }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -882,6 +882,7 @@
 		A5001208 /* UpdateTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001218 /* UpdateTitlebarAccessory.swift */; };
 		B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000005 /* VaultAgentProcessScanner.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
+		F15C01A00000000000000001 /* VerticalTabsSidebar+CustomSidebarRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15C01A00000000000000002 /* VerticalTabsSidebar+CustomSidebarRecents.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
@@ -1848,6 +1849,7 @@
 		A5001218 /* UpdateTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateTitlebarAccessory.swift; sourceTree = "<group>"; };
 		B35750000000000000000005 /* VaultAgentProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScanner.swift; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
+		F15C01A00000000000000002 /* VerticalTabsSidebar+CustomSidebarRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+CustomSidebarRecents.swift"; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
@@ -2237,6 +2239,7 @@
 				C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */,
 				C0DEF0A90000000000000002 /* ContentView+ForkAgentConversation.swift */,
 				D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */,
+				F15C01A00000000000000002 /* VerticalTabsSidebar+CustomSidebarRecents.swift */,
 				EA1F00000000000000000002 /* SidebarPathFormatter.swift */,
 				EA1F00000000000000000004 /* SidebarDirectoryText.swift */,
 				D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */,
@@ -3956,6 +3959,7 @@
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				B35750000000000000000006 /* VaultAgentProcessScanner.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
+				F15C01A00000000000000001 /* VerticalTabsSidebar+CustomSidebarRecents.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -125,11 +125,17 @@ Then right-click the sidebar button and choose **mine**.
   `progress` (`{ value: 0..1, label }`), `latestMessage` (last agent message),
   `latestPrompt` (last submitted prompt), `latestAt` (epoch), `remote`
   (`{ target, state, connected }`).
-- `tabs` (per workspace) — array of surfaces. Always: `id`, `title`,
-  `focused` (Bool), `pinned` (Bool). When available: `directory`, `branch` +
-  `dirty`, `ports` (array of Int).
+- `tabs` (per workspace) — array of surfaces. Always: `id`, `title`, `kind`
+  (`terminal`, `browser`, `markdown`, `filepreview`, `rightSidebarTool`,
+  `agentSession`, `project`, or `extensionBrowser`), `focused` (Bool),
+  `pinned` (Bool). When available: `directory`, `branch` + `dirty`, `ports`
+  (array of Int).
 - `workspaceCount` — Int. `selectedTitle` — active workspace's title.
   `selectedId` — its id. `unreadTotal` — total unread notifications.
+- `recents` — array of recently focused workspace/panel targets from cmux focus
+  history, newest first. Always: `workspaceId`, `workspaceTitle`, `position`
+  (`older` or `newer`), `focusedAt` (epoch). Present when available: `panelId`,
+  `panelTitle`. `recentCount` is the number of recent targets.
 - `clock` — `{ time ("HH:mm:ss"), hour, minute, second, weekday, epoch }`. The
   sidebar re-renders about once a second, so clocks/countdowns and workspace
   changes are live.
@@ -146,7 +152,8 @@ Containers: `VStack(alignment:spacing:)`, `HStack`, `ZStack`, `LazyVStack`,
 `ScrollView { ... }` (use `ScrollView(.horizontal) { HStack { ... } }` for a
 horizontal strip — vertical scrolling is automatic), and
 `HSplitView { columnA; columnB }` (two resizable, independently-scrolling
-columns with a persisted divider).
+columns with a persisted divider). `HSplitView` with three or more children
+renders Finder-style fixed-width columns; every column scrolls independently.
 
 Content: `Text("...")`, `Label("Title", systemImage: "folder")`,
 `Image(systemName: "folder.fill")` (SF Symbols),


### PR DESCRIPTION
## Summary
- render multi-child HSplitView as Finder-style fixed-width columns with independent per-column scrolling
- expose focus-history recents to custom sidebars as recents/recentCount
- update the custom sidebar docs and focused data/interpreter tests

## Verification
- cmux sidebar validate finder-columns
- ./scripts/reload-cloud.sh --tag fcol
- launched tagged app via http://127.0.0.1:17320/fcol
- selected finder-columns through CMUX_TAG=fcol scripts/cmux-debug-cli.sh sidebar select finder-columns
- verified tagged app identity on /tmp/cmux-debug-fcol.sock
- verified via Computer Use that the tagged sidebar renders five scroll areas and Recents populates from seeded focus history

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784436232&installation_id=133855650&pr_number=6428&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6428&signature=8a5e153f84e13850e2061a0853800db18ed280f084bae5e0c2a24e0b385923cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar UI and read-only interpreter bindings only; no auth or persistence changes beyond existing split fraction for two-column mode.
> 
> **Overview**
> Custom sidebars get **Finder-style layouts** when `HSplitView` has three or more children: `ResizableHSplit` switches from the existing two-pane draggable split to fixed-width (~168px) columns in a horizontal scroll, each with its own vertical scroll. Two-child behavior is unchanged.
> 
> The interpreter **data context** gains **`recents`** / **`recentCount`** from window focus history (up to 16 items, wired via `VerticalTabsSidebar+CustomSidebarRecents`), plus **`kind`** on each workspace **`tabs`** surface (panel type from live state). Docs and unit tests cover the new keys and multi-column `HSplitView` parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 143060b39852956b7e718a38d0484eba59a3759f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render `HSplitView` with 3+ children as Finder-style fixed-width columns in a horizontal scroll, while 2-child splits keep the original draggable divider. Expose focus history to custom sidebars via `recents`/`recentCount`, and surface panel `kind` in `tabs`.

- **New Features**
  - Multi-column `HSplitView`: 3+ children render as fixed-width (~168px) Finder-style columns in a horizontal scroll; each column scrolls independently; 2-child split is unchanged.
  - Sidebar context adds `recents` (newest first, up to 16) and `recentCount`. Each recent includes `workspaceId`, `workspaceTitle`, `position` (`older`/`newer`), `focusedAt` (epoch), and optional `panelId`, `panelTitle`.
  - `tabs` now include `kind` (e.g. `terminal`, `browser`, `markdown`) for each panel.
  - Docs updated for `HSplitView`, `recents`, and `kind`; tests cover data context and multi-child `HSplitView` parsing.

<sup>Written for commit 143060b39852956b7e718a38d0484eba59a3759f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “recently focused” history to custom sidebars via new read-only bindings: `recents` (newest first) and `recentCount`, including workspace and optional panel details.
  * Improved HSplitView rendering: when there are 3+ columns, it uses Finder-style fixed-width horizontally scrollable columns with independently scrolling content.
* **Documentation**
  * Updated custom sidebar docs to describe `recents`/`recentCount` and clarified the multi-column HSplitView behavior.
* **Tests**
  * Added/updated unit tests covering recent-focus context and the new multi-column view structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->