### PR TITLE
Stop browser web content on tab close

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4807,7 +4807,9 @@ final class BrowserPanel: Panel, ObservableObject {
             popup.closePopup()
         }
 
+        BrowserWindowPortalRegistry.detach(webView: webView)
         webView.stopLoading()
+        resetMediaPlaybackTracking()
         isMainFrameProvisionalNavigationActive = false
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -4816,9 +4818,12 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewDidRequestClose = nil
         webViewObservers.removeAll()
         webViewCancellables.removeAll()
+        _ = webView.loadHTMLString(Self.closedWebViewHTML, baseURL: nil)
         faviconTask?.cancel()
         faviconTask = nil
     }
+
+    private static let closedWebViewHTML = "<!doctype html><html><head></head><body></body></html>"
 
     // MARK: - Popup window management
 

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Testing
 import WebKit
 
@@ -8,10 +9,156 @@ import WebKit
 @testable import cmux
 #endif
 
+private final class BrowserCloseFetchProbeServer {
+    enum ServerError: Error {
+        case listenerDidNotBecomeReady
+        case listenerPortUnavailable
+    }
+
+    private let listener: NWListener
+    private let queue = DispatchQueue(label: "cmux.browser-close-fetch-probe-server")
+    private let lock = NSLock()
+    private var pingRequestCount = 0
+    private(set) var port: UInt16 = 0
+
+    init() throws {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(
+            host: NWEndpoint.Host("127.0.0.1"),
+            port: .any
+        )
+        listener = try NWListener(using: parameters)
+
+        let ready = DispatchSemaphore(value: 0)
+        listener.stateUpdateHandler = { state in
+            if case .ready = state {
+                ready.signal()
+            }
+        }
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection)
+        }
+        listener.start(queue: queue)
+
+        guard ready.wait(timeout: .now() + 2.0) == .success else {
+            throw ServerError.listenerDidNotBecomeReady
+        }
+        guard let port = listener.port?.rawValue else {
+            throw ServerError.listenerPortUnavailable
+        }
+        self.port = port
+    }
+
+    var pageURL: URL {
+        URL(string: "http://127.0.0.1:\(port)/")!
+    }
+
+    var pingCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return pingRequestCount
+    }
+
+    func stop() {
+        listener.cancel()
+    }
+
+    private func handle(_ connection: NWConnection) {
+        connection.start(queue: queue)
+        receiveRequest(on: connection)
+    }
+
+    private func receiveRequest(on connection: NWConnection, buffer: Data = Data()) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 4096) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if error != nil {
+                connection.cancel()
+                return
+            }
+
+            var nextBuffer = buffer
+            if let data {
+                nextBuffer.append(data)
+            }
+
+            guard let requestText = String(data: nextBuffer, encoding: .utf8),
+                  requestText.contains("\r\n\r\n") else {
+                if isComplete {
+                    connection.cancel()
+                    return
+                }
+                self.receiveRequest(on: connection, buffer: nextBuffer)
+                return
+            }
+
+            let requestLine = requestText.split(separator: "\r\n", maxSplits: 1).first ?? ""
+            let path = requestLine.split(separator: " ").dropFirst().first.map(String.init) ?? "/"
+            if path.hasPrefix("/ping") {
+                self.lock.lock()
+                self.pingRequestCount += 1
+                self.lock.unlock()
+                self.send(body: "ok", contentType: "text/plain", on: connection)
+                return
+            }
+
+            self.send(body: Self.fetchLoopPage, contentType: "text/html; charset=utf-8", on: connection)
+        }
+    }
+
+    private func send(body: String, contentType: String, on connection: NWConnection) {
+        let response = """
+        HTTP/1.1 200 OK\r
+        Content-Type: \(contentType)\r
+        Cache-Control: no-store\r
+        Content-Length: \(body.utf8.count)\r
+        Connection: close\r
+        \r
+        \(body)
+        """
+        connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    private static let fetchLoopPage = """
+    <!doctype html>
+    <html>
+    <head><title>cmux close fetch probe</title></head>
+    <body>
+    <script>
+    window.__cmuxCloseProbeInterval = setInterval(() => {
+      fetch('/ping?cacheBust=' + Date.now(), { cache: 'no-store' }).catch(() => {});
+    }, 100);
+    </script>
+    </body>
+    </html>
+    """
+}
+
 @MainActor
 @Suite(.serialized)
 struct BrowserWebContentProcessTests {
     private let recoveryURL = URL(string: "data:text/html,cmux-recovery")!
+
+    @Test
+    func closeStopsPageFetchLoop() async throws {
+        let server = try BrowserCloseFetchProbeServer()
+        defer { server.stop() }
+
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: server.pageURL
+        )
+
+        try await waitForBrowserCloseFetchProbe(server) { $0 >= 3 }
+
+        panel.close()
+        try await Task.sleep(for: .milliseconds(250))
+        let countAfterClose = server.pingCount
+        try await Task.sleep(for: .milliseconds(650))
+
+        #expect(server.pingCount == countAfterClose)
+    }
 
     @Test
     func browserPanelsShareDefaultWebsiteDataStore() {
@@ -197,5 +344,19 @@ struct BrowserWebContentProcessTests {
         #expect(popupWebView.uiDelegate == nil)
         #expect(popupWebView.window == nil)
         #expect(!popupWindow.isVisible)
+    }
+
+    private func waitForBrowserCloseFetchProbe(
+        _ server: BrowserCloseFetchProbeServer,
+        until predicate: (Int) -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(3)
+        while !predicate(server.pingCount) {
+            if Date() >= deadline {
+                Issue.record("Timed out waiting for browser fetch probe. Count: \(server.pingCount)")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
     }
 }


### PR DESCRIPTION
Summary
- Added a regression test that serves a page with a repeating fetch loop and closes the BrowserPanel.
- Changed BrowserPanel.close() to detach the portal web view, stop loading, replace the live document with blank HTML, and clear media playback tracking before releasing delegates.

Verification
- Red before fix: closeStopsPageFetchLoop() kept incrementing the probe count after panel.close().
- Green after fix: CMUX_ALLOW_LOCAL_XCODEBUILD=1 xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-bclose test -only-testing:cmuxTests/BrowserWebContentProcessTests/closeStopsPageFetchLoop()
- Tagged cloud reload: http://127.0.0.1:17320/bclose
- Tagged preflight: opened the loopback probe in surface:2 via /tmp/cmux-debug-bclose.sock, verified title "cmux close probe", closed the surface, and the ping count stayed at 16 afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784609696&installation_id=133855650&pr_number=6534&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6534&signature=a2e9e932269d07e3fb4724fb37dbd76a2311e803bc9e1c1c5d98e7f9eafbf4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle-only change on tab close with a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes **background activity after tab close** by extending `BrowserPanel.close()` teardown so the live `WKWebView` is fully neutralized, not only unhooked from delegates.
> 
> On close, the panel now **detaches** the web view from `BrowserWindowPortalRegistry`, **stops loading**, **clears media playback tracking**, and **loads a minimal blank HTML document** before observers and delegates are dropped—matching patterns already used when discarding or swapping web views.
> 
> Adds **`closeStopsPageFetchLoop`**: a local TCP probe serves a page with a `setInterval` + `fetch` loop and asserts `/ping` counts stop increasing after `panel.close()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b140e14c920a59fca84bdab4ff64a557375aeda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops web content from running after a tab is closed. Closing `BrowserPanel` now fully tears down the web view so pages can’t keep fetching or playing media in the background.

- **Bug Fixes**
  - `BrowserPanel.close()` detaches the web view from `BrowserWindowPortalRegistry`, calls `stopLoading()`, loads a blank HTML document, resets media playback tracking, and releases delegates/observers.
  - Adds a regression test that serves a page with a repeating fetch loop and asserts the ping count stops increasing after `panel.close()`.

<sup>Written for commit 2b140e14c920a59fca84bdab4ff64a557375aeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser panel shutdown to fully dismantle active web content, ensuring any ongoing page activity (including periodic fetch activity) and media-related tracking are stopped after the panel is dismissed.

* **Tests**
  * Added an automated test using a local HTTP probe to confirm that `/ping` requests stop increasing once the browser panel is closed, validating that background fetch loops do not continue post-dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->