### PR TITLE
Keep iOS mic button retryable after denial

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationController.swift
@@ -76,17 +76,12 @@ final class ComposerDictationController {
     init(textMerger: ComposerDictationTextMerger = ComposerDictationTextMerger()) {
         self.textMerger = textMerger
         self.recognizer = SFSpeechRecognizer()
-        // A nil recognizer (unsupported locale) is terminal: the mic is disabled.
+        // A nil recognizer (unsupported locale) is terminal: taps cannot start
+        // recognition until the system can provide one.
         if recognizer == nil {
             state = .unavailable
         }
     }
-
-    /// Whether the mic button should be shown enabled. False only when the
-    /// recognizer is permanently unavailable (unsupported locale, denied, or
-    /// restricted); a transient busy state still leaves the button enabled so the
-    /// user can toggle it off.
-    var isAvailable: Bool { state != .unavailable }
 
     /// Whether dictation currently owns the composer text, so the field must be
     /// locked (non-editable) until dictation settles to idle. True while
@@ -159,9 +154,10 @@ final class ComposerDictationController {
             beginRecognition()
             return
         case .denied:
-            self.onText = nil
-            state = .unavailable
-            return
+            // Keep denial retryable. The OS may return `false` immediately after
+            // a prior denial, but the user's next tap should still invoke the
+            // permission APIs instead of short-circuiting into a disabled state.
+            break
         case .undetermined:
             // First-ever request: fall through to the async prompt below.
             break
@@ -182,10 +178,12 @@ final class ComposerDictationController {
                 // overwrites the user's idle state with `unavailable`.
                 guard self.state == .requestingPermission else { return }
                 guard granted else {
-                    // Denied or restricted: a terminal rest state that disables the
-                    // mic. The captured callback is dropped.
+                    // Denied or restricted: drop the captured callback, but settle
+                    // back to idle so the mic remains tappable and can request
+                    // permission again on the next press.
                     self.onText = nil
-                    self.state = .unavailable
+                    self.baseText = ""
+                    self.state = .retryablePermissionDenied
                     return
                 }
                 self.beginRecognition()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/ComposerDictationTextMerge.swift
@@ -6,8 +6,9 @@ import Foundation
 ///
 /// Flow: `idle` -> `requestingPermission` (first tap, while authorization is
 /// resolved) -> `listening` (engine running, partials streaming) -> `stopping`
-/// (tearing down the engine/task) -> `idle`. A denied or unavailable recognizer
-/// lands in `unavailable`, a terminal rest state that disables the mic button.
+/// (tearing down the engine/task) -> `idle`. A denied permission request returns
+/// to `idle` so the mic can request authorization again on the next tap; only an
+/// unavailable recognizer or failed audio setup lands in `unavailable`.
 enum ComposerDictationState: Equatable {
     /// Not listening; the mic button offers to start.
     case idle
@@ -19,8 +20,8 @@ enum ComposerDictationState: Equatable {
     case listening
     /// Teardown is in progress (engine stopping, task cancelling). Transient.
     case stopping
-    /// Speech recognition is unavailable on this device, or permission was denied
-    /// or restricted. The mic button is disabled in this state.
+    /// Speech recognition is unavailable on this device, or audio setup failed.
+    /// Permission denial is retryable and settles back to ``idle`` instead.
     case unavailable
 
     /// Whether the engine is actively capturing audio (drives the listening UI).
@@ -57,6 +58,11 @@ enum ComposerDictationState: Equatable {
     /// the session has not fully settled. Distinguishes a graceful stop's transient
     /// wait from both the active ``listening`` state and the resting ``idle``.
     var isStopping: Bool { self == .stopping }
+
+    /// Resting state after the user declines speech or microphone permission.
+    /// Keeping this retryable lets the next mic tap invoke the permission APIs
+    /// again instead of stranding the control in an unavailable state.
+    static var retryablePermissionDenied: ComposerDictationState { .idle }
 }
 
 /// Pure text-merge for live dictation, factored out so it is host-testable

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -372,8 +372,8 @@ struct TerminalComposerView: View {
 
     /// Mic button for on-device voice dictation, beside the attach button on the
     /// leading side. Tapping toggles dictation; while listening it shows a filled,
-    /// tinted mic. Disabled when the recognizer is unavailable or permission was
-    /// denied so the user is never left tapping a dead control.
+    /// tinted mic. The button stays enabled after permission denial so a later tap
+    /// can request authorization again.
     private var micButton: some View {
         let listening = dictation.state.isListening
         return Button {
@@ -387,7 +387,6 @@ struct TerminalComposerView: View {
         .buttonStyle(.plain)
         .foregroundStyle(listening ? AnyShapeStyle(Color.red) : AnyShapeStyle(TerminalPalette.foreground.opacity(0.7)))
         .mobileGlassCircle()
-        .disabled(!dictation.isAvailable)
         .accessibilityIdentifier("MobileComposerMic")
         .accessibilityLabel(
             listening

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/ComposerDictationTests.swift
@@ -76,6 +76,12 @@ import Testing
         #expect(!state.isListening)
     }
 
+    @Test func deniedPermissionSettlesToStartableIdle() {
+        let state = ComposerDictationState.retryablePermissionDenied
+        #expect(state == .idle)
+        #expect(state.canStart)
+    }
+
     @Test func onlyRequestingPermissionCanCancelPendingStart() {
         // A second tap while authorization is resolving cancels the pending start;
         // every other state ignores cancellation (it has nothing to abort).


### PR DESCRIPTION
## Summary
- keep the iOS composer mic button enabled after speech or microphone permission denial
- route denied authorization back to idle so the next tap invokes the permission APIs again
- keep unavailable reserved for recognizer/audio setup failures and cover the retryable state in the dictation state tests

## Testing
- `swift test --filter ComposerDictationTests` (fails before compilation: fresh worktree is missing a built `GhosttyKit.xcframework`)
- `./scripts/reload-cloud.sh --tag dog` (passed, GitHub Actions run https://github.com/manaflow-ai/cmux/actions/runs/27853578184)
- web warmup: `/` 200, `/handler/sign-in` 200, `/handler/after-sign-in` 200 after redirect
- `./ios/scripts/reload.sh --tag dog` (blocked by local build guard for simulator reload)
- `./ios/scripts/reload-cloud.sh --tag dog --device-id E4058DA9-F4C7-52DD-951D-0354061B8E89 --wait` (archive/sign/install reported success, launch failed because CoreDevice lost the iPhone connection; follow-up `devicectl` reported the device unavailable)

## Issues
- Task: iOS mic button should never become disabled after the user taps Don't Allow; pressing it again should request permission again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784505495&installation_id=133855650&pr_number=6462&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6462&signature=ce601d07a608b5e810f681fef3a29ad32893a0bca8ddbb57c9bf13534bfea05a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized iOS composer dictation permission UX; authorization still goes through system APIs, with no change to recognition or send paths.
> 
> **Overview**
> Fixes the iOS composer mic staying **disabled** after the user taps **Don’t Allow** on speech or microphone permission.
> 
> **Dictation controller:** Denied or restricted authorization no longer moves to `unavailable`. The flow clears the captured callback and returns to **idle** (via `retryablePermissionDenied`), including when permissions were already denied synchronously—those taps now fall through to the async permission APIs instead of stopping early. **`unavailable`** is reserved for a missing recognizer or failed audio/recognition setup.
> 
> **UI:** Removes `isAvailable` and the mic button’s `.disabled(!dictation.isAvailable)` so the control stays tappable after denial.
> 
> **Tests:** Asserts that `retryablePermissionDenied` is idle and `canStart` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f900246a1886b53e7a659ca46172ff3a7bc441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the iOS composer mic button tappable after speech/microphone permission denial so the next tap re-requests authorization. Only unsupported locale or audio setup failures now disable dictation. Addresses task: iOS mic button should not be disabled after “Don’t Allow”; tapping again should request permission again.

- **Bug Fixes**
  - Route denied authorization back to idle via `ComposerDictationState.retryablePermissionDenied`; drop pending callback and reset `baseText`.
  - Keep the mic button enabled by removing UI disablement in `TerminalComposerView`.
  - Reserve `.unavailable` for nil `SFSpeechRecognizer` or audio setup failures; added a unit test to cover the retryable denial state.

<sup>Written for commit c5f900246a1886b53e7a659ca46172ff3a7bc441. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Microphone permission denials are now retryable—users can request authorization again without restarting the app.
  * Mic button remains enabled after permission denial, allowing users to tap and retry the permission request.

* **Tests**
  * Added test coverage for dictation permission denial retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->