### PR TITLE
Keep iOS composer pinned while growing

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -194,12 +194,19 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// sizes the surface band.
         @MainActor
         private func makeComposerController(store: CMUXMobileShellStore) -> UIHostingController<TerminalComposerView> {
-            let view = TerminalComposerView(store: store, terminalID: surfaceID) { [weak self] in
+            let view = TerminalComposerView(
+                store: store,
+                terminalID: surfaceID,
+                requestHeightRemeasure: { [weak self] in
                 // Content changed (a line added/removed, attachment row changed, or
                 // cleared after send): apply immediately so the composer bottom stays
                 // pinned to the keyboard and only the top edge moves.
                 self?.reportComposerHeight(animated: false)
-            }
+                },
+                onFocusChange: { [weak self] focused in
+                    self?.surfaceView?.setComposerFieldFocused(focused)
+                }
+            )
             let controller = UIHostingController(rootView: view)
             // The field is pinned edge-to-edge in the band, so the band frame (not an
             // intrinsic size) drives the hosting view's height; the measured ideal

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -165,8 +165,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 composerController = controller
                 surfaceView.mountComposerView(controller.view)
                 // The field opens at one line; report its initial height without
-                // animation (the composer's open transition already animates), then
-                // live grows/shrinks animate.
+                // animation. Live text/attachment grows also apply without animation
+                // so the bottom edge stays pinned to the keyboard.
                 reportComposerHeight(animated: false)
             } else {
                 // Symmetric close: animate the band to 0 with the field STILL
@@ -195,10 +195,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         @MainActor
         private func makeComposerController(store: CMUXMobileShellStore) -> UIHostingController<TerminalComposerView> {
             let view = TerminalComposerView(store: store, terminalID: surfaceID) { [weak self] in
-                // Content changed (a line added/removed, or cleared after send): live
-                // grows/shrinks animate. `setComposerBandHeight` is idempotent on
-                // unchanged heights, so a no-op change is harmless.
-                self?.reportComposerHeight(animated: true)
+                // Content changed (a line added/removed, attachment row changed, or
+                // cleared after send): apply immediately so the composer bottom stays
+                // pinned to the keyboard and only the top edge moves.
+                self?.reportComposerHeight(animated: false)
             }
             let controller = UIHostingController(rootView: view)
             // The field is pinned edge-to-edge in the band, so the band frame (not an
@@ -214,8 +214,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// current (pinned) frame, so it is not circular: the band height is set FROM
         /// this measurement, and the measurement does not depend on the band height.
         /// The proposed width is the surface width and the proposed height is unbounded
-        /// so a multi-line field measures its full desired height (capped to 14 lines by
-        /// the field's own `lineLimit`).
+        /// so a multi-line field measures its full desired height. The field's own
+        /// `lineLimit` and the surface's available-terminal-height cap bound the result.
         @MainActor
         private func reportComposerHeight(animated: Bool) {
             guard let controller = composerController, let surfaceView else { return }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -32,7 +32,7 @@ import UniformTypeIdentifiers
 /// the surface's composer band, directly above the always-visible accessory toolbar.
 /// The view reports its measured height through ``onHeightChange`` so the surface can
 /// reserve exactly that much above the toolbar; a field-grow therefore pushes ONLY the
-/// terminal up while the toolbar and keyboard below stay put. There is no
+/// terminal up without animating the keyboard-pinned bottom edge. There is no
 /// `safeAreaInset` and no toolbar handoff — the prior rounds' two-layout-systems fight
 /// is gone because there is only one layout system (the surface).
 struct TerminalComposerView: View {
@@ -42,9 +42,10 @@ struct TerminalComposerView: View {
     /// observes the same token, so only the view whose terminal matches the
     /// request's target may consume it and focus.
     let terminalID: String
-    /// Asks the host to re-measure and re-size the surface's composer band. Fired
-    /// whenever the field's content changes (the only driver of this view's height);
-    /// the host measures the ideal height via `sizeThatFits` and animates the band.
+/// Asks the host to re-measure and re-size the surface's composer band. Fired
+/// whenever the field's content changes (the only driver of this view's height);
+    /// the host measures the ideal height via `sizeThatFits` and applies it without a
+    /// steady-state animation.
     let requestHeightRemeasure: () -> Void
     @FocusState private var isFieldFocused: Bool
     /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
@@ -297,9 +298,9 @@ struct TerminalComposerView: View {
                         text: $store.terminalInputText,
                         axis: .vertical
                     )
-                    // Opens at a single line and grows up to 14 lines so a long message has
-                    // room. Each added line grows this view, which the host reserves above the
-                    // always-visible toolbar; the toolbar and keyboard never move.
+                    // Opens at a single line and grows up to 14 lines, further bounded by
+                    // the surface's available terminal height. Each added line grows this
+                    // view upward; the toolbar and keyboard never move.
                     .lineLimit(composerLineLimit)
                     // Natural-language to an agent, so normal iOS text assistance
                     // is on (autocorrect, sentence-case, spell check). The raw

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -47,6 +47,7 @@ struct TerminalComposerView: View {
     /// the host measures the ideal height via `sizeThatFits` and applies it without a
     /// steady-state animation.
     let requestHeightRemeasure: () -> Void
+    let onFocusChange: (Bool) -> Void
     @FocusState private var isFieldFocused: Bool
     /// Photo-picker selection bound to the system `PhotosPicker`. Cleared after
     /// each batch is encoded and staged so re-picking the same image fires again.
@@ -71,10 +72,16 @@ struct TerminalComposerView: View {
     /// `state` it reads (mic button enabled/listening) automatically.
     @State private var dictation = ComposerDictationController()
 
-    init(store: CMUXMobileShellStore, terminalID: String, requestHeightRemeasure: @escaping () -> Void) {
+    init(
+        store: CMUXMobileShellStore,
+        terminalID: String,
+        requestHeightRemeasure: @escaping () -> Void,
+        onFocusChange: @escaping (Bool) -> Void
+    ) {
         self.store = store
         self.terminalID = terminalID
         self.requestHeightRemeasure = requestHeightRemeasure
+        self.onFocusChange = onFocusChange
     }
 
     /// Single-line height of the round attach button beside the field. It stays
@@ -209,6 +216,7 @@ struct TerminalComposerView: View {
             // on the incoming composer) or merely looking at the default-open
             // field (keyboard stays down).
             store.composerFieldFocusChanged(focused)
+            onFocusChange(focused)
             // The field losing focus stops dictation gracefully (the user moved on
             // but keeps the draft, so the last words are finalized into it). Skip
             // this when dictation itself owns the field: locking it (.disabled

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1142,10 +1142,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// separately above the keyboard edge, never by reparenting the toolbar into a
     /// second layout system.
     private var composerActive = false
-    /// Whether the hosted composer text field owns first responder. While true, the
-    /// terminal shortcut toolbar is hidden and does not reserve grid height; the user
-    /// is composing a message, so the keyboard-pinned message field gets the whole
-    /// bottom dock instead of being squeezed by terminal shortcuts.
+    /// Whether the hosted composer text field owns first responder. The SwiftUI host
+    /// reports this for diagnostics and for the close/reveal reducer, but toolbar
+    /// reservation keys on the broader `composerActive && keyboardHeight > 0` state:
+    /// the screenshot repro had the keyboard owned by the terminal proxy while the
+    /// composer was visible, so a focus-only rule missed the bad layout.
     private var composerFieldFocused = false
     /// The composer band: a surface-owned container the host installs the SwiftUI
     /// compose field into (via a `UIHostingController` in
@@ -1200,6 +1201,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // keyboard comes up. Done before the frame animation so it animates in
         // with the keyboard instead of popping after.
         if wasDown { updateDockedToolbarVisibility() }
+        if composerActive {
+            focusMountedComposerField()
+            updateDockedToolbarVisibility()
+        }
         animateDockedToolbar(with: notification)
         setNeedsGeometrySync()
     }
@@ -1330,12 +1335,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Whether the terminal shortcut toolbar is currently on screen.
     ///
-    /// The explicit HIDE button suppresses all bottom chrome. Composer focus hides
-    /// only the terminal shortcut toolbar: the composer remains visible and pinned to
-    /// the keyboard, but the terminal-only shortcuts stop consuming vertical space
-    /// while the user is writing a message.
+    /// The explicit HIDE button suppresses all bottom chrome. Composer plus keyboard
+    /// hides only the terminal shortcut toolbar: the composer remains visible and
+    /// pinned to the keyboard, but terminal-only shortcuts stop consuming vertical
+    /// space while the user is writing a message. This intentionally uses keyboard
+    /// state, not only text-field focus, because the terminal proxy can briefly own
+    /// first responder while the message field is visible.
     private var dockedToolbarShouldBeVisible: Bool {
-        !chromeHidden && !(composerActive && composerFieldFocused)
+        !chromeHidden && !(composerActive && keyboardHeight > 0)
     }
 
     /// True while the HIDE button has temporarily suppressed the bottom chrome
@@ -1527,8 +1534,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     /// Update whether the hosted composer field owns first responder. The SwiftUI
     /// host reports this explicitly because the surface cannot observe `@FocusState`
-    /// directly. Focused composer input hides the terminal shortcut toolbar, leaving
-    /// the message field pinned to the keyboard with no competing control strip.
+    /// directly. Focus changes still trigger a dock refresh so the reducer probe and
+    /// frame state converge as soon as SwiftUI focus catches up with UIKit.
     public func setComposerFieldFocused(_ focused: Bool) {
         guard composerFieldFocused != focused else { return }
         composerFieldFocused = focused

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1137,10 +1137,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private weak var dockedToolbar: UIView?
     /// Whether the iMessage-style composer is currently open. The surface owns the
     /// whole bottom dock (terminal grid / toolbar / composer band / keyboard) in one
-    /// coordinate system, so `composerActive` drives only the first-responder handover
-    /// that keeps the keyboard up across the toggle. The composer band is reserved
-    /// separately above the keyboard edge, never by reparenting the toolbar into a
-    /// second layout system.
+    /// coordinate system. While this is true, the composer is the only text input
+    /// owner: terminal auto-focus and terminal taps route focus back to the composer
+    /// instead of letting the hidden terminal proxy keep first responder behind a
+    /// visible message field.
     private var composerActive = false
     /// Whether the hosted composer text field owns first responder. The SwiftUI host
     /// reports this for diagnostics and for the close/reveal reducer, but toolbar
@@ -1442,8 +1442,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         setNeedsGeometrySync()
     }
 
-    /// Track whether the composer is open and keep the keyboard up across the
-    /// draft↔normal toggle in BOTH directions.
+    /// Track whether the composer is open and keep keyboard ownership explicit across
+    /// the draft↔normal toggle in BOTH directions.
     ///
     /// The surface owns the whole bottom dock (terminal grid / composer band /
     /// toolbar / keyboard) in one coordinate system; the toolbar is never reparented
@@ -1451,10 +1451,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// only job here is the first-responder handover that keeps the keyboard from
     /// dropping across the toggle:
     ///
-    /// - Opening (`active == true`): deliberately do NOT resign the terminal input
-    ///   proxy. The composer's hosted text field becomes first responder while this
-    ///   keyboard is still up, so iOS hands the keyboard over in place. Resigning
-    ///   first tore the keyboard down and the composer re-summoned it (a flicker).
+    /// - Opening (`active == true`): the composer becomes the text-input owner. The
+    ///   terminal proxy must not continue receiving keyboard events behind a visible
+    ///   message field; the mounted composer is focused as soon as its host view exists.
     /// - Closing (`active == false`): two distinct intents share this path, told
     ///   apart by ``keyboardHeight``:
     ///   - Chevron-close while typing: `keyboardHeight > 0`. The user wants to keep the
@@ -1477,13 +1476,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             composerFieldFocused = false
         }
         if active {
-            // Opening: deliberately do NOT resign the terminal input proxy. The
-            // composer's hosted text field becomes first responder while this
-            // keyboard is still up, so iOS hands the keyboard over in place. The
-            // toolbar stays a child of this surface throughout — it is never
-            // reparented — so its buttons remain on screen. The composer band's
-            // height arrives separately via `setComposerBandHeight(_:animated:)` once
-            // the host mounts and measures the field.
+            // Opening: composer owns text input. Do not let the hidden terminal proxy
+            // keep accepting key events while the message field is visible; the host
+            // mount path below focuses the concrete SwiftUI-backed input once it exists.
+            if inputProxy.isFirstResponder {
+                resignInput()
+            }
+            focusMountedComposerField()
         } else {
             // Closing: re-take first responder on the terminal input proxy ONLY when the
             // keyboard is still up (`keyboardHeight > 0`, a chevron-close while typing) so
@@ -1499,10 +1498,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 inputProxy.becomeFirstResponder()
             }
         }
-        // The toolbar's visibility and reserved height do not change with the composer
-        // (it stays shown while the keyboard is up either way), so re-seat the whole
-        // bottom dock and re-sync the grid unconditionally: the composer band opening
-        // or closing changes where the terminal grid bottom and the dock sit.
+        // Re-seat the whole bottom dock and re-sync the grid unconditionally: the
+        // composer band opening or closing changes where the terminal grid bottom and
+        // the dock sit.
         updateDockedToolbarVisibility()
         layoutBottomDock()
         setNeedsGeometrySync()
@@ -1675,6 +1673,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             view.bottomAnchor.constraint(equalTo: composerContainer.bottomAnchor),
         ])
         composerContainer.isHidden = false
+        if composerActive {
+            focusMountedComposerField()
+        }
     }
 
     /// Set the height (points) the open composer band reserves below the docked
@@ -1707,6 +1708,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             guard let self else { return }
             self.layoutBottomDock()
             self.layoutIfNeeded()
+            if self.composerActive {
+                self.focusMountedComposerField()
+            }
         }
         if animated {
             UIView.animate(
@@ -1939,10 +1943,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         delegate?.ghosttySurfaceView(self, didTapAtCol: cell.col, row: cell.row)
         // A tap inside the composer band is excluded by the gesture recognizer
         // (`gestureRecognizer(_:shouldReceive:)`), so any tap reaching here is a
-        // deliberate terminal tap. Only a reveal-from-hide with the composer still
-        // presented re-focuses the composer; every other terminal tap focuses the
-        // terminal proxy as before.
-        if wasHidden, composerActive {
+        // deliberate terminal tap. While the composer is visible, it remains the text
+        // input owner; closing it is the explicit path back to terminal keyboard input.
+        if composerActive {
             delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
             focusMountedComposerField()
         } else {
@@ -2201,7 +2204,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             #endif
             setNeedsGeometrySync()
             setFocus(true)
-            if autoFocusOnWindowAttach {
+            if autoFocusOnWindowAttach, !composerActive {
                 focusInput()
             }
             startDisplayLink()
@@ -2364,6 +2367,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     @objc
     func focusInput() {
         onFocusInputRequestedForTesting?()
+        if composerActive {
+            delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+            focusMountedComposerField()
+            return
+        }
         Self.activeInputSurface = self
         setNeedsGeometrySync()
         inputProxy.updateAccessoryLayoutInsets()

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1136,14 +1136,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// edge (up) or above the home indicator (down).
     private weak var dockedToolbar: UIView?
     /// Whether the iMessage-style composer is currently open. The surface owns the
-    /// whole bottom dock (terminal grid / toolbar / composer band / keyboard) in ONE
-    /// coordinate system, so `composerActive` only drives the first-responder
-    /// handover that keeps the keyboard up across the toggle. It deliberately does
-    /// NOT gate the toolbar's visibility (the bar stays visible while composing) and
-    /// does NOT alter the keyboard occupancy math: the composer band is reserved
-    /// SEPARATELY (``composerBandHeight``) above the keyboard edge, never by
-    /// reparenting the toolbar into a second layout system.
+    /// whole bottom dock (terminal grid / toolbar / composer band / keyboard) in one
+    /// coordinate system, so `composerActive` drives only the first-responder handover
+    /// that keeps the keyboard up across the toggle. The composer band is reserved
+    /// separately above the keyboard edge, never by reparenting the toolbar into a
+    /// second layout system.
     private var composerActive = false
+    /// Whether the hosted composer text field owns first responder. While true, the
+    /// terminal shortcut toolbar is hidden and does not reserve grid height; the user
+    /// is composing a message, so the keyboard-pinned message field gets the whole
+    /// bottom dock instead of being squeezed by terminal shortcuts.
+    private var composerFieldFocused = false
     /// The composer band: a surface-owned container the host installs the SwiftUI
     /// compose field into (via a `UIHostingController` in
     /// `GhosttySurfaceRepresentable`, which can see both layers; the terminal package
@@ -1325,16 +1328,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// clipped by the terminal render bounds (item 6). Below the zoom HUD (1100).
     private static let bottomChromeZPosition: CGFloat = 1000
 
-    /// Whether the always-visible bottom chrome (the docked accessory toolbar and,
-    /// when open, the composer band) is currently on screen.
+    /// Whether the terminal shortcut toolbar is currently on screen.
     ///
-    /// Round 8 makes the toolbar ALWAYS visible — terminal mode, composer mode,
-    /// keyboard up AND down — so the only thing that hides it is the explicit HIDE
-    /// button (``chromeHidden``). The toolbar is no longer keyboard-tied. When the
-    /// keyboard is down the toolbar (and any open composer) ride above the bottom
-    /// safe area instead of disappearing; see ``bottomChromeInset``.
+    /// The explicit HIDE button suppresses all bottom chrome. Composer focus hides
+    /// only the terminal shortcut toolbar: the composer remains visible and pinned to
+    /// the keyboard, but the terminal-only shortcuts stop consuming vertical space
+    /// while the user is writing a message.
     private var dockedToolbarShouldBeVisible: Bool {
-        !chromeHidden
+        !chromeHidden && !(composerActive && composerFieldFocused)
     }
 
     /// True while the HIDE button has temporarily suppressed the bottom chrome
@@ -1382,12 +1383,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let reserved: CGFloat = shouldShow ? Self.persistentToolbarHeight : 0
         guard dockedToolbar?.isHidden != !shouldShow || reservedToolbarHeight != reserved else { return }
         dockedToolbar?.isHidden = !shouldShow
-        // The composer band rides with the toolbar: hide it when the chrome is
-        // suppressed, show it again when the chrome returns and a field is mounted.
-        // Its frame already collapses to `.zero` while hidden (see
-        // ``bottomDockFrames()``); toggling `isHidden` also stops it intercepting taps.
-        composerContainer.isHidden = !shouldShow || composerContainer.subviews.isEmpty
+        // Composer visibility is tied to the global chrome hide state, not to the
+        // terminal toolbar. While composing, the toolbar may be hidden but the field
+        // must stay mounted and keyboard-pinned.
+        composerContainer.isHidden = chromeHidden || composerContainer.subviews.isEmpty
         reservedToolbarHeight = reserved
+        layoutBottomDock()
         setNeedsGeometrySync()
         setNeedsLayout()
     }
@@ -1465,6 +1466,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func setComposerActive(_ active: Bool) {
         guard composerActive != active else { return }
         composerActive = active
+        if !active {
+            composerFieldFocused = false
+        }
         if active {
             // Opening: deliberately do NOT resign the terminal input proxy. The
             // composer's hosted text field becomes first responder while this
@@ -1519,6 +1523,19 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             c: inputProxy.isFirstResponder ? 1 : 0
         ))
         #endif
+    }
+
+    /// Update whether the hosted composer field owns first responder. The SwiftUI
+    /// host reports this explicitly because the surface cannot observe `@FocusState`
+    /// directly. Focused composer input hides the terminal shortcut toolbar, leaving
+    /// the message field pinned to the keyboard with no competing control strip.
+    public func setComposerFieldFocused(_ focused: Bool) {
+        guard composerFieldFocused != focused else { return }
+        composerFieldFocused = focused
+        updateDockedToolbarVisibility()
+        clampComposerBandHeightToAvailableSpace()
+        layoutBottomDock()
+        setNeedsGeometrySync()
     }
 
     /// Whether the composer's hosted field currently holds first responder.
@@ -1637,7 +1654,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public func mountComposerView(_ view: UIView?) {
         composerContainer.subviews.forEach { $0.removeFromSuperview() }
         guard let view else {
+            composerFieldFocused = false
             composerContainer.isHidden = true
+            updateDockedToolbarVisibility()
             return
         }
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -1727,14 +1746,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// docked toolbar, and the keyboard top stack consistently in the surface's single
     /// coordinate system.
     ///
-    /// Round 8 stack, from the BOTTOM up: the keyboard (or, keyboard-down, the bottom
-    /// safe area) occupies `keyboardOccupancyInBounds` at the surface bottom; the
-    /// composer band (when open) sits directly above that; the toolbar button band
-    /// sits directly above the composer; the terminal grid fills the rest. So the
-    /// visual order top→bottom is `terminal / toolbar / composer / keyboard` (item 1).
-    /// This is the inverse of Round 7 (toolbar-on-keyboard, composer-above-toolbar):
-    /// the composer is now the chrome closest to the keyboard, with the always-visible
-    /// toolbar above it.
+    /// Stack, from the bottom up: the keyboard (or, keyboard-down, the bottom safe
+    /// area) occupies `keyboardOccupancyInBounds`; the composer band sits directly
+    /// above that when open; the terminal shortcut toolbar sits above the composer
+    /// only when it is visible; the terminal grid fills the rest. While the composer
+    /// field is focused, the toolbar frame collapses to zero so the message field is
+    /// the only bottom chrome above the keyboard.
     ///
     /// The toolbar's button row is bottom-pinned inside its container (see
     /// `TerminalInputTextView.dockedButtonRowHeight`), so the controls always hug the
@@ -1759,6 +1776,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let bottomEdge = chromeHidden ? bounds.height : bounds.height - occupied
         let width = bounds.width
         let effectiveComposerHeight = chromeHidden ? 0 : composerBandHeight
+        let effectiveToolbarHeight = chromeHidden ? 0 : reservedToolbarHeight
         // Composer band sits directly above the keyboard (or the safe-area inset),
         // pinned to the bottom edge; the toolbar's button band reserves
         // `persistentToolbarHeight` directly above the composer. At height 0 the band
@@ -1768,9 +1786,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let composerTop = bottomEdge - effectiveComposerHeight
         let composerFrame = CGRect(x: 0, y: max(0, composerTop), width: width, height: effectiveComposerHeight)
         // Toolbar's reserved bottom is the composer's top (or the bottom edge with no
-        // composer), and its reserved top is one button-row band above that.
+        // composer), and its reserved top is one visible button-row band above that.
         let toolbarBottom = effectiveComposerHeight > 0 ? composerTop : bottomEdge
-        let toolbarReservedTop = toolbarBottom - Self.persistentToolbarHeight
+        let toolbarReservedTop = toolbarBottom - effectiveToolbarHeight
         // Toolbar top: with a composer band below, the toolbar container is exactly its
         // button band (no slack to absorb — the composer owns the space below). Without
         // a composer, let the top float up to the rendered terminal's bottom so the
@@ -1779,7 +1797,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // or above `toolbarReservedTop`). Never drop below `toolbarReservedTop` (that
         // would re-open the gap) and never go negative.
         let toolbarTop: CGFloat
-        if effectiveComposerHeight > 0 {
+        if effectiveToolbarHeight == 0 {
+            toolbarTop = toolbarBottom
+        } else if effectiveComposerHeight > 0 {
             toolbarTop = max(0, toolbarReservedTop)
         } else {
             let renderBottom = lastRenderRect.isEmpty ? toolbarReservedTop : lastRenderRect.maxY

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -755,6 +755,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // full height; the test compares the gap, not equality.
             "renderHeight=\(Int(lastRenderRect.height))",
             "boundsHeight=\(Int(bounds.height))",
+            "composerBandHeight=\(Int(composerBandHeight))",
+            "composerMaxHeight=\(Int(maximumComposerBandHeight))",
             inputProxy.accessoryLayoutDiagnostics,
         ].joined(separator: ";")
     }
@@ -1161,6 +1163,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// above it upward while the band stays pinned to the keyboard — the keyboard
     /// itself never moves.
     private var composerBandHeight: CGFloat = 0
+    /// Keep at least this much terminal visible above the composer. Past the cap,
+    /// the composer field scrolls internally instead of eating the whole viewport.
+    private static let minimumVisibleTerminalHeightAboveComposer: CGFloat = 160
     /// True once SwiftUI has dismantled the hosting representable for this
     /// surface. A dismantled surface performs no render, output, or
     /// accessibility work so a view SwiftUI has removed cannot keep driving the
@@ -1186,6 +1191,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard overlap != keyboardHeight else { return }
         let wasDown = keyboardHeight == 0
         keyboardHeight = overlap
+        clampComposerBandHeightToAvailableSpace()
         inputProxy.setKeyboardShown(true)
         // The bar is keyboard-tied: reveal it (and reserve its grid height) as the
         // keyboard comes up. Done before the frame animation so it animates in
@@ -1214,6 +1220,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         #endif
         keyboardHeight = 0
+        clampComposerBandHeightToAvailableSpace()
         inputProxy.setKeyboardShown(false)
         // Round 8 removes the `composerPresented ⇒ keyboardUp` enforcement: the
         // toolbar is ALWAYS visible and the composer band survives a keyboard-down, so
@@ -1647,24 +1654,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Set the height (points) the open composer band reserves below the docked
     /// toolbar, from the hosted compose field's intrinsic content size. Drives the
     /// grid reservation (so a field-grow pushes only the terminal up) and the dock
-    /// layout. When `animated`, the reservation + reflow run inside a `UIView.animate`
-    /// using the keyboard curve so the height change reads as one smooth motion with
-    /// the rest of the dock (item 3/4). Idempotent: a no-op when the height is
-    /// unchanged (then `completion` runs immediately so an unmount-on-close never
-    /// strands the mounted field).
+    /// layout. Live content changes apply without animation so the bottom edge stays
+    /// pinned to the keyboard; `animated` remains for presentation transitions such as
+    /// closing the composer. Idempotent: a no-op when the height is unchanged (then
+    /// `completion` runs immediately so an unmount-on-close never strands the mounted
+    /// field).
     ///
     /// - Parameters:
     ///   - height: The compose field's measured height, clamped to non-negative.
-    ///   - animated: Whether to animate the reflow (true for a live grow/shrink as the
-    ///     user types and for the symmetric close; false for the initial mount, where
-    ///     the open transition already animates).
+    ///   - animated: Whether to animate the reflow. Content growth passes false; the
+    ///     symmetric close path passes true so the field remains mounted while the band
+    ///     collapses.
     ///   - completion: Run after the reflow lands. The close path passes the field
     ///     unmount here so the band animates to 0 with the field STILL mounted (item 3:
     ///     a symmetric, coordinated close), and the field is removed only once the band
     ///     has collapsed — reversing the round-7 order that unmounted first and left the
     ///     band collapsing over empty space (the janky close).
     public func setComposerBandHeight(_ height: CGFloat, animated: Bool, completion: (() -> Void)? = nil) {
-        let clamped = max(0, height)
+        let clamped = clampedComposerBandHeight(height)
         guard abs(clamped - composerBandHeight) > 0.5 else {
             completion?()
             return
@@ -1690,10 +1697,30 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         setNeedsGeometrySync()
     }
 
-    /// Duration (seconds) of the composer band grow/shrink reflow. Matches the system
-    /// keyboard's default animation duration so a field-grow reads as one smooth
-    /// motion with the dock; the keyboard show/hide reflow uses the notification's own
-    /// curve/duration (``animateDockedToolbar(with:)``).
+    private var maximumComposerBandHeight: CGFloat {
+        TerminalLetterboxGeometry.maximumComposerBandHeight(
+            bounds: bounds.size,
+            keyboardHeight: keyboardHeight,
+            toolbarHeight: reservedToolbarHeight,
+            bottomSafeAreaInset: safeAreaInsetsBottom,
+            minimumTerminalHeight: Self.minimumVisibleTerminalHeightAboveComposer
+        )
+    }
+
+    private func clampedComposerBandHeight(_ height: CGFloat) -> CGFloat {
+        min(max(0, height), maximumComposerBandHeight)
+    }
+
+    private func clampComposerBandHeightToAvailableSpace() {
+        guard !chromeHidden else { return }
+        let clamped = clampedComposerBandHeight(composerBandHeight)
+        guard abs(clamped - composerBandHeight) > 0.5 else { return }
+        composerBandHeight = clamped
+    }
+
+    /// Duration (seconds) of composer presentation reflows. Live text height changes
+    /// do not use this; keyboard show/hide uses the notification's own curve/duration
+    /// (``animateDockedToolbar(with:)``).
     private static let composerReflowDuration: TimeInterval = 0.25
 
     /// Frames for the whole bottom dock, computed together so the composer band, the
@@ -2113,6 +2140,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         #endif
         inputProxy.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 1)
         inputProxy.updateAccessoryLayoutInsets()
+        clampComposerBandHeightToAvailableSpace()
         layoutBottomDock()
         layoutZoomOverlay()
         MobileDebugLog.anchormux("surface.layout bounds=\(Int(bounds.width))x\(Int(bounds.height)) window=\(window != nil)")
@@ -2130,6 +2158,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// next unrelated relayout.
     public override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
+        clampComposerBandHeightToAvailableSpace()
         layoutBottomDock()
         setNeedsGeometrySync()
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/UIView+FirstResponderSearch.swift
@@ -28,8 +28,8 @@ extension UIView {
         return nil
     }
 
-    /// Returns the first focusable text input (`UITextField` / `UITextView`)
-    /// within this view's subtree (including `self`), or `nil` when none exists.
+    /// Returns the first focusable text input within this view's subtree
+    /// (including `self`), or `nil` when none exists.
     ///
     /// Used as the deterministic UIKit focus path for the composer band: SwiftUI's
     /// programmatic `@FocusState` set can be dropped for a field hosted inside a
@@ -39,7 +39,12 @@ extension UIView {
     /// short-circuits on the first match, main-actor (UIKit).
     @MainActor
     func firstFocusableTextInputInSubtree() -> UIView? {
-        if (self is UITextField || self is UITextView), canBecomeFirstResponder {
+        let isTextInput =
+            self is UITextField ||
+            self is UITextView ||
+            self is any UITextInput ||
+            self is any UIKeyInput
+        if isTextInput, canBecomeFirstResponder {
             return self
         }
         for subview in subviews {

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -99,6 +99,28 @@ public struct TerminalLetterboxGeometry {
         return CGSize(width: containerW, height: containerH)
     }
 
+    /// Maximum composer height that still leaves a useful terminal viewport.
+    ///
+    /// The composer is bottom-pinned above the keyboard/safe-area and the toolbar
+    /// sits above it. Once the composer reaches this height, further text growth
+    /// must scroll inside the field instead of pushing the terminal completely off
+    /// screen.
+    public static func maximumComposerBandHeight(
+        bounds: CGSize,
+        keyboardHeight: CGFloat,
+        toolbarHeight: CGFloat,
+        bottomSafeAreaInset: CGFloat,
+        minimumTerminalHeight: CGFloat
+    ) -> CGFloat {
+        let occupancy = keyboardOccupancy(
+            keyboardHeight: keyboardHeight,
+            bottomSafeAreaInset: bottomSafeAreaInset
+        )
+        let nonComposerBottomReserve = max(0, toolbarHeight) + occupancy
+        let availableAboveBottomDock = max(0, bounds.height - nonComposerBottomReserve)
+        return max(0, availableAboveBottomDock - max(1, minimumTerminalHeight))
+    }
+
     /// Resolve the bottom safe-area inset, preferring the view's own inset and
     /// falling back to the window's when the view inset is zero (it can be zero
     /// before the view is on a window, and STALE for one layout pass right after

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -259,6 +259,52 @@ struct TerminalLetterboxGeometryTests {
         #expect(TerminalLetterboxGeometry.keyboardOccupancy(keyboardHeight: 0, bottomSafeAreaInset: -10) == 0)
     }
 
+    @Test("composer height cap leaves the minimum terminal viewport above keyboard and toolbar")
+    func composerHeightCapLeavesTerminalVisible() {
+        let cap = TerminalLetterboxGeometry.maximumComposerBandHeight(
+            bounds: Self.phoneBounds,
+            keyboardHeight: Self.keyboard,
+            toolbarHeight: Self.toolbar,
+            bottomSafeAreaInset: Self.homeIndicator,
+            minimumTerminalHeight: 160
+        )
+        #expect(cap == 874 - Self.keyboard - Self.toolbar - 160)
+
+        let terminal = TerminalLetterboxGeometry.terminalContainerSize(
+            bounds: Self.phoneBounds,
+            keyboardHeight: Self.keyboard,
+            composerBandHeight: cap,
+            toolbarHeight: Self.toolbar,
+            bottomSafeAreaInset: Self.homeIndicator,
+            chromeHidden: false
+        )
+        #expect(terminal.height == 160)
+    }
+
+    @Test("composer height cap uses safe area instead of keyboard while keyboard is down")
+    func composerHeightCapKeyboardDownUsesSafeArea() {
+        let cap = TerminalLetterboxGeometry.maximumComposerBandHeight(
+            bounds: Self.phoneBounds,
+            keyboardHeight: 0,
+            toolbarHeight: Self.toolbar,
+            bottomSafeAreaInset: Self.homeIndicator,
+            minimumTerminalHeight: 160
+        )
+        #expect(cap == 874 - Self.homeIndicator - Self.toolbar - 160)
+    }
+
+    @Test("composer height cap preserves remembered height while chrome is hidden")
+    func composerHeightCapIgnoresChromeHiddenState() {
+        let cap = TerminalLetterboxGeometry.maximumComposerBandHeight(
+            bounds: Self.phoneBounds,
+            keyboardHeight: Self.keyboard,
+            toolbarHeight: Self.toolbar,
+            bottomSafeAreaInset: Self.homeIndicator,
+            minimumTerminalHeight: 160
+        )
+        #expect(cap == 874 - Self.keyboard - Self.toolbar - 160)
+    }
+
     @Test("resolved safe-area inset distrusts a stale-zero view inset")
     func resolvedSafeAreaPrefersWindowWhenViewIsZero() {
         // Right after the keyboard hides, the view's own safeAreaInsets.bottom

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1426,6 +1426,56 @@ final class cmuxUITests: XCTestCase {
         assertDockCoherent(in: app, cycle: 1)
     }
 
+    /// Adding newlines should grow the composer upward from the keyboard edge, then
+    /// cap and scroll internally instead of eating the whole terminal viewport.
+    @MainActor
+    func testComposerGrowthStaysBottomPinnedAndCapped() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 8))
+
+        let composeButton = app.buttons[Composer.composeButton]
+        composeButton.tap()
+        let field = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(field.waitForExistence(timeout: 4))
+        waitForDock(in: app, describe: "OPEN: fieldFocused=1 before multiline typing") {
+            $0["composerActive"] == "1" && $0["fieldFocused"] == "1"
+        }
+
+        field.typeText("one")
+        _ = waitForDock(in: app, describe: "one line typed") { _ in
+            (self.storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? 0) >= 3
+        }
+        let oneLineFrame = field.frame
+
+        let longDraft = (2...30).map { "line \($0)" }.joined(separator: "\n")
+        field.typeText("\n" + longDraft)
+        let dock = waitForDock(in: app, timeout: 8, describe: "multiline draft typed and capped") { surface in
+            guard let bandHeight = surface["composerBandHeight"].flatMap(Int.init),
+                  let maxHeight = surface["composerMaxHeight"].flatMap(Int.init) else {
+                return false
+            }
+            let draftLength = self.storeComposer(in: app)["draftLength"].flatMap(Int.init) ?? 0
+            return draftLength >= ("one\n" + longDraft).count && bandHeight <= maxHeight
+        }
+        let expandedFrame = field.frame
+
+        XCTAssertGreaterThan(
+            expandedFrame.height,
+            oneLineFrame.height,
+            "composer should grow after adding lines. oneLine=\(oneLineFrame) expanded=\(expandedFrame) dock=\(dock)"
+        )
+        XCTAssertEqual(
+            expandedFrame.maxY,
+            oneLineFrame.maxY,
+            accuracy: 4,
+            "composer bottom must stay pinned while top grows upward. oneLine=\(oneLineFrame) expanded=\(expandedFrame) dock=\(dock)"
+        )
+    }
+
     /// Rapid double-toggle: two compose taps with no settle in between. This is the
     /// most direct provocation of the deferred-focus race — the second tap can land
     /// before the field has taken first responder, so the reducer mis-resolves and the


### PR DESCRIPTION
## Summary
- Stop animating composer height changes while typing so newline growth stays pinned to the keyboard edge.
- Clamp composer band height against available terminal space and expose debug probe values for UI coverage.
- Add regression coverage for multiline composer growth staying bottom-pinned and capped.

## Testing
- swift test --package-path Packages/iOS/CmuxMobileTerminalKit --filter TerminalLetterboxGeometryTests
- ./ios/scripts/reload.sh --tag txpin
- ./scripts/reload-cloud.sh --tag txpin, fell back to local ./scripts/reload.sh --tag txpin because no cloud builder slot was available
- Not run: physical iPhone reload, no connected device was available
- Not run directly: swift build --package-path Packages/iOS/CmuxMobileShellUI, the local package build path is blocked by the GhosttyKit binary target outside the reload build setup

## Regression structure
- Commit 1 adds the failing UI regression test.
- Commit 2 adds the fix.

Closes https://github.com/manaflow-ai/cmux/issues/6530

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784609456&installation_id=133855650&pr_number=6533&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6533&signature=86661f2c84142656dda18182822976e39a95e6aadf4c8f810fb521d03c0aaa14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the iOS composer bottom‑pinned to the keyboard as it grows, cap its height to keep the terminal visible, and hide the terminal toolbar while composing so the field gets the full bottom dock. The composer now owns keyboard focus while open; live height changes apply instantly so the top edge moves and the bottom edge stays pinned.

- **Bug Fixes**
  - Make the composer the text‑input owner while open; route terminal taps/focus back to it; return focus to the terminal only on close or explicit handoff.
  - Enforce a strict height cap via `TerminalLetterboxGeometry.maximumComposerBandHeight` (in `CmuxMobileTerminalKit`), applied in `CmuxMobileTerminal`’s `GhosttySurfaceView`; re‑clamp on keyboard/focus/bounds/safe‑area changes; expose `composerBandHeight` and `composerMaxHeight` in diagnostics.
  - Hide the terminal shortcut toolbar while composing with the keyboard up; keep the composer visible and pinned; restore the toolbar when the keyboard drops or composing ends.
  - Apply live content growth without animation; animate only presentation transitions (e.g., close). Add UI and unit tests for bottom‑pinned multiline growth and the cap.

<sup>Written for commit aa57d53e5cc362caecb30177a6697b5308c0ee7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Composer band resizing now applies immediately (non-animated), keeping the bottom edge pinned to the keyboard during live text and attachment growth/shrink.
  * Composer height is more strictly capped to preserve a minimum visible terminal area.
  * When the composer is focused/active (especially with the keyboard up), the bottom shortcut toolbar is suppressed to avoid overlap, and focus behavior no longer jumps back to the terminal.

* **Tests**
  * Added UI coverage to verify composer growth stays bottom-pinned and capped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->