### PR TITLE
CI: fix build lag DerivedData cache path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -817,8 +817,9 @@ jobs:
       - name: Prepare isolated DerivedData
         run: |
           set -euo pipefail
-          DERIVED_DATA_PATH="$RUNNER_TEMP/cmux-deriveddata-tests-build-and-lag-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          DERIVED_DATA_PATH="$RUNNER_TEMP/cmux-deriveddata-tests-build-and-lag"
           rm -rf "$DERIVED_DATA_PATH"
+          mkdir -p "$DERIVED_DATA_PATH"
           echo "CMUX_DERIVED_DATA_PATH=$DERIVED_DATA_PATH" >> "$GITHUB_ENV"
 
       - name: Capture Ghostty revision
@@ -856,7 +857,7 @@ jobs:
       - name: Cache DerivedData
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ~/Library/Developer/Xcode/DerivedData/cmux-*
+          path: ${{ runner.temp }}/cmux-deriveddata-tests-build-and-lag
           key: deriveddata-build-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ hashFiles('cmux.xcodeproj/project.pbxproj') }}-${{ steps.ghostty-revision.outputs.sha }}
 
       - name: Cache Swift packages
@@ -873,7 +874,7 @@ jobs:
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
-          rm -rf "$CMUX_DERIVED_DATA_PATH"
+          mkdir -p "$CMUX_DERIVED_DATA_PATH"
           mkdir -p "$SOURCE_PACKAGES_DIR"
 
           for attempt in 1 2 3; do

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -64,6 +64,34 @@ check_release_build_runner_disk_capacity() {
   echo "PASS: release-build uses release-specific macOS 26 runner fallback"
 }
 
+check_build_lag_deriveddata_cache_path() {
+  if ! awk '
+    /^  tests-build-and-lag:/ { in_job=1; next }
+    in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
+
+    in_job && /- name: Prepare isolated DerivedData/ { in_prepare=1; next }
+    in_prepare && /^[[:space:]]*- name:/ { in_prepare=0 }
+    in_prepare && /DERIVED_DATA_PATH="\$RUNNER_TEMP\/cmux-deriveddata-tests-build-and-lag"/ { saw_prepare_path=1 }
+    in_prepare && /GITHUB_RUN_ID|GITHUB_RUN_ATTEMPT/ { saw_dynamic_prepare_path=1 }
+
+    in_job && /- name: Cache DerivedData/ { in_cache=1; after_cache=1; next }
+    in_cache && /^[[:space:]]*- name:/ { in_cache=0 }
+    in_cache && /path:[[:space:]]*\$\{\{ runner\.temp \}\}\/cmux-deriveddata-tests-build-and-lag/ { saw_cache_path=1 }
+    in_cache && /Library\/Developer\/Xcode\/DerivedData/ { saw_home_cache_path=1 }
+
+    in_job && after_cache && /rm -rf "\$CMUX_DERIVED_DATA_PATH"/ { saw_post_cache_delete=1 }
+
+    END {
+      exit !(saw_prepare_path && saw_cache_path && !saw_dynamic_prepare_path && !saw_home_cache_path && !saw_post_cache_delete)
+    }
+  ' "$CI_FILE"; then
+    echo "FAIL: tests-build-and-lag DerivedData cache must restore into the stable RUNNER_TEMP path xcodebuild uses, and must not delete that path after restore"
+    exit 1
+  fi
+
+  echo "PASS: tests-build-and-lag DerivedData cache path matches xcodebuild path"
+}
+
 check_e2e_runner_fallbacks() {
   if ! awk '
     /^run-name:/ {
@@ -773,6 +801,7 @@ check_macos_runner "$CI_FILE" "ui-regressions"
 check_release_build_runner_disk_capacity
 check_display_runner_identity_guard "$CI_FILE" "tests-build-and-lag"
 check_display_runner_identity_guard "$CI_FILE" "ui-regressions"
+check_build_lag_deriveddata_cache_path
 
 # build-ghosttykit.yml
 check_macos_runner "$GHOSTTYKIT_FILE" "build-ghosttykit"


### PR DESCRIPTION
## Summary
- Restore the tests-build-and-lag DerivedData cache into the same stable RUNNER_TEMP path used by xcodebuild.
- Stop deleting CMUX_DERIVED_DATA_PATH after the cache restore.
- Add a workflow guard so this cache cannot drift back to an unused path.

## Evidence
- On https://github.com/manaflow-ai/cmux/actions/runs/27844044717, tests-build-and-lag spent about 3m45s in Build app.
- The workflow restored ~/Library/Developer/Xcode/DerivedData/cmux-* while xcodebuild used RUNNER_TEMP/cmux-deriveddata-tests-build-and-lag with a run-specific suffix, then Resolve Swift packages deleted CMUX_DERIVED_DATA_PATH after the cache step.

## Testing
- ./tests/test_ci_self_hosted_guard.sh
- python3 tests/test_ci_change_areas.py
- python3.9 tests/test_ci_change_areas.py
- python3 -m py_compile tests/test_ci_change_areas.py scripts/ci/detect_ci_change_areas.py
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'parsed ci.yml'"
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DerivedData caching for tests-build-and-lag by using the stable RUNNER_TEMP path that xcodebuild uses, preventing cache misses and cutting build lag. Adds a guard to keep the path consistent and stops deleting the directory after restore.

- **Bug Fixes**
  - Use RUNNER_TEMP/cmux-deriveddata-tests-build-and-lag for both prepare and cache steps; pre-create the directory.
  - Replace post-cache delete with mkdir -p and add an awk-based check in tests/test_ci_self_hosted_guard.sh to enforce the path and prevent regressions.

<sup>Written for commit c2ee3c61f2426810e864df3cbfe6c5e67a6041ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD configuration for more stable and consistent build caching during testing. Updated cache handling logic to use a fixed directory path instead of variable identifiers, reducing cache inconsistencies on build retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->