### PR TITLE
Speed up macOS CI lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,9 @@ jobs:
         shard: [1, 2, 3, 4]
     env:
       CMUX_SKIP_ZIG_BUILD: "1"
+      # Keep one-off focused gates on the lightest measured shard so shard 1 no
+      # longer carries the full shard plus every extra regression guard.
+      CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD: "4"
       # XCTest app-host crashes can leave xcodebuild waiting in Swift's crash
       # backtracer until the job timeout. Keep crash handling non-interactive
       # and cheap so xcodebuild can restart/finish the suite.
@@ -412,20 +415,9 @@ jobs:
         run: |
           ./scripts/download-prebuilt-ghosttykit.sh
 
-      - name: Install zig
-        run: |
-          ./scripts/install-zig-ci.sh
-
       - name: Install Rust
         run: |
           ./scripts/install-rust-ci.sh
-
-      - name: Cache Zig packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/zig
-          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
-          restore-keys: zig-packages-
 
       - name: Cache Swift packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -475,7 +467,7 @@ jobs:
           done
 
       - name: Run Ghostty split-theme appearance regression
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
           set -euo pipefail
           DERIVED_DATA_PATH="${RUNNER_TEMP:-/tmp}/cmux-terminal-core-split-theme"
@@ -504,7 +496,7 @@ jobs:
           fi
 
       - name: Run browser system proxy mirror regression
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
           # Focused gate for https://github.com/manaflow-ai/cmux/issues/5888.
           # The full "Run unit tests" step tolerates app-host crashes by
@@ -526,7 +518,7 @@ jobs:
             test
 
       - name: Run Option/Alt sided-modifier regression
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
@@ -626,14 +618,14 @@ jobs:
           fi
 
       - name: Run bundled Ghostty theme picker helper regression
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
           set -euo pipefail
           CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
             ./tests/test_bundled_ghostty_theme_picker_helper.sh
 
       - name: Run CLI no-socket regressions
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,18 +185,6 @@ jobs:
           chmod +x "$wrapper_dir/create-dmg"
           echo "$wrapper_dir" >> "$GITHUB_PATH"
 
-      - name: Build universal Ghostty CLI helper
-        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
-        env:
-          DEVELOPER_DIR: ${{ env.HELPER_DEVELOPER_DIR }}
-        run: |
-          set -euo pipefail
-          ./scripts/build-ghostty-cli-helper.sh --universal --output /tmp/cmux-ghostty-helper-universal
-          ARCHS_OUT="$(lipo -archs /tmp/cmux-ghostty-helper-universal)"
-          echo "Universal Ghostty CLI helper architectures: $ARCHS_OUT"
-          case " $ARCHS_OUT " in *" arm64 "*) ;; *) echo "helper missing arm64 slice" >&2; exit 1 ;; esac
-          case " $ARCHS_OUT " in *" x86_64 "*) ;; *) echo "helper missing x86_64 slice" >&2; exit 1 ;; esac
-
       - name: Download pre-built GhosttyKit.xcframework
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
@@ -233,20 +221,45 @@ jobs:
           echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
           echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
-      - name: Build universal nightly app (Release)
+      - name: Build universal nightly app and Ghostty CLI helper (Release)
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
-        env:
-          # Skip the in-Xcode zig helper build; it would fail to cross-link
-          # x86_64 against the macOS 26 SDK. The real universal helper is built
-          # by the "Build universal Ghostty CLI helper" step and injected below.
-          CMUX_SKIP_ZIG_BUILD: "1"
         run: |
-          xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
+          set -euo pipefail
+          HELPER_LOG="$RUNNER_TEMP/cmux-nightly-ghostty-helper.log"
+          (
+            set -euo pipefail
+            export DEVELOPER_DIR="$HELPER_DEVELOPER_DIR"
+            ./scripts/build-ghostty-cli-helper.sh --universal --output /tmp/cmux-ghostty-helper-universal
+            ARCHS_OUT="$(lipo -archs /tmp/cmux-ghostty-helper-universal)"
+            echo "Universal Ghostty CLI helper architectures: $ARCHS_OUT"
+            case " $ARCHS_OUT " in *" arm64 "*) ;; *) echo "helper missing arm64 slice" >&2; exit 1 ;; esac
+            case " $ARCHS_OUT " in *" x86_64 "*) ;; *) echo "helper missing x86_64 slice" >&2; exit 1 ;; esac
+          ) >"$HELPER_LOG" 2>&1 &
+          HELPER_PID=$!
+
+          APP_STATUS=0
+          set +e
+          # Skip only the in-Xcode helper build; the background helper process
+          # above must build the real universal Zig helper, not the CI stub.
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
             -clonedSourcePackagesDirPath .spm-cache \
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
+          APP_STATUS=$?
+          set -e
+          HELPER_STATUS=0
+          wait "$HELPER_PID" || HELPER_STATUS=$?
+          cat "$HELPER_LOG"
+          if [ "$APP_STATUS" -ne 0 ]; then
+            echo "Universal nightly app build failed" >&2
+            exit "$APP_STATUS"
+          fi
+          if [ "$HELPER_STATUS" -ne 0 ]; then
+            echo "Universal Ghostty CLI helper build failed" >&2
+            exit "$HELPER_STATUS"
+          fi
 
       - name: Inject universal Ghostty CLI helper
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
 
 if ! awk '
-  /^      - name: Build universal nightly app \(Release\)/ { in_universal=1; next }
+  /^      - name: Build universal nightly app and Ghostty CLI helper \(Release\)/ { in_universal=1; next }
   in_universal && /^      - name:/ { in_universal=0 }
   in_universal && /-destination '\''generic\/platform=macOS'\''/ { saw_universal_destination=1 }
   in_universal && /ARCHS="arm64 x86_64"/ { saw_universal_archs=1 }
@@ -20,14 +20,16 @@ if ! awk '
 fi
 
 if ! awk '
-  /^      - name: Build universal Ghostty CLI helper/ { in_helper=1; next }
+  /^      - name: Build universal nightly app and Ghostty CLI helper \(Release\)/ { in_helper=1; next }
   in_helper && /^      - name:/ { in_helper=0 }
   in_helper && /build-ghostty-cli-helper\.sh --universal/ { saw_build=1 }
   in_helper && /helper missing arm64 slice/ { saw_arm64_assert=1 }
   in_helper && /helper missing x86_64 slice/ { saw_x86_assert=1 }
-  END { exit !(saw_build && saw_arm64_assert && saw_x86_assert) }
+  in_helper && /wait "\$HELPER_PID"/ { saw_wait=1 }
+  in_helper && /cat "\$HELPER_LOG"/ { saw_log=1 }
+  END { exit !(saw_build && saw_arm64_assert && saw_x86_assert && saw_wait && saw_log) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must build and verify the real universal Ghostty helper"
+  echo "FAIL: nightly workflow must build and verify the real universal Ghostty helper alongside the app build"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Run the nightly Ghostty CLI helper build in parallel with the universal Release app build, then wait and verify before injection.
- Remove unused Zig setup from app-host unit-test shards and move focused one-off app-host/CLI gates from shard 1 to shard 4.
- Add a workflow guard for the app-host CI shape and update the nightly universal guard.

## Testing
- ./tests/test_ci_app_host_workflow_shape.sh
- bash ./tests/test_nightly_universal_build.sh
- python3 scripts/ci/cmux_unit_test_shard.py --validate
- bash -n tests/test_ci_app_host_workflow_shape.sh tests/test_nightly_universal_build.sh
- ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p) }; puts "yaml ok"' .github/workflows/ci.yml .github/workflows/nightly.yml\n- actionlint .github/workflows/ci.yml .github/workflows/nightly.yml\n- git diff --check\n- /Users/lawrence/fun/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main\n\n## Issues\n- Task: speed up Nightly macOS build / build-sign-notarize-nightly and CI / app-host unit tests (1/4)\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784532865&installation_id=133855650&pr_number=6490&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6490&signature=47a539355d9e561b84033b91dbea4f2734a48423d0806dae4bd80ece655dd627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow timing and shard placement; release artifacts and regression gates stay the same, with no application or security logic touched.
> 
> **Overview**
> **Nightly** no longer runs the universal Ghostty CLI helper as a separate step before the Release app build. One step starts `build-ghostty-cli-helper.sh --universal` in the background (with `HELPER_DEVELOPER_DIR`), runs `xcodebuild` with `CMUX_SKIP_ZIG_BUILD=1`, then waits on the helper, prints its log, and fails if either side failed. Injection and arch checks are unchanged.
> 
> **App-host unit tests** drop Zig install and the Zig package cache on every shard (tests already use prebuilt GhosttyKit and `CMUX_SKIP_ZIG_BUILD=1`). Focused one-off gates (split-theme, proxy mirror, Option/Alt mods, theme picker helper, CLI no-socket regressions) move off shard 1 onto shard **4** via `CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD` and `fromJSON(env.…)` in step `if` conditions.
> 
> `tests/test_nightly_universal_build.sh` now asserts the combined nightly step includes parallel helper build, `wait`, and log output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 628803843cbcc0e7fce8ca9edaf6a1e80ab8f3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up macOS CI by building the Nightly Release app and universal Ghostty CLI helper in one parallel step, and by rebalancing app-host unit-test shards while removing unused Zig setup. Satisfies the task to speed up Nightly macOS builds and app-host unit tests.

- **Refactors**
  - Nightly: combine app and universal helper builds; run helper in background with `DEVELOPER_DIR` override; wait and show log; assert `arm64`/`x86_64`; fail if either build fails; use `CMUX_SKIP_ZIG_BUILD=1` only for the in-Xcode helper; update `tests/test_nightly_universal_build.sh` to verify combined step, wait, and log.
  - App-host unit tests: move focused regressions to shard 4 via `CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD` and `fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD)`; drop Zig install and cache; keep `CMUX_SKIP_ZIG_BUILD=1`.

<sup>Written for commit 628803843cbcc0e7fce8ca9edaf6a1e80ab8f3b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized macOS continuous integration workflow with environment-based shard selection for focused regression tests, improving workflow configuration and maintainability.
  * Improved nightly build process efficiency by parallelizing universal binary helper compilation with the primary application build step, reducing total build time.
  * Updated test validation suite to reflect the consolidated build workflow structure and verify all build components correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->