### PR TITLE
Fix zoomed-out canvas pane drag lag

### DIFF
--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPaneView.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasPaneView.swift
@@ -27,6 +27,7 @@ final class CanvasPaneView: NSView {
 
     /// The container the panel content view is mounted into.
     let contentContainer = NSView()
+    private(set) var isContentSuppressedForDrag = false
 
     private let titleBarHost: NSHostingView<CanvasPaneTitleBarView>
     private var chrome = CanvasPaneChrome(
@@ -104,6 +105,12 @@ final class CanvasPaneView: NSView {
     }
 
     override var isFlipped: Bool { true }
+
+    func setContentSuppressedForDrag(_ suppressed: Bool) {
+        guard isContentSuppressedForDrag != suppressed else { return }
+        isContentSuppressedForDrag = suppressed
+        contentContainer.isHidden = suppressed
+    }
 
     /// Updates the tab strip and focus ring. No-op when nothing changed.
     func updateChrome(_ chrome: CanvasPaneChrome) {

--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView+PaneGestures.swift
@@ -9,6 +9,16 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         model.layout.selectedPanelId(in: view.paneID)?.rawValue
     }
 
+    private func applyDragPresentation(to view: CanvasPaneView) {
+        view.setContentSuppressedForDrag(
+            scrollView.magnification < Self.dragContentSuppressionMagnificationThreshold
+        )
+    }
+
+    private func clearDragPresentation(for paneID: CanvasPaneID) {
+        paneViews[paneID]?.setContentSuppressedForDrag(false)
+    }
+
     func paneView(_ view: CanvasPaneView, mouseDownAt documentPoint: CGPoint, region: CanvasPaneHitRegion) {
         guard let frame = model.layout.frame(of: view.paneID)?.cgRect else { return }
         dragSession = DragSession(
@@ -18,6 +28,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             startPoint: documentPoint,
             lastFrame: frame
         )
+        applyDragPresentation(to: view)
         if let panelId = selectedPanelId(of: view) {
             model.bringToFront(panelId)
         }
@@ -68,7 +79,6 @@ extension CanvasRootView: CanvasPaneViewDelegate {
         guidesView.setGuides(result.guides)
         updateJoinHighlight(for: session, at: documentPoint)
         updateMinimap(reveal: true)
-        callbacks.onViewportGeometryChanged(window)
     }
 
     /// Live drop indicator: when this drag would join the dragged single-tab
@@ -95,6 +105,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             return
         }
         dragSession = nil
+        clearDragPresentation(for: session.paneID)
         defer {
             releaseMinimapAfterInteraction()
         }
@@ -158,6 +169,7 @@ extension CanvasRootView: CanvasPaneViewDelegate {
                     lastFrame: frame,
                     lastPoint: point
                 )
+                applyDragPresentation(to: view)
                 holdMinimapVisible()
                 updateMinimap(reveal: true)
             }
@@ -183,6 +195,9 @@ extension CanvasRootView: CanvasPaneViewDelegate {
             lastFrame: frame,
             lastPoint: point
         )
+        if let paneView = paneViews[paneID] {
+            applyDragPresentation(to: paneView)
+        }
         holdMinimapVisible()
         updateMinimap(reveal: true)
         callbacks.onFocusPanel(panelId)

--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasRootView.swift
@@ -59,6 +59,7 @@ public final class CanvasRootView: NSView {
     /// Extra viewport fraction kept rendering around the visible rect so
     /// panes don't flicker on at the edge mid-flick.
     private static let lifecycleMarginFraction: CGFloat = 0.5
+    static let dragContentSuppressionMagnificationThreshold: CGFloat = 0.5
     static let revealMargin: CGFloat = 24
     static let overviewPadding: CGFloat = 48
     struct DragSession {

--- a/Packages/macOS/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
+++ b/Packages/macOS/CmuxCanvasUI/Tests/CmuxCanvasUITests/CanvasMinimapViewTests.swift
@@ -50,6 +50,75 @@ struct CanvasMinimapViewTests {
         #expect(root.minimapAutoHideScheduler.hasPendingHide)
     }
 
+    @Test func paneDragDefersViewportGeometryCallbackUntilDrop() {
+        let panelA = UUID()
+        let panelB = UUID()
+        var viewportGeometryChangeCount = 0
+        let root = makeRootWithMinimapContent(
+            panelA: panelA,
+            panelB: panelB,
+            onViewportGeometryChanged: { _ in
+                viewportGeometryChangeCount += 1
+            }
+        )
+        defer {
+            root.teardown()
+        }
+        viewportGeometryChangeCount = 0
+
+        let paneID = root.model.paneID(containing: panelA)!
+        let paneView = root.paneViews[paneID]!
+        root.paneView(paneView, mouseDownAt: CGPoint(x: 20, y: 10), region: .titleBar)
+        root.paneView(paneView, draggedTo: CGPoint(x: 64, y: 18), modifiers: [])
+        root.paneView(paneView, draggedTo: CGPoint(x: 96, y: 30), modifiers: [])
+        root.paneView(paneView, draggedTo: CGPoint(x: 128, y: 44), modifiers: [])
+
+        #expect(viewportGeometryChangeCount == 0)
+
+        root.paneViewDidEndDrag(paneView)
+
+        #expect(viewportGeometryChangeCount > 0)
+    }
+
+    @Test func lowZoomPaneDragSuppressesContentUntilDrop() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+        root.scrollView.magnification = CanvasRootView.dragContentSuppressionMagnificationThreshold - 0.01
+
+        let paneID = root.model.paneID(containing: panelA)!
+        let paneView = root.paneViews[paneID]!
+        root.paneView(paneView, mouseDownAt: CGPoint(x: 20, y: 10), region: .titleBar)
+
+        #expect(paneView.isContentSuppressedForDrag)
+        #expect(paneView.contentContainer.isHidden)
+
+        root.paneViewDidEndDrag(paneView)
+
+        #expect(!paneView.isContentSuppressedForDrag)
+        #expect(!paneView.contentContainer.isHidden)
+    }
+
+    @Test func normalZoomPaneDragKeepsContentVisible() {
+        let panelA = UUID()
+        let panelB = UUID()
+        let root = makeRootWithMinimapContent(panelA: panelA, panelB: panelB)
+        defer {
+            root.teardown()
+        }
+        root.scrollView.magnification = CanvasRootView.dragContentSuppressionMagnificationThreshold
+
+        let paneID = root.model.paneID(containing: panelA)!
+        let paneView = root.paneViews[paneID]!
+        root.paneView(paneView, mouseDownAt: CGPoint(x: 20, y: 10), region: .titleBar)
+
+        #expect(!paneView.isContentSuppressedForDrag)
+        #expect(!paneView.contentContainer.isHidden)
+    }
+
     @Test func minimapDragRecenterDoesNotScheduleAutoHideUntilRelease() {
         let panelA = UUID()
         let panelB = UUID()
@@ -217,12 +286,31 @@ struct CanvasMinimapViewTests {
     }
 
     private func makeRootWithMinimapContent(panelA: UUID, panelB: UUID) -> CanvasRootView {
-        makeRootWithMinimapContent(panelA: panelA, panelB: panelB, minimapClock: ContinuousClock())
+        makeRootWithMinimapContent(
+            panelA: panelA,
+            panelB: panelB,
+            onViewportGeometryChanged: { _ in },
+            minimapClock: ContinuousClock()
+        )
+    }
+
+    private func makeRootWithMinimapContent(
+        panelA: UUID,
+        panelB: UUID,
+        onViewportGeometryChanged: @escaping (NSWindow?) -> Void
+    ) -> CanvasRootView {
+        makeRootWithMinimapContent(
+            panelA: panelA,
+            panelB: panelB,
+            onViewportGeometryChanged: onViewportGeometryChanged,
+            minimapClock: ContinuousClock()
+        )
     }
 
     private func makeRootWithMinimapContent<C: Clock & Sendable>(
         panelA: UUID,
         panelB: UUID,
+        onViewportGeometryChanged: @escaping (NSWindow?) -> Void = { _ in },
         minimapClock: C
     ) -> CanvasRootView where C.Duration == Duration {
         let model = CanvasModel(metricsProvider: {
@@ -240,7 +328,8 @@ struct CanvasMinimapViewTests {
             callbacks: CanvasHostCallbacks(
                 onFocusPanel: { _ in },
                 onClosePanel: { _ in },
-                onLayoutChanged: {}
+                onLayoutChanged: {},
+                onViewportGeometryChanged: onViewportGeometryChanged
             ),
             themeProvider: {
                 CanvasTheme(canvasBackground: .windowBackgroundColor, paneBackground: .windowBackgroundColor)


### PR DESCRIPTION
Fixes low-zoom canvas pane drag lag by switching the live drag presentation to lightweight pane chrome below 0.5x magnification. During low-zoom drags, the heavy mounted content container is hidden while the title bar, border, frame, guides, and minimap continue tracking the pointer. On drop, content is restored before the durable layout commit finishes.

The PR also defers `onViewportGeometryChanged` until drop. That callback was not required for terminal pane live dragging and avoiding it keeps browser/window-portal sync out of the mouse event path.

Validation:
- `swift test --package-path Packages/macOS/CmuxCanvasUI`
- `./scripts/reload-cloud.sh --tag zdrag` (fell back to local build, succeeded)
- Tagged preflight: launched `zdrag`, moved it to `LG HDR 4K`, created `zdrag-lowzoom-drag`, switched to canvas, added two terminal panes, set viewport zoom to `0.25`, dragged a terminal pane. `canvas.info` showed the pane committed to `(640, 332)` with magnification still `0.25`.
- Screenshot: `/var/folders/xw/j2s0lpvj16b4y5_5hsfcphb00000gn/T/cmux-screenshots/zdrag-lowzoom-after-drag_2026-06-21T21-26-36Z_C936B395.png`

Tagged build: http://127.0.0.1:17320/zdrag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane dragging visuals by suppressing and restoring pane content during drag, and clearing the suppression when the drag ends.
  * Prevented viewport geometry change callbacks from firing repeatedly during active dragging; they now trigger only after the drop completes.

* **Tests**
  * Added coverage to confirm viewport geometry callbacks remain suppressed throughout drag updates and activate after drag completion.
  * Extended the minimap test harness to support injecting viewport-geometry callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->