### PR TITLE
perf: GTV hot-path latency baseline (probe unmask + handleAction timing + XCUITest)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -7,7 +7,7 @@
 11994	Sources/ContentView.swift
 11411	Sources/Panels/BrowserPanel.swift
 11285	Sources/Workspace.swift
-11115	Sources/GhosttyTerminalView.swift
+11131	Sources/GhosttyTerminalView.swift
 9331	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 7992	Sources/Panels/BrowserPanelView.swift
 7303	cmuxTests/WorkspaceUnitTests.swift
@@ -48,8 +48,8 @@
 2047	cmuxTests/ShortcutAndCommandPaletteTests.swift
 1949	Sources/Panels/BrowserWebAuthnSupport.swift
 1942	Sources/KeyboardShortcutSettingsFileStore.swift
+1898	Sources/TerminalController+ControlDebugContext.swift
 1880	Sources/RestorableAgentSession.swift
-1861	Sources/TerminalController+ControlDebugContext.swift
 1848	cmuxTests/NotificationAndMenuBarTests.swift
 1810	Sources/SessionIndexStore.swift
 1748	Sources/WindowDragHandleView.swift
@@ -200,6 +200,7 @@
 539	CLI/CodexTeamsApprovalBridge.swift
 538	Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift
 536	cmuxTests/CmuxConfigContextMenuTests.swift
+535	cmuxUITests/GTVHotPathPerfUITests.swift
 534	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
 534	Sources/TerminalController+ControlBrowserContext.swift
 531	Sources/App/WorkspaceRuntimeSettings.swift
@@ -220,6 +221,7 @@
 519	Sources/CmuxConfigExecutor.swift
 518	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/Corpus/stress-git-review-queue-command-deck.swift
 516	Sources/TerminalImageTransfer.swift
+515	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
 514	Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
 514	cmuxUITests/UpdatePillUITests.swift
 511	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/RemotePTY/ControlRemotePTYWorker.swift

--- a/Packages/macOS/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift
+++ b/Packages/macOS/CMUXDebugLog/Sources/CMUXDebugLog/DebugEventLog.swift
@@ -39,12 +39,14 @@ public final class DebugEventLog: @unchecked Sendable {
         "defaultname",
         "delayms",
         "dest",
+        "dispatchms",
         "destination",
         "depth",
         "dir",
         "directory",
         "dispatched",
         "downloading",
+        "elapsedms",
         "error",
         "eventtype",
         "expected",
@@ -66,6 +68,7 @@ public final class DebugEventLog: @unchecked Sendable {
         "initialinput",
         "input",
         "itemcount",
+        "keycode",
         "kind",
         "length",
         "linkurl",
@@ -88,6 +91,7 @@ public final class DebugEventLog: @unchecked Sendable {
         "query",
         "reason",
         "referer",
+        "repeat",
         "rejectedprimaryimageurl",
         "result",
         "route",
@@ -104,7 +108,11 @@ public final class DebugEventLog: @unchecked Sendable {
         "text",
         "title",
         "token",
+        "totalcount",
+        "totalms",
         "trace",
+        "trackedms",
+        "turnms",
         "types",
         "uaset",
         "url",
@@ -162,11 +170,31 @@ public final class DebugEventLog: @unchecked Sendable {
         logPath
     }
 
+    /// `path=` is normally redacted because it can carry a filesystem path. The
+    /// DEBUG typing/turn probes (`typing.timing` / `typing.phase` / `typing.delay`)
+    /// instead use `path=` for a fixed instrumentation identifier such as
+    /// `terminal.keyDown` or `terminal.handleAction.RENDER`, which is not sensitive
+    /// and must survive so per-path latency can be bucketed. For those lines only,
+    /// `path` is treated as a normal field.
+    private static func isTypingProbeMessage(_ message: String) -> Bool {
+        message.hasPrefix("typing.timing ") ||
+            message.hasPrefix("typing.phase ") ||
+            message.hasPrefix("typing.delay ")
+    }
+
     static func redactedDebugMessage(_ message: String) -> String {
         let nsMessage = message as NSString
         let fullRange = NSRange(location: 0, length: nsMessage.length)
         let matches = debugFieldPattern.matches(in: message, range: fullRange)
         guard !matches.isEmpty else { return message }
+
+        // For typing/turn probe lines, `path` is a non-sensitive instrumentation
+        // identifier, not a filesystem path.
+        let exemptPathField = isTypingProbeMessage(message)
+        func fieldIsSensitive(_ normalizedKey: String) -> Bool {
+            if exemptPathField && normalizedKey == "path" { return false }
+            return shouldRedactDebugField(normalizedKey)
+        }
 
         var result = ""
         var cursor = 0
@@ -190,9 +218,9 @@ public final class DebugEventLog: @unchecked Sendable {
             let key = nsMessage.substring(with: keyRange)
             let normalizedKey = key.lowercased()
             let valueStart = match.range.location + match.range.length
-            let sensitive = shouldRedactDebugField(normalizedKey)
+            let sensitive = fieldIsSensitive(normalizedKey)
             let nextMatchIndex = sensitive
-                ? nextKnownDebugFieldIndex(after: matchIndex, in: matches, message: nsMessage)
+                ? nextKnownDebugFieldIndex(after: matchIndex, in: matches, message: nsMessage, isSensitive: fieldIsSensitive)
                 : nextDebugFieldIndex(after: matchIndex, in: matches)
             let valueEnd: Int
 
@@ -238,12 +266,13 @@ public final class DebugEventLog: @unchecked Sendable {
     private static func nextKnownDebugFieldIndex(
         after index: Int,
         in matches: [NSTextCheckingResult],
-        message: NSString
+        message: NSString,
+        isSensitive: (String) -> Bool
     ) -> Int? {
         var nextIndex = index + 1
         while nextIndex < matches.count {
             let key = message.substring(with: matches[nextIndex].range(at: 2)).lowercased()
-            if knownDebugFieldNames.contains(key) || shouldRedactDebugField(key) {
+            if knownDebugFieldNames.contains(key) || isSensitive(key) {
                 return nextIndex
             }
             nextIndex += 1

--- a/Packages/macOS/CMUXDebugLog/Tests/CMUXDebugLogTests/DebugLogRedactorTests.swift
+++ b/Packages/macOS/CMUXDebugLog/Tests/CMUXDebugLogTests/DebugLogRedactorTests.swift
@@ -41,5 +41,42 @@ final class DebugLogRedactorTests: XCTestCase {
 
         XCTAssertEqual(DebugEventLog.redactedDebugMessage(message), message)
     }
+
+    // The typing/turn probes use `path=` for an instrumentation identifier, not a
+    // filesystem path. Both the identifier and the numeric measurement must survive
+    // so per-path latency can be bucketed from the tagged debug log.
+    func testTypingTimingProbeSurvivesUnredacted() {
+        let message = "typing.timing path=terminal.keyDown elapsedMs=2.34 eventType=10 keyCode=0 mods=256 repeat=0"
+
+        XCTAssertEqual(DebugEventLog.redactedDebugMessage(message), message)
+    }
+
+    func testTypingPhaseProbeSurvivesUnredacted() {
+        let message = "typing.phase path=terminal.keyDown totalMs=3.10 ghosttySend.total=2.05 interpretKeyEvents=0.80"
+
+        XCTAssertEqual(DebugEventLog.redactedDebugMessage(message), message)
+    }
+
+    func testHandleActionProbeSurvivesUnredacted() {
+        let message = "typing.timing path=terminal.handleAction.RENDER elapsedMs=0.42"
+
+        XCTAssertEqual(DebugEventLog.redactedDebugMessage(message), message)
+    }
+
+    func testTurnWorkProbeNumbersSurvive() {
+        let message = "main.turn.work turnMs=8.10 trackedMs=4.20 totalCount=3 next=beforeWaiting"
+
+        XCTAssertEqual(DebugEventLog.redactedDebugMessage(message), message)
+    }
+
+    // Real filesystem `path=` outside the probe lines must still be redacted.
+    func testNonProbePathStillRedacted() {
+        let message = "download.saved path=/Users/person/report.pdf bytes=42"
+
+        XCTAssertEqual(
+            DebugEventLog.redactedDebugMessage(message),
+            "download.saved path=<redacted:24b> bytes=42"
+        )
+    }
 }
 #endif

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -76,6 +76,10 @@ extension ControlCommandCoordinator {
             return debugReadTerminalText(request.params)
         case "debug.terminal.render_stats":
             return debugRenderStats(request.params)
+        case "debug.terminal.simulate_marked_text":
+            return debugSimulateMarkedText(request.params)
+        case "debug.terminal.simulate_unmark_text":
+            return debugSimulateUnmarkText(request.params)
         case "debug.layout":
             return debugLayout()
         case "debug.portal.stats":
@@ -203,6 +207,43 @@ extension ControlCommandCoordinator {
             // The legacy body's initial (unreachable) value, kept for the
             // equally unreachable unwired-context case.
             return .err(code: "internal_error", message: "No window", data: nil)
+        }
+    }
+
+    // MARK: - debug.terminal.simulate_marked_text
+
+    /// `debug.terminal.simulate_marked_text` — drive the focused terminal view's
+    /// `NSTextInputClient.setMarkedText` directly so the IME preedit hot path
+    /// (`terminal.setMarkedText`) can be exercised deterministically from tests
+    /// without a real input method. DEBUG-only; mirrors `debug.type`.
+    func debugSimulateMarkedText(_ params: [String: JSONValue]) -> ControlCallResult {
+        guard let text = rawString(params, "text") else {
+            return .err(code: "invalid_params", message: "Missing text", data: nil)
+        }
+        switch debugContext?.controlDebugSimulateMarkedText(text) {
+        case .noWindow:
+            return .err(code: "not_found", message: "No window", data: nil)
+        case .noFirstResponder:
+            return .err(code: "not_found", message: "No terminal first responder", data: nil)
+        case .inserted:
+            return .ok(.object([:]))
+        case nil:
+            return .err(code: "internal_error", message: "Debug context unavailable", data: nil)
+        }
+    }
+
+    /// `debug.terminal.simulate_unmark_text` — commit/clear the focused terminal
+    /// view's IME preedit via `unmarkText`, exercising `terminal.unmarkText`.
+    func debugSimulateUnmarkText(_ params: [String: JSONValue]) -> ControlCallResult {
+        switch debugContext?.controlDebugSimulateUnmarkText() {
+        case .noWindow:
+            return .err(code: "not_found", message: "No window", data: nil)
+        case .noFirstResponder:
+            return .err(code: "not_found", message: "No terminal first responder", data: nil)
+        case .inserted:
+            return .ok(.object([:]))
+        case nil:
+            return .err(code: "internal_error", message: "Debug context unavailable", data: nil)
         }
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
@@ -151,6 +151,19 @@ public protocol ControlDebugContext: AnyObject {
     /// - Returns: The insertion outcome.
     func controlDebugTypeText(_ text: String) -> ControlDebugTypeResolution
 
+    /// Drives the focused terminal view's `setMarkedText` for
+    /// `debug.terminal.simulate_marked_text`, exercising the IME preedit hot path
+    /// (`terminal.setMarkedText`) without a real input method. DEBUG test seam.
+    ///
+    /// - Parameter text: The marked (preedit) text to set.
+    /// - Returns: `.inserted` on success, `.noWindow`/`.noFirstResponder` when no
+    ///   terminal view is focused.
+    func controlDebugSimulateMarkedText(_ text: String) -> ControlDebugTypeResolution
+
+    /// Commits/clears the focused terminal view's IME preedit via `unmarkText`
+    /// for `debug.terminal.simulate_unmark_text`, exercising `terminal.unmarkText`.
+    func controlDebugSimulateUnmarkText() -> ControlDebugTypeResolution
+
     /// Whether the controller's primary `TabManager` is available (the
     /// `guard let tabManager` precondition several legacy debug bodies ran
     /// before parsing their params).

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCapabilitiesManifest.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCapabilitiesManifest.swift
@@ -292,6 +292,8 @@ public struct ControlCapabilitiesManifest: Sendable, Equatable {
             "debug.terminal.is_focused",
             "debug.terminal.read_text",
             "debug.terminal.render_stats",
+            "debug.terminal.simulate_marked_text",
+            "debug.terminal.simulate_unmark_text",
             "debug.layout",
             "debug.portal.stats",
             "debug.bonsplit_underflow.count",

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
@@ -29,6 +29,8 @@ extension ControlDebugContext {
     func controlDebugPanelSnapshotReset(surfaceArgument: String) -> String { "ERROR: not implemented" }
     func controlDebugCaptureScreenshot(label: String) -> String { "ERROR: not implemented" }
     func controlDebugTypeText(_ text: String) -> ControlDebugTypeResolution { .noWindow }
+    func controlDebugSimulateMarkedText(_ text: String) -> ControlDebugTypeResolution { .noWindow }
+    func controlDebugSimulateUnmarkText() -> ControlDebugTypeResolution { .noWindow }
     func controlDebugTabManagerAvailable() -> Bool { false }
     func controlDebugTextBoxInlineFixture(
         target: String?,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2193,12 +2193,28 @@ class GhosttyApp {
                 return tabManager.toggleSplitZoom(tabId: tabId, surfaceId: surfaceId)
             }
         case GHOSTTY_ACTION_RENDER:
+            // Timed so the refactor's handleAction inversion can prove the
+            // render-path dispatch did not regress. RENDER itself is a no-op here
+            // (the render is driven by Ghostty wakeups), so this measures pure
+            // dispatch overhead.
+            let renderTimingStart = CmuxTypingTiming.start()
+            defer {
+                CmuxTypingTiming.logDuration(path: "terminal.handleAction.RENDER", startedAt: renderTimingStart)
+            }
             return false
         case GHOSTTY_ACTION_SCROLLBAR:
+            let scrollbarTimingStart = CmuxTypingTiming.start()
+            defer {
+                CmuxTypingTiming.logDuration(path: "terminal.handleAction.SCROLLBAR", startedAt: scrollbarTimingStart)
+            }
             let scrollbar = GhosttyScrollbar(c: action.action.scrollbar)
             surfaceView.enqueueScrollbarUpdate(scrollbar)
             return true
         case GHOSTTY_ACTION_CELL_SIZE:
+            let cellSizeTimingStart = CmuxTypingTiming.start()
+            defer {
+                CmuxTypingTiming.logDuration(path: "terminal.handleAction.CELL_SIZE", startedAt: cellSizeTimingStart)
+            }
             let cellSize = CGSize(
                 width: CGFloat(action.action.cell_size.width),
                 height: CGFloat(action.action.cell_size.height)

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -134,6 +134,43 @@ extension TerminalController: ControlDebugContext {
         return .inserted
     }
 
+    func controlDebugSimulateMarkedText(_ text: String) -> ControlDebugTypeResolution {
+        guard let window = debugFocusedTerminalWindow() else { return .noWindow }
+        if Self.socketCommandAllowsInAppFocusMutations() {
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+        }
+        guard let client = window.firstResponder as? NSTextInputClient else {
+            return .noFirstResponder
+        }
+        client.setMarkedText(
+            text,
+            selectedRange: NSRange(location: text.utf16.count, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        return .inserted
+    }
+
+    func controlDebugSimulateUnmarkText() -> ControlDebugTypeResolution {
+        guard let window = debugFocusedTerminalWindow() else { return .noWindow }
+        if Self.socketCommandAllowsInAppFocusMutations() {
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+        }
+        guard let client = window.firstResponder as? NSTextInputClient else {
+            return .noFirstResponder
+        }
+        client.unmarkText()
+        return .inserted
+    }
+
+    private func debugFocusedTerminalWindow() -> NSWindow? {
+        NSApp.keyWindow
+            ?? NSApp.mainWindow
+            ?? NSApp.windows.first(where: { $0.isVisible })
+            ?? NSApp.windows.first
+    }
+
     // MARK: - debug.textbox.*
 
     func controlDebugTabManagerAvailable() -> Bool {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 		3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */; };
 		9E31AE7418ECFEB7BFCC0EB1 /* GotoSplitUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB0E61D015251F711FC4272 /* GotoSplitUITestRecorder.swift */; };
 		C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE10001A1B2C3D4E5F719 /* grok */; };
+		B900AAA2A1B2C3D4E5F60719 /* GTVHotPathPerfUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900AAA1A1B2C3D4E5F60719 /* GTVHotPathPerfUITests.swift */; };
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
@@ -1510,6 +1511,7 @@
 		3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsTests.swift; sourceTree = "<group>"; };
 		0DB0E61D015251F711FC4272 /* GotoSplitUITestRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GotoSplitUITestRecorder.swift; sourceTree = "<group>"; };
 		C1ADE10001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
+		B900AAA1A1B2C3D4E5F60719 /* GTVHotPathPerfUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GTVHotPathPerfUITests.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000006 /* HelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuUITests.swift; sourceTree = "<group>"; };
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
@@ -2192,6 +2194,7 @@
 			isa = PBXGroup;
 			children = (
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */,
+				B900AAA1A1B2C3D4E5F60719 /* GTVHotPathPerfUITests.swift */,
 				FEED0000000000000000F008 /* FeedSidebarUITests.swift */,
 				B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 				B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
@@ -4328,6 +4331,7 @@
 				B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,
 				D0E0F0B4A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift in Sources */,
+				B900AAA2A1B2C3D4E5F60719 /* GTVHotPathPerfUITests.swift in Sources */,
 				C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */,
 				B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 				E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */,

--- a/cmuxUITests/GTVHotPathPerfUITests.swift
+++ b/cmuxUITests/GTVHotPathPerfUITests.swift
@@ -1,0 +1,535 @@
+import XCTest
+import Foundation
+import Darwin
+
+/// GhosttyTerminalView (GTV) hot-path performance BASELINE.
+///
+/// Captures median/p95 latency for the instrumented typing/render hot paths so a
+/// later refactor (notably the `handleAction` inversion) can prove it did not
+/// regress frame/keystroke timing. It launches a tagged DEBUG build with
+/// `CMUX_KEY_LATENCY_PROBE=1` (so `CmuxTypingTiming` logs EVERY event) and a
+/// tagged `CMUX_DEBUG_LOG`, creates a workspace, runs a warmup plus three
+/// deterministic bursts, then parses the tagged log and prints a JSON summary to
+/// the test output so the numbers are recoverable from CI logs.
+///
+/// Bursts and the paths each exercises:
+///   1. keyDown burst  — `app.typeText` of real keystrokes through the responder
+///      chain: `terminal.keyDown`, `terminal.keyDown.ghosttySend(.total)`, and
+///      (via interpretKeyEvents -> insertText) `terminal.sendTextToSurface`.
+///   2. IME burst      — `debug.terminal.simulate_marked_text` / `..unmark_text`
+///      drive `setMarkedText` / `unmarkText`: `terminal.setMarkedText`,
+///      `terminal.unmarkText`.
+///   3. render burst   — a 4000-line `for` loop printed to the PTY drives Ghostty
+///      render/scroll actions: `terminal.handleAction.RENDER/SCROLLBAR/CELL_SIZE`.
+///   plus `main.turn.work` (turnMs) emitted by the main-thread turn profiler
+///   across all of the above.
+final class GTVHotPathPerfUITests: XCTestCase {
+    private var socketPath = ""
+    private var diagnosticsPath = ""
+    private var debugLogPath = ""
+    private let defaultsDomain = "com.cmuxterm.app.debug"
+    private var launchTag = ""
+    private var temporaryRoots: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        let uuid = UUID().uuidString
+        socketPath = "/tmp/cmux-debug-\(uuid).sock"
+        diagnosticsPath = "/tmp/cmux-gtvperf-diag-\(uuid).json"
+        debugLogPath = "/tmp/cmux-gtvperf-log-\(uuid).log"
+        launchTag = "gtvperf-\(uuid.prefix(8))"
+        temporaryRoots = []
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: debugLogPath)
+        // Pre-create the log so the app appends to a known path.
+        FileManager.default.createFile(atPath: debugLogPath, contents: Data())
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: debugLogPath)
+        for root in temporaryRoots {
+            try? FileManager.default.removeItem(at: root)
+        }
+        temporaryRoots = []
+        super.tearDown()
+    }
+
+    func testGTVHotPathBaseline() throws {
+        let app = configuredApp()
+        app.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 20.0),
+            "Expected app to launch. state=\(app.state.rawValue)"
+        )
+        XCTAssertTrue(
+            waitForSocketPong(timeout: 20.0),
+            "Expected control socket ping at \(socketPath). diagnostics=\(loadDiagnostics())"
+        )
+
+        let workdir = try makeWorkdir()
+        let workspace = try XCTUnwrap(
+            socketResult(
+                method: "workspace.create",
+                params: [
+                    "title": "GTV perf baseline",
+                    "working_directory": workdir.path,
+                    "focus": true,
+                ]
+            ),
+            "workspace.create failed"
+        )
+        let surfaceID = try XCTUnwrap(workspace["surface_id"] as? String, "no surface_id")
+
+        // Wait for the shell prompt so input lands in an interactive shell.
+        XCTAssertTrue(
+            waitForShellReady(surfaceID: surfaceID, timeout: 25.0),
+            "Shell did not become ready. text=\(readTerminalText(surfaceID: surfaceID) ?? "<nil>")"
+        )
+        // Make sure the terminal view is the focused first responder for typeText.
+        XCTAssertTrue(
+            waitForTerminalFocused(surfaceID: surfaceID, timeout: 8.0),
+            "Terminal surface never reported focused"
+        )
+
+        // ---- Warmup (not measured): JIT/first-touch the hot paths. ----
+        app.typeText("warmup warmup warmup\n")
+        for _ in 0..<8 {
+            _ = socketResult(method: "debug.terminal.simulate_marked_text", params: ["surface_id": surfaceID, "text": "x"])
+            _ = socketResult(method: "debug.terminal.simulate_unmark_text", params: ["surface_id": surfaceID])
+        }
+        _ = socketResult(method: "surface.send_text", params: ["surface_id": surfaceID, "text": "for i in $(seq 1 200); do echo warm $i; done"])
+        _ = socketResult(method: "surface.send_key", params: ["surface_id": surfaceID, "key": "return"])
+        Thread.sleep(forTimeInterval: 1.0)
+
+        // Truncate the log so only measured bursts are parsed.
+        try? "".write(toFile: debugLogPath, atomically: true, encoding: .utf8)
+
+        // ---- Burst 1: keyDown burst (real NSEvents via typeText). ----
+        // Alphanumerics only (predictable single-keystroke mapping). Each line is
+        // a separate typeText so AppKit dispatches discrete keyDowns.
+        let keyDownLines = 60
+        let keyDownChars = "the quick brown fox jumps over 13 lazy dogs "
+        for _ in 0..<keyDownLines {
+            app.typeText(keyDownChars)
+        }
+        // Clear the typed buffer so it doesn't run as a command.
+        app.typeText("\u{15}") // Ctrl-U (clear line) where supported
+
+        // ---- Burst 2: IME marked-text burst (setMarkedText / unmarkText). ----
+        let imeIterations = 80
+        for i in 0..<imeIterations {
+            _ = socketResult(
+                method: "debug.terminal.simulate_marked_text",
+                params: ["surface_id": surfaceID, "text": "\u{3042}\u{3044}\u{3046}\(i % 10)"]
+            )
+            _ = socketResult(
+                method: "debug.terminal.simulate_unmark_text",
+                params: ["surface_id": surfaceID]
+            )
+        }
+
+        // ---- Burst 3: render / scrollbar burst (4000-line for loop). ----
+        let renderLines = 4000
+        _ = socketResult(
+            method: "surface.send_text",
+            params: [
+                "surface_id": surfaceID,
+                "text": "for i in $(seq 1 \(renderLines)); do echo \"render line $i ---------------------------------\"; done",
+            ]
+        )
+        _ = socketResult(method: "surface.send_key", params: ["surface_id": surfaceID, "key": "return"])
+
+        // Let the render burst drain. Poll for completion by watching the log grow
+        // quiet rather than a fixed sleep.
+        waitForLogQuiescence(timeout: 30.0, quietFor: 2.0)
+
+        // ---- Parse + summarize. ----
+        let logText = (try? String(contentsOfFile: debugLogPath, encoding: .utf8)) ?? ""
+        let samples = parseSamples(from: logText)
+
+        let interestingPaths = [
+            "terminal.keyDown",
+            "terminal.keyDown.ghosttySend.total",
+            "terminal.setMarkedText",
+            "terminal.unmarkText",
+            "terminal.sendTextToSurface",
+            "terminal.handleAction.RENDER",
+            "terminal.handleAction.SCROLLBAR",
+            "terminal.handleAction.CELL_SIZE",
+            "main.turn.work",
+        ]
+
+        var summary: [[String: Any]] = []
+        for path in interestingPaths {
+            let values = samples[path] ?? []
+            let stats = computeStats(values)
+            summary.append([
+                "path": path,
+                "n": values.count,
+                "median_ms": stats.median,
+                "p95_ms": stats.p95,
+                "max_ms": stats.max,
+            ])
+        }
+
+        // Emit a machine-recoverable block to the test log.
+        let payload: [String: Any] = [
+            "kind": "gtv_hot_path_baseline",
+            "tag": launchTag,
+            "keyDownLines": keyDownLines,
+            "imeIterations": imeIterations,
+            "renderLines": renderLines,
+            "logBytes": logText.utf8.count,
+            "paths": summary,
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            print("GTV_PERF_BASELINE_JSON_BEGIN")
+            print(json)
+            print("GTV_PERF_BASELINE_JSON_END")
+        }
+        // Human-readable per-path lines too.
+        for entry in summary {
+            print(String(
+                format: "GTV_PERF path=%@ n=%@ median=%@ p95=%@ max=%@",
+                entry["path"] as? String ?? "?",
+                "\(entry["n"] as? Int ?? 0)",
+                fmt(entry["median_ms"] as? Double),
+                fmt(entry["p95_ms"] as? Double),
+                fmt(entry["max_ms"] as? Double)
+            ))
+        }
+
+        // The probe must have produced real numbers for the primary paths, else
+        // the baseline is not trustworthy and the test should fail loudly.
+        let keyDownN = (samples["terminal.keyDown"] ?? []).count
+        XCTAssertGreaterThan(
+            keyDownN, 20,
+            "Expected many terminal.keyDown samples from the keyDown burst. Log head:\n\(String(logText.prefix(2000)))"
+        )
+        let renderN = (samples["terminal.handleAction.RENDER"] ?? []).count
+            + (samples["terminal.handleAction.SCROLLBAR"] ?? []).count
+        XCTAssertGreaterThan(
+            renderN, 0,
+            "Expected render/scrollbar handleAction samples from the render burst."
+        )
+        // IME seam should fire (this branch wires the debug method).
+        XCTAssertGreaterThan(
+            (samples["terminal.setMarkedText"] ?? []).count, 0,
+            "Expected terminal.setMarkedText samples from the IME burst."
+        )
+
+        app.terminate()
+    }
+
+    // MARK: - Parsing / stats
+
+    /// Maps `path` -> [elapsedMs] across `typing.timing`, `typing.phase`
+    /// (totalMs and dotted sub-parts like `ghosttySend.total`), and
+    /// `main.turn.work` (turnMs) lines.
+    private func parseSamples(from log: String) -> [String: [Double]] {
+        var result: [String: [Double]] = [:]
+        func append(_ path: String, _ value: Double) {
+            result[path, default: []].append(value)
+        }
+        for rawLine in log.split(separator: "\n") {
+            let line = String(rawLine)
+            let fields = parseFields(line)
+            if line.contains("typing.timing"), let path = fields["path"], let ms = fields["elapsedMs"].flatMap(Double.init) {
+                append(path, ms)
+            } else if line.contains("typing.phase"), let path = fields["path"] {
+                if let total = fields["totalMs"].flatMap(Double.init) {
+                    append(path, total)
+                }
+                // Dotted sub-parts (e.g. ghosttySend.total) record under the
+                // composed `path.subpart` name so refactor comparisons can target
+                // the per-phase span explicitly.
+                for (key, value) in fields where key.contains(".") {
+                    if let v = Double(value) {
+                        append("\(path).\(key)", v)
+                    }
+                }
+            } else if line.contains("main.turn.work"), let ms = fields["turnMs"].flatMap(Double.init) {
+                append("main.turn.work", ms)
+            }
+        }
+        return result
+    }
+
+    /// Splits `k=v` space-delimited fields. Values are read up to the next space;
+    /// quoted values are not expected on the probe lines we parse.
+    private func parseFields(_ line: String) -> [String: String] {
+        var fields: [String: String] = [:]
+        for token in line.split(separator: " ") {
+            guard let eq = token.firstIndex(of: "=") else { continue }
+            let key = String(token[token.startIndex..<eq])
+            let value = String(token[token.index(after: eq)...])
+            if !key.isEmpty { fields[key] = value }
+        }
+        return fields
+    }
+
+    private func computeStats(_ values: [Double]) -> (median: Double, p95: Double, max: Double) {
+        guard !values.isEmpty else { return (0, 0, 0) }
+        let sorted = values.sorted()
+        return (percentile(sorted, 0.50), percentile(sorted, 0.95), sorted.last ?? 0)
+    }
+
+    private func percentile(_ sorted: [Double], _ p: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        if sorted.count == 1 { return sorted[0] }
+        let rank = p * Double(sorted.count - 1)
+        let low = Int(rank.rounded(.down))
+        let high = Int(rank.rounded(.up))
+        if low == high { return sorted[low] }
+        let frac = rank - Double(low)
+        return sorted[low] + (sorted[high] - sorted[low]) * frac
+    }
+
+    private func fmt(_ value: Double?) -> String {
+        guard let value else { return "-" }
+        return String(format: "%.3f", value)
+    }
+
+    // MARK: - Socket / readiness helpers
+
+    private func configuredApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += ["-socketControlMode", "allowAll"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        // Probe knobs: log EVERY typing/turn event, to the tagged path.
+        app.launchEnvironment["CMUX_KEY_LATENCY_PROBE"] = "1"
+        app.launchEnvironment["CMUX_DEBUG_LOG"] = debugLogPath
+        if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
+            app.launchEnvironment["PATH"] = path
+        }
+        return app
+    }
+
+    private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        if app.wait(for: .runningForeground, timeout: timeout) { return true }
+        if app.state == .runningBackground {
+            app.activate()
+            return app.wait(for: .runningForeground, timeout: 8.0)
+        }
+        return false
+    }
+
+    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        let ready = waitForControlSocketReady(
+            pingTimeout: timeout,
+            socketFileExists: { self.socketCandidates().contains { FileManager.default.fileExists(atPath: $0) } },
+            pingReturnsPong: {
+                let original = self.socketPath
+                for candidate in self.socketCandidates() where FileManager.default.fileExists(atPath: candidate) {
+                    self.socketPath = candidate
+                    if self.socketCommand("ping") == "PONG" { return true }
+                    self.socketPath = original
+                }
+                return false
+            }
+        )
+        return ready
+    }
+
+    private func socketCandidates() -> [String] {
+        var candidates = [socketPath, taggedSocketPath()]
+        if let expected = loadDiagnostics()["socketExpectedPath"], !expected.isEmpty {
+            candidates.append(expected)
+        }
+        var seen = Set<String>()
+        candidates.removeAll { !seen.insert($0).inserted }
+        return candidates
+    }
+
+    private func taggedSocketPath() -> String {
+        let slug = launchTag
+            .lowercased()
+            .replacingOccurrences(of: ".", with: "-")
+            .replacingOccurrences(of: "_", with: "-")
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return "/tmp/cmux-debug-\(slug).sock"
+    }
+
+    private func loadDiagnostics() -> [String: String] {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: diagnosticsPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        var result: [String: String] = [:]
+        for (key, value) in object { result[key] = String(describing: value) }
+        return result
+    }
+
+    private func socketCommand(_ command: String) -> String? {
+        ControlSocketClient(path: socketPath, responseTimeout: 1.0).sendLine(command)
+    }
+
+    private func socketResult(method: String, params: [String: Any]) -> [String: Any]? {
+        let request: [String: Any] = ["id": UUID().uuidString, "method": method, "params": params]
+        guard let envelope = ControlSocketClient(path: socketPath, responseTimeout: 5.0).sendJSON(request),
+              envelope["ok"] as? Bool == true else {
+            return nil
+        }
+        return (envelope["result"] as? [String: Any]) ?? [:]
+    }
+
+    private func readTerminalText(surfaceID: String) -> String? {
+        guard let result = socketResult(method: "debug.terminal.read_text", params: ["surface_id": surfaceID]),
+              let b64 = result["base64"] as? String,
+              let data = Data(base64Encoded: b64) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func waitForShellReady(surfaceID: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let text = readTerminalText(surfaceID: surfaceID), text.contains("$") || text.contains("%") || text.contains("#") {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+        return readTerminalText(surfaceID: surfaceID)?.isEmpty == false
+    }
+
+    private func waitForTerminalFocused(surfaceID: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let result = socketResult(method: "debug.terminal.is_focused", params: ["surface_id": surfaceID]),
+               (result["focused"] as? Bool == true || (result["focused"] as? Int ?? 0) == 1) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+        // Focus state is best-effort; typeText still routes to the key window.
+        return true
+    }
+
+    /// Polls the log file size and returns once it has not grown for `quietFor`
+    /// seconds (the render burst has drained) or `timeout` elapses.
+    private func waitForLogQuiescence(timeout: TimeInterval, quietFor: TimeInterval) {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastSize = logFileSize()
+        var lastChange = Date()
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+            let size = logFileSize()
+            if size != lastSize {
+                lastSize = size
+                lastChange = Date()
+            } else if Date().timeIntervalSince(lastChange) >= quietFor {
+                return
+            }
+        }
+    }
+
+    private func logFileSize() -> Int {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: debugLogPath)
+        return (attrs?[.size] as? Int) ?? 0
+    }
+
+    private func makeWorkdir() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-gtvperf-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        temporaryRoots.append(root)
+        return root
+    }
+
+    // MARK: - Unix-socket client
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendJSON(_ object: [String: Any]) -> [String: Any]? {
+            guard JSONSerialization.isValidJSONObject(object),
+                  let data = try? JSONSerialization.data(withJSONObject: object),
+                  let line = String(data: data, encoding: .utf8),
+                  let response = sendLine(line),
+                  let responseData = response.data(using: .utf8) else {
+                return nil
+            }
+            return (try? JSONSerialization.jsonObject(with: responseData)) as? [String: Any]
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+            var timeout = timeval(
+                tv_sec: Int(responseTimeout),
+                tv_usec: Int32((responseTimeout - floor(responseTimeout)) * 1_000_000)
+            )
+            withUnsafePointer(to: &timeout) { ptr in
+                _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+                _ = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, ptr, socklen_t(MemoryLayout<timeval>.size))
+            }
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let pathBytes = Array(path.utf8CString)
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            guard pathBytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                for index in 0..<pathBytes.count { raw[index] = pathBytes[index] }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + pathBytes.count)
+            let connected = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.connect(fd, sockaddrPtr, addrLen)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = Array((line + "\n").utf8)
+            let wrote = payload.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress else { return true }
+                return Darwin.write(fd, baseAddress, rawBuffer.count) == rawBuffer.count
+            }
+            guard wrote else { return nil }
+
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var accumulator = ""
+            let deadline = Date().addingTimeInterval(responseTimeout)
+            while Date() < deadline {
+                let count = Darwin.read(fd, &buffer, buffer.count)
+                guard count > 0 else { break }
+                if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
+                    accumulator.append(chunk)
+                    if let newline = accumulator.firstIndex(of: "\n") {
+                        return String(accumulator[..<newline])
+                    }
+                    if count < buffer.count { break }
+                }
+            }
+            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+}


### PR DESCRIPTION
Establishes a CI-runnable BASELINE for the GhosttyTerminalView (GTV) typing/render hot path so the god-file refactor (notably the planned handleAction inversion) can prove it did not regress frame/keystroke timing.

Source changes plus a measurement test:

1. debug-log probe unmask: the DEBUG typing/turn probes emit per-event latency (elapsedMs/totalMs/turnMs/trackedMs) and the typing probes lead with path=<identifier>. The redactor treated path= as sensitive and, because the numeric keys were absent from knownDebugFieldNames, swallowed every probe number as <redacted>. Fixed by adding the probe value keys to knownDebugFieldNames and, for the three typing.* probe prefixes only, treating path= as a non-sensitive instrumentation identifier. Real filesystem path= is still redacted (covered by test).

2. handleAction dispatch timing: GhosttyTerminalView.handleAction RENDER/SCROLLBAR/CELL_SIZE cases are now timed (terminal.handleAction.<case>) so the refactor inversion is measurable before/after.

3. DEBUG IME socket seam: debug.terminal.simulate_marked_text / simulate_unmark_text drive setMarkedText/unmarkText on the focused terminal view, so the IME hot path can be exercised deterministically from XCUITest (the socket text/key paths bypass NSTextInputClient).

4. GTVHotPathPerfUITests: launches a tagged DEBUG build with CMUX_KEY_LATENCY_PROBE=1 + tagged CMUX_DEBUG_LOG, creates a workspace, runs warmup + a keyDown burst (app.typeText), an IME burst, and a 4000-line render burst, then parses the tagged log and records median/p95/n per path, printing a JSON summary between GTV_PERF_BASELINE_JSON_BEGIN/END for recovery from CI logs.

After recipe for the refactor: run this same test on the handleAction-invert branch and compare; pass = no statistically meaningful median/p95 regression (run-to-run noise established by running the baseline twice).

Generated with Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784607932&installation_id=133855650&pr_number=6529&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6529&signature=25a0fbbf8be5d1237a34652efa1885472b867d01ae588882f9b4228dadbe0be1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI-friendly performance baseline for `GhosttyTerminalView` typing and render hot paths. This lets us verify the upcoming `handleAction` inversion doesn’t slow keystrokes or frames.

- **New Features**
  - Time `handleAction` dispatch for `RENDER`, `SCROLLBAR`, and `CELL_SIZE` as `terminal.handleAction.<case>`.
  - Add DEBUG control socket seams `debug.terminal.simulate_marked_text` and `debug.terminal.simulate_unmark_text` to exercise IME paths.
  - Add `GTVHotPathPerfUITests` to run keyDown, IME, and 4000-line render bursts, parse the tagged debug log, and emit median/p95 JSON for paths like `terminal.keyDown`, `terminal.setMarkedText`, and `terminal.handleAction.*`.

- **Bug Fixes**
  - Unmask typing/turn probe fields in the debug redactor: keep `path=` for typing probes and preserve keys like `elapsedMs`, `totalMs`, `turnMs`. Real filesystem `path=` remains redacted (with tests).
  - Refresh Swift file-length budget entries for touched files to satisfy CI.

<sup>Written for commit 69c74dff120072243999adcf813370a5e39f6829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

