### PR TITLE
Add README/site feature-parity review rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,6 +64,15 @@ reviews:
     - path: "CHANGELOG.md"
       instructions: |
         Apply `.github/review-bot-rules/full-internationalization.md` during review. Verify changelog copy rendered on the docs site has matching localized message coverage for every locale listed in `web/i18n/routing.ts`.
+    - path: "README.md"
+      instructions: |
+        Apply `.github/review-bot-rules/readme-site-feature-parity.md` during review. When the "## Features" section changes, flag feature names or factual claims that now contradict the homepage feature list (`home.feature.*` in `web/messages/en.json`) or FAQ (`home.faq*`). The README may stay the detailed superset; only shared features must use consistent names and non-contradicting claims.
+    - path: "web/app/[locale]/page.tsx"
+      instructions: |
+        Apply `.github/review-bot-rules/readme-site-feature-parity.md` during review. When the homepage feature list or FAQ structure changes, flag feature names or claims that contradict `README.md`'s "## Features" section.
+    - path: "web/messages/en.json"
+      instructions: |
+        Apply `.github/review-bot-rules/readme-site-feature-parity.md` during review. When `home.feature.*` or `home.faq*` copy changes, flag feature names or factual claims that contradict `README.md`'s "## Features" section (for example one surface says "Scriptable" and the other "Programmable"). Localization-only edits that preserve the English source meaning pass.
 
   pre_merge_checks:
     custom_checks:

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -26,5 +26,6 @@ Current rules:
 - `swift-logging.md`
 - `swiftui-state-layout.md`
 - `user-facing-errors.md`
+- `readme-site-feature-parity.md`
 
 Open source repository note: review bots should apply the configuration from the base branch. A PR that edits these rules should not be able to weaken its own review.

--- a/.github/review-bot-rules/readme-site-feature-parity.md
+++ b/.github/review-bot-rules/readme-site-feature-parity.md
@@ -1,0 +1,26 @@
+# README and Site Feature Parity
+
+Keep the user-facing feature claims in `README.md` consistent with the marketing site's feature list and FAQ. The README "## Features" section and the homepage feature list (`home.feature.*` in `web/messages/en.json`, rendered by `web/app/[locale]/page.tsx`) describe the same product, so a feature must not be named or described one way on one surface and contradicted on the other. The README is allowed to be the more detailed superset; the homepage and FAQ are a curated subset.
+
+Report a failure when a diff:
+
+- Renames or relabels a shared feature on one surface without matching the other (for example the README says "Scriptable" while the homepage feature is "Programmable", or vice versa).
+- Changes a feature's factual claim on one surface so it contradicts the other (platform support, price/free, license, supported agents, networking model, what is built in vs optional).
+- Adds a headline feature to the homepage feature list that directly conflicts with how the README presents the product, or removes a feature from one surface in a way that leaves the two materially inconsistent, without updating the other or stating why.
+- Changes a homepage FAQ answer (`home.faq*` in `web/messages/en.json`) so it contradicts a claim in `README.md` (for example FAQ says cmux is free while the README implies otherwise, or the FAQ describes a capability the README denies).
+
+Expected shape:
+
+- When a shared feature's name or factual claim changes on one surface, the same change lands on the other surface in the same PR, or the PR explains why they intentionally differ.
+- The README may keep extra features (for example SSH, Claude Code Teams, Custom commands, Browser import) that the curated homepage omits, as long as the features both surfaces do mention use consistent names and non-contradicting claims.
+- Wording length and detail may differ between the README and the homepage; only the feature name and the underlying factual claim need to agree.
+
+Allowed cases:
+
+- The README staying a more detailed superset of the homepage feature list.
+- Pure description/length differences where the feature name and factual claim still agree.
+- Localization-only changes that translate existing copy without changing the English source meaning.
+- Doc, blog, or changelog copy that is not a headline feature claim.
+- Existing inconsistencies the PR does not introduce or worsen, though mention nearby drift when it is adjacent to the change.
+
+When reporting, name the exact feature or FAQ entry and the specific `README.md` line it conflicts with, state the contradiction, and suggest the smallest fix: align the term or claim, or update the other surface in the same PR.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,6 +1,10 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax", "style"],
+  "commentTypes": [
+    "logic",
+    "syntax",
+    "style"
+  ],
   "triggerOnUpdates": true,
   "statusCheck": true,
   "updateExistingSummaryComment": true,
@@ -9,92 +13,180 @@
     {
       "id": "cmux-swift-actor-isolation",
       "rule": "Flag new or materially worsened Swift 6 actor isolation mistakes in production Swift: implicit MainActor value models or service protocols, file-scoped helpers that should be nonisolated, shared mutable Sendable reference types without isolation, or UI-bound stores used from background contexts.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-blocking-runtime",
       "rule": "Flag new blocking or timing-based synchronization in production Swift: semaphores, DispatchGroup.wait, sleeps, Task.sleep, asyncAfter, timers or polling for synchronization, DispatchQueue.main.sync, or manual locks where actor isolation or a real signal should own coordination.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-runtime-no-hacky-sleeps",
       "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"],
+      "scope": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs",
+        "**/*.sh",
+        "**/*.zsh"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-concurrency-modernization",
       "rule": "Flag new legacy async patterns in cmux-owned Swift where Swift concurrency is the correct shape: DispatchQueue.global for ordinary async work, new Combine app state, completion-handler APIs fully under cmux control, or fire-and-forget Tasks with meaningful lifecycle.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-concurrent-annotation",
       "rule": "Flag incorrect or missing use of Swift @concurrent and nonisolated async behavior, including nonisolated async work that should leave the caller actor, invalid @concurrent annotations, or CPU/file/network-heavy async helpers called from UI isolation without an explicit boundary.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-file-package-boundaries",
       "rule": "Flag Swift changes that add too much unrelated responsibility to one file or miss a SwiftPM package boundary: new production Swift files over 400 lines without one responsibility, files over 800 lines, large additions to existing oversized files, mixed UI/state/persistence/network/parsing/protocol code, or independently testable feature logic kept in the app target instead of a small package.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-logging",
       "rule": "Flag production Swift diagnostics that bypass unified logging or risk leaking sensitive data: print/debugPrint/dump/NSLog in app or runtime code, ad hoc stdout or file logging, MainActor-coupled file-scoped Logger constants, or unredacted secrets, tokens, customer content, or personal data.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-full-internationalization",
       "rule": "Flag production user-facing text that is not fully internationalized across every locale supported by the affected surface: Swift UI/menu/alert/tooltip/error/command text must use String(localized:defaultValue:) or an equivalent localized API with a matching translated string-catalog entry, app string catalog or Info.plist changes must include translated entries for every locale already supported by the touched catalog, and web UI, metadata, API response, rendered markdown, changelog, or user-facing data changes must read from next-intl or another locale-specific source and update every locale listed in web/i18n/routing.ts with matching web/messages entries. Pass for tests, operational docs not shown to end users, developer-only comments, debug-only logs, literal protocol/config tokens, and existing untranslated strings not worsened by the PR.",
-      "scope": ["**/*.swift", "CHANGELOG.md", "Resources/Info.plist", "Resources/*.xcstrings", "web/*.ts", "web/*.tsx", "web/*.js", "web/*.jsx", "web/*.mjs", "web/*.cjs", "web/**/*.ts", "web/**/*.tsx", "web/**/*.js", "web/**/*.jsx", "web/**/*.mjs", "web/**/*.cjs", "web/messages/**/*.json", "web/data/**/*.json", "web/app/**/*.md", "web/app/**/*.mdx"],
+      "scope": [
+        "**/*.swift",
+        "CHANGELOG.md",
+        "Resources/Info.plist",
+        "Resources/*.xcstrings",
+        "web/*.ts",
+        "web/*.tsx",
+        "web/*.js",
+        "web/*.jsx",
+        "web/*.mjs",
+        "web/*.cjs",
+        "web/**/*.ts",
+        "web/**/*.tsx",
+        "web/**/*.js",
+        "web/**/*.jsx",
+        "web/**/*.mjs",
+        "web/**/*.cjs",
+        "web/messages/**/*.json",
+        "web/data/**/*.json",
+        "web/app/**/*.md",
+        "web/app/**/*.mdx"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-algorithmic-complexity",
       "rule": "Flag production code that adds nested full-collection scans, per-target rescans for batch actions, repeated sort/filter/map work in hot UI/socket/search/process paths, in-memory joins that belong in the data store, or unbenchmarked slower algorithms for paths expected to handle about 1000 workspaces or similar user-owned records. Pass for tiny fixed-size collections, tests and benchmark harnesses, existing debt not worsened, and documented bounds with measurements.",
-      "scope": ["**/*.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"],
+      "scope": [
+        "**/*.swift",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs",
+        "**/*.sh",
+        "**/*.zsh"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-expensive-sync-load",
       "rule": "Flag production Swift that reads, decodes, or scans unbounded agent-history data on the main actor or interactive paths: RestorableAgentSessionIndex.load(), agent hook/session stores, agent-turn-diff-baselines.json, transcript files, trajectory files, workstream/event JSONL logs, broad directory scans, per-record syscalls, or large JSON/JSONL parsing. Require SharedLiveAgentIndex.shared, Task.detached, a background actor/repository parser, or another off-main cached path that returns to MainActor only for UI/process launch work. Pass for the cache/background loader itself, explicit nil-cache fallbacks with justification, and existing call sites not worsened.",
-      "scope": ["**/*.swift", "**/Package.swift"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swiftui-state-layout",
       "rule": "Flag SwiftUI changes that can cause stale state, broad invalidation, layout instability, or main-thread churn: new ObservableObject/@Published state where @Observable is correct, GeometryReader measurement that changes layout, lazy/list row subtrees holding store references, or state mutation during body rendering.",
-      "scope": ["**/*.swift"],
+      "scope": [
+        "**/*.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swift-architectural-rethink",
       "rule": "Flag Swift fixes that patch symptoms while leaving bad state representable: timing repairs, new flags/caches/singletons/observers/side channels, duplicate behavior wired through multiple entrypoints, split SwiftUI/AppKit lifecycle ownership, or fixes that do not name the invariant and source of truth.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"],
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-swiftpm-package-resolved",
       "rule": "Flag SwiftPM package, Xcode project, .gitignore, workflow, and dependency changes that violate cmux's Package.resolved policy: cmux-owned package .gitignore files must not ignore Package.resolved, external SwiftPM dependency resolution changes must include the relevant package-local Package.resolved diff, and Xcode project package-reference changes must include the root Xcode Package.resolved diff. The root Xcode project lockfile is not sufficient proof for standalone package resolution. Pass for vendored third-party directories preserving upstream policy.",
-      "scope": ["**/Package.swift", "**/Package.resolved", "**/.gitignore", "cmux.xcodeproj/**", ".github/workflows/**"],
+      "scope": [
+        "**/Package.swift",
+        "**/Package.resolved",
+        "**/.gitignore",
+        "cmux.xcodeproj/**",
+        ".github/workflows/**"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-no-test-debug-seam-in-production-source",
       "rule": "Flag Swift files under a production Sources path (matching **/Sources/** and not under **/Tests/**) that add a test-only or debug-only seam: a #if DEBUG (or other test-build-guarded) extension/member exposing internal state only for tests or a debugger with no production caller, a member named like debug…/…ForTesting/…ForTests/testOnly…/…TestHook/…TestSeam/_test…, or visibility widened together with a wrapper accessor added so a test can call it. Prefer observing internal state from the test target via @testable import after widening private to internal, or isolating a genuinely debug-only facility in a dedicated debug file or folder (canonical fix: cmux PR 6452). Pass for #if DEBUG blocks that gate real product behavior, scaffolding inside Tests/ or a test-support module, and existing seams not worsened by the PR.",
-      "scope": ["**/Sources/**/*.swift"],
+      "scope": [
+        "**/Sources/**/*.swift"
+      ],
       "severity": "high"
     },
     {
       "id": "cmux-source-control-artifacts",
       "rule": "Flag local tool output, generated logs, screenshots, recordings, temp folders, dependency checkouts, caches, build output, DerivedData, package-manager downloads, and broad scratch directories that enter source control without a deliberate product, docs, fixture, build, release, or test-system reason. Pass for intentional source files, configs, localization catalogs, review rules, durable docs assets, required fixtures, generated files that are already part of the repo's source-of-truth model, and PRs that only remove or ignore existing accidental artifacts.",
-      "scope": ["**/*"],
+      "scope": [
+        "**/*"
+      ],
       "severity": "high"
+    },
+    {
+      "id": "cmux-readme-site-feature-parity",
+      "rule": "Flag diffs that make README.md user-facing feature claims contradict the marketing site. When the README \"## Features\" section, the homepage feature list (home.feature.* in web/messages/en.json, rendered by web/app/[locale]/page.tsx), or the homepage FAQ (home.faq*) changes, fail when a shared feature is renamed or relabeled on one surface but not the other (e.g. README \"Scriptable\" vs site \"Programmable\"), or when a factual claim (platform, price/free, license, supported agents, networking, built-in vs optional) contradicts across surfaces. The README may remain the detailed superset; only shared features must use consistent names and non-contradicting claims. Pass for README-only extra features, pure description/length differences where name and claim agree, and localization-only edits that preserve English source meaning.",
+      "scope": [
+        "README.md",
+        "web/app/[locale]/page.tsx",
+        "web/messages/en.json"
+      ],
+      "severity": "medium"
     }
   ]
 }

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -3,87 +3,182 @@
     {
       "path": ".github/review-bot-rules/swift-actor-isolation.md",
       "description": "Source-of-truth cmux lint rule for Swift actor isolation review.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-architectural-rethink.md",
       "description": "Source-of-truth cmux lint rule for architectural review of Swift changes.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-blocking-runtime.md",
       "description": "Source-of-truth cmux lint rule for blocking and timing primitive review.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
+      "scope": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs",
+        "**/*.sh",
+        "**/*.zsh"
+      ]
     },
     {
       "path": ".github/review-bot-rules/full-internationalization.md",
       "description": "Source-of-truth cmux review rule for complete localization across every supported app and web locale.",
-      "scope": ["**/*.swift", "CHANGELOG.md", "Resources/Info.plist", "Resources/*.xcstrings", "web/*.ts", "web/*.tsx", "web/*.js", "web/*.jsx", "web/*.mjs", "web/*.cjs", "web/**/*.ts", "web/**/*.tsx", "web/**/*.js", "web/**/*.jsx", "web/**/*.mjs", "web/**/*.cjs", "web/messages/**/*.json", "web/data/**/*.json", "web/app/**/*.md", "web/app/**/*.mdx"]
+      "scope": [
+        "**/*.swift",
+        "CHANGELOG.md",
+        "Resources/Info.plist",
+        "Resources/*.xcstrings",
+        "web/*.ts",
+        "web/*.tsx",
+        "web/*.js",
+        "web/*.jsx",
+        "web/*.mjs",
+        "web/*.cjs",
+        "web/**/*.ts",
+        "web/**/*.tsx",
+        "web/**/*.js",
+        "web/**/*.jsx",
+        "web/**/*.mjs",
+        "web/**/*.cjs",
+        "web/messages/**/*.json",
+        "web/data/**/*.json",
+        "web/app/**/*.md",
+        "web/app/**/*.mdx"
+      ]
     },
     {
       "path": ".github/review-bot-rules/algorithmic-complexity.md",
       "description": "Source-of-truth cmux review rule for scalable collection algorithms and benchmark-backed complexity choices.",
-      "scope": ["**/*.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
+      "scope": [
+        "**/*.swift",
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs",
+        "**/*.sh",
+        "**/*.zsh"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-expensive-sync-load.md",
       "description": "Source-of-truth cmux review rule for keeping large agent-history JSON, transcript, trajectory, and syscall loads off MainActor and interactive Swift paths.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",
       "description": "Source-of-truth cmux lint rule for Swift concurrency modernization review.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrent-annotation.md",
       "description": "Source-of-truth cmux lint rule for @concurrent and nonisolated async review.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-file-package-boundaries.md",
       "description": "Source-of-truth cmux lint rule for Swift file size and SwiftPM package boundary review.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swift-logging.md",
       "description": "Source-of-truth cmux lint rule for production Swift logging review.",
-      "scope": ["**/*.swift", "**/Package.swift"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swiftui-state-layout.md",
       "description": "Source-of-truth cmux lint rule for SwiftUI state and layout review.",
-      "scope": ["**/*.swift"]
+      "scope": [
+        "**/*.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/no-test-debug-seam-in-production-source.md",
       "description": "Source-of-truth cmux review rule against adding test-only or debug-only seams to production Swift Sources.",
-      "scope": ["**/Sources/**/*.swift"]
+      "scope": [
+        "**/Sources/**/*.swift"
+      ]
     },
     {
       "path": ".github/review-bot-rules/source-control-artifacts.md",
       "description": "Source-of-truth cmux review rule for local/generated artifacts that should not enter source control.",
-      "scope": ["**/*"]
+      "scope": [
+        "**/*"
+      ]
     },
     {
       "path": ".github/review-bot-rules/swiftpm-package-resolved.md",
       "description": "Source-of-truth cmux review rule for SwiftPM Package.resolved lockfile policy.",
-      "scope": ["**/Package.swift", "**/Package.resolved", "**/.gitignore", "cmux.xcodeproj/**", ".github/workflows/**"]
+      "scope": [
+        "**/Package.swift",
+        "**/Package.resolved",
+        "**/.gitignore",
+        "cmux.xcodeproj/**",
+        ".github/workflows/**"
+      ]
     },
     {
       "path": "CLAUDE.md",
       "description": "Repo-local guidance for cmux Swift, SwiftUI, testing, shortcut, localization, and no-sleep policies.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ]
     },
     {
       "path": "AGENTS.md",
       "description": "Repo-local guidance for cmux agents, Swift conventions, testing, shortcuts, localization, and no-sleep policies.",
-      "scope": ["**/*.swift", "**/Package.swift", "cmux.xcodeproj/**"]
+      "scope": [
+        "**/*.swift",
+        "**/Package.swift",
+        "cmux.xcodeproj/**"
+      ]
+    },
+    {
+      "path": ".github/review-bot-rules/readme-site-feature-parity.md",
+      "description": "Source-of-truth cmux review rule for keeping README features consistent with the marketing site features and FAQ.",
+      "scope": [
+        "README.md",
+        "web/app/[locale]/page.tsx",
+        "web/messages/en.json"
+      ]
     }
   ]
 }

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -83,3 +83,11 @@ Pass for `#if DEBUG` blocks that gate real product behavior, scaffolding inside 
 For SwiftPM package, Xcode project, `.gitignore`, workflow, and dependency changes, flag cmux-owned package `.gitignore` files that ignore `Package.resolved`, external dependency resolution changes that omit the relevant package-local `Package.resolved` diff, or Xcode project package-reference changes that omit the root Xcode `Package.resolved` diff.
 
 The root Xcode project lockfile is not sufficient proof for standalone package resolution. Pass for vendored third-party directories preserving upstream policy.
+
+## README and Site Feature Parity
+
+For changes to `README.md`'s "## Features" section, the homepage feature list (`home.feature.*` in `web/messages/en.json`, rendered by `web/app/[locale]/page.tsx`), or the homepage FAQ (`home.faq*`), keep the user-facing feature claims consistent across the README and the marketing site.
+
+Flag a shared feature renamed or relabeled on one surface but not the other (for example README "Scriptable" vs site "Programmable"), and any factual claim that contradicts across surfaces (platform support, price/free, license, supported agents, networking model, built-in vs optional). The README may stay the more detailed superset of the homepage; only the features both surfaces mention need consistent names and non-contradicting claims.
+
+Pass for README-only extra features (SSH, Claude Code Teams, Custom commands, etc.), pure description or length differences where the feature name and factual claim still agree, and localization-only edits that preserve the English source meaning.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Sidebar shows git branch, linked PR status/number, working directory, listening 
 
 - **Browser import** — Import cookies, history, and sessions from Chrome, Firefox, Arc, and 20+ browsers so browser panes start authenticated
 - **Custom commands** — Define project-specific actions in [`cmux.json`](https://cmux.com/docs/custom-commands) that launch from the command palette
-- **Scriptable** — CLI and socket API to create workspaces, split panes, send keystrokes, and automate the browser
+- **Programmable** — CLI and socket API to create workspaces, split panes, send keystrokes, and automate the browser
 - **Native macOS app** — Built with Swift and AppKit, not Electron. Fast startup, low memory.
 - **Ghostty compatible** — Reads your existing `~/.config/ghostty/config` for themes, fonts, and colors
 - **GPU-accelerated** — Powered by libghostty for smooth rendering


### PR DESCRIPTION
Keeps `README.md` feature claims consistent with the marketing site, enforced by the review bots (per request).

## What
- New rule `.github/review-bot-rules/readme-site-feature-parity.md`: when the README "## Features" section, the homepage feature list (`home.feature.*` in `web/messages/en.json`, rendered by `web/app/[locale]/page.tsx`), or the homepage FAQ (`home.faq*`) changes, the bots flag renamed shared features (e.g. "Scriptable" vs "Programmable") or contradicting factual claims (platform, price/free, license, agents, networking, built-in vs optional). The README may stay the detailed superset; only shared features must agree.
- Wired into CodeRabbit (`path_instructions` for `README.md`, `web/app/[locale]/page.tsx`, `web/messages/en.json`) and Greptile (`config.json` rule `cmux-readme-site-feature-parity`, `files.json`, `rules.md`), plus the rules `README.md` index.
- Fixes today's drift: README "Scriptable" → "Programmable" to match the site.

## Why
The homepage features and README had already drifted (terminology and set). This makes the bots catch it going forward instead of relying on memory.

Review-config + docs only. No app/runtime changes, no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784632936&installation_id=133855650&pr_number=6540&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6540&signature=59bc6c9bf6fd5f7e9c7c1d682bf417189075bb426655e223fe4759de630f7ac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and review-bot configuration only; no app or runtime behavior changes.
> 
> **Overview**
> Adds automated review so **README** feature claims stay aligned with the marketing homepage and FAQ, and fixes one existing terminology mismatch.
> 
> A new rule in `.github/review-bot-rules/readme-site-feature-parity.md` tells bots to flag **shared** feature renames or contradicting facts (platform, pricing, license, agents, etc.) when `README.md` **## Features**, `home.feature.*` / `home.faq*` in `web/messages/en.json`, or the homepage in `web/app/[locale]/page.tsx` change. The README can still list extra bullets the site omits.
> 
> That rule is hooked into **CodeRabbit** (`path_instructions` on those three paths), **Greptile** (`cmux-readme-site-feature-parity` in `config.json`, `files.json`, and `rules.md`), and the review-rules index.
> 
> **README** renames **Scriptable** → **Programmable** so it matches the site’s `home.feature.scriptable` label. Greptile JSON edits are mostly formatting (multiline `scope` arrays).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742da7954e2e3cdffa5f99db616fa418ee0731ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review rule to keep README “Features” in sync with the marketing site’s feature list and FAQ, enforced by review bots. Also updates the README term to “Programmable” to match the site; no runtime changes.

- **New Features**
  - New rule `readme-site-feature-parity.md` ensures shared features use the same names and factual claims across `README.md`, `home.feature.*` in `web/messages/en.json`, and homepage FAQ (`home.faq*`).
  - Integrated with CodeRabbit path instructions and Greptile (`cmux-readme-site-feature-parity`) for `README.md`, `web/app/[locale]/page.tsx`, and `web/messages/en.json`.

- **Bug Fixes**
  - README: “Scriptable” → “Programmable” to match the homepage.

<sup>Written for commit 742da7954e2e3cdffa5f99db616fa418ee0731ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology in the README Features section to provide clearer descriptions of API capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->