### PR TITLE
Fix title-churn beachball in transcript adoption and sidebar rows

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,15 +1,15 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-34323	CLI/cmux.swift
+34330	CLI/cmux.swift
 17606	Sources/AppDelegate.swift
-16021	Sources/ContentView.swift
+16038	Sources/ContentView.swift
 14100	Sources/TerminalController.swift
 12695	Sources/Workspace.swift
 12144	cmuxTests/AppDelegateShortcutRoutingTests.swift
 11841	Sources/GhosttyTerminalView.swift
 11411	Sources/Panels/BrowserPanel.swift
-9339	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+9335	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7988	Sources/Panels/BrowserPanelView.swift
 7355	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -164,6 +164,7 @@
 608	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
 606	Sources/SettingsNavigation.swift
 604	Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteNucleoFFITests.swift
+601	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 596	cmuxTests/CmuxEventBusTests.swift
 594	Sources/SessionIndexModels.swift
@@ -211,6 +212,7 @@
 518	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-git-review-queue-command-deck.swift
 517	Sources/PaneMemoryGuardrail.swift
 516	Sources/TerminalImageTransfer.swift
+515	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
 509	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -162,9 +162,9 @@
 614	Sources/PortScanner.swift
 612	cmuxUITests/FeedSidebarUITests.swift
 608	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
+606	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 606	Sources/SettingsNavigation.swift
 604	Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteNucleoFFITests.swift
-601	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
 596	cmuxTests/CmuxEventBusTests.swift
 594	Sources/SessionIndexModels.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -151,8 +151,8 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
+651	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
-647	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -153,9 +153,9 @@
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
+638	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
-624	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -152,8 +152,8 @@
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
+642	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
-638	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -151,8 +151,8 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
+653	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
-644	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -152,7 +152,7 @@
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
-642	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+647	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -151,7 +151,6 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
-653	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -151,8 +151,8 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 654	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
-651	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
+644	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -155,6 +155,7 @@
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
+624	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
@@ -162,7 +163,6 @@
 614	Sources/PortScanner.swift
 612	cmuxUITests/FeedSidebarUITests.swift
 608	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
-606	Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
 606	Sources/SettingsNavigation.swift
 604	Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteNucleoFFITests.swift
 599	Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2029,7 +2029,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         auth.start()
         ensureMobileWorkspaceListObserver(for: tabManager)
         MobileTerminalRenderObserver.shared.start()
-        agentChatTranscriptService.start { TerminalController.shared.adoptDetectedAgentSessions(workspaceID: $0) }
+        agentChatTranscriptService.start { TerminalController.shared.adoptDetectedAgentSession(titleChange: $0) }
         installMobileHostSettingsObserver()
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)
         startPaneMemoryGuardrailIfNeeded(notificationStore: notificationStore)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12112,7 +12112,6 @@ struct VerticalTabsSidebar: View {
             notificationStore: notificationStore,
             tab: tab,
             index: index,
-            isActive: tabManager.selectedTabId == tab.id,
             workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
                 at: index,
                 workspaceCount: renderContext.workspaceCount
@@ -12914,7 +12913,6 @@ struct TabItemView: View, Equatable {
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
-        lhs.isActive == rhs.isActive &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.workspaceShortcutModifierSymbol == rhs.workspaceShortcutModifierSymbol &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
@@ -12943,7 +12941,6 @@ struct TabItemView: View, Equatable {
     @Environment(\.colorScheme) private var colorScheme
     let tab: Tab
     let index: Int
-    let isActive: Bool
     let workspaceShortcutDigit: Int?
     let workspaceShortcutModifierSymbol: String
     let canCloseWorkspace: Bool
@@ -12987,6 +12984,8 @@ struct TabItemView: View, Equatable {
     let onContextMenuAppear: () -> Void
     let onContextMenuDisappear: () -> Void
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
+    // Row-local selection projection: selectedTabId changes update only rows whose boolean flips.
+    @State private var observedIsActive: Bool?
     @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
     @State private var rowHeight: CGFloat = 1
@@ -13045,6 +13044,10 @@ struct TabItemView: View, Equatable {
 
     private var activeTabIndicatorStyle: WorkspaceIndicatorStyle {
         settings.activeTabIndicatorStyle
+    }
+
+    private var isActive: Bool {
+        observedIsActive ?? (tabManager.selectedTabId == tab.id)
     }
 
     private var sidebarSelectionColorHex: String? {
@@ -13697,7 +13700,16 @@ struct TabItemView: View, Equatable {
             )
         }
         .onAppear {
+            updateObservedActiveState(tabManager.selectedTabId == tab.id)
             refreshWorkspaceSnapshot(force: true)
+        }
+        .onReceive(
+            tabManager.selectedTabIdPublisher
+                .map { $0 == tab.id }
+                .removeDuplicates()
+                .receive(on: RunLoop.main)
+        ) { isSelected in
+            updateObservedActiveState(isSelected)
         }
         .task(id: workspaceFinderDirectoryOpenRequest) {
             guard let request = workspaceFinderDirectoryOpenRequest else { return }
@@ -13780,6 +13792,11 @@ struct TabItemView: View, Equatable {
                     flushDeferredWorkspaceObservationInvalidation()
                 }
         }
+    }
+
+    private func updateObservedActiveState(_ isActive: Bool) {
+        guard observedIsActive != isActive else { return }
+        observedIsActive = isActive
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -59,6 +59,15 @@ final class AgentChatSessionRegistry {
         records[sessionID]
     }
 
+    /// The current live session bound to a terminal surface, if any.
+    ///
+    /// - Parameter surfaceID: Terminal surface UUID string.
+    /// - Returns: A non-ended record bound to the surface, or `nil`.
+    func liveSession(surfaceID: String) -> AgentChatSessionRecord? {
+        sweepDeadProcesses()
+        return records.values.first { $0.surfaceID == surfaceID && $0.state != .ended }
+    }
+
     /// Every session id the registry already tracks. Title-detected adoption
     /// passes this to the transcript resolver so a second hook-bypassed claude
     /// in the same directory resolves to a *different* (unclaimed) transcript

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -7,6 +7,7 @@ import Foundation
 @MainActor
 final class AgentChatSessionRegistry {
     private var records: [String: AgentChatSessionRecord] = [:]
+    private var liveSessionIDBySurfaceID: [String: String] = [:]
     private let hookStore: AgentChatHookSessionStore
 
     /// Called after a record mutation with the previous value (nil for a
@@ -65,9 +66,14 @@ final class AgentChatSessionRegistry {
     /// - Returns: A non-ended record bound to the surface, or `nil`.
     func liveSession(surfaceID: String) -> AgentChatSessionRecord? {
         sweepDeadProcesses()
-        return records.values
-            .filter { $0.surfaceID == surfaceID && $0.state != .ended }
-            .max { $0.lastActivityAt < $1.lastActivityAt }
+        guard let sessionID = liveSessionIDBySurfaceID[surfaceID],
+              let record = records[sessionID],
+              record.surfaceID == surfaceID,
+              record.state != .ended else {
+            refreshLiveSessionIndex(surfaceID: surfaceID)
+            return liveSessionIDBySurfaceID[surfaceID].flatMap { records[$0] }
+        }
+        return record
     }
 
     /// Every session id the registry already tracks. Title-detected adoption
@@ -109,6 +115,8 @@ final class AgentChatSessionRegistry {
         var record = previous
         mutate(&record)
         records[sessionID] = record
+        refreshLiveSessionIndex(surfaceID: previous.surfaceID)
+        refreshLiveSessionIndex(surfaceID: record.surfaceID)
         onRecordChanged?(record, previous)
     }
 
@@ -138,7 +146,7 @@ final class AgentChatSessionRegistry {
             for entry in hookStore.entries(agentSource: source) {
                 guard records[entry.sessionID] == nil else { continue }
                 let alive = entry.pid.map { kill(pid_t($0), 0) == 0 } ?? false
-                records[entry.sessionID] = AgentChatSessionRecord(
+                let record = AgentChatSessionRecord(
                     sessionID: entry.sessionID,
                     agentKind: kind,
                     workspaceID: entry.workspaceID,
@@ -150,6 +158,8 @@ final class AgentChatSessionRegistry {
                     title: nil,
                     pid: entry.pid
                 )
+                records[entry.sessionID] = record
+                refreshLiveSessionIndex(surfaceID: record.surfaceID)
             }
         }
     }
@@ -195,6 +205,7 @@ final class AgentChatSessionRegistry {
             pid: nil
         )
         records[sessionID] = record
+        refreshLiveSessionIndex(surfaceID: surfaceID)
         onRecordChanged?(record, nil)
         return record
     }
@@ -260,8 +271,21 @@ final class AgentChatSessionRegistry {
         let previous = records[sessionID]
         record.state = Self.nextState(previous: record.state, event: event)
         records[sessionID] = record
+        refreshLiveSessionIndex(surfaceID: previous?.surfaceID)
+        refreshLiveSessionIndex(surfaceID: record.surfaceID)
         onRecordChanged?(record, previous)
         return record
+    }
+
+    private func refreshLiveSessionIndex(surfaceID: String?) {
+        guard let surfaceID else { return }
+        if let newest = records.values
+            .filter({ $0.surfaceID == surfaceID && $0.state != .ended })
+            .max(by: { $0.lastActivityAt < $1.lastActivityAt }) {
+            liveSessionIDBySurfaceID[surfaceID] = newest.sessionID
+        } else {
+            liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
+        }
     }
 
     /// Strips an agent-name prefix from prefixed workstream ids

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -65,12 +65,15 @@ final class AgentChatSessionRegistry {
     /// - Parameter surfaceID: Terminal surface UUID string.
     /// - Returns: A non-ended record bound to the surface, or `nil`.
     func liveSession(surfaceID: String) -> AgentChatSessionRecord? {
-        sweepDeadProcesses()
         guard let sessionID = liveSessionIDBySurfaceID[surfaceID],
               let record = records[sessionID],
               record.surfaceID == surfaceID,
               record.state != .ended else {
-            refreshLiveSessionIndex(surfaceID: surfaceID)
+            liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
+            return nil
+        }
+        if let pid = record.pid, processIsDead(pid) {
+            update(sessionID: sessionID) { $0.state = .ended }
             return liveSessionIDBySurfaceID[surfaceID].flatMap { records[$0] }
         }
         return record
@@ -115,8 +118,7 @@ final class AgentChatSessionRegistry {
         var record = previous
         mutate(&record)
         records[sessionID] = record
-        refreshLiveSessionIndex(surfaceID: previous.surfaceID)
-        refreshLiveSessionIndex(surfaceID: record.surfaceID)
+        updateLiveSessionIndex(previous: previous, current: record)
         onRecordChanged?(record, previous)
     }
 
@@ -159,7 +161,7 @@ final class AgentChatSessionRegistry {
                     pid: entry.pid
                 )
                 records[entry.sessionID] = record
-                refreshLiveSessionIndex(surfaceID: record.surfaceID)
+                updateLiveSessionIndex(previous: nil, current: record)
             }
         }
     }
@@ -189,7 +191,7 @@ final class AgentChatSessionRegistry {
         at timestamp: Date
     ) -> AgentChatSessionRecord {
         if let existing = records[sessionID] { return existing }
-        if let bound = records.values.first(where: { $0.surfaceID == surfaceID && $0.state != .ended }) {
+        if let bound = liveSession(surfaceID: surfaceID) {
             return bound
         }
         let record = AgentChatSessionRecord(
@@ -205,7 +207,7 @@ final class AgentChatSessionRegistry {
             pid: nil
         )
         records[sessionID] = record
-        refreshLiveSessionIndex(surfaceID: surfaceID)
+        updateLiveSessionIndex(previous: nil, current: record)
         onRecordChanged?(record, nil)
         return record
     }
@@ -271,13 +273,37 @@ final class AgentChatSessionRegistry {
         let previous = records[sessionID]
         record.state = Self.nextState(previous: record.state, event: event)
         records[sessionID] = record
-        refreshLiveSessionIndex(surfaceID: previous?.surfaceID)
-        refreshLiveSessionIndex(surfaceID: record.surfaceID)
+        updateLiveSessionIndex(previous: previous, current: record)
         onRecordChanged?(record, previous)
         return record
     }
 
-    private func refreshLiveSessionIndex(surfaceID: String?) {
+    private func updateLiveSessionIndex(
+        previous: AgentChatSessionRecord?,
+        current: AgentChatSessionRecord
+    ) {
+        let previousSurfaceID = Self.liveSurfaceID(previous)
+        let currentSurfaceID = Self.liveSurfaceID(current)
+        if let previousSurfaceID,
+           previousSurfaceID != currentSurfaceID,
+           liveSessionIDBySurfaceID[previousSurfaceID] == previous?.sessionID {
+            liveSessionIDBySurfaceID.removeValue(forKey: previousSurfaceID)
+            rebuildLiveSessionIndex(surfaceID: previousSurfaceID)
+        }
+        guard let currentSurfaceID else { return }
+        guard let indexedSessionID = liveSessionIDBySurfaceID[currentSurfaceID],
+              let indexed = records[indexedSessionID],
+              indexed.surfaceID == currentSurfaceID,
+              indexed.state != .ended else {
+            liveSessionIDBySurfaceID[currentSurfaceID] = current.sessionID
+            return
+        }
+        if indexed.sessionID == current.sessionID || current.lastActivityAt >= indexed.lastActivityAt {
+            liveSessionIDBySurfaceID[currentSurfaceID] = current.sessionID
+        }
+    }
+
+    private func rebuildLiveSessionIndex(surfaceID: String?) {
         guard let surfaceID else { return }
         if let newest = records.values
             .filter({ $0.surfaceID == surfaceID && $0.state != .ended })
@@ -286,6 +312,17 @@ final class AgentChatSessionRegistry {
         } else {
             liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
         }
+    }
+
+    private static func liveSurfaceID(_ record: AgentChatSessionRecord?) -> String? {
+        guard let record, record.state != .ended else {
+            return nil
+        }
+        return record.surfaceID
+    }
+
+    private func processIsDead(_ pid: Int) -> Bool {
+        kill(pid_t(pid), 0) != 0 && errno == ESRCH
     }
 
     /// Strips an agent-name prefix from prefixed workstream ids

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -65,26 +65,28 @@ final class AgentChatSessionRegistry {
     /// - Parameter surfaceID: Terminal surface UUID string.
     /// - Returns: A non-ended record bound to the surface, or `nil`.
     func liveSession(surfaceID: String) -> AgentChatSessionRecord? {
-        guard let sessionID = liveSessionIDBySurfaceID[surfaceID],
-              let record = records[sessionID],
-              record.surfaceID == surfaceID,
-              record.state != .ended else {
-            liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
-            return nil
+        while let sessionID = liveSessionIDBySurfaceID[surfaceID] {
+            guard let record = records[sessionID],
+                  record.surfaceID == surfaceID,
+                  record.state != .ended else {
+                liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
+                return nil
+            }
+            if let pid = record.pid, processIsDead(pid) {
+                update(sessionID: sessionID) { $0.state = .ended }
+                continue
+            }
+            return record
         }
-        if let pid = record.pid, processIsDead(pid) {
-            update(sessionID: sessionID) { $0.state = .ended }
-            return liveSessionIDBySurfaceID[surfaceID].flatMap { records[$0] }
-        }
-        return record
+        return nil
     }
 
-    /// Every live session id the registry already tracks. Title-detected adoption
+    /// Every session id the registry already tracks. Title-detected adoption
     /// passes this to the transcript resolver so a second hook-bypassed claude
     /// in the same directory resolves to a *different* (unclaimed) transcript
     /// instead of colliding on the newest file.
     func claimedSessionIDs() -> Set<String> {
-        Set(records.values.lazy.filter { $0.state != .ended }.map(\.sessionID))
+        Set(records.keys)
     }
 
     /// Re-reads the hook store for one session and adopts its bindings,

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -79,12 +79,12 @@ final class AgentChatSessionRegistry {
         return record
     }
 
-    /// Every session id the registry already tracks. Title-detected adoption
+    /// Every live session id the registry already tracks. Title-detected adoption
     /// passes this to the transcript resolver so a second hook-bypassed claude
     /// in the same directory resolves to a *different* (unclaimed) transcript
     /// instead of colliding on the newest file.
     func claimedSessionIDs() -> Set<String> {
-        Set(records.keys)
+        Set(records.values.lazy.filter { $0.state != .ended }.map(\.sessionID))
     }
 
     /// Re-reads the hook store for one session and adopts its bindings,

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -65,7 +65,9 @@ final class AgentChatSessionRegistry {
     /// - Returns: A non-ended record bound to the surface, or `nil`.
     func liveSession(surfaceID: String) -> AgentChatSessionRecord? {
         sweepDeadProcesses()
-        return records.values.first { $0.surfaceID == surfaceID && $0.state != .ended }
+        return records.values
+            .filter { $0.surfaceID == surfaceID && $0.state != .ended }
+            .max { $0.lastActivityAt < $1.lastActivityAt }
     }
 
     /// Every session id the registry already tracks. Title-detected adoption

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -6,16 +6,14 @@ import Foundation
 /// Preference order: the hook store's recorded `transcriptPath`, then the
 /// agent-specific conventional location (claude: encoded-cwd project dir;
 /// codex: rollout filename containing the session id).
-struct AgentChatTranscriptResolver {
+struct AgentChatTranscriptResolver: Sendable {
     private let homeDirectory: URL
-    private let fileManager: FileManager
 
     /// Creates a resolver.
     ///
     /// - Parameter homeDirectory: Injectable home directory for tests.
     init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
         self.homeDirectory = homeDirectory
-        self.fileManager = FileManager.default
     }
 
     /// Resolves the transcript path for a session.
@@ -24,6 +22,7 @@ struct AgentChatTranscriptResolver {
     ///   - record: The session's registry record.
     /// - Returns: An existing transcript path, or `nil` when none is found.
     func transcriptPath(for record: AgentChatSessionRecord) -> String? {
+        let fileManager = FileManager.default
         if let recorded = record.transcriptPath {
             let expanded = (recorded as NSString).expandingTildeInPath
             if fileManager.fileExists(atPath: expanded) {
@@ -61,6 +60,7 @@ struct AgentChatTranscriptResolver {
         excludingSessionIDs: Set<String> = [],
         titleHint: String? = nil
     ) -> (sessionID: String, path: String)? {
+        let fileManager = FileManager.default
         // The home project dir is a junk drawer of every home-rooted claude
         // conversation, so newest-by-mtime there is almost never *this*
         // terminal's session. Refuse title-detected adoption from $HOME; a
@@ -148,6 +148,7 @@ struct AgentChatTranscriptResolver {
     }
 
     private func claudeFallbackPath(record: AgentChatSessionRecord) -> String? {
+        let fileManager = FileManager.default
         guard let cwd = record.workingDirectory else { return nil }
         let projectDir = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd)
         let path = homeDirectory
@@ -163,6 +164,7 @@ struct AgentChatTranscriptResolver {
     /// under `~/.codex/sessions/YYYY/MM/DD/`; scan recent day directories for
     /// the session id.
     private func codexFallbackPath(sessionID: String) -> String? {
+        let fileManager = FileManager.default
         let root = homeDirectory
             .appendingPathComponent(".codex", isDirectory: true)
             .appendingPathComponent("sessions", isDirectory: true)

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -8,6 +8,9 @@ import Foundation
 /// codex: rollout filename containing the session id).
 struct AgentChatTranscriptResolver: Sendable {
     private let homeDirectory: URL
+    private static let claudeTranscriptTitleReadLimit = 1_048_576
+    private static let claudeTranscriptTitleChunkSize = 64 * 1024
+    private static let claudeTranscriptTitleMaxLineBytes = 256 * 1024
 
     /// Creates a resolver.
     ///
@@ -100,8 +103,13 @@ struct AgentChatTranscriptResolver: Sendable {
             }
             let newest: URL?
             if let normalizedTitleHint {
-                newest = transcriptCandidates
-                    .filter { Self.normalizedClaudeTitle($0.title) == normalizedTitleHint || $0.title == nil }
+                let exactTitleCandidates = transcriptCandidates
+                    .filter { Self.normalizedClaudeTitle($0.title) == normalizedTitleHint }
+                newest = (
+                    exactTitleCandidates.isEmpty
+                        ? transcriptCandidates.filter { $0.title == nil }
+                        : exactTitleCandidates
+                )
                     .max { $0.date < $1.date }?
                     .url
             } else {
@@ -203,17 +211,53 @@ struct AgentChatTranscriptResolver: Sendable {
     }
 
     private static func claudeTranscriptTitle(at url: URL) -> String? {
-        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
             return nil
         }
-        for line in contents.split(separator: "\n") where line.contains(#""ai-title""#) {
-            guard let data = line.data(using: .utf8),
-                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  object["type"] as? String == "ai-title" else {
-                continue
+        defer { try? handle.close() }
+
+        var buffered = Data()
+        var bytesRead = 0
+        var droppingOversizedLine = false
+        while bytesRead < claudeTranscriptTitleReadLimit {
+            guard !Task.isCancelled else { return nil }
+            let readSize = min(claudeTranscriptTitleChunkSize, claudeTranscriptTitleReadLimit - bytesRead)
+            guard let chunk = try? handle.read(upToCount: readSize),
+                  !chunk.isEmpty else {
+                break
             }
-            return object["aiTitle"] as? String
+            bytesRead += chunk.count
+            buffered.append(chunk)
+
+            while let newlineIndex = buffered.firstIndex(of: 0x0A) {
+                let lineData = Data(buffered[..<newlineIndex])
+                buffered.removeSubrange(...newlineIndex)
+                if droppingOversizedLine {
+                    droppingOversizedLine = false
+                    continue
+                }
+                if let title = claudeTranscriptTitle(in: lineData) {
+                    return title
+                }
+            }
+
+            if buffered.count > claudeTranscriptTitleMaxLineBytes {
+                buffered.removeAll(keepingCapacity: true)
+                droppingOversizedLine = true
+            }
         }
-        return nil
+        guard !droppingOversizedLine else {
+            return nil
+        }
+        return claudeTranscriptTitle(in: buffered)
+    }
+
+    private static func claudeTranscriptTitle(in lineData: Data) -> String? {
+        guard lineData.range(of: Data(#""ai-title""#.utf8)) != nil,
+              let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+              object["type"] as? String == "ai-title" else {
+            return nil
+        }
+        return object["aiTitle"] as? String
     }
 }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -217,19 +217,3 @@ struct AgentChatTranscriptResolver: Sendable {
         return nil
     }
 }
-
-actor AgentChatTranscriptScanQueue {
-    func newestClaudeTranscript(
-        resolver: AgentChatTranscriptResolver,
-        workingDirectory: String,
-        excludingSessionIDs: Set<String>,
-        titleHint: String?
-    ) -> (sessionID: String, path: String)? {
-        guard !Task.isCancelled else { return nil }
-        return resolver.newestClaudeTranscript(
-            workingDirectory: workingDirectory,
-            excludingSessionIDs: excludingSessionIDs,
-            titleHint: titleHint
-        )
-    }
-}

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -60,6 +60,7 @@ struct AgentChatTranscriptResolver: Sendable {
         excludingSessionIDs: Set<String> = [],
         titleHint: String? = nil
     ) -> (sessionID: String, path: String)? {
+        guard !Task.isCancelled else { return nil }
         let fileManager = FileManager.default
         // The home project dir is a junk drawer of every home-rooted claude
         // conversation, so newest-by-mtime there is almost never *this*
@@ -75,6 +76,7 @@ struct AgentChatTranscriptResolver: Sendable {
             .filter { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path != home }
         let normalizedTitleHint = Self.normalizedClaudeTitle(titleHint)
         for cwd in candidates {
+            guard !Task.isCancelled else { return nil }
             let projectDir = RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd)
             let dir = homeDirectory
                 .appendingPathComponent(".claude", isDirectory: true)
@@ -85,18 +87,17 @@ struct AgentChatTranscriptResolver: Sendable {
                 includingPropertiesForKeys: [.contentModificationDateKey],
                 options: [.skipsHiddenFiles]
             ) else { continue }
-            let transcriptCandidates = entries
-                .filter {
-                    $0.pathExtension == "jsonl"
-                        && !excludingSessionIDs.contains($0.deletingPathExtension().lastPathComponent)
-                }
-                .map { url in
-                    (
-                        url: url,
-                        date: (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast,
-                        title: Self.claudeTranscriptTitle(at: url)
-                    )
-                }
+            var transcriptCandidates: [(url: URL, date: Date, title: String?)] = []
+            for url in entries where url.pathExtension == "jsonl" {
+                guard !Task.isCancelled else { return nil }
+                let sessionID = url.deletingPathExtension().lastPathComponent
+                guard !excludingSessionIDs.contains(sessionID) else { continue }
+                transcriptCandidates.append((
+                    url: url,
+                    date: (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast,
+                    title: Self.claudeTranscriptTitle(at: url)
+                ))
+            }
             let newest: URL?
             if let normalizedTitleHint {
                 newest = transcriptCandidates
@@ -214,5 +215,21 @@ struct AgentChatTranscriptResolver: Sendable {
             return object["aiTitle"] as? String
         }
         return nil
+    }
+}
+
+actor AgentChatTranscriptScanQueue {
+    func newestClaudeTranscript(
+        resolver: AgentChatTranscriptResolver,
+        workingDirectory: String,
+        excludingSessionIDs: Set<String>,
+        titleHint: String?
+    ) -> (sessionID: String, path: String)? {
+        guard !Task.isCancelled else { return nil }
+        return resolver.newestClaudeTranscript(
+            workingDirectory: workingDirectory,
+            excludingSessionIDs: excludingSessionIDs,
+            titleHint: titleHint
+        )
     }
 }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptResolver.swift
@@ -105,13 +105,15 @@ struct AgentChatTranscriptResolver: Sendable {
             if let normalizedTitleHint {
                 let exactTitleCandidates = transcriptCandidates
                     .filter { Self.normalizedClaudeTitle($0.title) == normalizedTitleHint }
-                newest = (
-                    exactTitleCandidates.isEmpty
-                        ? transcriptCandidates.filter { $0.title == nil }
-                        : exactTitleCandidates
-                )
-                    .max { $0.date < $1.date }?
-                    .url
+                let untitledCandidates = transcriptCandidates.filter { $0.title == nil }
+                let newestExact = exactTitleCandidates.max { $0.date < $1.date }
+                let newestUntitled = untitledCandidates.max { $0.date < $1.date }
+                if let newestExact,
+                   let newestUntitled,
+                   newestUntitled.date > newestExact.date {
+                    return nil
+                }
+                newest = (newestExact ?? newestUntitled)?.url
             } else {
                 // A generic "Claude Code" title cannot identify one of several
                 // same-cwd sessions. Avoid stealing a transcript that already

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
@@ -43,6 +43,7 @@ extension AgentChatTranscriptService {
         transcriptResolutionTasks[surfaceID] = nil
         transcriptResolutionKeys.removeValue(forKey: surfaceID)
         transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
+        claimedDetectedTranscriptSessionIDsBySurfaceID.removeValue(forKey: surfaceID)
         detectionScanAt.removeValue(forKey: surfaceID)
     }
 
@@ -61,7 +62,8 @@ extension AgentChatTranscriptService {
             return
         }
 
-        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
+        var claimed = registry.claimedSessionIDs()
+            .union(activeClaimedDetectedTranscriptSessionIDs(excludingSurfaceID: surfaceID))
         if let excludingSessionID {
             claimed.remove(excludingSessionID)
         }
@@ -145,7 +147,7 @@ extension AgentChatTranscriptService {
         transcriptResolutionKeys[surfaceID] = nil
 
         guard let resolved else { return }
-        guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
+        guard !activeClaimedDetectedTranscriptSessionIDs(excludingSurfaceID: surfaceID).contains(resolved.sessionID) else {
             scheduleForcedClaudeTranscriptRetry(
                 workspaceID: workspaceID,
                 workingDirectory: workingDirectory,
@@ -177,7 +179,7 @@ extension AgentChatTranscriptService {
                 record.workingDirectory = workingDirectory
                 record.transcriptPath = resolved.path
             }
-            claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
+            claimDetectedTranscriptSessionID(resolved.sessionID, surfaceID: surfaceID)
             transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
             return
         }
@@ -193,7 +195,7 @@ extension AgentChatTranscriptService {
         )
         if adopted.surfaceID == surfaceID,
            adopted.transcriptPath == resolved.path {
-            claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
+            claimDetectedTranscriptSessionID(resolved.sessionID, surfaceID: surfaceID)
             transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
         }
     }
@@ -218,5 +220,18 @@ extension AgentChatTranscriptService {
             titleHint: titleHint,
             forceScan: true
         )
+    }
+
+    func activeClaimedDetectedTranscriptSessionIDs(excludingSurfaceID surfaceID: String) -> Set<String> {
+        var claimed = Set<String>()
+        for (claimedSurfaceID, sessionIDs) in claimedDetectedTranscriptSessionIDsBySurfaceID
+        where claimedSurfaceID != surfaceID {
+            claimed.formUnion(sessionIDs)
+        }
+        return claimed
+    }
+
+    func claimDetectedTranscriptSessionID(_ sessionID: String, surfaceID: String) {
+        claimedDetectedTranscriptSessionIDsBySurfaceID[surfaceID, default: []].insert(sessionID)
     }
 }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
@@ -42,6 +42,7 @@ extension AgentChatTranscriptService {
         transcriptResolutionTasks[surfaceID]?.cancel()
         transcriptResolutionTasks[surfaceID] = nil
         transcriptResolutionKeys.removeValue(forKey: surfaceID)
+        transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
         detectionScanAt.removeValue(forKey: surfaceID)
     }
 
@@ -77,6 +78,9 @@ extension AgentChatTranscriptService {
 
         detectionScanAt[surfaceID] = now
         transcriptResolutionKeys[surfaceID] = key
+        if !forceScan {
+            transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
+        }
         transcriptResolutionTasks[surfaceID]?.cancel()
         let resolver = self.resolver
         #if compiler(>=6.2)
@@ -142,32 +146,29 @@ extension AgentChatTranscriptService {
 
         guard let resolved else { return }
         guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
-            scheduleClaudeTranscriptResolution(
+            scheduleForcedClaudeTranscriptRetry(
                 workspaceID: workspaceID,
                 workingDirectory: workingDirectory,
                 surfaceID: surfaceID,
                 excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
-                titleHint: titleHint,
-                forceScan: true
+                titleHint: titleHint
             )
             return
         }
         if let claimed = registry.record(sessionID: resolved.sessionID),
            claimed.surfaceID != nil,
            claimed.surfaceID != surfaceID {
-            scheduleClaudeTranscriptResolution(
+            scheduleForcedClaudeTranscriptRetry(
                 workspaceID: workspaceID,
                 workingDirectory: workingDirectory,
                 surfaceID: surfaceID,
                 excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
-                titleHint: titleHint,
-                forceScan: true
+                titleHint: titleHint
             )
             return
         }
 
         detectionScanAt.removeValue(forKey: surfaceID)
-        claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
         if let bound = registry.liveSession(surfaceID: surfaceID) {
             guard bound.transcriptPath == nil else { return }
             registry.update(sessionID: bound.sessionID) { record in
@@ -176,10 +177,12 @@ extension AgentChatTranscriptService {
                 record.workingDirectory = workingDirectory
                 record.transcriptPath = resolved.path
             }
+            claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
+            transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
             return
         }
 
-        registry.adoptDetectedSession(
+        let adopted = registry.adoptDetectedSession(
             sessionID: resolved.sessionID,
             agentKind: .claude,
             workspaceID: workspaceID,
@@ -187,6 +190,33 @@ extension AgentChatTranscriptService {
             workingDirectory: workingDirectory,
             transcriptPath: resolved.path,
             at: Date()
+        )
+        if adopted.surfaceID == surfaceID,
+           adopted.transcriptPath == resolved.path {
+            claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
+            transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
+        }
+    }
+
+    func scheduleForcedClaudeTranscriptRetry(
+        workspaceID: String,
+        workingDirectory: String,
+        surfaceID: String,
+        excludingSessionID: String?,
+        titleHint: String?
+    ) {
+        let retryCount = transcriptResolutionForcedRetryCounts[surfaceID, default: 0]
+        guard retryCount < Self.maxTranscriptResolutionForcedRetries else {
+            return
+        }
+        transcriptResolutionForcedRetryCounts[surfaceID] = retryCount + 1
+        scheduleClaudeTranscriptResolution(
+            workspaceID: workspaceID,
+            workingDirectory: workingDirectory,
+            surfaceID: surfaceID,
+            excludingSessionID: excludingSessionID,
+            titleHint: titleHint,
+            forceScan: true
         )
     }
 }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
@@ -70,7 +70,8 @@ extension AgentChatTranscriptService {
             titleKey: Self.specificClaudeTitleKey(titleHint),
             forceScan: forceScan
         )
-        guard transcriptResolutionKeys[surfaceID] != key else {
+        if let currentKey = transcriptResolutionKeys[surfaceID],
+           currentKey == key {
             return
         }
 
@@ -132,7 +133,8 @@ extension AgentChatTranscriptService {
         surfaceID: String,
         titleHint: String?
     ) {
-        guard transcriptResolutionKeys[surfaceID] == key else {
+        guard let currentKey = transcriptResolutionKeys[surfaceID],
+              currentKey == key else {
             return
         }
         transcriptResolutionTasks[surfaceID] = nil

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
@@ -36,14 +36,19 @@ extension AgentChatTranscriptService {
         }
     }
 
-    func clearTitleDetectionState(surfaceID: String) {
+    func clearTitleDetectionState(
+        surfaceID: String,
+        releaseTranscriptClaims: Bool = false
+    ) {
         pendingTitleChanges.removeValue(forKey: surfaceID)
         deliveredTitleKeys.removeValue(forKey: surfaceID)
         transcriptResolutionTasks[surfaceID]?.cancel()
         transcriptResolutionTasks[surfaceID] = nil
         transcriptResolutionKeys.removeValue(forKey: surfaceID)
         transcriptResolutionForcedRetryCounts.removeValue(forKey: surfaceID)
-        claimedDetectedTranscriptSessionIDsBySurfaceID.removeValue(forKey: surfaceID)
+        if releaseTranscriptClaims {
+            claimedDetectedTranscriptSessionIDsBySurfaceID.removeValue(forKey: surfaceID)
+        }
         detectionScanAt.removeValue(forKey: surfaceID)
     }
 

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService+TitleDetection.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+extension AgentChatTranscriptService {
+    func scheduleTitleDetectedAdoption(_ change: GhosttyTitleChange) {
+        let surfaceID = change.surfaceId.uuidString
+        guard let titleKey = Self.claudeTitleDetectionKey(change.title) else {
+            clearTitleDetectionState(surfaceID: surfaceID)
+            return
+        }
+        if pendingTitleChanges[surfaceID]?.titleKey == titleKey {
+            return
+        }
+        if pendingTitleChanges[surfaceID] == nil,
+           deliveredTitleKeys[surfaceID] == titleKey,
+           registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
+            return
+        }
+
+        pendingTitleChanges[surfaceID] = (change: change, titleKey: titleKey)
+        titleChangeCoalescer.signal { [weak self] in
+            self?.flushTitleDetectedAdoptions()
+        }
+    }
+
+    func flushTitleDetectedAdoptions() {
+        guard !pendingTitleChanges.isEmpty else {
+            return
+        }
+        let pendingBySurface = pendingTitleChanges
+        pendingTitleChanges.removeAll(keepingCapacity: true)
+        for (surfaceID, pending) in pendingBySurface {
+            if titleAdoptionHandler?(pending.change) == true,
+               registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
+                deliveredTitleKeys[surfaceID] = pending.titleKey
+            }
+        }
+    }
+
+    func clearTitleDetectionState(surfaceID: String) {
+        pendingTitleChanges.removeValue(forKey: surfaceID)
+        deliveredTitleKeys.removeValue(forKey: surfaceID)
+        transcriptResolutionTasks[surfaceID]?.cancel()
+        transcriptResolutionTasks[surfaceID] = nil
+        transcriptResolutionKeys.removeValue(forKey: surfaceID)
+        detectionScanAt.removeValue(forKey: surfaceID)
+    }
+
+    func scheduleClaudeTranscriptResolution(
+        workspaceID: String,
+        workingDirectory: String,
+        surfaceID: String,
+        excludingSessionID: String?,
+        titleHint: String?,
+        forceScan: Bool
+    ) {
+        let now = Date()
+        if !forceScan,
+           let lastScan = detectionScanAt[surfaceID],
+           now.timeIntervalSince(lastScan) < Self.detectionScanThrottle {
+            return
+        }
+
+        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
+        if let excludingSessionID {
+            claimed.remove(excludingSessionID)
+        }
+        let key: ClaudeTranscriptResolutionKey = (
+            workingDirectory: workingDirectory,
+            claimedSessionIDs: claimed,
+            titleKey: Self.specificClaudeTitleKey(titleHint),
+            forceScan: forceScan
+        )
+        guard transcriptResolutionKeys[surfaceID] != key else {
+            return
+        }
+
+        detectionScanAt[surfaceID] = now
+        transcriptResolutionKeys[surfaceID] = key
+        transcriptResolutionTasks[surfaceID]?.cancel()
+        let resolver = self.resolver
+        #if compiler(>=6.2)
+        let resolveOperation: @concurrent @Sendable () async -> (sessionID: String, path: String)? = {
+            [resolver, workingDirectory, claimed, titleHint] in
+            resolver.newestClaudeTranscript(
+                workingDirectory: workingDirectory,
+                excludingSessionIDs: claimed,
+                titleHint: titleHint
+            )
+        }
+        #else
+        let resolveOperation: @Sendable () async -> (sessionID: String, path: String)? = {
+            [resolver, workingDirectory, claimed, titleHint] in
+            resolver.newestClaudeTranscript(
+                workingDirectory: workingDirectory,
+                excludingSessionIDs: claimed,
+                titleHint: titleHint
+            )
+        }
+        #endif
+        let scanTask = Task.detached(priority: .utility, operation: resolveOperation)
+        transcriptResolutionTasks[surfaceID] = Task { @MainActor [
+            weak self,
+            scanTask,
+            key,
+            workspaceID,
+            workingDirectory,
+            surfaceID,
+            titleHint
+        ] in
+            let resolved = await withTaskCancellationHandler {
+                await scanTask.value
+            } onCancel: {
+                scanTask.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            self?.applyClaudeTranscriptResolution(
+                resolved,
+                key: key,
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID,
+                titleHint: titleHint
+            )
+        }
+    }
+
+    func applyClaudeTranscriptResolution(
+        _ resolved: (sessionID: String, path: String)?,
+        key: ClaudeTranscriptResolutionKey,
+        workspaceID: String,
+        workingDirectory: String,
+        surfaceID: String,
+        titleHint: String?
+    ) {
+        guard transcriptResolutionKeys[surfaceID] == key else {
+            return
+        }
+        transcriptResolutionTasks[surfaceID] = nil
+        transcriptResolutionKeys[surfaceID] = nil
+
+        guard let resolved else { return }
+        guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
+            scheduleClaudeTranscriptResolution(
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID,
+                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
+                titleHint: titleHint,
+                forceScan: true
+            )
+            return
+        }
+        if let claimed = registry.record(sessionID: resolved.sessionID),
+           claimed.surfaceID != nil,
+           claimed.surfaceID != surfaceID {
+            scheduleClaudeTranscriptResolution(
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID,
+                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
+                titleHint: titleHint,
+                forceScan: true
+            )
+            return
+        }
+
+        detectionScanAt.removeValue(forKey: surfaceID)
+        claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
+        if let bound = registry.liveSession(surfaceID: surfaceID) {
+            guard bound.transcriptPath == nil else { return }
+            registry.update(sessionID: bound.sessionID) { record in
+                record.workspaceID = workspaceID
+                record.surfaceID = surfaceID
+                record.workingDirectory = workingDirectory
+                record.transcriptPath = resolved.path
+            }
+            return
+        }
+
+        registry.adoptDetectedSession(
+            sessionID: resolved.sessionID,
+            agentKind: .claude,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            workingDirectory: workingDirectory,
+            transcriptPath: resolved.path,
+            at: Date()
+        )
+    }
+}

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -351,7 +351,7 @@ final class AgentChatTranscriptService {
         let transcriptBecameAvailable = previous?.transcriptPath == nil && record.transcriptPath != nil
         if stateChanged, record.state == .ended {
             if let surfaceID = record.surfaceID {
-                clearTitleDetectionState(surfaceID: surfaceID)
+                clearTitleDetectionState(surfaceID: surfaceID, releaseTranscriptClaims: true)
             }
             if let tailer = tailers.removeValue(forKey: record.sessionID) {
                 // The transcript can no longer grow; release the file watcher

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -30,6 +30,7 @@ final class AgentChatTranscriptService {
     private var deliveredTitleKeys: [String: String] = [:]
     private var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
     private var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
+    private var claimedDetectedTranscriptSessionIDs: Set<String> = []
     private var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
     private static let detectionScanThrottle: TimeInterval = 4
     private static let titleChangeDebounceNanoseconds: UInt64 = 250_000_000
@@ -331,7 +332,7 @@ final class AgentChatTranscriptService {
             return
         }
 
-        var claimed = registry.claimedSessionIDs()
+        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
         if let excludingSessionID {
             claimed.remove(excludingSessionID)
         }
@@ -391,6 +392,9 @@ final class AgentChatTranscriptService {
         transcriptResolutionKeys[surfaceID] = nil
 
         guard let resolved else { return }
+        guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
+            return
+        }
         if let claimed = registry.record(sessionID: resolved.sessionID),
            claimed.surfaceID != nil,
            claimed.surfaceID != surfaceID {
@@ -398,6 +402,7 @@ final class AgentChatTranscriptService {
         }
 
         detectionScanAt.removeValue(forKey: surfaceID)
+        claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
         if let bound = registry.liveSession(surfaceID: surfaceID) {
             guard bound.transcriptPath == nil else { return }
             registry.update(sessionID: bound.sessionID) { record in

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -30,7 +30,7 @@ final class AgentChatTranscriptService {
     var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
     var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
     var transcriptResolutionForcedRetryCounts: [String: Int] = [:]
-    var claimedDetectedTranscriptSessionIDs: Set<String> = []
+    var claimedDetectedTranscriptSessionIDsBySurfaceID: [String: Set<String>] = [:]
     var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
     let titleChangeCoalescer = NotificationBurstCoalescer(delay: 0.25)
     static let detectionScanThrottle: TimeInterval = 4
@@ -404,7 +404,8 @@ final class AgentChatTranscriptService {
             return nil
         }
         detectionScanAt[surfaceID] = now
-        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
+        var claimed = registry.claimedSessionIDs()
+            .union(activeClaimedDetectedTranscriptSessionIDs(excludingSurfaceID: surfaceID))
         if let excludingSessionID {
             claimed.remove(excludingSessionID)
         }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -12,6 +12,7 @@ final class AgentChatTranscriptService {
 
     private let registry: AgentChatSessionRegistry
     private let resolver: AgentChatTranscriptResolver
+    private let scanQueue: AgentChatTranscriptScanQueue
     private let coding = ChatWireCoding()
     private var tailers: [String: AgentChatTranscriptTailer] = [:]
     /// Sessions whose transcript could not be resolved; skipped until an
@@ -50,10 +51,12 @@ final class AgentChatTranscriptService {
     ///   - resolver: Transcript path resolver.
     init(
         registry: AgentChatSessionRegistry,
-        resolver: AgentChatTranscriptResolver = AgentChatTranscriptResolver()
+        resolver: AgentChatTranscriptResolver = AgentChatTranscriptResolver(),
+        scanQueue: AgentChatTranscriptScanQueue = AgentChatTranscriptScanQueue()
     ) {
         self.registry = registry
         self.resolver = resolver
+        self.scanQueue = scanQueue
         registry.onRecordChanged = { [weak self] record, previous in
             self?.handleRecordChange(record, previous: previous)
         }
@@ -293,7 +296,8 @@ final class AgentChatTranscriptService {
             return
         }
         if pendingTitleChanges[surfaceID] == nil,
-           deliveredTitleKeys[surfaceID] == titleKey {
+           deliveredTitleKeys[surfaceID] == titleKey,
+           registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
             return
         }
 
@@ -315,7 +319,8 @@ final class AgentChatTranscriptService {
         guard let pending = pendingTitleChanges.removeValue(forKey: surfaceID) else {
             return
         }
-        if titleAdoptionHandler?(pending.change) == true {
+        if titleAdoptionHandler?(pending.change) == true,
+           registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
             deliveredTitleKeys[surfaceID] = pending.titleKey
         }
     }
@@ -370,13 +375,12 @@ final class AgentChatTranscriptService {
             titleHint,
             claimed
         ] in
-            let resolved = await Task.detached(priority: .utility) {
-                resolver.newestClaudeTranscript(
-                    workingDirectory: workingDirectory,
-                    excludingSessionIDs: claimed,
-                    titleHint: titleHint
-                )
-            }.value
+            let resolved = await scanQueue.newestClaudeTranscript(
+                resolver: resolver,
+                workingDirectory: workingDirectory,
+                excludingSessionIDs: claimed,
+                titleHint: titleHint
+            )
             guard !Task.isCancelled else { return }
             self?.applyClaudeTranscriptResolution(
                 resolved,

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -10,8 +10,8 @@ final class AgentChatTranscriptService {
     /// The push topic chat clients subscribe to.
     static let eventTopic = "chat.message"
 
-    private let registry: AgentChatSessionRegistry
-    private let resolver: AgentChatTranscriptResolver
+    let registry: AgentChatSessionRegistry
+    let resolver: AgentChatTranscriptResolver
     private let coding = ChatWireCoding()
     private var tailers: [String: AgentChatTranscriptTailer] = [:]
     /// Sessions whose transcript could not be resolved; skipped until an
@@ -23,16 +23,16 @@ final class AgentChatTranscriptService {
     /// resolution scheduling to once per `detectionScanThrottle` while a
     /// title-detected claude has not yet written its transcript; a successful
     /// adoption removes the entry.
-    private var detectionScanAt: [String: Date] = [:]
+    var detectionScanAt: [String: Date] = [:]
     private var ghosttyTitleSubscription: GhosttyTitleChangeSubscription?
-    private var pendingTitleChanges: [String: PendingTitleChange] = [:]
-    private var deliveredTitleKeys: [String: String] = [:]
-    private var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
-    private var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
-    private var claimedDetectedTranscriptSessionIDs: Set<String> = []
-    private var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
-    private let titleChangeCoalescer = NotificationBurstCoalescer(delay: 0.25)
-    private static let detectionScanThrottle: TimeInterval = 4
+    var pendingTitleChanges: [String: PendingTitleChange] = [:]
+    var deliveredTitleKeys: [String: String] = [:]
+    var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
+    var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
+    var claimedDetectedTranscriptSessionIDs: Set<String> = []
+    var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
+    let titleChangeCoalescer = NotificationBurstCoalescer(delay: 0.25)
+    static let detectionScanThrottle: TimeInterval = 4
     private static let provisionalClaudeSessionIDPrefix = "detected-claude-surface-"
 
     /// Creates the service with a hook-store-backed registry.
@@ -270,200 +270,13 @@ final class AgentChatTranscriptService {
 
     // MARK: - Internals
 
-    private typealias PendingTitleChange = (change: GhosttyTitleChange, titleKey: String)
-    private typealias ClaudeTranscriptResolutionKey = (
+    typealias PendingTitleChange = (change: GhosttyTitleChange, titleKey: String)
+    typealias ClaudeTranscriptResolutionKey = (
         workingDirectory: String,
         claimedSessionIDs: Set<String>,
         titleKey: String?,
         forceScan: Bool
     )
-
-    private func scheduleTitleDetectedAdoption(_ change: GhosttyTitleChange) {
-        let surfaceID = change.surfaceId.uuidString
-        guard let titleKey = Self.claudeTitleDetectionKey(change.title) else {
-            clearTitleDetectionState(surfaceID: surfaceID)
-            return
-        }
-        if pendingTitleChanges[surfaceID]?.titleKey == titleKey {
-            return
-        }
-        if pendingTitleChanges[surfaceID] == nil,
-           deliveredTitleKeys[surfaceID] == titleKey,
-           registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
-            return
-        }
-
-        pendingTitleChanges[surfaceID] = (change: change, titleKey: titleKey)
-        titleChangeCoalescer.signal { [weak self] in
-            self?.flushTitleDetectedAdoptions()
-        }
-    }
-
-    private func flushTitleDetectedAdoptions() {
-        guard !pendingTitleChanges.isEmpty else {
-            return
-        }
-        let pendingBySurface = pendingTitleChanges
-        pendingTitleChanges.removeAll(keepingCapacity: true)
-        for (surfaceID, pending) in pendingBySurface {
-            if titleAdoptionHandler?(pending.change) == true,
-               registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
-                deliveredTitleKeys[surfaceID] = pending.titleKey
-            }
-        }
-    }
-
-    private func clearTitleDetectionState(surfaceID: String) {
-        pendingTitleChanges.removeValue(forKey: surfaceID)
-        deliveredTitleKeys.removeValue(forKey: surfaceID)
-        transcriptResolutionTasks[surfaceID]?.cancel()
-        transcriptResolutionTasks[surfaceID] = nil
-        transcriptResolutionKeys.removeValue(forKey: surfaceID)
-        detectionScanAt.removeValue(forKey: surfaceID)
-    }
-
-    private func scheduleClaudeTranscriptResolution(
-        workspaceID: String,
-        workingDirectory: String,
-        surfaceID: String,
-        excludingSessionID: String?,
-        titleHint: String?,
-        forceScan: Bool
-    ) {
-        let now = Date()
-        if !forceScan,
-           let lastScan = detectionScanAt[surfaceID],
-           now.timeIntervalSince(lastScan) < Self.detectionScanThrottle {
-            return
-        }
-
-        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
-        if let excludingSessionID {
-            claimed.remove(excludingSessionID)
-        }
-        let key: ClaudeTranscriptResolutionKey = (
-            workingDirectory: workingDirectory,
-            claimedSessionIDs: claimed,
-            titleKey: Self.specificClaudeTitleKey(titleHint),
-            forceScan: forceScan
-        )
-        guard transcriptResolutionKeys[surfaceID] != key else {
-            return
-        }
-
-        detectionScanAt[surfaceID] = now
-        transcriptResolutionKeys[surfaceID] = key
-        transcriptResolutionTasks[surfaceID]?.cancel()
-        let resolver = self.resolver
-        #if compiler(>=6.2)
-        let resolveOperation: @concurrent @Sendable () async -> (sessionID: String, path: String)? = {
-            [resolver, workingDirectory, claimed, titleHint] in
-            resolver.newestClaudeTranscript(
-                workingDirectory: workingDirectory,
-                excludingSessionIDs: claimed,
-                titleHint: titleHint
-            )
-        }
-        #else
-        let resolveOperation: @Sendable () async -> (sessionID: String, path: String)? = {
-            [resolver, workingDirectory, claimed, titleHint] in
-            resolver.newestClaudeTranscript(
-                workingDirectory: workingDirectory,
-                excludingSessionIDs: claimed,
-                titleHint: titleHint
-            )
-        }
-        #endif
-        let scanTask = Task.detached(priority: .utility, operation: resolveOperation)
-        transcriptResolutionTasks[surfaceID] = Task { @MainActor [
-            weak self,
-            scanTask,
-            key,
-            workspaceID,
-            workingDirectory,
-            surfaceID,
-            titleHint
-        ] in
-            let resolved = await withTaskCancellationHandler {
-                await scanTask.value
-            } onCancel: {
-                scanTask.cancel()
-            }
-            guard !Task.isCancelled else { return }
-            self?.applyClaudeTranscriptResolution(
-                resolved,
-                key: key,
-                workspaceID: workspaceID,
-                workingDirectory: workingDirectory,
-                surfaceID: surfaceID,
-                titleHint: titleHint
-            )
-        }
-    }
-
-    private func applyClaudeTranscriptResolution(
-        _ resolved: (sessionID: String, path: String)?,
-        key: ClaudeTranscriptResolutionKey,
-        workspaceID: String,
-        workingDirectory: String,
-        surfaceID: String,
-        titleHint: String?
-    ) {
-        guard transcriptResolutionKeys[surfaceID] == key else {
-            return
-        }
-        transcriptResolutionTasks[surfaceID] = nil
-        transcriptResolutionKeys[surfaceID] = nil
-
-        guard let resolved else { return }
-        guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
-            scheduleClaudeTranscriptResolution(
-                workspaceID: workspaceID,
-                workingDirectory: workingDirectory,
-                surfaceID: surfaceID,
-                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
-                titleHint: titleHint,
-                forceScan: true
-            )
-            return
-        }
-        if let claimed = registry.record(sessionID: resolved.sessionID),
-           claimed.surfaceID != nil,
-           claimed.surfaceID != surfaceID {
-            scheduleClaudeTranscriptResolution(
-                workspaceID: workspaceID,
-                workingDirectory: workingDirectory,
-                surfaceID: surfaceID,
-                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
-                titleHint: titleHint,
-                forceScan: true
-            )
-            return
-        }
-
-        detectionScanAt.removeValue(forKey: surfaceID)
-        claimedDetectedTranscriptSessionIDs.insert(resolved.sessionID)
-        if let bound = registry.liveSession(surfaceID: surfaceID) {
-            guard bound.transcriptPath == nil else { return }
-            registry.update(sessionID: bound.sessionID) { record in
-                record.workspaceID = workspaceID
-                record.surfaceID = surfaceID
-                record.workingDirectory = workingDirectory
-                record.transcriptPath = resolved.path
-            }
-            return
-        }
-
-        registry.adoptDetectedSession(
-            sessionID: resolved.sessionID,
-            agentKind: .claude,
-            workspaceID: workspaceID,
-            surfaceID: surfaceID,
-            workingDirectory: workingDirectory,
-            transcriptPath: resolved.path,
-            at: Date()
-        )
-    }
 
     @discardableResult
     private func ensureTailer(for record: AgentChatSessionRecord) -> AgentChatTranscriptTailer? {
@@ -608,7 +421,7 @@ final class AgentChatTranscriptService {
         sessionID.hasPrefix(provisionalClaudeSessionIDPrefix)
     }
 
-    private static func claudeTitleDetectionKey(_ title: String?) -> String? {
+    static func claudeTitleDetectionKey(_ title: String?) -> String? {
         guard let title else {
             return nil
         }
@@ -619,7 +432,7 @@ final class AgentChatTranscriptService {
         return specificClaudeTitleKey(title) ?? "generic:claude"
     }
 
-    private static func specificClaudeTitleKey(_ title: String?) -> String? {
+    static func specificClaudeTitleKey(_ title: String?) -> String? {
         guard var title = title?.trimmingCharacters(in: .whitespacesAndNewlines),
               !title.isEmpty else {
             return nil
@@ -637,7 +450,7 @@ final class AgentChatTranscriptService {
         return "specific:\(normalized)"
     }
 
-    private static func isSpecificClaudeTitle(_ title: String?) -> Bool {
+    static func isSpecificClaudeTitle(_ title: String?) -> Bool {
         specificClaudeTitleKey(title) != nil
     }
 

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -12,7 +12,6 @@ final class AgentChatTranscriptService {
 
     private let registry: AgentChatSessionRegistry
     private let resolver: AgentChatTranscriptResolver
-    private let scanQueue: AgentChatTranscriptScanQueue
     private let coding = ChatWireCoding()
     private var tailers: [String: AgentChatTranscriptTailer] = [:]
     /// Sessions whose transcript could not be resolved; skipped until an
@@ -50,12 +49,10 @@ final class AgentChatTranscriptService {
     ///   - resolver: Transcript path resolver.
     init(
         registry: AgentChatSessionRegistry,
-        resolver: AgentChatTranscriptResolver = AgentChatTranscriptResolver(),
-        scanQueue: AgentChatTranscriptScanQueue = AgentChatTranscriptScanQueue()
+        resolver: AgentChatTranscriptResolver = AgentChatTranscriptResolver()
     ) {
         self.registry = registry
         self.resolver = resolver
-        self.scanQueue = scanQueue
         registry.onRecordChanged = { [weak self] record, previous in
             self?.handleRecordChange(record, previous: previous)
         }
@@ -273,17 +270,13 @@ final class AgentChatTranscriptService {
 
     // MARK: - Internals
 
-    private struct PendingTitleChange {
-        let change: GhosttyTitleChange
-        let titleKey: String
-    }
-
-    private struct ClaudeTranscriptResolutionKey: Equatable, Sendable {
-        let workingDirectory: String
-        let claimedSessionIDs: Set<String>
-        let titleKey: String?
-        let forceScan: Bool
-    }
+    private typealias PendingTitleChange = (change: GhosttyTitleChange, titleKey: String)
+    private typealias ClaudeTranscriptResolutionKey = (
+        workingDirectory: String,
+        claimedSessionIDs: Set<String>,
+        titleKey: String?,
+        forceScan: Bool
+    )
 
     private func scheduleTitleDetectedAdoption(_ change: GhosttyTitleChange) {
         let surfaceID = change.surfaceId.uuidString
@@ -300,7 +293,7 @@ final class AgentChatTranscriptService {
             return
         }
 
-        pendingTitleChanges[surfaceID] = PendingTitleChange(change: change, titleKey: titleKey)
+        pendingTitleChanges[surfaceID] = (change: change, titleKey: titleKey)
         titleChangeCoalescer.signal { [weak self] in
             self?.flushTitleDetectedAdoptions()
         }
@@ -348,7 +341,7 @@ final class AgentChatTranscriptService {
         if let excludingSessionID {
             claimed.remove(excludingSessionID)
         }
-        let key = ClaudeTranscriptResolutionKey(
+        let key: ClaudeTranscriptResolutionKey = (
             workingDirectory: workingDirectory,
             claimedSessionIDs: claimed,
             titleKey: Self.specificClaudeTitleKey(titleHint),
@@ -362,24 +355,40 @@ final class AgentChatTranscriptService {
         transcriptResolutionKeys[surfaceID] = key
         transcriptResolutionTasks[surfaceID]?.cancel()
         let resolver = self.resolver
-        let scanQueue = self.scanQueue
-        transcriptResolutionTasks[surfaceID] = Task { @MainActor [
-            weak self,
-            resolver,
-            scanQueue,
-            key,
-            workspaceID,
-            workingDirectory,
-            surfaceID,
-            titleHint,
-            claimed
-        ] in
-            let resolved = await scanQueue.newestClaudeTranscript(
-                resolver: resolver,
+        #if compiler(>=6.2)
+        let resolveOperation: @concurrent @Sendable () async -> (sessionID: String, path: String)? = {
+            [resolver, workingDirectory, claimed, titleHint] in
+            resolver.newestClaudeTranscript(
                 workingDirectory: workingDirectory,
                 excludingSessionIDs: claimed,
                 titleHint: titleHint
             )
+        }
+        #else
+        let resolveOperation: @Sendable () async -> (sessionID: String, path: String)? = {
+            [resolver, workingDirectory, claimed, titleHint] in
+            resolver.newestClaudeTranscript(
+                workingDirectory: workingDirectory,
+                excludingSessionIDs: claimed,
+                titleHint: titleHint
+            )
+        }
+        #endif
+        let scanTask = Task.detached(priority: .utility, operation: resolveOperation)
+        transcriptResolutionTasks[surfaceID] = Task { @MainActor [
+            weak self,
+            scanTask,
+            key,
+            workspaceID,
+            workingDirectory,
+            surfaceID,
+            titleHint
+        ] in
+            let resolved = await withTaskCancellationHandler {
+                await scanTask.value
+            } onCancel: {
+                scanTask.cancel()
+            }
             guard !Task.isCancelled else { return }
             self?.applyClaudeTranscriptResolution(
                 resolved,

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -330,6 +330,10 @@ final class AgentChatTranscriptService {
         titleChangeTasks[surfaceID]?.cancel()
         titleChangeTasks[surfaceID] = nil
         deliveredTitleKeys.removeValue(forKey: surfaceID)
+        transcriptResolutionTasks[surfaceID]?.cancel()
+        transcriptResolutionTasks[surfaceID] = nil
+        transcriptResolutionKeys.removeValue(forKey: surfaceID)
+        detectionScanAt.removeValue(forKey: surfaceID)
     }
 
     private func scheduleClaudeTranscriptResolution(

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -19,13 +19,20 @@ final class AgentChatTranscriptService {
     /// failures don't rescan the filesystem during tool storms.
     private var failedResolutions: Set<String> = []
     /// Last time `adoptDetectedClaudeSession` ran a filesystem scan for a
-    /// surface that had no session yet, keyed by surface id. Bounds the
-    /// main-actor directory walk to once per `detectionScanThrottle` while a
+    /// surface that had no session yet, keyed by surface id. Bounds transcript
+    /// resolution scheduling to once per `detectionScanThrottle` while a
     /// title-detected claude has not yet written its transcript; a successful
     /// adoption removes the entry.
     private var detectionScanAt: [String: Date] = [:]
     private var ghosttyTitleSubscription: GhosttyTitleChangeSubscription?
+    private var pendingTitleChanges: [String: PendingTitleChange] = [:]
+    private var titleChangeTasks: [String: Task<Void, Never>] = [:]
+    private var deliveredTitleKeys: [String: String] = [:]
+    private var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
+    private var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
+    private var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
     private static let detectionScanThrottle: TimeInterval = 4
+    private static let titleChangeDebounceNanoseconds: UInt64 = 250_000_000
     private static let provisionalClaudeSessionIDPrefix = "detected-claude-surface-"
 
     /// Creates the service with a hook-store-backed registry.
@@ -54,12 +61,14 @@ final class AgentChatTranscriptService {
     /// Seeds the session registry from the on-disk hook stores. Call once
     /// at app startup.
     ///
-    /// - Parameter adoptDetectedAgentSessions: Composition-root callback that
-    ///   adopts a title-detected agent for the workspace whose title changed.
-    func start(adoptDetectedAgentSessions: @escaping @MainActor (String) -> Void) {
+    /// - Parameter adoptDetectedAgentSession: Composition-root callback that
+    ///   adopts a title-detected agent for the surface whose title changed,
+    ///   returning whether the surface was resolved and adoption was queued.
+    func start(adoptDetectedAgentSession: @escaping @MainActor (GhosttyTitleChange) -> Bool) {
         guard ghosttyTitleSubscription == nil else { return }
+        titleAdoptionHandler = adoptDetectedAgentSession
         registry.seedFromHookStores()
-        observeAgentTitleChanges(adoptDetectedAgentSessions: adoptDetectedAgentSessions)
+        observeAgentTitleChanges()
     }
 
     /// Watches terminal title changes so a coding agent launched without a
@@ -67,12 +76,9 @@ final class AgentChatTranscriptService {
     /// adopted the instant its terminal title becomes the agent's (e.g.
     /// "✳ Claude Code"), not only when the workspace is next opened. Adoption
     /// emits a descriptor change, which pushes the toggle to listening phones.
-    private func observeAgentTitleChanges(adoptDetectedAgentSessions: @escaping @MainActor (String) -> Void) {
-        ghosttyTitleSubscription = GhosttyTitleChangeSubscription { change in
-            guard change.title.lowercased().contains("claude") else {
-                return
-            }
-            adoptDetectedAgentSessions(change.tabId.uuidString)
+    private func observeAgentTitleChanges() {
+        ghosttyTitleSubscription = GhosttyTitleChangeSubscription { [weak self] change in
+            self?.scheduleTitleDetectedAdoption(change)
         }
     }
 
@@ -134,55 +140,35 @@ final class AgentChatTranscriptService {
         workingDirectory: String,
         titleHint: String? = nil
     ) -> Bool {
-        if let bound = registry.sessions(workspaceID: nil)
-            .first(where: { $0.surfaceID == surfaceID && $0.state != .ended }) {
-            registry.update(sessionID: bound.sessionID) { record in
-                record.workspaceID = workspaceID
-                record.surfaceID = surfaceID
-                record.workingDirectory = workingDirectory
+        if let bound = registry.liveSession(surfaceID: surfaceID) {
+            if bound.workspaceID != workspaceID
+                || bound.surfaceID != surfaceID
+                || bound.workingDirectory != workingDirectory {
+                registry.update(sessionID: bound.sessionID) { record in
+                    record.workspaceID = workspaceID
+                    record.surfaceID = surfaceID
+                    record.workingDirectory = workingDirectory
+                }
             }
             guard bound.transcriptPath == nil else { return true }
-            if let resolved = newestClaudeTranscript(
+            scheduleClaudeTranscriptResolution(
+                workspaceID: workspaceID,
                 workingDirectory: workingDirectory,
                 surfaceID: surfaceID,
                 excludingSessionID: bound.sessionID,
                 titleHint: titleHint,
                 forceScan: Self.isSpecificClaudeTitle(titleHint)
-            ) {
-                detectionScanAt.removeValue(forKey: surfaceID)
-                registry.update(sessionID: bound.sessionID) { record in
-                    record.transcriptPath = resolved.path
-                    record.workingDirectory = workingDirectory
-                }
-            }
+            )
             return true
         }
         // A claude detected by title before it has written its transcript jsonl
         // (the launch race) resolves to nothing. List-level adoption runs this
         // on every workspace-list RPC and every "claude" title change across
-        // ALL workspaces, so without a throttle an un-resolvable surface drives
-        // a fresh main-actor directory walk on each call during a title burst.
-        // Bound the filesystem scan to once per surface per window; a success
-        // clears the entry (and `alreadyBound` short-circuits forever after).
-        if let resolved = newestClaudeTranscript(
-            workingDirectory: workingDirectory,
-            surfaceID: surfaceID,
-            excludingSessionID: nil,
-            titleHint: titleHint,
-            forceScan: false
-        ) {
-            detectionScanAt.removeValue(forKey: surfaceID)
-            registry.adoptDetectedSession(
-                sessionID: resolved.sessionID,
-                agentKind: .claude,
-                workspaceID: workspaceID,
-                surfaceID: surfaceID,
-                workingDirectory: workingDirectory,
-                transcriptPath: resolved.path,
-                at: Date()
-            )
-            return true
-        }
+        // ALL workspaces, so without a throttle an un-resolvable surface would
+        // schedule fresh transcript resolution on each call during a title
+        // burst. Bound the off-main resolution to once per surface per window;
+        // a success clears the entry (and `liveSession` short-circuits forever
+        // after once the transcript is bound).
         registry.adoptDetectedSession(
             sessionID: Self.provisionalClaudeSessionID(surfaceID: surfaceID),
             agentKind: .claude,
@@ -191,6 +177,14 @@ final class AgentChatTranscriptService {
             workingDirectory: workingDirectory,
             transcriptPath: nil,
             at: Date()
+        )
+        scheduleClaudeTranscriptResolution(
+            workspaceID: workspaceID,
+            workingDirectory: workingDirectory,
+            surfaceID: surfaceID,
+            excludingSessionID: nil,
+            titleHint: titleHint,
+            forceScan: false
         )
         return true
     }
@@ -275,6 +269,156 @@ final class AgentChatTranscriptService {
     }
 
     // MARK: - Internals
+
+    private struct PendingTitleChange {
+        let change: GhosttyTitleChange
+        let titleKey: String
+    }
+
+    private struct ClaudeTranscriptResolutionKey: Equatable, Sendable {
+        let workingDirectory: String
+        let claimedSessionIDs: Set<String>
+        let titleKey: String?
+        let forceScan: Bool
+    }
+
+    private func scheduleTitleDetectedAdoption(_ change: GhosttyTitleChange) {
+        guard let titleKey = Self.claudeTitleDetectionKey(change.title) else { return }
+        let surfaceID = change.surfaceId.uuidString
+        if pendingTitleChanges[surfaceID]?.titleKey == titleKey {
+            return
+        }
+        if pendingTitleChanges[surfaceID] == nil,
+           deliveredTitleKeys[surfaceID] == titleKey {
+            return
+        }
+
+        pendingTitleChanges[surfaceID] = PendingTitleChange(change: change, titleKey: titleKey)
+        titleChangeTasks[surfaceID]?.cancel()
+        titleChangeTasks[surfaceID] = Task { @MainActor [weak self] in
+            do {
+                // Bounded debounce for terminal title bursts; replaced by newer titles for this surface.
+                try await Task.sleep(nanoseconds: Self.titleChangeDebounceNanoseconds)
+            } catch {
+                return
+            }
+            self?.flushTitleDetectedAdoption(surfaceID: surfaceID)
+        }
+    }
+
+    private func flushTitleDetectedAdoption(surfaceID: String) {
+        titleChangeTasks[surfaceID] = nil
+        guard let pending = pendingTitleChanges.removeValue(forKey: surfaceID) else {
+            return
+        }
+        if titleAdoptionHandler?(pending.change) == true {
+            deliveredTitleKeys[surfaceID] = pending.titleKey
+        }
+    }
+
+    private func scheduleClaudeTranscriptResolution(
+        workspaceID: String,
+        workingDirectory: String,
+        surfaceID: String,
+        excludingSessionID: String?,
+        titleHint: String?,
+        forceScan: Bool
+    ) {
+        let now = Date()
+        if !forceScan,
+           let lastScan = detectionScanAt[surfaceID],
+           now.timeIntervalSince(lastScan) < Self.detectionScanThrottle {
+            return
+        }
+
+        var claimed = registry.claimedSessionIDs()
+        if let excludingSessionID {
+            claimed.remove(excludingSessionID)
+        }
+        let key = ClaudeTranscriptResolutionKey(
+            workingDirectory: workingDirectory,
+            claimedSessionIDs: claimed,
+            titleKey: Self.specificClaudeTitleKey(titleHint),
+            forceScan: forceScan
+        )
+        guard transcriptResolutionKeys[surfaceID] != key else {
+            return
+        }
+
+        detectionScanAt[surfaceID] = now
+        transcriptResolutionKeys[surfaceID] = key
+        transcriptResolutionTasks[surfaceID]?.cancel()
+        let resolver = self.resolver
+        transcriptResolutionTasks[surfaceID] = Task { @MainActor [
+            weak self,
+            resolver,
+            key,
+            workspaceID,
+            workingDirectory,
+            surfaceID,
+            titleHint,
+            claimed
+        ] in
+            let resolved = await Task.detached(priority: .utility) {
+                resolver.newestClaudeTranscript(
+                    workingDirectory: workingDirectory,
+                    excludingSessionIDs: claimed,
+                    titleHint: titleHint
+                )
+            }.value
+            guard !Task.isCancelled else { return }
+            self?.applyClaudeTranscriptResolution(
+                resolved,
+                key: key,
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID
+            )
+        }
+    }
+
+    private func applyClaudeTranscriptResolution(
+        _ resolved: (sessionID: String, path: String)?,
+        key: ClaudeTranscriptResolutionKey,
+        workspaceID: String,
+        workingDirectory: String,
+        surfaceID: String
+    ) {
+        guard transcriptResolutionKeys[surfaceID] == key else {
+            return
+        }
+        transcriptResolutionTasks[surfaceID] = nil
+        transcriptResolutionKeys[surfaceID] = nil
+
+        guard let resolved else { return }
+        if let claimed = registry.record(sessionID: resolved.sessionID),
+           claimed.surfaceID != nil,
+           claimed.surfaceID != surfaceID {
+            return
+        }
+
+        detectionScanAt.removeValue(forKey: surfaceID)
+        if let bound = registry.liveSession(surfaceID: surfaceID) {
+            guard bound.transcriptPath == nil else { return }
+            registry.update(sessionID: bound.sessionID) { record in
+                record.workspaceID = workspaceID
+                record.surfaceID = surfaceID
+                record.workingDirectory = workingDirectory
+                record.transcriptPath = resolved.path
+            }
+            return
+        }
+
+        registry.adoptDetectedSession(
+            sessionID: resolved.sessionID,
+            agentKind: .claude,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            workingDirectory: workingDirectory,
+            transcriptPath: resolved.path,
+            at: Date()
+        )
+    }
 
     @discardableResult
     private func ensureTailer(for record: AgentChatSessionRecord) -> AgentChatTranscriptTailer? {
@@ -415,19 +559,34 @@ final class AgentChatTranscriptService {
         sessionID.hasPrefix(provisionalClaudeSessionIDPrefix)
     }
 
-    private static func isSpecificClaudeTitle(_ title: String?) -> Bool {
+    private static func claudeTitleDetectionKey(_ title: String?) -> String? {
+        guard let title,
+              title.lowercased().contains("claude") else {
+            return nil
+        }
+        return specificClaudeTitleKey(title) ?? "generic:claude"
+    }
+
+    private static func specificClaudeTitleKey(_ title: String?) -> String? {
         guard var title = title?.trimmingCharacters(in: .whitespacesAndNewlines),
               !title.isEmpty else {
-            return false
+            return nil
         }
         while let first = title.first, !first.isLetter && !first.isNumber {
             title.removeFirst()
             title = title.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         let normalized = title.lowercased()
-        return !normalized.isEmpty
-            && normalized != "claude code"
-            && !normalized.hasPrefix("claude ·")
+        guard !normalized.isEmpty,
+              normalized != "claude code",
+              !normalized.hasPrefix("claude ·") else {
+            return nil
+        }
+        return "specific:\(normalized)"
+    }
+
+    private static func isSpecificClaudeTitle(_ title: String?) -> Bool {
+        specificClaudeTitleKey(title) != nil
     }
 
     /// Encodes a wire value into the `[String: Any]` payload shape the

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -373,7 +373,8 @@ final class AgentChatTranscriptService {
                 key: key,
                 workspaceID: workspaceID,
                 workingDirectory: workingDirectory,
-                surfaceID: surfaceID
+                surfaceID: surfaceID,
+                titleHint: titleHint
             )
         }
     }
@@ -383,7 +384,8 @@ final class AgentChatTranscriptService {
         key: ClaudeTranscriptResolutionKey,
         workspaceID: String,
         workingDirectory: String,
-        surfaceID: String
+        surfaceID: String,
+        titleHint: String?
     ) {
         guard transcriptResolutionKeys[surfaceID] == key else {
             return
@@ -393,11 +395,27 @@ final class AgentChatTranscriptService {
 
         guard let resolved else { return }
         guard !claimedDetectedTranscriptSessionIDs.contains(resolved.sessionID) else {
+            scheduleClaudeTranscriptResolution(
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID,
+                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
+                titleHint: titleHint,
+                forceScan: true
+            )
             return
         }
         if let claimed = registry.record(sessionID: resolved.sessionID),
            claimed.surfaceID != nil,
            claimed.surfaceID != surfaceID {
+            scheduleClaudeTranscriptResolution(
+                workspaceID: workspaceID,
+                workingDirectory: workingDirectory,
+                surfaceID: surfaceID,
+                excludingSessionID: registry.liveSession(surfaceID: surfaceID)?.sessionID,
+                titleHint: titleHint,
+                forceScan: true
+            )
             return
         }
 
@@ -545,7 +563,7 @@ final class AgentChatTranscriptService {
             return nil
         }
         detectionScanAt[surfaceID] = now
-        var claimed = registry.claimedSessionIDs()
+        var claimed = registry.claimedSessionIDs().union(claimedDetectedTranscriptSessionIDs)
         if let excludingSessionID {
             claimed.remove(excludingSessionID)
         }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -284,8 +284,11 @@ final class AgentChatTranscriptService {
     }
 
     private func scheduleTitleDetectedAdoption(_ change: GhosttyTitleChange) {
-        guard let titleKey = Self.claudeTitleDetectionKey(change.title) else { return }
         let surfaceID = change.surfaceId.uuidString
+        guard let titleKey = Self.claudeTitleDetectionKey(change.title) else {
+            clearTitleDetectionState(surfaceID: surfaceID)
+            return
+        }
         if pendingTitleChanges[surfaceID]?.titleKey == titleKey {
             return
         }
@@ -315,6 +318,13 @@ final class AgentChatTranscriptService {
         if titleAdoptionHandler?(pending.change) == true {
             deliveredTitleKeys[surfaceID] = pending.titleKey
         }
+    }
+
+    private func clearTitleDetectionState(surfaceID: String) {
+        pendingTitleChanges.removeValue(forKey: surfaceID)
+        titleChangeTasks[surfaceID]?.cancel()
+        titleChangeTasks[surfaceID] = nil
+        deliveredTitleKeys.removeValue(forKey: surfaceID)
     }
 
     private func scheduleClaudeTranscriptResolution(
@@ -512,13 +522,17 @@ final class AgentChatTranscriptService {
     private func handleRecordChange(_ record: AgentChatSessionRecord, previous: AgentChatSessionRecord?) {
         let stateChanged = previous?.state != record.state
         let transcriptBecameAvailable = previous?.transcriptPath == nil && record.transcriptPath != nil
-        if stateChanged, record.state == .ended,
-           let tailer = tailers.removeValue(forKey: record.sessionID) {
-            // The transcript can no longer grow; release the file watcher
-            // and cache instead of holding them until app quit. Evicting
-            // only on the TRANSITION keeps unrelated record updates (title
-            // discovery while paging an ended session) from churning it.
-            Task { await tailer.stop() }
+        if stateChanged, record.state == .ended {
+            if let surfaceID = record.surfaceID {
+                clearTitleDetectionState(surfaceID: surfaceID)
+            }
+            if let tailer = tailers.removeValue(forKey: record.sessionID) {
+                // The transcript can no longer grow; release the file watcher
+                // and cache instead of holding them until app quit. Evicting
+                // only on the TRANSITION keeps unrelated record updates (title
+                // discovery while paging an ended session) from churning it.
+                Task { await tailer.stop() }
+            }
         }
         guard MobileHostService.hasEventSubscribers(topic: Self.eventTopic) else { return }
         if transcriptBecameAvailable, record.state != .ended {

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -27,14 +27,13 @@ final class AgentChatTranscriptService {
     private var detectionScanAt: [String: Date] = [:]
     private var ghosttyTitleSubscription: GhosttyTitleChangeSubscription?
     private var pendingTitleChanges: [String: PendingTitleChange] = [:]
-    private var titleChangeTasks: [String: Task<Void, Never>] = [:]
     private var deliveredTitleKeys: [String: String] = [:]
     private var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
     private var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
     private var claimedDetectedTranscriptSessionIDs: Set<String> = []
     private var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
+    private let titleChangeCoalescer = NotificationBurstCoalescer(delay: 0.25)
     private static let detectionScanThrottle: TimeInterval = 4
-    private static let titleChangeDebounceNanoseconds: UInt64 = 250_000_000
     private static let provisionalClaudeSessionIDPrefix = "detected-claude-surface-"
 
     /// Creates the service with a hook-store-backed registry.
@@ -302,33 +301,27 @@ final class AgentChatTranscriptService {
         }
 
         pendingTitleChanges[surfaceID] = PendingTitleChange(change: change, titleKey: titleKey)
-        titleChangeTasks[surfaceID]?.cancel()
-        titleChangeTasks[surfaceID] = Task { @MainActor [weak self] in
-            do {
-                // Bounded debounce for terminal title bursts; replaced by newer titles for this surface.
-                try await Task.sleep(nanoseconds: Self.titleChangeDebounceNanoseconds)
-            } catch {
-                return
-            }
-            self?.flushTitleDetectedAdoption(surfaceID: surfaceID)
+        titleChangeCoalescer.signal { [weak self] in
+            self?.flushTitleDetectedAdoptions()
         }
     }
 
-    private func flushTitleDetectedAdoption(surfaceID: String) {
-        titleChangeTasks[surfaceID] = nil
-        guard let pending = pendingTitleChanges.removeValue(forKey: surfaceID) else {
+    private func flushTitleDetectedAdoptions() {
+        guard !pendingTitleChanges.isEmpty else {
             return
         }
-        if titleAdoptionHandler?(pending.change) == true,
-           registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
-            deliveredTitleKeys[surfaceID] = pending.titleKey
+        let pendingBySurface = pendingTitleChanges
+        pendingTitleChanges.removeAll(keepingCapacity: true)
+        for (surfaceID, pending) in pendingBySurface {
+            if titleAdoptionHandler?(pending.change) == true,
+               registry.liveSession(surfaceID: surfaceID)?.transcriptPath != nil {
+                deliveredTitleKeys[surfaceID] = pending.titleKey
+            }
         }
     }
 
     private func clearTitleDetectionState(surfaceID: String) {
         pendingTitleChanges.removeValue(forKey: surfaceID)
-        titleChangeTasks[surfaceID]?.cancel()
-        titleChangeTasks[surfaceID] = nil
         deliveredTitleKeys.removeValue(forKey: surfaceID)
         transcriptResolutionTasks[surfaceID]?.cancel()
         transcriptResolutionTasks[surfaceID] = nil

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -365,9 +365,11 @@ final class AgentChatTranscriptService {
         transcriptResolutionKeys[surfaceID] = key
         transcriptResolutionTasks[surfaceID]?.cancel()
         let resolver = self.resolver
+        let scanQueue = self.scanQueue
         transcriptResolutionTasks[surfaceID] = Task { @MainActor [
             weak self,
             resolver,
+            scanQueue,
             key,
             workspaceID,
             workingDirectory,
@@ -601,8 +603,11 @@ final class AgentChatTranscriptService {
     }
 
     private static func claudeTitleDetectionKey(_ title: String?) -> String? {
-        guard let title,
-              title.lowercased().contains("claude") else {
+        guard let title else {
+            return nil
+        }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard title.lowercased().contains("claude") || trimmed.hasPrefix("✳") else {
             return nil
         }
         return specificClaudeTitleKey(title) ?? "generic:claude"

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -29,10 +29,12 @@ final class AgentChatTranscriptService {
     var deliveredTitleKeys: [String: String] = [:]
     var transcriptResolutionTasks: [String: Task<Void, Never>] = [:]
     var transcriptResolutionKeys: [String: ClaudeTranscriptResolutionKey] = [:]
+    var transcriptResolutionForcedRetryCounts: [String: Int] = [:]
     var claimedDetectedTranscriptSessionIDs: Set<String> = []
     var titleAdoptionHandler: (@MainActor (GhosttyTitleChange) -> Bool)?
     let titleChangeCoalescer = NotificationBurstCoalescer(delay: 0.25)
     static let detectionScanThrottle: TimeInterval = 4
+    static let maxTranscriptResolutionForcedRetries = 3
     private static let provisionalClaudeSessionIDPrefix = "detected-claude-surface-"
 
     /// Creates the service with a hook-store-backed registry.

--- a/Sources/TerminalController+MobileChat.swift
+++ b/Sources/TerminalController+MobileChat.swift
@@ -94,6 +94,29 @@ extension TerminalController {
         adoptDetectedAgentSessions(workspace: resolved.workspace)
     }
 
+    /// Surface-scoped title-change adoption path. Unlike the workspace-list
+    /// sweep, this handles live terminal title churn and must avoid rescanning
+    /// every terminal in the workspace.
+    @discardableResult
+    func adoptDetectedAgentSession(titleChange: GhosttyTitleChange) -> Bool {
+        guard let resolved = mobileResolveWorkspaceAndSurface(
+            params: [
+                "workspace_id": titleChange.tabId.uuidString,
+                "surface_id": titleChange.surfaceId.uuidString,
+            ],
+            requireTerminal: false
+        ),
+            let surfaceId = resolved.surfaceId,
+            let panel = resolved.workspace.terminalPanel(for: surfaceId) else {
+            return false
+        }
+        return adoptDetectedAgentSession(
+            workspace: resolved.workspace,
+            panel: panel,
+            title: titleChange.title
+        )
+    }
+
     /// Workspace-typed core of ``adoptDetectedAgentSessions(workspaceID:)``,
     /// for callers that already hold the `Workspace` (the workspace-list RPC
     /// enumerates every workspace and adopts inline, so the toggle is known
@@ -102,30 +125,38 @@ extension TerminalController {
     /// once the surface has a session, so a repeat scan of an already-adopted
     /// workspace touches no filesystem.
     func adoptDetectedAgentSessions(workspace: Workspace) {
-        let workspaceID = workspace.id.uuidString
-        guard let service = agentChatTranscriptService else { return }
         for panel in workspace.panels.values.compactMap({ $0 as? TerminalPanel }) {
-            let context = WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace)
             let title = workspace.panelTitle(panelId: panel.id) ?? panel.displayTitle
-            let normalizedTitle = title.lowercased()
-            // Claude is the case the wrapper-launched workflow hits; detect by
-            // launch metadata (hook PID key / initial command) or the live
-            // terminal title claude sets ("✳ Claude Code", then "✳ <ai-title>").
-            let isClaude = TextBoxAgentDetection.isClaudeCode(context: context)
-                || normalizedTitle.contains("claude")
-                || title.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("✳")
-            guard isClaude else { continue }
-            let cwd = workspace.panelDirectories[panel.id]
-                ?? (panel.directory.isEmpty ? nil : panel.directory)
-                ?? (workspace.currentDirectory.isEmpty ? nil : workspace.currentDirectory)
-            guard let cwd, !cwd.isEmpty else { continue }
-            service.adoptDetectedClaudeSession(
-                workspaceID: workspaceID,
-                surfaceID: panel.id.uuidString,
-                workingDirectory: cwd,
-                titleHint: title
-            )
+            adoptDetectedAgentSession(workspace: workspace, panel: panel, title: title)
         }
+    }
+
+    @discardableResult
+    private func adoptDetectedAgentSession(
+        workspace: Workspace,
+        panel: TerminalPanel,
+        title: String
+    ) -> Bool {
+        guard let service = agentChatTranscriptService else { return false }
+        let context = WorkspaceContentView.terminalAgentContext(panel: panel, workspace: workspace)
+        let normalizedTitle = title.lowercased()
+        // Claude is the case the wrapper-launched workflow hits; detect by
+        // launch metadata (hook PID key / initial command) or the live
+        // terminal title claude sets ("✳ Claude Code", then "✳ <ai-title>").
+        let isClaude = TextBoxAgentDetection.isClaudeCode(context: context)
+            || normalizedTitle.contains("claude")
+            || title.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("✳")
+        guard isClaude else { return false }
+        let cwd = workspace.panelDirectories[panel.id]
+            ?? (panel.directory.isEmpty ? nil : panel.directory)
+            ?? (workspace.currentDirectory.isEmpty ? nil : workspace.currentDirectory)
+        guard let cwd, !cwd.isEmpty else { return false }
+        return service.adoptDetectedClaudeSession(
+            workspaceID: workspace.id.uuidString,
+            surfaceID: panel.id.uuidString,
+            workingDirectory: cwd,
+            titleHint: title
+        )
     }
 
     /// `mobile.chat.history`: one transcript page for a session.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		ACA7C4A70000000000000007 /* AgentChatSessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000008 /* AgentChatSessionRegistry.swift */; };
 		ACA7C4A70000000000000005 /* AgentChatTranscriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000006 /* AgentChatTranscriptResolver.swift */; };
 		A9E020000000000000000010 /* AgentChatTranscriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */; };
+		ACA7C4A70000000000000101 /* AgentChatTranscriptService+TitleDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000102 /* AgentChatTranscriptService+TitleDetection.swift */; };
 		ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */; };
 		ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
@@ -1059,6 +1060,7 @@
 		ACA7C4A70000000000000008 /* AgentChatSessionRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRegistry.swift"; sourceTree = "<group>"; };
 		ACA7C4A70000000000000006 /* AgentChatTranscriptResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptResolver.swift"; sourceTree = "<group>"; };
 		A9E010000000000000000010 /* AgentChatTranscriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatTranscriptResolverTests.swift; sourceTree = "<group>"; };
+		ACA7C4A70000000000000102 /* AgentChatTranscriptService+TitleDetection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService+TitleDetection.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptTailer.swift"; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
@@ -2149,6 +2151,7 @@
 				ACA7C4A70000000000000006 /* AgentChatTranscriptResolver.swift */,
 				ACA7C4A70000000000000008 /* AgentChatSessionRegistry.swift */,
 				ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */,
+				ACA7C4A70000000000000102 /* AgentChatTranscriptService+TitleDetection.swift */,
 				ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */,
 			);
 			name = AgentChat;
@@ -3496,6 +3499,7 @@
 				ACA7C4A70000000000000001 /* AgentChatSessionRecord.swift in Sources */,
 				ACA7C4A70000000000000007 /* AgentChatSessionRegistry.swift in Sources */,
 				ACA7C4A70000000000000005 /* AgentChatTranscriptResolver.swift in Sources */,
+				ACA7C4A70000000000000101 /* AgentChatTranscriptService+TitleDetection.swift in Sources */,
 				ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */,
 				ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */,
 				A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */,


### PR DESCRIPTION
## Summary

Closes #6459
Closes #5392

This fixes the main-thread beachball caused by terminal title churn feeding two expensive main-thread paths:

1. `AgentChatTranscriptService.observeAgentTitleChanges` synchronously routed every Claude title update through workspace-wide adoption, and `adoptDetectedClaudeSession` could scan the Claude project directory and parse the newest transcript on the main actor.
2. `VerticalTabsSidebar` passed global selected-workspace state through the row builder, so focus/selection changes made the whole `ForEach` depend on the same AttributeGraph selection node instead of letting unchanged rows stay behind `TabItemView.equatable()`.

## Changes

- Debounce and coalesce title-change adoption by terminal surface using the existing burst coalescer, so title churn queues one latest pending adoption per surface without a per-title sleep task.
- Cache delivered title keys per surface so repeated generic Claude title churn does not keep invoking adoption.
- Route live title changes to a surface-scoped `TerminalController.adoptDetectedAgentSession(titleChange:)` path instead of scanning every terminal in the workspace.
- Keep `adoptDetectedClaudeSession` main-actor work to cheap registry updates and scheduling. Claude transcript discovery/parsing now runs in a cancellable detached utility task, then hops back to the main actor only to apply a still-current result.
- Skip transcript work entirely once a live surface already has a transcript-bound session; provisional/no-transcript sessions are throttled and deduped by surface/input key.
- Move sidebar active-row state into `TabItemView` via a row-local `selectedTabIdPublisher` boolean projection. The parent no longer passes `isActive`, so unchanged rows keep the same equatable inputs when selection changes.

## Testability / verification

This is a main-thread timing/perf bug, so I did not fabricate a unit test. The meaningful verification is the user-controlled dev build + `arch -arm64 lldb` repro from #6459: split a workspace, rapidly switch pane focus, and confirm the 140% CPU spike and `ModifiedViewList.applyNodes` / recursive `swift_release` teardown are gone.

Per request, I did not run a local build, `reload.sh`, `xcodebuild`, or local tests. CI is the verification bar for compilation/checks on this branch.

## Localization

No user-facing strings were added or changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784500973&installation_id=133855650&pr_number=6460&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6460&signature=79a736edf333dfa80b1eaef6a3f35b343fee46ecb2f0713c6a9bfd361cce9cc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main-thread beachball from Claude title churn and stops sidebar rows from redrawing on selection changes. Moves to per-surface, coalesced title handling and resolves transcripts off the main thread with safer live-session indexing and claim management.

- **Bug Fixes**
  - Coalesced per-surface “✳ Claude” title changes (250ms) and routed adoption through `TerminalController.adoptDetectedAgentSession(titleChange:)`, avoiding workspace-wide sweeps; cleared per-surface state and canceled scans on title changes or session end.
  - Resolved transcripts off the main thread per surface with throttling (4s), deduping, and bounded forced retries (3); applied results only if the key still matches; preferred exact title-hints over newer untitled files; ignored `$HOME`; cancellable.
  - Tracked the newest non-ended session per surface with cache revalidation and dead-PID eviction; retained detected transcript-claim IDs while the session is live and released them on end to prevent cross-surface collisions; retried on bound-collision.
  - Sidebar: made row selection local via `selectedTabIdPublisher` so unchanged rows remain `Equatable` and don’t redraw on selection changes.

- **Refactors**
  - Split title detection/resolution scheduling into `AgentChatTranscriptService+TitleDetection.swift`; made `AgentChatTranscriptResolver` `Sendable`.

<sup>Written for commit e9062424ec0bf3e76189a806d5b1fe864d3d8872. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent chat transcript adoption on mobile by forwarding detected title changes to the correct terminal surface, improving session/transcript binding during startup and updates.
  * Enhanced live session selection by tracking the newest non-ended session per terminal surface to avoid incorrect or stale bindings.
* **Performance**
  * Reduced redundant transcript detection and resolution using per-surface throttling, coalesced title changes, deduped scheduling, and forced retries when needed.
  * Improved sidebar responsiveness by localizing workspace row “active” state to reduce unnecessary UI re-renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

