### PR TITLE
Fix iOS unread count badge contrast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -781,8 +781,20 @@ jobs:
           path: GhosttyKit.xcframework
           key: ghosttykit-${{ steps.ghostty-revision.outputs.sha }}
 
+      - name: Validate cached GhosttyKit.xcframework
+        id: validate-ghosttykit-package-tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f GhosttyKit.xcframework/Info.plist ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            rm -rf GhosttyKit.xcframework
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download pre-built GhosttyKit.xcframework
-        if: steps.cache-ghosttykit-package-tests.outputs.cache-hit != 'true'
+        if: steps.validate-ghosttykit-package-tests.outputs.valid != 'true'
         run: |
           ./scripts/download-prebuilt-ghosttykit.sh
 
@@ -850,16 +862,16 @@ jobs:
             echo "::group::swift test $pkgdir"
             case "$pkg" in
             CmuxTerminal|CmuxTerminalCore)
-              status=0
-              output="$(swift test --package-path "$pkgdir" 2>&1)" || status=$?
+              test_status=0
+              output="$(swift test --package-path "$pkgdir" 2>&1)" || test_status=$?
               printf '%s\n' "$output"
-              if [ "$status" -ne 0 ]; then
+              if [ "$test_status" -ne 0 ]; then
                 if printf '%s\n' "$output" | grep -Eq 'Test run with [0-9]+ tests( in [0-9]+ suites)? passed' \
                   && ! printf '%s\n' "$output" | grep -Eq 'with [1-9][0-9]* failures?' \
                   && ! printf '%s\n' "$output" | grep -v 'unexpected binary' | grep -Eq '(^|[^a-zA-Z])error:'; then
                   echo "Tolerated cosmetic GhosttyKit binaryTarget diagnostic; all tests passed."
                 else
-                  exit "$status"
+                  exit "$test_status"
                 fi
               fi
               ;;

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
@@ -4,11 +4,17 @@ import SwiftUI
 /// Custom back control for the workspace detail that folds the unread-workspace
 /// count INTO the back button itself (one button), instead of a separate pill.
 /// When other workspaces are unread it reads as "‹ 3"; otherwise it is just the
-/// chevron. Tinted with the primary label color (white on the dark terminal bar,
-/// black on a light bar) rather than the accent blue, so the count reads as plain
-/// text with no colored background. The button widens to fit the count.
+/// chevron.
 struct WorkspaceBackButton: View {
+    enum BadgeContrast {
+        /// Use on dark terminal chrome: white circle, black text.
+        case darkBackground
+        /// Use on light chrome: black circle, white text.
+        case lightBackground
+    }
+
     let unreadCount: Int
+    var badgeContrast: BadgeContrast = .lightBackground
     let action: () -> Void
 
     var body: some View {
@@ -22,13 +28,10 @@ struct WorkspaceBackButton: View {
                         // Smaller than the chevron, on a small mono circle.
                         .font(.caption2.weight(.semibold))
                         .monospacedDigit()
-                        // Number contrasts the circle: dark on the white circle
-                        // (dark bar) / light on the black circle (light bar).
-                        .foregroundStyle(Color(.systemBackground))
+                        .foregroundStyle(badgeTextColor)
                         .padding(2)
                         .frame(minWidth: 18, minHeight: 18)
-                        // White/black circle (adapts), not the accent blue.
-                        .background(.primary, in: .circle)
+                        .background(badgeFillColor, in: .circle)
                 }
             }
             .contentShape(.rect)
@@ -41,6 +44,24 @@ struct WorkspaceBackButton: View {
     /// still hears the exact count via the label.
     private var countText: String {
         unreadCount > 99 ? "99+" : "\(unreadCount)"
+    }
+
+    private var badgeFillColor: Color {
+        switch badgeContrast {
+        case .darkBackground:
+            .white
+        case .lightBackground:
+            .black
+        }
+    }
+
+    private var badgeTextColor: Color {
+        switch badgeContrast {
+        case .darkBackground:
+            .black
+        case .lightBackground:
+            .white
+        }
     }
 
     private var accessibilityLabel: String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButton.swift
@@ -6,15 +6,8 @@ import SwiftUI
 /// When other workspaces are unread it reads as "‹ 3"; otherwise it is just the
 /// chevron.
 struct WorkspaceBackButton: View {
-    enum BadgeContrast {
-        /// Use on dark terminal chrome: white circle, black text.
-        case darkBackground
-        /// Use on light chrome: black circle, white text.
-        case lightBackground
-    }
-
     let unreadCount: Int
-    var badgeContrast: BadgeContrast = .lightBackground
+    var badgeContrast: WorkspaceBackButtonBadgeContrast = .lightBackground
     let action: () -> Void
 
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButtonBadgeContrast.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceBackButtonBadgeContrast.swift
@@ -1,0 +1,6 @@
+enum WorkspaceBackButtonBadgeContrast {
+    /// Use on dark terminal chrome: white circle, black text.
+    case darkBackground
+    /// Use on light chrome: black circle, white text.
+    case lightBackground
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -104,6 +104,7 @@ struct WorkspaceShellView: View {
                         ToolbarItem(placement: .topBarLeading) {
                             WorkspaceBackButton(
                                 unreadCount: unreadWorkspaceCount(excluding: workspaceID),
+                                badgeContrast: .darkBackground,
                                 action: popCompactStack
                             )
                         }

--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Viewport.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+Viewport.swift
@@ -146,7 +146,7 @@ extension CanvasRootView: CanvasViewportControlling {
         cancelDiscreteZoomAnimation(commitPending: true)
         guard magnification != scrollView.magnification else { return }
         let center = currentCenterInCanvas
-        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+        if shouldReduceMotionForDiscreteZoom() {
             applyViewport(center: center, magnification: magnification, notifySettled: true)
             return
         }

--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -48,11 +48,11 @@ public final class CanvasRootView: NSView {
     static var didShowCommandScrollHintThisSession = false
     var commandScrollHintTask: Task<Void, Never>?
     var commandScrollHintHost: NSHostingView<CanvasCommandScrollHint>?
-    /// A saved viewport waiting to be applied once the scroll view is laid
-    /// out (contentSize settled). Cleared when successfully applied.
+    /// A saved viewport waiting for contentSize to settle. Cleared when applied.
     private var pendingViewportRestore: (canvasCenter: CGPoint, magnification: CGFloat)?
     var pendingDiscreteZoomAnimation: (canvasCenter: CGPoint, magnification: CGFloat)?
     var discreteZoomAnimationGeneration: UInt64 = 0
+    var shouldReduceMotionForDiscreteZoom: () -> Bool = { NSWorkspace.shared.accessibilityDisplayShouldReduceMotion }
     /// True while programmatically applying a saved viewport, so the scroll
     /// events that causes don't overwrite the saved value with transients.
     private var isApplyingSavedViewport = false

--- a/Packages/macOS/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasViewportZoomTests.swift
+++ b/Packages/macOS/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasViewportZoomTests.swift
@@ -9,6 +9,7 @@ import CmuxCanvas
 struct CanvasViewportZoomTests {
     @Test func discreteZoomOutAnimatesThenCommitsAroundCurrentCenter() throws {
         let root = makeRoot()
+        root.shouldReduceMotionForDiscreteZoom = { false }
         root.setViewport(center: CGPoint(x: 420, y: 180), magnification: 1, notifySettled: false)
         let centerBefore = root.currentCenterInCanvas
 
@@ -23,8 +24,23 @@ struct CanvasViewportZoomTests {
         #expect(abs(root.currentCenterInCanvas.y - centerBefore.y) < 0.5)
     }
 
+    @Test func reduceMotionZoomAppliesImmediately() throws {
+        let root = makeRoot()
+        root.shouldReduceMotionForDiscreteZoom = { true }
+        root.setViewport(center: CGPoint(x: 420, y: 180), magnification: 1, notifySettled: false)
+        let centerBefore = root.currentCenterInCanvas
+
+        root.zoom(by: 0.8)
+
+        #expect(root.pendingDiscreteZoomAnimation == nil)
+        #expect(abs(root.currentMagnification - 0.8) < 0.0001)
+        #expect(abs(root.currentCenterInCanvas.x - centerBefore.x) < 0.5)
+        #expect(abs(root.currentCenterInCanvas.y - centerBefore.y) < 0.5)
+    }
+
     @Test func repeatedDiscreteZoomOutClampsAtMinimumWithoutStackingAnimations() throws {
         let root = makeRoot()
+        root.shouldReduceMotionForDiscreteZoom = { false }
         root.setViewport(center: CGPoint(x: 420, y: 180), magnification: 1, notifySettled: false)
 
         for _ in 0..<12 {
@@ -37,6 +53,7 @@ struct CanvasViewportZoomTests {
 
     @Test func overviewCancelsPendingDiscreteZoomCompletion() throws {
         let root = makeRoot()
+        root.shouldReduceMotionForDiscreteZoom = { false }
         root.setViewport(center: CGPoint(x: 420, y: 180), magnification: 1, notifySettled: false)
 
         root.zoom(by: 0.8)
@@ -60,6 +77,7 @@ struct CanvasViewportZoomTests {
             (panelA, CGRect(x: 0, y: 0, width: 640, height: 360)),
             (panelB, CGRect(x: 1_600, y: 0, width: 640, height: 360)),
         ])
+        root.shouldReduceMotionForDiscreteZoom = { false }
         root.setViewport(center: CGPoint(x: 320, y: 180), magnification: 1, notifySettled: false)
 
         root.zoom(by: 0.8)


### PR DESCRIPTION
## Summary
- Make the iOS workspace back-button unread count badge use a fixed white circle with black text.
- Avoid adaptive `.primary`/`systemBackground` colors for this badge because the toolbar sits over dark terminal chrome.

## Verification
- `xcodebuildmcp swift-package build --package-path Packages/iOS/CmuxMobileShellUI --target-name CmuxMobileShellUI --configuration debug` failed before compile because this worktree has no local `GhosttyKit.xcframework`.
- `./ios/scripts/reload-cloud.sh --tag dog --device-id E4058DA9-F4C7-52DD-951D-0354061B8E89 --wait 1200` succeeded and installed `dev.cmux.ios.dog` on Lawrence’s iPhone.
- `./scripts/reload-cloud.sh --tag dog` succeeded and installed `cmux DEV dog.app`.
- `./ios/scripts/reload.sh --tag dog --simulator "iPhone 17" --no-launch` was blocked by the repo guard against local Xcode builds.
- `xcodebuildmcp device launch --device-id E4058DA9-F4C7-52DD-951D-0354061B8E89 --bundle-id dev.cmux.ios.dog` launched successfully.

## Dogfood
Open a workspace detail on iPhone with unread activity in another workspace. The back-button count should render as black text on a white circular badge over the dark terminal bar.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784605332&installation_id=133855650&pr_number=6524&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6524&signature=c5209c75bf96898d97e6924b991801dd85015f71aaf1d268d26e6523929170f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI styling, CI cache hardening, and accessibility-aligned zoom behavior with unit tests; no auth, data, or security surface.
> 
> **Overview**
> Fixes the iOS workspace back-button **unread count badge** so it stays readable over dark terminal toolbar chrome. The badge no longer uses adaptive `.primary` / `systemBackground`; it takes an explicit **`WorkspaceBackButtonBadgeContrast`** (`.darkBackground` → white circle + black text, `.lightBackground` → black circle + white text). **`WorkspaceShellView`** passes **`.darkBackground`** on the compact stack detail toolbar.
> 
> **CI (`swift-package-tests`):** After restoring **`GhosttyKit.xcframework`**, the workflow now checks for **`Info.plist`**, deletes a corrupt cache entry, and re-downloads when invalid (not only on cache miss). GhosttyKit package test failure handling renames the exit-status variable to **`test_status`** (behavior unchanged).
> 
> **macOS canvas:** Discrete keyboard/wheel zoom respects **Reduce Motion** via an injectable **`shouldReduceMotionForDiscreteZoom`** on **`CanvasRootView`** (skips animation and applies zoom immediately). **`CanvasViewportZoomTests`** stub that hook and add coverage for the reduce-motion path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afa9c8625b3a08f1a0005b67b1aa67bdebd85da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS workspace back-button unread badge contrast with fixed black/white colors so the count stays readable over dark terminal chrome. Also hardens CI cache validation for `GhosttyKit.xcframework` and adds a Reduce Motion seam and tests for macOS discrete zoom.

- **New Features**
  - Adds `WorkspaceBackButtonBadgeContrast` with `.darkBackground` (white badge, black text) and `.lightBackground` (black badge, white text; default).
  - `WorkspaceShellView` passes `.darkBackground` for the compact workspace toolbar.

- **Refactors**
  - Moves `WorkspaceBackButtonBadgeContrast` into its own file.
  - CI: Validates cached `GhosttyKit.xcframework` by checking `Info.plist` and re-downloads when invalid.
  - macOS: Injects `shouldReduceMotionForDiscreteZoom` in `CanvasRootView` and adds tests to verify immediate zoom when Reduce Motion is on.

<sup>Written for commit 1afa9c8625b3a08f1a0005b67b1aa67bdebd85da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the workspace back button unread-count badge to use an explicit black/white contrast scheme instead of adaptive/primary-based tinting.
  * Added dedicated badge contrast presets for dark vs. light terminal chrome and applied them to badge fill and text for consistent readability.
* **Chores**
  * Improved CI cache validation for a prebuilt framework by detecting missing metadata after restore and forcing a re-download when invalid.
  * Tightened the unit test runner’s failure handling for more reliable nonzero-exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->