### PR TITLE
docs: align heading text with body text

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -131,7 +131,10 @@ body {
     display: inline-block;
     font-family: var(--font-geist-mono);
     font-weight: 500;
-    margin-left: -1.45rem;
+    /* Net inline advance must be 0 so heading text aligns with body text:
+       margin-left + width + margin-right = -1.2 + 1 + 0.2 = 0. The "#" still
+       sits in the left gutter, revealed on hover. */
+    margin-left: -1.2rem;
     margin-right: 0.2rem;
     opacity: 0;
     text-decoration: none;


### PR DESCRIPTION
Docs headings sat ~4px to the left of the body paragraphs on every docs page.

Cause: the hover `#` heading anchor (`.docs-content .docs-heading-anchor`) is an inline-block with `margin-left: -1.45rem; width: 1rem; margin-right: 0.2rem`, a net inline advance of `-0.25rem`, which pulled the heading text left of where paragraphs start.

Fix: set `margin-left: -1.2rem` so the net advance is exactly 0 (`-1.2 + 1 + 0.2`). Heading text now starts at the same x as body text; the `#` still appears in the left gutter on hover.

One-line CSS change, applies to all docs pages. No app/runtime changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784635033&installation_id=133855650&pr_number=6542&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6542&signature=672f18c4132c5b84066082c4247da2ff5251befc604d1b1a8b07b7cd0fc55a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single docs-only CSS tweak with no runtime, API, or data-handling impact.
> 
> **Overview**
> Fixes docs headings sitting slightly left of body paragraphs by adjusting the hover `#` anchor spacing in `globals.css`.
> 
> **`.docs-content .docs-heading-anchor`** `margin-left` changes from `-1.45rem` to `-1.2rem`, with a short comment documenting that the net inline advance (`margin-left + width + margin-right`) should be **0** so heading copy lines up with paragraph text. The `#` link still sits in the left gutter and shows on hover/focus; only horizontal alignment of the visible heading text changes across all docs pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c399e58189ae7abee58ab3d48028f9857bc12de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align docs headings with body text by zeroing the anchor’s inline advance. Set `.docs-content .docs-heading-anchor` `margin-left: -1.2rem` (cancels `width: 1rem` + `margin-right: 0.2rem`) so heading text aligns with paragraphs; the `#` still appears in the left gutter on hover.

<sup>Written for commit c399e58189ae7abee58ab3d48028f9857bc12de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for documentation heading anchors to improve visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->