### PR TITLE
Add hot event fanout review rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,6 +43,9 @@ reviews:
     - path: "**/*.swift"
       instructions: |
         Apply `.github/review-bot-rules/swift-expensive-sync-load.md` during review. Flag heavy synchronous loaders (the canonical case is `RestorableAgentSessionIndex.load()`: per-record `sysctl` plus disk reads, 350ms-1.8s) added to or moved onto the main actor or interactive paths (workspace/panel/tab/window close, SwiftUI body, didSet, menu evaluation, socket handlers). Require routing through the off-main cached accessor `SharedLiveAgentIndex.shared`. Pass for the cache's own background loader and explicit cold-cache fallbacks guarded by a nil check.
+    - path: "**/*.swift"
+      instructions: |
+        Apply `.github/review-bot-rules/swift-hot-event-fanout.md` during review. For hot callbacks, publishers, observers, socket handlers, terminal title changes, and SwiftUI list/sidebar row updates, flag per-surface/per-row events that widen into workspace/app sweeps, main-actor scans, or parent-driven lazy-row fanout. Require preserving the event id, routing to one owner, per-key coalescing/dedupe/cancellation for expensive work, or row-local duplicate-filtered observation.
     - path: "**/*.{swift,ts,tsx,js,jsx,mjs,cjs}"
       instructions: |
         Apply `.github/review-bot-rules/cache-substitution-correctness.md` during review. When the diff replaces a fresh authoritative read with a cached value in a persistence, history, undo, or snapshot path, require explicit handling of cold (never-loaded) and stale (older-than-source) caches, or a documented graceful-degradation rationale. Pass for transient non-persisted UI hints and documented staleness tolerance.
@@ -91,6 +94,10 @@ reviews:
         mode: error
         instructions: |
           For production Swift, TypeScript, JavaScript, shell, and runtime code, fail when the diff violates `.github/review-bot-rules/algorithmic-complexity.md`: nested full-collection scans, per-target rescans for batch actions, repeated sorting/filtering in hot UI/socket/search/process paths, in-memory joins that belong in the data store, or unbenchmarked slower algorithms on paths expected to handle about 1000 workspaces or similar user-owned records. Pass for tiny fixed-size collections, tests and benchmark harnesses, existing debt not worsened, and documented bounds with measurements.
+      - name: "cmux Swift hot event fanout"
+        mode: error
+        instructions: |
+          For production Swift changes, fail when the diff violates `.github/review-bot-rules/swift-hot-event-fanout.md`: a hot per-surface, per-pane, per-session, or per-row event widens into a workspace/app sweep; a hot MainActor callback schedules unbounded filesystem, transcript, process, sort/filter, or collection work without per-key coalescing, in-flight dedupe, cancellation, and bounded retries; or SwiftUI lazy/list rows receive parent-computed volatile global state when row-local duplicate-filtered observation or immutable snapshots would update only the affected rows. Pass for explicit cold refresh/listing paths, tiny fixed-size collections, and benchmark-backed broad work.
       - name: "cmux Swift concurrency"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -23,6 +23,7 @@ Current rules:
 - `swift-concurrent-annotation.md`
 - `swift-expensive-sync-load.md`
 - `swift-file-package-boundaries.md`
+- `swift-hot-event-fanout.md`
 - `swift-logging.md`
 - `swiftui-state-layout.md`
 - `user-facing-errors.md`

--- a/.github/review-bot-rules/swift-hot-event-fanout.md
+++ b/.github/review-bot-rules/swift-hot-event-fanout.md
@@ -1,0 +1,23 @@
+# Swift Hot Event Fanout
+
+Flag Swift hot-path changes that widen a small event into broad work.
+
+Apply this rule to production Swift callbacks, publishers, observers, socket handlers, SwiftUI row updates, terminal title changes, filesystem/process notifications, and other paths that can fire while the user is typing, agents are streaming, terminals are changing titles, or sidebar/list rows are being reconciled.
+
+## Fail
+
+- A per-surface, per-pane, per-session, or per-row event calls a workspace-wide or app-wide sweep when the event already carries the id needed to update one owner.
+- A hot `@MainActor` callback performs or schedules an unbounded filesystem scan, transcript lookup, process walk, sort/filter, or full collection traversal without an explicit per-key coalescer, in-flight dedupe, cancellation, and bounded retry policy.
+- A SwiftUI `LazyVStack`, `LazyHStack`, `List`, or large `ForEach` row receives parent-computed values derived from volatile global state when only the affected row(s) should observe the change. Examples include selection, hover, focus, progress, title, or notification state that causes all rows to be re-instantiated or reconciled for a one-row/two-row change.
+- A hot event path reuses a cold refresh/listing function without preserving event scope. For example, a title-change observer for one terminal surface must not call a workspace adoption path that scans every terminal panel.
+
+## Pass
+
+- Cold refresh paths, explicit reload actions, and list endpoints that intentionally reconcile a full workspace or app snapshot and are not called from high-frequency event streams.
+- Hot paths that route to a single owner by id, then coalesce, cancel, or dedupe expensive work by surface/session/workspace key.
+- Lazy/list rows that receive immutable snapshots and closures, or subscribe row-locally to a global publisher with `removeDuplicates()` on the row's reduced value.
+- Tiny fixed-size collections, or broad work with a documented bound and benchmark/profiling note showing it stays within the relevant UI or runtime budget.
+
+## Report
+
+When this rule fails, name the hot event source, the widened scope, the collection or subsystem being swept, and the expected scale. Suggest the smallest source-of-truth fix: preserve the event's id, route to the single owner, add a per-key coalescer/in-flight task, move heavy work off the main actor, or make row observation local and duplicate-filtered.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -61,6 +61,12 @@
       "severity": "high"
     },
     {
+      "id": "cmux-swift-hot-event-fanout",
+      "rule": "Flag production Swift hot-path changes where a per-surface, per-pane, per-session, or per-row event widens into a workspace/app sweep, where a hot MainActor callback schedules unbounded filesystem/transcript/process/sort/filter/collection work without per-key coalescing, in-flight dedupe, cancellation, and bounded retries, or where SwiftUI lazy/list rows receive parent-computed volatile global state instead of immutable snapshots or row-local duplicate-filtered observation. Pass for explicit cold refresh/listing paths, tiny fixed-size collections, and benchmark-backed broad work.",
+      "scope": ["**/*.swift", "**/Package.swift"],
+      "severity": "high"
+    },
+    {
       "id": "cmux-swiftui-state-layout",
       "rule": "Flag SwiftUI changes that can cause stale state, broad invalidation, layout instability, or main-thread churn: new ObservableObject/@Published state where @Observable is correct, GeometryReader measurement that changes layout, lazy/list row subtrees holding store references, or state mutation during body rendering.",
       "scope": ["**/*.swift"],

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -31,6 +31,11 @@
       "scope": ["**/*.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
     },
     {
+      "path": ".github/review-bot-rules/swift-hot-event-fanout.md",
+      "description": "Source-of-truth cmux review rule for Swift hot events that must not widen into broad work or lazy-row fanout.",
+      "scope": ["**/*.swift", "**/Package.swift"]
+    },
+    {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",
       "description": "Source-of-truth cmux lint rule for Swift concurrency modernization review.",
       "scope": ["**/*.swift", "**/Package.swift"]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -18,6 +18,7 @@ Review production Swift and runtime changes for:
 - Architectural fixes that patch symptoms while leaving bad state representable.
 - User-facing errors, alerts, command output, API error bodies, and recovery copy that expose implementation details.
 - Algorithmic complexity regressions on scalable user-owned collections.
+- Swift hot event fanout where per-surface, per-session, or per-row events widen into workspace/app sweeps, main-actor scans, or parent-driven lazy-row invalidation.
 - Expensive synchronous index/disk/syscall loads (such as `RestorableAgentSessionIndex.load()`) on the main actor or interactive paths instead of the off-main cached accessor.
 - Substituting a cached value for a fresh authoritative read in persistence/history/undo paths without handling cold and stale caches.
 - Local/generated artifacts, dependency checkouts, caches, logs, screenshots, temp folders, and scratch directories that accidentally enter source control.
@@ -53,6 +54,16 @@ Error copy should say what happened in cmux terms, provide concrete user actiona
 For production code over scalable user-owned collections, flag nested full-collection scans, per-target rescans for batch actions, repeated sort/filter/map work in hot UI/socket/search/process paths, in-memory joins that belong in the data store, and unbenchmarked slower algorithms for paths expected to handle about 1000 workspaces or similar records.
 
 Pass for tiny fixed-size collections, tests, benchmark harnesses, existing inefficient code not worsened by the PR, and documented bounds backed by measurements.
+
+## Swift Hot Event Fanout
+
+For production Swift hot paths, preserve the scope of the event that arrived.
+
+Flag terminal title changes, publishers, observers, socket handlers, filesystem/process notifications, SwiftUI list/sidebar row updates, and similar event streams when a per-surface, per-pane, per-session, or per-row event calls a workspace-wide or app-wide sweep. Also flag hot `@MainActor` callbacks that schedule unbounded filesystem, transcript, process, sort/filter, or full collection work without per-key coalescing, in-flight dedupe, cancellation, and bounded retries.
+
+Large lazy/list rows should receive immutable snapshots and closures, or observe row-locally with `removeDuplicates()` on the reduced row value. Do not push parent-computed volatile global state through every row when only the affected row or previous/current selection rows should change.
+
+Pass for explicit cold refresh/listing paths, tiny fixed-size collections, or broad work with a documented bound and benchmark/profiling note.
 
 ## Source Control Artifacts
 


### PR DESCRIPTION
## Summary
- add a shared review-bot rule for Swift hot event fanout
- wire the rule into CodeRabbit and Greptile
- document the rule in the shared review-bot index

## Context
This targets the regression fixed by https://github.com/manaflow-ai/cmux/pull/6460, where title-change adoption and sidebar row selection updates widened small events into broad work.

## Validation
- jq -e . .greptile/config.json .greptile/files.json
- ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml")'
- /Users/lawrence/fun/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode local

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784514884&installation_id=133855650&pr_number=6467&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6467&signature=78ce652f8de1ee664f547a4ae22ddfad8ccf7cadc9a4ae573624b2ae9b69884b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-bot configuration only; no production code paths change.
> 
> **Overview**
> Adds **`swift-hot-event-fanout.md`** as a shared review-bot rule so PRs can catch Swift hot paths that turn small events into broad work (workspace/app sweeps, unbounded MainActor work without per-key coalescing, or parent-driven lazy-row invalidation).
> 
> The rule is wired into **CodeRabbit** (Swift path instructions plus error-mode pre-merge check **cmux Swift hot event fanout**), **Greptile** (`cmux-swift-hot-event-fanout` in config and `files.json`), and the shared index in **`.github/review-bot-rules/README.md`** and **`.greptile/rules.md`**. No app or runtime Swift behavior changes—only review automation and documentation, aligned with regressions like title-change adoption and sidebar selection fanout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b186f9e5dc5d458068dc9a2df0427aad720d2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new Swift code review guidelines and automated enforcement checks to flag specific event-handling patterns in production code during the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->