### PR TITLE
ci: run iOS TestFlight beta lane every ~2h (prompt internal builds)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -27,11 +27,22 @@ on:
         default: false
         type: boolean
   schedule:
-    # Nightly at 09:10 UTC. The decide job skips the run only when the current
-    # main HEAD was already uploaded by a prior successful run (SHA compare, not
-    # a wall-clock window), so a failed or missed nightly retries the
-    # not-yet-uploaded commit instead of permanently stranding it.
-    - cron: "10 9 * * *"
+    # Every ~2h (at :17 to stay off the top-of-hour rush). The decide job skips a
+    # run only when the current main HEAD was already uploaded by a prior
+    # successful run (SHA compare, not a wall-clock window), so an iOS-affecting
+    # change reaches internal TestFlight within ~2h of landing on main, and a
+    # failed or missed run retries the not-yet-uploaded commit instead of
+    # permanently stranding it.
+    #
+    # Why ~2h and not a push trigger / per-commit: a per-push lane needs either a
+    # shared concurrency group (which cancels superseded pending runs into red
+    # checks) or per-SHA concurrency (which removes the serialization that keeps
+    # parallel archives from racing on the timestamp build number). ~2h spacing
+    # keeps runs from overlapping (an archive+upload takes ~30-60m), so this
+    # single per-ref lane stays serialized and uploads never collide. If faster
+    # turnaround is ever needed, tighten the interval (still > one archive's
+    # duration) rather than adding a push trigger.
+    - cron: "17 */2 * * *"
 
 concurrency:
   group: ios-testflight-${{ github.ref_name }}


### PR DESCRIPTION
## Why

An iOS change waited up to ~24h to reach internal TestFlight (the lane ran on a nightly cron) — and if that one nightly failed, another day. You wanted iOS changes to reach internal builds promptly.

## What

One-line cadence change: run the existing `ios-testflight.yml` lane **every ~2h** (`17 */2 * * *`) instead of nightly. The `decide` job already SHA-compares HEAD to the last uploaded commit, so each run uploads the latest main only when it has advanced (green skip otherwise).

## Why not a push trigger / per-commit (autoreview drove this)

A per-push, build-per-commit lane looked simpler but isn't, and three autoreview rounds proved it:
- A **shared** concurrency group cancels superseded *pending* runs into red checks on intermediate commits (the original reason there was no push trigger).
- **Per-SHA** concurrency avoids that but removes the serialization that keeps parallel archives from racing on the timestamp `CFBundleVersion` (same-second collisions; or an older commit uploading after a newer one with a lower build number).
- The success-based dedupe can also strand a commit (a run can succeed without uploading).

Running the single, already-serialized per-ref lane more often sidesteps all of that. ~2h spacing exceeds one archive's duration (~30-60m), so runs never overlap and uploads never collide. If faster turnaround is needed later, tighten the interval (kept > one archive's duration) rather than adding a push trigger.

For an immediate beta, `workflow_dispatch` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI schedule and documentation only; no changes to signing, upload scripts, or dedupe logic.
> 
> **Overview**
> **Shortens internal TestFlight latency** by changing the `ios-testflight.yml` schedule from once daily (`10 9 * * *`) to **every ~2 hours** at minute 17 (`17 */2 * * *`).
> 
> The upload path is unchanged: the `decide` job still SHA-compares `main` HEAD to the last successful run and skips when nothing new needs shipping. Expanded workflow comments document why **~2h** beats a push trigger (concurrency/cancelled checks, `CFBundleVersion` races) and why the interval stays longer than a typical archive+upload (~30–60m) so the single serialized per-ref lane does not overlap.
> 
> `workflow_dispatch` remains for on-demand uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0de96dcea4d8f0350b29d551360565fcf1c474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build automation to generate TestFlight releases more frequently (every 2 hours instead of nightly).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->