### PR TITLE
Let terminal apps keep Ctrl digit shortcuts

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Sidebar/WindowChromeSidebarPresetOption.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/WindowChrome/Sidebar/WindowChromeSidebarPresetOption.swift
@@ -101,9 +101,9 @@ public enum WindowChromeSidebarPresetOption: String, CaseIterable, Identifiable,
         case .nativeSidebar: return 0.0
         case .glassBehind: return 0.0
         case .softBlur: return 0.0
-        case .popoverGlass: return 10.0
-        case .hudGlass: return 10.0
-        case .underWindow: return 6.0
+        case .popoverGlass: return 0.0
+        case .hudGlass: return 0.0
+        case .underWindow: return 0.0
         }
     }
 

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -91,8 +91,8 @@ extension ShortcutAction {
             return nil
         case .nextSurface: return ShortcutStroke(key: "]", command: true, shift: true)
         case .prevSurface: return ShortcutStroke(key: "[", command: true, shift: true)
-        case .selectSurfaceByNumber: return ShortcutStroke(key: "1", control: true)
-        case .selectWorkspaceByNumber: return ShortcutStroke(key: "1", command: true)
+        case .selectSurfaceByNumber: return nil
+        case .selectWorkspaceByNumber: return nil
         case .newSurface: return ShortcutStroke(key: "t", command: true)
         case .toggleTerminalCopyMode: return ShortcutStroke(key: "m", command: true, shift: true)
         case .focusTextBoxInput: return ShortcutStroke(key: "a", command: true, shift: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -278,8 +278,8 @@ extension ShortcutAction {
     /// focused they win their keystroke outright, and every other binding on the
     /// same stroke keeps firing outside that context. Conflict detection
     /// (``ShortcutWhenClause/bindingsCollide(_:lhsHasPriority:_:rhsHasPriority:)``)
-    /// uses this to accept such priority-resolved pairs — e.g. the factory
-    /// default Select Surface `⌃1…9` alongside the sidebar's `⌃1…5` — instead of
+    /// uses this to accept such priority-resolved pairs — e.g. a user-bound
+    /// Select Surface `⌃1…9` alongside the sidebar's `⌃1…5` — instead of
     /// rejecting them as colliding. Mirrors the app target's routing order in
     /// `handleCustomShortcut`; a drift test asserts the two stay aligned.
     public var hasPriorityShortcutRouting: Bool {

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
@@ -137,8 +137,8 @@ public indirect enum ShortcutWhenClause: Equatable, Sendable {
     /// still fire somewhere outside the winner's context
     /// (`canCoexist(loser, !winner)`): the winner owns every overlapping state
     /// and the loser owns the rest — the same most-specific-wins resolution VS
-    /// Code applies to `when` clauses. The shipped defaults rely on this:
-    /// Select Surface `⌃1…9` coexists with the sidebar's `⌃1…5`, which win only
+    /// Code applies to `when` clauses. Numbered opt-in bindings rely on this:
+    /// a user-bound Select Surface `⌃1…9` coexists with the sidebar's `⌃1…5`, which win only
     /// while the sidebar is focused.
     ///
     /// A loser with no states of its own (its clause implies the winner's) would

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutActionNumberedDigitTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutActionNumberedDigitTests.swift
@@ -13,6 +13,14 @@ struct ShortcutActionNumberedDigitTests {
         }
     }
 
+    @Test func selectSurfaceByNumberIsUnboundByDefault() {
+        #expect(ShortcutAction.selectSurfaceByNumber.defaultShortcut == nil)
+    }
+
+    @Test func selectWorkspaceByNumberIsUnboundByDefault() {
+        #expect(ShortcutAction.selectWorkspaceByNumber.defaultShortcut == nil)
+    }
+
     @Test func diffViewerScrollToTopDefaultIsChord() {
         #expect(
             ShortcutAction.diffViewerScrollToTop.defaultShortcut == StoredShortcut(

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutWhenClauseTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutWhenClauseTests.swift
@@ -54,7 +54,7 @@ struct ShortcutWhenClauseTests {
     @Test func priorityResolvedPairsCoexist() {
         let sidebar = ShortcutWhenClause.atom(.sidebarFocus)
         // The pre-routed sidebar action owns the overlap; an always-on binding
-        // keeps every other context — the factory Select Surface ⌃1…9 alongside
+        // keeps every other context — a user-bound Select Surface ⌃1…9 alongside
         // the sidebar's ⌃1…5.
         #expect(!ShortcutWhenClause.bindingsCollide(
             .always, lhsHasPriority: false, sidebar, rhsHasPriority: true))

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
@@ -390,7 +390,7 @@ public struct KeyboardShortcutsSection: View {
             // cannot decide the overlap. Context-disjoint clauses (e.g.
             // `!sidebarFocus` workspace digits vs the sidebar's own digits)
             // coexist, and a pre-routed action (sidebar modes) wins its context
-            // outright so the factory Select Surface ⌃1…9 coexists with the
+            // outright so a user-bound Select Surface ⌃1…9 coexists with the
             // sidebar's ⌃1…5 — matching the app target's authoritative check.
             guard ShortcutWhenClause.bindingsCollide(
                 proposedClause,

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutDisplayStringTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/ShortcutDisplayStringTests.swift
@@ -30,8 +30,8 @@ struct ShortcutDisplayStringTests {
     }
 
     @Test func numberedCommandDigitRendersAsRange() {
-        let defaultWorkspace = shortcut(key: "1", command: true)
-        #expect(shortcutDisplayString(defaultWorkspace, numbered: true) == "⌘1…9")
+        let workspaceDigits = shortcut(key: "1", command: true)
+        #expect(shortcutDisplayString(workspaceDigits, numbered: true) == "⌘1…9")
     }
 
     @Test func numberedRangeIgnoresWhichDigitWasRecorded() {

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -202,6 +202,7 @@ enum TerminalCopyOnSelectSettings {
 enum TerminalManagedGhosttySettings {
     static func ghosttyConfigContents(defaults: UserDefaults = .standard) -> String? {
         let lines = [
+            "window-padding-x = 2\nwindow-padding-y = 2",
             TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults),
         ].compactMap { $0 }
         guard !lines.isEmpty else { return nil }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13338,7 +13338,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // goto_tab fallback from creating a new window when the index is out of bounds.
         if shortcutWhenClauseAllows(action: .selectWorkspaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectWorkspaceByNumber) {
-            if let manager = tabManager,
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+            if let manager = routedManager,
                let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
                 cmuxDebugLog(
@@ -13353,10 +13354,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Numeric shortcuts for surfaces within the focused pane (9 = last)
         if shortcutWhenClauseAllows(action: .selectSurfaceByNumber, event: event),
            let digit = numberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
+            let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+#if DEBUG
+            cmuxDebugLog(
+                "shortcut.action name=surfaceDigit digit=\(digit) manager=\(debugManagerToken(routedManager)) \(debugShortcutRouteSnapshot(event: event))"
+            )
+#endif
             if digit == 9 {
-                tabManager?.selectLastSurface()
+                routedManager?.selectLastSurface()
             } else {
-                tabManager?.selectSurface(at: digit - 1)
+                routedManager?.selectSurface(at: digit - 1)
             }
             return true
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3933,6 +3933,30 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return currentBounds
     }
 
+    private func clampSurfaceSizeToVisibleWindowContent(_ size: CGSize) -> CGSize {
+        guard let contentView = window?.contentView,
+              contentView.window === window,
+              size.width > 0,
+              size.height > 0 else {
+            return size
+        }
+
+        let boundsInContent = convert(bounds, to: contentView)
+        let visible = boundsInContent.intersection(contentView.bounds)
+        guard !visible.isNull,
+              visible.width > 0,
+              visible.height > 0,
+              visible.width.isFinite,
+              visible.height.isFinite else {
+            return size
+        }
+
+        return CGSize(
+            width: min(size.width, visible.width),
+            height: min(size.height, visible.height)
+        )
+    }
+
     private static func hasTabDragPasteboardTypes() -> Bool {
         let types = NSPasteboard(name: .drag).types ?? []
         return types.contains(tabTransferPasteboardType) || types.contains(sidebarTabReorderPasteboardType)
@@ -3984,7 +4008,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         bypassLiveResizeCoalescing: Bool = false
     ) -> Bool {
         guard let terminalSurface = terminalSurface else { return false }
-        let size = resolvedSurfaceSize(preferred: size)
+        let resolvedSize = resolvedSurfaceSize(preferred: size)
+        let size = clampSurfaceSizeToVisibleWindowContent(resolvedSize)
         guard size.width > 0 && size.height > 0 else {
 #if DEBUG
             let signature = "nonPositive-\(Int(size.width))x\(Int(size.height))"
@@ -4057,6 +4082,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         }
 #if DEBUG
+        if !nearlyEqual(resolvedSize.width, size.width) || !nearlyEqual(resolvedSize.height, size.height) {
+            cmuxDebugLog(
+                "surface.size.clamp surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                "raw=\(String(format: "%.1fx%.1f", resolvedSize.width, resolvedSize.height)) " +
+                "visible=\(String(format: "%.1fx%.1f", size.width, size.height))"
+            )
+        }
         if lastSizeSkipSignature != nil {
             cmuxDebugLog(
                 "surface.size.resume surface=\(terminalSurface.id.uuidString.prefix(5)) " +
@@ -5331,6 +5363,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // AppKit text interpretation and send a single deterministic Ghostty key event.
         // This avoids intermittent drops after rapid split close/reparent transitions.
         if flags.contains(.control) && !flags.contains(.command) && !flags.contains(.option) && !hasMarkedText() {
+            if AppDelegate.shared?.handleConfiguredShortcutKeyEquivalent(event) == true {
+#if DEBUG
+                cmuxDebugLog(
+                    "key.ctrl path=cmuxShortcut surface=\(terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
+                    "keyCode=\(event.keyCode) chars=\((event.characters?.unicodeScalarHexList ?? "")) " +
+                    "ign=\((event.charactersIgnoringModifiers?.unicodeScalarHexList ?? "")) mods=\(event.modifierFlags.rawValue)"
+                )
+#endif
+                return
+            }
             terminalSurface?.recordExternalFocusState(true)
             ghostty_surface_set_focus(surface, true)
             var keyEvent = ghostty_input_key_s()

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -102,7 +102,7 @@ extension KeyboardShortcutSettings.Action {
     /// Whether `handleCustomShortcut` consumes this action before general
     /// configured-shortcut matching whenever its context holds (the
     /// `rightSidebarModeShortcut` pre-route). Priority-resolved pairs — the
-    /// sidebar's `⌃1…5` over the Select Surface `⌃1…9` family — coexist in
+    /// sidebar's `⌃1…5` over a user-bound Select Surface `⌃1…9` family — coexist in
     /// conflict detection because the winner owns the overlapping context and
     /// the other binding keeps every other state. Mirrors
     /// `ShortcutAction.hasPriorityShortcutRouting` in CmuxSettings; the drift

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -460,7 +460,10 @@ enum KeyboardShortcutSettings {
             case .prevSurface:
                 return StoredShortcut(key: "[", command: true, shift: true, option: false, control: false)
             case .selectSurfaceByNumber:
-                return StoredShortcut(key: "1", command: false, shift: false, option: false, control: true)
+                // Unbound by default so foreground terminal apps keep plain
+                // Ctrl+1…9. Users who want cmux-owned surface digits can opt in
+                // via Settings or cmux.json.
+                return .unbound
             case .newSurface:
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
@@ -483,7 +486,10 @@ enum KeyboardShortcutSettings {
                 // chord. Rebindable in Settings → Keyboard Shortcuts.
                 return StoredShortcut(key: "k", command: true, shift: true, option: false, control: false)
             case .selectWorkspaceByNumber:
-                return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
+                // Unbound by default so terminal apps and window managers keep
+                // digit chords. Users who want cmux-owned workspace digits can
+                // opt in via Settings or cmux.json.
+                return .unbound
             case .toggleRightSidebar:
                 return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
             case .saveFilePreview:
@@ -625,7 +631,7 @@ enum KeyboardShortcutSettings {
             // make them non-overlapping — e.g. ⌃1 selecting a workspace only when
             // the sidebar is NOT focused coexists with the sidebar's ⌃1 (issue
             // #5189) — and a pre-routed action (sidebar modes) wins its context
-            // outright, so the factory Select Surface ⌃1…9 coexists with the
+            // outright, so a user-bound Select Surface ⌃1…9 coexists with the
             // sidebar's ⌃1…5 by priority.
             guard ShortcutWhenClause.bindingsCollide(
                 KeyboardShortcutSettings.effectiveWhenClause(for: self),

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -181,7 +181,7 @@ enum FocusFlashCurve: Equatable {
 
 enum PanelOverlayRingMetrics {
     static let inset: CGFloat = 2
-    static let cornerRadius: CGFloat = 6
+    static let cornerRadius: CGFloat = 0
     static let lineWidth: CGFloat = 2.5
 
     static func pathRect(in bounds: CGRect) -> CGRect {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -56,7 +56,7 @@ enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
                 groupBackground: false,
                 groupPadding: EdgeInsets(),
                 buttonBackground: false,
-                buttonCornerRadius: 5,
+                buttonCornerRadius: 0,
                 hoverBackground: false
             )
         case .roomy:
@@ -69,7 +69,7 @@ enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
                 groupBackground: false,
                 groupPadding: EdgeInsets(),
                 buttonBackground: false,
-                buttonCornerRadius: 7,
+                buttonCornerRadius: 0,
                 hoverBackground: false
             )
         case .pillGroup:
@@ -82,7 +82,7 @@ enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
                 groupBackground: false,
                 groupPadding: EdgeInsets(top: 1, leading: 3, bottom: 1, trailing: 3),
                 buttonBackground: false,
-                buttonCornerRadius: 6,
+                buttonCornerRadius: 0,
                 hoverBackground: true
             )
         case .softButtons:
@@ -95,7 +95,7 @@ enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
                 groupBackground: false,
                 groupPadding: EdgeInsets(),
                 buttonBackground: true,
-                buttonCornerRadius: 6,
+                buttonCornerRadius: 0,
                 hoverBackground: false
             )
         }

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -22,7 +22,7 @@ enum HeaderChromeControlMetrics {
     static let buttonSize: CGFloat = 20
     static let iconSize: CGFloat = 12
     static let iconFrameSize: CGFloat = 14
-    static let cornerRadius: CGFloat = 6
+    static let cornerRadius: CGFloat = 0
     static let titlebarControlsLeadingPadding: CGFloat = 4
 
     static func iconFrameSize(forIconSize iconSize: CGFloat) -> CGFloat {
@@ -37,7 +37,7 @@ enum RightSidebarChromeMetrics {
     static let barVerticalPadding: CGFloat = 4
     static let controlHeight: CGFloat = secondaryBarHeight - (barVerticalPadding * 2)
     static let controlHorizontalPadding: CGFloat = 8
-    static let controlCornerRadius: CGFloat = 5
+    static let controlCornerRadius: CGFloat = 0
     static let headerControlSize: CGFloat = HeaderChromeControlMetrics.buttonSize
     static let headerIconSize: CGFloat = 10
     static let headerIconFrameSize: CGFloat = headerIconSize

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -790,7 +790,10 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
         )
         XCTAssertFalse(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
         XCTAssertNil(TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults))
-        XCTAssertNil(TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults))
+        XCTAssertEqual(
+            TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
+            "window-padding-x = 2\nwindow-padding-y = 2"
+        )
 
         let notificationCenter = NotificationCenter()
         var notificationCount = 0
@@ -815,7 +818,7 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
         )
         XCTAssertEqual(
             TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
-            "copy-on-select = clipboard"
+            "window-padding-x = 2\nwindow-padding-y = 2\ncopy-on-select = clipboard"
         )
         XCTAssertEqual(notificationCount, 1)
 
@@ -831,7 +834,7 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
         )
         XCTAssertEqual(
             TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
-            "copy-on-select = false"
+            "window-padding-x = 2\nwindow-padding-y = 2\ncopy-on-select = false"
         )
         XCTAssertEqual(notificationCount, 2)
 
@@ -841,7 +844,10 @@ final class TerminalCopyOnSelectSettingsTests: XCTestCase {
         )
         XCTAssertFalse(TerminalCopyOnSelectSettings.isEnabled(defaults: defaults))
         XCTAssertNil(TerminalCopyOnSelectSettings.ghosttyConfigContents(defaults: defaults))
-        XCTAssertNil(TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults))
+        XCTAssertEqual(
+            TerminalManagedGhosttySettings.ghosttyConfigContents(defaults: defaults),
+            "window-padding-x = 2\nwindow-padding-y = 2"
+        )
         XCTAssertEqual(notificationCount, 2)
     }
 }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2527,7 +2527,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
     func testGhosttyConfigDoesNotRetainNumberedGotoTabFallback() throws {
         // Regression for https://github.com/manaflow-ai/cmux/issues/5189.
-        // cmux owns "Select Workspace 1…9" (default ⌘1–9) through KeyboardShortcutSettings.
+        // cmux owns any user-bound "Select Workspace 1…9" shortcut through
+        // KeyboardShortcutSettings.
         // Ghostty's built-in super+1…8 = goto_tab and super+9 = last_tab fallbacks must be
         // unbound — exactly like cmux already unbinds super+d / super+w — so the numbered
         // shortcut is driven solely by the configured value. Otherwise a remapped-away ⌘1–9
@@ -2558,7 +2559,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                     modifiers: [.command],
                     keyCode: keyCode
                 ),
-                "Ghostty must not retain its super+\(digit) goto_tab/last_tab fallback; the numbered workspace shortcut is owned by KeyboardShortcutSettings"
+                "Ghostty must not retain its super+\(digit) goto_tab/last_tab fallback; any numbered workspace shortcut is owned by KeyboardShortcutSettings"
             )
         }
     }
@@ -3104,6 +3105,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
     func testRightSidebarHeaderChromeUsesSharedButtonsWithCompactIcons() {
         let titlebarConfig = TitlebarControlsStyle.classic.config
 
+        for style in TitlebarControlsStyle.allCases {
+            XCTAssertEqual(style.config.buttonCornerRadius, 0, accuracy: 0.001)
+        }
         XCTAssertEqual(HeaderChromeControlMetrics.buttonSize, titlebarConfig.buttonSize, accuracy: 0.001)
         XCTAssertEqual(HeaderChromeControlMetrics.iconSize, titlebarConfig.iconSize, accuracy: 0.001)
         XCTAssertEqual(HeaderChromeControlMetrics.cornerRadius, titlebarConfig.buttonCornerRadius, accuracy: 0.001)
@@ -3120,6 +3124,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             HeaderChromeIconStyle.iconFrameSize(forIconSize: titlebarConfig.iconSize)
         )
         XCTAssertEqual(RightSidebarChromeMetrics.headerControlCornerRadius, titlebarConfig.buttonCornerRadius, accuracy: 0.001)
+        XCTAssertEqual(RightSidebarChromeMetrics.controlCornerRadius, 0, accuracy: 0.001)
         XCTAssertEqual(RightSidebarChromeMetrics.controlHeight, RightSidebarChromeMetrics.headerControlSize, accuracy: 0.001)
         XCTAssertEqual(RightSidebarChromeMetrics.barVerticalPadding, 4, accuracy: 0.001)
         XCTAssertEqual(RightSidebarChromeMetrics.headerControlCenterAlignmentAdjustment, 0, accuracy: 0.001)
@@ -6599,6 +6604,90 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 )
             }
         }
+    }
+
+    func testDefaultControlDigitFallsThroughToTerminalApps() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        guard let event = makeKeyDownEvent(
+            key: "1",
+            modifiers: [.control],
+            keyCode: 18,
+            windowNumber: 0
+        ) else {
+            XCTFail("Failed to construct Ctrl+1 event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Default Ctrl+1 must fall through so foreground terminal apps can handle it"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+    }
+
+    func testCustomControlDigitSurfaceShortcutRoutesBeforeTerminalInput() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        guard let event = makeKeyDownEvent(
+            key: "2",
+            modifiers: [.control],
+            keyCode: 19,
+            windowNumber: 0
+        ) else {
+            XCTFail("Failed to construct Ctrl+2 event")
+            return
+        }
+
+        let surfaceDigits = StoredShortcut(
+            key: "1",
+            command: false,
+            shift: false,
+            option: false,
+            control: true
+        )
+
+        withTemporaryShortcut(action: .selectSurfaceByNumber, shortcut: surfaceDigits) {
+            XCTAssertTrue(
+                appDelegate.handleConfiguredShortcutKeyEquivalent(event),
+                "A user-bound Select Surface 1…9 Ctrl digit must be claimed before Ghostty's Ctrl fast path"
+            )
+        }
+    }
+
+    func testDefaultCommandDigitFallsThroughToTerminalApps() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        guard let event = makeKeyDownEvent(
+            key: "1",
+            modifiers: [.command],
+            keyCode: 18,
+            windowNumber: 0
+        ) else {
+            XCTFail("Failed to construct Cmd+1 event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertFalse(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Default Cmd+1 must fall through so foreground terminal apps can handle it"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
     }
 
     func testStaleCloseDefaultShortcutsSuppressMenuFallbackAfterReassignment() {

--- a/cmuxTests/KeyboardShortcutContextTests.swift
+++ b/cmuxTests/KeyboardShortcutContextTests.swift
@@ -209,15 +209,15 @@ final class KeyboardShortcutContextTests: XCTestCase {
     }
 
     func testSurfaceDigitFamilyCoexistsWithPrioritizedSidebarModeShortcuts() {
-        let surfaceDigits = KeyboardShortcutSettings.Action.selectSurfaceByNumber.defaultShortcut
+        let surfaceDigits = StoredShortcut(key: "1", command: false, shift: false, option: false, control: true)
         let sidebarFiles = KeyboardShortcutSettings.Action.switchRightSidebarToFiles.defaultShortcut
 
-        // Re-recording the factory default ⌃1 for Select Surface 1…9 must not be
+        // Binding ⌃1 for Select Surface 1…9 must not be
         // rejected against Show Sidebar Files (⌃1): the key router consumes the
         // sidebar-mode shortcuts before general shortcut matching whenever the
         // right sidebar is focused, so the pair is resolved by priority — the
         // sidebar action owns the overlap and the digit family keeps every other
-        // context. The shipped defaults rely on exactly this coexistence.
+        // context.
         XCTAssertFalse(
             KeyboardShortcutSettings.Action.switchRightSidebarToFiles.conflicts(
                 with: surfaceDigits,

--- a/cmuxTests/NumberedShortcutSwapTests.swift
+++ b/cmuxTests/NumberedShortcutSwapTests.swift
@@ -19,16 +19,18 @@ struct NumberedShortcutSwapTests {
         }
         KeyboardShortcutSettings.resetAll()
 
-        let workspaceDefault = KeyboardShortcutSettings.Action.selectWorkspaceByNumber.defaultShortcut
-        let surfaceDefault = KeyboardShortcutSettings.Action.selectSurfaceByNumber.defaultShortcut
+        let workspaceDigits = StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
+        let surfaceDigits = StoredShortcut(key: "1", command: false, shift: false, option: false, control: true)
+        KeyboardShortcutSettings.setShortcut(workspaceDigits, for: .selectWorkspaceByNumber)
+        KeyboardShortcutSettings.setShortcut(surfaceDigits, for: .selectSurfaceByNumber)
 
         let presentation = try #require(ShortcutRecorderValidationPresentation(
             attempt: ShortcutRecorderRejectedAttempt(
                 reason: .conflictsWithAction(.selectSurfaceByNumber),
-                proposedShortcut: surfaceDefault
+                proposedShortcut: surfaceDigits
             ),
             action: .selectWorkspaceByNumber,
-            currentShortcut: workspaceDefault
+            currentShortcut: workspaceDigits
         ))
 
         #expect(presentation.message == "This shortcut conflicts with Select Surface 1…9 (⌃1…9). Swap shortcuts?")
@@ -38,13 +40,13 @@ struct NumberedShortcutSwapTests {
 
         #expect(
             KeyboardShortcutSettings.swapShortcutConflict(
-                proposedShortcut: surfaceDefault,
+                proposedShortcut: surfaceDigits,
                 currentAction: .selectWorkspaceByNumber,
                 conflictingAction: .selectSurfaceByNumber,
-                previousShortcut: workspaceDefault
+                previousShortcut: workspaceDigits
             )
         )
-        #expect(KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber) == surfaceDefault)
-        #expect(KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber) == workspaceDefault)
+        #expect(KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber) == surfaceDigits)
+        #expect(KeyboardShortcutSettings.shortcut(for: .selectSurfaceByNumber) == workspaceDigits)
     }
 }

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -12,6 +12,12 @@ import SwiftUI
 #endif
 
 final class WindowAppearanceSnapshotTests: XCTestCase {
+    func testSidebarChromePresetsUseSquareCorners() {
+        for preset in WindowChromeSidebarPresetOption.allCases {
+            XCTAssertEqual(preset.cornerRadius, 0, accuracy: 0.001)
+        }
+    }
+
     func testUnifiedSurfaceBackdropsUseSingleWindowRootBackdrop() {
         let snapshot = makeSnapshot(unifySurfaceBackdrops: true)
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -527,6 +527,14 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         }
     }
 
+    func testSelectSurfaceByNumberIsUnboundByDefault() {
+        XCTAssertTrue(KeyboardShortcutSettings.Action.selectSurfaceByNumber.defaultShortcut.isUnbound)
+    }
+
+    func testSelectWorkspaceByNumberIsUnboundByDefault() {
+        XCTAssertTrue(KeyboardShortcutSettings.Action.selectWorkspaceByNumber.defaultShortcut.isUnbound)
+    }
+
     func testSettingsVisibleShortcutActionsIncludeRemappableExampleShortcuts() {
         let visibleActions = Set(KeyboardShortcutSettings.settingsVisibleActions)
 
@@ -2794,6 +2802,7 @@ final class StoredShortcutMatchingTests: XCTestCase {
     }
 
     func testShortcutRecorderValidationPresentationUsesNumberedDisplayOnlyForNumberedConflicts() {
+        let workspaceDigits = StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
         let presentation = ShortcutRecorderValidationPresentation(
             attempt: ShortcutRecorderRejectedAttempt(
                 reason: .conflictsWithAction(.selectWorkspaceByNumber),
@@ -2801,7 +2810,9 @@ final class StoredShortcutMatchingTests: XCTestCase {
             ),
             action: .openBrowser,
             currentShortcut: KeyboardShortcutSettings.Action.openBrowser.defaultShortcut,
-            shortcutForAction: { $0.defaultShortcut }
+            shortcutForAction: { action in
+                action == .selectWorkspaceByNumber ? workspaceDigits : action.defaultShortcut
+            }
         )
 
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
- unbind Select Workspace 1-9 and Select Surface 1-9 by default so terminal and window-manager digit chords pass through
- keep explicit user Select Surface 1-9 bindings working from focused terminals before Ghostty handles Ctrl input
- clamp Ghostty drawable size to the visible window-content intersection when portal geometry is oversized
- reduce managed Ghostty terminal padding to 2px on each axis
- square panel rings, titlebar controls, right-sidebar controls, and sidebar chrome presets

## Test
- swift test --package-path Packages/macOS/CmuxSettings --filter ShortcutActionNumberedDigitTests
- swift test --package-path Packages/macOS/CmuxSettingsUI --filter ShortcutDisplayStringTests.numberedCommandDigitRendersAsRange
- git diff --check
- local xcodebuild test/build blocked by cmuxterm-hq guard
- ./scripts/reload-cloud.sh --tag niri, run 27864219861 succeeded
- tagged preflight: bound Select Surface 1-9 to Ctrl+1, real Ctrl+1 keypress changed focused surface surface:4 to surface:6
- tagged preflight: oversized 2344x1352 terminal drawable clamped to visible 2064x1187
- tagged screenshot: /var/folders/rr/vmfx6xh12dz2tlvgtmyvjmf80000gn/T/cmux-screenshots/niri-preflight_2026-06-20T07-32-58Z_B706846D.png

Dogfood tag: http://127.0.0.1:17320/niri