### PR TITLE
Docs: add CI path-gating smoke check

### DIFF
--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -120,3 +120,11 @@ Residual: this guard checks workflow literals, not repo-variable values. Do not
 set `MACOS_RUNNER_*` / `LINUX_RUNNER` to a self-hosted label; keep them on
 Blacksmith. Fully closing the variable-value path requires removing the
 colliding labels from the minis (runner-side, needs org/runner admin).
+
+## Path-gating smoke checks
+
+A docs-only PR is the cheapest live smoke check for CI path gating. The
+`changes` job should classify ordinary `docs/` and `README.md` edits as
+`macos=false`, `web=false`, and `go=false`; routed macOS, web, and remote-daemon
+jobs should be skipped; `workflow-guard-tests` and `ci-status` should still run
+and pass.


### PR DESCRIPTION
## Summary
- document how docs-only PRs verify CI path gating
- expected live behavior: `changes` emits `macos=false web=false go=false`, expensive routed jobs skip, and `ci-status` passes

## Testing
- `python3 scripts/ci/detect_ci_change_areas.py --event-name pull_request --files-from /tmp/cmux-verification-files.txt`
- `git diff --check`

## Verification
This PR intentionally changes only `docs/ci-runners.md` so GitHub Actions can prove the path-gating change from https://github.com/manaflow-ai/cmux/pull/6429 skips unrelated expensive jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784485204&installation_id=133855650&pr_number=6451&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6451&signature=9b9eacac63a99a365ddaa007de273958aadc2dc6f427e14c0de44fa13c79c4ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the CI path-gating smoke check in `docs/ci-runners.md` using docs-only PRs. It explains that `changes` should emit `macos=false`, `web=false`, `go=false`, routed macOS/web/remote-daemon jobs should skip, and `workflow-guard-tests` and `ci-status` should still run and pass.

<sup>Written for commit 9be53dffe1f669286e4557c9766ac215cf7e45c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on CI smoke tests for documentation-only pull requests, including expected test behavior and classification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->