### PR TITLE
Fix Dia browser import profile detection

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/BrowserImportBrowserDescriptor.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/BrowserImportBrowserDescriptor.swift
@@ -9,6 +9,8 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
     public let id: String
     /// Human-readable browser name.
     public let displayName: String
+    /// Extra user-facing lookup names accepted by CLI and automation.
+    public let aliases: [String]
     /// The engine family used to decode the browser's data.
     public let family: BrowserImportEngineFamily
     /// Detection-priority tier; lower tiers are preferred when scores tie.
@@ -29,6 +31,7 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
     /// - Parameters:
     ///   - id: Stable slug identifier.
     ///   - displayName: Human-readable browser name.
+    ///   - aliases: Extra user-facing lookup names accepted by CLI and automation.
     ///   - family: The engine family used to decode the browser's data.
     ///   - tier: Detection-priority tier; lower tiers are preferred on ties.
     ///   - bundleIdentifiers: Known bundle identifiers for the application.
@@ -39,6 +42,7 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
     public init(
         id: String,
         displayName: String,
+        aliases: [String] = [],
         family: BrowserImportEngineFamily,
         tier: Int,
         bundleIdentifiers: [String],
@@ -49,6 +53,7 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
     ) {
         self.id = id
         self.displayName = displayName
+        self.aliases = aliases
         self.family = family
         self.tier = tier
         self.bundleIdentifiers = bundleIdentifiers
@@ -78,6 +83,7 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
         BrowserImportBrowserDescriptor(
             id: "google-chrome",
             displayName: "Google Chrome",
+            aliases: ["chrome"],
             family: .chromium,
             tier: 1,
             bundleIdentifiers: ["com.google.Chrome"],
@@ -198,7 +204,7 @@ public struct BrowserImportBrowserDescriptor: Hashable, Sendable {
             tier: 2,
             bundleIdentifiers: ["company.thebrowser.Dia", "company.thebrowser.dia"],
             appNames: ["Dia.app"],
-            dataRootRelativePaths: ["Library/Application Support/Dia"],
+            dataRootRelativePaths: ["Library/Application Support/Dia/User Data"],
             dataArtifactRelativePaths: [],
             supportsDataOnlyDetection: true
         ),

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/InstalledBrowserCandidate.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Values/InstalledBrowserCandidate.swift
@@ -30,6 +30,19 @@ public struct InstalledBrowserCandidate: Identifiable, Hashable, Sendable {
     /// Convenience list of profile data-directory URLs.
     public var profileURLs: [URL] { profiles.map(\.rootURL) }
 
+    /// Whether a user-supplied lookup string names this browser.
+    public func matchesLookupQuery(_ query: String) -> Bool {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+        if id.lowercased() == normalized { return true }
+        if displayName.lowercased() == normalized { return true }
+        if descriptor.aliases.contains(where: { $0.lowercased() == normalized }) { return true }
+        return descriptor.appNames.contains { appName in
+            appName.lowercased() == normalized ||
+                appName.replacingOccurrences(of: ".app", with: "").lowercased() == normalized
+        }
+    }
+
     /// Creates a detected-browser candidate.
     ///
     /// - Parameters:

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserImportValueTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserImportValueTests.swift
@@ -28,6 +28,26 @@ struct BrowserImportValueTests {
         #expect(a.id == b.id)
     }
 
+    @Test("browser candidate lookup accepts explicit aliases")
+    func browserCandidateLookupAcceptsAliases() throws {
+        let descriptor = try #require(BrowserImportBrowserDescriptor.allBrowserDescriptors.first { $0.id == "google-chrome" })
+        let candidate = InstalledBrowserCandidate(
+            descriptor: descriptor,
+            resolvedFamily: .chromium,
+            homeDirectoryURL: URL(fileURLWithPath: "/"),
+            appURL: nil,
+            dataRootURL: nil,
+            profiles: [],
+            detectionSignals: [],
+            detectionScore: 1
+        )
+
+        #expect(candidate.matchesLookupQuery("chrome"))
+        #expect(candidate.matchesLookupQuery("Google Chrome"))
+        #expect(candidate.matchesLookupQuery("Google Chrome.app"))
+        #expect(!candidate.matchesLookupQuery("chromium"))
+    }
+
     @Test("step-3 presentation reflects plan shape")
     func step3Presentation() {
         let single = BrowserImportStep3Presentation(

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Import/BrowserInstalledBrowserDetectorTests.swift
@@ -40,6 +40,50 @@ struct BrowserInstalledBrowserDetectorTests {
         #expect(chrome.detectionScore > 0)
     }
 
+    @Test("detects Dia Chromium profiles under User Data")
+    func detectsDiaProfilesUnderUserData() throws {
+        let home = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let diaUserDataRoot = home
+            .appendingPathComponent("Library/Application Support/Dia/User Data", isDirectory: true)
+        let defaultProfile = diaUserDataRoot.appendingPathComponent("Default", isDirectory: true)
+        let workProfile = diaUserDataRoot.appendingPathComponent("Profile 1", isDirectory: true)
+        try FileManager.default.createDirectory(at: defaultProfile, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: workProfile, withIntermediateDirectories: true)
+        try Data().write(to: defaultProfile.appendingPathComponent("Cookies"))
+        try Data().write(to: workProfile.appendingPathComponent("Cookies"))
+        try Data(
+            """
+            {
+              "profile": {
+                "info_cache": {
+                  "Default": {
+                    "name": "Personal"
+                  },
+                  "Profile 1": {
+                    "name": "Work"
+                  }
+                }
+              }
+            }
+            """.utf8
+        ).write(to: diaUserDataRoot.appendingPathComponent("Local State"))
+
+        let detector = BrowserInstalledBrowserDetector(
+            homeDirectoryURL: home,
+            bundleLookup: { _ in nil },
+            applicationSearchDirectories: [],
+            fileManager: .default
+        )
+
+        let dia = try #require(detector.detectInstalledBrowsers().first { $0.id == "dia" })
+        #expect(dia.family == .chromium)
+        #expect(dia.dataRootURL == diaUserDataRoot)
+        #expect(dia.profiles.map(\.displayName) == ["Personal", "Work"])
+        #expect(dia.profiles.map(\.rootURL.lastPathComponent) == ["Default", "Profile 1"])
+    }
+
     @Test("detects a Firefox browser and reads its profiles.ini name")
     func detectsFirefoxFromINI() throws {
         let home = try makeTempHome()

--- a/Sources/Panels/BrowserAutomation.swift
+++ b/Sources/Panels/BrowserAutomation.swift
@@ -500,13 +500,7 @@ enum BrowserImportAutomation {
     }
 
     private static func matchesBrowser(_ browser: InstalledBrowserCandidate, query: String) -> Bool {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalized.isEmpty else { return false }
-        if browser.id.lowercased() == normalized { return true }
-        if browser.displayName.lowercased() == normalized { return true }
-        return browser.descriptor.appNames.contains {
-            $0.replacingOccurrences(of: ".app", with: "").lowercased() == normalized
-        }
+        browser.matchesLookupQuery(query)
     }
 
     private static func matchesProfile(_ profile: InstalledBrowserProfile, query: String) -> Bool {


### PR DESCRIPTION
## Summary
- Point Dia browser detection at `~/Library/Application Support/Dia/User Data` so Chromium profiles resolve to `Default`, `Profile 1`, etc.
- Move browser lookup matching onto `InstalledBrowserCandidate` and add an explicit `chrome` alias for `--from chrome`.

## Testing
- `swift test --package-path Packages/macOS/CmuxBrowser`
- `./scripts/reload-cloud.sh --tag dia6437`
- Tagged preflight via `/tmp/cmux-debug-dia6437.sock`: `browser import --from dia --profile Default --domain cmux.invalid -y --json` returned `browser: Dia` and `source_profiles: [Personal]`.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/6437

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized browser-import detection and lookup changes with new unit tests; no auth or data-store redesign.
> 
> **Overview**
> Fixes **Dia** import by pointing its data root at `~/Library/Application Support/Dia/User Data` so Chromium-style profiles (`Default`, `Profile 1`, etc.) and names from `Local State` resolve correctly instead of looking one directory too high.
> 
> **CLI / automation browser selection** is centralized on `InstalledBrowserCandidate.matchesLookupQuery`, which now honors descriptor **aliases** (e.g. `--from chrome` for Google Chrome) plus id, display name, and `.app` bundle names. `BrowserAutomation` delegates to that helper instead of duplicating match logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3adb5a688813ae74a5f7d45d229f367f96098ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784518794&installation_id=133855650&pr_number=6478&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6478&signature=815e23db5b0a3f8c192e3640b584ab22c64f92bddebfa0ffcc6f652393d80268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Dia browser import by scanning the correct Chromium data path so profiles like "Default" and "Profile 1" are detected and named. Also accept "chrome" as a CLI alias and unify browser lookup matching for consistent behavior.

- **Bug Fixes**
  - Detect Dia profiles under `~/Library/Application Support/Dia/User Data` and read names from "Local State".
  - Added tests to confirm Dia profile roots and display names.

- **Refactors**
  - Centralized lookup logic in `InstalledBrowserCandidate.matchesLookupQuery` and use it in automation.
  - Added `aliases` to `BrowserImportBrowserDescriptor`; Google Chrome now accepts the `chrome` alias for `--from`.

<sup>Written for commit e3adb5a688813ae74a5f7d45d229f367f96098ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for browser aliases, enabling users to search browsers by alternative names (e.g., "chrome" for Google Chrome)
  * Improved browser lookup with enhanced query normalization and matching logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->