### PR TITLE
ios: fix broken Release archive blocking all TestFlight builds

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -187,8 +187,8 @@
 561	cmuxTests/GhosttyConfigPathResolverTests.swift
 560	cmuxTests/CLISSHPTYResizeInputTests.swift
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
-555	Sources/Panels/BrowserAutomation.swift
 551	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
+549	Sources/Panels/BrowserAutomation.swift
 541	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
 540	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 539	CLI/CMUXCLI+Themes.swift
@@ -221,5 +221,6 @@
 505	cmuxUITests/DisplayResolutionRegressionUITests.swift
 504	Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
 504	cmuxTests/TerminalNotificationSocketActionTests.swift
+503	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
 503	Sources/Settings/ConfigSource.swift
 502	Sources/CmuxEventPublishing.swift

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -78,6 +78,18 @@ struct CMUXMobileRootView: View {
         #endif
     }
 
+    // `WorkspaceListLayoutPreviewView` is `#if DEBUG`-only (a simulator
+    // screenshot fixture), so referencing it directly in `rootContent` breaks the
+    // Release archive ("cannot find ... in scope"). Gate the reference here, the
+    // same way `terminalLayoutPreview` does, so Release compiles to `EmptyView`.
+    @ViewBuilder private var workspaceListLayoutPreview: some View {
+        #if os(iOS) && DEBUG
+        WorkspaceListLayoutPreviewView()
+        #else
+        EmptyView()
+        #endif
+    }
+
     var body: some View {
         rootContent
         .sheet(isPresented: addDeviceSheetBinding) {
@@ -167,7 +179,7 @@ struct CMUXMobileRootView: View {
         if shouldShowTerminalLayoutPreview {
             terminalLayoutPreview
         } else if shouldShowWorkspaceListLayoutPreview {
-            WorkspaceListLayoutPreviewView()
+            workspaceListLayoutPreview
         } else if shouldShowRestoringSession {
             RestoringSessionView()
         } else if !isAuthenticated {


### PR DESCRIPTION
## The bug

`CMUXMobileRootView.rootContent` references `WorkspaceListLayoutPreviewView()` **directly**, but that view is `#if canImport(UIKit) && DEBUG`-only (a simulator screenshot fixture). PR CI builds **Debug** (where the symbol exists), so this passed review — but the TestFlight **Release archive** fails:

```
CMUXMobileRootView.swift:170: error: cannot find 'WorkspaceListLayoutPreviewView' in scope
** ARCHIVE FAILED **
```

This has silently blocked **every** TestFlight build since it landed: last successful upload was **2026-06-18**, and both the **2026-06-19 nightly** and a **2026-06-20 dispatch** failed here. (It's why the merged backspace fix and everything since hasn't reached beta.)

## The fix

`shouldShowWorkspaceListLayoutPreview` is already `false` in Release, so the branch is dead code there. Route the reference through a `workspaceListLayoutPreview` `@ViewBuilder` that compiles to `EmptyView` in Release — exactly mirroring the existing `terminalLayoutPreview`. One-file, no behavior change in Debug.

## Note

PR CI (Debug) can't catch this class of bug. A companion PR adds an on-iOS-change TestFlight (Release archive) lane so a broken Release archive surfaces immediately instead of silently stranding beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784532443&installation_id=133855650&pr_number=6488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6488&signature=055f394113ca5283aab6be1d3f6b0a9e6e24ccf5eed34439d6393289cd2550d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time gating only; Release behavior was already dead code via `shouldShowWorkspaceListLayoutPreview`, with no production UI or auth changes.
> 
> **Overview**
> Fixes **TestFlight Release archive failures** caused by `rootContent` referencing `WorkspaceListLayoutPreviewView()` directly while that type exists only under `#if DEBUG`.
> 
> Adds a **`workspaceListLayoutPreview`** `@ViewBuilder` (same pattern as `terminalLayoutPreview`) so Release builds compile the branch to `EmptyView`, and **`rootContent`** now uses that helper instead of the raw type. Debug simulator screenshot fixtures are unchanged when the preview flags are on.
> 
> Also updates **`.github/swift-file-length-budget.tsv`** for small line-count shifts in `CMUXMobileRootView.swift` and `BrowserAutomation.swift`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96959211eb87a600a19d1c3d20b8e1bd0d8e4a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix iOS Release archive by gating the DEBUG-only `WorkspaceListLayoutPreviewView` behind a `@ViewBuilder` that compiles to `EmptyView` in Release. This unblocks TestFlight uploads with no Debug behavior change.

- **Bug Fixes**
  - Routed `WorkspaceListLayoutPreviewView` through `workspaceListLayoutPreview` with `#if os(iOS) && DEBUG`, mirroring `terminalLayoutPreview`.
  - Updated `rootContent` to use the gated view so Release no longer fails with “cannot find ... in scope”.
  - Refreshed `.github/swift-file-length-budget.tsv` for `CMUXMobileRootView.swift` to keep CI passing after adding the gate helper.

<sup>Written for commit 96959211eb87a600a19d1c3d20b8e1bd0d8e4a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved conditional logic for preview components to ensure correct behavior across different build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->