### PR TITLE
iOS: allow terminal zoom-out below 8pt (min 8 -> 2)

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalFontPreference.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/MobileTerminalFontPreference.swift
@@ -20,8 +20,9 @@ public struct MobileTerminalFontPreference {
     /// scale as macOS (see the iOS DPI handling in `ghostty/src/font/face.zig`);
     /// the Retina pixel multiplier is applied separately via content scale.
     public static let defaultSize: Float32 = 10
-    /// Smallest size the zoom controls will reach.
-    static let minimumSize: Float32 = 8
+    /// Smallest size the zoom controls will reach. Intentionally tiny so the
+    /// pinch/zoom-out can pack many columns/rows onto the phone for an overview.
+    static let minimumSize: Float32 = 2
     /// Largest size the zoom controls will reach.
     static let maximumSize: Float32 = 28
 }


### PR DESCRIPTION
Lowers the iOS terminal pinch/zoom-out floor from 8pt to 2pt so you can shrink the terminal much smaller for a high-density overview.

`MobileTerminalFontPreference.minimumSize` is the single clamp every zoom path honors (the step + absolute-zoom guards in `GhosttySurfaceView` both read it), so this one constant flows through. `defaultSize` (10) is unchanged — fresh launches are unaffected; only how far you can zoom out changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784529572&installation_id=133855650&pr_number=6486&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6486&signature=f1e03b6f93d5de4d9a73d5599cedea3a54aebf98c6b39ed0f22147f96215a85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and comment change in iOS font zoom bounds; no auth, data, or launch behavior changes.
> 
> **Overview**
> **Lowers the iOS terminal pinch/zoom-out floor** by changing `MobileTerminalFontPreference.minimumSize` from **8pt to 2pt**, with an updated comment explaining the intent (dense overview with more columns/rows).
> 
> `defaultSize` (**10pt**) is unchanged, so launch font size is the same; only how far zoom controls can shrink the live font is affected. `GhosttySurfaceView` already clamps step and absolute zoom against this constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fbdce967ef6b92f0860affd2b0166556d0bafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the iOS terminal minimum zoom size from 8pt to 2pt so you can zoom out much further for a high-density overview. The default size (10pt) is unchanged; only the zoom-out floor is lower.

<sup>Written for commit f5fbdce967ef6b92f0860affd2b0166556d0bafc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reduced the minimum font zoom level for the iOS terminal, allowing users to fit more content on screen by enabling smaller font sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->