### PR TITLE
Fix visible helper setup targeting

### DIFF
--- a/CLI/CMUXCLI+V2Output.swift
+++ b/CLI/CMUXCLI+V2Output.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension CMUXCLI {
+    func printV2Payload(
+        _ payload: [String: Any],
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        fallbackText: String
+    ) {
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+        } else {
+            print(fallbackText)
+        }
+    }
+}

--- a/CLI/CMUXCLI+VisibleHelper.swift
+++ b/CLI/CMUXCLI+VisibleHelper.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+extension CMUXCLI {
+    static let visibleHelperCommandHelp = """
+    Usage: cmux visible-helper [flags] [-- <command>]
+
+    Create or reuse a right-side helper pane in the visually focused workspace.
+
+    Flags:
+      --type <terminal|browser>    Helper surface type (default: terminal)
+      --url <url>                  URL for browser helpers
+      --cwd <path>                 Working directory for terminal helpers
+      --working-directory <path>   Alias for --cwd
+      --command <text>             Initial terminal command
+      --window <id|ref|index>      Window context for focused workspace lookup
+      --json                       Print structured placement details
+
+    Example:
+      cmux visible-helper --command 'pwd'
+      cmux visible-helper --type browser --url http://localhost:3000 --json
+    """
+
+    func runVisibleHelperCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let options = try parseVisibleHelperOptions(commandArgs)
+        var params: [String: Any] = ["target": "focused"]
+        if let caller = callerContextFromEnvironment() {
+            params["caller"] = caller
+        }
+        let winId = try normalizeWindowHandle(options.windowHandle ?? windowOverride, client: client)
+        if let winId { params["window_id"] = winId }
+        if let type = options.type { params["type"] = type }
+        if let url = options.url { params["url"] = url }
+        if let workingDirectory = options.workingDirectory {
+            params["working_directory"] = resolvePath(workingDirectory)
+        }
+        if let command = options.initialCommand {
+            params["initial_command"] = command
+        }
+
+        let payload = try client.sendV2(method: "helper.visible", params: params)
+        printV2Payload(
+            payload,
+            jsonOutput: jsonOutput || options.jsonOutput,
+            idFormat: idFormat,
+            fallbackText: visibleHelperSummary(payload, idFormat: idFormat)
+        )
+    }
+
+    private struct VisibleHelperOptions {
+        let type: String?
+        let url: String?
+        let workingDirectory: String?
+        let initialCommand: String?
+        let windowHandle: String?
+        let jsonOutput: Bool
+    }
+
+    private func parseVisibleHelperOptions(_ args: [String]) throws -> VisibleHelperOptions {
+        let (typeOpt, rem0) = parseOption(args, name: "--type")
+        let (urlOpt, rem1) = parseOption(rem0, name: "--url")
+        let (cwdOpt, rem2) = parseOption(rem1, name: "--cwd")
+        let (workingDirectoryOpt, rem3) = parseOption(rem2, name: "--working-directory")
+        let (commandOpt, rem4) = parseOption(rem3, name: "--command")
+        let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+
+        var jsonOutput = false
+        var remaining: [String] = []
+        var commandFromTerminator: String?
+        var iterator = rem5.makeIterator()
+        while let arg = iterator.next() {
+            if arg == "--json" {
+                jsonOutput = true
+                continue
+            }
+            if arg == "--" {
+                var commandParts: [String] = []
+                while let commandPart = iterator.next() {
+                    commandParts.append(commandPart)
+                }
+                commandFromTerminator = commandParts.joined(separator: " ")
+                break
+            }
+            remaining.append(arg)
+        }
+
+        if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
+            throw CLIError(message: "visible-helper: unknown flag '\(unknown)'")
+        }
+        if let extra = remaining.first {
+            throw CLIError(message: "visible-helper: unexpected argument '\(extra)'")
+        }
+        if commandOpt != nil, commandFromTerminator != nil {
+            throw CLIError(message: "visible-helper: pass either --command or -- <command>, not both")
+        }
+
+        return VisibleHelperOptions(
+            type: typeOpt,
+            url: urlOpt,
+            workingDirectory: workingDirectoryOpt ?? cwdOpt,
+            initialCommand: commandOpt ?? commandFromTerminator?.nilIfEmpty,
+            windowHandle: windowOpt,
+            jsonOutput: jsonOutput
+        )
+    }
+
+    private func callerContextFromEnvironment() -> [String: Any]? {
+        let environment = ProcessInfo.processInfo.environment
+        var caller: [String: Any] = [:]
+        if let workspace = environment["CMUX_WORKSPACE_ID"]?.nilIfEmpty {
+            caller["workspace_id"] = workspace
+        }
+        if let surface = (environment["CMUX_SURFACE_ID"] ?? environment["CMUX_TAB_ID"])?.nilIfEmpty {
+            caller["surface_id"] = surface
+            caller["tab_id"] = surface
+        }
+        return caller.isEmpty ? nil : caller
+    }
+
+    private func visibleHelperSummary(_ payload: [String: Any], idFormat: CLIIDFormat) -> String {
+        var parts = ["OK", "target=focused"]
+        if let workspace = formatHandle(payload, kind: "workspace", idFormat: idFormat) {
+            parts.append("workspace=\(workspace)")
+        }
+        if let pane = formatHandle(payload, kind: "pane", idFormat: idFormat) {
+            parts.append("pane=\(pane)")
+        }
+        if let surface = formatHandle(payload, kind: "surface", idFormat: idFormat) {
+            parts.append("surface=\(surface)")
+        }
+        if let strategy = payload["placement_strategy"] as? String {
+            parts.append("strategy=\(strategy)")
+        }
+        if let diverged = payload["caller_focused_diverged"] as? Bool {
+            parts.append("caller_focused_diverged=\(diverged ? "true" : "false")")
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4222,6 +4222,9 @@ struct CMUXCLI {
             let payload = try client.sendV2(method: "surface.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2CreationSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
+        case "visible-helper":
+            try runVisibleHelperCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat, windowOverride: windowId)
+
         case "surface":
             try runSurfaceCommand(
                 commandArgs: commandArgs,
@@ -5355,6 +5358,7 @@ struct CMUXCLI {
         "unbind-key",
         "uninstall-hooks",
         "version",
+        "visible-helper",
         "vm",
         "vm-pty-attach",
         "vm-pty-connect",
@@ -6287,19 +6291,6 @@ struct CMUXCLI {
                 return "\(ref) (\(id))"
             }
             return ref ?? id
-        }
-    }
-
-    func printV2Payload(
-        _ payload: [String: Any],
-        jsonOutput: Bool,
-        idFormat: CLIIDFormat,
-        fallbackText: String
-    ) {
-        if jsonOutput {
-            print(jsonString(formatIDs(payload, mode: idFormat)))
-        } else {
-            print(fallbackText)
         }
     }
 
@@ -15129,6 +15120,8 @@ struct CMUXCLI {
               cmux new-surface --type browser --pane pane:1 --url https://example.com
               cmux new-surface --type agent-session --provider claude --renderer solid --focus true
             """
+        case "visible-helper":
+            return Self.visibleHelperCommandHelp
         case "close-surface":
             return """
             Usage: cmux close-surface [flags]
@@ -34169,6 +34162,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           focus-pane --pane <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
           new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--focus <true|false>]
           new-surface [--type <terminal|browser|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]
+          visible-helper [--type <terminal|browser>] [--url <url>] [--cwd <path>] [--working-directory <path>] [--command <text>] [--window <id|ref|index>] [--json] [-- <command>]
           close-surface [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>]
           move-surface --surface <id|ref|index> [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--before <id|ref|index>] [--after <id|ref|index>] [--index <n>] [--focus <true|false>]
           split-off --surface <id|ref|index> <left|right|up|down> [--workspace <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>]

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -72,6 +72,7 @@ public final class ControlCommandCoordinator {
         if let result = handleFeed(request) { return result }
         if let result = handleNotification(request) { return result }
         if let result = handleWorkspaceGroup(request) { return result }
+        if let result = handleHelper(request) { return result }
         if let result = handlePane(request) { return result }
         if let result = handleCanvas(request) { return result }
         if let result = handleMobileHost(request) { return result }
@@ -87,6 +88,18 @@ public final class ControlCommandCoordinator {
         // handleSidebarV1 / handleBrowserPanelV1 are V1 string-command handlers;
         // the app's v1 dispatcher calls them directly with (command:args:).
         return nil
+    }
+
+    /// Runs one decoded request through an async-capable coordinator domain.
+    /// Synchronous domains still use ``handle(_:)``; domains that need to wait on
+    /// a real app event, such as `helper.visible`, are routed here by the socket
+    /// worker path so they can suspend instead of blocking the main actor.
+    ///
+    /// - Parameter request: The decoded request envelope.
+    /// - Returns: The command result, or `nil` if not owned here.
+    public func handleAsync(_ request: ControlRequest) async -> ControlCallResult? {
+        if let result = await handleHelperAsync(request) { return result }
+        return handle(request)
     }
 
     // MARK: - Handle registry (shared ref minting)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+Helper.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+Helper.swift
@@ -1,0 +1,159 @@
+internal import Foundation
+
+/// Agent-facing helper setup commands. These intentionally compose existing
+/// pane/surface mutation paths so helper automation gets one hard-to-misuse
+/// entrypoint without forking split creation or focus policy.
+extension ControlCommandCoordinator {
+    func handleHelper(_ request: ControlRequest) -> ControlCallResult? {
+        switch request.method {
+        case "helper.visible":
+            return .err(
+                code: "invalid_dispatch",
+                message: "helper.visible must run on the socket worker",
+                data: nil
+            )
+        default:
+            return nil
+        }
+    }
+
+    func handleHelperAsync(_ request: ControlRequest) async -> ControlCallResult? {
+        switch request.method {
+        case "helper.visible":
+            return await helperVisible(request.params)
+        default:
+            return nil
+        }
+    }
+
+    /// `helper.visible` creates or reuses a right-side helper pane in the
+    /// visually focused workspace. The response carries caller and focused
+    /// identity so caller-vs-focused divergence stays explicit to automation.
+    func helperVisible(_ params: [String: JSONValue]) async -> ControlCallResult {
+        let targetRaw = string(params, "target") ?? "focused"
+        guard normalizedToken(targetRaw) == "focused" else {
+            return .err(
+                code: "invalid_params",
+                message: "helper.visible only supports target=focused",
+                data: .object(["target": .string(targetRaw)])
+            )
+        }
+
+        let typeRaw = string(params, "type")
+        switch normalizedToken(typeRaw ?? "terminal") {
+        case "terminal", "browser":
+            break
+        default:
+            return .err(
+                code: "invalid_params",
+                message: "helper.visible supports type=terminal or type=browser",
+                data: typeRaw.map { .object(["type": .string($0)]) }
+            )
+        }
+
+        var identifyParams: [String: JSONValue] = [:]
+        if case .object(let callerObject)? = params["caller"], !callerObject.isEmpty {
+            identifyParams["caller"] = .object(callerObject)
+        }
+        if let windowID = uuid(params, "window_id") {
+            identifyParams["window_id"] = .string(windowID.uuidString)
+        } else if params["window_id"] != nil {
+            return .err(code: "invalid_params", message: "Invalid window_id", data: params["window_id"])
+        }
+
+        let identify = helperVisibleIdentifyPayload(params: identifyParams)
+        guard let focusedWorkspaceID = uuidAny(identify.focused["workspace_id"]) else {
+            return .err(code: "not_found", message: "Focused workspace not found", data: nil)
+        }
+
+        var routingParams: [String: JSONValue] = [
+            "workspace_id": .string(focusedWorkspaceID.uuidString),
+        ]
+        let focusedWindowID = uuidAny(identify.focused["window_id"])
+        if let focusedWindowID {
+            routingParams["window_id"] = .string(focusedWindowID.uuidString)
+        }
+        let routing = routingSelectors(routingParams)
+        guard context?.controlPaneRoutingResolvesTabManager(routing: routing) ?? false else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let snapshot = context?.controlPaneList(routing: routing) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+        guard let initialHealth = context?.controlSurfaceHealth(routing: routing) else {
+            return helperVisibleVisibilityError(
+                message: "helper.visible cannot verify target workspace surface visibility",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: ["visibility_source": .string("surface.health")]
+            )
+        }
+
+        let requestedType = normalizedToken(typeRaw ?? "terminal")
+        switch helperVisiblePlacement(
+            in: snapshot,
+            focused: identify.focused,
+            health: initialHealth,
+            requestedType: requestedType
+        ) {
+        case .reuse(let helperPane, let helperSurface):
+            let result = helperVisibleReuseResult(
+                helperPane: helperPane,
+                helperSurface: helperSurface,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID
+            )
+            return await helperVisibleAnnotateAndVerify(
+                result,
+                params: params,
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                routing: routing,
+                placementStrategy: "reused_right_pane",
+                reusedPane: true,
+                createdPane: false,
+                createdSurface: false,
+                paneID: helperPane.paneID
+            )
+        case .blockedInvisible(let helperPane):
+            return helperVisibleVisibilityError(
+                message: "helper.visible found a structural helper pane, but none of its surfaces are visible in the target window",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: [
+                    "pane_id": .string(helperPane.paneID.uuidString),
+                    "pane_ref": ref(.pane, helperPane.paneID),
+                    "surface_ids": .array(helperPane.surfaceIDs.map { .string($0.uuidString) }),
+                    "surface_refs": .array(helperPane.surfaceIDs.map { ref(.surface, $0) }),
+                    "surface_health": helperVisibleHealthPayload(initialHealth),
+                ]
+            )
+        case .create:
+            break
+        }
+
+        var createParams = helperVisibleBaseCreateParams(
+            from: params,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID
+        )
+        createParams["direction"] = .string("right")
+        let result = paneCreate(createParams)
+        return await helperVisibleAnnotateAndVerify(
+            result,
+            params: params,
+            identify: identify,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID,
+            routing: routing,
+            placementStrategy: "created_right_pane",
+            reusedPane: false,
+            createdPane: true,
+            createdSurface: true,
+            paneID: nil
+        )
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+Helper.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+Helper.swift
@@ -1,4 +1,8 @@
+internal import Dispatch
 internal import Foundation
+
+private let helperVisibleMutationStartDeadlineParam =
+    "_cmux_helper_visible_latest_mutation_start_uptime_ns"
 
 /// Agent-facing helper setup commands. These intentionally compose existing
 /// pane/surface mutation paths so helper automation gets one hard-to-misuse
@@ -89,8 +93,40 @@ extension ControlCommandCoordinator {
                 extra: ["visibility_source": .string("surface.health")]
             )
         }
+        guard helperVisibleTargetSurfaceIsVisible(
+            in: snapshot,
+            focused: identify.focused,
+            health: initialHealth
+        ) else {
+            return helperVisibleVisibilityError(
+                message: "helper.visible cannot verify that the target workspace is visible in the target window",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: [
+                    "visibility_source": .string("surface.health"),
+                    "target_surface_visible": .bool(false),
+                    "surface_health": helperVisibleHealthPayload(initialHealth),
+                ]
+            )
+        }
 
         let requestedType = normalizedToken(typeRaw ?? "terminal")
+        if requestedType != "terminal",
+           (string(params, "command") != nil || string(params, "initial_command") != nil) {
+            return helperVisibleUnsupportedError(
+                code: "invalid_params",
+                message: "helper.visible command delivery is only supported for terminal helpers",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: [
+                    "type": .string(requestedType),
+                    "mutation_started": .bool(false),
+                    "placement_strategy": .string("non_terminal_command_rejected_before_mutation"),
+                ]
+            )
+        }
         switch helperVisiblePlacement(
             in: snapshot,
             focused: identify.focused,
@@ -98,6 +134,24 @@ extension ControlCommandCoordinator {
             requestedType: requestedType
         ) {
         case .reuse(let helperPane, let helperSurface):
+            if requestedType == "browser", string(params, "url") != nil {
+                return helperVisibleUnsupportedError(
+                    code: "unsupported",
+                    message: "helper.visible cannot reuse an existing browser helper for a requested URL",
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    extra: [
+                        "pane_id": .string(helperPane.paneID.uuidString),
+                        "pane_ref": ref(.pane, helperPane.paneID),
+                        "surface_id": .string(helperSurface.surfaceID.uuidString),
+                        "surface_ref": ref(.surface, helperSurface.surfaceID),
+                        "type": .string(helperSurface.typeRawValue),
+                        "mutation_started": .bool(false),
+                        "placement_strategy": .string("browser_url_reuse_rejected_before_mutation"),
+                    ]
+                )
+            }
             let result = helperVisibleReuseResult(
                 helperPane: helperPane,
                 helperSurface: helperSurface,
@@ -132,6 +186,58 @@ extension ControlCommandCoordinator {
                 ]
             )
         case .create:
+            if Task.isCancelled {
+                return helperVisibleUnsupportedError(
+                    code: "cancelled",
+                    message: "helper.visible was cancelled before creating a helper pane",
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    extra: [
+                        "mutation_started": .bool(false),
+                        "placement_strategy": .string("cancelled_before_create"),
+                    ]
+                )
+            }
+            if helperVisibleMutationDeadlineExpired(params) {
+                return helperVisibleUnsupportedError(
+                    code: "timeout",
+                    message: "helper.visible timed out before creating a helper pane",
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    extra: [
+                        "mutation_started": .bool(false),
+                        "placement_strategy": .string("deadline_expired_before_create"),
+                    ]
+                )
+            }
+            if snapshot.isRemoteTmuxMirror, requestedType == "terminal" {
+                return helperVisibleUnsupportedError(
+                    code: "unsupported",
+                    message: "helper.visible cannot create a visible terminal helper in a remote tmux mirror workspace",
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    extra: [
+                        "routed_target": .string("remote-tmux"),
+                        "placement_strategy": .string("remote_tmux_rejected_before_mutation"),
+                    ]
+                )
+            }
+            if requestedType == "browser", context?.controlPaneBrowserCreationDisabled() == true {
+                return helperVisibleUnsupportedError(
+                    code: "browser_disabled",
+                    message: "helper.visible cannot create a visible browser helper while the cmux browser is disabled",
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    extra: [
+                        "mutation_started": .bool(false),
+                        "placement_strategy": .string("browser_disabled_rejected_before_mutation"),
+                    ]
+                )
+            }
             break
         }
 
@@ -155,5 +261,13 @@ extension ControlCommandCoordinator {
             createdSurface: true,
             paneID: nil
         )
+    }
+
+    private func helperVisibleMutationDeadlineExpired(_ params: [String: JSONValue]) -> Bool {
+        guard let latestMutationStart = int(params, helperVisibleMutationStartDeadlineParam),
+              latestMutationStart > 0 else {
+            return false
+        }
+        return DispatchTime.now().uptimeNanoseconds > UInt64(latestMutationStart)
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperPlacement.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperPlacement.swift
@@ -1,0 +1,178 @@
+internal import Foundation
+
+extension ControlCommandCoordinator {
+    struct HelperVisibleIdentify {
+        let focused: [String: JSONValue]
+        let caller: [String: JSONValue]
+    }
+
+    func helperVisibleIdentifyPayload(params: [String: JSONValue]) -> HelperVisibleIdentify {
+        let payload = systemContext?.controlSystemIdentify(params: params) ?? .object([:])
+        guard case .object(let object) = payload else {
+            return HelperVisibleIdentify(focused: [:], caller: [:])
+        }
+        let focused: [String: JSONValue]
+        if case .object(let focusedObject)? = object["focused"] {
+            focused = focusedObject
+        } else {
+            focused = [:]
+        }
+        let caller: [String: JSONValue]
+        if case .object(let callerObject)? = object["caller"] {
+            caller = callerObject
+        } else {
+            caller = [:]
+        }
+        return HelperVisibleIdentify(focused: focused, caller: caller)
+    }
+
+    enum HelperVisiblePlacement {
+        case reuse(ControlPaneSummary, ControlSurfaceHealthEntry)
+        case blockedInvisible(ControlPaneSummary)
+        case create
+    }
+
+    func helperVisiblePlacement(
+        in snapshot: ControlPaneListSnapshot,
+        focused: [String: JSONValue],
+        health: ControlSurfaceHealthSnapshot,
+        requestedType: String
+    ) -> HelperVisiblePlacement {
+        guard snapshot.panes.count > 1 else { return .create }
+        let focusedPaneID = uuidAny(focused["pane_id"]) ?? snapshot.panes.first(where: \.isFocused)?.paneID
+        let candidates = snapshot.panes.filter { pane in
+            guard pane.paneID != focusedPaneID else { return false }
+            return !pane.surfaceIDs.isEmpty
+        }
+        guard !candidates.isEmpty else { return .create }
+
+        let orderedCandidates = helperVisibleOrderedCandidatePanes(
+            candidates,
+            in: snapshot,
+            focusedPaneID: focusedPaneID
+        )
+        let healthEntriesByID = Dictionary(uniqueKeysWithValues: health.surfaces.map { entry in
+            (entry.surfaceID, entry)
+        })
+        let visibleEntriesByID = Dictionary(uniqueKeysWithValues: health.surfaces.compactMap { entry in
+            entry.inWindow == true ? (entry.surfaceID, entry) : nil
+        })
+        for pane in orderedCandidates {
+            if let entry = helperVisiblePreferredVisibleSurface(
+                in: pane,
+                visibleEntriesByID: visibleEntriesByID,
+                requestedType: requestedType
+            ) {
+                return .reuse(pane, entry)
+            }
+        }
+
+        for pane in orderedCandidates {
+            let hasRequestedOrUnknownSurface = pane.surfaceIDs.contains { surfaceID in
+                guard let entry = healthEntriesByID[surfaceID] else { return true }
+                return normalizedToken(entry.typeRawValue) == requestedType
+            }
+            if hasRequestedOrUnknownSurface {
+                return .blockedInvisible(pane)
+            }
+        }
+        return .create
+    }
+
+    private func helperVisiblePreferredVisibleSurface(
+        in pane: ControlPaneSummary,
+        visibleEntriesByID: [UUID: ControlSurfaceHealthEntry],
+        requestedType: String
+    ) -> ControlSurfaceHealthEntry? {
+        if let selectedSurfaceID = pane.selectedSurfaceID,
+           let entry = visibleEntriesByID[selectedSurfaceID],
+           normalizedToken(entry.typeRawValue) == requestedType {
+            return entry
+        }
+
+        for surfaceID in pane.surfaceIDs {
+            if let entry = visibleEntriesByID[surfaceID],
+               normalizedToken(entry.typeRawValue) == requestedType {
+                return entry
+            }
+        }
+        return nil
+    }
+
+    private func helperVisibleOrderedCandidatePanes(
+        _ candidates: [ControlPaneSummary],
+        in snapshot: ControlPaneListSnapshot,
+        focusedPaneID: UUID?
+    ) -> [ControlPaneSummary] {
+        if let focusedPane = focusedPaneID.flatMap({ id in snapshot.panes.first { $0.paneID == id } }),
+           let focusedFrame = focusedPane.pixelFrame {
+            let rightSide = candidates.filter { pane in
+                guard let frame = pane.pixelFrame else { return false }
+                return frame.x >= focusedFrame.x + (focusedFrame.width * 0.5)
+            }.sorted { lhs, rhs in
+                let lhsFrame = lhs.pixelFrame!
+                let rhsFrame = rhs.pixelFrame!
+                if lhsFrame.x == rhsFrame.x {
+                    return lhsFrame.y < rhsFrame.y
+                }
+                return lhsFrame.x < rhsFrame.x
+            }
+            if !rightSide.isEmpty {
+                return rightSide
+            }
+            return []
+        }
+
+        return Array(candidates.reversed())
+    }
+
+    func helperVisibleReuseResult(
+        helperPane: ControlPaneSummary,
+        helperSurface: ControlSurfaceHealthEntry,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?
+    ) -> ControlCallResult {
+        .ok(.object([
+            "window_id": orNull(focusedWindowID?.uuidString),
+            "window_ref": ref(.window, focusedWindowID),
+            "workspace_id": .string(focusedWorkspaceID.uuidString),
+            "workspace_ref": ref(.workspace, focusedWorkspaceID),
+            "pane_id": .string(helperPane.paneID.uuidString),
+            "pane_ref": ref(.pane, helperPane.paneID),
+            "surface_id": .string(helperSurface.surfaceID.uuidString),
+            "surface_ref": ref(.surface, helperSurface.surfaceID),
+            "type": .string(helperSurface.typeRawValue),
+        ]))
+    }
+
+    func helperVisibleBaseCreateParams(
+        from params: [String: JSONValue],
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?
+    ) -> [String: JSONValue] {
+        var createParams: [String: JSONValue] = [
+            "workspace_id": .string(focusedWorkspaceID.uuidString),
+            "focus": .bool(false),
+        ]
+        if let focusedWindowID {
+            createParams["window_id"] = .string(focusedWindowID.uuidString)
+        }
+        for key in [
+            "type",
+            "url",
+            "provider",
+            "provider_id",
+            "renderer",
+            "renderer_kind",
+            "working_directory",
+            "startup_environment",
+            "initial_env",
+            "initial_divider_position",
+        ] {
+            if let value = params[key] {
+                createParams[key] = value
+            }
+        }
+        return createParams
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperPlacement.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperPlacement.swift
@@ -1,11 +1,6 @@
 internal import Foundation
 
 extension ControlCommandCoordinator {
-    struct HelperVisibleIdentify {
-        let focused: [String: JSONValue]
-        let caller: [String: JSONValue]
-    }
-
     func helperVisibleIdentifyPayload(params: [String: JSONValue]) -> HelperVisibleIdentify {
         let payload = systemContext?.controlSystemIdentify(params: params) ?? .object([:])
         guard case .object(let object) = payload else {
@@ -24,12 +19,6 @@ extension ControlCommandCoordinator {
             caller = [:]
         }
         return HelperVisibleIdentify(focused: focused, caller: caller)
-    }
-
-    enum HelperVisiblePlacement {
-        case reuse(ControlPaneSummary, ControlSurfaceHealthEntry)
-        case blockedInvisible(ControlPaneSummary)
-        case create
     }
 
     func helperVisiblePlacement(
@@ -55,7 +44,7 @@ extension ControlCommandCoordinator {
             (entry.surfaceID, entry)
         })
         let visibleEntriesByID = Dictionary(uniqueKeysWithValues: health.surfaces.compactMap { entry in
-            entry.inWindow == true ? (entry.surfaceID, entry) : nil
+            entry.visibleInUI == true ? (entry.surfaceID, entry) : nil
         })
         for pane in orderedCandidates {
             if let entry = helperVisiblePreferredVisibleSurface(
@@ -79,6 +68,18 @@ extension ControlCommandCoordinator {
         return .create
     }
 
+    func helperVisibleTargetSurfaceIsVisible(
+        in snapshot: ControlPaneListSnapshot,
+        focused: [String: JSONValue],
+        health: ControlSurfaceHealthSnapshot
+    ) -> Bool {
+        guard health.windowVisible == true else { return false }
+        let focusedSurfaceID = uuidAny(focused["surface_id"])
+            ?? snapshot.panes.first(where: \.isFocused)?.selectedSurfaceID
+        guard let focusedSurfaceID else { return false }
+        return health.surfaces.first { $0.surfaceID == focusedSurfaceID }?.visibleInUI == true
+    }
+
     private func helperVisiblePreferredVisibleSurface(
         in pane: ControlPaneSummary,
         visibleEntriesByID: [UUID: ControlSurfaceHealthEntry],
@@ -88,13 +89,6 @@ extension ControlCommandCoordinator {
            let entry = visibleEntriesByID[selectedSurfaceID],
            normalizedToken(entry.typeRawValue) == requestedType {
             return entry
-        }
-
-        for surfaceID in pane.surfaceIDs {
-            if let entry = visibleEntriesByID[surfaceID],
-               normalizedToken(entry.typeRawValue) == requestedType {
-                return entry
-            }
         }
         return nil
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibility.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibility.swift
@@ -55,6 +55,16 @@ extension ControlCommandCoordinator {
         if let health = visibility.snapshot {
             payload["surface_health"] = helperVisibleHealthPayload(health)
         }
+        if Task.isCancelled {
+            return helperVisibleUnsupportedError(
+                code: "cancelled",
+                message: "helper.visible was cancelled before sending the requested command",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: payload
+            )
+        }
         guard visibility.isVisible else {
             return helperVisibleVisibilityError(
                 message: "helper.visible created or reused a helper surface, but surface.health did not report in_window=true",
@@ -161,7 +171,7 @@ extension ControlCommandCoordinator {
             return (false, nil, nil, 1, windowEventObserved)
         }
         let entry = snapshot.surfaces.first { $0.surfaceID == surfaceID }
-        return (entry?.inWindow == true, entry, snapshot, 1, windowEventObserved)
+        return (snapshot.windowVisible == true && entry?.visibleInUI == true, entry, snapshot, 1, windowEventObserved)
     }
 
     func helperVisibleHealthPayload(_ snapshot: ControlSurfaceHealthSnapshot) -> JSONValue {
@@ -170,12 +180,14 @@ extension ControlCommandCoordinator {
             "workspace_ref": ref(.workspace, snapshot.workspaceID),
             "window_id": orNull(snapshot.windowID?.uuidString),
             "window_ref": ref(.window, snapshot.windowID),
+            "window_visible": snapshot.windowVisible.map { .bool($0) } ?? .null,
             "surfaces": .array(snapshot.surfaces.map { entry in
                 .object([
                     "id": .string(entry.surfaceID.uuidString),
                     "ref": ref(.surface, entry.surfaceID),
                     "type": .string(entry.typeRawValue),
                     "in_window": entry.inWindow.map { .bool($0) } ?? .null,
+                    "visible_in_ui": entry.visibleInUI.map { .bool($0) } ?? .null,
                 ])
             }),
         ])
@@ -200,6 +212,28 @@ extension ControlCommandCoordinator {
             data[key] = value
         }
         return .err(code: "not_visible", message: message, data: .object(data))
+    }
+
+    func helperVisibleUnsupportedError(
+        code: String,
+        message: String,
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        extra: [String: JSONValue]
+    ) -> ControlCallResult {
+        let callerWorkspaceID = uuidAny(identify.caller["workspace_id"])
+        let diverged = callerWorkspaceID.map { $0 != focusedWorkspaceID } ?? false
+        var data = helperVisibleFailureData(
+            identify: identify,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID,
+            callerFocusedDiverged: diverged
+        )
+        for (key, value) in extra {
+            data[key] = value
+        }
+        return .err(code: code, message: message, data: .object(data))
     }
 
     private func helperVisibleCommandFailureError(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibility.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibility.swift
@@ -1,0 +1,243 @@
+internal import Foundation
+
+extension ControlCommandCoordinator {
+    func helperVisibleAnnotateAndVerify(
+        _ result: ControlCallResult,
+        params: [String: JSONValue],
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        routing: ControlRoutingSelectors,
+        placementStrategy: String,
+        reusedPane: Bool,
+        createdPane: Bool,
+        createdSurface: Bool,
+        paneID: UUID?
+    ) async -> ControlCallResult {
+        guard case .ok(.object(var payload)) = result else { return result }
+
+        if payload["pane_id"] == nil, let paneID {
+            payload["pane_id"] = .string(paneID.uuidString)
+            payload["pane_ref"] = ref(.pane, paneID)
+        }
+        let callerWorkspaceID = uuidAny(identify.caller["workspace_id"])
+        let diverged = callerWorkspaceID.map { $0 != focusedWorkspaceID } ?? false
+        payload["target_workspace_source"] = .string("focused")
+        payload["caller_focused_diverged"] = .bool(diverged)
+        payload["placement_strategy"] = .string(placementStrategy)
+        payload["reused_pane"] = .bool(reusedPane)
+        payload["created_pane"] = .bool(createdPane)
+        payload["created_surface"] = .bool(createdSurface)
+        payload["sent_command"] = .bool(false)
+        payload["focused"] = identify.focused.isEmpty ? .null : .object(identify.focused)
+        payload["caller"] = identify.caller.isEmpty ? .null : .object(identify.caller)
+        guard let surfaceID = uuidAny(payload["surface_id"]) else {
+            payload["surface_visible"] = .bool(false)
+            return helperVisibleVisibilityError(
+                message: "helper.visible did not create a helper surface in the target window",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: payload
+            )
+        }
+
+        let visibility = await helperVisibleSurfaceVisibility(
+            surfaceID: surfaceID,
+            routing: routing,
+            waitForWindowEvent: createdSurface
+        )
+        payload["surface_visible"] = .bool(visibility.isVisible)
+        payload["surface_health_found"] = .bool(visibility.entry != nil)
+        payload["surface_health_in_window"] = visibility.entry?.inWindow.map { .bool($0) } ?? .null
+        payload["surface_health_attempts"] = .int(Int64(visibility.attempts))
+        payload["surface_window_event_observed"] = visibility.windowEventObserved.map { .bool($0) } ?? .null
+        if let health = visibility.snapshot {
+            payload["surface_health"] = helperVisibleHealthPayload(health)
+        }
+        guard visibility.isVisible else {
+            return helperVisibleVisibilityError(
+                message: "helper.visible created or reused a helper surface, but surface.health did not report in_window=true",
+                identify: identify,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID,
+                extra: payload
+            )
+        }
+        if let command = helperVisibleCommandText(params) {
+            let sendResult = helperVisibleSendCommand(
+                command,
+                surfaceID: surfaceID,
+                focusedWorkspaceID: focusedWorkspaceID,
+                focusedWindowID: focusedWindowID
+            )
+            guard case .ok(.object(let sendPayload)) = sendResult else {
+                payload["sent_command"] = .bool(false)
+                payload["command"] = .string(command)
+                return helperVisibleCommandError(
+                    sendResult,
+                    identify: identify,
+                    focusedWorkspaceID: focusedWorkspaceID,
+                    focusedWindowID: focusedWindowID,
+                    payload: payload
+                )
+            }
+            payload["sent_command"] = .bool(true)
+            payload["command_queued"] = sendPayload["queued"] ?? .null
+        }
+        return .ok(.object(payload))
+    }
+
+    private func helperVisibleCommandText(_ params: [String: JSONValue]) -> String? {
+        string(params, "command") ?? string(params, "initial_command")
+    }
+
+    private func helperVisibleSendCommand(
+        _ command: String,
+        surfaceID: UUID,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?
+    ) -> ControlCallResult {
+        var text = command
+        if !text.hasSuffix("\n") {
+            text.append("\n")
+        }
+        var sendParams: [String: JSONValue] = [
+            "workspace_id": .string(focusedWorkspaceID.uuidString),
+            "surface_id": .string(surfaceID.uuidString),
+            "text": .string(text),
+        ]
+        if let focusedWindowID {
+            sendParams["window_id"] = .string(focusedWindowID.uuidString)
+        }
+        return surfaceSendText(sendParams)
+    }
+
+    private func helperVisibleCommandError(
+        _ sendResult: ControlCallResult,
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        payload: [String: JSONValue]
+    ) -> ControlCallResult {
+        var extra = payload
+        if case .err(let code, let message, let data) = sendResult {
+            extra["send_error"] = .object([
+                "code": .string(code),
+                "message": .string(message),
+                "data": data ?? .null,
+            ])
+        }
+        return helperVisibleCommandFailureError(
+            message: "helper.visible verified a visible helper surface, but failed to send the requested command",
+            identify: identify,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID,
+            extra: extra
+        )
+    }
+
+    private func helperVisibleSurfaceVisibility(
+        surfaceID: UUID,
+        routing: ControlRoutingSelectors,
+        waitForWindowEvent: Bool
+    ) async -> (
+        isVisible: Bool,
+        entry: ControlSurfaceHealthEntry?,
+        snapshot: ControlSurfaceHealthSnapshot?,
+        attempts: Int,
+        windowEventObserved: Bool?
+    ) {
+        let windowEventObserved: Bool?
+        if waitForWindowEvent {
+            windowEventObserved = await context?.controlSurfaceWaitForInWindow(
+                routing: routing,
+                surfaceID: surfaceID
+            ) ?? false
+        } else {
+            windowEventObserved = nil
+        }
+        guard let snapshot = context?.controlSurfaceHealth(routing: routing) else {
+            return (false, nil, nil, 1, windowEventObserved)
+        }
+        let entry = snapshot.surfaces.first { $0.surfaceID == surfaceID }
+        return (entry?.inWindow == true, entry, snapshot, 1, windowEventObserved)
+    }
+
+    func helperVisibleHealthPayload(_ snapshot: ControlSurfaceHealthSnapshot) -> JSONValue {
+        .object([
+            "workspace_id": .string(snapshot.workspaceID.uuidString),
+            "workspace_ref": ref(.workspace, snapshot.workspaceID),
+            "window_id": orNull(snapshot.windowID?.uuidString),
+            "window_ref": ref(.window, snapshot.windowID),
+            "surfaces": .array(snapshot.surfaces.map { entry in
+                .object([
+                    "id": .string(entry.surfaceID.uuidString),
+                    "ref": ref(.surface, entry.surfaceID),
+                    "type": .string(entry.typeRawValue),
+                    "in_window": entry.inWindow.map { .bool($0) } ?? .null,
+                ])
+            }),
+        ])
+    }
+
+    func helperVisibleVisibilityError(
+        message: String,
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        extra: [String: JSONValue]
+    ) -> ControlCallResult {
+        let callerWorkspaceID = uuidAny(identify.caller["workspace_id"])
+        let diverged = callerWorkspaceID.map { $0 != focusedWorkspaceID } ?? false
+        var data = helperVisibleFailureData(
+            identify: identify,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID,
+            callerFocusedDiverged: diverged
+        )
+        for (key, value) in extra {
+            data[key] = value
+        }
+        return .err(code: "not_visible", message: message, data: .object(data))
+    }
+
+    private func helperVisibleCommandFailureError(
+        message: String,
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        extra: [String: JSONValue]
+    ) -> ControlCallResult {
+        let callerWorkspaceID = uuidAny(identify.caller["workspace_id"])
+        let diverged = callerWorkspaceID.map { $0 != focusedWorkspaceID } ?? false
+        var data = helperVisibleFailureData(
+            identify: identify,
+            focusedWorkspaceID: focusedWorkspaceID,
+            focusedWindowID: focusedWindowID,
+            callerFocusedDiverged: diverged
+        )
+        for (key, value) in extra {
+            data[key] = value
+        }
+        return .err(code: "command_failed", message: message, data: .object(data))
+    }
+
+    private func helperVisibleFailureData(
+        identify: HelperVisibleIdentify,
+        focusedWorkspaceID: UUID,
+        focusedWindowID: UUID?,
+        callerFocusedDiverged: Bool
+    ) -> [String: JSONValue] {
+        [
+            "workspace_id": .string(focusedWorkspaceID.uuidString),
+            "workspace_ref": ref(.workspace, focusedWorkspaceID),
+            "window_id": orNull(focusedWindowID?.uuidString),
+            "window_ref": ref(.window, focusedWindowID),
+            "target_workspace_source": .string("focused"),
+            "caller_focused_diverged": .bool(callerFocusedDiverged),
+            "focused": identify.focused.isEmpty ? .null : .object(identify.focused),
+            "caller": identify.caller.isEmpty ? .null : .object(identify.caller),
+        ]
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibleIdentify.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisibleIdentify.swift
@@ -1,0 +1,8 @@
+internal import Foundation
+
+extension ControlCommandCoordinator {
+    struct HelperVisibleIdentify {
+        let focused: [String: JSONValue]
+        let caller: [String: JSONValue]
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisiblePlacement.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Helper/ControlCommandCoordinator+HelperVisiblePlacement.swift
@@ -1,0 +1,9 @@
+internal import Foundation
+
+extension ControlCommandCoordinator {
+    enum HelperVisiblePlacement {
+        case reuse(ControlPaneSummary, ControlSurfaceHealthEntry)
+        case blockedInvisible(ControlPaneSummary)
+        case create
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneContext.swift
@@ -54,6 +54,10 @@ public protocol ControlPaneContext: AnyObject {
         paneID: UUID?
     ) -> ControlPaneSurfacesSnapshot?
 
+    /// Whether browser pane creation is disabled and would fall back to
+    /// opening URLs externally instead of creating a local surface.
+    func controlPaneBrowserCreationDisabled() -> Bool
+
     /// Creates a split pane for `pane.create`.
     ///
     /// - Parameters:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneListSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneListSnapshot.swift
@@ -14,6 +14,9 @@ public struct ControlPaneListSnapshot: Sendable, Equatable {
     public let windowID: UUID?
     /// The panes, in `allPaneIds` order.
     public let panes: [ControlPaneSummary]
+    /// Whether terminal pane creation is routed through a remote tmux mirror
+    /// instead of synchronously producing a local surface.
+    public let isRemoteTmuxMirror: Bool
     /// The container's width, in pixels.
     public let containerWidth: Double
     /// The container's height, in pixels.
@@ -31,12 +34,14 @@ public struct ControlPaneListSnapshot: Sendable, Equatable {
         workspaceID: UUID,
         windowID: UUID?,
         panes: [ControlPaneSummary],
+        isRemoteTmuxMirror: Bool = false,
         containerWidth: Double,
         containerHeight: Double
     ) {
         self.workspaceID = workspaceID
         self.windowID = windowID
         self.panes = panes
+        self.isRemoteTmuxMirror = isRemoteTmuxMirror
         self.containerWidth = containerWidth
         self.containerHeight = containerHeight
     }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceContext.swift
@@ -47,6 +47,20 @@ public protocol ControlSurfaceContext: AnyObject {
     /// - Returns: The health snapshot, or `nil` when no workspace resolves.
     func controlSurfaceHealth(routing: ControlRoutingSelectors) -> ControlSurfaceHealthSnapshot?
 
+    /// Waits until the app observes the requested surface's hosted view entering
+    /// a window. This is an event signal, not a polling delay; callers must
+    /// still verify the result with ``controlSurfaceHealth(routing:)`` before
+    /// reporting a surface as visible.
+    ///
+    /// - Parameters:
+    ///   - routing: The routing selectors.
+    ///   - surfaceID: The surface whose hosted view should enter a window.
+    /// - Returns: Whether the app observed the surface entering a window.
+    func controlSurfaceWaitForInWindow(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID
+    ) async -> Bool
+
     /// The app-bundle-resolved localized error strings for `surface.respawn`. The
     /// app resolves each `String(localized:)` with the identical key + default
     /// value so the package never binds them to the wrong bundle.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceHealthEntry.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceHealthEntry.swift
@@ -15,6 +15,9 @@ public struct ControlSurfaceHealthEntry: Sendable, Equatable {
     /// (`isViewInWindow`) and browser (`webView.window != nil`) panels, `nil`
     /// (JSON `null`) for any other panel type.
     public let inWindow: Bool?
+    /// Whether the surface is visually active in the UI, not merely mounted in
+    /// an `NSWindow`.
+    public let visibleInUI: Bool?
 
     /// Creates a surface-health entry.
     ///
@@ -26,10 +29,12 @@ public struct ControlSurfaceHealthEntry: Sendable, Equatable {
     public init(
         surfaceID: UUID,
         typeRawValue: String,
-        inWindow: Bool?
+        inWindow: Bool?,
+        visibleInUI: Bool? = nil
     ) {
         self.surfaceID = surfaceID
         self.typeRawValue = typeRawValue
         self.inWindow = inWindow
+        self.visibleInUI = visibleInUI
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceHealthSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceHealthSnapshot.swift
@@ -11,6 +11,8 @@ public struct ControlSurfaceHealthSnapshot: Sendable, Equatable {
     public let workspaceID: UUID
     /// The enclosing window's identifier, if it resolved.
     public let windowID: UUID?
+    /// Whether the enclosing window is currently visible to the user.
+    public let windowVisible: Bool?
     /// The ordered health rows.
     public let surfaces: [ControlSurfaceHealthEntry]
 
@@ -23,10 +25,12 @@ public struct ControlSurfaceHealthSnapshot: Sendable, Equatable {
     public init(
         workspaceID: UUID,
         windowID: UUID?,
+        windowVisible: Bool? = nil,
         surfaces: [ControlSurfaceHealthEntry]
     ) {
         self.workspaceID = workspaceID
         self.windowID = windowID
+        self.windowVisible = windowVisible
         self.surfaces = surfaces
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -55,6 +55,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         "feed.permission.reply",
         "feed.question.reply",
         "feed.exit_plan.reply",
+        "helper.visible",
         "browser.download.wait",
         "browser.profiles.list",
         "browser.profiles.create",

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -352,7 +352,7 @@ extension ControlSurfaceContext {
     func controlSurfaceList(routing: ControlRoutingSelectors) -> ControlSurfaceListSnapshot? { nil }
     func controlSurfaceCurrent(routing: ControlRoutingSelectors) -> ControlSurfaceCurrentSnapshot? { nil }
     func controlSurfaceHealth(routing: ControlRoutingSelectors) -> ControlSurfaceHealthSnapshot? { nil }
-
+    func controlSurfaceWaitForInWindow(routing: ControlRoutingSelectors, surfaceID: UUID) async -> Bool { false }
     func controlSurfaceFocus(
         routing: ControlRoutingSelectors,
         surfaceID: UUID

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs.swift
@@ -28,6 +28,7 @@ extension ControlPaneContext {
         routing: ControlRoutingSelectors,
         paneID: UUID?
     ) -> ControlPaneSurfacesSnapshot? { nil }
+    func controlPaneBrowserCreationDisabled() -> Bool { false }
     func controlPaneCreate(
         routing: ControlRoutingSelectors,
         inputs: ControlPaneCreateInputs

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTestSupport.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTestSupport.swift
@@ -1,0 +1,217 @@
+import Foundation
+@testable import CmuxControlSocket
+
+@MainActor
+final class FakeHelperControlCommandContext: ControlCommandContext {
+    let windowID = UUID()
+    let callerWorkspaceID = UUID()
+    let callerPaneID = UUID()
+    let callerSurfaceID = UUID()
+    let focusedWorkspaceID = UUID()
+    let focusedPaneID = UUID()
+    let focusedSurfaceID = UUID()
+    let leftPaneID = UUID()
+    let leftSurfaceID = UUID()
+    let helperPaneID = UUID()
+    let helperSurfaceID = UUID()
+    let extraHelperSurfaceID = UUID()
+    let createdPaneID = UUID()
+    let createdSurfaceID = UUID()
+
+    var includeExistingHelperPane = false
+    var includeLeftPane = false
+    var includeExtraHelperSurface = false
+    var helperSelectedSurfaceID: UUID?
+    var existingHelperSurfaceVisible = true
+    var leftSurfaceTypeRaw = "terminal"
+    var helperSurfaceTypeRaw = "terminal"
+    var extraHelperSurfaceTypeRaw = "terminal"
+    var createdSurfaceVisible = true
+    var createdSurfaceVisibleAfterWindowEvent: Bool?
+    var surfaceSendTextFails = false
+    private(set) var identifyParams: [String: JSONValue] = [:]
+    private(set) var paneListRoutings: [ControlRoutingSelectors] = []
+    private(set) var surfaceHealthRoutings: [ControlRoutingSelectors] = []
+    private(set) var surfaceWindowWaits: [(routing: ControlRoutingSelectors, surfaceID: UUID)] = []
+    private(set) var paneCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlPaneCreateInputs)] = []
+    private(set) var surfaceCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlSurfaceCreateInputs)] = []
+    private(set) var surfaceSendTextCalls: [(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
+        text: String
+    )] = []
+
+    func controlSystemIdentify(params: [String: JSONValue]) -> JSONValue {
+        identifyParams = params
+        return .object([
+            "focused": .object([
+                "window_id": .string(windowID.uuidString),
+                "workspace_id": .string(focusedWorkspaceID.uuidString),
+                "pane_id": .string(focusedPaneID.uuidString),
+                "surface_id": .string(focusedSurfaceID.uuidString),
+            ]),
+            "caller": .object([
+                "window_id": .string(windowID.uuidString),
+                "workspace_id": .string(callerWorkspaceID.uuidString),
+                "pane_id": .string(callerPaneID.uuidString),
+                "surface_id": .string(callerSurfaceID.uuidString),
+            ]),
+        ])
+    }
+
+    func controlPaneRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routing.workspaceID == focusedWorkspaceID
+    }
+
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routing.workspaceID == focusedWorkspaceID
+    }
+
+    func controlPaneList(routing: ControlRoutingSelectors) -> ControlPaneListSnapshot? {
+        paneListRoutings.append(routing)
+        var panes = [
+            ControlPaneSummary(
+                paneID: focusedPaneID,
+                isFocused: true,
+                surfaceIDs: [focusedSurfaceID],
+                selectedSurfaceID: focusedSurfaceID,
+                pixelFrame: ControlPanePixelFrame(x: 0, y: 0, width: 500, height: 500),
+                gridSize: nil
+            ),
+        ]
+        if includeLeftPane {
+            panes.append(ControlPaneSummary(
+                paneID: leftPaneID,
+                isFocused: false,
+                surfaceIDs: [leftSurfaceID],
+                selectedSurfaceID: leftSurfaceID,
+                pixelFrame: ControlPanePixelFrame(x: -500, y: 0, width: 500, height: 500),
+                gridSize: nil
+            ))
+        }
+        if includeExistingHelperPane {
+            var surfaceIDs = [helperSurfaceID]
+            if includeExtraHelperSurface {
+                surfaceIDs.insert(extraHelperSurfaceID, at: 0)
+            }
+            panes.append(ControlPaneSummary(
+                paneID: helperPaneID,
+                isFocused: false,
+                surfaceIDs: surfaceIDs,
+                selectedSurfaceID: helperSelectedSurfaceID ?? helperSurfaceID,
+                pixelFrame: ControlPanePixelFrame(x: 500, y: 0, width: 500, height: 500),
+                gridSize: nil
+            ))
+        }
+        return ControlPaneListSnapshot(
+            workspaceID: focusedWorkspaceID,
+            windowID: windowID,
+            panes: panes,
+            containerWidth: 1_000,
+            containerHeight: 500
+        )
+    }
+
+    func controlSurfaceHealth(routing: ControlRoutingSelectors) -> ControlSurfaceHealthSnapshot? {
+        surfaceHealthRoutings.append(routing)
+        var surfaces = [
+            ControlSurfaceHealthEntry(
+                surfaceID: focusedSurfaceID,
+                typeRawValue: "terminal",
+                inWindow: true
+            ),
+        ]
+        if includeLeftPane {
+            surfaces.append(ControlSurfaceHealthEntry(
+                surfaceID: leftSurfaceID,
+                typeRawValue: leftSurfaceTypeRaw,
+                inWindow: true
+            ))
+        }
+        if includeExistingHelperPane {
+            if includeExtraHelperSurface {
+                surfaces.append(ControlSurfaceHealthEntry(
+                    surfaceID: extraHelperSurfaceID,
+                    typeRawValue: extraHelperSurfaceTypeRaw,
+                    inWindow: true
+                ))
+            }
+            surfaces.append(ControlSurfaceHealthEntry(
+                surfaceID: helperSurfaceID,
+                typeRawValue: helperSurfaceTypeRaw,
+                inWindow: existingHelperSurfaceVisible
+            ))
+        }
+        if !paneCreateCalls.isEmpty || !surfaceCreateCalls.isEmpty {
+            let isCreatedSurfaceVisible = createdSurfaceVisibleAfterWindowEvent ?? createdSurfaceVisible
+            surfaces.append(ControlSurfaceHealthEntry(
+                surfaceID: createdSurfaceID,
+                typeRawValue: "terminal",
+                inWindow: isCreatedSurfaceVisible
+            ))
+        }
+        return ControlSurfaceHealthSnapshot(
+            workspaceID: focusedWorkspaceID,
+            windowID: windowID,
+            surfaces: surfaces
+        )
+    }
+
+    func controlSurfaceWaitForInWindow(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID
+    ) async -> Bool {
+        surfaceWindowWaits.append((routing, surfaceID))
+        if let visibleAfterWindowEvent = createdSurfaceVisibleAfterWindowEvent {
+            createdSurfaceVisible = visibleAfterWindowEvent
+        }
+        return true
+    }
+
+    func controlPaneCreate(
+        routing: ControlRoutingSelectors,
+        inputs: ControlPaneCreateInputs
+    ) -> ControlPaneCreateResolution {
+        paneCreateCalls.append((routing, inputs))
+        return .created(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            paneID: createdPaneID,
+            surfaceID: createdSurfaceID,
+            typeRawValue: inputs.typeRaw ?? "terminal"
+        )
+    }
+
+    func controlSurfaceCreate(
+        routing: ControlRoutingSelectors,
+        inputs: ControlSurfaceCreateInputs
+    ) -> ControlSurfaceCreateResolution {
+        surfaceCreateCalls.append((routing, inputs))
+        return .created(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            paneID: inputs.requestedPaneID ?? helperPaneID,
+            surfaceID: createdSurfaceID,
+            typeRawValue: inputs.typeRaw ?? "terminal"
+        )
+    }
+
+    func controlSurfaceSendText(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
+        text: String
+    ) -> ControlSurfaceSendResolution {
+        surfaceSendTextCalls.append((routing, surfaceID, hasSurfaceIDParam, text))
+        if surfaceSendTextFails {
+            return .surfaceUnavailable(surfaceID ?? createdSurfaceID)
+        }
+        return .sent(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            surfaceID: surfaceID ?? createdSurfaceID,
+            queued: false
+        )
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTestSupport.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTestSupport.swift
@@ -22,12 +22,23 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
     var includeLeftPane = false
     var includeExtraHelperSurface = false
     var helperSelectedSurfaceID: UUID?
+    var windowVisible = true
+    var focusedSurfaceVisible = true
+    var focusedSurfaceVisibleInUI: Bool?
     var existingHelperSurfaceVisible = true
+    var existingHelperSurfaceVisibleInUI: Bool?
     var leftSurfaceTypeRaw = "terminal"
+    var leftSurfaceVisibleInUI = true
     var helperSurfaceTypeRaw = "terminal"
     var extraHelperSurfaceTypeRaw = "terminal"
+    var extraHelperSurfaceVisibleInUI = false
     var createdSurfaceVisible = true
     var createdSurfaceVisibleAfterWindowEvent: Bool?
+    var createdSurfaceVisibleInUI: Bool?
+    var createdSurfaceWindowEventObserved = true
+    var isRemoteTmuxMirror = false
+    var browserCreationDisabled = false
+    var onSurfaceWindowWait: (() -> Void)?
     var surfaceSendTextFails = false
     private(set) var identifyParams: [String: JSONValue] = [:]
     private(set) var paneListRoutings: [ControlRoutingSelectors] = []
@@ -108,6 +119,7 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
             workspaceID: focusedWorkspaceID,
             windowID: windowID,
             panes: panes,
+            isRemoteTmuxMirror: isRemoteTmuxMirror,
             containerWidth: 1_000,
             containerHeight: 500
         )
@@ -119,14 +131,16 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
             ControlSurfaceHealthEntry(
                 surfaceID: focusedSurfaceID,
                 typeRawValue: "terminal",
-                inWindow: true
+                inWindow: focusedSurfaceVisible,
+                visibleInUI: focusedSurfaceVisibleInUI ?? focusedSurfaceVisible
             ),
         ]
         if includeLeftPane {
             surfaces.append(ControlSurfaceHealthEntry(
                 surfaceID: leftSurfaceID,
                 typeRawValue: leftSurfaceTypeRaw,
-                inWindow: true
+                inWindow: true,
+                visibleInUI: leftSurfaceVisibleInUI
             ))
         }
         if includeExistingHelperPane {
@@ -134,13 +148,15 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
                 surfaces.append(ControlSurfaceHealthEntry(
                     surfaceID: extraHelperSurfaceID,
                     typeRawValue: extraHelperSurfaceTypeRaw,
-                    inWindow: true
+                    inWindow: true,
+                    visibleInUI: extraHelperSurfaceVisibleInUI
                 ))
             }
             surfaces.append(ControlSurfaceHealthEntry(
                 surfaceID: helperSurfaceID,
                 typeRawValue: helperSurfaceTypeRaw,
-                inWindow: existingHelperSurfaceVisible
+                inWindow: existingHelperSurfaceVisible,
+                visibleInUI: existingHelperSurfaceVisibleInUI ?? existingHelperSurfaceVisible
             ))
         }
         if !paneCreateCalls.isEmpty || !surfaceCreateCalls.isEmpty {
@@ -148,12 +164,14 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
             surfaces.append(ControlSurfaceHealthEntry(
                 surfaceID: createdSurfaceID,
                 typeRawValue: "terminal",
-                inWindow: isCreatedSurfaceVisible
+                inWindow: isCreatedSurfaceVisible,
+                visibleInUI: createdSurfaceVisibleInUI ?? isCreatedSurfaceVisible
             ))
         }
         return ControlSurfaceHealthSnapshot(
             workspaceID: focusedWorkspaceID,
             windowID: windowID,
+            windowVisible: windowVisible,
             surfaces: surfaces
         )
     }
@@ -163,10 +181,18 @@ final class FakeHelperControlCommandContext: ControlCommandContext {
         surfaceID: UUID
     ) async -> Bool {
         surfaceWindowWaits.append((routing, surfaceID))
+        onSurfaceWindowWait?()
+        guard createdSurfaceWindowEventObserved else {
+            return false
+        }
         if let visibleAfterWindowEvent = createdSurfaceVisibleAfterWindowEvent {
             createdSurfaceVisible = visibleAfterWindowEvent
         }
         return true
+    }
+
+    func controlPaneBrowserCreationDisabled() -> Bool {
+        browserCreationDisabled
     }
 
     func controlPaneCreate(

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
@@ -3,184 +3,6 @@ import Testing
 @testable import CmuxControlSocket
 
 @MainActor
-private final class FakeHelperControlCommandContext: ControlCommandContext {
-    let windowID = UUID()
-    let callerWorkspaceID = UUID()
-    let callerPaneID = UUID()
-    let callerSurfaceID = UUID()
-    let focusedWorkspaceID = UUID()
-    let focusedPaneID = UUID()
-    let focusedSurfaceID = UUID()
-    let helperPaneID = UUID()
-    let helperSurfaceID = UUID()
-    let extraHelperSurfaceID = UUID()
-    let createdPaneID = UUID()
-    let createdSurfaceID = UUID()
-
-    var includeExistingHelperPane = false
-    var includeExtraHelperSurface = false
-    var existingHelperSurfaceVisible = true
-    var createdSurfaceVisible = true
-    var createdSurfaceVisibleAfterHealthSample: Int?
-    private(set) var identifyParams: [String: JSONValue] = [:]
-    private(set) var paneListRoutings: [ControlRoutingSelectors] = []
-    private(set) var surfaceHealthRoutings: [ControlRoutingSelectors] = []
-    private(set) var paneCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlPaneCreateInputs)] = []
-    private(set) var surfaceCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlSurfaceCreateInputs)] = []
-    private(set) var surfaceSendTextCalls: [(
-        routing: ControlRoutingSelectors,
-        surfaceID: UUID?,
-        hasSurfaceIDParam: Bool,
-        text: String
-    )] = []
-
-    func controlSystemIdentify(params: [String: JSONValue]) -> JSONValue {
-        identifyParams = params
-        return .object([
-            "focused": .object([
-                "window_id": .string(windowID.uuidString),
-                "workspace_id": .string(focusedWorkspaceID.uuidString),
-                "pane_id": .string(focusedPaneID.uuidString),
-                "surface_id": .string(focusedSurfaceID.uuidString),
-            ]),
-            "caller": .object([
-                "window_id": .string(windowID.uuidString),
-                "workspace_id": .string(callerWorkspaceID.uuidString),
-                "pane_id": .string(callerPaneID.uuidString),
-                "surface_id": .string(callerSurfaceID.uuidString),
-            ]),
-        ])
-    }
-
-    func controlPaneRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
-        routing.workspaceID == focusedWorkspaceID
-    }
-
-    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
-        routing.workspaceID == focusedWorkspaceID
-    }
-
-    func controlPaneList(routing: ControlRoutingSelectors) -> ControlPaneListSnapshot? {
-        paneListRoutings.append(routing)
-        var panes = [
-            ControlPaneSummary(
-                paneID: focusedPaneID,
-                isFocused: true,
-                surfaceIDs: [focusedSurfaceID],
-                selectedSurfaceID: focusedSurfaceID,
-                pixelFrame: ControlPanePixelFrame(x: 0, y: 0, width: 500, height: 500),
-                gridSize: nil
-            ),
-        ]
-        if includeExistingHelperPane {
-            var surfaceIDs = [helperSurfaceID]
-            if includeExtraHelperSurface {
-                surfaceIDs.insert(extraHelperSurfaceID, at: 0)
-            }
-            panes.append(ControlPaneSummary(
-                paneID: helperPaneID,
-                isFocused: false,
-                surfaceIDs: surfaceIDs,
-                selectedSurfaceID: helperSurfaceID,
-                pixelFrame: ControlPanePixelFrame(x: 500, y: 0, width: 500, height: 500),
-                gridSize: nil
-            ))
-        }
-        return ControlPaneListSnapshot(
-            workspaceID: focusedWorkspaceID,
-            windowID: windowID,
-            panes: panes,
-            containerWidth: 1_000,
-            containerHeight: 500
-        )
-    }
-
-    func controlSurfaceHealth(routing: ControlRoutingSelectors) -> ControlSurfaceHealthSnapshot? {
-        surfaceHealthRoutings.append(routing)
-        var surfaces = [
-            ControlSurfaceHealthEntry(
-                surfaceID: focusedSurfaceID,
-                typeRawValue: "terminal",
-                inWindow: true
-            ),
-        ]
-        if includeExistingHelperPane {
-            if includeExtraHelperSurface {
-                surfaces.append(ControlSurfaceHealthEntry(
-                    surfaceID: extraHelperSurfaceID,
-                    typeRawValue: "terminal",
-                    inWindow: true
-                ))
-            }
-            surfaces.append(ControlSurfaceHealthEntry(
-                surfaceID: helperSurfaceID,
-                typeRawValue: "terminal",
-                inWindow: existingHelperSurfaceVisible
-            ))
-        }
-        if !paneCreateCalls.isEmpty || !surfaceCreateCalls.isEmpty {
-            let sampleNumber = surfaceHealthRoutings.count
-            let isCreatedSurfaceVisible = createdSurfaceVisibleAfterHealthSample.map {
-                sampleNumber >= $0
-            } ?? createdSurfaceVisible
-            surfaces.append(ControlSurfaceHealthEntry(
-                surfaceID: createdSurfaceID,
-                typeRawValue: "terminal",
-                inWindow: isCreatedSurfaceVisible
-            ))
-        }
-        return ControlSurfaceHealthSnapshot(
-            workspaceID: focusedWorkspaceID,
-            windowID: windowID,
-            surfaces: surfaces
-        )
-    }
-
-    func controlPaneCreate(
-        routing: ControlRoutingSelectors,
-        inputs: ControlPaneCreateInputs
-    ) -> ControlPaneCreateResolution {
-        paneCreateCalls.append((routing, inputs))
-        return .created(
-            windowID: windowID,
-            workspaceID: focusedWorkspaceID,
-            paneID: createdPaneID,
-            surfaceID: createdSurfaceID,
-            typeRawValue: inputs.typeRaw ?? "terminal"
-        )
-    }
-
-    func controlSurfaceCreate(
-        routing: ControlRoutingSelectors,
-        inputs: ControlSurfaceCreateInputs
-    ) -> ControlSurfaceCreateResolution {
-        surfaceCreateCalls.append((routing, inputs))
-        return .created(
-            windowID: windowID,
-            workspaceID: focusedWorkspaceID,
-            paneID: inputs.requestedPaneID ?? helperPaneID,
-            surfaceID: createdSurfaceID,
-            typeRawValue: inputs.typeRaw ?? "terminal"
-        )
-    }
-
-    func controlSurfaceSendText(
-        routing: ControlRoutingSelectors,
-        surfaceID: UUID?,
-        hasSurfaceIDParam: Bool,
-        text: String
-    ) -> ControlSurfaceSendResolution {
-        surfaceSendTextCalls.append((routing, surfaceID, hasSurfaceIDParam, text))
-        return .sent(
-            windowID: windowID,
-            workspaceID: focusedWorkspaceID,
-            surfaceID: surfaceID ?? createdSurfaceID,
-            queued: false
-        )
-    }
-}
-
-@MainActor
 @Suite("ControlCommandCoordinator helper domain")
 struct ControlCommandCoordinatorHelperTests {
     private func makeCoordinator() -> (ControlCommandCoordinator, FakeHelperControlCommandContext) {
@@ -193,9 +15,9 @@ struct ControlCommandCoordinatorHelperTests {
         ControlRequest(id: .int(1), method: "helper.visible", params: params)
     }
 
-    @Test func visibleHelperTargetsFocusedWorkspaceWhenCallerDiffers() throws {
+    @Test func visibleHelperTargetsFocusedWorkspaceWhenCallerDiffers() async throws {
         let (coordinator, context) = makeCoordinator()
-        let result = coordinator.handle(request([
+        let result = await coordinator.handleHelperAsync(request([
             "caller": .object(["workspace_id": .string(context.callerWorkspaceID.uuidString)]),
         ]))
 
@@ -217,18 +39,21 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["surface_visible"] == .bool(true))
         #expect(payload["surface_health_in_window"] == .bool(true))
         #expect(payload["surface_health_attempts"] == .int(1))
+        #expect(payload["surface_window_event_observed"] == .bool(true))
         #expect(context.paneCreateCalls.count == 1)
         #expect(context.surfaceCreateCalls.isEmpty)
         #expect(context.surfaceSendTextCalls.isEmpty)
         #expect(context.surfaceHealthRoutings.count == 2)
+        #expect(context.surfaceWindowWaits.count == 1)
+        #expect(context.surfaceWindowWaits.first?.surfaceID == context.createdSurfaceID)
         #expect(context.paneCreateCalls.first?.routing.workspaceID == context.focusedWorkspaceID)
         #expect(context.paneCreateCalls.first?.inputs.directionRaw == "right")
         #expect(context.paneCreateCalls.first?.inputs.requestedFocus == false)
     }
 
-    @Test func visibleHelperCreatesVisiblePaneBeforeSendingCommand() throws {
+    @Test func visibleHelperCreatesVisiblePaneBeforeSendingCommand() async throws {
         let (coordinator, context) = makeCoordinator()
-        let result = coordinator.handle(request([
+        let result = await coordinator.handleHelperAsync(request([
             "initial_command": .string("echo created"),
         ]))
 
@@ -251,13 +76,15 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceSendTextCalls.count == 1)
         #expect(context.surfaceSendTextCalls.first?.surfaceID == context.createdSurfaceID)
         #expect(context.surfaceSendTextCalls.first?.text == "echo created\n")
+        #expect(context.surfaceWindowWaits.count == 1)
     }
 
-    @Test func visibleHelperRetriesUntilNewlyCreatedSurfaceIsInWindow() throws {
+    @Test func visibleHelperWaitsForNewlyCreatedSurfaceWindowEvent() async throws {
         let (coordinator, context) = makeCoordinator()
-        context.createdSurfaceVisibleAfterHealthSample = 3
+        context.createdSurfaceVisible = false
+        context.createdSurfaceVisibleAfterWindowEvent = true
 
-        let result = coordinator.handle(request([
+        let result = await coordinator.handleHelperAsync(request([
             "initial_command": .string("echo delayed"),
         ]))
 
@@ -270,18 +97,21 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
         #expect(payload["surface_visible"] == .bool(true))
         #expect(payload["surface_health_in_window"] == .bool(true))
-        #expect(payload["surface_health_attempts"] == .int(2))
+        #expect(payload["surface_health_attempts"] == .int(1))
+        #expect(payload["surface_window_event_observed"] == .bool(true))
         #expect(payload["sent_command"] == .bool(true))
         #expect(context.paneCreateCalls.count == 1)
         #expect(context.surfaceSendTextCalls.count == 1)
-        #expect(context.surfaceHealthRoutings.count == 3)
+        #expect(context.surfaceHealthRoutings.count == 2)
+        #expect(context.surfaceWindowWaits.count == 1)
+        #expect(context.surfaceWindowWaits.first?.surfaceID == context.createdSurfaceID)
     }
 
-    @Test func visibleHelperReusesExistingRightPaneWithoutDuplicatingPanes() throws {
+    @Test func visibleHelperReusesExistingRightPaneWithoutDuplicatingPanes() async throws {
         let (coordinator, context) = makeCoordinator()
         context.includeExistingHelperPane = true
 
-        let result = coordinator.handle(request())
+        let result = await coordinator.handleHelperAsync(request())
 
         guard case .ok(.object(let payload)) = result else {
             Issue.record("unexpected helper.visible result: \(String(describing: result))")
@@ -298,17 +128,18 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["sent_command"] == .bool(false))
         #expect(payload["surface_visible"] == .bool(true))
         #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(payload["surface_window_event_observed"] == .null)
         #expect(context.paneCreateCalls.isEmpty)
         #expect(context.surfaceCreateCalls.isEmpty)
         #expect(context.surfaceSendTextCalls.isEmpty)
         #expect(context.surfaceHealthRoutings.count == 2)
     }
 
-    @Test func visibleHelperSendsCommandToExistingVisibleTerminalWithoutDuplicatingPanes() throws {
+    @Test func visibleHelperSendsCommandToExistingVisibleTerminalWithoutDuplicatingPanes() async throws {
         let (coordinator, context) = makeCoordinator()
         context.includeExistingHelperPane = true
 
-        let result = coordinator.handle(request([
+        let result = await coordinator.handleHelperAsync(request([
             "initial_command": .string("echo helper"),
         ]))
 
@@ -328,6 +159,7 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["command_queued"] == .bool(false))
         #expect(payload["surface_visible"] == .bool(true))
         #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(payload["surface_window_event_observed"] == .null)
         #expect(context.paneCreateCalls.isEmpty)
         #expect(context.surfaceCreateCalls.isEmpty)
         #expect(context.surfaceSendTextCalls.count == 1)
@@ -337,12 +169,12 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceHealthRoutings.count == 2)
     }
 
-    @Test func visibleHelperSendsCommandToSelectedHelperSurfaceWhenPaneHasMultipleSurfaces() throws {
+    @Test func visibleHelperSendsCommandToSelectedHelperSurfaceWhenPaneHasMultipleSurfaces() async throws {
         let (coordinator, context) = makeCoordinator()
         context.includeExistingHelperPane = true
         context.includeExtraHelperSurface = true
 
-        let result = coordinator.handle(request([
+        let result = await coordinator.handleHelperAsync(request([
             "initial_command": .string("echo selected"),
         ]))
 
@@ -361,12 +193,84 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceSendTextCalls.first?.surfaceID != context.extraHelperSurfaceID)
     }
 
-    @Test func visibleHelperRejectsStructuralHelperPaneThatIsNotVisible() throws {
+    @Test func visibleHelperReusesVisibleRequestedSurfaceWhenSelectedSurfaceIsNotVisible() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.includeExtraHelperSurface = true
+        context.existingHelperSurfaceVisible = false
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo visible extra"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.extraHelperSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("reused_right_pane"))
+        #expect(payload["reused_pane"] == .bool(true))
+        #expect(payload["created_pane"] == .bool(false))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.extraHelperSurfaceID)
+    }
+
+    @Test func visibleHelperDoesNotReuseVisibleNonRightPane() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeLeftPane = true
+        context.includeExistingHelperPane = true
+        context.helperSurfaceTypeRaw = "browser"
+
+        let result = await coordinator.handleHelperAsync(request([
+            "type": .string("terminal"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["pane_id"] == .string(context.createdPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("created_right_pane"))
+        #expect(payload["reused_pane"] == .bool(false))
+        #expect(payload["created_pane"] == .bool(true))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperWrongTypeInvisiblePaneDoesNotBlockRequestedTypeCreation() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.existingHelperSurfaceVisible = false
+        context.helperSurfaceTypeRaw = "browser"
+
+        let result = await coordinator.handleHelperAsync(request([
+            "type": .string("terminal"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["pane_id"] == .string(context.createdPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("created_right_pane"))
+        #expect(payload["created_pane"] == .bool(true))
+        #expect(context.paneCreateCalls.count == 1)
+    }
+
+    @Test func visibleHelperRejectsStructuralHelperPaneThatIsNotVisible() async throws {
         let (coordinator, context) = makeCoordinator()
         context.includeExistingHelperPane = true
         context.existingHelperSurfaceVisible = false
 
-        let result = coordinator.handle(request())
+        let result = await coordinator.handleHelperAsync(request())
 
         guard case .err(let code, let message, let data) = result else {
             Issue.record("unexpected helper.visible result: \(String(describing: result))")
@@ -388,11 +292,38 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceHealthRoutings.count == 1)
     }
 
-    @Test func visibleHelperFailsWhenCreatedSurfaceIsNotInWindow() throws {
+    @Test func visibleHelperCommandSendFailureUsesCommandFailedCode() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.surfaceSendTextFails = true
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo fails"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "command_failed")
+        #expect(message.contains("failed to send"))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(payload["sent_command"] == .bool(false))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+    }
+
+    @Test func visibleHelperFailsWhenCreatedSurfaceIsNotInWindow() async throws {
         let (coordinator, context) = makeCoordinator()
         context.createdSurfaceVisible = false
 
-        let result = coordinator.handle(request())
+        let result = await coordinator.handleHelperAsync(request())
 
         guard case .err(let code, let message, let data) = result else {
             Issue.record("unexpected helper.visible result: \(String(describing: result))")
@@ -411,10 +342,12 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["surface_visible"] == .bool(false))
         #expect(payload["surface_health_found"] == .bool(true))
         #expect(payload["surface_health_in_window"] == .bool(false))
-        #expect(payload["surface_health_attempts"] == .int(6))
+        #expect(payload["surface_health_attempts"] == .int(1))
+        #expect(payload["surface_window_event_observed"] == .bool(true))
         #expect(context.paneCreateCalls.count == 1)
         #expect(context.surfaceCreateCalls.isEmpty)
         #expect(context.surfaceSendTextCalls.isEmpty)
-        #expect(context.surfaceHealthRoutings.count == 7)
+        #expect(context.surfaceHealthRoutings.count == 2)
+        #expect(context.surfaceWindowWaits.count == 1)
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
@@ -79,6 +79,66 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceWindowWaits.count == 1)
     }
 
+    @Test func visibleHelperRejectsOffscreenTargetBeforeCreatingPane() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.focusedSurfaceVisible = false
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo should-not-create"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("target workspace is visible"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["target_surface_visible"] == .bool(false))
+        #expect(payload["visibility_source"] == .string("surface.health"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceWindowWaits.isEmpty)
+    }
+
+    @Test func visibleHelperRejectsHiddenWindowBeforeCreatingPane() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.windowVisible = false
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo should-not-create"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("target workspace is visible"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["target_surface_visible"] == .bool(false))
+        if case .object(let health)? = payload["surface_health"] {
+            #expect(health["window_visible"] == .bool(false))
+        } else {
+            Issue.record("missing surface_health payload")
+        }
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceWindowWaits.isEmpty)
+    }
+
     @Test func visibleHelperWaitsForNewlyCreatedSurfaceWindowEvent() async throws {
         let (coordinator, context) = makeCoordinator()
         context.createdSurfaceVisible = false
@@ -193,7 +253,7 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(context.surfaceSendTextCalls.first?.surfaceID != context.extraHelperSurfaceID)
     }
 
-    @Test func visibleHelperReusesVisibleRequestedSurfaceWhenSelectedSurfaceIsNotVisible() async throws {
+    @Test func visibleHelperRejectsPaneWhenSelectedSurfaceIsNotVisible() async throws {
         let (coordinator, context) = makeCoordinator()
         context.includeExistingHelperPane = true
         context.includeExtraHelperSurface = true
@@ -203,20 +263,47 @@ struct ControlCommandCoordinatorHelperTests {
             "initial_command": .string("echo visible extra"),
         ]))
 
-        guard case .ok(.object(let payload)) = result else {
+        guard case .err(let code, let message, let data) = result else {
             Issue.record("unexpected helper.visible result: \(String(describing: result))")
             return
         }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
 
+        #expect(code == "not_visible")
+        #expect(message.contains("structural helper pane"))
         #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
-        #expect(payload["surface_id"] == .string(context.extraHelperSurfaceID.uuidString))
-        #expect(payload["placement_strategy"] == .string("reused_right_pane"))
-        #expect(payload["reused_pane"] == .bool(true))
-        #expect(payload["created_pane"] == .bool(false))
-        #expect(payload["sent_command"] == .bool(true))
+        #expect(payload["target_workspace_source"] == .string("focused"))
         #expect(context.paneCreateCalls.isEmpty)
-        #expect(context.surfaceSendTextCalls.count == 1)
-        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.extraHelperSurfaceID)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperRejectsMountedButHiddenSelectedHelperSurface() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.existingHelperSurfaceVisible = true
+        context.existingHelperSurfaceVisibleInUI = false
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo hidden"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("structural helper pane"))
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
     }
 
     @Test func visibleHelperDoesNotReuseVisibleNonRightPane() async throws {
@@ -263,6 +350,227 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["placement_strategy"] == .string("created_right_pane"))
         #expect(payload["created_pane"] == .bool(true))
         #expect(context.paneCreateCalls.count == 1)
+    }
+
+    @Test func visibleHelperRejectsRemoteTmuxTerminalCreateBeforeMutation() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.isRemoteTmuxMirror = true
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo remote"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "unsupported")
+        #expect(message.contains("remote tmux mirror"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["target_workspace_source"] == .string("focused"))
+        #expect(payload["routed_target"] == .string("remote-tmux"))
+        #expect(payload["placement_strategy"] == .string("remote_tmux_rejected_before_mutation"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceWindowWaits.isEmpty)
+    }
+
+    @Test func visibleHelperReusesVisibleRemoteTmuxHelperWithoutCreatingPane() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.isRemoteTmuxMirror = true
+        context.includeExistingHelperPane = true
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo reused remote"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.helperSurfaceID.uuidString))
+        #expect(payload["reused_pane"] == .bool(true))
+        #expect(payload["created_pane"] == .bool(false))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.helperSurfaceID)
+    }
+
+    @Test func visibleHelperRejectsBrowserDisabledCreateBeforeExternalOpenFallback() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.browserCreationDisabled = true
+
+        let result = await coordinator.handleHelperAsync(request([
+            "type": .string("browser"),
+            "url": .string("https://example.com"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "browser_disabled")
+        #expect(message.contains("browser is disabled"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["mutation_started"] == .bool(false))
+        #expect(payload["placement_strategy"] == .string("browser_disabled_rejected_before_mutation"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperRejectsBrowserCommandBeforeCreatingPane() async throws {
+        let (coordinator, context) = makeCoordinator()
+
+        let result = await coordinator.handleHelperAsync(request([
+            "type": .string("browser"),
+            "initial_command": .string("echo invalid"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "invalid_params")
+        #expect(message.contains("only supported for terminal"))
+        #expect(payload["type"] == .string("browser"))
+        #expect(payload["mutation_started"] == .bool(false))
+        #expect(payload["placement_strategy"] == .string("non_terminal_command_rejected_before_mutation"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperRejectsBrowserURLReuseBeforeMutation() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.helperSurfaceTypeRaw = "browser"
+
+        let result = await coordinator.handleHelperAsync(request([
+            "type": .string("browser"),
+            "url": .string("https://example.com"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "unsupported")
+        #expect(message.contains("requested URL"))
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.helperSurfaceID.uuidString))
+        #expect(payload["mutation_started"] == .bool(false))
+        #expect(payload["placement_strategy"] == .string("browser_url_reuse_rejected_before_mutation"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperCancellationBeforeCreateDoesNotMutate() async throws {
+        let (coordinator, context) = makeCoordinator()
+        let task = Task {
+            await coordinator.handleHelperAsync(request([
+                "initial_command": .string("echo should-not-create"),
+            ]))
+        }
+        task.cancel()
+
+        let result = await task.value
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "cancelled")
+        #expect(message.contains("before creating"))
+        #expect(payload["mutation_started"] == .bool(false))
+        #expect(payload["placement_strategy"] == .string("cancelled_before_create"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperExpiredMutationDeadlineDoesNotMutate() async throws {
+        let (coordinator, context) = makeCoordinator()
+
+        let result = await coordinator.handleHelperAsync(request([
+            "_cmux_helper_visible_latest_mutation_start_uptime_ns": .int(1),
+            "initial_command": .string("echo should-not-create"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "timeout")
+        #expect(message.contains("before creating"))
+        #expect(payload["mutation_started"] == .bool(false))
+        #expect(payload["placement_strategy"] == .string("deadline_expired_before_create"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+    }
+
+    @Test func visibleHelperCancellationAfterVisibilityDoesNotSendCommand() async throws {
+        let (coordinator, context) = makeCoordinator()
+        nonisolated(unsafe) var task: Task<ControlCallResult?, Never>?
+        context.onSurfaceWindowWait = {
+            task?.cancel()
+        }
+        let createdTask = Task {
+            await coordinator.handleHelperAsync(request([
+                "initial_command": .string("echo should-not-send"),
+            ]))
+        }
+        task = createdTask
+
+        let result = await createdTask.value
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "cancelled")
+        #expect(message.contains("before sending"))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.isEmpty)
     }
 
     @Test func visibleHelperRejectsStructuralHelperPaneThatIsNotVisible() async throws {
@@ -344,6 +652,41 @@ struct ControlCommandCoordinatorHelperTests {
         #expect(payload["surface_health_in_window"] == .bool(false))
         #expect(payload["surface_health_attempts"] == .int(1))
         #expect(payload["surface_window_event_observed"] == .bool(true))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceHealthRoutings.count == 2)
+        #expect(context.surfaceWindowWaits.count == 1)
+    }
+
+    @Test func visibleHelperFailsWhenCreatedSurfaceWindowEventIsNotObserved() async throws {
+        let (coordinator, context) = makeCoordinator()
+        context.createdSurfaceVisible = false
+        context.createdSurfaceWindowEventObserved = false
+
+        let result = await coordinator.handleHelperAsync(request([
+            "initial_command": .string("echo should-not-send"),
+        ]))
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("in_window=true"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("created_right_pane"))
+        #expect(payload["surface_visible"] == .bool(false))
+        #expect(payload["surface_health_found"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(false))
+        #expect(payload["surface_window_event_observed"] == .bool(false))
+        #expect(payload["sent_command"] == .bool(false))
         #expect(context.paneCreateCalls.count == 1)
         #expect(context.surfaceCreateCalls.isEmpty)
         #expect(context.surfaceSendTextCalls.isEmpty)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorHelperTests.swift
@@ -1,0 +1,420 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+@MainActor
+private final class FakeHelperControlCommandContext: ControlCommandContext {
+    let windowID = UUID()
+    let callerWorkspaceID = UUID()
+    let callerPaneID = UUID()
+    let callerSurfaceID = UUID()
+    let focusedWorkspaceID = UUID()
+    let focusedPaneID = UUID()
+    let focusedSurfaceID = UUID()
+    let helperPaneID = UUID()
+    let helperSurfaceID = UUID()
+    let extraHelperSurfaceID = UUID()
+    let createdPaneID = UUID()
+    let createdSurfaceID = UUID()
+
+    var includeExistingHelperPane = false
+    var includeExtraHelperSurface = false
+    var existingHelperSurfaceVisible = true
+    var createdSurfaceVisible = true
+    var createdSurfaceVisibleAfterHealthSample: Int?
+    private(set) var identifyParams: [String: JSONValue] = [:]
+    private(set) var paneListRoutings: [ControlRoutingSelectors] = []
+    private(set) var surfaceHealthRoutings: [ControlRoutingSelectors] = []
+    private(set) var paneCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlPaneCreateInputs)] = []
+    private(set) var surfaceCreateCalls: [(routing: ControlRoutingSelectors, inputs: ControlSurfaceCreateInputs)] = []
+    private(set) var surfaceSendTextCalls: [(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
+        text: String
+    )] = []
+
+    func controlSystemIdentify(params: [String: JSONValue]) -> JSONValue {
+        identifyParams = params
+        return .object([
+            "focused": .object([
+                "window_id": .string(windowID.uuidString),
+                "workspace_id": .string(focusedWorkspaceID.uuidString),
+                "pane_id": .string(focusedPaneID.uuidString),
+                "surface_id": .string(focusedSurfaceID.uuidString),
+            ]),
+            "caller": .object([
+                "window_id": .string(windowID.uuidString),
+                "workspace_id": .string(callerWorkspaceID.uuidString),
+                "pane_id": .string(callerPaneID.uuidString),
+                "surface_id": .string(callerSurfaceID.uuidString),
+            ]),
+        ])
+    }
+
+    func controlPaneRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routing.workspaceID == focusedWorkspaceID
+    }
+
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool {
+        routing.workspaceID == focusedWorkspaceID
+    }
+
+    func controlPaneList(routing: ControlRoutingSelectors) -> ControlPaneListSnapshot? {
+        paneListRoutings.append(routing)
+        var panes = [
+            ControlPaneSummary(
+                paneID: focusedPaneID,
+                isFocused: true,
+                surfaceIDs: [focusedSurfaceID],
+                selectedSurfaceID: focusedSurfaceID,
+                pixelFrame: ControlPanePixelFrame(x: 0, y: 0, width: 500, height: 500),
+                gridSize: nil
+            ),
+        ]
+        if includeExistingHelperPane {
+            var surfaceIDs = [helperSurfaceID]
+            if includeExtraHelperSurface {
+                surfaceIDs.insert(extraHelperSurfaceID, at: 0)
+            }
+            panes.append(ControlPaneSummary(
+                paneID: helperPaneID,
+                isFocused: false,
+                surfaceIDs: surfaceIDs,
+                selectedSurfaceID: helperSurfaceID,
+                pixelFrame: ControlPanePixelFrame(x: 500, y: 0, width: 500, height: 500),
+                gridSize: nil
+            ))
+        }
+        return ControlPaneListSnapshot(
+            workspaceID: focusedWorkspaceID,
+            windowID: windowID,
+            panes: panes,
+            containerWidth: 1_000,
+            containerHeight: 500
+        )
+    }
+
+    func controlSurfaceHealth(routing: ControlRoutingSelectors) -> ControlSurfaceHealthSnapshot? {
+        surfaceHealthRoutings.append(routing)
+        var surfaces = [
+            ControlSurfaceHealthEntry(
+                surfaceID: focusedSurfaceID,
+                typeRawValue: "terminal",
+                inWindow: true
+            ),
+        ]
+        if includeExistingHelperPane {
+            if includeExtraHelperSurface {
+                surfaces.append(ControlSurfaceHealthEntry(
+                    surfaceID: extraHelperSurfaceID,
+                    typeRawValue: "terminal",
+                    inWindow: true
+                ))
+            }
+            surfaces.append(ControlSurfaceHealthEntry(
+                surfaceID: helperSurfaceID,
+                typeRawValue: "terminal",
+                inWindow: existingHelperSurfaceVisible
+            ))
+        }
+        if !paneCreateCalls.isEmpty || !surfaceCreateCalls.isEmpty {
+            let sampleNumber = surfaceHealthRoutings.count
+            let isCreatedSurfaceVisible = createdSurfaceVisibleAfterHealthSample.map {
+                sampleNumber >= $0
+            } ?? createdSurfaceVisible
+            surfaces.append(ControlSurfaceHealthEntry(
+                surfaceID: createdSurfaceID,
+                typeRawValue: "terminal",
+                inWindow: isCreatedSurfaceVisible
+            ))
+        }
+        return ControlSurfaceHealthSnapshot(
+            workspaceID: focusedWorkspaceID,
+            windowID: windowID,
+            surfaces: surfaces
+        )
+    }
+
+    func controlPaneCreate(
+        routing: ControlRoutingSelectors,
+        inputs: ControlPaneCreateInputs
+    ) -> ControlPaneCreateResolution {
+        paneCreateCalls.append((routing, inputs))
+        return .created(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            paneID: createdPaneID,
+            surfaceID: createdSurfaceID,
+            typeRawValue: inputs.typeRaw ?? "terminal"
+        )
+    }
+
+    func controlSurfaceCreate(
+        routing: ControlRoutingSelectors,
+        inputs: ControlSurfaceCreateInputs
+    ) -> ControlSurfaceCreateResolution {
+        surfaceCreateCalls.append((routing, inputs))
+        return .created(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            paneID: inputs.requestedPaneID ?? helperPaneID,
+            surfaceID: createdSurfaceID,
+            typeRawValue: inputs.typeRaw ?? "terminal"
+        )
+    }
+
+    func controlSurfaceSendText(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
+        text: String
+    ) -> ControlSurfaceSendResolution {
+        surfaceSendTextCalls.append((routing, surfaceID, hasSurfaceIDParam, text))
+        return .sent(
+            windowID: windowID,
+            workspaceID: focusedWorkspaceID,
+            surfaceID: surfaceID ?? createdSurfaceID,
+            queued: false
+        )
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator helper domain")
+struct ControlCommandCoordinatorHelperTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeHelperControlCommandContext) {
+        let context = FakeHelperControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+        return (coordinator, context)
+    }
+
+    private func request(_ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: "helper.visible", params: params)
+    }
+
+    @Test func visibleHelperTargetsFocusedWorkspaceWhenCallerDiffers() throws {
+        let (coordinator, context) = makeCoordinator()
+        let result = coordinator.handle(request([
+            "caller": .object(["workspace_id": .string(context.callerWorkspaceID.uuidString)]),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["pane_id"] == .string(context.createdPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["target_workspace_source"] == .string("focused"))
+        #expect(payload["caller_focused_diverged"] == .bool(true))
+        #expect(payload["placement_strategy"] == .string("created_right_pane"))
+        #expect(payload["reused_pane"] == .bool(false))
+        #expect(payload["created_pane"] == .bool(true))
+        #expect(payload["created_surface"] == .bool(true))
+        #expect(payload["sent_command"] == .bool(false))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(payload["surface_health_attempts"] == .int(1))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceHealthRoutings.count == 2)
+        #expect(context.paneCreateCalls.first?.routing.workspaceID == context.focusedWorkspaceID)
+        #expect(context.paneCreateCalls.first?.inputs.directionRaw == "right")
+        #expect(context.paneCreateCalls.first?.inputs.requestedFocus == false)
+    }
+
+    @Test func visibleHelperCreatesVisiblePaneBeforeSendingCommand() throws {
+        let (coordinator, context) = makeCoordinator()
+        let result = coordinator.handle(request([
+            "initial_command": .string("echo created"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["pane_id"] == .string(context.createdPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["created_pane"] == .bool(true))
+        #expect(payload["created_surface"] == .bool(true))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(payload["command_queued"] == .bool(false))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.paneCreateCalls.first?.inputs.initialCommand == nil)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.createdSurfaceID)
+        #expect(context.surfaceSendTextCalls.first?.text == "echo created\n")
+    }
+
+    @Test func visibleHelperRetriesUntilNewlyCreatedSurfaceIsInWindow() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.createdSurfaceVisibleAfterHealthSample = 3
+
+        let result = coordinator.handle(request([
+            "initial_command": .string("echo delayed"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(payload["surface_health_attempts"] == .int(2))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceHealthRoutings.count == 3)
+    }
+
+    @Test func visibleHelperReusesExistingRightPaneWithoutDuplicatingPanes() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+
+        let result = coordinator.handle(request())
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.helperSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("reused_right_pane"))
+        #expect(payload["reused_pane"] == .bool(true))
+        #expect(payload["created_pane"] == .bool(false))
+        #expect(payload["created_surface"] == .bool(false))
+        #expect(payload["sent_command"] == .bool(false))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceHealthRoutings.count == 2)
+    }
+
+    @Test func visibleHelperSendsCommandToExistingVisibleTerminalWithoutDuplicatingPanes() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+
+        let result = coordinator.handle(request([
+            "initial_command": .string("echo helper"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.helperSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("reused_right_pane"))
+        #expect(payload["reused_pane"] == .bool(true))
+        #expect(payload["created_pane"] == .bool(false))
+        #expect(payload["created_surface"] == .bool(false))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(payload["command_queued"] == .bool(false))
+        #expect(payload["surface_visible"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(true))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.first?.routing.workspaceID == context.focusedWorkspaceID)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.helperSurfaceID)
+        #expect(context.surfaceSendTextCalls.first?.text == "echo helper\n")
+        #expect(context.surfaceHealthRoutings.count == 2)
+    }
+
+    @Test func visibleHelperSendsCommandToSelectedHelperSurfaceWhenPaneHasMultipleSurfaces() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.includeExtraHelperSurface = true
+
+        let result = coordinator.handle(request([
+            "initial_command": .string("echo selected"),
+        ]))
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["surface_id"] == .string(context.helperSurfaceID.uuidString))
+        #expect(payload["sent_command"] == .bool(true))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.count == 1)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID == context.helperSurfaceID)
+        #expect(context.surfaceSendTextCalls.first?.surfaceID != context.extraHelperSurfaceID)
+    }
+
+    @Test func visibleHelperRejectsStructuralHelperPaneThatIsNotVisible() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.includeExistingHelperPane = true
+        context.existingHelperSurfaceVisible = false
+
+        let result = coordinator.handle(request())
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("structural helper pane"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["pane_id"] == .string(context.helperPaneID.uuidString))
+        #expect(payload["target_workspace_source"] == .string("focused"))
+        #expect(context.paneCreateCalls.isEmpty)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceHealthRoutings.count == 1)
+    }
+
+    @Test func visibleHelperFailsWhenCreatedSurfaceIsNotInWindow() throws {
+        let (coordinator, context) = makeCoordinator()
+        context.createdSurfaceVisible = false
+
+        let result = coordinator.handle(request())
+
+        guard case .err(let code, let message, let data) = result else {
+            Issue.record("unexpected helper.visible result: \(String(describing: result))")
+            return
+        }
+        guard case .object(let payload)? = data else {
+            Issue.record("unexpected helper.visible error data: \(String(describing: data))")
+            return
+        }
+
+        #expect(code == "not_visible")
+        #expect(message.contains("in_window=true"))
+        #expect(payload["workspace_id"] == .string(context.focusedWorkspaceID.uuidString))
+        #expect(payload["surface_id"] == .string(context.createdSurfaceID.uuidString))
+        #expect(payload["placement_strategy"] == .string("created_right_pane"))
+        #expect(payload["surface_visible"] == .bool(false))
+        #expect(payload["surface_health_found"] == .bool(true))
+        #expect(payload["surface_health_in_window"] == .bool(false))
+        #expect(payload["surface_health_attempts"] == .int(6))
+        #expect(context.paneCreateCalls.count == 1)
+        #expect(context.surfaceCreateCalls.isEmpty)
+        #expect(context.surfaceSendTextCalls.isEmpty)
+        #expect(context.surfaceHealthRoutings.count == 7)
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -22,7 +22,7 @@ struct ControlCommandExecutionPolicyTests {
             "system.ping", "system.capabilities", "auth.status", "auth.sign_in_url",
             "feed.push", "browser.download.wait", "system.top", "system.memory",
             "workspace.remote.pty_bridge", "workspace.env", "sidebar.custom.reload",
-            "sidebar.custom.open",
+            "sidebar.custom.open", "helper.visible",
             "debug.sidebar.simulate_drag", "mobile.attach_ticket.create",
             // JavaScript-evaluating browser methods block on page JS and must
             // not hold the main actor (see socketWorkerMethods rationale).

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3827,14 +3827,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Reconcile the already-started runtime with the real window backing context.
         terminalSurface?.attachToView(self)
         if let terminalSurface {
-            NotificationCenter.default.post(
-                name: .terminalSurfaceHostedViewDidMoveToWindow,
-                object: terminalSurface,
-                userInfo: [
-                    "surfaceId": terminalSurface.id,
-                    "workspaceId": terminalSurface.tabId
-                ]
-            )
+            let userInfo: [AnyHashable: Any] = [
+                "surfaceId": terminalSurface.id,
+                "workspaceId": terminalSurface.tabId
+            ]
+            NotificationCenter.default.post(name: .surfaceHostedViewDidMoveToWindow, object: terminalSurface, userInfo: userInfo)
+            NotificationCenter.default.post(name: .terminalSurfaceHostedViewDidMoveToWindow, object: terminalSurface, userInfo: userInfo)
         }
 
         windowObserver = NotificationCenter.default.addObserver(

--- a/Sources/NotificationName+ControlSurfaceWindow.swift
+++ b/Sources/NotificationName+ControlSurfaceWindow.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension Notification.Name {
+    static let surfaceHostedViewDidMoveToWindow = Notification.Name("cmux.surfaceHostedViewDidMoveToWindow")
+}

--- a/Sources/Panels/BrowserPanel+SurfaceHostedWindowNotification.swift
+++ b/Sources/Panels/BrowserPanel+SurfaceHostedWindowNotification.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension BrowserPanel {
+    func postSurfaceHostedViewDidMoveToWindow() {
+        NotificationCenter.default.post(
+            name: .surfaceHostedViewDidMoveToWindow,
+            object: self,
+            userInfo: ["surfaceId": id, "workspaceId": workspaceId]
+        )
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4233,6 +4233,15 @@ final class BrowserPanel: Panel, ObservableObject {
         return hiddenWebViewDiscardManager.restoredSessionShouldRenderWebView ?? shouldRenderWebView
     }
 
+    var debugWebViewVisibleInUI: Bool {
+        isWebViewVisibleInUI &&
+            shouldRenderWebView &&
+            webView.window != nil &&
+            !webView.isHiddenOrHasHiddenAncestor &&
+            webView.bounds.width > 1 &&
+            webView.bounds.height > 1
+    }
+
     func shouldPersistSessionSnapshot() -> Bool {
         // Diff viewer surfaces are otherwise treated as temporary. Persist them
         // only when they can actually be restored via the custom scheme (a

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7639,7 +7639,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             Self.installPortalAnchorView(portalAnchorView, in: host)
         }
         let activeOmnibarSuggestions = coordinator.desiredPortalVisibleInUI ? omnibarSuggestions : nil
-
         host.onDidMoveToWindow = { [weak host, weak webView, weak coordinator, weak portalAnchorView, weak browserPanel = panel] in
             guard let host, let webView, let coordinator, let portalAnchorView, let browserPanel else { return }
             guard coordinator.attachGeneration == generation else { return }
@@ -7652,6 +7651,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 reason: "didMoveToWindow"
             ) else { return }
             guard host.window != nil else { return }
+            browserPanel.postSurfaceHostedViewDidMoveToWindow()
             Self.installPortalAnchorView(portalAnchorView, in: host)
             BrowserWindowPortalRegistry.bind(
                 webView: webView,

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -95,6 +95,7 @@ extension TerminalController: ControlPaneContext {
             workspaceID: ws.id,
             windowID: windowId,
             panes: panes,
+            isRemoteTmuxMirror: ws.isRemoteTmuxMirror,
             containerWidth: snapshot.containerFrame.width,
             containerHeight: snapshot.containerFrame.height
         )
@@ -167,6 +168,10 @@ extension TerminalController: ControlPaneContext {
             windowID: windowId,
             surfaces: surfaces
         )
+    }
+
+    func controlPaneBrowserCreationDisabled() -> Bool {
+        BrowserAvailabilitySettings.isDisabled()
     }
 
     // MARK: - create

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -168,6 +168,47 @@ extension TerminalController: ControlSurfaceContext {
         )
     }
 
+    func controlSurfaceWaitForInWindow(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID
+    ) async -> Bool {
+        if controlSurfaceHealth(routing: routing)?
+            .surfaces
+            .first(where: { $0.surfaceID == surfaceID })?
+            .inWindow == true {
+            return true
+        }
+
+        let (surfaceIDs, surfaceIDContinuation) = AsyncStream<UUID>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let observer = NotificationCenter.default.addObserver(
+            forName: .surfaceHostedViewDidMoveToWindow,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard let hostedSurfaceID = notification.userInfo?["surfaceId"] as? UUID else {
+                return
+            }
+            surfaceIDContinuation.yield(hostedSurfaceID)
+        }
+        defer {
+            surfaceIDContinuation.finish()
+            NotificationCenter.default.removeObserver(observer)
+        }
+
+        for await hostedSurfaceID in surfaceIDs {
+            if Task.isCancelled {
+                return false
+            }
+            guard hostedSurfaceID == surfaceID else {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
     // MARK: - focus
 
     func controlSurfaceFocus(

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -150,20 +150,32 @@ extension TerminalController: ControlSurfaceContext {
         }
         let items: [ControlSurfaceHealthEntry] = orderedPanels(in: ws).map { panel in
             var inWindow: Bool?
+            var visibleInUI: Bool?
             if let tp = panel as? TerminalPanel {
                 inWindow = tp.surface.isViewInWindow
+                visibleInUI = inWindow == true
+                    && tp.hostedView.debugPortalVisibleInUI
+                    && !tp.hostedView.isHiddenOrHasHiddenAncestor
+                    && tp.hostedView.bounds.width > 1
+                    && tp.hostedView.bounds.height > 1
             } else if let bp = panel as? BrowserPanel {
                 inWindow = bp.webView.window != nil
+                visibleInUI = inWindow == true && bp.debugWebViewVisibleInUI
             }
             return ControlSurfaceHealthEntry(
                 surfaceID: panel.id,
                 typeRawValue: panel.panelType.rawValue,
-                inWindow: inWindow
+                inWindow: inWindow,
+                visibleInUI: visibleInUI
             )
+        }
+        let windowVisible = tabManager.window.map { window in
+            window.isVisible && !window.isMiniaturized
         }
         return ControlSurfaceHealthSnapshot(
             workspaceID: ws.id,
             windowID: v2ResolveWindowId(tabManager: tabManager),
+            windowVisible: windowVisible,
             surfaces: items
         )
     }
@@ -172,41 +184,30 @@ extension TerminalController: ControlSurfaceContext {
         routing: ControlRoutingSelectors,
         surfaceID: UUID
     ) async -> Bool {
-        if controlSurfaceHealth(routing: routing)?
-            .surfaces
-            .first(where: { $0.surfaceID == surfaceID })?
-            .inWindow == true {
+        if controlSurfaceIsVisibleInTargetUI(routing: routing, surfaceID: surfaceID) {
             return true
         }
 
-        let (surfaceIDs, surfaceIDContinuation) = AsyncStream<UUID>.makeStream(
-            bufferingPolicy: .bufferingNewest(1)
+        return await SurfaceHostedWindowWait(
+            surfaceID: surfaceID,
+            isVisible: { [weak self] in
+                self?.controlSurfaceIsVisibleInTargetUI(routing: routing, surfaceID: surfaceID) == true
+            }
+        ).wait(
+            timeout: .milliseconds(1_500)
         )
-        let observer = NotificationCenter.default.addObserver(
-            forName: .surfaceHostedViewDidMoveToWindow,
-            object: nil,
-            queue: nil
-        ) { notification in
-            guard let hostedSurfaceID = notification.userInfo?["surfaceId"] as? UUID else {
-                return
-            }
-            surfaceIDContinuation.yield(hostedSurfaceID)
-        }
-        defer {
-            surfaceIDContinuation.finish()
-            NotificationCenter.default.removeObserver(observer)
-        }
+    }
 
-        for await hostedSurfaceID in surfaceIDs {
-            if Task.isCancelled {
-                return false
-            }
-            guard hostedSurfaceID == surfaceID else {
-                continue
-            }
-            return true
+    private func controlSurfaceIsVisibleInTargetUI(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID
+    ) -> Bool {
+        guard let health = controlSurfaceHealth(routing: routing),
+              health.windowVisible == true,
+              let entry = health.surfaces.first(where: { $0.surfaceID == surfaceID }) else {
+            return false
         }
-        return false
+        return entry.visibleInUI == true
     }
 
     // MARK: - focus
@@ -237,5 +238,65 @@ extension TerminalController: ControlSurfaceContext {
             workspaceID: ws.id,
             surfaceID: surfaceID
         )
+    }
+}
+
+@MainActor
+private final class SurfaceHostedWindowWait {
+    private let surfaceID: UUID
+    private let isVisible: @MainActor () -> Bool
+    private var observer: NSObjectProtocol?
+    private var timeoutTask: Task<Void, Never>?
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var completed = false
+
+    init(
+        surfaceID: UUID,
+        isVisible: @escaping @MainActor () -> Bool
+    ) {
+        self.surfaceID = surfaceID
+        self.isVisible = isVisible
+    }
+
+    func wait(timeout: Duration) async -> Bool {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            observer = NotificationCenter.default.addObserver(
+                forName: .surfaceHostedViewDidMoveToWindow,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let hostedSurfaceID = notification.userInfo?["surfaceId"] as? UUID else {
+                    return
+                }
+                Task { @MainActor [weak self] in
+                    guard let self, hostedSurfaceID == self.surfaceID else { return }
+                    guard self.isVisible() else { return }
+                    self.complete(observed: true)
+                }
+            }
+            timeoutTask = Task { [weak self] in
+                do {
+                    try await ContinuousClock().sleep(for: timeout)
+                } catch {
+                    return
+                }
+                await self?.complete(observed: false)
+            }
+        }
+    }
+
+    private func complete(observed: Bool) {
+        guard !completed else { return }
+        completed = true
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observer = nil
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume(returning: observed)
     }
 }

--- a/Sources/TerminalController+SocketWorkerHelperVisible.swift
+++ b/Sources/TerminalController+SocketWorkerHelperVisible.swift
@@ -1,7 +1,13 @@
 import CmuxControlSocket
+import Dispatch
 import Foundation
 
 extension TerminalController {
+    nonisolated private static let helperVisibleMutationStartDeadlineParam =
+        "_cmux_helper_visible_latest_mutation_start_uptime_ns"
+    nonisolated private static let helperVisibleTimeoutSeconds: TimeInterval = 8
+    nonisolated private static let helperVisiblePostMutationBudgetSeconds: TimeInterval = 3
+
     nonisolated static func typedRequest(from request: V2SocketRequest) -> ControlRequest? {
         let id: JSONValue?
         if let rawID = request.id {
@@ -41,8 +47,13 @@ extension TerminalController {
         guard let typedRequest = Self.typedRequest(from: request) else {
             return v2Error(id: request.id, code: "invalid_request", message: "Invalid helper.visible request")
         }
-        return v2AsyncResultCall(id: request.id, timeoutSeconds: 2) {
-            let result = await self.controlCommandCoordinator.handleAsync(typedRequest)
+        var params = typedRequest.params
+        let latestMutationStart = DispatchTime.now().uptimeNanoseconds
+            + UInt64((Self.helperVisibleTimeoutSeconds - Self.helperVisiblePostMutationBudgetSeconds) * 1_000_000_000)
+        params[Self.helperVisibleMutationStartDeadlineParam] = .int(Int64(latestMutationStart))
+        let deadlineRequest = ControlRequest(id: typedRequest.id, method: typedRequest.method, params: params)
+        return v2AsyncResultCall(id: request.id, timeoutSeconds: Self.helperVisibleTimeoutSeconds) {
+            let result = await self.controlCommandCoordinator.handleAsync(deadlineRequest)
                 ?? .err(code: "method_not_found", message: "Unknown method", data: nil)
             return self.v2CallResult(from: result)
         }

--- a/Sources/TerminalController+SocketWorkerHelperVisible.swift
+++ b/Sources/TerminalController+SocketWorkerHelperVisible.swift
@@ -1,0 +1,59 @@
+import CmuxControlSocket
+import Foundation
+
+extension TerminalController {
+    nonisolated static func typedRequest(from request: V2SocketRequest) -> ControlRequest? {
+        let id: JSONValue?
+        if let rawID = request.id {
+            guard let value = JSONValue(foundationObject: rawID) else { return nil }
+            id = value
+        } else {
+            id = nil
+        }
+        guard let params = JSONValue(foundationObject: request.params),
+              case .object(let typedParams) = params else {
+            return nil
+        }
+        return ControlRequest(id: id, method: request.method, params: typedParams)
+    }
+
+    nonisolated static func feedPushWaitTimeoutSeconds(params: [String: Any]) -> TimeInterval? {
+        guard let rawTimeout = params["wait_timeout_seconds"] else {
+            return 0
+        }
+        let seconds: Double?
+        if let number = rawTimeout as? NSNumber {
+            seconds = number.doubleValue
+        } else if let value = rawTimeout as? Double {
+            seconds = value
+        } else if let value = rawTimeout as? Int {
+            seconds = Double(value)
+        } else {
+            seconds = nil
+        }
+        guard let seconds, seconds.isFinite, seconds >= 0, seconds <= 120 else {
+            return nil
+        }
+        return seconds
+    }
+
+    nonisolated func v2HelperVisibleResponse(_ request: V2SocketRequest) -> String {
+        guard let typedRequest = Self.typedRequest(from: request) else {
+            return v2Error(id: request.id, code: "invalid_request", message: "Invalid helper.visible request")
+        }
+        return v2AsyncResultCall(id: request.id, timeoutSeconds: 2) {
+            let result = await self.controlCommandCoordinator.handleAsync(typedRequest)
+                ?? .err(code: "method_not_found", message: "Unknown method", data: nil)
+            return self.v2CallResult(from: result)
+        }
+    }
+
+    nonisolated func v2CallResult(from result: ControlCallResult) -> V2CallResult {
+        switch result {
+        case .ok(let payload):
+            return .ok(payload.foundationObject)
+        case .err(let code, let message, let data):
+            return .err(code: code, message: message, data: data?.foundationObject)
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -910,7 +910,7 @@ class TerminalController {
     /// (`Any`) field shapes, so the existing command bodies keep their
     /// `[String: Any]` params until they migrate onto the typed DTOs in the
     /// ControlCommandCoordinator stage.
-    private struct V2SocketRequest {
+    struct V2SocketRequest {
         let id: Any?
         let method: String
         let params: [String: Any]
@@ -970,26 +970,6 @@ class TerminalController {
         }
     }
 
-    private nonisolated static func feedPushWaitTimeoutSeconds(params: [String: Any]) -> TimeInterval? {
-        guard let rawTimeout = params["wait_timeout_seconds"] else {
-            return 0
-        }
-        let seconds: Double?
-        if let number = rawTimeout as? NSNumber {
-            seconds = number.doubleValue
-        } else if let value = rawTimeout as? Double {
-            seconds = value
-        } else if let value = rawTimeout as? Int {
-            seconds = Double(value)
-        } else {
-            seconds = nil
-        }
-        guard let seconds, seconds.isFinite, seconds >= 0, seconds <= 120 else {
-            return nil
-        }
-        return seconds
-    }
-
     private nonisolated func socketWorkerV2Response(_ request: V2SocketRequest) -> String {
         switch request.method {
         case "auth.status":
@@ -1042,6 +1022,8 @@ class TerminalController {
             return v2Result(id: request.id, v2FeedQuestionReply(params: request.params))
         case "feed.exit_plan.reply":
             return v2Result(id: request.id, v2FeedExitPlanReply(params: request.params))
+        case "helper.visible":
+            return v2HelperVisibleResponse(request)
         case "browser.download.wait":
             return v2Result(id: request.id, v2BrowserDownloadWaitOnSocketWorker(params: request.params))
         case "browser.navigate", "browser.back", "browser.forward", "browser.reload",
@@ -2088,6 +2070,7 @@ class TerminalController {
             "surface.read_text",
             "surface.clear_history",
             "surface.trigger_flash",
+            "helper.visible",
             "pane.list",
             "pane.focus",
             "pane.surfaces",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */; };
 		A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MX00 /* BrowserPanel+MediaPlayback.swift */; };
 		D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */; };
+		6491B1026491B1026491B102 /* BrowserPanel+SurfaceHostedWindowNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491B1016491B1016491B101 /* BrowserPanel+SurfaceHostedWindowNotification.swift */; };
 		A5001402 /* BrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001412 /* BrowserPanel.swift */; };
 		C62530010000000000000001 /* BrowserPanelReloadMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62530010000000000000002 /* BrowserPanelReloadMode.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -224,6 +225,8 @@
 		B9000048A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000049A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift */; };
 		B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */; };
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
+		6491C1046491C1046491C104 /* CMUXCLI+V2Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491C1036491C1036491C103 /* CMUXCLI+V2Output.swift */; };
+		6491C1026491C1026491C102 /* CMUXCLI+VisibleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491C1016491C1016491C101 /* CMUXCLI+VisibleHelper.swift */; };
 		C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */; };
 		A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */; };
 		C12985000000000000000004 /* CMUXCLISentryTelemetryRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */; };
@@ -557,6 +560,7 @@
 		8B1B2AB6EC6ACDB2CD39A9BB /* NewBrowserWorkspaceShortcutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04698069140539D8495D6B9B /* NewBrowserWorkspaceShortcutUITests.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
 		D7AB00000000000000B021 /* NotificationDismissSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */; };
+		6491A1026491A1026491A102 /* NotificationName+ControlSurfaceWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491A1016491A1016491A101 /* NotificationName+ControlSurfaceWindow.swift */; };
 		B7F00002 /* NotificationSoundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F00001 /* NotificationSoundSettings.swift */; };
 		4E5F60720000000000000001 /* NotificationSoundSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
@@ -855,6 +859,7 @@
 		C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */; };
 		D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */; };
 		A31B24551C6E01E86D76B07E /* TerminalController+RemoteTmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B11974CF8937E165A3FAEE /* TerminalController+RemoteTmux.swift */; };
+		6491A1046491A1046491A104 /* TerminalController+SocketWorkerHelperVisible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6491A1036491A1036491A103 /* TerminalController+SocketWorkerHelperVisible.swift */; };
 		A5001007 /* TerminalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001019 /* TerminalController.swift */; };
 		C0DE00000000000000000C32 /* TerminalControllerControlCommandContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C31 /* TerminalControllerControlCommandContext.swift */; };
 		C7A50A000000000000000002 /* TerminalControllerPaneResizeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */; };
@@ -1190,6 +1195,7 @@
 		D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropTargetView.swift; sourceTree = "<group>"; };
 		A500MX00 /* BrowserPanel+MediaPlayback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MediaPlayback.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
+		6491B1016491B1016491B101 /* BrowserPanel+SurfaceHostedWindowNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+SurfaceHostedWindowNotification.swift"; sourceTree = "<group>"; };
 		A5001412 /* BrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanel.swift; sourceTree = "<group>"; };
 		C62530010000000000000002 /* BrowserPanelReloadMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelReloadMode.swift; sourceTree = "<group>"; };
 		58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelTests.swift; sourceTree = "<group>"; };
@@ -1282,6 +1288,8 @@
 		B9000049A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatHUDSupport.swift"; sourceTree = "<group>"; };
 		B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatSupport.swift"; sourceTree = "<group>"; };
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
+		6491C1036491C1036491C103 /* CMUXCLI+V2Output.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+V2Output.swift"; sourceTree = "<group>"; };
+		6491C1016491C1016491C101 /* CMUXCLI+VisibleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+VisibleHelper.swift"; sourceTree = "<group>"; };
 		C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIErrorOutputRegressionTests.swift; sourceTree = "<group>"; };
 		8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxCLIPathInstaller.swift; sourceTree = "<group>"; };
 		C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLISentryTelemetryRegressionTests.swift; sourceTree = "<group>"; };
@@ -1573,6 +1581,7 @@
 		04698069140539D8495D6B9B /* NewBrowserWorkspaceShortcutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBrowserWorkspaceShortcutUITests.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationDismissSyncTests.swift"; sourceTree = "<group>"; };
+		6491A1016491A1016491A101 /* NotificationName+ControlSurfaceWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+ControlSurfaceWindow.swift"; sourceTree = "<group>"; };
 		B7F00001 /* NotificationSoundSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettings.swift; sourceTree = "<group>"; };
 		4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSoundSettingsTests.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
@@ -1858,6 +1867,7 @@
 		C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileWorkspaceList.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000C /* TerminalController+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		95B11974CF8937E165A3FAEE /* TerminalController+RemoteTmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+RemoteTmux.swift"; sourceTree = "<group>"; };
+		6491A1036491A1036491A103 /* TerminalController+SocketWorkerHelperVisible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketWorkerHelperVisible.swift"; sourceTree = "<group>"; };
 		A5001019 /* TerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalController.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000C31 /* TerminalControllerControlCommandContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerControlCommandContext.swift; sourceTree = "<group>"; };
 		C7A50A000000000000000001 /* TerminalControllerPaneResizeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerPaneResizeSupport.swift; sourceTree = "<group>"; };
@@ -2358,6 +2368,7 @@
 				6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */,
 				8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */,
 				47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */,
+				6491A1016491A1016491A101 /* NotificationName+ControlSurfaceWindow.swift */,
 				C1713001C1713001C1713001 /* CommandPaletteShortcutRouting.swift */,
 				B42A82C6AA614E74873D9A5F /* ShortcutRoutingSupport.swift */,
 				81B8CFAF8FCA4231C702D16A /* WindowKeyDownReplayGuard.swift */,
@@ -2601,6 +2612,7 @@
 				4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */,
 				4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */,
 				D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */,
+				6491B1016491B1016491B101 /* BrowserPanel+SurfaceHostedWindowNotification.swift */,
 				A500MR00 /* BrowserMediaPlaybackReport.swift */,
 				A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */,
 				A500MX00 /* BrowserPanel+MediaPlayback.swift */,
@@ -2733,6 +2745,7 @@
 				CE24906539C19AB10E4C1C71 /* RemoteTmuxPostAttachAction.swift */,
 				59B80C0A6FC64A59BD274E1E /* RemoteTmuxProcessCancellation.swift */,
 				95B11974CF8937E165A3FAEE /* TerminalController+RemoteTmux.swift */,
+				6491A1036491A1036491A103 /* TerminalController+SocketWorkerHelperVisible.swift */,
 				50FE16F529BD6FBA4FBDECFC /* RemoteTmuxController.swift */,
 				9E3E94F6022485BB12789444 /* RemoteTmuxSessionEndAction.swift */,
 				0E17C0DE0E17C0DE0E17C001 /* RemoteTmuxTransportRegistry.swift */,
@@ -2863,6 +2876,8 @@
 				B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */,
 				B900002CA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift */,
 				B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */,
+				6491C1036491C1036491C103 /* CMUXCLI+V2Output.swift */,
+				6491C1016491C1016491C101 /* CMUXCLI+VisibleHelper.swift */,
 				B9000065A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */,
 				B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */,
 				C12984000000000000000001 /* CMUXCLI+SIGPIPEProbes.swift */,
@@ -3635,6 +3650,7 @@
 				D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */,
 				A500MX01 /* BrowserPanel+MediaPlayback.swift in Sources */,
 				D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */,
+				6491B1026491B1026491B102 /* BrowserPanel+SurfaceHostedWindowNotification.swift in Sources */,
 				A5001402 /* BrowserPanel.swift in Sources */,
 				C62530010000000000000001 /* BrowserPanelReloadMode.swift in Sources */,
 				A5001404 /* BrowserPanelView.swift in Sources */,
@@ -3848,6 +3864,7 @@
 				C9CFB398DF94D6DDEAF42D67 /* MobileTerminalRenderObserver.swift in Sources */,
 				00C3AA443F6DA8D94E28CE17 /* MobileWorkspaceListObserver.swift in Sources */,
 				596100000000000000000003 /* NativeNotificationDeliveryHooks.swift in Sources */,
+				6491A1026491A1026491A102 /* NotificationName+ControlSurfaceWindow.swift in Sources */,
 				B7F00002 /* NotificationSoundSettings.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				D36090020000000000000001 /* NSWindow+CmuxPeerWindow.swift in Sources */,
@@ -4034,6 +4051,7 @@
 				C7A50B000000000000000012 /* TerminalController+MobileWorkspaceList.swift in Sources */,
 				D7AB0000000000000000000B /* TerminalController+MoveTabToNewWorkspace.swift in Sources */,
 				A31B24551C6E01E86D76B07E /* TerminalController+RemoteTmux.swift in Sources */,
+				6491A1046491A1046491A104 /* TerminalController+SocketWorkerHelperVisible.swift in Sources */,
 				A5001007 /* TerminalController.swift in Sources */,
 				C0DE00000000000000000C32 /* TerminalControllerControlCommandContext.swift in Sources */,
 				C7A50A000000000000000002 /* TerminalControllerPaneResizeSupport.swift in Sources */,
@@ -4173,6 +4191,8 @@
 				B9000048A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift in Sources */,
 				B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */,
 				B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */,
+				6491C1046491C1046491C104 /* CMUXCLI+V2Output.swift in Sources */,
+				6491C1026491C1026491C102 /* CMUXCLI+VisibleHelper.swift in Sources */,
 				C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */,
 					FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,
 				C0DEF0B10000000000000003 /* JSONCParser.swift in Sources */,


### PR DESCRIPTION
## Summary
- Add `helper.visible` and `cmux visible-helper` as the focused-workspace helper setup path.
- Make caller-vs-focused divergence explicit in responses, with `target_workspace_source=focused` and `caller_focused_diverged`.
- Treat only `surface.health in_window=true` as visible, waiting on a hosted-view window event for newly created surfaces and failing loudly when structural helper state is not actually visible.
- Reuse a visible right-side helper surface when possible, without duplicating panes or stealing focus.

## Testing
- `swift test --package-path Packages/macOS/CmuxControlSocket --filter ControlCommandCoordinatorHelperTests` passed, 12 tests.
- `swift test --package-path Packages/macOS/CmuxControlSocket --filter ControlCommandExecutionPolicyTests` passed, 5 tests.
- `./scripts/reload-cloud.sh --tag vh6491` passed, run https://github.com/manaflow-ai/cmux/actions/runs/27866417817.
- Tagged app proof on `/tmp/cmux-debug-vh6491.sock`: fake caller `workspace:8`, focused `workspace:9`; `visible-helper` returned `caller_focused_diverged=true`, `target_workspace_source=focused`, `workspace_ref=workspace:9`, `surface_ref=surface:13`, `surface_health_in_window=true`, and `surface_window_event_observed=true`.
- Reuse proof: repeated `visible-helper` reused `pane:13`/`surface:13`, `created_pane=false`, `created_surface=false`; focused pane count stayed 2.
- Visibility proof: `surface-health --workspace workspace:9` showed `surface:13 type=terminal in_window=true`; `read-screen --workspace workspace:9 --surface surface:13` showed `6491-event-visible-helper`; caller `workspace:8` still had only its original pane.
- Screenshot proof: `/var/folders/rr/vmfx6xh12dz2tlvgtmyvjmf80000gn/T/cmux-screenshots/vh6491-visible-helper-proof_2026-06-20T09-10-17Z_1DF84E3B.png`.

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/6491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `cmux visible-helper` CLI subcommand to create or reuse helper panes/surfaces and to send an optional initial command only after the target becomes visible/in-window (supports `terminal` and `browser`).
  * Added `helper.visible` to the socket v2 capability set to coordinate helper placement and visibility before sending commands.
  * Added a new notification event when a hosted surface view moves into a window.

* **Documentation**
  * Updated CLI help, usage text, and command/flag listings for `visible-helper`.

* **Tests**
  * Added comprehensive helper-visible test coverage for success, reuse, and error flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pane/split layout and automation routing (focused vs caller workspace) with async visibility gates; risk is mitigated by reusing existing pane/surface paths and broad unit tests, but wrong targeting could still confuse agents or duplicate panes in edge layouts.
> 
> **Overview**
> Adds **`cmux visible-helper`** and the **`helper.visible`** socket v2 method so automation can create or reuse a **right-side helper pane** in the **visually focused** workspace (not the caller’s `CMUX_*` context), with responses that spell out **`target_workspace_source=focused`** and **`caller_focused_diverged`**.
> 
> The coordinator **reuses** a visible right-side pane/surface of the requested type when possible, otherwise **`pane.create`** with **`direction=right`** and **`focus=false`**. Success requires **`surface.health` `in_window=true`**; new surfaces **await** a **`surfaceHostedViewDidMoveToWindow`** notification (terminal + browser) before verifying health and optionally **`surface.send_text`** for `--command` / `initial_command`. **`helper.visible`** runs on the **socket worker** via **`handleAsync`** so waits do not block the main actor.
> 
> CLI help, command lists, and **`printV2Output`** extraction are included; **12 coordinator helper tests** cover reuse, create, visibility failures, and command send errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4ef1f5cb7170fcb13280fd052677557572ce32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->