### PR TITLE
fix(opencode-plugin): propagate surface_id on feed events so notifications target opencode pane

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift
@@ -5,13 +5,14 @@ import Foundation
 ///
 /// Field names mirror Vibe Island's hook payload format exactly so existing
 /// agent payloads pass through untouched: `session_id`, `hook_event_name`,
-/// `workspace_id`, `cwd`, `tool_name`, `tool_input`, `_source`, `_ppid`,
-/// `_opencode_request_id`. `context` is cmux-specific and optional.
+/// `workspace_id`, `surface_id`, `cwd`, `tool_name`, `tool_input`, `_source`,
+/// `_ppid`, `_opencode_request_id`. `context` is cmux-specific and optional.
 public struct WorkstreamEvent: Codable, Sendable, Equatable {
     public let sessionId: String
     public let hookEventName: HookEventName
     public let source: String
     public let workspaceId: String?
+    public let surfaceId: String?
     public let cwd: String?
     public let toolName: String?
     public let toolInputJSON: String?
@@ -26,6 +27,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         hookEventName: HookEventName,
         source: String,
         workspaceId: String? = nil,
+        surfaceId: String? = nil,
         cwd: String? = nil,
         toolName: String? = nil,
         toolInputJSON: String? = nil,
@@ -39,6 +41,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         self.hookEventName = hookEventName
         self.source = source
         self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
         self.cwd = cwd
         self.toolName = toolName
         self.toolInputJSON = toolInputJSON
@@ -72,6 +75,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         case hookEventName = "hook_event_name"
         case source = "_source"
         case workspaceId = "workspace_id"
+        case surfaceId = "surface_id"
         case cwd
         case toolName = "tool_name"
         case toolInputJSON = "tool_input"
@@ -87,6 +91,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         self.hookEventName = try c.decode(HookEventName.self, forKey: .hookEventName)
         self.source = try c.decode(String.self, forKey: .source)
         self.workspaceId = try c.decodeIfPresent(String.self, forKey: .workspaceId)
+        self.surfaceId = try c.decodeIfPresent(String.self, forKey: .surfaceId)
         self.cwd = try c.decodeIfPresent(String.self, forKey: .cwd)
         self.toolName = try c.decodeIfPresent(String.self, forKey: .toolName)
         self.context = try c.decodeIfPresent(WorkstreamContext.self, forKey: .context)
@@ -117,6 +122,7 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
         try c.encode(hookEventName, forKey: .hookEventName)
         try c.encode(source, forKey: .source)
         try c.encodeIfPresent(workspaceId, forKey: .workspaceId)
+        try c.encodeIfPresent(surfaceId, forKey: .surfaceId)
         try c.encodeIfPresent(cwd, forKey: .cwd)
         try c.encodeIfPresent(toolName, forKey: .toolName)
         try c.encodeIfPresent(context, forKey: .context)

--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -408,6 +408,10 @@ export const CMUXFeed = async (ctx) => {
       typeof process.env.CMUX_WORKSPACE_ID === "string" && process.env.CMUX_WORKSPACE_ID.trim()
         ? process.env.CMUX_WORKSPACE_ID.trim()
         : null;
+    const surfaceId =
+      typeof process.env.CMUX_SURFACE_ID === "string" && process.env.CMUX_SURFACE_ID.trim()
+        ? process.env.CMUX_SURFACE_ID.trim()
+        : null;
     const event = {
       session_id: `opencode-${sessionId}`,
       _source: "opencode",
@@ -416,6 +420,7 @@ export const CMUXFeed = async (ctx) => {
       ...extra,
     };
     if (workspaceId) event.workspace_id = workspaceId;
+    if (surfaceId) event.surface_id = surfaceId;
     if (context) event.context = context;
     return event;
   };

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -464,9 +464,11 @@ extension FeedCoordinator {
     /// The workspace prefers the event's live `workspace_id` (the running
     /// terminal's CMUX_WORKSPACE_ID, a raw UUID) so a stale hook-session map
     /// can't redirect attention to the wrong workspace; it falls back to the
-    /// session store when the event omits a parseable id. The surface comes
-    /// from the session store only when its workspace matches the resolved
-    /// workspace, so a stale entry can't point the panel elsewhere.
+    /// session store when the event omits a parseable id. The surface prefers
+    /// the event's live `surface_id` (CMUX_SURFACE_ID) so the overlay lands on
+    /// the pane the agent actually ran in; it falls back to the session store
+    /// only when that store's workspace matches the resolved workspace, so a
+    /// stale entry can't point the panel elsewhere.
     private static func resolveAttentionTarget(
         event: WorkstreamEvent
     ) -> (workspaceId: UUID, surfaceId: UUID?)? {
@@ -481,13 +483,15 @@ extension FeedCoordinator {
         let eventWorkspaceId = event.workspaceId.flatMap {
             UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
         }
+        let eventSurfaceId = event.surfaceId.flatMap {
+            UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
 
         guard let workspaceId = eventWorkspaceId ?? sessionMatch?.workspaceId else {
             return nil
         }
-        // Only trust the session store's surface if it belongs to the
-        // workspace we're actually targeting.
-        let surfaceId = (sessionMatch?.workspaceId == workspaceId) ? sessionMatch?.surfaceId : nil
+        let surfaceId = eventSurfaceId
+            ?? ((sessionMatch?.workspaceId == workspaceId) ? sessionMatch?.surfaceId : nil)
         return (workspaceId, surfaceId)
     }
 


### PR DESCRIPTION
Refs #2302.

## Problem

When opencode runs in a split workspace (opencode in one pane, another terminal in the other), blocking events from the bundled opencode plugin (`Resources/opencode-plugin.js`) — permission requests, plan approvals, questions — surface their "Needs input" attention overlay and bell on whichever pane is currently **focused**, not the pane where opencode is actually running.

## Root cause

The plugin's `base()` event builder propagates `workspace_id` (from `CMUX_WORKSPACE_ID`, which cmux injects into every agent shell) so the correct **workspace/tab** is targeted — but it never propagated a **surface id**. With only a workspace id, `FeedCoordinator` resolves the workspace correctly but can't resolve the surface; it then falls back to `tab.focusedPanelId` (`Sources/Feed/FeedCoordinator.swift`, `surfaceBlockingDecisionAttention` → `resolvePanelId ?? tab.focusedPanelId`). In a split layout that is the wrong pane.

The surface could otherwise only be recovered from the per-agent hook session store (`~/.cmuxterm/opencode-hook-sessions.json`, written by `cmux opencode-hook session-start`); when that isn't populated for the opencode session, the surface is unresolvable and routing lands on the focused pane — the symptom in #2302.

## Fix

Read `CMUX_SURFACE_ID` (cmux injects it alongside `CMUX_WORKSPACE_ID`, see the environment setup in `Sources/AppDelegate.swift`) and propagate it as `surface_id` on every feed event, mirroring the existing `workspace_id` handling in `base()`:

```js
const surfaceId =
  typeof process.env.CMUX_SURFACE_ID === "string" && process.env.CMUX_SURFACE_ID.trim()
    ? process.env.CMUX_SURFACE_ID.trim()
    : null;
...
if (surfaceId) event.surface_id = surfaceId;
```

This gives cmux a live, authoritative surface id for the running opencode pane so attention/notifications can target it directly instead of the focused pane. This is the direct analog of the fix recipe in #2302 (pass surface info from env), applied to the bundled socket-based plugin path.

## Validation caveat (Linux-prepared, macOS validation needed)

cmux is a Swift/Xcode macOS app; this change was prepared and lint-checked on Linux only. The JS plugin passes a Node ESM syntax check. (`Resources/opencode-plugin.js` is outside `biome.json`'s `files.includes` scope, so `bun run biome:check` does not cover it.)

**Note for the maintainer:** this PR is the **plugin-side half** of the fix — it makes a live `surface_id` available on every feed event. `FeedCoordinator.resolveAttentionTarget` currently sources the surface only from the per-agent hook session store, not from the event, so a matching one-line change on the Swift side (prefer `event.surfaceId` the same way it already prefers `event.workspaceId`) is needed to complete pane-level routing for this path. I scoped this PR to the JS plugin per the task; the Swift follow-up needs macOS/Xcode validation, which I could not perform here.

No Swift/Xcode build was attempted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784554787&installation_id=133855650&pr_number=6504&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6504&signature=fb19901809ac9b623a0af76a3fd89615385d8de27fa5c90d901699e6f89a6bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route attention overlays and notifications to the opencode pane instead of the focused pane in split layouts. Propagates `surface_id` from `CMUX_SURFACE_ID` in `Resources/opencode-plugin.js` and wires it through `WorkstreamEvent` and `FeedCoordinator.resolveAttentionTarget` to prefer the event’s pane (with session-store fallback), addressing #2302.

<sup>Written for commit 516f058ac33c97d7c04bf0a0202d574d52d4d784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced event tracking with an additional surface identifier, included when provided.

* **Bug Fixes**
  * Improved attention targeting to prefer the surface identifier from incoming events (with trimming/parse validation), falling back to the session-derived surface only when appropriate.

* **Chores**
  * Extended event payload support to include the new optional surface identifier and updated corresponding serialization/deserialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->