### PR TITLE
Route agent session web resource CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       macos: ${{ steps.detect.outputs.macos }}
       web: ${{ steps.detect.outputs.web }}
       go: ${{ steps.detect.outputs.go }}
+      agent_session_web: ${{ steps.detect.outputs.agent_session_web }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,6 +43,7 @@ jobs:
               echo "macos=true"
               echo "web=true"
               echo "go=true"
+              echo "agent_session_web=true"
             } >> "$GITHUB_OUTPUT"
           }
 
@@ -817,7 +819,7 @@ jobs:
 
   agent-session-web-resources:
     needs: changes
-    if: ${{ needs.changes.outputs.macos == 'true' }}
+    if: ${{ needs.changes.outputs.agent_session_web == 'true' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,45 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
 
+  tests-required-status:
+    name: tests
+    needs:
+      - changes
+      - tests
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    timeout-minutes: 5
+    steps:
+      - name: Check app-host unit test routing
+        env:
+          TESTS_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["TESTS_NEEDS"])
+          changes = needs["changes"]
+          tests = needs["tests"]
+          macos = changes.get("outputs", {}).get("macos")
+
+          if changes["result"] != "success":
+              print(f"changes: {changes['result']}", file=sys.stderr)
+              sys.exit(1)
+
+          if macos == "true" and tests["result"] != "success":
+              print(f"app-host unit tests were required but did not pass: {tests['result']}", file=sys.stderr)
+              sys.exit(1)
+
+          if macos != "true" and tests["result"] not in {"success", "skipped"}:
+              print(f"app-host unit tests had unexpected result for macos={macos}: {tests['result']}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"changes.macos={macos}")
+          print(f"app-host unit tests={tests['result']}")
+          PY
+
   swift-package-tests:
     needs: changes
     if: ${{ needs.changes.outputs.macos == 'true' }}
@@ -1856,6 +1895,7 @@ jobs:
       - react-apps-check
       - web-db-migrations
       - tests
+      - tests-required-status
       - swift-package-tests
       - agent-session-web-resources
       - tests-build-and-lag

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -20,7 +20,7 @@ class ChangeAreas:
     agent_session_web: bool
 
     @classmethod
-    def all(cls) -> "ChangeAreas":
+    def all(cls) -> ChangeAreas:
         return cls(macos=True, web=True, go=True, agent_session_web=True)
 
     def as_output_lines(self) -> list[str]:

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -17,16 +17,18 @@ class ChangeAreas:
     macos: bool
     web: bool
     go: bool
+    agent_session_web: bool
 
     @classmethod
     def all(cls) -> "ChangeAreas":
-        return cls(macos=True, web=True, go=True)
+        return cls(macos=True, web=True, go=True, agent_session_web=True)
 
     def as_output_lines(self) -> list[str]:
         return [
             f"macos={bool_output(self.macos)}",
             f"web={bool_output(self.web)}",
             f"go={bool_output(self.go)}",
+            f"agent_session_web={bool_output(self.agent_session_web)}",
         ]
 
 
@@ -83,6 +85,25 @@ def is_go_change(path: str) -> bool:
     }
 
 
+def is_agent_session_web_change(path: str) -> bool:
+    if path.startswith(
+        (
+            "webviews/src/agent-session/",
+            "Resources/agent-session-react/",
+            "Resources/agent-session-solid/",
+        )
+    ):
+        return True
+    return path in {
+        "package.json",
+        "bun.lock",
+        "webviews/package.json",
+        "webviews/bun.lock",
+        "scripts/build-agent-session-web.sh",
+        "Resources/markdown-viewer/marked.min.js",
+    }
+
+
 def is_macos_neutral(path: str) -> bool:
     if path.startswith(("docs/", "design/", "plans/", "ios/", "web/", "webviews/", "daemon/remote/")):
         return True
@@ -105,6 +126,7 @@ def classify_files(paths: Iterable[str]) -> ChangeAreas:
     macos = False
     web = False
     go = False
+    agent_session_web = False
 
     for raw_path in paths:
         path = normalize_path(raw_path)
@@ -114,15 +136,23 @@ def classify_files(paths: Iterable[str]) -> ChangeAreas:
             macos = True
             web = True
             go = True
+            agent_session_web = True
             continue
         if is_web_change(path):
             web = True
         if is_go_change(path):
             go = True
+        if is_agent_session_web_change(path):
+            agent_session_web = True
         if is_macos_change(path):
             macos = True
 
-    return ChangeAreas(macos=macos, web=web, go=go)
+    return ChangeAreas(
+        macos=macos,
+        web=web,
+        go=go,
+        agent_session_web=agent_session_web,
+    )
 
 
 def run_git(args: list[str]) -> str:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -394,6 +394,7 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
         "react-apps-check",
         "web-db-migrations",
         "tests",
+        "tests-required-status",
         "tests-build-and-lag",
         "release-ghostty-cli-helper",
         "release-build",
@@ -403,6 +404,17 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
 
     assert "if: ${{ always() }}" in block
     assert 'allowed = {"success", "skipped"}' in block
+
+
+def test_required_tests_status_waits_for_app_host_matrix() -> None:
+    block = workflow_job_block("tests-required-status")
+
+    assert "name: tests" in block
+    assert "      - changes" in block
+    assert "      - tests" in block
+    assert "if: ${{ always() }}" in block
+    assert 'macos == "true" and tests["result"] != "success"' in block
+    assert 'tests["result"] not in {"success", "skipped"}' in block
 
 
 def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -23,11 +23,19 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
 
-def assert_areas(paths: list[str], *, macos: bool, web: bool, go: bool) -> None:
+def assert_areas(
+    paths: list[str],
+    *,
+    macos: bool,
+    web: bool,
+    go: bool,
+    agent_session_web: bool = False,
+) -> None:
     actual = module.classify_files(paths)
     assert actual.macos is macos, (paths, actual)
     assert actual.web is web, (paths, actual)
     assert actual.go is go, (paths, actual)
+    assert actual.agent_session_web is agent_session_web, (paths, actual)
 
 
 def test_docs_only_skips_expensive_areas() -> None:
@@ -46,8 +54,18 @@ def test_web_only_runs_web_without_macos() -> None:
     assert_areas(["web/app/page.tsx", "webviews/src/diff/App.tsx"], macos=False, web=True, go=False)
 
 
+def test_website_only_does_not_run_agent_session_resource_check() -> None:
+    assert_areas(["web/app/page.tsx"], macos=False, web=True, go=False, agent_session_web=False)
+
+
 def test_agent_session_webview_sources_run_bundled_asset_check() -> None:
-    assert_areas(["webviews/src/agent-session/shared/message.test.ts"], macos=True, web=True, go=False)
+    assert_areas(
+        ["webviews/src/agent-session/shared/message.test.ts"],
+        macos=True,
+        web=True,
+        go=False,
+        agent_session_web=True,
+    )
 
 
 def test_markdown_viewer_resources_run_webviews_asset_guard() -> None:
@@ -56,16 +74,35 @@ def test_markdown_viewer_resources_run_webviews_asset_guard() -> None:
         macos=True,
         web=True,
         go=False,
+        agent_session_web=True,
     )
 
 
 def test_root_agent_web_dependencies_run_web_and_macos() -> None:
-    assert_areas(["package.json", "bun.lock"], macos=True, web=True, go=False)
+    assert_areas(
+        ["package.json", "bun.lock"],
+        macos=True,
+        web=True,
+        go=False,
+        agent_session_web=True,
+    )
 
 
 def test_agent_session_resources_run_web_and_macos() -> None:
-    assert_areas(["Resources/agent-session-react/index.js"], macos=True, web=True, go=False)
-    assert_areas(["Resources/agent-session-solid/index.js"], macos=True, web=True, go=False)
+    assert_areas(
+        ["Resources/agent-session-react/index.js"],
+        macos=True,
+        web=True,
+        go=False,
+        agent_session_web=True,
+    )
+    assert_areas(
+        ["Resources/agent-session-solid/index.js"],
+        macos=True,
+        web=True,
+        go=False,
+        agent_session_web=True,
+    )
     assert_areas(["Resources/agent-session-backup/index.js"], macos=True, web=False, go=False)
 
 
@@ -86,7 +123,13 @@ def test_app_source_runs_macos() -> None:
 
 
 def test_workflow_changes_run_everything() -> None:
-    assert_areas([".github/workflows/ci.yml"], macos=True, web=True, go=True)
+    assert_areas(
+        [".github/workflows/ci.yml"],
+        macos=True,
+        web=True,
+        go=True,
+        agent_session_web=True,
+    )
 
 
 def detect_step_script(workflow_path: Path = CI_WORKFLOW) -> str:
@@ -176,7 +219,7 @@ def test_workflow_self_change_guard_runs_before_detector_imports() -> None:
     result, outputs = run_detect_step_for_paths(["scripts/ci/subprocess.py"])
 
     assert "CI router changed; running all CI areas." in result.stdout
-    assert outputs == ["macos=true", "web=true", "go=true"]
+    assert outputs == ["macos=true", "web=true", "go=true", "agent_session_web=true"]
 
 
 def test_workflow_diff_failure_runs_all_areas() -> None:
@@ -206,6 +249,7 @@ def test_workflow_diff_failure_runs_all_areas() -> None:
             "macos=true",
             "web=true",
             "go=true",
+            "agent_session_web=true",
         ]
 
 
@@ -213,13 +257,31 @@ def test_workflow_empty_diff_runs_all_areas() -> None:
     result, outputs = run_detect_step_for_paths([])
 
     assert "PR diff is empty; running all CI areas." in result.stdout
-    assert outputs == ["macos=true", "web=true", "go=true"]
+    assert outputs == ["macos=true", "web=true", "go=true", "agent_session_web=true"]
 
 
 def test_router_changes_run_everything() -> None:
-    assert_areas(["scripts/ci/detect_ci_change_areas.py"], macos=True, web=True, go=True)
-    assert_areas(["scripts/ci/subprocess.py"], macos=True, web=True, go=True)
-    assert_areas(["tests/test_ci_change_areas.py"], macos=True, web=True, go=True)
+    assert_areas(
+        ["scripts/ci/detect_ci_change_areas.py"],
+        macos=True,
+        web=True,
+        go=True,
+        agent_session_web=True,
+    )
+    assert_areas(
+        ["scripts/ci/subprocess.py"],
+        macos=True,
+        web=True,
+        go=True,
+        agent_session_web=True,
+    )
+    assert_areas(
+        ["tests/test_ci_change_areas.py"],
+        macos=True,
+        web=True,
+        go=True,
+        agent_session_web=True,
+    )
 
 
 def test_ghosttykit_checksum_pin_runs_macos() -> None:
@@ -262,6 +324,7 @@ def test_cli_writes_github_outputs() -> None:
             "macos=false",
             "web=true",
             "go=false",
+            "agent_session_web=false",
         ]
 
 
@@ -289,11 +352,12 @@ def test_cli_empty_diff_runs_all_areas() -> None:
         )
 
         assert "PR diff is empty; running all CI areas." in result.stdout
-        assert "Resolved areas: macos=true web=true go=true" in result.stdout
+        assert "Resolved areas: macos=true web=true go=true agent_session_web=true" in result.stdout
         assert output_path.read_text(encoding="utf-8").splitlines() == [
             "macos=true",
             "web=true",
             "go=true",
+            "agent_session_web=true",
         ]
 
 
@@ -306,7 +370,7 @@ def test_non_pr_events_run_all_areas() -> None:
         stderr=subprocess.PIPE,
     )
 
-    assert "Resolved areas: macos=true web=true go=true" in result.stdout
+    assert "Resolved areas: macos=true web=true go=true agent_session_web=true" in result.stdout
 
 
 def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
@@ -331,11 +395,17 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
     assert 'allowed = {"success", "skipped"}' in block
 
 
+def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> None:
+    block = workflow_job_block("agent-session-web-resources")
+
+    assert "if: ${{ needs.changes.outputs.agent_session_web == 'true' }}" in block
+
+
 def test_perf_activation_workflow_keeps_required_status_while_gating_benchmark() -> None:
     result, outputs = run_detect_step_for_paths(["docs/ci-runners.md"], PERF_ACTIVATION_WORKFLOW)
 
     assert "Resolved areas: macos=false web=false go=false" in result.stdout
-    assert outputs == ["macos=false", "web=false", "go=false"]
+    assert outputs == ["macos=false", "web=false", "go=false", "agent_session_web=false"]
 
     benchmark = workflow_job_block("activation-session-benchmark", PERF_ACTIVATION_WORKFLOW)
     sentinel = workflow_job_block("activation-session", PERF_ACTIVATION_WORKFLOW)

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -78,6 +78,16 @@ def test_markdown_viewer_resources_run_webviews_asset_guard() -> None:
     )
 
 
+def test_markdown_viewer_webview_app_does_not_run_agent_session_resource_check() -> None:
+    assert_areas(
+        ["Resources/markdown-viewer/webviews-app/index.js"],
+        macos=True,
+        web=True,
+        go=False,
+        agent_session_web=False,
+    )
+
+
 def test_root_agent_web_dependencies_run_web_and_macos() -> None:
     assert_areas(
         ["package.json", "bun.lock"],


### PR DESCRIPTION
## Summary
- Add a focused `agent_session_web` CI router output for bundled agent-session web assets.
- Run `agent-session-web-resources` only when agent-session web sources, generated resources, or their direct build inputs change.
- Keep router/workflow edits failing open to all CI areas, including the new output.

## Evidence
- Swift-only probe: `Sources/AppDelegate.swift` => `macos=true web=false go=false agent_session_web=false`
- Website-only probe: `web/app/page.tsx` => `macos=false web=true go=false agent_session_web=false`
- Agent-session probe: `webviews/src/agent-session/shared/message.test.ts` => `macos=true web=true go=false agent_session_web=true`

## Tests
- `python3 tests/test_ci_change_areas.py`
- `python3.9 tests/test_ci_change_areas.py`
- `python3 -m py_compile tests/test_ci_change_areas.py scripts/ci/detect_ci_change_areas.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784518393&installation_id=133855650&pr_number=6474&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6474&signature=c5212fd5061251047d0700882c93ea10a6d74d5c8e60bf9159dec7baa29dbb46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the agent‑session web assets job behind a new `agent_session_web` CI change area so it runs only when its sources or inputs change. Adds a tests required‑status sentinel that enforces app-host unit tests only when macOS changes are detected.

- **New Features**
  - Added `agent_session_web` to the detector and GHA outputs; triggers on `webviews/src/agent-session/**`, `Resources/agent-session-{react,solid}/**`, root and `webviews` `package.json`/`bun.lock`, `scripts/build-agent-session-web.sh`, and `Resources/markdown-viewer/marked.min.js`.
  - Gated `agent-session-web-resources` with `if: ${{ needs.changes.outputs.agent_session_web == 'true' }}`; router/workflow diffs fail open and set `agent_session_web=true`.
  - Introduced `tests-required-status` that depends on `changes` and `tests`: requires success when `macos=true`, otherwise allows success or skipped; included in the final CI status aggregation.

<sup>Written for commit c4d55a1a1068ee938a8f2640b0c2fe8c9f5376cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI change-area detection to include a new *agent-session web* flag.
  * Adjusted workflow gating so agent-session web resource checks run only when that flag is set, avoiding unnecessary CI work.

* **Tests**
  * Expanded change-area and workflow contract tests to verify the new flag behavior across multiple scenarios, including correct routing and required status evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->