### PR TITLE
Add cmux profiling capture action

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -50,7 +50,7 @@
 1949	Sources/Panels/BrowserWebAuthnSupport.swift
 1940	Sources/KeyboardShortcutSettingsFileStore.swift
 1880	Sources/RestorableAgentSession.swift
-1868	cmuxTests/NotificationAndMenuBarTests.swift
+1869	cmuxTests/NotificationAndMenuBarTests.swift
 1810	Sources/SessionIndexStore.swift
 1748	Sources/WindowDragHandleView.swift
 1732	cmuxTests/WorkspacePullRequestSidebarTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -50,7 +50,7 @@
 1949	Sources/Panels/BrowserWebAuthnSupport.swift
 1940	Sources/KeyboardShortcutSettingsFileStore.swift
 1880	Sources/RestorableAgentSession.swift
-1869	cmuxTests/NotificationAndMenuBarTests.swift
+1868	cmuxTests/NotificationAndMenuBarTests.swift
 1810	Sources/SessionIndexStore.swift
 1748	Sources/WindowDragHandleView.swift
 1732	cmuxTests/WorkspacePullRequestSidebarTests.swift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Validate app-host xcodebuild attempt budget
         run: ./tests/test_ci_app_host_xcodebuild_attempts.sh
 
+      - name: Validate cmux profiling support scripts
+        run: ./tests/test_start_cmux_profiling.sh
+
       - name: Validate Xcode SourcePackages cache sanitizer
         run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
 

--- a/Resources/bin/start-cmux-profiling
+++ b/Resources/bin/start-cmux-profiling
@@ -357,6 +357,10 @@ if [ -z "$test_ps_file" ] && ! ps -p "$pid" >/dev/null 2>&1; then
   exit 1
 fi
 
+safe_name() {
+  sanitize_path "$1"
+}
+
 if [ -z "$out_dir" ]; then
   profile_root="${HOME}/Desktop/cmux-profiles"
   if [ ! -d "${HOME}/Desktop" ]; then
@@ -365,11 +369,17 @@ if [ -z "$out_dir" ]; then
   out_dir="${profile_root}/cmux-profile-${pid}-$(date +%Y%m%d-%H%M%S)"
 fi
 
-mkdir -p "$out_dir"
+if [ "$dry_run" = "true" ]; then
+  echo "Target: pid=$pid channel=$channel bundle=${bundle_id:-unknown} name=$display_name app=${app_path:-unknown}"
+  for template in "${templates[@]}"; do
+    trace_name="$(safe_name "$template")"
+    echo "xcrun xctrace record --template \"$template\" --attach \"$pid\" --time-limit ${duration}s --output \"$out_dir/${trace_name}.trace\""
+  done
+  echo "Output: $out_dir"
+  exit 0
+fi
 
-safe_name() {
-  sanitize_path "$1"
-}
+mkdir -p "$out_dir"
 
 write_manifest() {
   cat > "$out_dir/summary.md" <<EOF
@@ -400,16 +410,6 @@ write_manifest
 
 if [ "$open_output" = "true" ] && command -v open >/dev/null 2>&1; then
   open "$out_dir" >/dev/null 2>&1 || true
-fi
-
-if [ "$dry_run" = "true" ]; then
-  echo "Target: pid=$pid channel=$channel bundle=${bundle_id:-unknown} name=$display_name app=${app_path:-unknown}"
-  for template in "${templates[@]}"; do
-    trace_name="$(safe_name "$template")"
-    echo "xcrun xctrace record --template \"$template\" --attach \"$pid\" --time-limit ${duration}s --output \"$out_dir/${trace_name}.trace\""
-  done
-  echo "Output: $out_dir"
-  exit 0
 fi
 
 if ! command -v xcrun >/dev/null 2>&1 || ! xcrun -f xctrace >/dev/null 2>&1; then

--- a/Resources/bin/start-cmux-profiling
+++ b/Resources/bin/start-cmux-profiling
@@ -471,6 +471,9 @@ export_toc() {
   fi
 }
 
+successful_traces=0
+failed_traces=0
+
 for template in "${templates[@]}"; do
   trace_name="$(safe_name "$template")"
   trace_path="$out_dir/${trace_name}.trace"
@@ -483,15 +486,35 @@ for template in "${templates[@]}"; do
       --attach "$pid" \
       --time-limit "${duration}s" \
       --output "$trace_path"; then
-    export_toc "$trace_path" "$out_dir/${trace_name}-toc.xml" "$out_dir/${trace_name}-toc.log" || true
+    if [ -e "$trace_path" ]; then
+      successful_traces=$((successful_traces + 1))
+      export_toc "$trace_path" "$out_dir/${trace_name}-toc.xml" "$out_dir/${trace_name}-toc.log" || true
+    else
+      failed_traces=$((failed_traces + 1))
+      echo "start-cmux-profiling: template did not produce a trace: $template. See $log_path" >&2
+    fi
   else
+    failed_traces=$((failed_traces + 1))
     echo "start-cmux-profiling: template failed: $template. See $log_path" >&2
   fi
 done
 
+if [ "$successful_traces" -eq 0 ]; then
+  cat >> "$out_dir/summary.md" <<EOF
+
+Failed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Successful traces: 0
+Failed templates: $failed_traces
+EOF
+  echo "start-cmux-profiling: all profiling templates failed; capture not submitted. Output: $out_dir" >&2
+  exit 1
+fi
+
 cat >> "$out_dir/summary.md" <<EOF
 
 Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Successful traces: $successful_traces
+Failed templates: $failed_traces
 EOF
 
 if [ "$submit_profile" = "true" ]; then

--- a/Resources/bin/start-cmux-profiling
+++ b/Resources/bin/start-cmux-profiling
@@ -1,0 +1,511 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: start-cmux-profiling [--pid <pid> | --channel <stable|nightly|staging|dev> [--tag <tag>]]
+                            [--duration <seconds>] [--out <dir>] [--template <name>...]
+                            [--list-targets] [--open-output] [--no-submit]
+
+Capture a short Instruments bundle for a live cmux process. The default capture
+runs the useful general-purpose templates for support diagnostics:
+Time Profiler, SwiftUI, Allocations, and System Trace.
+
+Target selection:
+  --pid <pid>        Profile exactly this process. Best when more than one cmux is running.
+  --channel <name>   Select stable, nightly, staging, or dev by bundle identifier.
+  --tag <tag>        Narrow dev/nightly/staging selection to a tagged build.
+  --list-targets     Print discovered cmux processes and exit.
+
+If no target selector is passed, the script profiles the only discovered cmux
+process. If several are running, it prints them and asks for --pid.
+
+After a successful capture, the script opens a separate submission helper that
+creates a founders email draft with the profile archive attached. Use
+--no-submit to skip that helper.
+USAGE
+}
+
+duration="15"
+out_dir=""
+target_pid=""
+target_channel=""
+target_tag=""
+list_targets="false"
+open_output="false"
+submit_profile="true"
+dry_run="false"
+test_ps_file="${CMUX_PROFILE_TEST_PS_FILE:-}"
+plist_buddy="${CMUX_PROFILE_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+templates=()
+using_default_templates="true"
+
+default_templates=(
+  "Time Profiler"
+  "SwiftUI"
+  "Allocations"
+  "System Trace"
+)
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pid)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --pid requires a value" >&2
+        usage
+        exit 2
+      fi
+      target_pid="$2"
+      shift 2
+      ;;
+    --channel)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --channel requires a value" >&2
+        usage
+        exit 2
+      fi
+      target_channel="$2"
+      shift 2
+      ;;
+    --tag)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --tag requires a value" >&2
+        usage
+        exit 2
+      fi
+      target_tag="$2"
+      shift 2
+      ;;
+    --duration)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --duration requires a value" >&2
+        usage
+        exit 2
+      fi
+      duration="$2"
+      shift 2
+      ;;
+    --out)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --out requires a value" >&2
+        usage
+        exit 2
+      fi
+      out_dir="$2"
+      shift 2
+      ;;
+    --template)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --template requires a value" >&2
+        usage
+        exit 2
+      fi
+      if [ "$using_default_templates" = "true" ]; then
+        templates=()
+        using_default_templates="false"
+      fi
+      templates+=("$2")
+      shift 2
+      ;;
+    --list-targets)
+      list_targets="true"
+      shift
+      ;;
+    --open-output)
+      open_output="true"
+      shift
+      ;;
+    --no-submit)
+      submit_profile="false"
+      shift
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    --test-ps-file)
+      if [ "$#" -lt 2 ] || [[ "${2:-}" == --* ]]; then
+        echo "start-cmux-profiling: --test-ps-file requires a value" >&2
+        usage
+        exit 2
+      fi
+      test_ps_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "start-cmux-profiling: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$using_default_templates" = "true" ]; then
+  templates=("${default_templates[@]}")
+fi
+
+if ! [[ "$duration" =~ ^[0-9]+$ ]] || [ "$duration" -lt 1 ]; then
+  echo "start-cmux-profiling: --duration must be a positive integer number of seconds" >&2
+  exit 2
+fi
+
+case "$target_channel" in
+  ""|stable|nightly|staging|dev)
+    ;;
+  *)
+    echo "start-cmux-profiling: --channel must be stable, nightly, staging, or dev" >&2
+    exit 2
+    ;;
+esac
+
+sanitize_bundle() {
+  local raw="$1"
+  local cleaned
+  cleaned="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g')"
+  if [ -z "$cleaned" ]; then
+    cleaned="agent"
+  fi
+  printf '%s' "$cleaned"
+}
+
+sanitize_path() {
+  local raw="$1"
+  printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+plist_value() {
+  local plist="$1"
+  local key="$2"
+  if [ -f "$plist" ] && [ -x "$plist_buddy" ]; then
+    "$plist_buddy" -c "Print :${key}" "$plist" 2>/dev/null || true
+  fi
+}
+
+channel_for_bundle() {
+  local bundle_id="$1"
+  case "$bundle_id" in
+    com.cmuxterm.app)
+      printf 'stable'
+      ;;
+    com.cmuxterm.app.nightly|com.cmuxterm.app.nightly.*)
+      printf 'nightly'
+      ;;
+    com.cmuxterm.app.staging|com.cmuxterm.app.staging.*)
+      printf 'staging'
+      ;;
+    com.cmuxterm.app.debug|com.cmuxterm.app.debug.*)
+      printf 'dev'
+      ;;
+    *)
+      printf 'unknown'
+      ;;
+  esac
+}
+
+process_rows() {
+  if [ -n "$test_ps_file" ]; then
+    cat "$test_ps_file"
+  else
+    ps -axo pid=,args=
+  fi
+}
+
+pids=()
+apps=()
+bundles=()
+names=()
+channels=()
+
+discover_targets() {
+  local pid args executable app_path plist bundle_id display_name channel
+  while read -r pid args; do
+    [[ "${pid:-}" =~ ^[0-9]+$ ]] || continue
+    [[ "${args:-}" =~ (/.*cmux[^/]*\.app/Contents/MacOS/cmux)([[:space:]]|$) ]] || continue
+    executable="${BASH_REMATCH[1]}"
+    app_path="${executable%/Contents/MacOS/cmux}"
+    plist="${app_path}/Contents/Info.plist"
+    bundle_id="$(plist_value "$plist" "CFBundleIdentifier")"
+    display_name="$(plist_value "$plist" "CFBundleDisplayName")"
+    if [ -z "$display_name" ]; then
+      display_name="$(plist_value "$plist" "CFBundleName")"
+    fi
+    if [ -z "$display_name" ]; then
+      display_name="$(basename "$app_path" .app)"
+    fi
+    channel="$(channel_for_bundle "$bundle_id")"
+    pids+=("$pid")
+    apps+=("$app_path")
+    bundles+=("$bundle_id")
+    names+=("$display_name")
+    channels+=("$channel")
+  done < <(process_rows)
+}
+
+print_targets() {
+  if [ "${#pids[@]}" -eq 0 ]; then
+    echo "No running cmux app processes found."
+    return
+  fi
+
+  local i
+  for (( i = 0; i < ${#pids[@]}; i++ )); do
+    printf 'pid=%s channel=%s bundle=%s name=%s app=%s\n' \
+      "${pids[$i]}" "${channels[$i]}" "${bundles[$i]:-unknown}" "${names[$i]}" "${apps[$i]}"
+  done
+}
+
+tag_matches() {
+  local bundle_id="$1"
+  local display_name="$2"
+  local app_path="$3"
+  local tag="$4"
+  [ -z "$tag" ] && return 0
+
+  local bundle_tag path_tag app_base
+  bundle_tag="$(sanitize_bundle "$tag")"
+  path_tag="$(sanitize_path "$tag")"
+  app_base="$(basename "$app_path" .app)"
+
+  case "$bundle_id" in
+    *."$bundle_tag")
+      return 0
+      ;;
+  esac
+  [ "$display_name" = "cmux DEV ${path_tag}" ] && return 0
+  [ "$display_name" = "cmux NIGHTLY ${path_tag}" ] && return 0
+  [ "$display_name" = "cmux STAGING ${path_tag}" ] && return 0
+  [ "$app_base" = "cmux DEV ${path_tag}" ] && return 0
+  [ "$app_base" = "cmux NIGHTLY ${path_tag}" ] && return 0
+  [ "$app_base" = "cmux STAGING ${path_tag}" ] && return 0
+  return 1
+}
+
+selected_indexes=()
+
+select_targets() {
+  selected_indexes=()
+  local i
+  for (( i = 0; i < ${#pids[@]}; i++ )); do
+    if [ -n "$target_pid" ] && [ "${pids[$i]}" != "$target_pid" ]; then
+      continue
+    fi
+    if [ -n "$target_channel" ] && [ "${channels[$i]}" != "$target_channel" ]; then
+      continue
+    fi
+    if ! tag_matches "${bundles[$i]}" "${names[$i]}" "${apps[$i]}" "$target_tag"; then
+      continue
+    fi
+    selected_indexes+=("$i")
+  done
+}
+
+discover_targets
+
+if [ "$list_targets" = "true" ]; then
+  print_targets
+  exit 0
+fi
+
+if [ -n "$target_pid" ] && ! [[ "$target_pid" =~ ^[0-9]+$ ]]; then
+  echo "start-cmux-profiling: --pid must be numeric" >&2
+  exit 2
+fi
+
+select_targets
+
+if [ "${#selected_indexes[@]}" -eq 0 ]; then
+  if [ -n "$target_pid" ] && [ -z "$test_ps_file" ] && ps -p "$target_pid" >/dev/null 2>&1; then
+    pids=("$target_pid")
+    apps=("")
+    bundles=("")
+    names=("pid ${target_pid}")
+    channels=("unknown")
+    selected_indexes=(0)
+  else
+    echo "start-cmux-profiling: no cmux process matched the selector" >&2
+    print_targets >&2
+    exit 1
+  fi
+fi
+
+if [ -z "$target_pid" ] && [ -z "$target_channel" ] && [ -z "$target_tag" ] && [ "${#pids[@]}" -gt 1 ]; then
+  echo "start-cmux-profiling: multiple cmux processes are running. Re-run with --pid." >&2
+  print_targets >&2
+  exit 1
+fi
+
+if [ "${#selected_indexes[@]}" -gt 1 ]; then
+  echo "start-cmux-profiling: selector matched multiple cmux processes. Re-run with --pid." >&2
+  print_targets >&2
+  exit 1
+fi
+
+selected="${selected_indexes[0]}"
+pid="${pids[$selected]}"
+app_path="${apps[$selected]}"
+bundle_id="${bundles[$selected]}"
+display_name="${names[$selected]}"
+channel="${channels[$selected]}"
+
+if [ -z "$test_ps_file" ] && ! ps -p "$pid" >/dev/null 2>&1; then
+  echo "start-cmux-profiling: selected pid is no longer running: $pid" >&2
+  exit 1
+fi
+
+if [ -z "$out_dir" ]; then
+  profile_root="${HOME}/Desktop/cmux-profiles"
+  if [ ! -d "${HOME}/Desktop" ]; then
+    profile_root="${TMPDIR:-/tmp}/cmux-profiles"
+  fi
+  out_dir="${profile_root}/cmux-profile-${pid}-$(date +%Y%m%d-%H%M%S)"
+fi
+
+mkdir -p "$out_dir"
+
+safe_name() {
+  sanitize_path "$1"
+}
+
+write_manifest() {
+  cat > "$out_dir/summary.md" <<EOF
+# cmux Profiling Capture
+
+Target:
+- PID: $pid
+- Channel: $channel
+- Bundle ID: ${bundle_id:-unknown}
+- Name: $display_name
+- App: ${app_path:-unknown}
+
+Capture:
+- Duration per template: ${duration}s
+- Templates: ${templates[*]}
+- Started: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+Notes:
+- Time Profiler is the primary CPU stack trace.
+- SwiftUI captures body/update churn.
+- Allocations captures memory growth and allocation stacks.
+- System Trace captures scheduler, hangs, and thread-state context.
+- Leaks is intentionally not part of the default support capture because it is heavier and can pause a large busy process.
+EOF
+}
+
+write_manifest
+
+if [ "$open_output" = "true" ] && command -v open >/dev/null 2>&1; then
+  open "$out_dir" >/dev/null 2>&1 || true
+fi
+
+if [ "$dry_run" = "true" ]; then
+  echo "Target: pid=$pid channel=$channel bundle=${bundle_id:-unknown} name=$display_name app=${app_path:-unknown}"
+  for template in "${templates[@]}"; do
+    trace_name="$(safe_name "$template")"
+    echo "xcrun xctrace record --template \"$template\" --attach \"$pid\" --time-limit ${duration}s --output \"$out_dir/${trace_name}.trace\""
+  done
+  echo "Output: $out_dir"
+  exit 0
+fi
+
+if ! command -v xcrun >/dev/null 2>&1 || ! xcrun -f xctrace >/dev/null 2>&1; then
+  echo "start-cmux-profiling: xcrun xctrace was not found. Install Xcode or Xcode command line tools." >&2
+  exit 1
+fi
+
+wait_with_timeout() {
+  local child_pid="$1"
+  local timeout_seconds="$2"
+  local log_file="$3"
+  local elapsed=0
+
+  while kill -0 "$child_pid" >/dev/null 2>&1; do
+    if [ "$elapsed" -ge "$timeout_seconds" ]; then
+      echo "Timed out after ${timeout_seconds}s; terminating pid ${child_pid}" >> "$log_file"
+      kill "$child_pid" >/dev/null 2>&1 || true
+      sleep 1
+      kill -9 "$child_pid" >/dev/null 2>&1 || true
+      wait "$child_pid" >/dev/null 2>&1 || true
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  wait "$child_pid"
+}
+
+run_and_log() {
+  local timeout_seconds="$1"
+  local log_file="$2"
+  shift 2
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n'
+  } > "$log_file" 2>&1
+  "$@" >> "$log_file" 2>&1 &
+  wait_with_timeout "$!" "$timeout_seconds" "$log_file"
+}
+
+export_toc() {
+  local trace_path="$1"
+  local toc_path="$2"
+  local log_file="$3"
+  local timeout_seconds="${CMUX_PROFILE_TOC_TIMEOUT_SECONDS:-30}"
+
+  {
+    printf '$'
+    printf ' %q' xcrun xctrace export --input "$trace_path" --toc
+    printf '\n'
+  } > "$log_file"
+
+  xcrun xctrace export --input "$trace_path" --toc > "$toc_path" 2>> "$log_file" &
+  if ! wait_with_timeout "$!" "$timeout_seconds" "$log_file"; then
+    [ -s "$toc_path" ] || rm -f "$toc_path"
+    return 1
+  fi
+}
+
+for template in "${templates[@]}"; do
+  trace_name="$(safe_name "$template")"
+  trace_path="$out_dir/${trace_name}.trace"
+  log_path="$out_dir/${trace_name}.log"
+  record_timeout=$((duration + 90))
+
+  if run_and_log "$record_timeout" "$log_path" \
+    xcrun xctrace record \
+      --template "$template" \
+      --attach "$pid" \
+      --time-limit "${duration}s" \
+      --output "$trace_path"; then
+    export_toc "$trace_path" "$out_dir/${trace_name}-toc.xml" "$out_dir/${trace_name}-toc.log" || true
+  else
+    echo "start-cmux-profiling: template failed: $template. See $log_path" >&2
+  fi
+done
+
+cat >> "$out_dir/summary.md" <<EOF
+
+Completed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
+if [ "$submit_profile" = "true" ]; then
+  submitter="${script_dir}/submit-cmux-profile"
+  if [ -x "$submitter" ]; then
+    "$submitter" \
+      --profile "$out_dir" \
+      --target-name "$display_name" \
+      --target-pid "$pid" \
+      --channel "$channel" \
+      --bundle-id "${bundle_id:-unknown}" >/dev/null 2>&1 &
+  else
+    echo "start-cmux-profiling: submission helper not found: $submitter" >&2
+  fi
+fi
+
+printf 'cmux profiling capture written to %s\n' "$out_dir"

--- a/Resources/bin/submit-cmux-profile
+++ b/Resources/bin/submit-cmux-profile
@@ -74,8 +74,6 @@ safe_base="$(basename "$profile_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^
 [ -n "$safe_base" ] || safe_base="cmux-profile"
 archive_dir="${TMPDIR:-/tmp}/cmux-profile-submissions"
 archive_path="${archive_dir}/${safe_base}.zip"
-mkdir -p "$archive_dir"
-rm -f "$archive_path"
 
 if [ "$dry_run" = "true" ]; then
   printf 'Archive: %s\n' "$archive_path"
@@ -84,6 +82,8 @@ if [ "$dry_run" = "true" ]; then
   exit 0
 fi
 
+mkdir -p "$archive_dir"
+rm -f "$archive_path"
 "$ditto_bin" -c -k --sequesterRsrc --keepParent "$profile_dir" "$archive_path"
 
 subject="cmux profiling capture: ${target_name}"
@@ -103,7 +103,8 @@ EOF
 )"
 
 apple_script="$(mktemp "${TMPDIR:-/tmp}/cmux-profile-submit.XXXXXX")"
-trap 'rm -f "$apple_script"' EXIT
+apple_error="$(mktemp "${TMPDIR:-/tmp}/cmux-profile-submit-error.XXXXXX")"
+trap 'rm -f "$apple_script" "$apple_error"' EXIT
 cat > "$apple_script" <<'OSA'
 on run argv
   set archivePath to item 1 of argv
@@ -127,11 +128,15 @@ on run argv
 end run
 OSA
 
-if "$osascript_bin" "$apple_script" "$archive_path" "$recipient" "$subject" "$body"
-then
+if "$osascript_bin" "$apple_script" "$archive_path" "$recipient" "$subject" "$body" 2>"$apple_error"; then
   exit 0
 fi
 
+if grep -Fq "(-128)" "$apple_error"; then
+  exit 0
+fi
+
+cat "$apple_error" >&2
 "$open_bin" -R "$archive_path" >/dev/null 2>&1 || true
 "$open_bin" "mailto:${recipient}?subject=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$subject")" >/dev/null 2>&1 || true
 exit 1

--- a/Resources/bin/submit-cmux-profile
+++ b/Resources/bin/submit-cmux-profile
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: submit-cmux-profile --profile <dir> [--target-name <name>] [--target-pid <pid>]
+                           [--channel <channel>] [--bundle-id <id>] [--dry-run]
+
+Package a cmux profiling directory and open a separate submission window. The
+window creates an email draft to founders@manaflow.com with the archive attached.
+USAGE
+}
+
+profile_dir=""
+target_name="cmux"
+target_pid=""
+channel="unknown"
+bundle_id="unknown"
+dry_run="false"
+recipient="${CMUX_PROFILE_FEEDBACK_EMAIL:-founders@manaflow.com}"
+osascript_bin="${CMUX_PROFILE_OSASCRIPT:-/usr/bin/osascript}"
+open_bin="${CMUX_PROFILE_OPEN:-/usr/bin/open}"
+ditto_bin="${CMUX_PROFILE_DITTO:-/usr/bin/ditto}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --profile)
+      [ "$#" -ge 2 ] || { echo "submit-cmux-profile: --profile requires a value" >&2; exit 2; }
+      profile_dir="$2"
+      shift 2
+      ;;
+    --target-name)
+      [ "$#" -ge 2 ] || { echo "submit-cmux-profile: --target-name requires a value" >&2; exit 2; }
+      target_name="$2"
+      shift 2
+      ;;
+    --target-pid)
+      [ "$#" -ge 2 ] || { echo "submit-cmux-profile: --target-pid requires a value" >&2; exit 2; }
+      target_pid="$2"
+      shift 2
+      ;;
+    --channel)
+      [ "$#" -ge 2 ] || { echo "submit-cmux-profile: --channel requires a value" >&2; exit 2; }
+      channel="$2"
+      shift 2
+      ;;
+    --bundle-id)
+      [ "$#" -ge 2 ] || { echo "submit-cmux-profile: --bundle-id requires a value" >&2; exit 2; }
+      bundle_id="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "submit-cmux-profile: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$profile_dir" ] || [ ! -d "$profile_dir" ]; then
+  echo "submit-cmux-profile: --profile must point to a profiling directory" >&2
+  exit 2
+fi
+
+safe_base="$(basename "$profile_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+[ -n "$safe_base" ] || safe_base="cmux-profile"
+archive_dir="${TMPDIR:-/tmp}/cmux-profile-submissions"
+archive_path="${archive_dir}/${safe_base}.zip"
+mkdir -p "$archive_dir"
+rm -f "$archive_path"
+
+if [ "$dry_run" = "true" ]; then
+  printf 'Archive: %s\n' "$archive_path"
+  printf 'Recipient: %s\n' "$recipient"
+  printf 'Subject: cmux profiling capture: %s\n' "$target_name"
+  exit 0
+fi
+
+"$ditto_bin" -c -k --sequesterRsrc --keepParent "$profile_dir" "$archive_path"
+
+subject="cmux profiling capture: ${target_name}"
+[ -n "$target_pid" ] && subject="${subject} pid ${target_pid}"
+body="$(cat <<EOF
+cmux profiling capture attached.
+
+Target: ${target_name}
+PID: ${target_pid:-unknown}
+Channel: ${channel}
+Bundle ID: ${bundle_id}
+Profile directory: ${profile_dir}
+Archive: ${archive_path}
+
+Notes:
+EOF
+)"
+
+apple_script="$(mktemp "${TMPDIR:-/tmp}/cmux-profile-submit.XXXXXX")"
+trap 'rm -f "$apple_script"' EXIT
+cat > "$apple_script" <<'OSA'
+on run argv
+  set archivePath to item 1 of argv
+  set recipientAddress to item 2 of argv
+  set messageSubject to item 3 of argv
+  set baseBody to item 4 of argv
+
+  set dialogText to "cmux created a profiling archive. Add any context, then open an email draft to Manaflow with the archive attached."
+  set dialogResult to display dialog dialogText default answer "" buttons {"Cancel", "Open Draft"} default button "Open Draft" cancel button "Cancel" with title "Submit cmux Profile"
+  set noteText to text returned of dialogResult
+  set messageBody to baseBody & return & noteText
+
+  tell application "Mail"
+    activate
+    set newMessage to make new outgoing message with properties {subject:messageSubject, content:messageBody & return & return, visible:true}
+    tell newMessage
+      make new to recipient at end of to recipients with properties {address:recipientAddress}
+      make new attachment with properties {file name:(POSIX file archivePath)} at after last paragraph
+    end tell
+  end tell
+end run
+OSA
+
+if "$osascript_bin" "$apple_script" "$archive_path" "$recipient" "$subject" "$body"
+then
+  exit 0
+fi
+
+"$open_bin" -R "$archive_path" >/dev/null 2>&1 || true
+"$open_bin" "mailto:${recipient}?subject=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$subject")" >/dev/null 2>&1 || true
+exit 1

--- a/Resources/bin/submit-cmux-profile
+++ b/Resources/bin/submit-cmux-profile
@@ -75,10 +75,46 @@ safe_base="$(basename "$profile_dir" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^
 archive_dir="${TMPDIR:-/tmp}/cmux-profile-submissions"
 archive_path="${archive_dir}/${safe_base}.zip"
 
+language_source="${CMUX_PROFILE_LOCALE:-${LANG:-}}"
+if [ -z "$language_source" ] && [ -x /usr/bin/defaults ]; then
+  language_source="$(/usr/bin/defaults read -g AppleLanguages 2>/dev/null || true)"
+fi
+language_source="$(printf '%s' "$language_source" | tr '[:upper:]' '[:lower:]')"
+
+if [[ "$language_source" == *"ja"* ]]; then
+  subject_prefix="cmuxプロファイリングキャプチャ"
+  body_intro="cmuxプロファイリングキャプチャを添付しました。"
+  body_target_label="対象"
+  body_pid_label="PID"
+  body_channel_label="チャンネル"
+  body_bundle_label="バンドルID"
+  body_profile_label="プロファイルディレクトリ"
+  body_archive_label="アーカイブ"
+  body_notes_label="メモ"
+  dialog_text="cmuxはプロファイリングアーカイブを作成しました。状況を追記してから、アーカイブ付きのManaflow宛メール下書きを開いてください。"
+  cancel_button="キャンセル"
+  open_draft_button="下書きを開く"
+  dialog_title="cmuxプロファイルを送信"
+else
+  subject_prefix="cmux profiling capture"
+  body_intro="cmux profiling capture attached."
+  body_target_label="Target"
+  body_pid_label="PID"
+  body_channel_label="Channel"
+  body_bundle_label="Bundle ID"
+  body_profile_label="Profile directory"
+  body_archive_label="Archive"
+  body_notes_label="Notes"
+  dialog_text="cmux created a profiling archive. Add any context, then open an email draft to Manaflow with the archive attached."
+  cancel_button="Cancel"
+  open_draft_button="Open Draft"
+  dialog_title="Submit cmux Profile"
+fi
+
 if [ "$dry_run" = "true" ]; then
   printf 'Archive: %s\n' "$archive_path"
   printf 'Recipient: %s\n' "$recipient"
-  printf 'Subject: cmux profiling capture: %s\n' "$target_name"
+  printf 'Subject: %s: %s\n' "$subject_prefix" "$target_name"
   exit 0
 fi
 
@@ -86,19 +122,19 @@ mkdir -p "$archive_dir"
 rm -f "$archive_path"
 "$ditto_bin" -c -k --sequesterRsrc --keepParent "$profile_dir" "$archive_path"
 
-subject="cmux profiling capture: ${target_name}"
+subject="${subject_prefix}: ${target_name}"
 [ -n "$target_pid" ] && subject="${subject} pid ${target_pid}"
 body="$(cat <<EOF
-cmux profiling capture attached.
+${body_intro}
 
-Target: ${target_name}
-PID: ${target_pid:-unknown}
-Channel: ${channel}
-Bundle ID: ${bundle_id}
-Profile directory: ${profile_dir}
-Archive: ${archive_path}
+${body_target_label}: ${target_name}
+${body_pid_label}: ${target_pid:-unknown}
+${body_channel_label}: ${channel}
+${body_bundle_label}: ${bundle_id}
+${body_profile_label}: ${profile_dir}
+${body_archive_label}: ${archive_path}
 
-Notes:
+${body_notes_label}:
 EOF
 )"
 
@@ -111,9 +147,12 @@ on run argv
   set recipientAddress to item 2 of argv
   set messageSubject to item 3 of argv
   set baseBody to item 4 of argv
+  set dialogText to item 5 of argv
+  set cancelButton to item 6 of argv
+  set openDraftButton to item 7 of argv
+  set dialogTitle to item 8 of argv
 
-  set dialogText to "cmux created a profiling archive. Add any context, then open an email draft to Manaflow with the archive attached."
-  set dialogResult to display dialog dialogText default answer "" buttons {"Cancel", "Open Draft"} default button "Open Draft" cancel button "Cancel" with title "Submit cmux Profile"
+  set dialogResult to display dialog dialogText default answer "" buttons {cancelButton, openDraftButton} default button openDraftButton cancel button cancelButton with title dialogTitle
   set noteText to text returned of dialogResult
   set messageBody to baseBody & return & noteText
 
@@ -128,7 +167,7 @@ on run argv
 end run
 OSA
 
-if "$osascript_bin" "$apple_script" "$archive_path" "$recipient" "$subject" "$body" 2>"$apple_error"; then
+if "$osascript_bin" "$apple_script" "$archive_path" "$recipient" "$subject" "$body" "$dialog_text" "$cancel_button" "$open_draft_button" "$dialog_title" 2>"$apple_error"; then
   exit 0
 fi
 

--- a/Sources/App/MenuBarExtraController.swift
+++ b/Sources/App/MenuBarExtraController.swift
@@ -104,7 +104,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         taskManagerItem.target = self
         taskManagerItem.action = #selector(taskManagerAction)
         menu.addItem(taskManagerItem)
-
+        menu.addItem(MenuBarProfilingMenuItem.make())
         menu.addItem(notificationListSeparator)
         notificationSectionSeparator.isHidden = true
         menu.addItem(notificationSectionSeparator)

--- a/Sources/App/MenuBarProfilingLauncher.swift
+++ b/Sources/App/MenuBarProfilingLauncher.swift
@@ -51,25 +51,3 @@ enum MenuBarProfilingLauncher {
         }
     }
 }
-
-@MainActor
-enum MenuBarProfilingMenuItem {
-    static func make() -> NSMenuItem {
-        let item = NSMenuItem(
-            title: String(localized: "statusMenu.startProfiling", defaultValue: "Start Profiling"),
-            action: #selector(MenuBarProfilingMenuItemTarget.startProfiling(_:)),
-            keyEquivalent: ""
-        )
-        item.target = MenuBarProfilingMenuItemTarget.shared
-        return item
-    }
-}
-
-@MainActor
-private final class MenuBarProfilingMenuItemTarget: NSObject {
-    static let shared = MenuBarProfilingMenuItemTarget()
-
-    @objc func startProfiling(_ sender: NSMenuItem) {
-        MenuBarProfilingLauncher.start()
-    }
-}

--- a/Sources/App/MenuBarProfilingLauncher.swift
+++ b/Sources/App/MenuBarProfilingLauncher.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+import os.log
+
+nonisolated private let menuBarProfilingLogger = Logger(subsystem: "com.cmuxterm.app", category: "MenuBarProfiling")
+
+enum MenuBarProfilingLauncher {
+    static let defaultDurationSeconds = 15
+
+    static func bundledScriptURL(bundle: Bundle = .main) -> URL? {
+        bundle.url(forResource: "start-cmux-profiling", withExtension: nil, subdirectory: "bin")
+    }
+
+    static func arguments(
+        pid: Int32 = ProcessInfo.processInfo.processIdentifier,
+        durationSeconds: Int = defaultDurationSeconds,
+        openOutput: Bool = true
+    ) -> [String] {
+        var args = ["--pid", String(pid), "--duration", String(durationSeconds)]
+        if openOutput {
+            args.append("--open-output")
+        }
+        return args
+    }
+
+    @discardableResult
+    static func start(
+        pid: Int32 = ProcessInfo.processInfo.processIdentifier,
+        scriptURL: URL? = bundledScriptURL()
+    ) -> Bool {
+        guard let scriptURL else {
+            menuBarProfilingLogger.error("Unable to start profiling because bundled script is missing")
+            NSSound.beep()
+            return false
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [scriptURL.path] + arguments(pid: pid)
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            menuBarProfilingLogger.notice("Started cmux profiling for pid \(pid)")
+            return true
+        } catch {
+            menuBarProfilingLogger.error("Failed to start cmux profiling for pid \(pid): \(error.localizedDescription, privacy: .public)")
+            NSSound.beep()
+            return false
+        }
+    }
+}
+
+@MainActor
+enum MenuBarProfilingMenuItem {
+    static func make() -> NSMenuItem {
+        let item = NSMenuItem(
+            title: String(localized: "statusMenu.startProfiling", defaultValue: "Start Profiling"),
+            action: #selector(MenuBarProfilingMenuItemTarget.startProfiling(_:)),
+            keyEquivalent: ""
+        )
+        item.target = MenuBarProfilingMenuItemTarget.shared
+        return item
+    }
+}
+
+@MainActor
+private final class MenuBarProfilingMenuItemTarget: NSObject {
+    static let shared = MenuBarProfilingMenuItemTarget()
+
+    @objc func startProfiling(_ sender: NSMenuItem) {
+        MenuBarProfilingLauncher.start()
+    }
+}

--- a/Sources/App/MenuBarProfilingMenuItem.swift
+++ b/Sources/App/MenuBarProfilingMenuItem.swift
@@ -1,0 +1,15 @@
+import AppKit
+import Foundation
+
+@MainActor
+enum MenuBarProfilingMenuItem {
+    static func make() -> NSMenuItem {
+        let item = NSMenuItem(
+            title: String(localized: "statusMenu.startProfiling", defaultValue: "Start Profiling"),
+            action: #selector(MenuBarProfilingMenuItemTarget.startProfiling(_:)),
+            keyEquivalent: ""
+        )
+        item.target = MenuBarProfilingMenuItemTarget.shared
+        return item
+    }
+}

--- a/Sources/App/MenuBarProfilingMenuItemTarget.swift
+++ b/Sources/App/MenuBarProfilingMenuItemTarget.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+@MainActor
+final class MenuBarProfilingMenuItemTarget: NSObject {
+    static let shared = MenuBarProfilingMenuItemTarget()
+
+    @objc func startProfiling(_ sender: NSMenuItem) {
+        MenuBarProfilingLauncher.start()
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -512,6 +512,8 @@
 		606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */; };
 		C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */; };
 		C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */; };
+		C0DE70550000000000000002 /* MenuBarProfilingMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70550000000000000001 /* MenuBarProfilingMenuItem.swift */; };
+		C0DE70540000000000000002 /* MenuBarProfilingMenuItemTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70540000000000000001 /* MenuBarProfilingMenuItemTarget.swift */; };
 		3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0033865B0033865B003 /* MenubarSearchPopover.swift */; };
 		E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */; };
 		C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */; };
@@ -1494,6 +1496,8 @@
 		606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarOnlyActivationPolicyTests.swift; sourceTree = "<group>"; };
 		C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingLauncher.swift; sourceTree = "<group>"; };
 		C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarProfilingLauncherTests.swift; sourceTree = "<group>"; };
+		C0DE70550000000000000001 /* MenuBarProfilingMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingMenuItem.swift; sourceTree = "<group>"; };
+		C0DE70540000000000000001 /* MenuBarProfilingMenuItemTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingMenuItemTarget.swift; sourceTree = "<group>"; };
 		3865B0033865B0033865B003 /* MenubarSearchPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/MenubarSearchPopover.swift; sourceTree = "<group>"; };
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 		C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/MinimalModeSidebarControls.swift; sourceTree = "<group>"; };
@@ -2299,6 +2303,8 @@
 					E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */,
 					C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
 					C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */,
+					C0DE70550000000000000001 /* MenuBarProfilingMenuItem.swift */,
+					C0DE70540000000000000001 /* MenuBarProfilingMenuItemTarget.swift */,
 					2F0C07000000000000000001 /* CmuxMainWindow.swift */,
 				AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */,
 				A6D1F0200000000000000001 /* WindowCloseObserver.swift */,
@@ -3727,6 +3733,8 @@
 					A50014F9 /* MarkdownWebSupport.swift in Sources */,
 					1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */,
 					C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */,
+					C0DE70550000000000000002 /* MenuBarProfilingMenuItem.swift in Sources */,
+					C0DE70540000000000000002 /* MenuBarProfilingMenuItemTarget.swift in Sources */,
 					3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */,
 				C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */,
 				284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -510,6 +510,8 @@
 		A50014F9 /* MarkdownWebSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F8 /* MarkdownWebSupport.swift */; };
 		1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */; };
 		606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */; };
+		C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */; };
+		C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */; };
 		3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0033865B0033865B003 /* MenubarSearchPopover.swift */; };
 		E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */; };
 		C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */; };
@@ -771,7 +773,9 @@
 		E30780000000000000000012 /* SSHPTYAttachStartupCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000011 /* SSHPTYAttachStartupCommandBuilder.swift */; };
 		F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */; };
 		F20F85FC5900550685FA33AD /* StackAuth in Frameworks */ = {isa = PBXBuildFile; productRef = A8BD195031FC4B82B4354297 /* StackAuth */; };
+		C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70500000000000000001 /* start-cmux-profiling */; };
 		D35B71010000000000000001 /* StartupBreadcrumbLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B71010000000000000002 /* StartupBreadcrumbLog.swift */; };
+		C0DE70530000000000000002 /* submit-cmux-profile in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70530000000000000001 /* submit-cmux-profile */; };
 		D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
 		C9A5720BC9A5720BC9A5720B /* TabItemView+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */; };
@@ -1019,8 +1023,10 @@
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */,
 				C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */,
-				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
-			);
+					D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
+					C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */,
+					C0DE70530000000000000002 /* submit-cmux-profile in Copy CLI */,
+				);
 			name = "Copy CLI";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1486,6 +1492,8 @@
 		A50014F8 /* MarkdownWebSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebSupport.swift; sourceTree = "<group>"; };
 		C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarExtraController.swift; sourceTree = "<group>"; };
 		606500010000000000000002 /* MenuBarOnlyActivationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarOnlyActivationPolicyTests.swift; sourceTree = "<group>"; };
+		C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MenuBarProfilingLauncher.swift; sourceTree = "<group>"; };
+		C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarProfilingLauncherTests.swift; sourceTree = "<group>"; };
 		3865B0033865B0033865B003 /* MenubarSearchPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/MenubarSearchPopover.swift; sourceTree = "<group>"; };
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 		C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/MinimalModeSidebarControls.swift; sourceTree = "<group>"; };
@@ -1738,7 +1746,9 @@
 		C510C1E00000000000000001 /* SocketOperationTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketOperationTelemetry.swift; sourceTree = "<group>"; };
 		E30780000000000000000011 /* SSHPTYAttachStartupCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachStartupCommandBuilder.swift; sourceTree = "<group>"; };
 		F6355601A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHStartupSignalLifecycleTests.swift; sourceTree = "<group>"; };
+		C0DE70500000000000000001 /* start-cmux-profiling */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/start-cmux-profiling"; sourceTree = SOURCE_ROOT; };
 		D35B71010000000000000002 /* StartupBreadcrumbLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/StartupBreadcrumbLog.swift; sourceTree = "<group>"; };
+		C0DE70530000000000000001 /* submit-cmux-profile */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/submit-cmux-profile"; sourceTree = SOURCE_ROOT; };
 		D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupersededPhoneDismissBuffer.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabItemView+WorkspaceGroups.swift"; sourceTree = "<group>"; };
@@ -2041,9 +2051,11 @@
 			children = (
 				B2E7294509CC42FE9191870E /* xterm-ghostty */,
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
-				C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
-				C1ADE10001A1B2C3D4E5F719 /* grok */,
-				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
+					C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
+					C1ADE10001A1B2C3D4E5F719 /* grok */,
+					C0DE70500000000000000001 /* start-cmux-profiling */,
+					C0DE70530000000000000001 /* submit-cmux-profile */,
+					DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,
 				FEED0000000000000000F006 /* opencode-plugin.js */,
 				FEED0A00000000000000F006 /* feed-tui */,
@@ -2284,9 +2296,10 @@
 				604500200000000000000002 /* WindowTitleTemplateContext.swift */,
 				604500100000000000000002 /* WindowTitleTemplate.swift */,
 				AB7F2E9143904957AAA70726 /* ShortcutBareStartRouting.swift */,
-				E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */,
-				C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
-				2F0C07000000000000000001 /* CmuxMainWindow.swift */,
+					E5C0F1A1E5C0F1A1E5C0F1A1 /* TerminalFindEscapeRouting.swift */,
+					C7934BB35B66491B1BCA8064 /* MenuBarExtraController.swift */,
+					C0DE70510000000000000001 /* MenuBarProfilingLauncher.swift */,
+					2F0C07000000000000000001 /* CmuxMainWindow.swift */,
 				AA5269A0C0DE0001FACE0001 /* ForeignFirstResponderPolicy.swift */,
 				A6D1F0200000000000000001 /* WindowCloseObserver.swift */,
 				A6D1F0300000000000000001 /* MainWindowVisibilityController+Lifecycle.swift */,
@@ -2941,9 +2954,10 @@
 				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
 				86544CEFA1CA33CA9225FB6E /* MobileWorkspaceListFidelityTests.swift */,
 				645645000000000000000001 /* NumberedShortcutSwapTests.swift */,
-				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
-				D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
-				596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */,
+					B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
+					D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
+					C0DE70520000000000000001 /* MenuBarProfilingLauncherTests.swift */,
+					596100000000000000000002 /* NativeNotificationFallbackCommandTests.swift */,
 				596100000000000000000006 /* TerminalNotificationStore+NativeNotificationDeliveryTesting.swift */,
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
@@ -3710,9 +3724,10 @@
 				F5168A060000000000000001 /* MarkdownTypographyDefaults.swift in Sources */,
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
 				A50014F5 /* MarkdownWebRenderer.swift in Sources */,
-				A50014F9 /* MarkdownWebSupport.swift in Sources */,
-				1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */,
-				3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */,
+					A50014F9 /* MarkdownWebSupport.swift in Sources */,
+					1A8BEE693C9E4C3190CB7F20 /* MenuBarExtraController.swift in Sources */,
+					C0DE70510000000000000002 /* MenuBarProfilingLauncher.swift in Sources */,
+					3865A0033865A0033865A003 /* MenubarSearchPopover.swift in Sources */,
 				C0DE3150A00000000000001 /* MinimalModeSidebarControls.swift in Sources */,
 				284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */,
 				C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */,
@@ -4239,15 +4254,16 @@
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
+					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				4C1A7E10B2D34F56A8C90013 /* MobileHostStatusVerificationLimiterTests.swift in Sources */,
 				9B08F916D7FF7626C6820727 /* MobilePairingConnectionTransitionTests.swift in Sources */,
 				F6448F377504F33956E7E03B /* MobileWorkspaceListFidelityTests.swift in Sources */,
-				596100000000000000000001 /* NativeNotificationFallbackCommandTests.swift in Sources */,
-				734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
-				D7AB00000000000000B021 /* NotificationDismissSyncTests.swift in Sources */,
+					596100000000000000000001 /* NativeNotificationFallbackCommandTests.swift in Sources */,
+					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
+					D7AB00000000000000B021 /* NotificationDismissSyncTests.swift in Sources */,
 				4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */,
 				645645000000000000000002 /* NumberedShortcutSwapTests.swift in Sources */,
 				4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,

--- a/cmuxTests/MenuBarProfilingLauncherTests.swift
+++ b/cmuxTests/MenuBarProfilingLauncherTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class MenuBarProfilingLauncherTests: XCTestCase {
+    func testMenuBarProfilingLaunchesCurrentProcessForFifteenSecondsAndOpensOutput() {
+        XCTAssertEqual(
+            MenuBarProfilingLauncher.arguments(pid: 1234),
+            ["--pid", "1234", "--duration", "15", "--open-output"]
+        )
+    }
+}

--- a/cmuxTests/MenuBarProfilingLauncherTests.swift
+++ b/cmuxTests/MenuBarProfilingLauncherTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -6,9 +6,10 @@ import XCTest
 @testable import cmux
 #endif
 
-final class MenuBarProfilingLauncherTests: XCTestCase {
+struct MenuBarProfilingLauncherTests {
+    @Test
     func testMenuBarProfilingLaunchesCurrentProcessForFifteenSecondsAndOpensOutput() {
-        XCTAssertEqual(
+        #expect(
             MenuBarProfilingLauncher.arguments(pid: 1234),
             ["--pid", "1234", "--duration", "15", "--open-output"]
         )

--- a/cmuxTests/MenuBarProfilingLauncherTests.swift
+++ b/cmuxTests/MenuBarProfilingLauncherTests.swift
@@ -9,9 +9,7 @@ import Testing
 struct MenuBarProfilingLauncherTests {
     @Test
     func testMenuBarProfilingLaunchesCurrentProcessForFifteenSecondsAndOpensOutput() {
-        #expect(
-            MenuBarProfilingLauncher.arguments(pid: 1234),
-            ["--pid", "1234", "--duration", "15", "--open-output"]
-        )
+        let arguments = MenuBarProfilingLauncher.arguments(pid: 1234)
+        #expect(arguments == ["--pid", "1234", "--duration", "15", "--open-output"])
     }
 }

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1721,7 +1721,6 @@ final class MenuBarBuildHintFormatterTests: XCTestCase {
     }
 }
 
-
 final class MenuBarNotificationLineFormatterTests: XCTestCase {
     func testPlainTitleContainsUnreadDotBodyAndTab() {
         let notification = TerminalNotification(

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1721,6 +1721,7 @@ final class MenuBarBuildHintFormatterTests: XCTestCase {
     }
 }
 
+
 final class MenuBarNotificationLineFormatterTests: XCTestCase {
     func testPlainTitleContainsUnreadDotBodyAndTab() {
         let notification = TerminalNotification(

--- a/tests/test_start_cmux_profiling.sh
+++ b/tests/test_start_cmux_profiling.sh
@@ -33,6 +33,29 @@ make_app "$stable_app" "com.cmuxterm.app" "cmux"
 make_app "$nightly_app" "com.cmuxterm.app.nightly" "cmux NIGHTLY"
 make_app "$dev_app" "com.cmuxterm.app.debug.dog" "cmux DEV dog"
 
+plist_buddy="$TMP_DIR/plistbuddy"
+cat > "$plist_buddy" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${2:-}"
+plist="${3:-}"
+key="${command#Print :}"
+python3 - "$key" "$plist" <<'PY'
+import plistlib
+import sys
+
+key = sys.argv[1]
+path = sys.argv[2]
+with open(path, "rb") as handle:
+    value = plistlib.load(handle).get(key, "")
+if value:
+    print(value)
+PY
+EOF
+chmod +x "$plist_buddy"
+export CMUX_PROFILE_PLIST_BUDDY="$plist_buddy"
+
 ps_file="$TMP_DIR/ps.txt"
 cat > "$ps_file" <<EOF
 101 $stable_app/Contents/MacOS/cmux
@@ -172,7 +195,17 @@ exit 42
 EOF
 chmod +x "$open_bin"
 
-CMUX_PROFILE_OSASCRIPT="$cancel_bin" CMUX_PROFILE_OPEN="$open_bin" "$ROOT_DIR/Resources/bin/submit-cmux-profile" \
+ditto_bin="$TMP_DIR/ditto"
+cat > "$ditto_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+dest="${@: -1}"
+mkdir -p "$(dirname "$dest")"
+printf 'zip' > "$dest"
+EOF
+chmod +x "$ditto_bin"
+
+CMUX_PROFILE_OSASCRIPT="$cancel_bin" CMUX_PROFILE_OPEN="$open_bin" CMUX_PROFILE_DITTO="$ditto_bin" "$ROOT_DIR/Resources/bin/submit-cmux-profile" \
   --profile "$timeout_out" \
   --target-name "cmux DEV dog" \
   --target-pid 303 \

--- a/tests/test_start_cmux_profiling.sh
+++ b/tests/test_start_cmux_profiling.sh
@@ -166,6 +166,52 @@ if ! grep -Fq "Completed:" "$timeout_out/summary.md"; then
   cat "$timeout_out/summary.md" >&2
   exit 1
 fi
+if ! grep -Fq "Successful traces: 1" "$timeout_out/summary.md"; then
+  echo "FAIL: script did not count the successful trace" >&2
+  cat "$timeout_out/summary.md" >&2
+  exit 1
+fi
+
+fail_bin="$TMP_DIR/fail-bin"
+mkdir -p "$fail_bin"
+cat > "$fail_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-f" ]; then
+  echo "$0"
+  exit 0
+fi
+
+if [ "${1:-}" = "xctrace" ] && [ "${2:-}" = "record" ]; then
+  echo "record failed" >&2
+  exit 2
+fi
+
+exit 1
+EOF
+chmod +x "$fail_bin/xcrun"
+
+all_failed_out="$TMP_DIR/all-failed-out"
+if PATH="$fail_bin:$PATH" "$SCRIPT" \
+  --test-ps-file "$ps_file" \
+  --channel dev \
+  --tag dog \
+  --duration 1 \
+  --template "Time Profiler" \
+  --no-submit \
+  --out "$all_failed_out" >/tmp/cmux-profile-all-failed.log 2>&1; then
+  echo "FAIL: all-failed profiling run should exit nonzero" >&2
+  exit 1
+fi
+if ! grep -Fq "all profiling templates failed" /tmp/cmux-profile-all-failed.log ||
+   ! grep -Fq "Successful traces: 0" "$all_failed_out/summary.md" ||
+   grep -Fq "Completed:" "$all_failed_out/summary.md"; then
+  echo "FAIL: all-failed profiling run did not surface failure correctly" >&2
+  cat /tmp/cmux-profile-all-failed.log >&2
+  cat "$all_failed_out/summary.md" >&2
+  exit 1
+fi
 
 submit_output="$("$ROOT_DIR/Resources/bin/submit-cmux-profile" --dry-run --profile "$timeout_out" --target-name "cmux DEV dog" --target-pid 303 --channel dev --bundle-id com.cmuxterm.app.debug.dog)"
 if [[ "$submit_output" != *"Recipient: founders@manaflow.com"* ]] ||

--- a/tests/test_start_cmux_profiling.sh
+++ b/tests/test_start_cmux_profiling.sh
@@ -89,6 +89,11 @@ if [[ "$dry_run" != *'--template "System Trace" --attach "303" --time-limit 7s'*
   echo "$dry_run" >&2
   exit 1
 fi
+if [ -e "$TMP_DIR/out" ]; then
+  echo "FAIL: dry run created the output directory" >&2
+  find "$TMP_DIR/out" -maxdepth 2 -type f -print >&2
+  exit 1
+fi
 
 if "$SCRIPT" --dry-run --test-ps-file "$ps_file" --out "$TMP_DIR/ambiguous" >/tmp/cmux-profile-ambiguous.log 2>&1; then
   echo "FAIL: unqualified selection should reject multiple cmux processes" >&2
@@ -211,5 +216,28 @@ CMUX_PROFILE_OSASCRIPT="$cancel_bin" CMUX_PROFILE_OPEN="$open_bin" CMUX_PROFILE_
   --target-pid 303 \
   --channel dev \
   --bundle-id com.cmuxterm.app.debug.dog
+
+capture_osascript="$TMP_DIR/capture-osascript"
+captured_args="$TMP_DIR/captured-osascript-args"
+cat > "$capture_osascript" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$captured_args"
+exit 0
+EOF
+chmod +x "$capture_osascript"
+
+CMUX_PROFILE_LOCALE=ja_JP CMUX_PROFILE_OSASCRIPT="$capture_osascript" CMUX_PROFILE_DITTO="$ditto_bin" "$ROOT_DIR/Resources/bin/submit-cmux-profile" \
+  --profile "$timeout_out" \
+  --target-name "cmux DEV dog" \
+  --target-pid 303 \
+  --channel dev \
+  --bundle-id com.cmuxterm.app.debug.dog
+if ! grep -Fq "cmuxプロファイルを送信" "$captured_args" ||
+   ! grep -Fq "下書きを開く" "$captured_args" ||
+   ! grep -Fq "cmuxプロファイリングキャプチャ" "$captured_args"; then
+  echo "FAIL: submit helper did not pass localized Japanese dialog/body strings" >&2
+  cat "$captured_args" >&2
+  exit 1
+fi
 
 echo "PASS: start-cmux-profiling target selection and default templates"

--- a/tests/test_start_cmux_profiling.sh
+++ b/tests/test_start_cmux_profiling.sh
@@ -147,4 +147,36 @@ if [[ "$submit_output" != *"Recipient: founders@manaflow.com"* ]] ||
   exit 1
 fi
 
+archive_path="$(printf '%s\n' "$submit_output" | sed -n 's/^Archive: //p')"
+mkdir -p "$(dirname "$archive_path")"
+printf 'keep me' > "$archive_path"
+"$ROOT_DIR/Resources/bin/submit-cmux-profile" --dry-run --profile "$timeout_out" --target-name "cmux DEV dog" >/dev/null
+if [ "$(cat "$archive_path")" != "keep me" ]; then
+  echo "FAIL: submit helper dry run modified an existing archive" >&2
+  exit 1
+fi
+
+cancel_bin="$TMP_DIR/cancel-osascript"
+cat > "$cancel_bin" <<'EOF'
+#!/usr/bin/env bash
+echo "execution error: User canceled. (-128)" >&2
+exit 1
+EOF
+chmod +x "$cancel_bin"
+
+open_bin="$TMP_DIR/open-should-not-run"
+cat > "$open_bin" <<'EOF'
+#!/usr/bin/env bash
+echo "fallback open should not run" >&2
+exit 42
+EOF
+chmod +x "$open_bin"
+
+CMUX_PROFILE_OSASCRIPT="$cancel_bin" CMUX_PROFILE_OPEN="$open_bin" "$ROOT_DIR/Resources/bin/submit-cmux-profile" \
+  --profile "$timeout_out" \
+  --target-name "cmux DEV dog" \
+  --target-pid 303 \
+  --channel dev \
+  --bundle-id com.cmuxterm.app.debug.dog
+
 echo "PASS: start-cmux-profiling target selection and default templates"

--- a/tests/test_start_cmux_profiling.sh
+++ b/tests/test_start_cmux_profiling.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT_DIR/Resources/bin/start-cmux-profiling"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+make_app() {
+  local path="$1"
+  local bundle_id="$2"
+  local display_name="$3"
+  mkdir -p "$path/Contents/MacOS"
+  cat > "$path/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>$bundle_id</string>
+  <key>CFBundleDisplayName</key>
+  <string>$display_name</string>
+</dict>
+</plist>
+EOF
+  : > "$path/Contents/MacOS/cmux"
+}
+
+stable_app="$TMP_DIR/cmux.app"
+nightly_app="$TMP_DIR/cmux NIGHTLY.app"
+dev_app="$TMP_DIR/cmux DEV dog.app"
+make_app "$stable_app" "com.cmuxterm.app" "cmux"
+make_app "$nightly_app" "com.cmuxterm.app.nightly" "cmux NIGHTLY"
+make_app "$dev_app" "com.cmuxterm.app.debug.dog" "cmux DEV dog"
+
+ps_file="$TMP_DIR/ps.txt"
+cat > "$ps_file" <<EOF
+101 $stable_app/Contents/MacOS/cmux
+202 $nightly_app/Contents/MacOS/cmux
+303 $dev_app/Contents/MacOS/cmux
+EOF
+
+dry_run="$("$SCRIPT" --dry-run --test-ps-file "$ps_file" --channel dev --tag dog --duration 7 --out "$TMP_DIR/out")"
+if [[ "$dry_run" != *"Target: pid=303 channel=dev bundle=com.cmuxterm.app.debug.dog name=cmux DEV dog"* ]]; then
+  echo "FAIL: dev tag selector did not choose the tagged dev process" >&2
+  echo "$dry_run" >&2
+  exit 1
+fi
+if [[ "$dry_run" != *'--template "Time Profiler" --attach "303" --time-limit 7s'* ]]; then
+  echo "FAIL: dry run did not include Time Profiler for the selected process" >&2
+  echo "$dry_run" >&2
+  exit 1
+fi
+if [[ "$dry_run" != *'--template "SwiftUI" --attach "303" --time-limit 7s'* ]]; then
+  echo "FAIL: dry run did not include SwiftUI for the selected process" >&2
+  echo "$dry_run" >&2
+  exit 1
+fi
+if [[ "$dry_run" != *'--template "Allocations" --attach "303" --time-limit 7s'* ]]; then
+  echo "FAIL: dry run did not include Allocations for the selected process" >&2
+  echo "$dry_run" >&2
+  exit 1
+fi
+if [[ "$dry_run" != *'--template "System Trace" --attach "303" --time-limit 7s'* ]]; then
+  echo "FAIL: dry run did not include System Trace for the selected process" >&2
+  echo "$dry_run" >&2
+  exit 1
+fi
+
+if "$SCRIPT" --dry-run --test-ps-file "$ps_file" --out "$TMP_DIR/ambiguous" >/tmp/cmux-profile-ambiguous.log 2>&1; then
+  echo "FAIL: unqualified selection should reject multiple cmux processes" >&2
+  exit 1
+fi
+if ! grep -Fq "multiple cmux processes are running" /tmp/cmux-profile-ambiguous.log; then
+  echo "FAIL: ambiguous selection did not explain how to discriminate instances" >&2
+  cat /tmp/cmux-profile-ambiguous.log >&2
+  exit 1
+fi
+
+list_output="$("$SCRIPT" --list-targets --test-ps-file "$ps_file")"
+if [[ "$list_output" != *"pid=101 channel=stable bundle=com.cmuxterm.app"* ]] ||
+   [[ "$list_output" != *"pid=202 channel=nightly bundle=com.cmuxterm.app.nightly"* ]] ||
+   [[ "$list_output" != *"pid=303 channel=dev bundle=com.cmuxterm.app.debug.dog"* ]]; then
+  echo "FAIL: --list-targets did not show stable/nightly/dev discrimination" >&2
+  echo "$list_output" >&2
+  exit 1
+fi
+
+fake_bin="$TMP_DIR/fake-bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-f" ]; then
+  echo "$0"
+  exit 0
+fi
+
+if [ "${1:-}" = "xctrace" ] && [ "${2:-}" = "record" ]; then
+  output=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--output" ]; then
+      output="$2"
+      break
+    fi
+    shift
+  done
+  mkdir -p "$output"
+  exit 0
+fi
+
+if [ "${1:-}" = "xctrace" ] && [ "${2:-}" = "export" ]; then
+  sleep 5
+  exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$fake_bin/xcrun"
+
+timeout_out="$TMP_DIR/timeout-out"
+PATH="$fake_bin:$PATH" CMUX_PROFILE_TOC_TIMEOUT_SECONDS=1 "$SCRIPT" \
+  --test-ps-file "$ps_file" \
+  --channel dev \
+  --tag dog \
+  --duration 1 \
+  --template "Time Profiler" \
+  --no-submit \
+  --out "$timeout_out" >/dev/null
+if ! grep -Fq "Timed out after 1s" "$timeout_out/time-profiler-toc.log"; then
+  echo "FAIL: hung TOC export did not time out" >&2
+  cat "$timeout_out/time-profiler-toc.log" >&2
+  exit 1
+fi
+if ! grep -Fq "Completed:" "$timeout_out/summary.md"; then
+  echo "FAIL: script did not complete after TOC export timeout" >&2
+  cat "$timeout_out/summary.md" >&2
+  exit 1
+fi
+
+submit_output="$("$ROOT_DIR/Resources/bin/submit-cmux-profile" --dry-run --profile "$timeout_out" --target-name "cmux DEV dog" --target-pid 303 --channel dev --bundle-id com.cmuxterm.app.debug.dog)"
+if [[ "$submit_output" != *"Recipient: founders@manaflow.com"* ]] ||
+   [[ "$submit_output" != *"Subject: cmux profiling capture: cmux DEV dog"* ]]; then
+  echo "FAIL: submit helper dry run did not describe the founders draft" >&2
+  echo "$submit_output" >&2
+  exit 1
+fi
+
+echo "PASS: start-cmux-profiling target selection and default templates"


### PR DESCRIPTION
## Summary

Adds an internal support script and menu bar action for collecting short cmux Instruments captures.

- adds `Resources/bin/start-cmux-profiling`, which captures Time Profiler, SwiftUI, Allocations, and System Trace for 15 seconds by default
- supports targeting by exact PID, channel (`stable`, `nightly`, `staging`, `dev`), and tag, plus `--list-targets` for ambiguity
- adds `Start Profiling` to the status menu, wired to profile the current app process by PID and open the output directory

## Tool choice

The default capture uses the useful broad diagnostics: CPU stacks (`Time Profiler`), SwiftUI update/body churn (`SwiftUI`), allocation growth (`Allocations`), and scheduling/hang context (`System Trace`). `Leaks` is intentionally not default because it is heavier and can pause a busy process.

## Verification

- `tests/test_start_cmux_profiling.sh`
- `bash -n Resources/bin/start-cmux-profiling tests/test_start_cmux_profiling.sh`
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/check-pbxproj.sh`
- `git diff --check`
- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-prof -only-testing:cmuxTests/MenuBarProfilingLauncherTests SWIFT_ENABLE_BATCH_MODE=NO DEBUG_INFORMATION_FORMAT= GCC_GENERATE_DEBUGGING_SYMBOLS=NO 'OTHER_SWIFT_FLAGS=$(inherited) -Xllvm -aarch64-enable-global-isel-at-O=-1'`
- `./scripts/reload-cloud.sh --tag prof`
- launched tagged app `prof`, verified `/tmp/cmux-debug-prof.sock`, ran bundled script `--dry-run --channel dev --tag prof`, and captured a 1 second Time Profiler trace

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784438749&installation_id=133855650&pr_number=6433&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6433&signature=3697346eed0bd163f534888c736c285b0971f8f660de9ee0505f0b61db8a20c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new support tooling and menu wiring; profiling runs externally via xctrace and submission is user-initiated email, with no changes to auth or core app logic.
> 
> **Overview**
> Adds **support diagnostics** for short Xcode Instruments captures of a running cmux instance, wired from the status menu and bundled CLI scripts.
> 
> New **`start-cmux-profiling`** runs default **Time Profiler**, **SwiftUI**, **Allocations**, and **System Trace** (15s each), with targeting by **PID**, **channel**, or **tag**, ambiguity handling, **`summary.md`**, optional TOC export with timeouts, and async **`submit-cmux-profile`** (zip + Mail draft to founders, EN/JA). **`submit-cmux-profile`** supports dry-run, cancel handling, and test hooks via env overrides.
> 
> The status menu gains **Start Profiling**, which launches the bundled script for the **current process** with **`--open-output`**. Scripts ship in the app **`bin`** copy phase; **EN/JA** `statusMenu.startProfiling` strings, a launcher unit test, **`tests/test_start_cmux_profiling.sh`**, and a **CI** workflow step validate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524aab8bda1ddf0139deec30f799e6f2b5ab5830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support scripts and a status‑menu action to capture short Xcode Instruments profiles of the running cmux app, with safe defaults, clearer dry‑run output, and an email submission flow. Now skips submission when no traces are captured, and tightens tests and CI with portable mocks, timeouts, and locale‑aware prompts.

- **New Features**
  - Bundled `Resources/bin/start-cmux-profiling` (uses `xcrun xctrace`) with 15s default; supports `--duration`, `--out`, repeated `--template`, `--open-output`, `--no-submit`, `--list-targets`; writes `summary.md` and per-trace TOC; dry-run prints target and planned commands without creating files.
  - Flexible targeting: `--pid`, `--channel` (stable/nightly/staging/dev), `--tag`; rejects ambiguous selection; `Leaks` excluded by default.
  - Added “Start Profiling” to the status menu; profiles the current process and opens the output. Scripts are bundled via the Copy CLI phase; EN/JA strings and a unit test cover launcher args.

- **Bug Fixes**
  - `Resources/bin/submit-cmux-profile` zips the capture and opens a Mail draft; handles AppleScript cancel, falls back to Finder reveal + mailto; supports `CMUX_PROFILE_OSASCRIPT`/`CMUX_PROFILE_OPEN`/`CMUX_PROFILE_DITTO`; dry-run is side‑effect free and reports archive/recipient/subject; added `CMUX_PROFILE_LOCALE` override for EN/JA dialog text; avoids submitting empty captures by exiting when all templates fail and marking the summary as failed.
  - More robust tests: `CMUX_PROFILE_PLIST_BUDDY` and `CMUX_PROFILE_TOC_TIMEOUT_SECONDS` overrides; CI runs `tests/test_start_cmux_profiling.sh` to validate selection, TOC export timeout, dry-run behavior, and JA localization; fixed Swift Testing assertion in `MenuBarProfilingLauncherTests`.

<sup>Written for commit 524aab8bda1ddf0139deec30f799e6f2b5ab5830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profiling menu option to capture performance data with automatic result display
  * Added ability to submit profiling captures via email

* **Localization**
  * Added Japanese language support for profiling features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->