### PR TITLE
ci: aggregate required gates (stop branch-protection desync on renames/splits)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,9 +665,16 @@ jobs:
 
   tests-required-status:
     name: tests
+    # Aggregate gate for the test/build suites in this workflow. Required by
+    # branch protection under the stable name "tests", and references each suite
+    # by its job KEY via needs:, so renaming/sharding a job's display name never
+    # desyncs the required-checks list (the failure mode from the #6464 sharding
+    # that stranded the old "tests" check). Add new ci.yml test/build jobs here.
     needs:
       - changes
       - tests
+      - swift-package-tests
+      - agent-session-web-resources
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
     timeout-minutes: 5
@@ -698,8 +705,20 @@ jobs:
               print(f"app-host unit tests had unexpected result for macos={macos}: {tests['result']}", file=sys.stderr)
               sys.exit(1)
 
+          # The remaining test/build suites in this workflow gate too. A job that
+          # opts out via its own path filter reports "skipped", which is fine; a
+          # job that actually ran and failed must block the merge.
+          allowed = {"success", "skipped"}
+          for name in ("swift-package-tests", "agent-session-web-resources"):
+              result = needs[name]["result"]
+              if result not in allowed:
+                  print(f"{name} did not pass: {result}", file=sys.stderr)
+                  sys.exit(1)
+
           print(f"changes.macos={macos}")
           print(f"app-host unit tests={tests['result']}")
+          for name in ("swift-package-tests", "agent-session-web-resources"):
+              print(f"{name}={needs[name]['result']}")
           PY
 
   swift-package-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
           DIRECT_DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
         run: bun run test:db:behavior
 
-  tests:
+  app-host-unit-tests:
     needs: changes
     if: ${{ needs.changes.outputs.macos == 'true' }}
     name: app-host unit tests (${{ matrix.shard }}/4)
@@ -663,7 +663,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_omp_extension_install.py
 
-  tests-required-status:
+  tests:
     name: tests
     # Aggregate gate for the test/build suites in this workflow. Required by
     # branch protection under the stable name "tests", and references each suite
@@ -672,7 +672,7 @@ jobs:
     # that stranded the old "tests" check). Add new ci.yml test/build jobs here.
     needs:
       - changes
-      - tests
+      - app-host-unit-tests
       - swift-package-tests
       - agent-session-web-resources
     if: ${{ always() }}
@@ -690,7 +690,7 @@ jobs:
 
           needs = json.loads(os.environ["TESTS_NEEDS"])
           changes = needs["changes"]
-          tests = needs["tests"]
+          tests = needs["app-host-unit-tests"]
           macos = changes.get("outputs", {}).get("macos")
 
           if changes["result"] != "success":
@@ -1913,8 +1913,8 @@ jobs:
       - web-typecheck
       - react-apps-check
       - web-db-migrations
+      - app-host-unit-tests
       - tests
-      - tests-required-status
       - swift-package-tests
       - agent-session-web-resources
       - tests-build-and-lag

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -364,3 +364,52 @@ jobs:
             fi
             exit "$status"
           done
+
+  ios-tests:
+    name: ios-tests
+    # Aggregate gate for this workflow's iOS suites. Add this check to the branch
+    # protection required list (it is the iOS sibling of ci.yml's "tests" gate).
+    # References each suite by job KEY via needs:, so renaming or sharding a job
+    # never desyncs the required-checks list. Add new iOS jobs to needs: here.
+    needs:
+      - detect-ios-changes
+      - package-conventions-lint
+      - mobile-core-package
+      - ios-simulator
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'warp-ubuntu-latest-x64-4x' }}
+    timeout-minutes: 5
+    steps:
+      - name: Check iOS test routing
+        env:
+          IOS_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["IOS_NEEDS"])
+
+          # The routing job must succeed for its should_run/should_lint outputs to
+          # be trustworthy; the suites below run or skip based on those outputs.
+          if needs["detect-ios-changes"]["result"] != "success":
+              print(f"detect-ios-changes: {needs['detect-ios-changes']['result']}", file=sys.stderr)
+              sys.exit(1)
+
+          # A suite that opted out via the routing filter reports "skipped", which
+          # is fine; a suite that actually ran and failed must block the merge.
+          allowed = {"success", "skipped"}
+          bad = {
+              name: data["result"]
+              for name, data in sorted(needs.items())
+              if name != "detect-ios-changes" and data["result"] not in allowed
+          }
+          if bad:
+              for name, result in bad.items():
+                  print(f"{name} did not pass: {result}", file=sys.stderr)
+              sys.exit(1)
+
+          for name, data in sorted(needs.items()):
+              print(f"{name}={data['result']}")
+          PY

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -393,8 +393,8 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
         "web-typecheck",
         "react-apps-check",
         "web-db-migrations",
+        "app-host-unit-tests",
         "tests",
-        "tests-required-status",
         "tests-build-and-lag",
         "release-ghostty-cli-helper",
         "release-build",
@@ -407,11 +407,11 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
 
 
 def test_required_tests_status_waits_for_app_host_matrix() -> None:
-    block = workflow_job_block("tests-required-status")
+    block = workflow_job_block("tests")
 
     assert "name: tests" in block
     assert "      - changes" in block
-    assert "      - tests" in block
+    assert "      - app-host-unit-tests" in block
     assert "if: ${{ always() }}" in block
     assert 'macos == "true" and tests["result"] != "success"' in block
     assert 'tests["result"] not in {"success", "skipped"}' in block

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -711,7 +711,8 @@ check_no_bare_github_hosted_runners() {
   # switch is a single repo-variable flip with no PR. A bare GitHub-hosted
   # label (ubuntu-*, macos-NN) cannot be redirected, so it is forbidden.
   # Bare paid-provider labels (blacksmith-*, warp-*, depot-*) stay allowed for
-  # deliberate single-runner pins such as the testmanagerd-wedged `tests` job.
+  # deliberate single-runner pins such as the testmanagerd-wedged
+  # `app-host-unit-tests` job.
   local hits
   hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)[[:space:]]*$" "$ROOT_DIR/.github/workflows" || true)"
   if [[ -n "$hits" ]]; then
@@ -793,7 +794,7 @@ check_no_self_hosted_fleet_runners() {
 # ci.yml jobs
 check_no_bare_github_hosted_runners
 check_no_self_hosted_fleet_runners
-check_macos_runner "$CI_FILE" "tests"
+check_macos_runner "$CI_FILE" "app-host-unit-tests"
 check_macos_runner "$CI_FILE" "tests-build-and-lag"
 check_macos_runner "$CI_FILE" "release-ghostty-cli-helper"
 check_macos_runner "$CI_FILE" "release-build"


### PR DESCRIPTION
## Why

Branch protection matches required status checks by **literal name**, and that list is hand-maintained. The recent CI burst kept changing names out from under it:

- #6464 sharded the `tests` job → reported as `app-host unit tests (N/4)`, so the required `tests` context went "expected" forever and blocked every PR built on top of it (until #6474 added a `tests` summary back).
- iOS jobs live in a separate `test-ios.yml`; new suites (`swift-package-tests`, `agent-session-web-resources`) were added — none added to the required list, so they run but don't gate.

This is a recurring class of breakage: **every rename / shard / workflow-split silently desyncs the required-checks name list.**

## What

Gate via **aggregate summary jobs** that reference suites by their job **KEY** through `needs:` (immune to display-name and shard changes), one per workflow:

- **`ci.yml` → `tests-required-status`** (reported as `tests`, already required): now also `needs:` `swift-package-tests` + `agent-session-web-resources`. A real failure in either blocks merge; a path-filtered skip is allowed.
- **`test-ios.yml` → new `ios-tests` aggregate**: `needs:` `detect-ios-changes`, `package-conventions-lint`, `mobile-core-package`, `ios-simulator`, same skip-tolerant logic.

Both mirror the existing `ci-status` / `tests-required-status` pattern.

## Settings change required (after merge)

- Add **`ios-tests`** to the `main` ruleset's required status checks. Do this **after** this PR merges, so the job exists first.
- The `tests` change needs **no** settings change (same check name).

## Policy note

`ios-tests` makes a real iOS suite failure block **iOS-touching** PRs (iOS jobs skip on non-iOS PRs via `detect-ios-changes`, and skip = pass here). If iOS sim flakiness should stay advisory, drop `ios-simulator` from the `ios-tests` `needs:` and keep only `mobile-core-package` + `package-conventions-lint`. Your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784587511&installation_id=133855650&pr_number=6519&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6519&signature=77c7b21c95e130f7b0dba9d978c68f68e64eb21b664dad2ecae6364be58c7642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate CI gates to keep branch protection stable when jobs are renamed or sharded. Expands the `tests` gate, adds a new `ios-tests` gate, and renames the unit-test matrix job key to `app-host-unit-tests`; updates CI guard tests and wiring to match.

- **Refactors**
  - `ci.yml`: `tests` gate now needs `app-host-unit-tests`, `swift-package-tests`, and `agent-session-web-resources`; updated `ci-status` needs to reference the new keys.
  - `test-ios.yml`: adds `ios-tests` gate over `detect-ios-changes`, `package-conventions-lint`, `mobile-core-package`, and `ios-simulator`.
  - Rename: sharded unit-test job key `tests` → `app-host-unit-tests`; aggregate is keyed `tests`. Updated `tests/test_ci_change_areas.py` and `tests/test_ci_self_hosted_guard.sh`.

- **Migration**
  - After merge, add `ios-tests` to the main ruleset’s required checks. `tests` needs no change.

<sup>Written for commit 9c882ec6fbdf9fdea2743d5b83a53596fccd3163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI merge gating by renaming the app-host unit test job and updating downstream workflow wiring and aggregation of required suite results.
  * Expanded CI required-status validation to include additional iOS and Swift/web-related suites, allowing only `success` or `skipped`.
  * Added an iOS aggregate gate that blocks merges unless change detection succeeds and all required iOS suites complete with `success`/`skipped`.
  * Updated CI validation tests and the self-hosted runner guard to match the revised job names and checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->