### PR TITLE
Fix keyboard shortcut recorder for arrow keys

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/ShortcutRecorderView.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/ShortcutRecorderView.swift
@@ -342,13 +342,20 @@ public final class RecorderHostButton: NSButton {
 
         guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else { return }
 
+        // Arrow keys report `charactersIgnoringModifiers` as a Private Use Area
+        // function-key scalar (NSLeftArrowFunctionKey, …), not "←/→/↑/↓".
+        // Storing that raw value renders as a missing-glyph "?" and never
+        // matches at runtime, so canonicalize the arrow virtual key codes to
+        // the same tokens the default bindings (e.g. focusLeft) already use.
+        let key = Self.canonicalKey(forKeyCode: event.keyCode) ?? chars.lowercased()
+
         let hasModifier = event.modifierFlags.contains(.command)
             || event.modifierFlags.contains(.option)
             || event.modifierFlags.contains(.control)
             || event.modifierFlags.contains(.shift)
 
         let stroke = ShortcutStroke(
-            key: chars.lowercased(),
+            key: key,
             command: event.modifierFlags.contains(.command),
             shift: event.modifierFlags.contains(.shift),
             option: event.modifierFlags.contains(.option),
@@ -386,6 +393,21 @@ public final class RecorderHostButton: NSButton {
         hasPendingRejection = false
         onStroke?(stroke)
         stopRecording()
+    }
+
+    /// Canonical key tokens for virtual key codes whose
+    /// `charactersIgnoringModifiers` is not the value cmux stores. Currently
+    /// the four arrow keys, which report Private Use Area function-key scalars;
+    /// these tokens match the arrow defaults in `ShortcutAction+Defaults` and
+    /// the config parser, so a recorded arrow displays and matches correctly.
+    private static func canonicalKey(forKeyCode keyCode: UInt16) -> String? {
+        switch keyCode {
+        case 123: return "←"
+        case 124: return "→"
+        case 125: return "↓"
+        case 126: return "↑"
+        default: return nil
+        }
     }
 
     /// Clears the internal "pending rejection" state so the button

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutRecorderViewTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutRecorderViewTests.swift
@@ -49,6 +49,52 @@ struct ShortcutRecorderViewTests {
         #expect(button.debugIsRecording)
     }
 
+    @Test func recordsArrowKeysAsCanonicalTokens() throws {
+        let button = RecorderHostButton(frame: .zero)
+        defer {
+            if button.debugIsRecording {
+                button.debugStopRecording()
+            }
+        }
+        var recordedStroke: ShortcutStroke?
+        button.onStroke = { recordedStroke = $0 }
+        button.debugStartRecording()
+
+        try #require(button.debugIsRecording)
+        // A real Ctrl+Cmd+RightArrow keystroke reports its
+        // charactersIgnoringModifiers as the right-arrow function-key scalar
+        // (NSRightArrowFunctionKey, a Private Use Area code point), not "→".
+        // Storing that raw scalar renders as a missing-glyph "?" and never
+        // matches at runtime, so the recorder must canonicalize it to "→".
+        button.debugHandleRecordingEvent(
+            try arrowKeyDownEvent(functionKey: NSRightArrowFunctionKey, keyCode: 124)
+        )
+
+        #expect(
+            recordedStroke == ShortcutStroke(key: "→", command: true, control: true, keyCode: 124)
+        )
+        #expect(!button.debugIsRecording)
+    }
+
+    private func arrowKeyDownEvent(functionKey: Int, keyCode: UInt16) throws -> NSEvent {
+        let scalar = try #require(UnicodeScalar(functionKey))
+        let chars = String(Character(scalar))
+        return try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.command, .control],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: chars,
+                charactersIgnoringModifiers: chars,
+                isARepeat: false,
+                keyCode: keyCode
+            )
+        )
+    }
+
     private func keyDownEvent(key: String, keyCode: UInt16) throws -> NSEvent {
         try #require(
             NSEvent.keyEvent(


### PR DESCRIPTION
## Summary

The Settings → Keyboard Shortcuts recorder cannot record arrow keys. Pressing an arrow while recording shows a missing-glyph `?` (e.g. `⌃⌘?` instead of `⌃⌘←`), and the resulting binding does not work.

## Root cause

The package recorder builds its `ShortcutStroke` straight from `event.charactersIgnoringModifiers`:

```swift
// Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Rows/ShortcutRecorderView.swift
let stroke = ShortcutStroke(key: chars.lowercased(), ...)
```

For the arrow keys, `charactersIgnoringModifiers` is a Private Use Area function-key scalar (`NSLeftArrowFunctionKey`, …), **not** `←/→/↑/↓`. Storing that raw scalar has two consequences:

1. It has no glyph, so the recorder/display renders it as `?`.
2. The stored `key` is not the canonical arrow token, so the binding never matches at runtime and cannot round-trip through the config.

Only the **recorder** is affected — the config parser (`StoredShortcut.parseConfig` / `parseConfigKeyToken`) and the runtime matcher already understand `←/→/↑/↓` (the default `focusLeft`/`focusRight`/… bindings use them). So canonicalizing at record time is the one missing link.

## Fix

In `RecorderHostButton.handleRecordingEvent`, map the four arrow virtual key codes (123–126) to the same `←/→/↑/↓` tokens the defaults and the config parser already use; every other key keeps falling back to `charactersIgnoringModifiers`:

```swift
let key = Self.canonicalKey(forKeyCode: event.keyCode) ?? chars.lowercased()
```

After this, a recorded arrow displays correctly, persists to `cmux.json` as the canonical token, and matches at runtime.

## Two-commit structure (per regression-test policy)

1. **Commit 1 — failing test only.** Records a synthetic `Ctrl+Cmd+RightArrow` (whose `charactersIgnoringModifiers` is `NSRightArrowFunctionKey`) and asserts the stored key is `→`. Red before the fix.
2. **Commit 2 — the fix.** Green.

## Test plan

- [x] Unit: `recordsArrowKeysAsCanonicalTokens` in `CmuxSettingsUITests/ShortcutRecorderViewTests.swift`; `swift test` (CmuxSettingsUI) green.
- [x] Manual (debug build): recording `⌥⌘←` now shows `⌥⌘←` (not `⌥⌘?`), persists to `~/.config/cmux/cmux.json` as `"key": "←"`, and the binding works at runtime (e.g. bound to Previous Surface, it switches surfaces).

## Notes for reviewers

- The new test lives in the `CmuxSettingsUI` package `Tests/`, not in `cmuxTests/`, so no `project.pbxproj` test wiring is required.
- **Localization:** no new user-facing strings — arrows render as the glyphs `←/→/↑/↓`, which are language-neutral, so no `Localizable.xcstrings` changes are needed.
- Sibling precedent: #3281 fixed the same class of "recorder drops special keys" for Page Up/Down/Home/End in the app-target shortcut tables; this PR fixes arrows in the package recorder that backs the live Settings window.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784513627&installation_id=133855650&pr_number=6466&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6466&signature=94d1bebb7750a28c1cc1f4ca5571775373e9dd028c85c2ea3cf90c2ab8c0da2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings keyboard shortcut recorder so arrow keys record, display, and match correctly. Arrow presses now show the proper glyphs and persist as canonical tokens.

- **Bug Fixes**
  - Map arrow virtual key codes 123–126 to "←/→/↑/↓" in `RecorderHostButton.handleRecordingEvent`; other keys still use `charactersIgnoringModifiers`.
  - Add unit test `recordsArrowKeysAsCanonicalTokens` in `CmuxSettingsUI` verifying Ctrl+Cmd+RightArrow stores "→" and ends recording.

<sup>Written for commit ef679538544829e09362feaf64977f8c7291c10b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shortcut recording for arrow keys so recorded strokes use the correct arrow symbols (←, →, ↓, ↑), matching the app’s expected display and bindings.
  * Added tests to confirm arrow-key canonicalization preserves modifier behavior and records the correct Unicode token for the Right Arrow case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->