### PR TITLE
Fix right sidebar surface shortcut spam routing

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13140,11 +13140,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Surface navigation: Cmd+Shift+] / Cmd+Shift+[
         if matchConfiguredShortcut(event: event, action: .nextSurface) {
-            tabManager?.selectNextSurface()
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            routedManager?.selectNextSurface()
             return true
         }
         if matchConfiguredShortcut(event: event, action: .prevSurface) {
-            tabManager?.selectPreviousSurface()
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            routedManager?.selectPreviousSurface()
             return true
         }
 
@@ -13339,7 +13341,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // goto_tab fallback from creating a new window when the index is out of bounds.
         if shortcutWhenClauseAllows(action: .selectWorkspaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectWorkspaceByNumber) {
-            if let manager = tabManager,
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            if let manager = routedManager,
                let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
                 cmuxDebugLog(
@@ -13354,10 +13357,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Numeric shortcuts for surfaces within the focused pane (9 = last)
         if shortcutWhenClauseAllows(action: .selectSurfaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             if digit == 9 {
-                tabManager?.selectLastSurface()
+                routedManager?.selectLastSurface()
             } else {
-                tabManager?.selectSurface(at: digit - 1)
+                routedManager?.selectSurface(at: digit - 1)
             }
             return true
         }
@@ -13480,11 +13484,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Surface navigation (legacy Ctrl+Tab support)
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: false, option: false, control: true)) {
-            tabManager?.selectNextSurface()
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            routedManager?.selectNextSurface()
             return true
         }
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: true, option: false, control: true)) {
-            tabManager?.selectPreviousSurface()
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            routedManager?.selectPreviousSurface()
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6677,7 +6677,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isRightSidebarFocusResponder(responder, in: window) { return true }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }
         guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
-              let panelId = ghosttyView.terminalSurface?.id else { return sidebarIntentActive }
+              let panelId = ghosttyView.terminalSurface?.id else { return false }
         return GhosttyApp.terminalSurfaceRegistry.isRightSidebarDockSurface(id: panelId)
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13140,13 +13140,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Surface navigation: Cmd+Shift+] / Cmd+Shift+[
         if matchConfiguredShortcut(event: event, action: .nextSurface) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            routedManager?.selectNextSurface()
+            (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectNextSurface()
             return true
         }
         if matchConfiguredShortcut(event: event, action: .prevSurface) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            routedManager?.selectPreviousSurface()
+            (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectPreviousSurface()
             return true
         }
 
@@ -13341,8 +13339,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // goto_tab fallback from creating a new window when the index is out of bounds.
         if shortcutWhenClauseAllows(action: .selectWorkspaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectWorkspaceByNumber) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            if let manager = routedManager,
+            if let manager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager,
                let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
                 cmuxDebugLog(
@@ -13357,11 +13354,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Numeric shortcuts for surfaces within the focused pane (9 = last)
         if shortcutWhenClauseAllows(action: .selectSurfaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
             if digit == 9 {
-                routedManager?.selectLastSurface()
+                (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectLastSurface()
             } else {
-                routedManager?.selectSurface(at: digit - 1)
+                (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectSurface(at: digit - 1)
             }
             return true
         }
@@ -13484,13 +13480,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Surface navigation (legacy Ctrl+Tab support)
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: false, option: false, control: true)) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            routedManager?.selectNextSurface()
+            (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectNextSurface()
             return true
         }
         if matchTabShortcut(event: event, shortcut: StoredShortcut(key: "\t", command: false, shift: true, option: false, control: true)) {
-            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            routedManager?.selectPreviousSurface()
+            (preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager)?.selectPreviousSurface()
             return true
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6671,17 +6671,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func shouldRouteRightSidebarModeShortcut(in window: NSWindow?) -> Bool {
-        guard let window,
-              let responder = window.firstResponder else {
-            return false
-        }
-        if isRightSidebarFocusResponder(responder, in: window) {
-            return true
-        }
+        guard let window else { return false }
+        let sidebarIntentActive = keyboardFocusCoordinator(for: window)?.activeRightSidebarMode != nil
+        guard let responder = window.firstResponder else { return sidebarIntentActive }
+        if isRightSidebarFocusResponder(responder, in: window) { return true }
+        if terminalKeyboardFocusRequest(for: responder) != nil { return false }
         guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
-              let panelId = ghosttyView.terminalSurface?.id else {
-            return false
-        }
+              let panelId = ghosttyView.terminalSurface?.id else { return sidebarIntentActive }
         return GhosttyApp.terminalSurfaceRegistry.isRightSidebarDockSurface(id: panelId)
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */; };
 		6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */; };
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
+		4E6A6F5C1D2B4980A1234568 /* AppDelegateSurfaceShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6A6F5C1D2B4980A1234567 /* AppDelegateSurfaceShortcutRoutingTests.swift */; };
 		A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB000000000000000001 /* AppearanceSettings.swift */; };
 		A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAA000000000000000001 /* AppearanceSettingsTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
@@ -1132,6 +1133,7 @@
 		C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateRenameShortcutContextTests.swift; sourceTree = "<group>"; };
 		6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingRepairProbe.swift; sourceTree = "<group>"; };
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
+		4E6A6F5C1D2B4980A1234567 /* AppDelegateSurfaceShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateSurfaceShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		A11EAB000000000000000001 /* AppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettings.swift; sourceTree = "<group>"; };
 		A11EAA000000000000000001 /* AppearanceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTests.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
@@ -2885,9 +2887,10 @@
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
-				6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */,
-				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
-				C3467AB10000000000000002 /* ShortcutWhenClauseTests.swift */,
+					6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */,
+					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
+					4E6A6F5C1D2B4980A1234567 /* AppDelegateSurfaceShortcutRoutingTests.swift */,
+					C3467AB10000000000000002 /* ShortcutWhenClauseTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
 				C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
 				17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */,
@@ -4211,10 +4214,11 @@
 				E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */,
 				2907A0032907A0032907A003 /* AppDelegateIssue2907RoutingTests.swift in Sources */,
 				D7AB0000000000000000000F /* AppDelegateMoveTabToNewWorkspaceTests.swift in Sources */,
-				C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
-				6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */,
-				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
-				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
+					C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
+					6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */,
+					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
+					4E6A6F5C1D2B4980A1234568 /* AppDelegateSurfaceShortcutRoutingTests.swift in Sources */,
+					A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
 				FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */,
 				7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7261,6 +7261,69 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertTrue(secondPanel.isTextBoxActive, "Cmd+Shift+A should activate TextBox in the event window")
     }
 
+    func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId),
+              let firstWorkspace = firstManager.selectedWorkspace,
+              let secondWorkspace = secondManager.selectedWorkspace,
+              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil,
+              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil else {
+            XCTFail("Expected two window contexts and three surfaces in the event window")
+            return
+        }
+
+        let expectedSurfaceIds = Array(secondWorkspace.orderedPanelIds.prefix(3))
+        XCTAssertEqual(expectedSurfaceIds.count, 3, "Test needs three ordered surfaces")
+        XCTAssertNotEqual(firstWorkspace.id, secondWorkspace.id)
+
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        let digitEvents: [(digit: Int, event: NSEvent)] = [
+            (1, makeKeyDownEvent(key: "1", modifiers: [.control], keyCode: 18, windowNumber: secondWindow.windowNumber)),
+            (2, makeKeyDownEvent(key: "2", modifiers: [.control], keyCode: 19, windowNumber: secondWindow.windowNumber)),
+            (3, makeKeyDownEvent(key: "3", modifiers: [.control], keyCode: 20, windowNumber: secondWindow.windowNumber))
+        ].compactMap { digit, event in
+            guard let event else { return nil }
+            return (digit, event)
+        }
+        XCTAssertEqual(digitEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
+
+        withTemporaryShortcut(action: .selectSurfaceByNumber) {
+            for cycle in 0..<10 {
+                for (digit, event) in digitEvents {
+#if DEBUG
+                    XCTAssertTrue(
+                        appDelegate.debugHandleCustomShortcut(event: event),
+                        "Ctrl+\(digit) should be handled on cycle \(cycle)"
+                    )
+#else
+                    XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+                    XCTAssertEqual(
+                        secondWorkspace.focusedPanelId,
+                        expectedSurfaceIds[digit - 1],
+                        "Ctrl+\(digit) should focus surface \(digit) in the event window on cycle \(cycle)"
+                    )
+                }
+            }
+        }
+    }
+
     func testTextBoxFocusIntentRestoresAfterYieldToAnotherPanel() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -7261,69 +7261,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertTrue(secondPanel.isTextBoxActive, "Cmd+Shift+A should activate TextBox in the event window")
     }
 
-    func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
-
-        let firstWindowId = appDelegate.createMainWindow()
-        let secondWindowId = appDelegate.createMainWindow()
-
-        defer {
-            closeWindow(withId: firstWindowId)
-            closeWindow(withId: secondWindowId)
-        }
-
-        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
-              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
-              let secondWindow = window(withId: secondWindowId),
-              let firstWorkspace = firstManager.selectedWorkspace,
-              let secondWorkspace = secondManager.selectedWorkspace,
-              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil,
-              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil else {
-            XCTFail("Expected two window contexts and three surfaces in the event window")
-            return
-        }
-
-        let expectedSurfaceIds = Array(secondWorkspace.orderedPanelIds.prefix(3))
-        XCTAssertEqual(expectedSurfaceIds.count, 3, "Test needs three ordered surfaces")
-        XCTAssertNotEqual(firstWorkspace.id, secondWorkspace.id)
-
-        appDelegate.tabManager = firstManager
-        XCTAssertTrue(appDelegate.tabManager === firstManager)
-
-        let digitEvents: [(digit: Int, event: NSEvent)] = [
-            (1, makeKeyDownEvent(key: "1", modifiers: [.control], keyCode: 18, windowNumber: secondWindow.windowNumber)),
-            (2, makeKeyDownEvent(key: "2", modifiers: [.control], keyCode: 19, windowNumber: secondWindow.windowNumber)),
-            (3, makeKeyDownEvent(key: "3", modifiers: [.control], keyCode: 20, windowNumber: secondWindow.windowNumber))
-        ].compactMap { digit, event in
-            guard let event else { return nil }
-            return (digit, event)
-        }
-        XCTAssertEqual(digitEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
-
-        withTemporaryShortcut(action: .selectSurfaceByNumber) {
-            for cycle in 0..<10 {
-                for (digit, event) in digitEvents {
-#if DEBUG
-                    XCTAssertTrue(
-                        appDelegate.debugHandleCustomShortcut(event: event),
-                        "Ctrl+\(digit) should be handled on cycle \(cycle)"
-                    )
-#else
-                    XCTFail("debugHandleCustomShortcut is only available in DEBUG")
-#endif
-                    XCTAssertEqual(
-                        secondWorkspace.focusedPanelId,
-                        expectedSurfaceIds[digit - 1],
-                        "Ctrl+\(digit) should focus surface \(digit) in the event window on cycle \(cycle)"
-                    )
-                }
-            }
-        }
-    }
-
     func testTextBoxFocusIntentRestoresAfterYieldToAnotherPanel() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -7,6 +7,10 @@ import Testing
 @testable import cmux
 #endif
 
+private final class ShortcutUnrelatedResponderView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}
+
 @MainActor
 @Suite(.serialized)
 struct AppDelegateSurfaceShortcutRoutingTests {
@@ -56,6 +60,44 @@ struct AppDelegateSurfaceShortcutRoutingTests {
                     )
                 }
             }
+        }
+    }
+
+    @Test func rightSidebarModeShortcutsDoNotUseStaleIntentForUnrelatedResponder() throws {
+        try withIsolatedShortcutSettings {
+            let appDelegate = try #require(AppDelegate.shared)
+
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
+
+            let window = try #require(window(withId: windowId))
+            window.makeKeyAndOrderFront(nil)
+            window.displayIfNeeded()
+            appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .sessions, in: window)
+            let fileExplorerState = try #require(appDelegate.fileExplorerState)
+            fileExplorerState.mode = .sessions
+
+            let unrelatedResponder = ShortcutUnrelatedResponderView(frame: NSRect(x: 0, y: 0, width: 8, height: 8))
+            window.contentView?.addSubview(unrelatedResponder)
+            defer { unrelatedResponder.removeFromSuperview() }
+            #expect(window.makeFirstResponder(unrelatedResponder))
+            #expect(window.firstResponder === unrelatedResponder)
+
+            let event = try #require(makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: window.windowNumber))
+#if DEBUG
+            _ = appDelegate.debugHandleCustomShortcut(event: event)
+#else
+            Issue.record("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+            #expect(
+                fileExplorerState.mode == .sessions,
+                "Ctrl+1 should not switch right-sidebar mode when a non-sidebar responder owns focus"
+            )
+            #expect(
+                window.firstResponder === unrelatedResponder,
+                "Ctrl+1 should not move focus away from the unrelated responder"
+            )
         }
     }
 

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import AppKit
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -8,124 +8,105 @@ import AppKit
 #endif
 
 @MainActor
-final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
-    func testRightSidebarModeShortcutsDoNotFallThroughWhenResponderTemporarilyClears() {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
+@Suite(.serialized)
+struct AppDelegateSurfaceShortcutRoutingTests {
+    @Test func rightSidebarModeShortcutsDoNotFallThroughWhenResponderTemporarilyClears() throws {
+        try withIsolatedShortcutSettings {
+            let appDelegate = try #require(AppDelegate.shared)
 
-        let windowId = appDelegate.createMainWindow()
-        defer { closeWindow(withId: windowId) }
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
 
-        guard let window = window(withId: windowId),
-              let manager = appDelegate.tabManagerFor(windowId: windowId),
-              let workspace = manager.selectedWorkspace,
-              let panelId = workspace.focusedPanelId,
-              let terminalPanel = workspace.terminalPanel(for: panelId) else {
-            XCTFail("Expected focused terminal surface")
-            return
-        }
+            let window = try #require(window(withId: windowId))
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            let workspace = try #require(manager.selectedWorkspace)
+            let panelId = try #require(workspace.focusedPanelId)
+            let terminalPanel = try #require(workspace.terminalPanel(for: panelId))
 
-        window.makeKeyAndOrderFront(nil)
-        window.displayIfNeeded()
-        terminalPanel.hostedView.setVisibleInUI(true)
-        terminalPanel.hostedView.setActive(true)
-        appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .sessions, in: window)
+            window.makeKeyAndOrderFront(nil)
+            window.displayIfNeeded()
+            terminalPanel.hostedView.setVisibleInUI(true)
+            terminalPanel.hostedView.setActive(true)
+            appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .sessions, in: window)
 
-        let rawModeEvents: [(mode: RightSidebarMode, event: NSEvent?)] = [
-            (.files, makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: window.windowNumber)),
-            (.find, makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: window.windowNumber)),
-            (.sessions, makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: window.windowNumber))
-        ]
-        let modeEvents = rawModeEvents.compactMap { entry -> (mode: RightSidebarMode, event: NSEvent)? in
-            guard let event = entry.event else { return nil }
-            return (entry.mode, event)
-        }
-        XCTAssertEqual(modeEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
+            let modeEvents: [(mode: RightSidebarMode, event: NSEvent)] = [
+                (.files, try #require(makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: window.windowNumber))),
+                (.find, try #require(makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: window.windowNumber))),
+                (.sessions, try #require(makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: window.windowNumber)))
+            ]
 
-        for cycle in 0..<10 {
-            for (mode, event) in modeEvents {
-                _ = window.makeFirstResponder(nil)
+            for cycle in 0..<10 {
+                for (mode, event) in modeEvents {
+                    _ = window.makeFirstResponder(nil)
 #if DEBUG
-                XCTAssertTrue(
-                    appDelegate.debugHandleCustomShortcut(event: event),
-                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should be handled on cycle \(cycle)"
-                )
+                    #expect(
+                        appDelegate.debugHandleCustomShortcut(event: event),
+                        "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should be handled on cycle \(cycle)"
+                    )
 #else
-                XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+                    Issue.record("debugHandleCustomShortcut is only available in DEBUG")
 #endif
-                XCTAssertEqual(
-                    appDelegate.fileExplorerState?.mode,
-                    mode,
-                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should keep routing as a right-sidebar mode shortcut on cycle \(cycle)"
-                )
-                XCTAssertFalse(
-                    terminalPanel.hostedView.isSurfaceViewFirstResponder(),
-                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should not refocus the terminal on cycle \(cycle)"
-                )
+                    #expect(
+                        appDelegate.fileExplorerState?.mode == mode,
+                        "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should keep routing as a right-sidebar mode shortcut on cycle \(cycle)"
+                    )
+                    #expect(
+                        !terminalPanel.hostedView.isSurfaceViewFirstResponder(),
+                        "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should not refocus the terminal on cycle \(cycle)"
+                    )
+                }
             }
         }
     }
 
-    func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
-        guard let appDelegate = AppDelegate.shared else {
-            XCTFail("Expected AppDelegate.shared")
-            return
-        }
+    @Test func surfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() throws {
+        try withIsolatedShortcutSettings {
+            let appDelegate = try #require(AppDelegate.shared)
 
-        let firstWindowId = appDelegate.createMainWindow()
-        let secondWindowId = appDelegate.createMainWindow()
-        defer {
-            closeWindow(withId: firstWindowId)
-            closeWindow(withId: secondWindowId)
-        }
+            let firstWindowId = appDelegate.createMainWindow()
+            let secondWindowId = appDelegate.createMainWindow()
+            defer {
+                closeWindow(withId: firstWindowId)
+                closeWindow(withId: secondWindowId)
+            }
 
-        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
-              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
-              let secondWindow = window(withId: secondWindowId),
-              let firstWorkspace = firstManager.selectedWorkspace,
-              let secondWorkspace = secondManager.selectedWorkspace,
-              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil,
-              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil else {
-            XCTFail("Expected two window contexts and three surfaces in the event window")
-            return
-        }
+            let firstManager = try #require(appDelegate.tabManagerFor(windowId: firstWindowId))
+            let secondManager = try #require(appDelegate.tabManagerFor(windowId: secondWindowId))
+            let secondWindow = try #require(window(withId: secondWindowId))
+            let firstWorkspace = try #require(firstManager.selectedWorkspace)
+            let secondWorkspace = try #require(secondManager.selectedWorkspace)
+            _ = try #require(secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true))
+            _ = try #require(secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true))
 
-        let expectedSurfaceIds = Array(secondWorkspace.orderedPanelIds.prefix(3))
-        XCTAssertEqual(expectedSurfaceIds.count, 3, "Test needs three ordered surfaces")
-        XCTAssertNotEqual(firstWorkspace.id, secondWorkspace.id)
+            let expectedSurfaceIds = Array(secondWorkspace.orderedPanelIds.prefix(3))
+            #expect(expectedSurfaceIds.count == 3, "Test needs three ordered surfaces")
+            #expect(firstWorkspace.id != secondWorkspace.id)
 
-        appDelegate.tabManager = firstManager
-        XCTAssertTrue(appDelegate.tabManager === firstManager)
+            appDelegate.tabManager = firstManager
+            #expect(appDelegate.tabManager === firstManager)
 
-        let rawDigitEvents: [(digit: Int, event: NSEvent?)] = [
-            (1, makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: secondWindow.windowNumber)),
-            (2, makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: secondWindow.windowNumber)),
-            (3, makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: secondWindow.windowNumber))
-        ]
-        let digitEvents = rawDigitEvents.compactMap { entry -> (digit: Int, event: NSEvent)? in
-            guard let event = entry.event else { return nil }
-            return (entry.digit, event)
-        }
-        XCTAssertEqual(digitEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
+            let digitEvents: [(digit: Int, event: NSEvent)] = [
+                (1, try #require(makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: secondWindow.windowNumber))),
+                (2, try #require(makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: secondWindow.windowNumber))),
+                (3, try #require(makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: secondWindow.windowNumber)))
+            ]
 
-        withTemporaryShortcut(action: .selectSurfaceByNumber) {
-            for cycle in 0..<10 {
-                for (digit, event) in digitEvents {
+            try withTemporaryShortcut(action: .selectSurfaceByNumber) {
+                for cycle in 0..<10 {
+                    for (digit, event) in digitEvents {
 #if DEBUG
-                    XCTAssertTrue(
-                        appDelegate.debugHandleCustomShortcut(event: event),
-                        "Ctrl+\(digit) should be handled on cycle \(cycle)"
-                    )
+                        #expect(
+                            appDelegate.debugHandleCustomShortcut(event: event),
+                            "Ctrl+\(digit) should be handled on cycle \(cycle)"
+                        )
 #else
-                    XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+                        Issue.record("debugHandleCustomShortcut is only available in DEBUG")
 #endif
-                    XCTAssertEqual(
-                        secondWorkspace.focusedPanelId,
-                        expectedSurfaceIds[digit - 1],
-                        "Ctrl+\(digit) should focus surface \(digit) in the event window on cycle \(cycle)"
-                    )
+                        #expect(
+                            secondWorkspace.focusedPanelId == expectedSurfaceIds[digit - 1],
+                            "Ctrl+\(digit) should focus surface \(digit) in the event window on cycle \(cycle)"
+                        )
+                    }
                 }
             }
         }
@@ -146,7 +127,7 @@ final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
         )
     }
 
-    private func withTemporaryShortcut(action: KeyboardShortcutSettings.Action, _ body: () -> Void) {
+    private func withTemporaryShortcut(action: KeyboardShortcutSettings.Action, _ body: () throws -> Void) rethrows {
         let hadPersistedShortcut = UserDefaults.standard.object(forKey: action.defaultsKey) != nil
         let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
         defer {
@@ -163,7 +144,42 @@ final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
 #if DEBUG
         AppDelegate.shared?.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
 #endif
-        body()
+        try body()
+    }
+
+    private func withIsolatedShortcutSettings(_ body: () throws -> Void) rethrows {
+        let actionsWithPersistedShortcut = Set(
+            KeyboardShortcutSettings.Action.allCases.filter {
+                UserDefaults.standard.object(forKey: $0.defaultsKey) != nil
+            }
+        )
+        let savedShortcutsByAction = Dictionary(
+            uniqueKeysWithValues: actionsWithPersistedShortcut.map { action in
+                (action, KeyboardShortcutSettings.shortcut(for: action))
+            }
+        )
+        let originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
+            prefix: "cmux-surface-shortcut-routing"
+        )
+        KeyboardShortcutSettings.resetAll()
+#if DEBUG
+        AppDelegate.shared?.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
+#endif
+        defer {
+            KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+            for action in KeyboardShortcutSettings.Action.allCases {
+                if actionsWithPersistedShortcut.contains(action),
+                   let savedShortcut = savedShortcutsByAction[action] {
+                    KeyboardShortcutSettings.setShortcut(savedShortcut, for: action)
+                } else {
+                    KeyboardShortcutSettings.resetShortcut(for: action)
+                }
+            }
+#if DEBUG
+            AppDelegate.shared?.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
+#endif
+        }
+        try body()
     }
 
     private func window(withId windowId: UUID) -> NSWindow? {

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
+    func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId),
+              let firstWorkspace = firstManager.selectedWorkspace,
+              let secondWorkspace = secondManager.selectedWorkspace,
+              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil,
+              secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true) != nil else {
+            XCTFail("Expected two window contexts and three surfaces in the event window")
+            return
+        }
+
+        let expectedSurfaceIds = Array(secondWorkspace.orderedPanelIds.prefix(3))
+        XCTAssertEqual(expectedSurfaceIds.count, 3, "Test needs three ordered surfaces")
+        XCTAssertNotEqual(firstWorkspace.id, secondWorkspace.id)
+
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        let digitEvents: [(digit: Int, event: NSEvent)] = [
+            (1, makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: secondWindow.windowNumber)),
+            (2, makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: secondWindow.windowNumber)),
+            (3, makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: secondWindow.windowNumber))
+        ].compactMap { digit, event in
+            guard let event else { return nil }
+            return (digit, event)
+        }
+        XCTAssertEqual(digitEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
+
+        withTemporaryShortcut(action: .selectSurfaceByNumber) {
+            for cycle in 0..<10 {
+                for (digit, event) in digitEvents {
+#if DEBUG
+                    XCTAssertTrue(
+                        appDelegate.debugHandleCustomShortcut(event: event),
+                        "Ctrl+\(digit) should be handled on cycle \(cycle)"
+                    )
+#else
+                    XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+                    XCTAssertEqual(
+                        secondWorkspace.focusedPanelId,
+                        expectedSurfaceIds[digit - 1],
+                        "Ctrl+\(digit) should focus surface \(digit) in the event window on cycle \(cycle)"
+                    )
+                }
+            }
+        }
+    }
+
+    private func makeKeyDownEvent(key: String, keyCode: UInt16, windowNumber: Int) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: key,
+            charactersIgnoringModifiers: key,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+
+    private func withTemporaryShortcut(action: KeyboardShortcutSettings.Action, _ body: () -> Void) {
+        let hadPersistedShortcut = UserDefaults.standard.object(forKey: action.defaultsKey) != nil
+        let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
+        defer {
+            if hadPersistedShortcut {
+                KeyboardShortcutSettings.setShortcut(originalShortcut, for: action)
+            } else {
+                KeyboardShortcutSettings.resetShortcut(for: action)
+            }
+#if DEBUG
+            AppDelegate.shared?.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
+#endif
+        }
+        KeyboardShortcutSettings.setShortcut(action.defaultShortcut, for: action)
+#if DEBUG
+        AppDelegate.shared?.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
+#endif
+        body()
+    }
+
+    private func window(withId windowId: UUID) -> NSWindow? {
+        AppDelegate.shared?.windowForMainWindowId(windowId)
+    }
+
+    private func closeWindow(withId windowId: UUID) {
+        guard let window = window(withId: windowId) else { return }
+        window.close()
+    }
+}

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -21,7 +21,7 @@ struct AppDelegateSurfaceShortcutRoutingTests {
             let windowId = appDelegate.createMainWindow()
             defer { closeWindow(withId: windowId) }
 
-            let window = try #require(window(withId: windowId))
+            let window = try #require(mainWindow(for: windowId))
             let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
             let workspace = try #require(manager.selectedWorkspace)
             let panelId = try #require(workspace.focusedPanelId)
@@ -70,7 +70,7 @@ struct AppDelegateSurfaceShortcutRoutingTests {
             let windowId = appDelegate.createMainWindow()
             defer { closeWindow(withId: windowId) }
 
-            let window = try #require(window(withId: windowId))
+            let window = try #require(mainWindow(for: windowId))
             window.makeKeyAndOrderFront(nil)
             window.displayIfNeeded()
             appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .sessions, in: window)
@@ -114,7 +114,7 @@ struct AppDelegateSurfaceShortcutRoutingTests {
 
             let firstManager = try #require(appDelegate.tabManagerFor(windowId: firstWindowId))
             let secondManager = try #require(appDelegate.tabManagerFor(windowId: secondWindowId))
-            let secondWindow = try #require(window(withId: secondWindowId))
+            let secondWindow = try #require(mainWindow(for: secondWindowId))
             let firstWorkspace = try #require(firstManager.selectedWorkspace)
             let secondWorkspace = try #require(secondManager.selectedWorkspace)
             _ = try #require(secondWorkspace.newTerminalSurfaceInFocusedPane(focus: true))
@@ -224,12 +224,12 @@ struct AppDelegateSurfaceShortcutRoutingTests {
         try body()
     }
 
-    private func window(withId windowId: UUID) -> NSWindow? {
+    private func mainWindow(for windowId: UUID) -> NSWindow? {
         AppDelegate.shared?.windowForMainWindowId(windowId)
     }
 
     private func closeWindow(withId windowId: UUID) {
-        guard let window = window(withId: windowId) else { return }
+        guard let window = mainWindow(for: windowId) else { return }
         window.close()
     }
 }

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -7,6 +7,7 @@ import AppKit
 @testable import cmux
 #endif
 
+@MainActor
 final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
     func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
         guard let appDelegate = AppDelegate.shared else {
@@ -39,13 +40,14 @@ final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
         appDelegate.tabManager = firstManager
         XCTAssertTrue(appDelegate.tabManager === firstManager)
 
-        let digitEvents: [(digit: Int, event: NSEvent)] = [
+        let rawDigitEvents: [(digit: Int, event: NSEvent?)] = [
             (1, makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: secondWindow.windowNumber)),
             (2, makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: secondWindow.windowNumber)),
             (3, makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: secondWindow.windowNumber))
-        ].compactMap { digit, event in
-            guard let event else { return nil }
-            return (digit, event)
+        ]
+        let digitEvents = rawDigitEvents.compactMap { entry -> (digit: Int, event: NSEvent)? in
+            guard let event = entry.event else { return nil }
+            return (entry.digit, event)
         }
         XCTAssertEqual(digitEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
 

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -83,6 +83,11 @@ struct AppDelegateSurfaceShortcutRoutingTests {
             #expect(window.makeFirstResponder(unrelatedResponder))
             #expect(window.firstResponder === unrelatedResponder)
 
+            KeyboardShortcutSettings.clearShortcut(for: .selectSurfaceByNumber)
+#if DEBUG
+            appDelegate.debugResetShortcutRoutingStateForTesting(clearFocusedWindowOverride: false)
+#endif
+
             let event = try #require(makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: window.windowNumber))
 #if DEBUG
             _ = appDelegate.debugHandleCustomShortcut(event: event)

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -9,6 +9,65 @@ import AppKit
 
 @MainActor
 final class AppDelegateSurfaceShortcutRoutingTests: XCTestCase {
+    func testRightSidebarModeShortcutsDoNotFallThroughWhenResponderTemporarilyClears() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId,
+              let terminalPanel = workspace.terminalPanel(for: panelId) else {
+            XCTFail("Expected focused terminal surface")
+            return
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        terminalPanel.hostedView.setVisibleInUI(true)
+        terminalPanel.hostedView.setActive(true)
+        appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .sessions, in: window)
+
+        let rawModeEvents: [(mode: RightSidebarMode, event: NSEvent?)] = [
+            (.files, makeKeyDownEvent(key: "1", keyCode: 18, windowNumber: window.windowNumber)),
+            (.find, makeKeyDownEvent(key: "2", keyCode: 19, windowNumber: window.windowNumber)),
+            (.sessions, makeKeyDownEvent(key: "3", keyCode: 20, windowNumber: window.windowNumber))
+        ]
+        let modeEvents = rawModeEvents.compactMap { entry -> (mode: RightSidebarMode, event: NSEvent)? in
+            guard let event = entry.event else { return nil }
+            return (entry.mode, event)
+        }
+        XCTAssertEqual(modeEvents.count, 3, "Failed to construct Ctrl+1/2/3 events")
+
+        for cycle in 0..<10 {
+            for (mode, event) in modeEvents {
+                _ = window.makeFirstResponder(nil)
+#if DEBUG
+                XCTAssertTrue(
+                    appDelegate.debugHandleCustomShortcut(event: event),
+                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should be handled on cycle \(cycle)"
+                )
+#else
+                XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+                XCTAssertEqual(
+                    appDelegate.fileExplorerState?.mode,
+                    mode,
+                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should keep routing as a right-sidebar mode shortcut on cycle \(cycle)"
+                )
+                XCTAssertFalse(
+                    terminalPanel.hostedView.isSurfaceViewFirstResponder(),
+                    "Ctrl+\(event.charactersIgnoringModifiers ?? "?") should not refocus the terminal on cycle \(cycle)"
+                )
+            }
+        }
+    }
+
     func testSurfaceNumberShortcutsCycleInEventWindowWhenActiveManagerIsStale() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")


### PR DESCRIPTION
## Summary
- Add a regression test that cycles Ctrl+1, Ctrl+2, and Ctrl+3 ten times against the event window while the app-wide TabManager is stale.
- Route numbered surface shortcuts, numbered workspace shortcuts, and adjacent surface shortcuts through the shortcut event/focused window context before falling back to the global manager.

## Testing
- git diff --check
- Local unit test execution blocked by cmuxterm-hq guard: xcodebuildmcp test launches the TEST_HOST app locally and must run on CI or a cloud Mac.
- ./scripts/reload-cloud.sh --tag rs3 (running)

## Issues
- Task: Keyboard shortcuts like Ctrl 1, 2, 3 in the right sidebar get messed up when spammed; add a ten-cycle regression test and fix routing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784516251&installation_id=133855650&pr_number=6472&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6472&signature=09d3022bb0ca9b17acfbc5749ca9f1ef0feb71b4a69cb9cdeb0dbfb4be9aff9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global keyboard shortcut routing and focus/sidebar intent logic in AppDelegate; behavior changes affect multi-window and rapid key repeat, though scoped to navigation shortcuts with new regression tests.
> 
> **Overview**
> Fixes wrong-window and fallthrough behavior when spamming **right-sidebar mode** shortcuts (Ctrl+1/2/3) and **numbered surface** shortcuts.
> 
> **Right-sidebar routing:** `shouldRouteRightSidebarModeShortcut` now treats an active right-sidebar keyboard intent as sufficient when `firstResponder` is temporarily `nil`, so mode shortcuts stay on the sidebar instead of falling through to terminal/surface handlers. It also refuses sidebar routing when the responder is a terminal focus request, and no longer applies stale sidebar intent when an unrelated responder owns focus.
> 
> **Multi-window routing:** Next/previous surface (including legacy Ctrl+Tab), workspace-by-number, and surface-by-number shortcuts now target the **event/focused window’s** `TabManager` via `preferredMainWindowContextForShortcutRouting`, with fallback to the global `tabManager`—so shortcuts hit the window that received the key event when the app-wide manager is stale.
> 
> Adds **`AppDelegateSurfaceShortcutRoutingTests`** (10-cycle spam, unrelated-responder safety, stale-manager multi-window surface digits) and wires the file into the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0ac18dad95eef640bb45ba007823ccae38a153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong-window routing and fallthrough when spamming right sidebar mode shortcuts and surface/workspace digits. Navigation now uses the focused window and respects active sidebar intent without stealing unrelated focus.

- **Bug Fixes**
  - Route surface navigation (Cmd+Shift+]/[ and legacy Ctrl+Tab) and digit-based shortcuts (workspace and surface 1–9, 9 = last) through the event/focused window’s tab manager, with fallback to the global manager.
  - Keep right sidebar mode shortcuts (Ctrl+1/2/3) on the sidebar when a sidebar intent is active; terminal-focus requests block sidebar routing; ignore stale sidebar intent when an unrelated responder owns focus.
  - Add Swift Testing `AppDelegateSurfaceShortcutRoutingTests`: 10-cycle Ctrl+1/2/3 spam; unrelated-responder safety (temporarily unbinds surface-number shortcut to avoid interference); and digit-based selection in the event window when the app-wide manager is stale; also avoids window helper naming collisions.

<sup>Written for commit 5c0ac18dad95eef640bb45ba007823ccae38a153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed right-sidebar mode shortcut routing when responder focus temporarily lacks terminal-surface context, preventing incorrect fallthrough.
  * Improved surface navigation shortcut behavior across multiple windows: next/previous surface and digit-based surface/workspace selection now target the correct active window state, including legacy Ctrl+Tab behavior.
* **Tests**
  * Added XCTest coverage for right-sidebar shortcut stability and digit-based surface selection cycling across multiple windows, including stale active-manager scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->