### PR TITLE
Fix Cmd+grave show/hide global hotkey

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -794,7 +794,7 @@ enum KeyboardShortcutSettings {
             reserved.append(shortcut)
         }
 
-        reserved.append(contentsOf: hardcodedSystemWideHotkeyConflicts)
+        reserved.append(contentsOf: hardcodedSystemWideHotkeyConflicts.filter { currentAction != .showHideAllWindows || $0.key != "`" || !$0.command || $0.option || $0.control })
         return reserved
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -807,6 +807,7 @@
 		C0DE70530000000000000002 /* submit-cmux-profile in Copy CLI */ = {isa = PBXBuildFile; fileRef = C0DE70530000000000000001 /* submit-cmux-profile */; };
 		D7AB00000000000000B041 /* SupersededPhoneDismissBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */; };
 		A5001303 /* SurfaceSearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001301 /* SurfaceSearchOverlay.swift */; };
+		FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65154DD251384EE0A2C8923A /* SystemWideHotkeyShortcutPolicyTests.swift */; };
 		C9A5720BC9A5720BC9A5720B /* TabItemView+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */; };
 		D7AB00000000000000000013 /* TabManager+DetachedWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000014 /* TabManager+DetachedWorkspace.swift */; };
 		E3309A03 /* TabManager+EqualizeSplits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A04 /* TabManager+EqualizeSplits.swift */; };
@@ -1810,6 +1811,7 @@
 		C0DE70530000000000000001 /* submit-cmux-profile */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/submit-cmux-profile"; sourceTree = SOURCE_ROOT; };
 		D7AB00000000000000B040 /* SupersededPhoneDismissBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupersededPhoneDismissBuffer.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
+		65154DD251384EE0A2C8923A /* SystemWideHotkeyShortcutPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemWideHotkeyShortcutPolicyTests.swift; sourceTree = "<group>"; };
 		C9A5720CC9A5720CC9A5720C /* TabItemView+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabItemView+WorkspaceGroups.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000014 /* TabManager+DetachedWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+DetachedWorkspace.swift"; sourceTree = "<group>"; };
 		E3309A04 /* TabManager+EqualizeSplits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabManager+EqualizeSplits.swift"; sourceTree = "<group>"; };
@@ -2928,6 +2930,7 @@
 				C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */,
 				C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */,
 				3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */,
+				65154DD251384EE0A2C8923A /* SystemWideHotkeyShortcutPolicyTests.swift */,
 				E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */,
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
@@ -4456,6 +4459,7 @@
 						E60610300000000000000003 /* SSHPTYAttachReconnectInputFilterState.swift in Sources */,
 						B6285B71BA6F82AF8F945E00 /* SSHPTYAttachReconnectInputFilterTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
+				FBE660ABA1854983B84368C6 /* SystemWideHotkeyShortcutPolicyTests.swift in Sources */,
 				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Carbon
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -52,6 +53,42 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         XCTAssertEqual(
             KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(bareShortcut),
             .rejected(.systemWideHotkeyRequiresModifier)
+        )
+    }
+
+    func testShowHideAllWindowsAcceptsCommandGravePhysicalSystemWideHotkey() {
+        let shortcut = StoredShortcut(
+            key: "`",
+            command: true,
+            shift: false,
+            option: false,
+            control: false,
+            keyCode: 50
+        )
+
+        XCTAssertEqual(
+            shortcut.carbonHotKeyRegistration,
+            CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey))
+        )
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shortcut),
+            .accepted(shortcut)
+        )
+    }
+
+    func testGlobalSearchStillRejectsCommandGraveWindowCyclingHotkey() {
+        let shortcut = StoredShortcut(
+            key: "`",
+            command: true,
+            shift: false,
+            option: false,
+            control: false,
+            keyCode: 50
+        )
+
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(shortcut),
+            .rejected(.reservedBySystem)
         )
     }
 

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import Carbon
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -53,60 +52,6 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
         XCTAssertEqual(
             KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(bareShortcut),
             .rejected(.systemWideHotkeyRequiresModifier)
-        )
-    }
-
-    func testShowHideAllWindowsAcceptsCommandGravePhysicalSystemWideHotkey() {
-        let shortcut = StoredShortcut(
-            key: "`",
-            command: true,
-            shift: false,
-            option: false,
-            control: false,
-            keyCode: 50
-        )
-
-        XCTAssertEqual(
-            shortcut.carbonHotKeyRegistration,
-            CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey))
-        )
-        XCTAssertEqual(
-            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shortcut),
-            .accepted(shortcut)
-        )
-
-        let shiftedShortcut = StoredShortcut(
-            key: "`",
-            command: true,
-            shift: true,
-            option: false,
-            control: false,
-            keyCode: 50
-        )
-
-        XCTAssertEqual(
-            shiftedShortcut.carbonHotKeyRegistration,
-            CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey | shiftKey))
-        )
-        XCTAssertEqual(
-            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shiftedShortcut),
-            .accepted(shiftedShortcut)
-        )
-    }
-
-    func testGlobalSearchStillRejectsCommandGraveWindowCyclingHotkey() {
-        let shortcut = StoredShortcut(
-            key: "`",
-            command: true,
-            shift: false,
-            option: false,
-            control: false,
-            keyCode: 50
-        )
-
-        XCTAssertEqual(
-            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(shortcut),
-            .rejected(.reservedBySystem)
         )
     }
 

--- a/cmuxTests/GlobalSearchShortcutSettingsTests.swift
+++ b/cmuxTests/GlobalSearchShortcutSettingsTests.swift
@@ -74,6 +74,24 @@ final class GlobalSearchShortcutSettingsTests: XCTestCase {
             KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shortcut),
             .accepted(shortcut)
         )
+
+        let shiftedShortcut = StoredShortcut(
+            key: "`",
+            command: true,
+            shift: true,
+            option: false,
+            control: false,
+            keyCode: 50
+        )
+
+        XCTAssertEqual(
+            shiftedShortcut.carbonHotKeyRegistration,
+            CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey | shiftKey))
+        )
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shiftedShortcut),
+            .accepted(shiftedShortcut)
+        )
     }
 
     func testGlobalSearchStillRejectsCommandGraveWindowCyclingHotkey() {

--- a/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
+++ b/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
@@ -73,13 +73,13 @@ final class SystemWideHotkeyShortcutPolicyTests {
         )
     }
 
-    private static var shortcutDefaultsKeys: [String] {
+    private nonisolated static var shortcutDefaultsKeys: [String] {
         KeyboardShortcutSettings.Action.allCases.map(\.defaultsKey) + [
             SystemWideHotkeySettings.legacyShortcutKey,
         ]
     }
 
-    private static func defaultsSnapshot() -> [String: Any] {
+    private nonisolated static func defaultsSnapshot() -> [String: Any] {
         let defaults = UserDefaults.standard
         return shortcutDefaultsKeys.reduce(into: [:]) { snapshot, key in
             if let value = defaults.object(forKey: key) {
@@ -88,14 +88,14 @@ final class SystemWideHotkeyShortcutPolicyTests {
         }
     }
 
-    private static func clearShortcutDefaults() {
+    private nonisolated static func clearShortcutDefaults() {
         let defaults = UserDefaults.standard
         for key in shortcutDefaultsKeys {
             defaults.removeObject(forKey: key)
         }
     }
 
-    private static func restoreDefaults(_ snapshot: [String: Any]) {
+    private nonisolated static func restoreDefaults(_ snapshot: [String: Any]) {
         clearShortcutDefaults()
         let defaults = UserDefaults.standard
         for (key, value) in snapshot {

--- a/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
+++ b/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
@@ -1,4 +1,5 @@
 import Carbon
+import Foundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -7,7 +8,27 @@ import Testing
 @testable import cmux
 #endif
 
-@Suite struct SystemWideHotkeyShortcutPolicyTests {
+@MainActor
+@Suite(.serialized)
+final class SystemWideHotkeyShortcutPolicyTests {
+    private let originalSettingsFileStore: KeyboardShortcutSettingsFileStore
+    private let savedDefaults: [String: Any]
+
+    init() {
+        savedDefaults = Self.defaultsSnapshot()
+        originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(
+            prefix: "cmux-system-wide-hotkey-policy"
+        )
+        Self.clearShortcutDefaults()
+        KeyboardShortcutSettings.resetAll()
+    }
+
+    deinit {
+        Self.clearShortcutDefaults()
+        KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+        Self.restoreDefaults(savedDefaults)
+    }
+
     @Test func showHideAllWindowsAcceptsCommandGravePhysicalHotkeys() {
         let shortcut = commandGraveShortcut()
 
@@ -50,5 +71,35 @@ import Testing
             control: false,
             keyCode: 50
         )
+    }
+
+    private static var shortcutDefaultsKeys: [String] {
+        KeyboardShortcutSettings.Action.allCases.map(\.defaultsKey) + [
+            SystemWideHotkeySettings.legacyShortcutKey,
+        ]
+    }
+
+    private static func defaultsSnapshot() -> [String: Any] {
+        let defaults = UserDefaults.standard
+        return shortcutDefaultsKeys.reduce(into: [:]) { snapshot, key in
+            if let value = defaults.object(forKey: key) {
+                snapshot[key] = value
+            }
+        }
+    }
+
+    private static func clearShortcutDefaults() {
+        let defaults = UserDefaults.standard
+        for key in shortcutDefaultsKeys {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private static func restoreDefaults(_ snapshot: [String: Any]) {
+        clearShortcutDefaults()
+        let defaults = UserDefaults.standard
+        for (key, value) in snapshot {
+            defaults.set(value, forKey: key)
+        }
     }
 }

--- a/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
+++ b/cmuxTests/SystemWideHotkeyShortcutPolicyTests.swift
@@ -1,0 +1,54 @@
+import Carbon
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct SystemWideHotkeyShortcutPolicyTests {
+    @Test func showHideAllWindowsAcceptsCommandGravePhysicalHotkeys() {
+        let shortcut = commandGraveShortcut()
+
+        #expect(
+            shortcut.carbonHotKeyRegistration ==
+                CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey))
+        )
+        #expect(
+            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shortcut) ==
+                .accepted(shortcut)
+        )
+
+        let shiftedShortcut = commandGraveShortcut(shift: true)
+
+        #expect(
+            shiftedShortcut.carbonHotKeyRegistration ==
+                CarbonHotKeyRegistration(keyCode: 50, modifiers: UInt32(cmdKey | shiftKey))
+        )
+        #expect(
+            KeyboardShortcutSettings.Action.showHideAllWindows.normalizedRecordedShortcutResult(shiftedShortcut) ==
+                .accepted(shiftedShortcut)
+        )
+    }
+
+    @Test func globalSearchStillRejectsCommandGraveWindowCyclingHotkey() {
+        let shortcut = commandGraveShortcut()
+
+        #expect(
+            KeyboardShortcutSettings.Action.globalSearch.normalizedRecordedShortcutResult(shortcut) ==
+                .rejected(.reservedBySystem)
+        )
+    }
+
+    private func commandGraveShortcut(shift: Bool = false) -> StoredShortcut {
+        StoredShortcut(
+            key: "`",
+            command: true,
+            shift: shift,
+            option: false,
+            control: false,
+            keyCode: 50
+        )
+    }
+}


### PR DESCRIPTION
## Root cause

`showHideAllWindows` could persist a Cmd+grave binding from Settings / `cmux.json`, but runtime registration dropped it before calling `RegisterEventHotKey`. The hardcoded system-wide conflict list always reserved Cmd+grave and Cmd+Shift+grave as macOS window-cycling shortcuts, and `SystemWideHotkeyController.refreshRegistration` re-runs that conflict check before registering.

I verified the registration path rather than assuming the OS rejects it: a local Carbon probe for keyCode 50 returned `status=0` for Cmd+grave, Cmd+Shift+grave, and Opt+grave. Ghostty’s working implementation uses a CGEvent tap for global keybinds, but cmux’s immediate failure was self-inflicted: the configured shortcut was never allowed to reach Carbon registration.

## Fix

Allow the Cmd+grave window-cycle pair only for the `showHideAllWindows` system-wide action. The existing hardcoded reservations remain in place for other global hotkeys, including Global Search, and Cmd+. is still rejected for Show/Hide because it is AppKit’s standard cancel keystroke.

## Why this should not break other hotkeys

The change only filters the hardcoded Cmd+grave/Cmd+Shift+grave reservation when the current action being validated is `showHideAllWindows`. Other system-wide actions still see that reservation, existing cmux action conflict checks still run, and the Carbon keyCode/modifier mapping path is unchanged.

## Verification

- Added a regression test that the reporter’s exact shape (`key: "`", keyCode: 50, command: true`) maps to `CarbonHotKeyRegistration(keyCode: 50, modifiers: cmdKey)` and is accepted for `showHideAllWindows`.
- Added coverage that Global Search still rejects the same Cmd+grave reservation.
- Probed `RegisterEventHotKey(50, cmdKey, ...)` locally with a tiny Swift snippet: Carbon returned `noErr` for Cmd+grave.
- Did not run a local cmux build or local tests per task instruction. The true end-to-end proof needs a running tagged app plus a global keypress from another app, so CI and later dogfood are the validation path.

Closes #6435

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784518678&installation_id=133855650&pr_number=6477&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6477&signature=a82185bb13d2ff664197b4374941fe8167d4968317cdf5e7b7dd5c65185be5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the global Cmd+` show/hide hotkey so it registers and works system-wide on macOS. Only `showHideAllWindows` can use Cmd+` and Cmd+Shift+`; other actions stay reserved, and Cmd+. remains blocked.

- **Bug Fixes**
  - Filtered the hardcoded reservation so Cmd+`/Cmd+Shift+` for `showHideAllWindows` aren’t treated as conflicts; others stay reserved.
  - Moved hotkey policy tests to Swift Testing with isolated `UserDefaults` and settings store, added teardown to restore state, and covered acceptance for `showHideAllWindows`, rejection for Global Search, and Carbon keyCode/modifier mapping.

<sup>Written for commit e3e8a558312ccdca5de8961cedf42cacddc503a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system-wide keyboard shortcut conflict handling by applying action-specific filtering for command+grave (`) hotkeys—ensuring show/hide all windows accepts valid variants while other actions still respect reserved-shortcut rules.

* **Tests**
  * Added a new test suite covering system-wide shortcut policy behavior, including acceptance of command+grave (with and without shift) for show/hide all windows and rejection of command+grave for global search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->