### PR TITLE
CI: gate activation benchmark on macOS changes

### DIFF
--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -43,7 +43,69 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  activation-session:
+  activation_changes:
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    timeout-minutes: 5
+    outputs:
+      macos: ${{ steps.detect.outputs.macos }}
+      web: ${{ steps.detect.outputs.web }}
+      go: ${{ steps.detect.outputs.go }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect CI change areas
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          emit_all_areas() {
+            echo "macos=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          }
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" \
+              || ! git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/cmux-activation-changed-files.txt; then
+              echo "Could not compute PR diff; running activation benchmark." >&2
+              emit_all_areas
+              exit 0
+            fi
+
+            if [ ! -s /tmp/cmux-activation-changed-files.txt ]; then
+              echo "PR diff is empty; running activation benchmark."
+              emit_all_areas
+              exit 0
+            fi
+
+            # This guard runs before the PR-editable Python detector. Workflow
+            # and detector edits must fail open to the benchmark.
+            if grep -Eq '^(\.github/workflows/[^/]+\.ya?ml|scripts/ci/[^/]+\.py|tests/test_ci_change_areas\.py)$' /tmp/cmux-activation-changed-files.txt; then
+              echo "CI router changed; running activation benchmark."
+              emit_all_areas
+              exit 0
+            fi
+
+            python3 scripts/ci/detect_ci_change_areas.py \
+              --event-name "$EVENT_NAME" \
+              --files-from /tmp/cmux-activation-changed-files.txt
+            exit 0
+          fi
+
+          python3 scripts/ci/detect_ci_change_areas.py \
+            --event-name "$EVENT_NAME" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"
+
+  activation-session-benchmark:
+    needs: activation_changes
+    if: ${{ needs.activation_changes.outputs.macos == 'true' }}
     runs-on: ${{ github.event_name == 'pull_request' && 'depot-macos-latest' || ((!inputs.runner || inputs.runner == 'auto') && (vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x') || inputs.runner) }}
     timeout-minutes: 45
     env:
@@ -305,3 +367,46 @@ jobs:
         run: |
           pkill -f "cmux DEV ${PERF_TAG}.app/Contents/MacOS/cmux DEV" || true
           rm -f "/tmp/cmux-debug-${PERF_TAG}.sock"
+
+  activation-session:
+    needs:
+      - activation_changes
+      - activation-session-benchmark
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    steps:
+      - name: Check activation benchmark routing
+        env:
+          ACTIVATION_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["ACTIVATION_NEEDS"])
+          changes = needs["activation_changes"]
+          benchmark = needs["activation-session-benchmark"]
+          macos = changes.get("outputs", {}).get("macos")
+
+          if changes["result"] != "success":
+              print(f"changes: {changes['result']}", file=sys.stderr)
+              sys.exit(1)
+
+          if macos == "true" and benchmark["result"] != "success":
+              print(
+                  f"Activation benchmark was required but did not pass: {benchmark['result']}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          if macos != "true" and benchmark["result"] not in {"success", "skipped"}:
+              print(
+                  f"Activation benchmark had unexpected result for macos={macos}: {benchmark['result']}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+
+          print(f"changes.macos={macos}")
+          print(f"activation-session-benchmark={benchmark['result']}")
+          PY

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect CI change areas
         id: detect
@@ -374,6 +375,7 @@ jobs:
       - activation-session-benchmark
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    timeout-minutes: 5
     steps:
       - name: Check activation benchmark routing
         env:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -14,6 +14,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "ci" / "detect_ci_change_areas.py"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+PERF_ACTIVATION_WORKFLOW = ROOT / ".github" / "workflows" / "perf-activation.yml"
 
 spec = importlib.util.spec_from_file_location("detect_ci_change_areas", HELPER)
 assert spec and spec.loader
@@ -88,8 +89,8 @@ def test_workflow_changes_run_everything() -> None:
     assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
 
 
-def detect_step_script() -> str:
-    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+def detect_step_script(workflow_path: Path = CI_WORKFLOW) -> str:
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
     for index, line in enumerate(lines):
         if line == "      - name: Detect CI change areas":
             for run_index in range(index + 1, len(lines)):
@@ -108,8 +109,8 @@ def detect_step_script() -> str:
     raise AssertionError("Detect CI change areas run block not found")
 
 
-def workflow_job_block(job_name: str) -> str:
-    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+def workflow_job_block(job_name: str, workflow_path: Path = CI_WORKFLOW) -> str:
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
     marker = f"  {job_name}:"
     for index, line in enumerate(lines):
         if line == marker:
@@ -122,13 +123,19 @@ def workflow_job_block(job_name: str) -> str:
     raise AssertionError(f"{job_name} job not found")
 
 
-def run_detect_step_for_paths(paths: list[str]) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    script = detect_step_script()
+def run_detect_step_for_paths(
+    paths: list[str],
+    workflow_path: Path = CI_WORKFLOW,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    script = detect_step_script(workflow_path)
     with tempfile.TemporaryDirectory() as temp_dir:
         repo = Path(temp_dir)
         subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.email", "ci@example.test"], cwd=repo, check=True)
         subprocess.run(["git", "config", "user.name", "CI Test"], cwd=repo, check=True)
+        helper_copy = repo / "scripts" / "ci" / "detect_ci_change_areas.py"
+        helper_copy.parent.mkdir(parents=True, exist_ok=True)
+        helper_copy.write_text(HELPER.read_text(encoding="utf-8"), encoding="utf-8")
         (repo / "base.txt").write_text("base\n", encoding="utf-8")
         subprocess.run(["git", "add", "."], cwd=repo, check=True)
         subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
@@ -322,6 +329,26 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
 
     assert "if: ${{ always() }}" in block
     assert 'allowed = {"success", "skipped"}' in block
+
+
+def test_perf_activation_workflow_keeps_required_status_while_gating_benchmark() -> None:
+    result, outputs = run_detect_step_for_paths(["docs/ci-runners.md"], PERF_ACTIVATION_WORKFLOW)
+
+    assert "Resolved areas: macos=false web=false go=false" in result.stdout
+    assert outputs == ["macos=false", "web=false", "go=false"]
+
+    benchmark = workflow_job_block("activation-session-benchmark", PERF_ACTIVATION_WORKFLOW)
+    sentinel = workflow_job_block("activation-session", PERF_ACTIVATION_WORKFLOW)
+
+    assert "needs: activation_changes" in benchmark
+    assert "if: ${{ needs.activation_changes.outputs.macos == 'true' }}" in benchmark
+    assert "depot-macos-latest" in benchmark
+
+    assert "      - activation_changes" in sentinel
+    assert "      - activation-session-benchmark" in sentinel
+    assert "if: ${{ always() }}" in sentinel
+    assert 'macos == "true" and benchmark["result"] != "success"' in sentinel
+    assert 'benchmark["result"] not in {"success", "skipped"}' in sentinel
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- split the activation performance workflow into a cheap `activation_changes` detector, a gated `activation-session-benchmark`, and a stable `activation-session` sentinel check
- skip the Depot/macOS activation benchmark for docs-only and other non-macOS PRs while preserving the existing `activation-session` check name
- extend the CI path-gating tests to execute the `perf-activation.yml` detector against a docs-only diff

## Testing
- `python3 tests/test_ci_change_areas.py`
- `python3.9 tests/test_ci_change_areas.py`
- `python3 -m py_compile tests/test_ci_change_areas.py scripts/ci/detect_ci_change_areas.py`
- `python3.9 -m py_compile tests/test_ci_change_areas.py scripts/ci/detect_ci_change_areas.py`
- `./tests/test_ci_self_hosted_guard.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/perf-activation.yml'); puts 'parsed perf-activation.yml'"`\n- `git diff --check`\n\n## Notes\nFollow-up to https://github.com/manaflow-ai/cmux/pull/6429 and live verification in https://github.com/manaflow-ai/cmux/pull/6451. The verification PR showed the main `ci.yml` expensive jobs skipping correctly, but `activation-session` still ran for docs-only changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784486430&installation_id=133855650&pr_number=6453&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6453&signature=1573afcd611233640af1efef601aa5f2d13cd65c77a3e50112feb7ff9d714814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the macOS activation benchmark behind a change detector and a sentinel check to run it only when relevant. Docs-only and non-macOS PRs now skip the expensive job while the `activation-session` status remains stable.

- **Refactors**
  - Split `perf-activation.yml` into `activation_changes` detector, gated `activation-session-benchmark`, and always-on `activation-session` sentinel that verifies routing.
  - Hardened routing: fail-open if diff is missing/empty or CI router files change; invoke `scripts/ci/detect_ci_change_areas.py`; sentinel validates `needs` results and enforces success/skipped rules.
  - Extended tests to cover perf-activation workflow gating and required status, parameterize helpers to parse that workflow, and verify the macOS benchmark uses the Depot runner when required.

<sup>Written for commit 632f27ea4331695eb202ce66e4d371c4311130fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance-activation CI workflow to determine benchmark targets from pull request changes, using sensible default routing when the diff can’t be evaluated.
  * Repurposed the activation-session workflow step into a lightweight gate that verifies benchmark status alignment before allowing benchmark jobs to proceed.
* **Tests**
  * Added/expanded integration tests to validate platform selection and routing behavior for the performance-activation workflow, including required job relationships and conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->