### PR TITLE
CI: skip expensive jobs for unrelated PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    timeout-minutes: 5
+    outputs:
+      macos: ${{ steps.detect.outputs.macos }}
+      web: ${{ steps.detect.outputs.web }}
+      go: ${{ steps.detect.outputs.go }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect CI change areas
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/ci/detect_ci_change_areas.py \
+            --event-name "$EVENT_NAME" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"
+
   workflow-guard-tests:
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     steps:
@@ -86,6 +111,9 @@ jobs:
       - name: Validate release asset guard
         run: node scripts/release_asset_guard.test.js
 
+      - name: Validate CI change area filter
+        run: python3 tests/test_ci_change_areas.py
+
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh
 
@@ -132,6 +160,8 @@ jobs:
         run: python3 scripts/check-test-determinism.py --strict
 
   remote-daemon-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.go == 'true' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     steps:
       - name: Checkout
@@ -151,6 +181,8 @@ jobs:
         run: ./tests/test_remote_daemon_release_assets.sh
 
   web-typecheck:
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     defaults:
       run:
@@ -174,6 +206,8 @@ jobs:
   # Checks for in-app React webviews (currently the diff viewer; more cmux React
   # surfaces will live alongside it).
   react-apps-check:
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     steps:
       - name: Checkout
@@ -205,6 +239,8 @@ jobs:
         run: bun run react-doctor:ci
 
   web-db-migrations:
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     defaults:
       run:
@@ -253,6 +289,8 @@ jobs:
         run: bun run test:db:behavior
 
   tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     # App-host XCTest needs a runner that can broker testmanagerd control
     # sessions. Keep this job on the hosted GUI-capable pool until the
     # MACOS_RUNNER_15/Austin runner-infra issue is fixed separately.
@@ -658,6 +696,8 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
 
   tests-build-and-lag:
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     # Build the full cmux scheme and run the lag regression on macOS CI.
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
@@ -987,6 +1027,8 @@ jobs:
           rm -f "${VDISPLAY_HELPER_PATH:-}" "${VDISPLAY_READY:-}" "${VDISPLAY_ID_PATH:-}" "${VDISPLAY_LOG:-}"
 
   release-ghostty-cli-helper:
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 20
     steps:
@@ -1043,7 +1085,10 @@ jobs:
           overwrite: true
 
   release-build:
-    needs: release-ghostty-cli-helper
+    needs:
+      - changes
+      - release-ghostty-cli-helper
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
@@ -1185,6 +1230,8 @@ jobs:
           [[ "$SDK_VERSION" == 26.* ]]
 
   ui-regressions:
+    needs: changes
+    if: ${{ needs.changes.outputs.macos == 'true' }}
     runs-on: ${{ vars.MACOS_RUNNER_DISPLAY || 'warp-macos-15-arm64-6x' }}
     # Cold builds after project/package changes can spend more than 25 minutes
     # in build-for-testing before the UI regression script starts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
               exit 0
             fi
 
+            if [ ! -s /tmp/cmux-ci-changed-files.txt ]; then
+              echo "PR diff is empty; running all CI areas."
+              emit_all_areas
+              exit 0
+            fi
+
             # This guard lives in workflow YAML, before the PR-editable detector
             # runs. Router/workflow edits must fail open even if a PR breaks the
             # detector's own self-change classification.
@@ -1733,3 +1739,45 @@ jobs:
           fi
           scripts/ci/virtual-display-lock.sh release || true
           rm -f "${VDISPLAY_PERSISTENT_HELPER_PATH:-}" "${VDISPLAY_PERSISTENT_READY:-}" "${VDISPLAY_PERSISTENT_ID_PATH:-}" "${VDISPLAY_PERSISTENT_LOG:-}"
+
+  ci-status:
+    needs:
+      - changes
+      - workflow-guard-tests
+      - remote-daemon-tests
+      - web-typecheck
+      - react-apps-check
+      - web-db-migrations
+      - tests
+      - tests-build-and-lag
+      - release-ghostty-cli-helper
+      - release-build
+      - ui-regressions
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    steps:
+      - name: Check routed CI jobs
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["CI_NEEDS"])
+          allowed = {"success", "skipped"}
+          bad = {
+              name: data["result"]
+              for name, data in sorted(needs.items())
+              if data["result"] not in allowed
+          }
+
+          if bad:
+              for name, result in bad.items():
+                  print(f"{name}: {result}", file=sys.stderr)
+              sys.exit(1)
+
+          for name, data in sorted(needs.items()):
+              print(f"{name}: {data['result']}")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,26 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          emit_all_areas() {
+            echo "macos=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          }
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
-            git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/cmux-ci-changed-files.txt
+            if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" \
+              || ! git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/cmux-ci-changed-files.txt; then
+              echo "Could not compute PR diff; running all CI areas." >&2
+              emit_all_areas
+              exit 0
+            fi
 
             # This guard lives in workflow YAML, before the PR-editable detector
             # runs. Router/workflow edits must fail open even if a PR breaks the
             # detector's own self-change classification.
             if grep -Eq '^(\.github/workflows/ci\.yml|scripts/ci/[^/]+\.py|tests/test_ci_change_areas\.py)$' /tmp/cmux-ci-changed-files.txt; then
               echo "CI router changed; running all CI areas."
-              echo "macos=true" >> "$GITHUB_OUTPUT"
-              echo "web=true" >> "$GITHUB_OUTPUT"
-              echo "go=true" >> "$GITHUB_OUTPUT"
+              emit_all_areas
               exit 0
             fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,28 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+            git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/cmux-ci-changed-files.txt
+
+            # This guard lives in workflow YAML, before the PR-editable detector
+            # runs. Router/workflow edits must fail open even if a PR breaks the
+            # detector's own self-change classification.
+            if grep -Eq '^(\.github/workflows/ci\.yml|scripts/ci/detect_ci_change_areas\.py|tests/test_ci_change_areas\.py)$' /tmp/cmux-ci-changed-files.txt; then
+              echo "CI router changed; running all CI areas."
+              echo "macos=true" >> "$GITHUB_OUTPUT"
+              echo "web=true" >> "$GITHUB_OUTPUT"
+              echo "go=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            python3 scripts/ci/detect_ci_change_areas.py \
+              --event-name "$EVENT_NAME" \
+              --files-from /tmp/cmux-ci-changed-files.txt
+            exit 0
+          fi
+
           python3 scripts/ci/detect_ci_change_areas.py \
             --event-name "$EVENT_NAME" \
             --base-sha "$BASE_SHA" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             # This guard lives in workflow YAML, before the PR-editable detector
             # runs. Router/workflow edits must fail open even if a PR breaks the
             # detector's own self-change classification.
-            if grep -Eq '^(\.github/workflows/ci\.yml|scripts/ci/detect_ci_change_areas\.py|tests/test_ci_change_areas\.py)$' /tmp/cmux-ci-changed-files.txt; then
+            if grep -Eq '^(\.github/workflows/ci\.yml|scripts/ci/[^/]+\.py|tests/test_ci_change_areas\.py)$' /tmp/cmux-ci-changed-files.txt; then
               echo "CI router changed; running all CI areas."
               echo "macos=true" >> "$GITHUB_OUTPUT"
               echo "web=true" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -45,6 +45,13 @@ def is_workflow(path: str) -> bool:
     return path.startswith(".github/workflows/")
 
 
+def forces_all_areas(path: str) -> bool:
+    return is_workflow(path) or path in {
+        "scripts/ci/detect_ci_change_areas.py",
+        "tests/test_ci_change_areas.py",
+    }
+
+
 def is_web_change(path: str) -> bool:
     if path.startswith(("web/", "webviews/", "Resources/agent-session")):
         return True
@@ -59,7 +66,10 @@ def is_web_change(path: str) -> bool:
 
 
 def is_go_change(path: str) -> bool:
-    return path.startswith("daemon/remote/") or path == "tests/test_remote_daemon_release_assets.sh"
+    return path.startswith("daemon/remote/") or path in {
+        "scripts/build_remote_daemon_release_assets.sh",
+        "tests/test_remote_daemon_release_assets.sh",
+    }
 
 
 def is_macos_neutral(path: str) -> bool:
@@ -67,11 +77,11 @@ def is_macos_neutral(path: str) -> bool:
         return True
     if path.startswith(".github/") and not is_workflow(path):
         return True
-    return path.endswith((".md", ".mdx", ".rst", ".txt"))
+    return path.endswith((".md", ".mdx", ".rst"))
 
 
 def is_macos_change(path: str) -> bool:
-    if is_workflow(path):
+    if forces_all_areas(path):
         return True
     if path in {"package.json", "bun.lock", "biome.json"}:
         return True
@@ -89,7 +99,7 @@ def classify_files(paths: Iterable[str]) -> ChangeAreas:
         path = normalize_path(raw_path)
         if not path:
             continue
-        if is_workflow(path):
+        if forces_all_areas(path):
             macos = True
             web = True
             go = True

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -53,7 +53,7 @@ def forces_all_areas(path: str) -> bool:
 
 
 def is_web_change(path: str) -> bool:
-    if path.startswith(("web/", "webviews/", "Resources/agent-session")):
+    if path.startswith(("web/", "webviews/", "Resources/agent-session", "Resources/markdown-viewer/")):
         return True
     if path == "CHANGELOG.md":
         return True
@@ -84,6 +84,8 @@ def is_macos_neutral(path: str) -> bool:
 
 def is_macos_change(path: str) -> bool:
     if forces_all_areas(path):
+        return True
+    if path.startswith("webviews/src/agent-session/"):
         return True
     if path == "docs/cli-contract.md":
         return True

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -54,7 +54,15 @@ def forces_all_areas(path: str) -> bool:
 
 
 def is_web_change(path: str) -> bool:
-    if path.startswith(("web/", "webviews/", "Resources/agent-session", "Resources/markdown-viewer/")):
+    if path.startswith(
+        (
+            "web/",
+            "webviews/",
+            "Resources/agent-session-react/",
+            "Resources/agent-session-solid/",
+            "Resources/markdown-viewer/",
+        )
+    ):
         return True
     if path == "CHANGELOG.md":
         return True
@@ -82,15 +90,13 @@ def is_macos_neutral(path: str) -> bool:
 
 
 def is_macos_change(path: str) -> bool:
-    if forces_all_areas(path):
-        return True
     if path.startswith("webviews/src/agent-session/"):
         return True
     if path == "docs/cli-contract.md":
         return True
     if path in {"package.json", "bun.lock", "biome.json"}:
         return True
-    if path.startswith("Resources/agent-session"):
+    if path.startswith(("Resources/agent-session-react/", "Resources/agent-session-solid/")):
         return True
     return not is_macos_neutral(path)
 
@@ -173,7 +179,11 @@ def main(argv: list[str]) -> int:
             if not args.base_sha or not args.head_sha:
                 raise RuntimeError("pull_request event is missing base/head SHA")
             files = changed_files(args.base_sha, args.head_sha)
-        areas = classify_files(files)
+        if files:
+            areas = classify_files(files)
+        else:
+            areas = ChangeAreas.all()
+            print("PR diff is empty; running all CI areas.")
     except Exception as error:
         areas = ChangeAreas.all()
         print(f"Could not classify diff, running all CI areas: {error}", file=sys.stderr)

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -77,9 +77,7 @@ def is_go_change(path: str) -> bool:
 def is_macos_neutral(path: str) -> bool:
     if path.startswith(("docs/", "design/", "plans/", "ios/", "web/", "webviews/", "daemon/remote/")):
         return True
-    if path.startswith(".github/") and not is_workflow(path):
-        return True
-    return path.endswith((".md", ".mdx", ".rst"))
+    return path == "README.md" or (path.startswith("README.") and path.endswith(".md"))
 
 
 def is_macos_change(path: str) -> bool:

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Classify a PR diff into CI areas that should run."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class ChangeAreas:
+    macos: bool
+    web: bool
+    go: bool
+
+    @classmethod
+    def all(cls) -> "ChangeAreas":
+        return cls(macos=True, web=True, go=True)
+
+    def as_output_lines(self) -> list[str]:
+        return [
+            f"macos={bool_output(self.macos)}",
+            f"web={bool_output(self.web)}",
+            f"go={bool_output(self.go)}",
+        ]
+
+
+def bool_output(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def is_workflow(path: str) -> bool:
+    return path.startswith(".github/workflows/")
+
+
+def is_web_change(path: str) -> bool:
+    if path.startswith(("web/", "webviews/", "Resources/agent-session")):
+        return True
+    return path in {
+        "package.json",
+        "bun.lock",
+        "biome.json",
+        "scripts/build-agent-session-web.sh",
+        "scripts/build-webviews-app.sh",
+        "scripts/check-webviews-react-compiler.mjs",
+    }
+
+
+def is_go_change(path: str) -> bool:
+    return path.startswith("daemon/remote/") or path == "tests/test_remote_daemon_release_assets.sh"
+
+
+def is_macos_neutral(path: str) -> bool:
+    if path.startswith(("docs/", "design/", "plans/", "ios/", "web/", "webviews/", "daemon/remote/")):
+        return True
+    if path.startswith(".github/") and not is_workflow(path):
+        return True
+    return path.endswith((".md", ".mdx", ".rst", ".txt"))
+
+
+def is_macos_change(path: str) -> bool:
+    if is_workflow(path):
+        return True
+    if path in {"package.json", "bun.lock", "biome.json"}:
+        return True
+    if path.startswith("Resources/agent-session"):
+        return True
+    return not is_macos_neutral(path)
+
+
+def classify_files(paths: Iterable[str]) -> ChangeAreas:
+    macos = False
+    web = False
+    go = False
+
+    for raw_path in paths:
+        path = normalize_path(raw_path)
+        if not path:
+            continue
+        if is_workflow(path):
+            macos = True
+            web = True
+            go = True
+            continue
+        if is_web_change(path):
+            web = True
+        if is_go_change(path):
+            go = True
+        if is_macos_change(path):
+            macos = True
+
+    return ChangeAreas(macos=macos, web=web, go=go)
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True, stderr=subprocess.STDOUT).strip()
+
+
+def changed_files(base_sha: str, head_sha: str) -> list[str]:
+    merge_base = run_git(["merge-base", base_sha, head_sha])
+    output = run_git(["diff", "--name-only", merge_base, head_sha])
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def write_outputs(areas: ChangeAreas, output_path: Optional[str]) -> None:
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as handle:
+        for line in areas.as_output_lines():
+            handle.write(f"{line}\n")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Path to append GitHub Actions step outputs to.",
+    )
+    parser.add_argument(
+        "--files-from",
+        type=Path,
+        help="Read changed files from this newline-delimited file instead of git.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if args.event_name != "pull_request":
+        areas = ChangeAreas.all()
+        print(f"Non-PR event '{args.event_name or 'unknown'}'; running all CI areas.")
+        write_outputs(areas, args.github_output)
+        print("Resolved areas: " + " ".join(areas.as_output_lines()))
+        return 0
+
+    files: list[str] = []
+    try:
+        if args.files_from:
+            files = args.files_from.read_text(encoding="utf-8").splitlines()
+        else:
+            if not args.base_sha or not args.head_sha:
+                raise RuntimeError("pull_request event is missing base/head SHA")
+            files = changed_files(args.base_sha, args.head_sha)
+        areas = classify_files(files)
+    except Exception as error:
+        areas = ChangeAreas.all()
+        print(f"Could not classify diff, running all CI areas: {error}", file=sys.stderr)
+
+    if files:
+        print("Changed files:")
+        for path in files:
+            print(path)
+    else:
+        print("Changed files: (none)")
+
+    write_outputs(areas, args.github_output)
+    print("Resolved areas: " + " ".join(areas.as_output_lines()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -46,10 +46,11 @@ def is_workflow(path: str) -> bool:
 
 
 def forces_all_areas(path: str) -> bool:
-    return is_workflow(path) or path in {
-        "scripts/ci/detect_ci_change_areas.py",
-        "tests/test_ci_change_areas.py",
-    }
+    ci_script_prefix = "scripts/ci/"
+    is_direct_ci_python = path.startswith(ci_script_prefix) and path.endswith(".py")
+    if is_direct_ci_python:
+        is_direct_ci_python = "/" not in path[len(ci_script_prefix) :]
+    return is_workflow(path) or is_direct_ci_python or path == "tests/test_ci_change_areas.py"
 
 
 def is_web_change(path: str) -> bool:

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -55,6 +55,8 @@ def forces_all_areas(path: str) -> bool:
 def is_web_change(path: str) -> bool:
     if path.startswith(("web/", "webviews/", "Resources/agent-session")):
         return True
+    if path == "CHANGELOG.md":
+        return True
     return path in {
         "package.json",
         "bun.lock",
@@ -82,6 +84,8 @@ def is_macos_neutral(path: str) -> bool:
 
 def is_macos_change(path: str) -> bool:
     if forces_all_areas(path):
+        return True
+    if path == "docs/cli-contract.md":
         return True
     if path in {"package.json", "bun.lock", "biome.json"}:
         return True

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -64,6 +64,8 @@ def test_root_agent_web_dependencies_run_web_and_macos() -> None:
 
 def test_agent_session_resources_run_web_and_macos() -> None:
     assert_areas(["Resources/agent-session-react/index.js"], macos=True, web=True, go=False)
+    assert_areas(["Resources/agent-session-solid/index.js"], macos=True, web=True, go=False)
+    assert_areas(["Resources/agent-session-backup/index.js"], macos=True, web=False, go=False)
 
 
 def test_ios_only_skips_main_macos_ci() -> None:
@@ -106,6 +108,20 @@ def detect_step_script() -> str:
     raise AssertionError("Detect CI change areas run block not found")
 
 
+def workflow_job_block(job_name: str) -> str:
+    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    marker = f"  {job_name}:"
+    for index, line in enumerate(lines):
+        if line == marker:
+            body = [line]
+            for body_line in lines[index + 1 :]:
+                if body_line.startswith("  ") and not body_line.startswith("    ") and body_line.strip():
+                    break
+                body.append(body_line)
+            return "\n".join(body)
+    raise AssertionError(f"{job_name} job not found")
+
+
 def run_detect_step_for_paths(paths: list[str]) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     script = detect_step_script()
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -118,13 +134,16 @@ def run_detect_step_for_paths(paths: list[str]) -> tuple[subprocess.CompletedPro
         subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
         base_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
 
-        for path in paths:
-            target = repo / path
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text("changed\n", encoding="utf-8")
-        subprocess.run(["git", "add", "."], cwd=repo, check=True)
-        subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
-        head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+        if paths:
+            for path in paths:
+                target = repo / path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text("changed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+            head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+        else:
+            head_sha = base_sha
 
         output_path = repo / "github-output.txt"
         env = {
@@ -183,6 +202,13 @@ def test_workflow_diff_failure_runs_all_areas() -> None:
         ]
 
 
+def test_workflow_empty_diff_runs_all_areas() -> None:
+    result, outputs = run_detect_step_for_paths([])
+
+    assert "PR diff is empty; running all CI areas." in result.stdout
+    assert outputs == ["macos=true", "web=true", "go=true"]
+
+
 def test_router_changes_run_everything() -> None:
     assert_areas(["scripts/ci/detect_ci_change_areas.py"], macos=True, web=True, go=True)
     assert_areas(["scripts/ci/subprocess.py"], macos=True, web=True, go=True)
@@ -232,6 +258,38 @@ def test_cli_writes_github_outputs() -> None:
         ]
 
 
+def test_cli_empty_diff_runs_all_areas() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        files_path = Path(temp_dir) / "files.txt"
+        output_path = Path(temp_dir) / "github-output.txt"
+        files_path.write_text("", encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--event-name",
+                "pull_request",
+                "--files-from",
+                str(files_path),
+                "--github-output",
+                str(output_path),
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        assert "PR diff is empty; running all CI areas." in result.stdout
+        assert "Resolved areas: macos=true web=true go=true" in result.stdout
+        assert output_path.read_text(encoding="utf-8").splitlines() == [
+            "macos=true",
+            "web=true",
+            "go=true",
+        ]
+
+
 def test_non_pr_events_run_all_areas() -> None:
     result = subprocess.run(
         [sys.executable, str(HELPER), "--event-name", "workflow_dispatch"],
@@ -242,6 +300,28 @@ def test_non_pr_events_run_all_areas() -> None:
     )
 
     assert "Resolved areas: macos=true web=true go=true" in result.stdout
+
+
+def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
+    block = workflow_job_block("ci-status")
+
+    for job_name in [
+        "changes",
+        "workflow-guard-tests",
+        "remote-daemon-tests",
+        "web-typecheck",
+        "react-apps-check",
+        "web-db-migrations",
+        "tests",
+        "tests-build-and-lag",
+        "release-ghostty-cli-helper",
+        "release-build",
+        "ui-regressions",
+    ]:
+        assert f"      - {job_name}" in block
+
+    assert "if: ${{ always() }}" in block
+    assert 'allowed = {"success", "skipped"}' in block
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -31,6 +31,14 @@ def test_docs_only_skips_expensive_areas() -> None:
     assert_areas(["docs/ci.md", "README.md"], macos=False, web=False, go=False)
 
 
+def test_cli_contract_doc_runs_macos_contract_tests() -> None:
+    assert_areas(["docs/cli-contract.md"], macos=True, web=False, go=False)
+
+
+def test_changelog_runs_web_validation() -> None:
+    assert_areas(["CHANGELOG.md"], macos=False, web=True, go=False)
+
+
 def test_web_only_runs_web_without_macos() -> None:
     assert_areas(["web/app/page.tsx", "webviews/src/diff/App.tsx"], macos=False, web=True, go=False)
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "ci" / "detect_ci_change_areas.py"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 
 spec = importlib.util.spec_from_file_location("detect_ci_change_areas", HELPER)
 assert spec and spec.loader
@@ -82,6 +83,15 @@ def test_app_source_runs_macos() -> None:
 
 def test_workflow_changes_run_everything() -> None:
     assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
+
+
+def test_workflow_has_trusted_self_change_guard() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "CI router changed; running all CI areas." in workflow
+    assert "--files-from /tmp/cmux-ci-changed-files.txt" in workflow
+    assert r"\.github/workflows/ci\.yml" in workflow
+    assert r"scripts/ci/detect_ci_change_areas\.py" in workflow
+    assert r"tests/test_ci_change_areas\.py" in workflow
 
 
 def test_router_changes_run_everything() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -90,12 +90,13 @@ def test_workflow_has_trusted_self_change_guard() -> None:
     assert "CI router changed; running all CI areas." in workflow
     assert "--files-from /tmp/cmux-ci-changed-files.txt" in workflow
     assert r"\.github/workflows/ci\.yml" in workflow
-    assert r"scripts/ci/detect_ci_change_areas\.py" in workflow
+    assert r"scripts/ci/[^/]+\.py" in workflow
     assert r"tests/test_ci_change_areas\.py" in workflow
 
 
 def test_router_changes_run_everything() -> None:
     assert_areas(["scripts/ci/detect_ci_change_areas.py"], macos=True, web=True, go=True)
+    assert_areas(["scripts/ci/subprocess.py"], macos=True, web=True, go=True)
     assert_areas(["tests/test_ci_change_areas.py"], macos=True, web=True, go=True)
 
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the CI path filter."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "ci" / "detect_ci_change_areas.py"
+
+spec = importlib.util.spec_from_file_location("detect_ci_change_areas", HELPER)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+def assert_areas(paths: list[str], *, macos: bool, web: bool, go: bool) -> None:
+    actual = module.classify_files(paths)
+    assert actual.macos is macos, (paths, actual)
+    assert actual.web is web, (paths, actual)
+    assert actual.go is go, (paths, actual)
+
+
+def test_docs_only_skips_expensive_areas() -> None:
+    assert_areas(["docs/ci.md", "README.md"], macos=False, web=False, go=False)
+
+
+def test_web_only_runs_web_without_macos() -> None:
+    assert_areas(["web/app/page.tsx", "webviews/src/diff/App.tsx"], macos=False, web=True, go=False)
+
+
+def test_root_agent_web_dependencies_run_web_and_macos() -> None:
+    assert_areas(["package.json", "bun.lock"], macos=True, web=True, go=False)
+
+
+def test_agent_session_resources_run_web_and_macos() -> None:
+    assert_areas(["Resources/agent-session-react/index.js"], macos=True, web=True, go=False)
+
+
+def test_ios_only_skips_main_macos_ci() -> None:
+    assert_areas(["ios/cmux/ContentView.swift"], macos=False, web=False, go=False)
+
+
+def test_remote_daemon_runs_go_only() -> None:
+    assert_areas(["daemon/remote/main.go"], macos=False, web=False, go=True)
+
+
+def test_app_source_runs_macos() -> None:
+    assert_areas(["Sources/AppDelegate.swift"], macos=True, web=False, go=False)
+
+
+def test_workflow_changes_run_everything() -> None:
+    assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
+
+
+def test_non_workflow_github_metadata_is_neutral() -> None:
+    assert_areas([".github/review-bot-rules/code.yml"], macos=False, web=False, go=False)
+
+
+def test_cli_writes_github_outputs() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        files_path = Path(temp_dir) / "files.txt"
+        output_path = Path(temp_dir) / "github-output.txt"
+        files_path.write_text("web/app/page.tsx\n", encoding="utf-8")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--event-name",
+                "pull_request",
+                "--files-from",
+                str(files_path),
+                "--github-output",
+                str(output_path),
+            ],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        assert "Resolved areas: macos=false web=true go=false" in result.stdout
+        assert output_path.read_text(encoding="utf-8").splitlines() == [
+            "macos=false",
+            "web=true",
+            "go=false",
+        ]
+
+
+def test_non_pr_events_run_all_areas() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "--event-name", "workflow_dispatch"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert "Resolved areas: macos=true web=true go=true" in result.stdout
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: CI change area filter")

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -51,12 +51,25 @@ def test_remote_daemon_runs_go_only() -> None:
     assert_areas(["daemon/remote/main.go"], macos=False, web=False, go=True)
 
 
+def test_remote_daemon_asset_builder_runs_go_validation() -> None:
+    assert_areas(["scripts/build_remote_daemon_release_assets.sh"], macos=True, web=False, go=True)
+
+
 def test_app_source_runs_macos() -> None:
     assert_areas(["Sources/AppDelegate.swift"], macos=True, web=False, go=False)
 
 
 def test_workflow_changes_run_everything() -> None:
     assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
+
+
+def test_router_changes_run_everything() -> None:
+    assert_areas(["scripts/ci/detect_ci_change_areas.py"], macos=True, web=True, go=True)
+    assert_areas(["tests/test_ci_change_areas.py"], macos=True, web=True, go=True)
+
+
+def test_ghosttykit_checksum_pin_runs_macos() -> None:
+    assert_areas(["scripts/ghosttykit-checksums.txt"], macos=True, web=False, go=False)
 
 
 def test_non_workflow_github_metadata_is_neutral() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -43,6 +43,19 @@ def test_web_only_runs_web_without_macos() -> None:
     assert_areas(["web/app/page.tsx", "webviews/src/diff/App.tsx"], macos=False, web=True, go=False)
 
 
+def test_agent_session_webview_sources_run_bundled_asset_check() -> None:
+    assert_areas(["webviews/src/agent-session/shared/message.test.ts"], macos=True, web=True, go=False)
+
+
+def test_markdown_viewer_resources_run_webviews_asset_guard() -> None:
+    assert_areas(
+        ["Resources/markdown-viewer/webviews-app/index.js", "Resources/markdown-viewer/marked.min.js"],
+        macos=True,
+        web=True,
+        go=False,
+    )
+
+
 def test_root_agent_web_dependencies_run_web_and_macos() -> None:
     assert_areas(["package.json", "bun.lock"], macos=True, web=True, go=False)
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -85,13 +86,101 @@ def test_workflow_changes_run_everything() -> None:
     assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
 
 
-def test_workflow_has_trusted_self_change_guard() -> None:
-    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
-    assert "CI router changed; running all CI areas." in workflow
-    assert "--files-from /tmp/cmux-ci-changed-files.txt" in workflow
-    assert r"\.github/workflows/ci\.yml" in workflow
-    assert r"scripts/ci/[^/]+\.py" in workflow
-    assert r"tests/test_ci_change_areas\.py" in workflow
+def detect_step_script() -> str:
+    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if line == "      - name: Detect CI change areas":
+            for run_index in range(index + 1, len(lines)):
+                if lines[run_index] == "        run: |":
+                    body: list[str] = []
+                    for body_line in lines[run_index + 1 :]:
+                        if body_line.startswith("          "):
+                            body.append(body_line[10:])
+                            continue
+                        if not body_line.strip():
+                            body.append("")
+                            continue
+                        break
+                    return "\n".join(body)
+            break
+    raise AssertionError("Detect CI change areas run block not found")
+
+
+def run_detect_step_for_paths(paths: list[str]) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    script = detect_step_script()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo = Path(temp_dir)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "ci@example.test"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "CI Test"], cwd=repo, check=True)
+        (repo / "base.txt").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+        base_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+
+        for path in paths:
+            target = repo / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("changed\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=repo, check=True)
+        head_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+
+        output_path = repo / "github-output.txt"
+        env = {
+            **os.environ,
+            "EVENT_NAME": "pull_request",
+            "BASE_SHA": base_sha,
+            "HEAD_SHA": head_sha,
+            "GITHUB_OUTPUT": str(output_path),
+        }
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return result, output_path.read_text(encoding="utf-8").splitlines()
+
+
+def test_workflow_self_change_guard_runs_before_detector_imports() -> None:
+    result, outputs = run_detect_step_for_paths(["scripts/ci/subprocess.py"])
+
+    assert "CI router changed; running all CI areas." in result.stdout
+    assert outputs == ["macos=true", "web=true", "go=true"]
+
+
+def test_workflow_diff_failure_runs_all_areas() -> None:
+    script = detect_step_script()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo = Path(temp_dir)
+        output_path = repo / "github-output.txt"
+        env = {
+            **os.environ,
+            "EVENT_NAME": "pull_request",
+            "BASE_SHA": "missing-base",
+            "HEAD_SHA": "missing-head",
+            "GITHUB_OUTPUT": str(output_path),
+        }
+        result = subprocess.run(
+            ["bash", "-c", script],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+        assert "Could not compute PR diff; running all CI areas." in result.stderr
+        assert output_path.read_text(encoding="utf-8").splitlines() == [
+            "macos=true",
+            "web=true",
+            "go=true",
+        ]
 
 
 def test_router_changes_run_everything() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -36,7 +36,7 @@ def test_cli_contract_doc_runs_macos_contract_tests() -> None:
 
 
 def test_changelog_runs_web_validation() -> None:
-    assert_areas(["CHANGELOG.md"], macos=False, web=True, go=False)
+    assert_areas(["CHANGELOG.md"], macos=True, web=True, go=False)
 
 
 def test_web_only_runs_web_without_macos() -> None:
@@ -93,8 +93,12 @@ def test_ghosttykit_checksum_pin_runs_macos() -> None:
     assert_areas(["scripts/ghosttykit-checksums.txt"], macos=True, web=False, go=False)
 
 
-def test_non_workflow_github_metadata_is_neutral() -> None:
-    assert_areas([".github/review-bot-rules/code.yml"], macos=False, web=False, go=False)
+def test_app_bundled_markdown_runs_macos() -> None:
+    assert_areas(["THIRD_PARTY_LICENSES.md"], macos=True, web=False, go=False)
+
+
+def test_swift_warning_budget_runs_macos() -> None:
+    assert_areas([".github/swift-warning-budget.tsv"], macos=True, web=False, go=False)
 
 
 def test_cli_writes_github_outputs() -> None:


### PR DESCRIPTION
## Summary

Adds a cheap `changes` job to classify PR diffs into macOS, web, and Go areas, then skips expensive unrelated CI jobs. Non-PR events and diff-classification failures run every area, so pushes to `main`, manual runs, and ambiguous diffs keep full coverage.

## Evidence

Recent green `main` CI runs put the critical path on macOS app checks. In run 27803892749, `tests` took 26m31s, including ~15m08s in app-host unit tests and ~4m57s in Swift package tests. `tests-build-and-lag` took 7m38s, `ui-regressions` took 7m00s, and `release-build` took 8m54s. Cache logs show SwiftPM cache restores around 906 MB and the app-host `tests` job still uses fresh DerivedData.

The larger sharding effort is already in flight at https://github.com/manaflow-ai/cmux/pull/6135. This PR is the smaller safe win: docs-only, iOS-only, web-only, and Go-only PRs stop spending paid macOS runner minutes on app/runtime checks that cannot observe those changes.

## Checks

- `python3 tests/test_ci_change_areas.py`
- `python3 -m py_compile scripts/ci/detect_ci_change_areas.py tests/test_ci_change_areas.py`
- `python3.9 -m py_compile scripts/ci/detect_ci_change_areas.py tests/test_ci_change_areas.py`
- `./tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784436520&installation_id=133855650&pr_number=6429&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6429&signature=c0f0fefb7b37eacbb607414aa3cd3ae15133fffe0d80c0f679b0c629d8b54d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips unrelated expensive CI jobs by classifying PR diffs into macOS, web, and Go. Fails open on ambiguity and adds a final `ci-status` check to ensure routed jobs complete or are skipped.

- **New Features**
  - Added a `changes` job in `ci.yml` that outputs `macos`, `web`, and `go` flags, then gates macOS tests/UI/release, web typecheck/react apps/DB migrations, and Go remote-daemon tests via `needs`/`if`.
  - Implemented `scripts/ci/detect_ci_change_areas.py` with refined rules: `webviews/src/agent-session/*`, `Resources/agent-session-react/*`, `Resources/agent-session-solid/*`, `Resources/markdown-viewer/*`, and root JS config (`package.json`, `bun.lock`, `biome.json`) run web+macOS; `docs/cli-contract.md` runs macOS; `CHANGELOG.md` runs web+macOS; `daemon/remote/*` runs Go-only; `scripts/build_remote_daemon_release_assets.sh` runs Go+macOS; neutral paths include `docs/`, `ios/`, `web/`, `webviews/` (except agent-session), `design/`, `plans/`, and `README*.md`.
  - Added an early YAML guard to run all areas when `.github/workflows/ci.yml`, any `scripts/ci/*.py`, or `tests/test_ci_change_areas.py` change, or when the PR diff cannot be computed. Introduced a `ci-status` job that fails the run if any routed job finishes in a state other than success or skipped.

<sup>Written for commit dc719d35452f42a777ae1b56fbb21b1d96543a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI efficiency by automatically detecting which areas (macOS, web, and Go) were affected in a pull request and running only the relevant job groups.
  * Added CI workflow routing logic and strengthened workflow validation to ensure the gating behavior works as intended.
* **Tests**
  * Added automated unit and CLI integration coverage for the change-area classifier, including verification of resolved area decisions and the exact generated output flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->