### PR TITLE
Prioritize full command palette title matches

### DIFF
--- a/Native/CommandPaletteNucleoFFI/src/lib.rs
+++ b/Native/CommandPaletteNucleoFFI/src/lib.rs
@@ -26,6 +26,7 @@ pub struct CmuxNucleoMatch {
 
 struct Candidate {
     title: String,
+    search_title: String,
     search_text: String,
     search_lines: Vec<String>,
     rank: i32,
@@ -165,9 +166,11 @@ pub unsafe extern "C" fn cmux_nucleo_index_create(
         let (search_low, search_high) = ascii_mask(search_text);
         let title_initials = title_word_initials(title);
         let title_char_count = title.chars().count();
+        let search_title = title_search_word_text(title);
         let search_lines = search_text.lines().map(str::to_owned).collect();
         candidates.push(Candidate {
             title: title.to_owned(),
+            search_title,
             search_text: search_text.to_owned(),
             search_lines,
             rank: span.rank,
@@ -427,7 +430,10 @@ fn weighted_query_score(
     // jackpot in `exact_search_text_line_score`. `title_literal_score` sits above every keyword
     // tier so the visible title wins. This mirrors the Swift `CommandPaletteSearchEngine`
     // reference ordering (title prefix > exact keyword).
-    match (token_score, title_literal_score(state, title_literal, candidate)) {
+    match (
+        token_score,
+        title_literal_score(state, title_literal, candidate),
+    ) {
         (Some(token), Some(literal)) => Some(token.max(literal)),
         (Some(token), None) => Some(token),
         (None, Some(literal)) => Some(literal),
@@ -581,7 +587,21 @@ fn title_literal_score(
     if state.atom_score(&query.exact, &candidate.title).is_some() {
         return Some(TITLE_EXACT_TOKEN_SCORE * token_count);
     }
+    if !candidate.search_title.is_empty()
+        && state
+            .atom_score(&query.exact, &candidate.search_title)
+            .is_some()
+    {
+        return Some(TITLE_EXACT_TOKEN_SCORE * token_count);
+    }
     if state.atom_score(&query.prefix, &candidate.title).is_some() {
+        return Some(TITLE_PREFIX_TOKEN_SCORE * token_count);
+    }
+    if !candidate.search_title.is_empty()
+        && state
+            .atom_score(&query.prefix, &candidate.search_title)
+            .is_some()
+    {
         return Some(TITLE_PREFIX_TOKEN_SCORE * token_count);
     }
     None
@@ -660,6 +680,28 @@ fn title_word_initials(title: &str) -> Vec<char> {
         previous_was_boundary = is_boundary;
     }
     starts
+}
+
+fn title_search_word_text(title: &str) -> String {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    for character in title.chars() {
+        if is_title_word_boundary(character) {
+            append_search_word(&mut words, &mut current);
+            continue;
+        }
+        current.push(character);
+    }
+    append_search_word(&mut words, &mut current);
+    words.join(" ")
+}
+
+fn append_search_word(words: &mut Vec<String>, current: &mut String) {
+    if current.chars().any(char::is_alphanumeric) {
+        words.push(std::mem::take(current));
+    } else {
+        current.clear();
+    }
 }
 
 fn is_title_word_boundary(character: char) -> bool {

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
@@ -15,14 +15,10 @@ public struct CommandPaletteFuzzyMatcher {
     public let preparedQuery: PreparedQuery
 
     /// Prepares `query` for matching.
-    public init(query: String) {
-        self.preparedQuery = Self.preparedQuery(query)
-    }
+    public init(query: String) { self.preparedQuery = Self.preparedQuery(query) }
 
     /// Binds an already-prepared query.
-    public init(preparedQuery: PreparedQuery) {
-        self.preparedQuery = preparedQuery
-    }
+    public init(preparedQuery: PreparedQuery) { self.preparedQuery = preparedQuery }
 
     /// Scores `candidate` against this matcher's query; nil when it does not
     /// match.
@@ -184,6 +180,8 @@ public struct CommandPaletteFuzzyMatcher {
     public struct PreparedQuery {
         /// The full normalized query text.
         public let normalizedText: String
+        /// Normalized query tokens joined by single spaces.
+        public let normalizedTokenText: String
         /// The prepared tokens, in query order.
         public let tokens: [PreparedToken]
 
@@ -196,13 +194,15 @@ public struct CommandPaletteFuzzyMatcher {
     /// Normalizes and tokenizes `query` for matching.
     public static func preparedQuery(_ query: String) -> PreparedQuery {
         let normalizedQuery = normalizeForSearch(query)
+        let tokens = normalizedQuery
+            .split(separator: " ")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+            .map(PreparedToken.init)
         return PreparedQuery(
             normalizedText: normalizedQuery,
-            tokens: normalizedQuery
-                .split(separator: " ")
-                .map(String.init)
-                .filter { !$0.isEmpty }
-                .map(PreparedToken.init)
+            normalizedTokenText: tokens.map(\.normalizedText).joined(separator: " "),
+            tokens: tokens
         )
     }
 

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchCorpusEntry.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchCorpusEntry.swift
@@ -11,6 +11,8 @@ public struct CommandPaletteSearchCorpusEntry<Payload>: Sendable where Payload: 
     public let title: String
     /// Prepared normalized title, or nil when the title normalizes to empty.
     public let preparedTitle: CommandPaletteFuzzyMatcher.PreparedCandidateText?
+    /// Normalized title word text excluding symbol-only segments.
+    public let normalizedTitleSearchWordText: String
     /// Prepared normalized searchable texts (title, subtitle, keywords).
     public let preparedSearchableTexts: [CommandPaletteFuzzyMatcher.PreparedCandidateText]
     /// Set of normalized searchable texts for exact-match checks.
@@ -26,7 +28,11 @@ public struct CommandPaletteSearchCorpusEntry<Payload>: Sendable where Payload: 
         self.rank = rank
         self.title = title
         let normalizedTitle = CommandPaletteFuzzyMatcher.normalizeForSearch(title)
-        self.preparedTitle = CommandPaletteFuzzyMatcher.prepareNormalizedCandidateText(normalizedTitle)
+        let preparedTitle = CommandPaletteFuzzyMatcher.prepareNormalizedCandidateText(normalizedTitle)
+        self.preparedTitle = preparedTitle
+        self.normalizedTitleSearchWordText = preparedTitle.map {
+            commandPaletteNormalizedSearchWordText(characters: $0.characters, segments: $0.wordSegments)
+        } ?? ""
 
         var nucleoSearchTexts: [String] = []
         var normalizedTexts: [String] = []

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchEngine.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchEngine.swift
@@ -237,8 +237,46 @@ public struct CommandPaletteSearchEngine<Payload: Sendable>: Sendable {
                 preparedQuery: preparedQuery,
                 preparedCandidate: preparedTitle
             ) {
-            return max(fuzzyScore, titleScore + titleMatchBonus)
+            return max(
+                fuzzyScore,
+                titleScore + titleMatchBonus,
+                commandPaletteTitleWordScore(
+                    preparedQuery: preparedQuery,
+                    titleNormalizedText: preparedTitle.normalizedText,
+                    titleSearchWordText: entry.normalizedTitleSearchWordText
+                ) ?? Int.min
+            )
         }
         return fuzzyScore
     }
+}
+
+private func commandPaletteTitleWordScore(
+    preparedQuery: CommandPaletteFuzzyMatcher.PreparedQuery,
+    titleNormalizedText: String,
+    titleSearchWordText: String
+) -> Int? {
+    guard !preparedQuery.isEmpty, titleSearchWordText != titleNormalizedText else {
+        return nil
+    }
+
+    if titleSearchWordText == preparedQuery.normalizedTokenText {
+        let exactTokenScore = preparedQuery.tokens.reduce(0) { score, token in
+            score + token.scoreUpperBound
+        }
+        return exactTokenScore + commandPaletteScaledTitleMatchBonus(tokenCount: preparedQuery.tokens.count)
+    }
+
+    guard titleSearchWordText.hasPrefix(preparedQuery.normalizedTokenText) else {
+        return nil
+    }
+
+    let prefixTokenScore = preparedQuery.tokens.reduce(0) { score, token in
+        score + token.scoreUpperBoundWithoutExactMatch
+    }
+    return prefixTokenScore + commandPaletteScaledTitleMatchBonus(tokenCount: preparedQuery.tokens.count)
+}
+
+private func commandPaletteScaledTitleMatchBonus(tokenCount: Int) -> Int {
+    2000 * max(1, tokenCount)
 }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchWordText.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSearchWordText.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+func commandPaletteNormalizedSearchWordText(
+    characters: [Character],
+    segments: [CommandPaletteFuzzyMatcher.WordSegment]
+) -> String {
+    var words: [String] = []
+    words.reserveCapacity(segments.count)
+
+    for segment in segments {
+        let wordCharacters = characters[segment.start..<segment.end]
+        guard wordCharacters.contains(where: commandPaletteContainsSearchWordScalar) else {
+            continue
+        }
+        words.append(String(wordCharacters))
+    }
+
+    return words.joined(separator: " ")
+}
+
+private func commandPaletteContainsSearchWordScalar(_ character: Character) -> Bool {
+    character.unicodeScalars.contains {
+        CharacterSet.alphanumerics.contains($0)
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteEmojiTitleSearchTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteEmojiTitleSearchTests.swift
@@ -1,0 +1,156 @@
+import Testing
+
+@testable import CmuxCommandPalette
+
+struct CommandPaletteEmojiTitleSearchTests {
+    @Test func searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() {
+        let entries = [
+            FixtureEntry(
+                id: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.partialTitlePrefix",
+                rank: 0,
+                title: "Command Palette Archive",
+                searchableTexts: ["Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+        ]
+
+        let results = optimizedResults(entries: entries, query: "command palette", resultLimit: 5)
+
+        #expect(results.first?.id == "workspace.fullTitleMatch")
+    }
+
+    @Test func searchPrefersEmojiPrefixedTitleWordPrefixOverHiddenTokenMatches() {
+        let entries = [
+            FixtureEntry(
+                id: "workspace.titlePrefixMatch",
+                rank: 20,
+                title: "🧪 Command Palette Archive",
+                searchableTexts: ["🧪 Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: [
+                    "Other Workspace",
+                    "Workspace",
+                    "workspace",
+                    "switch",
+                    "go",
+                    "command",
+                    "palette",
+                ]
+            ),
+        ]
+
+        let results = optimizedResults(entries: entries, query: "command palette", resultLimit: 5)
+
+        #expect(results.first?.id == "workspace.titlePrefixMatch")
+    }
+
+    @Test func searchPrefersEmojiPrefixedFullTitleWordsWithRepeatedQuerySpaces() {
+        let entries = [
+            FixtureEntry(
+                id: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: ["Other Workspace", "Workspace", "command", "palette"]
+            ),
+        ]
+
+        let results = optimizedResults(entries: entries, query: "command  palette", resultLimit: 5)
+
+        #expect(results.first?.id == "workspace.fullTitleMatch")
+    }
+
+    @Test func nucleoFFIPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() throws {
+        guard let library = try NucleoLibrary.loadIfAvailable() else { return }
+        // Skipped: nucleo FFI dylib not built in this environment.
+        let entries = [
+            FixtureEntry(
+                id: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.partialTitlePrefix",
+                rank: 0,
+                title: "Command Palette Archive",
+                searchableTexts: ["Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "command palette", limit: 5).map(\.id)
+
+        #expect(resultIDs.first == "workspace.fullTitleMatch")
+    }
+
+    @Test func nucleoFFIPrefersEmojiPrefixedTitleWordPrefixOverHiddenTokenMatches() throws {
+        guard let library = try NucleoLibrary.loadIfAvailable() else { return }
+        // Skipped: nucleo FFI dylib not built in this environment.
+        let entries = [
+            FixtureEntry(
+                id: "workspace.titlePrefixMatch",
+                rank: 20,
+                title: "🧪 Command Palette Archive",
+                searchableTexts: ["🧪 Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: [
+                    "Other Workspace",
+                    "Workspace",
+                    "workspace",
+                    "switch",
+                    "go",
+                    "command",
+                    "palette",
+                ]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "command palette", limit: 5).map(\.id)
+
+        #expect(resultIDs.first == "workspace.titlePrefixMatch")
+    }
+
+    @Test func nucleoFFIPrefersEmojiPrefixedFullTitleWordsWithRepeatedQuerySpaces() throws {
+        guard let library = try NucleoLibrary.loadIfAvailable() else { return }
+        // Skipped: nucleo FFI dylib not built in this environment.
+        let entries = [
+            FixtureEntry(
+                id: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: ["Other Workspace", "Workspace", "command", "palette"]
+            ),
+        ]
+        let index = try NucleoIndex(library: library, entries: entries)
+
+        let resultIDs = try index.search(query: "command  palette", limit: 5).map(\.id)
+
+        #expect(resultIDs.first == "workspace.fullTitleMatch")
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchEngineTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchEngineTests.swift
@@ -217,9 +217,10 @@ struct CommandPaletteSearchEngineTests {
                 FixtureResult(id: entry.id, rank: entry.rank, title: entry.title, score: 0, titleMatchIndices: [])
             }
             : entries.compactMap { entry in
-                guard let fuzzyScore = weightedReferenceScore(
+                guard let fuzzyScore = commandPaletteWeightedReferenceScore(
                     query: query,
-                    entry: entry
+                    title: entry.title,
+                    searchableTexts: entry.searchableTexts
                 ) else {
                     return nil
                 }
@@ -255,25 +256,6 @@ struct CommandPaletteSearchEngineTests {
         queryDurationsMs.reduce(0) { total, durationMs in
             total + max(0, Int(ceil(durationMs / frameBudgetMs)) - 1)
         }
-    }
-
-    private func weightedReferenceScore(
-        query: String,
-        entry: FixtureEntry
-    ) -> Int? {
-        guard let fuzzyScore = CommandPaletteFuzzyMatcher.score(
-            query: query,
-            candidates: entry.searchableTexts
-        ) else {
-            return nil
-        }
-        guard let titleScore = CommandPaletteFuzzyMatcher.score(
-            query: query,
-            candidate: entry.title
-        ) else {
-            return fuzzyScore
-        }
-        return max(fuzzyScore, titleScore + 2000)
     }
 
     private func benchmarkElapsedMs(operation: () -> Void) -> Double {
@@ -879,27 +861,6 @@ struct CommandPaletteSearchEngineTests {
             results.prefix(2).map(\.id) ==
             ["command.checkForUpdates", "command.attemptUpdate"]
         )
-    }
-
-    @Test func searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() {
-        let entries = [
-            FixtureEntry(
-                id: "workspace.fullTitleMatch",
-                rank: 20,
-                title: "🧪 Command Palette",
-                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
-            ),
-            FixtureEntry(
-                id: "workspace.partialTitlePrefix",
-                rank: 0,
-                title: "Command Palette Archive",
-                searchableTexts: ["Command Palette Archive", "Workspace", "workspace", "switch", "go"]
-            ),
-        ]
-
-        let results = optimizedResults(entries: entries, query: "command palette")
-
-        #expect(results.first?.id == "workspace.fullTitleMatch")
     }
 
     @Test func previewCandidateCommandIDsAreBounded() {

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchEngineTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchEngineTests.swift
@@ -881,6 +881,27 @@ struct CommandPaletteSearchEngineTests {
         )
     }
 
+    @Test func searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() {
+        let entries = [
+            FixtureEntry(
+                id: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            FixtureEntry(
+                id: "workspace.partialTitlePrefix",
+                rank: 0,
+                title: "Command Palette Archive",
+                searchableTexts: ["Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+        ]
+
+        let results = optimizedResults(entries: entries, query: "command palette")
+
+        #expect(results.first?.id == "workspace.fullTitleMatch")
+    }
+
     @Test func previewCandidateCommandIDsAreBounded() {
         let resultIDs = (0..<500).map { "command.\($0)" }
 

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchReferenceScoring.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteSearchReferenceScoring.swift
@@ -1,0 +1,49 @@
+@testable import CmuxCommandPalette
+
+func commandPaletteWeightedReferenceScore(
+    query: String,
+    title: String,
+    searchableTexts: [String]
+) -> Int? {
+    let preparedQuery = CommandPaletteFuzzyMatcher.preparedQuery(query)
+    guard let fuzzyScore = CommandPaletteFuzzyMatcher.score(
+        preparedQuery: preparedQuery,
+        normalizedCandidates: searchableTexts.map(CommandPaletteFuzzyMatcher.normalizeForSearch)
+    ) else {
+        return nil
+    }
+    guard let preparedTitle = CommandPaletteFuzzyMatcher.prepareCandidateText(title),
+          let titleScore = CommandPaletteFuzzyMatcher.score(
+            preparedQuery: preparedQuery,
+            preparedCandidate: preparedTitle
+          ) else {
+        return fuzzyScore
+    }
+    return max(
+        fuzzyScore,
+        titleScore + 2000,
+        commandPaletteTitleWordReferenceScore(preparedQuery: preparedQuery, preparedTitle: preparedTitle) ?? Int.min
+    )
+}
+
+private func commandPaletteTitleWordReferenceScore(
+    preparedQuery: CommandPaletteFuzzyMatcher.PreparedQuery,
+    preparedTitle: CommandPaletteFuzzyMatcher.PreparedCandidateText
+) -> Int? {
+    guard !preparedQuery.isEmpty else { return nil }
+
+    let titleBonus = 2000 * max(1, preparedQuery.tokens.count)
+    let titleSearchWordText = commandPaletteNormalizedSearchWordText(
+        characters: preparedTitle.characters,
+        segments: preparedTitle.wordSegments
+    )
+    guard titleSearchWordText != preparedTitle.normalizedText else { return nil }
+
+    if titleSearchWordText == preparedQuery.normalizedTokenText {
+        return preparedQuery.tokens.reduce(0) { $0 + $1.scoreUpperBound } + titleBonus
+    }
+    if titleSearchWordText.hasPrefix(preparedQuery.normalizedTokenText) {
+        return preparedQuery.tokens.reduce(0) { $0 + $1.scoreUpperBoundWithoutExactMatch } + titleBonus
+    }
+    return nil
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4041001000000000000001A /* CommandClickFileOpenRouter.swift */; };
+		C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */; };
 		C0DE32470000000000000005 /* CommandPaletteIdentifierClipboardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */; };
 		C0DEC0DE000000000000F202 /* CommandPaletteNucleoFFILibrarySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F201 /* CommandPaletteNucleoFFILibrarySupport.swift */; };
 		C0DEC0DE000000000000F102 /* CommandPaletteNucleoFFITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F101 /* CommandPaletteNucleoFFITests.swift */; };
@@ -1345,6 +1346,7 @@
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
 		C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsApprovalBridge.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
+		C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteEmojiTitleSearchTests.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteIdentifierClipboardUITests.swift; sourceTree = "<group>"; };
 		C0DEC0DE000000000000F201 /* CommandPaletteNucleoFFILibrarySupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteNucleoFFILibrarySupport.swift; sourceTree = "<group>"; };
 		C0DEC0DE000000000000F101 /* CommandPaletteNucleoFFITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteNucleoFFITests.swift; sourceTree = "<group>"; };
@@ -2947,6 +2949,7 @@
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 				A5008380 /* BrowserFindJavaScriptTests.swift */,
 				C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */,
+				C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */,
 				A5008382 /* CommandPaletteSearchEngineTests.swift */,
 				C0DEC0DE000000000000F101 /* CommandPaletteNucleoFFITests.swift */,
 				C0DEC0DE000000000000F201 /* CommandPaletteNucleoFFILibrarySupport.swift */,
@@ -4317,6 +4320,7 @@
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
+				C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */,
 				C0DEC0DE000000000000F202 /* CommandPaletteNucleoFFILibrarySupport.swift in Sources */,
 				C0DEC0DE000000000000F102 /* CommandPaletteNucleoFFITests.swift in Sources */,
 				C0DEC0DE000000000000F204 /* CommandPaletteNucleoFixtures.swift in Sources */,

--- a/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
+++ b/cmuxTests/CommandPaletteEmojiTitleSearchTests.swift
@@ -1,0 +1,76 @@
+import CmuxCommandPalette
+import Testing
+
+struct CommandPaletteEmojiTitleSearchTests {
+    @Test func searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix() {
+        let entries = [
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.partialTitlePrefix",
+                rank: 0,
+                title: "Command Palette Archive",
+                searchableTexts: ["Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+        ]
+
+        let results = CommandPaletteSearchEngine(entries: entries).search(
+            query: "command palette",
+            resultLimit: 5
+        ) { _, _ in 0 }
+
+        #expect(results.first?.payload == "workspace.fullTitleMatch")
+    }
+
+    @Test func searchPrefersEmojiPrefixedTitleWordPrefixOverHiddenTokenMatches() {
+        let entries = [
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.titlePrefixMatch",
+                rank: 20,
+                title: "🧪 Command Palette Archive",
+                searchableTexts: ["🧪 Command Palette Archive", "Workspace", "workspace", "switch", "go"]
+            ),
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: ["Other Workspace", "Workspace", "workspace", "switch", "go", "command", "palette"]
+            ),
+        ]
+
+        let results = CommandPaletteSearchEngine(entries: entries).search(
+            query: "command palette",
+            resultLimit: 5
+        ) { _, _ in 0 }
+
+        #expect(results.first?.payload == "workspace.titlePrefixMatch")
+    }
+
+    @Test func searchPrefersEmojiPrefixedFullTitleWordsWithRepeatedQuerySpaces() {
+        let entries = [
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.fullTitleMatch",
+                rank: 20,
+                title: "🧪 Command Palette",
+                searchableTexts: ["🧪 Command Palette", "Workspace", "workspace", "switch", "go"]
+            ),
+            CommandPaletteSearchCorpusEntry(
+                payload: "workspace.hiddenTokenMatches",
+                rank: 0,
+                title: "Other Workspace",
+                searchableTexts: ["Other Workspace", "Workspace", "command", "palette"]
+            ),
+        ]
+
+        let results = CommandPaletteSearchEngine(entries: entries).search(
+            query: "command  palette",
+            resultLimit: 5
+        ) { _, _ in 0 }
+
+        #expect(results.first?.payload == "workspace.fullTitleMatch")
+    }
+}


### PR DESCRIPTION
## Summary
- Prioritize command-palette results whose visible title words exactly match or prefix-match the query, even when the title starts with an emoji/symbol badge.
- Keep Swift fallback and Nucleo FFI ranking semantics aligned.
- Add regression coverage for emoji-prefixed full-title and prefix-title ordering.

## Testing
- swift test --filter CommandPaletteSearchEngineTests/searchPrefersEmojiPrefixedFullTitleWordsOverPartialTitlePrefix (red before fix, green after fix)
- swift test --filter CommandPaletteSearchEngineTests/optimizedSearchMatchesReferencePipeline
- swift test
- cargo fmt --check && cargo test && cargo build --release (Native/CommandPaletteNucleoFFI)
- /Users/lawrence/fun/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base origin/main
- ./scripts/reload-cloud.sh --tag sort
- UI preflight in tagged app: Cmd+P, query `command palette`, verified `Command Palette` ranks above `Command Palette Archive`

## Issues
- Task: user reported bad command-palette sorting order and suspected emoji/full-match priority.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784540171&installation_id=133855650&pr_number=6498&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6498&signature=d7b2520e8e9626028dc6c2945246490a3a49f71576531b45ca1fc4a2357e538e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized search-ranking changes with dual-path parity tests; no auth, data, or network surface—only Cmd+P result ordering.
> 
> **Overview**
> Command palette ranking now treats **visible title words** (alphanumeric segments only, dropping emoji/symbol-only chunks) as a first-class match target, so queries like `command palette` prefer **🧪 Command Palette** over **Command Palette Archive** or rows that only hit hidden keywords.
> 
> **Swift:** Corpus entries precompute `normalizedTitleSearchWordText`; `PreparedQuery` adds `normalizedTokenText` (tokens joined with single spaces). `CommandPaletteSearchEngine` takes the max of fuzzy score, title fuzzy + bonus, and a new **title-word exact/prefix** tier keyed off `normalizedTokenText` (including repeated spaces in the query). Shared helper `commandPaletteNormalizedSearchWordText` mirrors the Rust word extraction.
> 
> **Rust (Nucleo FFI):** Each candidate stores `search_title` from the same word-stripping logic; `title_literal_score` applies exact/prefix atom checks against `search_title` when the raw title does not match.
> 
> Reference scoring and regression tests cover Swift engine, Nucleo FFI, and emoji-prefixed / hidden-token ordering cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15fd56451ce649d139ff4815c3b6f67477c439bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritize command palette results whose visible title words exactly or prefix-match the query, including emoji-prefixed titles. Full-title matches now outrank partial title prefixes and hidden keyword hits across Swift and `Nucleo` FFI.

- **Bug Fixes**
  - Normalize title “search-word” text by dropping symbol-only segments; store as `normalizedTitleSearchWordText` in Swift and `search_title` in Rust; use it for exact/prefix title tiers.
  - Scoring now takes the max of: fuzzy score; title literal score + a scaled per-token bonus; and a new exact/prefix match on normalized title-word text via `PreparedQuery.normalizedTokenText` (handles repeated spaces).
  - Keep Swift, `Nucleo` FFI, and a reference scorer aligned; add regression tests for emoji-prefixed full/prefix matches, repeated-space queries, and cross-FFI ordering.

<sup>Written for commit 15fd56451ce649d139ff4815c3b6f67477c439bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved command palette search ranking by boosting matches against normalized title “word” text (including exact and prefix tiers).
  * Enhanced emoji-aware title search so emoji-prefixed titles are prioritized over partial/hidden-token matches.
* **Tests**
  * Added/expanded unit and Nucleo-backed test coverage to verify the updated title-word and emoji-aware ranking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->