### PR TITLE
Inherit the active tab's working directory for ssh-tmux new tabs

### DIFF
--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -394,13 +394,18 @@ final class RemoteTmuxController {
     /// returning `true` would let socket callers report an accepted mutation
     /// that never reached tmux.
     ///
+    /// - Parameter workingDirectory: the directory the new tmux window should
+    ///   start in (the focused tab's cwd, resolved by the caller), so a new tab
+    ///   inherits the active tab's directory the way local cmux does. A
+    ///   nil/blank/unsafe value sends a bare `new-window` and lets tmux pick its
+    ///   default-path (`~`).
     /// - Returns: `true` if routed to the remote; `false` if there is no live
     ///   mirror/connection (callers must still NOT create a local tab in a
     ///   mirror workspace — they report failure instead).
-    func handleMirrorNewTabRequested(workspaceId: UUID) -> Bool {
+    func handleMirrorNewTabRequested(workspaceId: UUID, workingDirectory: String? = nil) -> Bool {
         guard let mirror = sessionMirrors.values.first(where: { $0.mirroredWorkspaceId == workspaceId }),
               mirror.connection.connectionState == .connected else { return false }
-        return mirror.connection.send("new-window")
+        return mirror.connection.send(RemoteTmuxHost.newWindowCommand(workingDirectory: workingDirectory))
     }
 
     /// A mirrored workspace was renamed → `rename-session` on the remote so the

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -194,6 +194,11 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
         return value
     }
 
+    /// The tmux control-mode command that opens a new window for a mirror tab.
+    static func newWindowCommand(workingDirectory: String?) -> String {
+        "new-window"
+    }
+
     /// Builds the `ssh` argv (for direct `Process` execution, no shell) that
     /// runs `tmux -CC` control mode for `sessionName` on this host.
     ///

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -194,9 +194,25 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
         return value
     }
 
-    /// The tmux control-mode command that opens a new window for a mirror tab.
+    /// The tmux control-mode command that opens a new window, optionally seeded
+    /// with a starting directory so the new tmux window inherits the active
+    /// tab's working directory — matching how a new tab inherits cwd in local
+    /// cmux. A nil/blank/unsafe directory yields a bare `new-window`, letting
+    /// tmux fall back to its default-path (typically `~`).
+    ///
+    /// The path is single-quoted so spaces and shell metacharacters survive
+    /// tmux's command parser (the same quoting the `rename-*` commands use on
+    /// this stream), and rejected outright when it carries CR/LF/control bytes
+    /// that could terminate the command line before tmux parses the quoted
+    /// argument (same line-safety contract as ``controlModeCommandName(_:)``).
     static func newWindowCommand(workingDirectory: String?) -> String {
-        "new-window"
+        guard let directory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !directory.isEmpty,
+              controlModeLineSafeName(directory) != nil
+        else {
+            return "new-window"
+        }
+        return "new-window -c \(shellSingleQuoted(directory))"
     }
 
     /// Builds the `ssh` argv (for direct `Process` execution, no shell) that

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6529,9 +6529,19 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     /// The directory a new tab (`new-window`) should inherit in a remote-tmux
-    /// mirror, based on the source tab.
+    /// mirror: strictly the source tab's last-reported `#{pane_current_path}`
+    /// (`panelDirectories[sourcePanelId]`), or nil when the remote has not
+    /// reported one yet.
+    ///
+    /// It must not use ``resolvedTerminalStartupWorkingDirectory(requestedWorkingDirectory:sourcePanelId:)``:
+    /// that resolver falls back to `currentDirectory`, which on a mirror
+    /// workspace can be a local path (it is seeded from the local workspace the
+    /// mirror was created from). A local path passed as `new-window -c` need not
+    /// exist on the remote host, and tmux may reject the command — creating no
+    /// tab. `panelDirectories[sourcePanelId]` is fed only by the tab's remote cwd
+    /// reports, so it is the one safe source.
     func remoteTmuxNewWindowWorkingDirectory(forSourcePanelId sourcePanelId: UUID?) -> String? {
-        resolvedTerminalStartupWorkingDirectory(requestedWorkingDirectory: nil, sourcePanelId: sourcePanelId)
+        Self.normalizedTerminalWorkingDirectory(sourcePanelId.flatMap { panelDirectories[$0] })
     }
 
     /// Candidate terminal panels used as the source when creating inherited Ghostty config.
@@ -6980,8 +6990,24 @@ final class Workspace: Identifiable, ObservableObject {
         // breaking the 1:1 invariant (symmetric with newBrowserSurface). A dead
         // mirror workspace is torn down separately via handleSessionEndedRemotely.
         if isRemoteTmuxMirror {
+            // Inherit the focused tab's directory like a local new tab, sourcing
+            // it only from that tab's confirmed remote cwd (see
+            // remoteTmuxNewWindowWorkingDirectory). The socket/CLI layer rejects
+            // an explicit working_directory for mirror workspaces
+            // (mirrorRoutedUnsupportedOptions), so inheritance is the only source.
+            let resolvedWorkingDirectory: String?
+            if inheritWorkingDirectoryFallback {
+                let inheritSourcePanelId = workingDirectoryFallbackSourcePanelId
+                    ?? bonsplitController.selectedTab(inPane: paneId).map(\.id).flatMap(panelIdFromSurfaceId)
+                resolvedWorkingDirectory = remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: inheritSourcePanelId)
+            } else {
+                resolvedWorkingDirectory = nil
+            }
             let routed = AppDelegate.shared?.remoteTmuxController
-                .handleMirrorNewTabRequested(workspaceId: id) ?? false
+                .handleMirrorNewTabRequested(
+                    workspaceId: id,
+                    workingDirectory: resolvedWorkingDirectory
+                ) ?? false
             return routed ? .routedToRemote : .failed
         }
         guard let panel = newTerminalSurfaceLocal(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6528,6 +6528,12 @@ final class Workspace: Identifiable, ObservableObject {
         ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
     }
 
+    /// The directory a new tab (`new-window`) should inherit in a remote-tmux
+    /// mirror, based on the source tab.
+    func remoteTmuxNewWindowWorkingDirectory(forSourcePanelId sourcePanelId: UUID?) -> String? {
+        resolvedTerminalStartupWorkingDirectory(requestedWorkingDirectory: nil, sourcePanelId: sourcePanelId)
+    }
+
     /// Candidate terminal panels used as the source when creating inherited Ghostty config.
     /// Preference order:
     /// 1) explicitly preferred terminal panel (when the caller has one),

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		E54DED0FDC24F51BF1470A1A /* RemoteTmuxLayoutNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5717357D55291686F99625 /* RemoteTmuxLayoutNode.swift */; };
 		D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */; };
 		F861B8D7C62A0BCB252A523A /* RemoteTmuxMirrorTabActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */; };
+		0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */; };
 		E9A8CC35D632F14A8669B7D1 /* RemoteTmuxPaneForegroundState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */; };
 		740FC5FDE4E13EAA440872C3 /* RemoteTmuxPaneHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F225C1630E640224D11E09 /* RemoteTmuxPaneHeader.swift */; };
 		761639EDDD6C40883902D781 /* RemoteTmuxPostAttachAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE24906539C19AB10E4C1C71 /* RemoteTmuxPostAttachAction.swift */; };
@@ -1622,6 +1623,7 @@
 		8A5717357D55291686F99625 /* RemoteTmuxLayoutNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxLayoutNode.swift; sourceTree = "<group>"; };
 		A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorSplitRoutingTests.swift; sourceTree = "<group>"; };
 		6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorTabActivity.swift; sourceTree = "<group>"; };
+		0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNewWindowCwdTests.swift; sourceTree = "<group>"; };
 		123BF93B1ADC00C5D25EE028 /* RemoteTmuxPaneForegroundState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneForegroundState.swift; sourceTree = "<group>"; };
 		F6F225C1630E640224D11E09 /* RemoteTmuxPaneHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPaneHeader.swift; sourceTree = "<group>"; };
 		CE24906539C19AB10E4C1C71 /* RemoteTmuxPostAttachAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxPostAttachAction.swift; sourceTree = "<group>"; };
@@ -2983,6 +2985,7 @@
 				A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */,
 				FA00C0DE0002BEEF0002CAFE /* RemoteTmuxWindowRegistryTests.swift */,
 				0A17C0DE0A17C0DE0A17C003 /* RemoteTmuxAuthTests.swift */,
+				0C7D0CDD0C7D0CDD0C7D0001 /* RemoteTmuxNewWindowCwdTests.swift */,
 				5F5553CA5553CA5553CA0002 /* RemoteTmuxCapabilitiesTests.swift */,
 				5F5553CB5553CB5553CB0002 /* RightSidebarRemoteCommandTests.swift */,
 				3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */,
@@ -4306,6 +4309,7 @@
 				B2FDE62450514C4C27FBD8F1 /* RemoteTmuxControlParserTests.swift in Sources */,
 				B0555301B0555301B0555301 /* RemoteTmuxControlStreamParserBudgetTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
+				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxNewWindowCwdTests.swift
+++ b/cmuxTests/RemoteTmuxNewWindowCwdTests.swift
@@ -1,0 +1,148 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for remote-tmux (`cmux ssh-tmux`) new-tab cwd inheritance.
+///
+/// In local cmux a new tab inherits the active tab's working directory; the
+/// remote mirror routes a new tab to a tmux `new-window`, which — without an
+/// explicit `-c <path>` — starts in tmux's default-path (`~`) instead of the
+/// focused tab's directory. cmux seeds that directory via
+/// ``RemoteTmuxHost/newWindowCommand(workingDirectory:)``.
+///
+/// These assert the produced control-mode command: a known directory must carry
+/// a single-quoted `-c`, and absent/blank/unsafe directories must fall back to a
+/// bare `new-window` so a missing cwd can never break the control stream.
+@Suite struct RemoteTmuxNewWindowCwdTests {
+
+    @Test func seedsStartingDirectoryWhenKnown() {
+        #expect(
+            RemoteTmuxHost.newWindowCommand(workingDirectory: "/Users/me/proj")
+                == "new-window -c '/Users/me/proj'"
+        )
+    }
+
+    @Test func singleQuotesPathsWithSpaces() {
+        #expect(
+            RemoteTmuxHost.newWindowCommand(workingDirectory: "/Users/me/My Project")
+                == "new-window -c '/Users/me/My Project'"
+        )
+    }
+
+    @Test func escapesEmbeddedSingleQuote() {
+        // shell single-quote escaping: ' -> '\'' so the path survives tmux's parser.
+        #expect(
+            RemoteTmuxHost.newWindowCommand(workingDirectory: "/Users/me/o'brien")
+                == "new-window -c '/Users/me/o'\\''brien'"
+        )
+    }
+
+    @Test(arguments: [
+        nil,
+        "",
+        "   ",
+        "\t",
+    ])
+    func fallsBackToBareNewWindowWhenDirectoryUnusable(_ directory: String?) {
+        #expect(RemoteTmuxHost.newWindowCommand(workingDirectory: directory) == "new-window")
+    }
+
+    @Test(arguments: [
+        "/Users/me/pro\nject",
+        "/Users/me/pro\rject",
+        "/Users/me/pro\u{0}ject",
+    ])
+    func rejectsDirectoriesThatCouldBreakTheControlStream(_ directory: String) {
+        // CR/LF/control bytes could terminate the command line before tmux parses
+        // the quoted argument, so an unsafe path must degrade to a bare command.
+        #expect(RemoteTmuxHost.newWindowCommand(workingDirectory: directory) == "new-window")
+    }
+}
+
+/// Coverage for the workspace-side resolution that feeds the command above. A
+/// remote-tmux mirror new tab must inherit ONLY a directory the remote actually
+/// reported for the source tab (`panelDirectories`, sourced from
+/// `#{pane_current_path}`) — never the generic resolver's `currentDirectory`
+/// fallback, which for a mirror is seeded from the LOCAL workspace it was
+/// created from. Sending that local path as `new-window -c` would point the
+/// remote at a nonexistent directory and tmux could reject the command,
+/// silently producing no tab.
+@MainActor
+@Suite(.serialized) struct RemoteTmuxNewWindowWorkingDirectoryResolutionTests {
+    @Test func inheritsSourceTabsReportedRemoteDirectory() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.workspace.panelDirectories[harness.sourcePanelId] = "/srv/remote/project"
+
+        #expect(
+            harness.workspace.remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: harness.sourcePanelId)
+                == "/srv/remote/project"
+        )
+    }
+
+    @Test func ignoresLocalCurrentDirectoryWhenSourceTabHasNoRemoteReport() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        // The mirror workspace's currentDirectory is seeded from the local
+        // workspace — it must NOT leak into a remote `new-window -c`.
+        harness.workspace.currentDirectory = "/Users/local/home"
+        harness.workspace.panelDirectories.removeValue(forKey: harness.sourcePanelId)
+
+        #expect(
+            harness.workspace.remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: harness.sourcePanelId) == nil
+        )
+    }
+
+    @Test func returnsNilForUnknownSourcePanel() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        #expect(harness.workspace.remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: nil) == nil)
+        #expect(harness.workspace.remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: UUID()) == nil)
+    }
+
+    @Test func treatsBlankReportedDirectoryAsUnknown() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        harness.workspace.panelDirectories[harness.sourcePanelId] = "   "
+
+        #expect(
+            harness.workspace.remoteTmuxNewWindowWorkingDirectory(forSourcePanelId: harness.sourcePanelId) == nil
+        )
+    }
+
+    @MainActor
+    private struct Harness {
+        let appDelegate: AppDelegate
+        let windowId: UUID
+        let workspace: Workspace
+        let sourcePanelId: UUID
+
+        init() throws {
+            appDelegate = try #require(AppDelegate.shared)
+            windowId = appDelegate.createMainWindow()
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            workspace = try #require(manager.selectedWorkspace)
+            workspace.isRemoteTmuxMirror = true
+            sourcePanelId = try #require(workspace.focusedPanelId)
+        }
+
+        func tearDown() {
+            workspace.isRemoteTmuxMirror = false
+            let identifier = "cmux.main.\(windowId.uuidString)"
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                window.performClose(nil)
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

In local cmux, a new tab inherits the working directory of the currently active tab. In a remote tmux (`cmux ssh-tmux`) mirror it does not — every new tab opens in tmux's default directory (`~`) regardless of where the active tab is.

## Cause

A new tab in a mirror workspace routes to tmux as a bare `new-window`. With no `-c <path>`, tmux starts the window in its default directory, so the active tab's working directory is never carried over.

## Fix

Resolve the active tab's directory and pass it through as `new-window -c '<path>'`:

- **`RemoteTmuxHost.newWindowCommand`** builds `new-window -c '<path>'` with the path single-quoted (same quoting the `rename-*` commands use on this control stream). A blank path, or one containing control bytes that could break the control-mode line, falls back to a bare `new-window`.
- **`Workspace.remoteTmuxNewWindowWorkingDirectory`** reads the directory strictly from the source tab's last-reported `#{pane_current_path}` (`panelDirectories`, which on a mirror is fed only by remote cwd reports). It deliberately does **not** use the general terminal resolver, whose `currentDirectory` fallback can be a *local* path on a mirror workspace — passing a local path as `new-window -c` would point the remote at a directory that need not exist there, and tmux can reject the command, leaving no tab created.
- **`RemoteTmuxController.handleMirrorNewTabRequested`** forwards the resolved directory into the new-window command.

When no remote directory is known for the tab yet, it sends a bare `new-window` (the previous behavior) so a missing cwd can never break the control stream.

## Tests

`cmuxTests/RemoteTmuxNewWindowCwdTests.swift`:
- `newWindowCommand` formatting: `-c` for a known directory, single-quoting of spaces and embedded quotes, and fallback to bare `new-window` for blank/control-byte paths.
- Workspace resolution: inherits the source tab's reported remote directory, and returns `nil` (→ bare `new-window`) when only a local `currentDirectory` is set — guarding the local-path-to-remote regression.

Split into two commits per the repo's regression policy: the first adds the failing tests (CI red), the second adds the fix (CI green).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784464992&installation_id=133855650&pr_number=6444&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6444&signature=e40a0b474cf82f35c684c7b34fb9428806827375a9e6e1f25d812038079811d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New ssh-tmux tabs now inherit the active tab’s working directory instead of always opening in `~`. We resolve the remote cwd and pass it to tmux via `new-window -c '<path>'` with a safe fallback to a bare `new-window` when unknown.

- **Bug Fixes**
  - `RemoteTmuxHost.newWindowCommand`: builds `new-window -c` with a single-quoted path; rejects blank/unsafe values and falls back to `new-window`.
  - `Workspace.remoteTmuxNewWindowWorkingDirectory`: sources cwd only from the source tab’s remote `panelDirectories` (never local `currentDirectory` in mirrors).
  - `RemoteTmuxController.handleMirrorNewTabRequested`: forwards the resolved cwd to tmux.
  - Added `RemoteTmuxNewWindowCwdTests` for command formatting and workspace resolution.

<sup>Written for commit 2425387f72681eae4b5e475a8b5b79206516ca21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New terminal windows created in remote sessions now open in the working directory from the source session, with proper path validation and shell escaping.

* **Tests**
  * Added comprehensive test coverage for working directory preservation and path safety in remote terminal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->