### PR TITLE
Align group plus button trailing inset

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13663,7 +13663,7 @@ struct TabItemView: View, Equatable {
         // row is always animating, so the sidebar-wide layout re-runs at display
         // refresh rate (#5764 / #5845). Lazy rows must be height-stable after
         // they appear; content changes now apply in one discrete layout pass.
-        .padding(.horizontal, 10)
+        .padding(.horizontal, SidebarWorkspaceListMetrics.rowContentHorizontalPadding)
         .padding(.vertical, 8)
         .background(
             RoundedRectangle(cornerRadius: 6)
@@ -13691,7 +13691,7 @@ struct TabItemView: View, Equatable {
             fontSize: scaledFontSize(10)
         )
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
-        .padding(.horizontal, 6)
+        .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .background { rowHeightProbe }
         .contentShape(Rectangle())
         .opacity(isBeingDragged ? 0.6 : 1)

--- a/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderMetrics.swift
@@ -11,8 +11,9 @@ import CoreGraphics
 /// from one scaling path.
 ///
 /// The `base*` constants are the design sizes at the default sidebar font size,
-/// where ``SidebarTabItemFontScale/scale(for:)`` returns `1.0`. Every metric is
-/// the corresponding base value multiplied by ``fontScale``.
+/// where ``SidebarTabItemFontScale/scale(for:)`` returns `1.0`. Most metrics are
+/// the corresponding base value multiplied by ``fontScale``. Control frames keep
+/// a minimum hit size so they stay aligned with normal workspace row controls.
 ///
 /// ```swift
 /// let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: settings.sidebarFontScale)
@@ -50,8 +51,9 @@ struct SidebarWorkspaceGroupHeaderMetrics: Equatable {
     static let baseUnreadVerticalPadding: CGFloat = 1
     /// Plus-button glyph point size at the default sidebar font size.
     static let basePlusFontSize: CGFloat = 11
-    /// Plus-button frame edge at the default sidebar font size.
-    static let basePlusFrame: CGFloat = 18
+    /// Plus-button frame edge at the default sidebar font size. This matches the
+    /// normal workspace close-button frame so their centers share the same x-position.
+    static let basePlusFrame: CGFloat = 16
 
     /// Scaled chevron glyph point size.
     var chevronFontSize: CGFloat { Self.baseChevronFontSize * fontScale }
@@ -72,5 +74,5 @@ struct SidebarWorkspaceGroupHeaderMetrics: Equatable {
     /// Scaled plus-button glyph point size.
     var plusFontSize: CGFloat { Self.basePlusFontSize * fontScale }
     /// Scaled plus-button frame edge.
-    var plusFrame: CGFloat { Self.basePlusFrame * fontScale }
+    var plusFrame: CGFloat { max(Self.basePlusFrame, Self.basePlusFrame * fontScale) }
 }

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -70,7 +70,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onEditConfig: () -> Void
     let onOpenDocs: () -> Void
 
-    @State private var isHovered = false
+    @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
     @State private var rowHeight: CGFloat = 1
 
     private var metrics: SidebarWorkspaceGroupHeaderMetrics {
@@ -158,7 +158,10 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 defaultValue: "Focus the group's anchor workspace"
             )))
 
-            let plusVisible = isHovered && !showsShortcutHint
+            let plusVisible = rowInteractionState.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: showsShortcutHint
+            )
             Button(action: onTapPlus) {
                 Image(systemName: "plus")
                     .font(.system(size: metrics.plusFontSize, weight: .medium))
@@ -214,6 +217,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             }
         }
         .padding(.vertical, 5)
+        .padding(.trailing, SidebarWorkspaceListMetrics.rowContentHorizontalPadding)
         .contentShape(Rectangle())
         .background(
             isAnchorActive
@@ -227,7 +231,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             offsetX: shortcutHintXOffset,
             offsetY: shortcutHintYOffset
         )
-        .padding(.horizontal, 6)
+        .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .background { rowHeightProbe }
         .shortcutHintVisibilityAnimation(value: showsShortcutHint)
         .opacity(isBeingDragged ? 0.6 : 1)
@@ -238,12 +242,12 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 rowSpacing: rowSpacing
             )
         }
+        .overlay {
+            SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
+        }
         .onDrag(onDragStart)
         .internalOnlyTabDrag()
         .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: tabDropDelegateFactory(rowHeight))
-        .onHover { hovering in
-            isHovered = hovering
-        }
         .contextMenu {
             Button(
                 String(

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -49,8 +49,18 @@ enum RightSidebarChromeMetrics {
 enum SidebarWorkspaceListMetrics {
     static let firstRowTopOffset: CGFloat = MinimalModeChromeMetrics.titlebarHeight + 2
     static let rowVerticalPadding: CGFloat = 8
+    static let rowOuterHorizontalPadding: CGFloat = 6
+    static let rowContentHorizontalPadding: CGFloat = 10
     static let topScrimHeight: CGFloat = firstRowTopOffset + 20
     static let bottomScrimHeight: CGFloat = topScrimHeight
+
+    static var trailingAccessoryRightEdgeOffset: CGFloat {
+        rowOuterHorizontalPadding + rowContentHorizontalPadding
+    }
+
+    static func trailingAccessoryCenterOffset(controlWidth: CGFloat) -> CGFloat {
+        trailingAccessoryRightEdgeOffset + (controlWidth / 2)
+    }
 
     static var scrollTopInset: CGFloat {
         max(0, firstRowTopOffset - rowVerticalPadding)

--- a/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
+++ b/cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import CmuxFoundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -52,7 +53,7 @@ import Testing
         #expect(metrics.unreadHorizontalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadHorizontalPadding * scale)
         #expect(metrics.unreadVerticalPadding == SidebarWorkspaceGroupHeaderMetrics.baseUnreadVerticalPadding * scale)
         #expect(metrics.plusFontSize == SidebarWorkspaceGroupHeaderMetrics.basePlusFontSize * scale)
-        #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame * scale)
+        #expect(metrics.plusFrame == SidebarWorkspaceGroupHeaderMetrics.basePlusFrame)
     }
 
     @Test func headerAndRowFontScaleShareOneScalingPath() {
@@ -65,5 +66,36 @@ import Testing
 
         #expect(metrics.nameFontSize == SidebarWorkspaceGroupHeaderMetrics.baseNameFontSize * rowScale)
         #expect(rowScale > 1)
+    }
+
+    @Test func groupPlusAndWorkspaceCloseShareTrailingXPositions() {
+        let closeButtonWidth = SidebarTrailingAccessoryWidthPolicy().closeButtonWidth
+        let metrics = SidebarWorkspaceGroupHeaderMetrics(fontScale: 1)
+
+        #expect(SidebarWorkspaceListMetrics.rowContentHorizontalPadding == 10)
+        #expect(SidebarWorkspaceListMetrics.rowOuterHorizontalPadding == 6)
+        #expect(metrics.plusFrame == closeButtonWidth)
+        #expect(SidebarWorkspaceListMetrics.trailingAccessoryRightEdgeOffset == 16)
+        #expect(SidebarWorkspaceListMetrics.trailingAccessoryCenterOffset(controlWidth: metrics.plusFrame) == 24)
+        #expect(
+            SidebarWorkspaceListMetrics.trailingAccessoryCenterOffset(controlWidth: metrics.plusFrame)
+                == SidebarWorkspaceListMetrics.trailingAccessoryCenterOffset(controlWidth: closeButtonWidth)
+        )
+    }
+
+    @Test func groupPlusAndWorkspaceCloseStayAlignedWhenFontScaleChanges() {
+        for scale in [CGFloat(0.5), CGFloat(1), CGFloat(2)] {
+            let closeButtonWidth = max(
+                SidebarTrailingAccessoryWidthPolicy().closeButtonWidth,
+                SidebarWorkspaceGroupHeaderMetrics.basePlusFrame * scale
+            )
+            let plusButtonWidth = SidebarWorkspaceGroupHeaderMetrics(fontScale: scale).plusFrame
+
+            #expect(plusButtonWidth == closeButtonWidth)
+            #expect(
+                SidebarWorkspaceListMetrics.trailingAccessoryCenterOffset(controlWidth: plusButtonWidth)
+                    == SidebarWorkspaceListMetrics.trailingAccessoryCenterOffset(controlWidth: closeButtonWidth)
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Share sidebar row outer/content padding through `SidebarWorkspaceListMetrics`.
- Make the workspace group `+` use the same 16 px trailing accessory frame as the normal workspace `x`, so both right edge and center x-position match.
- Keep the group `+` hover-only, using the same AppKit hover tracker path as normal workspace row controls instead of SwiftUI `.onHover`.
- Add focused metric tests documenting the exact offsets and scaled-font behavior.

## Testing
- `git diff --check`
- Source-derived close-loop check: `sourceRightEdgeOffsetPx=16 sourcePlusCenterOffsetPx=24 sourceCloseCenterOffsetPx=24 sourceDeltaPx=0`
- `xcodebuild test -project cmux.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-gpplus -only-testing:cmuxTests/SidebarWorkspaceGroupHeaderMetricsTests` (blocked by local cmuxterm-hq guard)
- `./scripts/reload-cloud.sh --tag gpplus` (passed, GitHub Actions run https://github.com/manaflow-ai/cmux/actions/runs/27902995465)
- Tagged preflight: launched `gpplus`, verified `/tmp/cmux-debug-gpplus.sock` identifies `com.cmuxterm.app.debug.gpplus`, captured no-hover screenshot `gpplus-hover-only-no-plus_2026-06-21T11-38-40Z_4AC1B506.png` showing the group `+` hidden when not hovered.

## Issues
- Plain-text task: plus button on groups needs to be the same px from right as the x button on normal workspaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar layout and hover-only UI polish with no auth, data, or business-logic changes; risk is limited to visual alignment and plus-button discoverability on group headers.
> 
> **Overview**
> **Aligns the workspace group “+” with the normal row close (“×”) on the trailing edge** by centralizing sidebar row padding in `SidebarWorkspaceListMetrics` and applying those values to workspace rows (`ContentView`) and group headers (`SidebarWorkspaceGroupHeaderView`).
> 
> The group plus control frame drops from **18px to 16px** to match `SidebarTrailingAccessoryWidthPolicy` close width, with **`plusFrame` clamped to a minimum** at small font scales so hit targets stay aligned. New helpers (`trailingAccessoryRightEdgeOffset`, `trailingAccessoryCenterOffset`) document the shared **16px right edge / 24px center** geometry.
> 
> Group header **plus visibility** now follows the same path as row close buttons: `SidebarWorkspaceRowInteractionState` + `SidebarWorkspaceRowHoverTracker` (replacing raw `onHover`), hiding the plus when shortcut hints are active. Tests lock in padding values and plus/close alignment across font scales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c13b2a30757d79d1dfe6e82f5506a284851949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style / UI**
  * Standardized workspace sidebar horizontal padding using shared layout metrics for both inner content and outer row spacing.
  * Updated the group-header “plus” button to use interaction-driven visibility (replacing hover-based logic) and adjusted related spacing.
  * Refined “plus” button sizing to enforce a minimum hit target across font scales.
* **Tests**
  * Updated metric expectations and added coverage to ensure geometric alignment between the group-header “plus” and the workspace row close accessory across font scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->