### PR TITLE
Mock: run full CI after CI routing changes

### DIFF
--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -217,6 +217,7 @@ def test_workflow_empty_diff_runs_all_areas() -> None:
 
 
 def test_router_changes_run_everything() -> None:
+    # Mock verification PRs touch this file to prove the router still fails open.
     assert_areas(["scripts/ci/detect_ci_change_areas.py"], macos=True, web=True, go=True)
     assert_areas(["scripts/ci/subprocess.py"], macos=True, web=True, go=True)
     assert_areas(["tests/test_ci_change_areas.py"], macos=True, web=True, go=True)


### PR DESCRIPTION
## Summary
- Mock PR to verify full CI still works after the CI routing/cache changes merged.
- Touches `tests/test_ci_change_areas.py`, which is intentionally classified as a CI-router change and should run all routed CI areas.
- Do not merge. Close after the full check set is green.

## Testing
- `python3 tests/test_ci_change_areas.py`
- `python3.9 tests/test_ci_change_areas.py`
- `python3 -m py_compile tests/test_ci_change_areas.py scripts/ci/detect_ci_change_areas.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784515923&installation_id=133855650&pr_number=6470&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6470&signature=d5171d1be023434428fbf29b9dbc7fd626f005f514b79cc9dd328a97e7665a10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triggers a full CI run to confirm the router still fails open after recent CI routing/cache updates by touching tests/test_ci_change_areas.py. Test-only change (adds a clarifying comment); close once all checks are green.

<sup>Written for commit 6a47d72ab53c889e69e25b2fc89b586023b32c6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clarifying documentation to test logic explaining expected behavior in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->