### PR TITLE
feat(sidebar): show claude agents --json sessions in custom sidebars

### DIFF
--- a/Examples/CustomSidebars/claude-agents.swift
+++ b/Examples/CustomSidebars/claude-agents.swift
@@ -1,0 +1,54 @@
+// Claude Code background agents, grouped by project (working directory).
+//
+// Binds to the live `agents` array (mirrors `claude agents --json --all`):
+// every live session plus background sessions that are still working or
+// blocked, and completed ones. A status dot encodes state, and the right side
+// shows what a blocked session is waiting on plus its raw state.
+VStack(alignment: .leading, spacing: 4) {
+    Text("Claude Agents").font(.headline)
+    Text("\(agentsWorkingCount) working · \(agentsBlockedCount) blocked · \(agentsCount) total")
+        .font(.system(size: 10)).monospacedDigit().foregroundColor(.secondary)
+    Divider()
+
+    let sorted = agents.sorted { $0.cwd < $1.cwd }
+    ScrollView {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(sorted.enumerated()), id: \.offset) { i, a in
+                let parts = a.cwd.split(separator: "/")
+                let proj = parts.count > 0 ? String(parts.last) : a.cwd
+                let prevCwd = i > 0 ? sorted[i - 1].cwd : ""
+                let showHeader = i == 0 || a.cwd != prevCwd
+                let dot = a.working ? "#34C759" : (a.blocked ? "#FF9F0A" : (a.failed ? "#F85149" : "#8E8E93"))
+
+                VStack(alignment: .leading, spacing: 0) {
+                    if showHeader {
+                        Text(proj)
+                            .font(.system(size: 10)).bold().textCase(.uppercase)
+                            .foregroundColor(.secondary)
+                            .padding(.top, i == 0 ? 2 : 8)
+                            .padding(.bottom, 2)
+                    }
+                    HStack(alignment: .center, spacing: 6) {
+                        Text("●").font(.system(size: 7)).foregroundColor(dot)
+                        Text(a.name != nil ? a.name : (a.id != nil ? a.id : "session"))
+                            .font(.system(size: 11)).lineLimit(1).truncationMode(.tail)
+                        Spacer(minLength: 4)
+                        if a.waitingFor != nil {
+                            Text(a.waitingFor)
+                                .font(.system(size: 9)).foregroundColor("#FF9F0A")
+                                .lineLimit(1).truncationMode(.tail).layoutPriority(-1)
+                        }
+                        if a.state != nil {
+                            Text(a.state)
+                                .font(.system(size: 9)).monospaced()
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    .padding(.horizontal, 6)
+                    .frame(height: 22, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/ClaudeAgentsSessionParser.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/ClaudeAgentsSessionParser.swift
@@ -1,0 +1,53 @@
+public import Foundation
+
+/// Parses the JSON array printed by `claude agents --json` (optionally with
+/// `--all`) into ``CustomSidebarAgentSnapshot`` values for the custom-sidebar
+/// interpreter context.
+///
+/// Parsing is deliberately lenient: a payload that fails to decode (claude not
+/// installed, an error written to stdout, a schema change) yields an empty
+/// array rather than throwing, and individual entries missing a `cwd` are
+/// dropped instead of failing the whole batch. This keeps the sidebar render
+/// resilient — a bad poll simply shows no agents instead of breaking.
+public enum ClaudeAgentsSessionParser {
+    /// Decodes `claude agents --json` stdout into agent snapshots. Returns an
+    /// empty array on any decode failure.
+    public static func parse(_ data: Data) -> [CustomSidebarAgentSnapshot] {
+        guard let entries = try? JSONDecoder().decode([Entry].self, from: data) else {
+            return []
+        }
+        return entries.compactMap { $0.snapshot }
+    }
+
+    /// A lenient mirror of one `claude agents --json` array element. Every field
+    /// is optional so a single malformed or partial entry cannot fail the whole
+    /// decode; entries without a `cwd` are dropped when projecting.
+    private struct Entry: Decodable {
+        let id: String?
+        let cwd: String?
+        let kind: String?
+        let name: String?
+        let sessionId: String?
+        let state: String?
+        let status: String?
+        let pid: Int?
+        let startedAt: Double?
+        let waitingFor: String?
+
+        var snapshot: CustomSidebarAgentSnapshot? {
+            guard let cwd, !cwd.isEmpty else { return nil }
+            return CustomSidebarAgentSnapshot(
+                id: id,
+                cwd: cwd,
+                kind: kind ?? "",
+                name: name,
+                sessionId: sessionId,
+                state: state,
+                status: status,
+                pid: pid,
+                startedAt: startedAt.map { Int($0) },
+                waitingFor: waitingFor
+            )
+        }
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/ClaudeAgentsSessionPoller.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/ClaudeAgentsSessionPoller.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Periodically refreshes the list of Claude Code agent sessions shown in a
+/// custom sidebar (the interpreter's top-level `agents` array).
+///
+/// The poller owns no process-spawning or executable-resolution logic itself —
+/// that is the app's concern and is injected as the `fetch` closure, which is
+/// expected to run `claude agents --json --all` off the main thread and return
+/// parsed snapshots (see ``ClaudeAgentsSessionParser``). Keeping the subprocess
+/// out of this UI package preserves the layering and makes the poller trivially
+/// testable with a stub fetch.
+///
+/// Lifecycle is explicit: ``start()`` begins a single non-overlapping refresh
+/// loop (each tick awaits the previous fetch before sleeping), and ``stop()``
+/// cancels it. The owning view should start the poller when a custom sidebar
+/// appears and stop it when it disappears, so no `claude` subprocess runs while
+/// no custom sidebar is on screen. `sessions` is read on each ~1s sidebar tick;
+/// because this type is not observable, updates are picked up by that tick
+/// rather than by invalidating SwiftUI — intentionally, to avoid the
+/// orthogonal-invalidation churn the sidebar list is sensitive to.
+@MainActor
+public final class ClaudeAgentsSessionPoller {
+    /// The most recent successfully-fetched agent sessions. Empty until the
+    /// first successful poll; a failed poll leaves the previous value in place.
+    public private(set) var sessions: [CustomSidebarAgentSnapshot] = []
+
+    private let interval: Duration
+    private let fetch: @Sendable () async -> [CustomSidebarAgentSnapshot]?
+    private var task: Task<Void, Never>?
+
+    /// Creates a poller.
+    ///
+    /// - Parameters:
+    ///   - interval: Delay between the end of one fetch and the start of the
+    ///     next. Defaults to 3 seconds — frequent enough to feel live without
+    ///     spawning `claude` too aggressively.
+    ///   - fetch: Returns the current agent sessions, or `nil` on failure (in
+    ///     which case the previous `sessions` value is kept). Must do its work
+    ///     off the main thread.
+    public nonisolated init(
+        interval: Duration = .seconds(3),
+        fetch: @escaping @Sendable () async -> [CustomSidebarAgentSnapshot]?
+    ) {
+        self.interval = interval
+        self.fetch = fetch
+    }
+
+    /// Starts the refresh loop. No-op if already running.
+    public func start() {
+        guard task == nil else { return }
+        let fetch = self.fetch
+        let interval = self.interval
+        task = Task { [weak self] in
+            while !Task.isCancelled {
+                if let result = await fetch() {
+                    self?.sessions = result
+                }
+                if Task.isCancelled { break }
+                try? await Task.sleep(for: interval)
+            }
+        }
+    }
+
+    /// Cancels the refresh loop. Safe to call when not running.
+    public func stop() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarAgentSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarAgentSnapshot.swift
@@ -1,0 +1,60 @@
+/// One Claude Code agent session projected into the custom-sidebar interpreter
+/// context (the top-level `agents` array).
+///
+/// Mirrors a single entry of `claude agents --json --all`: every live session
+/// plus background sessions that are still working or blocked, and (with
+/// `--all`) completed background sessions. Optional fields follow the CLI's own
+/// presence rules — e.g. `id` and `state` appear for background sessions,
+/// `pid`/`status` only while the process is alive, and `waitingFor` only when a
+/// session is blocked on something such as a permission prompt.
+public struct CustomSidebarAgentSnapshot: Sendable, Equatable {
+    /// The short background-session id (usable with `claude attach/logs/stop`),
+    /// or `nil` for interactive sessions that have no background id.
+    public let id: String?
+    /// The session's working directory. Used to group sessions by project.
+    public let cwd: String
+    /// `background` or `interactive`.
+    public let kind: String
+    /// The session's display name, when one was set.
+    public let name: String?
+    /// The full conversation/session UUID, when present.
+    public let sessionId: String?
+    /// Background lifecycle state: `working`, `blocked`, `done`, `failed`, or
+    /// `stopped`. `nil` for plain interactive sessions.
+    public let state: String?
+    /// Live process status (e.g. `busy`, `idle`, `waiting`), present only while
+    /// the process is alive.
+    public let status: String?
+    /// The OS process id, present only while the process is alive.
+    public let pid: Int?
+    /// Start time in milliseconds since the Unix epoch, when reported.
+    public let startedAt: Int?
+    /// What a blocked session is waiting on (e.g. `permission prompt`), present
+    /// only while `status` is `waiting`.
+    public let waitingFor: String?
+
+    /// Creates an agent-session snapshot from already-resolved values.
+    public init(
+        id: String?,
+        cwd: String,
+        kind: String,
+        name: String?,
+        sessionId: String?,
+        state: String?,
+        status: String?,
+        pid: Int?,
+        startedAt: Int?,
+        waitingFor: String?
+    ) {
+        self.id = id
+        self.cwd = cwd
+        self.kind = kind
+        self.name = name
+        self.sessionId = sessionId
+        self.state = state
+        self.status = status
+        self.pid = pid
+        self.startedAt = startedAt
+        self.waitingFor = waitingFor
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarContextSnapshot.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarContextSnapshot.swift
@@ -17,6 +17,9 @@ public struct CustomSidebarContextSnapshot: Sendable, Equatable {
     public let selectedWorkspaceTitle: String
     /// The total unread count across all workspaces (`unreadTotal`).
     public let totalUnreadCount: Int
+    /// The Claude Code agent sessions shown in the `agents` array, in the order
+    /// returned by `claude agents --json`. Empty when none are known.
+    public let agents: [CustomSidebarAgentSnapshot]
     /// The wall-clock instant the `clock` object is derived from.
     public let now: Date
 
@@ -26,12 +29,14 @@ public struct CustomSidebarContextSnapshot: Sendable, Equatable {
         selectedWorkspaceId: UUID?,
         selectedWorkspaceTitle: String,
         totalUnreadCount: Int,
+        agents: [CustomSidebarAgentSnapshot] = [],
         now: Date
     ) {
         self.workspaces = workspaces
         self.selectedWorkspaceId = selectedWorkspaceId
         self.selectedWorkspaceTitle = selectedWorkspaceTitle
         self.totalUnreadCount = totalUnreadCount
+        self.agents = agents
         self.now = now
     }
 }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Layout/CustomSidebarDataContextBuilder.swift
@@ -46,14 +46,69 @@ public struct CustomSidebarDataContextBuilder {
             "weekday": .int(components.weekday ?? 0),
             "epoch": .int(Int(snapshot.now.timeIntervalSince1970)),
         ])
+        let agents: [SwiftValue] = snapshot.agents.map(agentValue(_:))
+        let workingCount = snapshot.agents.filter { $0.state == "working" }.count
+        let blockedCount = snapshot.agents.filter { $0.state == "blocked" }.count
         return [
             "workspaces": .array(workspaces),
             "workspaceCount": .int(snapshot.workspaces.count),
             "selectedTitle": .string(snapshot.selectedWorkspaceTitle),
             "selectedId": .string(snapshot.selectedWorkspaceId?.uuidString ?? ""),
             "unreadTotal": .int(snapshot.totalUnreadCount),
+            "agents": .array(agents),
+            "agentsCount": .int(snapshot.agents.count),
+            "agentsWorkingCount": .int(workingCount),
+            "agentsBlockedCount": .int(blockedCount),
             "clock": clock,
         ]
+    }
+
+    /// Projects one Claude Code agent session into the interpreter value tree.
+    ///
+    /// Always-present fields (`cwd`, `kind`) map straight through. Optional CLI
+    /// fields are omitted when absent so interpreted `if let` / ternary
+    /// truthiness behaves. Convenience booleans derived from `state`
+    /// (`working`, `blocked`, `done`, `failed`, `stopped`, `active`) and
+    /// `kind` (`background`) are always present so sidebar files can branch on
+    /// them without string comparisons.
+    public func agentValue(_ agent: CustomSidebarAgentSnapshot) -> SwiftValue {
+        let state = agent.state
+        var fields: [String: SwiftValue] = [
+            "cwd": .string(agent.cwd),
+            "kind": .string(agent.kind),
+            "background": .bool(agent.kind == "background"),
+            "working": .bool(state == "working"),
+            "blocked": .bool(state == "blocked"),
+            "done": .bool(state == "done"),
+            "failed": .bool(state == "failed"),
+            "stopped": .bool(state == "stopped"),
+            "active": .bool(state == "working" || state == "blocked"),
+        ]
+        if let id = agent.id, !id.isEmpty {
+            fields["id"] = .string(id)
+        }
+        if let name = agent.name, !name.isEmpty {
+            fields["name"] = .string(name)
+        }
+        if let sessionId = agent.sessionId, !sessionId.isEmpty {
+            fields["sessionId"] = .string(sessionId)
+        }
+        if let state, !state.isEmpty {
+            fields["state"] = .string(state)
+        }
+        if let status = agent.status, !status.isEmpty {
+            fields["status"] = .string(status)
+        }
+        if let pid = agent.pid {
+            fields["pid"] = .int(pid)
+        }
+        if let startedAt = agent.startedAt {
+            fields["startedAt"] = .int(startedAt)
+        }
+        if let waitingFor = agent.waitingFor, !waitingFor.isEmpty {
+            fields["waitingFor"] = .string(waitingFor)
+        }
+        return .object(fields)
     }
 
     /// Projects one workspace's snapshot into the interpreter value tree.

--- a/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/ClaudeAgentsSessionParserTests.swift
+++ b/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/ClaudeAgentsSessionParserTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import CmuxSidebar
+
+@Suite("ClaudeAgentsSessionParser")
+struct ClaudeAgentsSessionParserTests {
+    @Test("Maps a representative claude agents --json payload")
+    func mapsRepresentativePayload() {
+        let json = """
+        [
+          {
+            "id": "8e89cfdd",
+            "cwd": "/repo/.claude/worktrees/feature",
+            "kind": "background",
+            "startedAt": 1781774127358,
+            "sessionId": "8e89cfdd-da22-4e97-be61-2630364ef5b1",
+            "name": "theme translation",
+            "status": "busy",
+            "state": "blocked",
+            "pid": 93132,
+            "waitingFor": "permission prompt"
+          },
+          {
+            "pid": 81685,
+            "cwd": "/repo",
+            "kind": "interactive",
+            "startedAt": 1781885175275,
+            "sessionId": "250a28e4-dcd5-421d-b9bb-f39a6060f1b2",
+            "status": "idle"
+          }
+        ]
+        """
+        let agents = ClaudeAgentsSessionParser.parse(Data(json.utf8))
+
+        #expect(agents.count == 2)
+
+        let background = agents[0]
+        #expect(background.id == "8e89cfdd")
+        #expect(background.cwd == "/repo/.claude/worktrees/feature")
+        #expect(background.kind == "background")
+        #expect(background.name == "theme translation")
+        #expect(background.state == "blocked")
+        #expect(background.status == "busy")
+        #expect(background.pid == 93132)
+        #expect(background.startedAt == 1_781_774_127_358)
+        #expect(background.waitingFor == "permission prompt")
+
+        let interactive = agents[1]
+        #expect(interactive.id == nil)
+        #expect(interactive.kind == "interactive")
+        #expect(interactive.state == nil)
+        #expect(interactive.status == "idle")
+    }
+
+    @Test("Drops entries without a cwd instead of failing the batch")
+    func dropsEntriesMissingCwd() {
+        let json = """
+        [
+          { "kind": "background", "state": "done" },
+          { "cwd": "/keep", "kind": "background", "state": "done" }
+        ]
+        """
+        let agents = ClaudeAgentsSessionParser.parse(Data(json.utf8))
+        #expect(agents.count == 1)
+        #expect(agents.first?.cwd == "/keep")
+    }
+
+    @Test("Non-JSON output yields an empty array")
+    func nonJSONYieldsEmpty() {
+        let agents = ClaudeAgentsSessionParser.parse(Data("claude: command not found".utf8))
+        #expect(agents.isEmpty)
+    }
+}

--- a/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
+++ b/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/CustomSidebarDataContextBuilderTests.swift
@@ -308,4 +308,113 @@ struct CustomSidebarDataContextBuilderTests {
         #expect(bare.member("branch") == nil)
         #expect(bare.member("ports") == nil)
     }
+
+    private func agent(
+        id: String? = nil,
+        cwd: String = "/repo",
+        kind: String = "background",
+        name: String? = nil,
+        state: String? = nil,
+        status: String? = nil,
+        pid: Int? = nil,
+        startedAt: Int? = nil,
+        waitingFor: String? = nil
+    ) -> CustomSidebarAgentSnapshot {
+        CustomSidebarAgentSnapshot(
+            id: id,
+            cwd: cwd,
+            kind: kind,
+            name: name,
+            sessionId: nil,
+            state: state,
+            status: status,
+            pid: pid,
+            startedAt: startedAt,
+            waitingFor: waitingFor
+        )
+    }
+
+    @Test("Agents array and counts are produced")
+    func agentsTopLevel() {
+        let builder = CustomSidebarDataContextBuilder(calendar: fixedCalendar())
+        let snapshot = CustomSidebarContextSnapshot(
+            workspaces: [],
+            selectedWorkspaceId: nil,
+            selectedWorkspaceTitle: "",
+            totalUnreadCount: 0,
+            agents: [
+                agent(state: "working"),
+                agent(state: "blocked"),
+                agent(state: "done"),
+            ],
+            now: Date(timeIntervalSince1970: 0)
+        )
+
+        let context = builder.dataContext(for: snapshot)
+
+        #expect(context["agentsCount"] == .int(3))
+        #expect(context["agentsWorkingCount"] == .int(1))
+        #expect(context["agentsBlockedCount"] == .int(1))
+        #expect(context["agents"]?.iterationValues?.count == 3)
+    }
+
+    @Test("Agents default to an empty array when none are provided")
+    func agentsDefaultEmpty() {
+        let builder = CustomSidebarDataContextBuilder(calendar: fixedCalendar())
+        let snapshot = CustomSidebarContextSnapshot(
+            workspaces: [],
+            selectedWorkspaceId: nil,
+            selectedWorkspaceTitle: "",
+            totalUnreadCount: 0,
+            now: Date(timeIntervalSince1970: 0)
+        )
+
+        let context = builder.dataContext(for: snapshot)
+
+        #expect(context["agentsCount"] == .int(0))
+        #expect(context["agents"] == .array([]))
+    }
+
+    @Test("Agent value maps fields and derives state booleans")
+    func agentValueMapsFields() {
+        let builder = CustomSidebarDataContextBuilder(calendar: fixedCalendar())
+
+        let blocked = builder.agentValue(
+            agent(
+                id: "abc123",
+                cwd: "/repo/.claude/worktrees/x",
+                kind: "background",
+                name: "migrate config",
+                state: "blocked",
+                status: "waiting",
+                pid: 4242,
+                startedAt: 1_781_774_127_358,
+                waitingFor: "permission prompt"
+            )
+        )
+        #expect(blocked.member("cwd") == .string("/repo/.claude/worktrees/x"))
+        #expect(blocked.member("kind") == .string("background"))
+        #expect(blocked.member("background") == .bool(true))
+        #expect(blocked.member("id") == .string("abc123"))
+        #expect(blocked.member("name") == .string("migrate config"))
+        #expect(blocked.member("state") == .string("blocked"))
+        #expect(blocked.member("status") == .string("waiting"))
+        #expect(blocked.member("pid") == .int(4242))
+        #expect(blocked.member("startedAt") == .int(1_781_774_127_358))
+        #expect(blocked.member("waitingFor") == .string("permission prompt"))
+        #expect(blocked.member("blocked") == .bool(true))
+        #expect(blocked.member("active") == .bool(true))
+        #expect(blocked.member("working") == .bool(false))
+        #expect(blocked.member("done") == .bool(false))
+
+        // Optional fields are omitted; derived booleans stay present.
+        let minimal = builder.agentValue(agent(cwd: "/repo", kind: "interactive", status: "idle"))
+        #expect(minimal.member("id") == nil)
+        #expect(minimal.member("name") == nil)
+        #expect(minimal.member("state") == nil)
+        #expect(minimal.member("pid") == nil)
+        #expect(minimal.member("background") == .bool(false))
+        #expect(minimal.member("active") == .bool(false))
+        #expect(minimal.member("status") == .string("idle"))
+    }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10037,6 +10037,16 @@ struct VerticalTabsSidebar: View {
     @LiveSetting(\.customSidebars.renderer) private var customSidebarRenderer
     @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
 
+    // Polls `claude agents --json --all` while a custom sidebar is on screen so
+    // the interpreter's top-level `agents` array stays live. The subprocess and
+    // executable resolution live in `ClaudeAgentsSessionSource` (app layer); the
+    // poller (CmuxSidebar) just owns the refresh loop and the cached result, and
+    // is started/stopped with the custom-sidebar surface's appear/disappear so
+    // no `claude` process runs when no custom sidebar is shown.
+    @State private var claudeAgentsSessionPoller = ClaudeAgentsSessionPoller(
+        fetch: { await ClaudeAgentsSessionSource.fetch() }
+    )
+
     // The provider to actually render. Built-in views are always honored; only
     // the hosted-extension selection falls back to the default workspaces
     // sidebar while the experimental Extensions feature is disabled, since
@@ -10081,6 +10091,7 @@ struct VerticalTabsSidebar: View {
             selectedWorkspaceId: selectedId,
             selectedWorkspaceTitle: selectedWorkspace?.customTitle ?? selectedWorkspace?.title ?? "",
             totalUnreadCount: sidebarUnread.totalUnreadCount,
+            agents: claudeAgentsSessionPoller.sessions,
             now: now
         )
         return CustomSidebarDataContextBuilder().dataContext(for: snapshot)
@@ -10777,6 +10788,9 @@ struct VerticalTabsSidebar: View {
                     bottomHeight: sidebarBottomScrimHeight
                 )
             )
+            // Only poll `claude agents --json` while a custom sidebar is shown.
+            .onAppear { claudeAgentsSessionPoller.start() }
+            .onDisappear { claudeAgentsSessionPoller.stop() }
         } else {
             TimelineView(.periodic(from: .now, by: 30)) { timeline in
                 let model = extensionSidebarRenderModel(renderContext: renderContext, now: timeline.date)
@@ -16032,4 +16046,55 @@ private struct ExtensionSidebarBrowserStackEndDropDelegate: DropDelegate {
 enum SidebarSelection {
     case tabs
     case notifications
+}
+
+/// App-layer source for the custom-sidebar `agents` array: runs
+/// `claude agents --json --all` off the main thread and parses it into
+/// ``CustomSidebarAgentSnapshot`` values. Injected into
+/// ``ClaudeAgentsSessionPoller`` so the CmuxSidebar package stays free of
+/// process-spawning and executable-resolution concerns.
+enum ClaudeAgentsSessionSource {
+    /// Resolves the user's `claude` binary, runs `claude agents --json --all`,
+    /// and returns the parsed sessions. Returns `nil` on any failure (claude not
+    /// found, non-zero exit, unreadable output) so the poller keeps its last
+    /// good value. The subprocess runs on a utility queue, never the main
+    /// thread.
+    static func fetch() async -> [CustomSidebarAgentSnapshot]? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: runOnce())
+            }
+        }
+    }
+
+    private static func runOnce() -> [CustomSidebarAgentSnapshot]? {
+        let resolver = AgentExecutableResolver(
+            configuredExecutablePaths: AgentExecutableResolver.cmuxConfiguredExecutablePaths()
+        )
+        guard let plan = try? resolver.resolve(.claude) else { return nil }
+
+        let process = Process()
+        process.executableURL = plan.executableURL
+        process.arguments = ["agents", "--json", "--all"]
+        process.environment = plan.environment
+
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        // Discard stderr so a chatty diagnostic can't fill an undrained pipe
+        // buffer and wedge the process before it exits.
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        // Read to EOF before waiting so a large `--all` payload can't deadlock
+        // against a full stdout pipe buffer.
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        return ClaudeAgentsSessionParser.parse(data)
+    }
 }

--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -139,13 +139,27 @@ with:
   `dirty`, `ports` (array of Int).
 - `workspaceCount` — Int. `selectedTitle` — active workspace's title.
   `selectedId` — its id. `unreadTotal` — total unread notifications.
+- `agents` — array of Claude Code agent sessions, mirroring `claude agents
+  --json --all` (every live session plus background sessions that are still
+  working or blocked, and completed background sessions). Refreshed by polling
+  `claude` every few seconds while a custom sidebar is shown, so it is empty if
+  `claude` is not installed/on PATH. Always present per entry: `cwd` (working
+  directory, good for grouping by project), `kind` (`background` or
+  `interactive`), and the derived booleans `background`, `working`, `blocked`,
+  `done`, `failed`, `stopped`, `active` (= working or blocked). Present when the
+  CLI reports them (use `if let` / ternary): `id` (short background id, usable
+  with `claude attach/logs/stop`), `name`, `sessionId`, `state`
+  (`working|blocked|done|failed|stopped`), `status` (`busy|idle|waiting`, while
+  the process is alive), `pid`, `startedAt` (epoch ms), `waitingFor` (what a
+  blocked session is waiting on, e.g. `permission prompt`). Plus the scalars
+  `agentsCount`, `agentsWorkingCount`, `agentsBlockedCount`.
 - `clock` — `{ time ("HH:mm:ss"), hour, minute, second, weekday, epoch }`. The
   sidebar re-renders about once a second, so clocks/countdowns and workspace
   changes are live.
 
-Optional fields are omitted when the workspace doesn't have them, so guard with
-`if let b = w.branch { ... }` or `w.pr != nil ? ... : ...` rather than assuming
-they exist.
+Optional fields are omitted when the workspace or agent doesn't have them, so
+guard with `if let b = w.branch { ... }` or `a.name != nil ? ... : ...` rather
+than assuming they exist.
 
 ## Views
 


### PR DESCRIPTION
## Why

Custom sidebars can only render the data context cmux hands the interpreter (`workspaces`, `clock`), so a sidebar file cannot shell out to `claude agents --json` itself. This adds an app-side bridge so a custom sidebar can show Claude Code background agent sessions (the worktree-agent sessions you spawn), grouped by project, like a native sidebar.

## What

- **CmuxSidebar package** (pure, testable, no pbxproj):
  - `CustomSidebarAgentSnapshot` — one `claude agents --json --all` entry.
  - `ClaudeAgentsSessionParser` — lenient JSON → snapshots (bad/partial output degrades to empty rather than throwing).
  - `ClaudeAgentsSessionPoller` — `@MainActor` refresh loop with an injected fetch closure (keeps the subprocess out of the UI package).
  - `CustomSidebarContextSnapshot` carries `agents`; the data-context builder emits a top-level `agents` array plus `agentsCount` / `agentsWorkingCount` / `agentsBlockedCount` and per-agent derived booleans (`working`, `blocked`, `done`, `failed`, `stopped`, `active`, `background`).
- **App**: `ContentView` resolves the user's `claude` binary via `AgentExecutableResolver`, runs `claude agents --json --all` off the main thread, and feeds the parsed sessions into the custom-sidebar context. Polling runs only while a custom sidebar is on screen (started/stopped with its appear/disappear), so no `claude` process runs otherwise.
- **Docs**: `docs/custom-sidebars.md` documents the new `agents` data.
- **Example**: `Examples/CustomSidebars/claude-agents.swift` groups sessions by `cwd` with state dots.

## Notes

- No new app-target source files (all new types live in the SPM package), so no `project.pbxproj` changes.
- New unit tests cover the parser (mapping, leniency, non-JSON) and the builder (agents array, counts, per-agent field/boolean projection). `swift test` for CmuxSidebar passes locally.
- The app target could not be built locally (unrelated zig 0.15.2 vs Xcode 26.5 SDK toolchain mismatch on this machine); relying on CI to build/verify the app side.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784535761&installation_id=133855650&pr_number=6493&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6493&signature=c5b8fc8b49bc6cba7c2ba063fae919c4f20ac4b100d0d998f2972365d5c9f5f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Claude Code agent sessions in custom sidebars by exposing `claude agents --json --all` data, with live polling only while a custom sidebar is visible. This lets sidebar files group and display agent activity by project with simple state flags.

- New Features
  - `CmuxSidebar`: add `CustomSidebarAgentSnapshot`, a lenient `ClaudeAgentsSessionParser`, and `ClaudeAgentsSessionPoller` with an injected fetch.
  - Data context: emit `agents` plus `agentsCount`, `agentsWorkingCount`, `agentsBlockedCount`, and per-agent booleans (`working`, `blocked`, `done`, `failed`, `stopped`, `active`, `background`).
  - App: resolve the user’s `claude` via `AgentExecutableResolver`, run `claude agents --json --all` off the main thread, and poll only while a custom sidebar is shown.
  - Docs/Example: document the new `agents` data and add `Examples/CustomSidebars/claude-agents.swift` (groups by `cwd` with state dots).
  - Tests: cover parser leniency/mapping and data-context projection.

<sup>Written for commit c12f310b7f64a76dc778cd13f959cdf87f6346d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom sidebars can now display Claude Code agent sessions with live, auto-refreshing status updates.
  * Shows working, blocked, and failed agents with aggregate counts.
  * Each agent displays name, working directory, and optional wait information.

* **Documentation**
  * Updated custom sidebar documentation to detail the new `agents` binding and available agent properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->