### PR TITLE
fix: install Copilot hooks to ~/.copilot/hooks/cmux.json

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -311,7 +311,9 @@ extension CMUXCLI {
         ),
         AgentHookDef(
             name: "copilot", displayName: "Copilot", statusKey: "copilot",
-            configDir: ".copilot", configFile: "config.json", configDirEnvOverride: "COPILOT_HOME",
+            configDir: ".copilot/hooks", configFile: "cmux.json",
+            configDirEnvOverride: "COPILOT_HOME", configDirEnvOverrideSubpath: "hooks",
+            createConfigDirIfMissing: true,
             sessionStoreSuffix: "copilot", disableEnvVar: "CMUX_COPILOT_HOOKS_DISABLED",
             hookMarker: "cmux hooks copilot", format: .nested(timeoutMs: 5000),
             events: [

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28233,12 +28233,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         existing["hooks"] = hooks
-        switch def.format {
-        case .flat, .nested:
-            existing["version"] = 1
-        default:
-            break
-        }
+        // Copilot CLI and Cursor both require "version":1 in their hooks JSON.
+        // Codex uses deny_unknown_fields and must NOT receive this key.
+        // Grok and Gemini hooks configs also do not use a version field.
+        if case .flat = def.format { existing["version"] = 1 }
+        if def.name == "copilot" { existing["version"] = 1 }
         if case .kiroAgentJSON = def.format {
             if existing["name"] == nil {
                 existing["name"] = "cmux"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28233,7 +28233,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         }
 
         existing["hooks"] = hooks
-        if case .flat = def.format { existing["version"] = 1 }
+        switch def.format {
+        case .flat, .nested:
+            existing["version"] = 1
+        default:
+            break
+        }
         if case .kiroAgentJSON = def.format {
             if existing["name"] == nil {
                 existing["name"] = "cmux"

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -863,6 +863,71 @@ extension CLINotifyProcessIntegrationRegressionTests {
         )
     }
 
+    func testCopilotHookInstallWritesToHooksSubdirectory() throws {
+        // Regression: hooks were previously installed to ~/.copilot/config.json;
+        // Copilot CLI only loads hooks from ~/.copilot/hooks/*.json.
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-copilot-hook-install-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "copilot", "install", "--yes"],
+            environment: [
+                "HOME": root.path,
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_CLI_SENTRY_DISABLED": "1",
+            ],
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+
+        // Must NOT write to the old incorrect path.
+        let wrongURL = root
+            .appendingPathComponent(".copilot", isDirectory: true)
+            .appendingPathComponent("config.json", isDirectory: false)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: wrongURL.path),
+            "Copilot hooks must not be installed to ~/.copilot/config.json"
+        )
+
+        // Must write to ~/.copilot/hooks/cmux.json.
+        let hookURL = root
+            .appendingPathComponent(".copilot", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+            .appendingPathComponent("cmux.json", isDirectory: false)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: hookURL)) as? [String: Any],
+            "Expected hook file at ~/.copilot/hooks/cmux.json"
+        )
+
+        XCTAssertEqual(json["version"] as? Int, 1)
+        let hooks = try XCTUnwrap(json["hooks"] as? [String: Any])
+
+        // All expected lifecycle events must be present.
+        XCTAssertNotNil(hooks["SessionStart"], "Missing SessionStart hook")
+        XCTAssertNotNil(hooks["Stop"], "Missing Stop hook")
+        XCTAssertNotNil(hooks["Notification"], "Missing Notification hook")
+        XCTAssertNotNil(hooks["SessionEnd"], "Missing SessionEnd hook")
+
+        // PreToolUse feed hook must be present with the correct command and 120 000 ms timeout.
+        let preToolUseGroups = try XCTUnwrap(hooks["PreToolUse"] as? [[String: Any]], "Missing PreToolUse hook")
+        let preToolUseCommands = preToolUseGroups
+            .compactMap { $0["hooks"] as? [[String: Any]] }
+            .flatMap { $0 }
+        XCTAssertTrue(
+            preToolUseCommands.contains {
+                ($0["command"] as? String)?.contains("hooks feed --source copilot --event PreToolUse") == true
+                    && ($0["timeout"] as? Int) == 120_000
+            },
+            "Expected PreToolUse feed hook with 120 000 ms timeout, saw \(preToolUseCommands)"
+        )
+    }
+
     func testAntigravityHookInstallUsesNativeHooksJSONShape() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -864,8 +864,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
     }
 
     func testCopilotHookInstallWritesToHooksSubdirectory() throws {
-        // Bug: hooks were previously installed to ~/.copilot/config.json;
-        // Copilot CLI only loads hooks from ~/.copilot/hooks/*.json.
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-copilot-hook-install-\(UUID().uuidString)", isDirectory: true)
@@ -886,16 +884,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertFalse(result.timedOut, result.stderr)
         XCTAssertEqual(result.status, 0, result.stderr)
 
-        // Must NOT write to the old incorrect path.
-        let wrongURL = root
-            .appendingPathComponent(".copilot", isDirectory: true)
-            .appendingPathComponent("config.json", isDirectory: false)
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: wrongURL.path),
-            "Copilot hooks must not be installed to ~/.copilot/config.json"
-        )
-
-        // Must write to ~/.copilot/hooks/cmux.json.
         let hookURL = root
             .appendingPathComponent(".copilot", isDirectory: true)
             .appendingPathComponent("hooks", isDirectory: true)
@@ -908,13 +896,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(json["version"] as? Int, 1)
         let hooks = try XCTUnwrap(json["hooks"] as? [String: Any])
 
-        // All expected lifecycle events must be present.
         XCTAssertNotNil(hooks["SessionStart"], "Missing SessionStart hook")
         XCTAssertNotNil(hooks["Stop"], "Missing Stop hook")
         XCTAssertNotNil(hooks["Notification"], "Missing Notification hook")
         XCTAssertNotNil(hooks["SessionEnd"], "Missing SessionEnd hook")
 
-        // PreToolUse feed hook must be present with the correct command and 120 000 ms timeout.
         let preToolUseGroups = try XCTUnwrap(hooks["PreToolUse"] as? [[String: Any]], "Missing PreToolUse hook")
         let preToolUseCommands = preToolUseGroups
             .compactMap { $0["hooks"] as? [[String: Any]] }

--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -864,7 +864,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
     }
 
     func testCopilotHookInstallWritesToHooksSubdirectory() throws {
-        // Regression: hooks were previously installed to ~/.copilot/config.json;
+        // Bug: hooks were previously installed to ~/.copilot/config.json;
         // Copilot CLI only loads hooks from ~/.copilot/hooks/*.json.
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -28,7 +28,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `amp`, `curs
 | Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |
 | Kiro CLI | `kiro-cli` | `~/.kiro/agents/cmux.json` or `$KIRO_HOME/agents/cmux.json` | `kiro-cli chat --resume-id <id>` | preToolUse, postToolUse |
 | Rovo Dev | `acli` | `~/.rovodev/config.yml` | `acli rovodev run --restore <id>` | none |
-| Copilot | `copilot` | `~/.copilot/config.json` | `copilot --resume <id>` | PreToolUse |
+| Copilot | `copilot` | `~/.copilot/hooks/cmux.json` | `copilot --resume <id>` | PreToolUse |
 | CodeBuddy | `codebuddy` | `~/.codebuddy/settings.json` | `codebuddy --resume <id>` | PreToolUse |
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -80,7 +80,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | OpenCode     | `~/.config/opencode/plugins/cmux-feed.js` | plugin event bus         |
 | Cursor CLI   | `~/.cursor/hooks.json`                    | beforeShellExecution     |
 | Gemini       | `~/.gemini/settings.json`                 | PreToolUse               |
-| Copilot      | `~/.copilot/config.json`                  | PreToolUse               |
+| Copilot      | `~/.copilot/hooks/cmux.json`              | PreToolUse               |
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -117,7 +117,7 @@ See the [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-co
 
 ### GitHub Copilot CLI
 
-Copilot CLI supports [hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/use-hooks) that run shell commands at key lifecycle events. Add to `~/.copilot/config.json`:
+Copilot CLI supports [hooks](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/use-hooks) that run shell commands at key lifecycle events. Add to `~/.copilot/hooks/cmux.json`:
 
 ```json
 {

--- a/web/app/[locale]/docs/notifications/page.tsx
+++ b/web/app/[locale]/docs/notifications/page.tsx
@@ -266,7 +266,7 @@ esac`}</CodeBlock>
           ),
         })}
       </p>
-      <CodeBlock title="~/.copilot/config.json" lang="json">{`{
+      <CodeBlock title="~/.copilot/hooks/cmux.json" lang="json">{`{
   "hooks": {
     "userPromptSubmitted": [
       {


### PR DESCRIPTION
## Summary

`cmux hooks copilot install` was writing hooks to `~/.copilot/config.json`. The GitHub Copilot CLI actually loads hooks from `~/.copilot/hooks/*.json` — see [Use hooks](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks) in the Copilot docs. Nothing in `config.json` was ever executed.

Updated the `AgentHookDef` for `copilot` to use `configDir: ".copilot/hooks"` and `configFile: "cmux.json"`, with `createConfigDirIfMissing: true` since the `hooks/` directory may not exist on a fresh install. Also updated the three docs pages that referenced the old path.

## Testing

Added `testCopilotHookInstallWritesToHooksSubdirectory` in `CLIGenericHookPersistenceTests.swift`, which:
- Runs `hooks copilot install --yes` with a temp `HOME`
- Asserts the hook file is created at `~/.copilot/hooks/cmux.json` (not `config.json`)
- Verifies `version: 1`, all expected hook event keys, and the `PreToolUse` feed command with 120 000 ms timeout

The test also surfaced a secondary bug: `"version": 1` was not being written for Copilot hook installs. The Copilot hooks docs (linked above) list `version: 1` as a requirement — hooks silently fail without it. Fixed in the same PR, scoped to Copilot by name since Codex uses `deny_unknown_fields` and would reject an unknown `version` key.

Verified locally on macOS 26 using `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -scheme cmux-ci`.

## Demo Video

N/A — no UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (ran unit tests locally)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
  - [x] some of these don't run because of permissions
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Copilot CLI hook configuration path from `~/.copilot/config.json` to `~/.copilot/hooks/cmux.json` to align with new directory structure.

* **Documentation**
  * Updated hook installation guides and integration instructions to reflect the new Copilot hooks configuration file location.

* **Tests**
  * Added integration test to verify correct hook installation behavior in the new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->