### PR TITLE
ios: auto-generate per-build TestFlight "What to Test" + stamp next beta version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Validate Xcode SourcePackages cache sanitizer
         run: python3 tests/test_ci_sanitize_xcode_source_packages_cache.py
 
+      - name: Validate TestFlight notes generator
+        run: python3 tests/test_ios_testflight_notes.py
+
       - name: Validate cmux scheme test configuration
         run: ./tests/test_ci_scheme_testaction_debug.sh
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -61,6 +61,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
+      last_uploaded_sha: ${{ steps.decide.outputs.last_uploaded_sha }}
     steps:
       - name: Decide whether a TestFlight upload is needed
         id: decide
@@ -72,18 +73,13 @@ jobs:
             const forceBuild = process.env.FORCE_BUILD === 'true';
             const { owner, repo } = context.repo;
 
-            // workflow_dispatch always builds (the operator asked for it).
-            // Scheduled runs build unless the current commit has ALREADY been
-            // uploaded by a prior successful run. We compare HEAD to the head_sha
-            // of the most recent successful run of this workflow, not a wall-clock
-            // window: a failed or missed nightly leaves the last success on an
-            // older SHA, so the next run retries the un-uploaded commit instead of
-            // stranding it. A successful run either uploaded HEAD or correctly
-            // skipped an already-uploaded HEAD, so its head_sha is always an
-            // uploaded commit.
-            let needsBuild = true;
+            // The head_sha of the most recent successful run of this workflow is
+            // the last uploaded beta commit. We always resolve it: the schedule
+            // SHA-compare uses it to skip an already-uploaded HEAD, AND the upload
+            // job uses it as the base of the "What to Test" commit range so each
+            // build's notes reflect what changed since the previous beta.
             let lastUploadedSha = null;
-            if (!forceBuild && context.eventName === 'schedule') {
+            try {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
@@ -92,11 +88,23 @@ jobs:
                 per_page: 1,
               });
               lastUploadedSha = runs.data.workflow_runs[0]?.head_sha ?? null;
+            } catch (e) {
+              core.warning(`could not resolve last uploaded sha: ${e.message}`);
+            }
+
+            // workflow_dispatch always builds (the operator asked for it).
+            // Scheduled runs build unless HEAD was ALREADY uploaded by a prior
+            // successful run (a SHA compare, not a wall-clock window: a failed or
+            // missed run leaves the last success on an older SHA, so the next run
+            // retries the un-uploaded commit instead of stranding it).
+            let needsBuild = true;
+            if (!forceBuild && context.eventName === 'schedule') {
               needsBuild = lastUploadedSha !== context.sha;
             }
 
             const shouldBuild = forceBuild || context.eventName === 'workflow_dispatch' || needsBuild;
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');
+            core.setOutput('last_uploaded_sha', lastUploadedSha || '');
             core.summary
               .addHeading('iOS TestFlight upload decision')
               .addTable([
@@ -126,6 +134,10 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+          # Full history + tags so generate-testflight-notes.sh can walk the
+          # commit range since the last beta and --auto-version can read ios-v*.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Select Xcode
         run: |
@@ -260,9 +272,19 @@ jobs:
           # The script writes the CFBundleVersion that actually shipped here (the
           # monotonic guard may bump it), so the summary reports the real value.
           CMUX_BUILD_NUMBER_OUT_FILE: ${{ runner.temp }}/cmux-final-build-number.txt
+          # The previous beta's commit (the last successful run's head_sha): base
+          # of the per-build "What to Test" commit range. Empty on the very first
+          # run / a missing history, where the generator falls back gracefully.
+          LAST_UPLOADED_SHA: ${{ needs.decide.outputs.last_uploaded_sha }}
         run: |
           set -euo pipefail
-          ARGS=(--lane beta --signing manual)
+          # --auto-version: every beta stamps the next-release marketing version.
+          # --notes-from-range: auto-generate the Internal "What to Test" from the
+          # commits since the previous beta (skipped if we have no base SHA yet).
+          ARGS=(--lane beta --signing manual --auto-version)
+          if [ -n "${LAST_UPLOADED_SHA:-}" ]; then
+            ARGS+=(--notes-from-range "$LAST_UPLOADED_SHA")
+          fi
           if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
             ARGS+=(--build-number "$INPUT_BUILD_NUMBER")
           fi

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -85,6 +85,7 @@ jobs:
             // next real beta's notes base (the generator also fails closed to a
             // fallback line when the base is not an ancestor of HEAD).
             let lastUploadedSha = null;
+            let lookupFailed = false;
             try {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner,
@@ -96,7 +97,20 @@ jobs:
               });
               lastUploadedSha = runs.data.workflow_runs[0]?.head_sha ?? null;
             } catch (e) {
+              lookupFailed = true;
               core.warning(`could not resolve last uploaded sha: ${e.message}`);
+            }
+
+            // A scheduled run must FAIL CLOSED when the history lookup ERRORED: a
+            // null last-uploaded SHA reads as "not HEAD" below, so the lane would
+            // re-upload the same already-shipped main commit every 2h with a fresh
+            // build number and fallback notes. Before this job wrapped the lookup in
+            // try/catch the throw failed the job here; preserve that. A genuine
+            // no-prior-run (the API SUCCEEDED but returned no runs) is NOT a failure:
+            // lookupFailed stays false and the first beta builds normally.
+            if (context.eventName === 'schedule' && lookupFailed) {
+              core.setFailed('could not resolve the last uploaded beta SHA (workflow run history lookup failed); refusing to auto-upload to avoid duplicate TestFlight builds');
+              return;
             }
 
             // workflow_dispatch always builds (the operator asked for it).

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -73,17 +73,24 @@ jobs:
             const forceBuild = process.env.FORCE_BUILD === 'true';
             const { owner, repo } = context.repo;
 
-            // The head_sha of the most recent successful run of this workflow is
-            // the last uploaded beta commit. We always resolve it: the schedule
-            // SHA-compare uses it to skip an already-uploaded HEAD, AND the upload
-            // job uses it as the base of the "What to Test" commit range so each
-            // build's notes reflect what changed since the previous beta.
+            // The head_sha of the most recent successful run of this workflow on
+            // main is the last uploaded beta commit. We always resolve it: the
+            // schedule SHA-compare uses it to skip an already-uploaded HEAD, AND
+            // the upload job uses it as the base of the "What to Test" commit range
+            // so each build's notes reflect what changed since the previous beta.
+            // branch:'main' is required: the upload job is gated on
+            // github.ref == 'refs/heads/main', so a workflow_dispatch run on a
+            // feature branch SUCCEEDS without uploading anything. Without this
+            // filter its branch SHA would become last_uploaded_sha and poison the
+            // next real beta's notes base (the generator also fails closed to a
+            // fallback line when the base is not an ancestor of HEAD).
             let lastUploadedSha = null;
             try {
               const runs = await github.rest.actions.listWorkflowRuns({
                 owner,
                 repo,
                 workflow_id: 'ios-testflight.yml',
+                branch: 'main',
                 status: 'success',
                 per_page: 1,
               });

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Generate TestFlight "What to Test" notes from the iOS-affecting commits in
+# <base-ref>..HEAD, so every beta build's notes reflect what actually changed
+# since the previous beta instead of a hand-maintained changelog top entry.
+#
+#   internal (default): terse, dev-facing bullets, keeps the PR number.
+#   external:           a cleaned DRAFT (no PR numbers, no conventional prefix)
+#                       for human curation before a founders cut.
+#
+# Output is the bullet list only (no "### Internal" heading), suitable to pass to
+# `set-testflight-notes.sh --notes "$(...)"`. An empty or unreachable range emits
+# a deterministic fallback line and exits 0, so the non-fatal notes step in
+# upload-testflight.sh never breaks an upload.
+#
+# Usage:
+#   ios/scripts/generate-testflight-notes.sh <base-ref> [--audience internal|external]
+#
+# Portable to macOS bash 3.2 + BSD sed (runs on the fleet/CI macOS runners): no
+# mapfile, no GNU-only sed escapes.
+
+set -euo pipefail
+
+usage() { sed -n '3,21p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+AUDIENCE="internal"
+BASE=""
+MAX="${CMUX_NOTES_MAX:-20}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --audience) AUDIENCE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*) echo "error: unknown option $1" >&2; exit 2 ;;
+    *) BASE="$1"; shift ;;
+  esac
+done
+
+case "$AUDIENCE" in
+  internal|external) ;;
+  *) echo "error: --audience must be internal or external" >&2; exit 2 ;;
+esac
+
+fallback() {
+  echo "- Latest main; no notable iOS changes detected since the previous build."
+}
+
+# No base, or a base not reachable in this checkout (shallow clone, unknown SHA):
+# fall back rather than fail. Notes are non-fatal; a missing range must not break
+# the upload.
+if [[ -z "$BASE" ]] || ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null; then
+  fallback
+  exit 0
+fi
+
+# iOS-affecting paths: mirror the push-trigger filter in ios-testflight.yml so the
+# notes only mention changes that could be in this build.
+PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-sdk-prerelease scripts/ghosttykit-checksums.txt"
+
+# First-line subjects of non-merge commits in range touching those paths. Squash
+# merges carry the PR title + "(#N)" as the subject, which is exactly what we want.
+emitted=0
+seen="|"
+
+while IFS= read -r subject; do
+  [[ -n "$subject" ]] || continue
+
+  # Drop noise that is not tester-relevant.
+  case "$subject" in
+    chore:*|chore\(*|ci:*|ci\(*|build:*|build\(*|test:*|test\(*|docs:*|docs\(*) continue ;;
+    Merge\ *|"Bump version"*|*"bump version"*|*"version bump"*) continue ;;
+  esac
+
+  # De-dupe identical subjects, preserving first-seen order.
+  case "$seen" in *"|${subject}|"*) continue ;; esac
+  seen="${seen}${subject}|"
+
+  if [[ "$emitted" -ge "$MAX" ]]; then
+    echo "- ...and more (see the commit log)"
+    break
+  fi
+
+  if [[ "$AUDIENCE" == "external" ]]; then
+    # Clean for founders: strip "(#N)" / "#N", and a leading conventional prefix
+    # like "ios:" / "fix(mobile):". Keep it a DRAFT; a human curates wording.
+    clean="$(printf '%s' "$subject" \
+      | sed -E 's/ *\(#[0-9]+\)//g; s/ +#[0-9]+//g' \
+      | sed -E 's/^[a-z]+(\([^)]*\))?(!)?: *//')"
+    [[ -n "$clean" ]] || clean="$subject"
+    echo "- ${clean}"
+  else
+    echo "- ${subject}"
+  fi
+  emitted=$((emitted + 1))
+done < <(git log --no-merges --format='%s' "${BASE}..HEAD" -- $PATHS 2>/dev/null || true)
+
+if [[ "$emitted" -eq 0 ]]; then
+  fallback
+fi

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -68,7 +68,12 @@ PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-s
 # First-line subjects of non-merge commits in range touching those paths. Squash
 # merges carry the PR title + "(#N)" as the subject, which is exactly what we want.
 emitted=0
-seen="|"
+# Newline-delimited set of subjects already emitted. A commit subject is one git
+# log line, so it never contains a newline; membership is an exact fixed-string
+# line match (grep -Fx), which avoids both glob interpretation and a separator
+# collision (an earlier `|`-delimited scheme dropped distinct subjects that
+# happened to contain `|`, e.g. "feat: support A|B mode").
+seen=""
 
 while IFS= read -r subject; do
   [[ -n "$subject" ]] || continue
@@ -80,8 +85,9 @@ while IFS= read -r subject; do
   esac
 
   # De-dupe identical subjects, preserving first-seen order.
-  case "$seen" in *"|${subject}|"*) continue ;; esac
-  seen="${seen}${subject}|"
+  if printf '%s\n' "$seen" | grep -Fxq -- "$subject"; then continue; fi
+  seen="${seen}${subject}
+"
 
   if [[ "$emitted" -ge "$MAX" ]]; then
     echo "- ...and more (see the commit log)"

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -53,6 +53,14 @@ if [[ -z "$BASE" ]] || ! git rev-parse --verify --quiet "${BASE}^{commit}" >/dev
   exit 0
 fi
 
+# Base must be an ancestor of HEAD, or "BASE..HEAD" is not a meaningful "since the
+# previous beta" range (e.g. the caller fed a SHA from an unrelated branch). Fail
+# closed to the fallback line rather than emit notes for a bogus commit range.
+if ! git merge-base --is-ancestor "$BASE" HEAD 2>/dev/null; then
+  fallback
+  exit 0
+fi
+
 # iOS-affecting paths: mirror the push-trigger filter in ios-testflight.yml so the
 # notes only mention changes that could be in this build.
 PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-sdk-prerelease scripts/ghosttykit-checksums.txt"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -876,7 +876,17 @@ else
   NOTES_SOURCE_ARGS=()
   NOTES_SOURCE_DESC="ios/CHANGELOG.md"
   if [[ "$RANGE_NOTES_MODE" -eq 1 ]]; then
-    GENERATED_NOTES="$("$SCRIPT_DIR/generate-testflight-notes.sh" "$NOTES_RANGE_BASE" --audience "$NOTES_AUDIENCE" 2>/dev/null || true)"
+    # Keep generator stderr on the CI transcript (its fallback/unreachable-base
+    # diagnostics are useful); only swallow a non-zero EXIT so a generator hiccup
+    # cannot fail the already-uploaded build. Guard against an empty result: an
+    # empty --notes would be treated downstream as "no override" and silently fall
+    # back to changelog mode (the wrong notes for an auto-version build), or push
+    # blank What to Test. Substitute the generator's own fallback line instead.
+    GENERATED_NOTES="$("$SCRIPT_DIR/generate-testflight-notes.sh" "$NOTES_RANGE_BASE" --audience "$NOTES_AUDIENCE" || true)"
+    if [[ -z "$GENERATED_NOTES" ]]; then
+      GENERATED_NOTES="- Latest main; no notable iOS changes detected since the previous build."
+      echo "warning: notes generator produced no output; using the fallback What to Test line" >&2
+    fi
     NOTES_SOURCE_ARGS=( --notes "$GENERATED_NOTES" )
     if [[ -n "$NOTES_RANGE_BASE" ]]; then
       NOTES_SOURCE_DESC="commits since the previous beta (${NOTES_RANGE_BASE})"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -136,7 +136,12 @@ Options:
                             (no repo commit) to the next patch above the last
                             iOS release (newest ios-v<X.Y.Z> tag, else the
                             checked-in MARKETING_VERSION), so betas show e.g.
-                            1.0.4 while 1.0.3 is the last release.
+                            1.0.4 while 1.0.3 is the last release. Implies
+                            range-notes mode (skips the changelog preflight and
+                            version-match guard, since the stamped version
+                            deliberately will not match the changelog top); when
+                            no --notes-from-range base is given the generator
+                            emits its fallback line.
   -h, --help                Show this help.
 EOF
 }
@@ -317,6 +322,19 @@ if [[ "$AUTO_VERSION" -eq 1 ]]; then
   fi
 fi
 
+# Are the notes auto-generated from a commit range instead of the changelog?
+# True when an explicit --notes-from-range base was given, OR when --auto-version
+# is set: an auto-version build stamps the NEXT beta marketing version, which by
+# design will not equal the checked-in changelog top entry, so the changelog
+# preflight + version-match guard must not run for it. The range generator has its
+# own empty/unreachable-base fallback, so this stays correct on the first beta or a
+# missing-history lookup where NOTES_RANGE_BASE is empty (it would otherwise fall
+# back to changelog validation and abort against the stale top version).
+RANGE_NOTES_MODE=0
+if [[ -n "$NOTES_RANGE_BASE" || "$AUTO_VERSION" -eq 1 ]]; then
+  RANGE_NOTES_MODE=1
+fi
+
 # Preflight the TestFlight "What to Test" notes BEFORE the expensive archive, so a
 # deterministic local error (missing ios/CHANGELOG.md, empty audience block) fails
 # fast here instead of being discovered only AFTER the build is already uploaded
@@ -325,8 +343,8 @@ fi
 # build's marketing version) happens later for a reused --archive-path / post-build,
 # where the actual marketing version is known. Skipped when there is no upload to
 # annotate (--export-only), notes are turned off (--skip-notes), or notes come from
-# a commit range (--notes-from-range) rather than the changelog.
-if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && -z "$NOTES_RANGE_BASE" ]]; then
+# a commit range (range-notes mode) rather than the changelog.
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && "$RANGE_NOTES_MODE" -ne 1 ]]; then
   if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only --audience "$NOTES_AUDIENCE"; then
     echo "error: TestFlight What to Test notes preflight failed (see above). Fix ios/CHANGELOG.md before uploading, or pass --skip-notes to upload without notes." >&2
     exit 1
@@ -531,10 +549,10 @@ fi
 # fails BEFORE the export/upload, not after (when the notes step is non-fatal and
 # would just ship an opaque build). Skipped for --export-only / --skip-notes. If the
 # archive's version is unreadable, the version-match guard simply does not run.
-# Skipped for --notes-from-range: the notes come from the commit range, not the
+# Skipped in range-notes mode: the notes come from the commit range, not the
 # changelog, and --auto-version intentionally stamps a version the changelog would
 # not match.
-if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && -z "$NOTES_RANGE_BASE" ]]; then
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && "$RANGE_NOTES_MODE" -ne 1 ]]; then
   ARCHIVE_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
   if [[ "$ARCHIVE_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
     if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only \
@@ -848,16 +866,23 @@ else
   # re-applied later. NOTES_AUDIENCE was set early. Re-read the archived marketing
   # version so the mutation still carries the version-match guard.
   NOTES_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
-  # With --notes-from-range the notes come from the commit range (not the
-  # changelog), so pass them via --notes and skip the changelog version-match
+  # In range-notes mode the notes come from the commit range (not the changelog),
+  # so pass them via --notes and skip the changelog version-match
   # (--expect-marketing-version validates the changelog top, which we are not
-  # using). Otherwise keep the changelog-driven behavior + version-match guard.
+  # using). The generator self-falls-back when the base is empty/unreachable, so an
+  # auto-version build with no previous-beta SHA still gets a valid fallback line
+  # here instead of dropping back to changelog validation. Otherwise keep the
+  # changelog-driven behavior + version-match guard.
   NOTES_SOURCE_ARGS=()
   NOTES_SOURCE_DESC="ios/CHANGELOG.md"
-  if [[ -n "$NOTES_RANGE_BASE" ]]; then
+  if [[ "$RANGE_NOTES_MODE" -eq 1 ]]; then
     GENERATED_NOTES="$("$SCRIPT_DIR/generate-testflight-notes.sh" "$NOTES_RANGE_BASE" --audience "$NOTES_AUDIENCE" 2>/dev/null || true)"
     NOTES_SOURCE_ARGS=( --notes "$GENERATED_NOTES" )
-    NOTES_SOURCE_DESC="commits since the previous beta (${NOTES_RANGE_BASE})"
+    if [[ -n "$NOTES_RANGE_BASE" ]]; then
+      NOTES_SOURCE_DESC="commits since the previous beta (${NOTES_RANGE_BASE})"
+    else
+      NOTES_SOURCE_DESC="auto-generated notes (no previous beta; fallback)"
+    fi
   elif [[ "$NOTES_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
     NOTES_SOURCE_ARGS=( --expect-marketing-version "$NOTES_MARKETING_VERSION" )
   fi

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -302,6 +302,15 @@ NOTES_AUDIENCE="internal"
 MARKETING_VERSION_ARGS=()
 BETA_MARKETING_VERSION=""
 if [[ "$AUTO_VERSION" -eq 1 ]]; then
+  # --auto-version stamps the marketing version at archive time and disables the
+  # changelog version guard (RANGE_NOTES_MODE). Both only make sense when THIS
+  # script archives. A reused --archive-path is already built, so there is nothing
+  # to stamp and the guard would be skipped over an unknown embedded version: fail
+  # closed rather than upload a prebuilt archive with a possibly-stale version.
+  if [[ -n "$ARCHIVE_PATH" ]]; then
+    echo "error: --auto-version cannot restamp a prebuilt --archive-path. Re-archive without --archive-path, or drop --auto-version." >&2
+    exit 2
+  fi
   base_version=""
   last_ios_tag="$(git -C "$IOS_DIR" tag --list 'ios-v*' --sort=-version:refname 2>/dev/null | head -1 || true)"
   if [[ "$last_ios_tag" =~ ^ios-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
@@ -318,7 +327,11 @@ if [[ "$AUTO_VERSION" -eq 1 ]]; then
     MARKETING_VERSION_ARGS=( "MARKETING_VERSION=$BETA_MARKETING_VERSION" )
     echo "auto-version: stamping beta MARKETING_VERSION=$BETA_MARKETING_VERSION (last release base ${base_version:-unknown})" >&2
   else
-    echo "warning: --auto-version could not compute a beta version (base '${base_version:-}'); leaving the checked-in MARKETING_VERSION" >&2
+    # Fail closed: --auto-version disables the changelog version guard, so if we
+    # cannot compute a stamp we must not silently upload the un-bumped checked-in
+    # version with the guard off.
+    echo "error: --auto-version could not compute a beta version (base '${base_version:-}'); refusing to upload with the version guard disabled and no stamp. Ensure an ios-v<X.Y.Z> tag or a valid MARKETING_VERSION in ios/Config/Shared.xcconfig." >&2
+    exit 1
   fi
 fi
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -126,6 +126,17 @@ Options:
                             ios/CHANGELOG.md entry to the build (the Internal block,
                             or the External block with --external). Also via
                             CMUX_TESTFLIGHT_SKIP_NOTES=1.
+  --notes-from-range <base> Auto-generate the "What to Test" notes from the
+                            iOS-affecting commits in <base>..HEAD instead of the
+                            ios/CHANGELOG.md top entry (used by the every-2h beta
+                            lane so each build's notes reflect what changed since
+                            the previous beta). Skips the changelog preflight and
+                            version-match guard.
+  --auto-version            Stamp the build's MARKETING_VERSION at archive time
+                            (no repo commit) to the next patch above the last
+                            iOS release (newest ios-v<X.Y.Z> tag, else the
+                            checked-in MARKETING_VERSION), so betas show e.g.
+                            1.0.4 while 1.0.3 is the last release.
   -h, --help                Show this help.
 EOF
 }
@@ -175,6 +186,18 @@ SKIP_NOTES=0
 if [[ "${CMUX_TESTFLIGHT_SKIP_NOTES:-}" == "1" ]]; then
   SKIP_NOTES=1
 fi
+# --notes-from-range <base>: auto-generate the "What to Test" notes from the
+# iOS-affecting commits in <base>..HEAD (via generate-testflight-notes.sh) instead
+# of the hand-maintained ios/CHANGELOG.md top entry. Used by the every-2h beta lane
+# so each build's notes reflect what actually changed since the previous beta. When
+# set, the changelog preflight + version-match guard are skipped (the notes no
+# longer come from the changelog, and --auto-version stamps a version the changelog
+# would not match).
+NOTES_RANGE_BASE=""
+# --auto-version: stamp the build's MARKETING_VERSION at archive time (no repo
+# commit-back, mirroring the timestamp build number) to the next patch above the
+# last iOS release, so betas show e.g. 1.0.4 while 1.0.3 is the last release.
+AUTO_VERSION=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -209,6 +232,15 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-notes)
       SKIP_NOTES=1
+      shift
+      ;;
+    --notes-from-range)
+      require_option_value "$1" "${2:-}"
+      NOTES_RANGE_BASE="$2"
+      shift 2
+      ;;
+    --auto-version)
+      AUTO_VERSION=1
       shift
       ;;
     -h|--help)
@@ -254,6 +286,37 @@ DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-7WLXT3NR37}"
 NOTES_AUDIENCE="internal"
 [[ "$EXTERNAL_TESTING" == "1" ]] && NOTES_AUDIENCE="external"
 
+# --auto-version: compute the beta marketing version (next patch above the last
+# iOS release) and prepare it as an archive build-setting override. No repo write:
+# this mirrors the timestamp BUILD_NUMBER, which is also stamped at archive time
+# and never committed. Source of "last release" is the newest `ios-v<X.Y.Z>` git
+# tag (the `v1.x` tags are the macOS app); fallback to the checked-in
+# MARKETING_VERSION if no iOS tag exists. So while 1.0.3 is the last release, every
+# beta archives as 1.0.4; a real release sets + tags the version and the stamp
+# tracks it.
+MARKETING_VERSION_ARGS=()
+BETA_MARKETING_VERSION=""
+if [[ "$AUTO_VERSION" -eq 1 ]]; then
+  base_version=""
+  last_ios_tag="$(git -C "$IOS_DIR" tag --list 'ios-v*' --sort=-version:refname 2>/dev/null | head -1 || true)"
+  if [[ "$last_ios_tag" =~ ^ios-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    base_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+  else
+    base_version="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION[[:space:]]*=[[:space:]]*([0-9]+(\.[0-9]+){1,2}).*/\1/p' "$IOS_DIR/Config/Shared.xcconfig" 2>/dev/null | head -1)"
+  fi
+  if [[ "$base_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
+  elif [[ "$base_version" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+    BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.$(( BASH_REMATCH[2] + 1 )).0"
+  fi
+  if [[ -n "$BETA_MARKETING_VERSION" ]]; then
+    MARKETING_VERSION_ARGS=( "MARKETING_VERSION=$BETA_MARKETING_VERSION" )
+    echo "auto-version: stamping beta MARKETING_VERSION=$BETA_MARKETING_VERSION (last release base ${base_version:-unknown})" >&2
+  else
+    echo "warning: --auto-version could not compute a beta version (base '${base_version:-}'); leaving the checked-in MARKETING_VERSION" >&2
+  fi
+fi
+
 # Preflight the TestFlight "What to Test" notes BEFORE the expensive archive, so a
 # deterministic local error (missing ios/CHANGELOG.md, empty audience block) fails
 # fast here instead of being discovered only AFTER the build is already uploaded
@@ -261,8 +324,9 @@ NOTES_AUDIENCE="internal"
 # and needs no ASC credentials. The version-match check (changelog top == the
 # build's marketing version) happens later for a reused --archive-path / post-build,
 # where the actual marketing version is known. Skipped when there is no upload to
-# annotate (--export-only) or notes are turned off (--skip-notes).
-if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 ]]; then
+# annotate (--export-only), notes are turned off (--skip-notes), or notes come from
+# a commit range (--notes-from-range) rather than the changelog.
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && -z "$NOTES_RANGE_BASE" ]]; then
   if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only --audience "$NOTES_AUDIENCE"; then
     echo "error: TestFlight What to Test notes preflight failed (see above). Fix ios/CHANGELOG.md before uploading, or pass --skip-notes to upload without notes." >&2
     exit 1
@@ -426,6 +490,7 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
       DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
       PRODUCT_BUNDLE_IDENTIFIER="$PRODUCT_BUNDLE_IDENTIFIER" \
       CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+      "${MARKETING_VERSION_ARGS[@]}" \
       CODE_SIGN_STYLE=Automatic \
       CODE_SIGN_ENTITLEMENTS="Config/cmux-release.entitlements" \
       CODE_SIGN_IDENTITY="Apple Distribution" \
@@ -447,6 +512,7 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
       DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
       PRODUCT_BUNDLE_IDENTIFIER="$PRODUCT_BUNDLE_IDENTIFIER" \
       CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+      "${MARKETING_VERSION_ARGS[@]}" \
       CODE_SIGNING_ALLOWED=NO \
       CODE_SIGNING_REQUIRED=NO \
       CODE_SIGN_IDENTITY="" \
@@ -465,7 +531,10 @@ fi
 # fails BEFORE the export/upload, not after (when the notes step is non-fatal and
 # would just ship an opaque build). Skipped for --export-only / --skip-notes. If the
 # archive's version is unreadable, the version-match guard simply does not run.
-if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 ]]; then
+# Skipped for --notes-from-range: the notes come from the commit range, not the
+# changelog, and --auto-version intentionally stamps a version the changelog would
+# not match.
+if [[ "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && -z "$NOTES_RANGE_BASE" ]]; then
   ARCHIVE_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
   if [[ "$ARCHIVE_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
     if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only \
@@ -779,18 +848,27 @@ else
   # re-applied later. NOTES_AUDIENCE was set early. Re-read the archived marketing
   # version so the mutation still carries the version-match guard.
   NOTES_MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
-  NOTES_VERSION_ARGS=()
-  if [[ "$NOTES_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
-    NOTES_VERSION_ARGS=( --expect-marketing-version "$NOTES_MARKETING_VERSION" )
+  # With --notes-from-range the notes come from the commit range (not the
+  # changelog), so pass them via --notes and skip the changelog version-match
+  # (--expect-marketing-version validates the changelog top, which we are not
+  # using). Otherwise keep the changelog-driven behavior + version-match guard.
+  NOTES_SOURCE_ARGS=()
+  NOTES_SOURCE_DESC="ios/CHANGELOG.md"
+  if [[ -n "$NOTES_RANGE_BASE" ]]; then
+    GENERATED_NOTES="$("$SCRIPT_DIR/generate-testflight-notes.sh" "$NOTES_RANGE_BASE" --audience "$NOTES_AUDIENCE" 2>/dev/null || true)"
+    NOTES_SOURCE_ARGS=( --notes "$GENERATED_NOTES" )
+    NOTES_SOURCE_DESC="commits since the previous beta (${NOTES_RANGE_BASE})"
+  elif [[ "$NOTES_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+    NOTES_SOURCE_ARGS=( --expect-marketing-version "$NOTES_MARKETING_VERSION" )
   fi
-  echo "setting TestFlight '$NOTES_AUDIENCE' What to Test notes for build $SHIPPED_BUILD_NUMBER (${NOTES_MARKETING_VERSION:-unknown version}) from ios/CHANGELOG.md" >&2
+  echo "setting TestFlight '$NOTES_AUDIENCE' What to Test notes for build $SHIPPED_BUILD_NUMBER (${NOTES_MARKETING_VERSION:-unknown version}) from ${NOTES_SOURCE_DESC}" >&2
   if ASC_API_KEY_ID="$ASC_API_KEY_ID" ASC_API_ISSUER_ID="$ASC_API_ISSUER_ID" \
      ASC_API_KEY_PATH="${ASC_API_KEY_PATH:-}" ASC_API_KEY_P8_BASE64="${ASC_API_KEY_P8_BASE64:-}" \
      "$SCRIPT_DIR/set-testflight-notes.sh" \
        --build-number "$SHIPPED_BUILD_NUMBER" \
        --audience "$NOTES_AUDIENCE" \
        --bundle-id "$PRODUCT_BUNDLE_IDENTIFIER" \
-       "${NOTES_VERSION_ARGS[@]}"; then
+       "${NOTES_SOURCE_ARGS[@]}"; then
     echo "TestFlight What to Test notes set for build $SHIPPED_BUILD_NUMBER" >&2
   else
     echo "warning: could not set TestFlight What to Test notes for build $SHIPPED_BUILD_NUMBER (the upload succeeded; re-run ios/scripts/set-testflight-notes.sh --build-number $SHIPPED_BUILD_NUMBER --audience $NOTES_AUDIENCE once the build finishes processing)" >&2

--- a/tests/test_ios_testflight_notes.py
+++ b/tests/test_ios_testflight_notes.py
@@ -89,6 +89,19 @@ def main():
         bogus = _gen(repo, "deadbeefdeadbeef", "internal")
         _check("no notable iOS changes" in bogus, "unreachable base -> fallback line")
 
+        # A base that is a real commit but NOT an ancestor of HEAD (e.g. a SHA from
+        # an unrelated branch) must fail closed to the fallback, not emit notes for
+        # a bogus range.
+        _git(repo, "checkout", "-q", "-b", "side", base)
+        _commit(repo, "ios/cmux/Side.swift", "ios: side-branch only change (#900)")
+        side = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "checkout", "-q", "main")
+        non_ancestor = _gen(repo, side, "internal")
+        _check("no notable iOS changes" in non_ancestor,
+               "non-ancestor base -> fallback line")
+        _check("side-branch only change" not in non_ancestor,
+               "non-ancestor base does not leak unrelated commits")
+
     if FAILURES:
         print(f"\n{len(FAILURES)} failure(s)")
         sys.exit(1)

--- a/tests/test_ios_testflight_notes.py
+++ b/tests/test_ios_testflight_notes.py
@@ -44,6 +44,10 @@ def _gen(repo, base, audience="internal"):
     env = dict(os.environ)
     out = subprocess.run(["bash", SCRIPT, base, "--audience", audience],
                          cwd=repo, capture_output=True, text=True, env=env)
+    # The generator must always exit 0 (notes are non-fatal; a failure here would
+    # abort the upload). Assert it, since callers only read stdout.
+    _check(out.returncode == 0,
+           f"generator exits 0 (base={base or 'EMPTY'}, {audience})")
     return out.stdout
 
 
@@ -68,6 +72,11 @@ def main():
         _commit(repo, "ios/cmux/Chore.swift", "chore: bump deps (#105)")
         _commit(repo, "ios/cmux/Ci.swift", "ci: tweak workflow (#106)")
 
+        # Subjects containing the literal '|' must not corrupt de-duplication
+        # (regression: a '|'-delimited seen-set dropped distinct later subjects).
+        _commit(repo, "ios/cmux/Pipe.swift", "ios: support A|B mode (#107)")
+        _commit(repo, "ios/cmux/Pipe2.swift", "ios: support A (#108)")
+
         internal = _gen(repo, base, "internal")
         _check("fix the thing (#101)" in internal, "internal includes iOS PR title + number")
         _check("add a feature (#102)" in internal, "internal includes Packages/iOS commit")
@@ -75,6 +84,9 @@ def main():
         _check("unrelated web change" not in internal, "internal excludes non-iOS commit")
         _check("bump deps" not in internal and "tweak workflow" not in internal,
                "internal excludes chore/ci noise")
+        _check("support A|B mode (#107)" in internal, "pipe-subject preserved")
+        _check("support A (#108)" in internal,
+               "distinct subject not dropped by a pipe-bearing earlier subject")
 
         external = _gen(repo, base, "external")
         _check("#101" not in external and "#102" not in external,

--- a/tests/test_ios_testflight_notes.py
+++ b/tests/test_ios_testflight_notes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for ios/scripts/generate-testflight-notes.sh.
+
+The generator turns the iOS-affecting commits in <base>..HEAD into the per-build
+TestFlight "What to Test" notes (internal keeps PR numbers; external is a cleaned
+draft). These tests build a throwaway git repo so the assertions are deterministic
+and do not depend on the real history.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(REPO_ROOT, "ios", "scripts", "generate-testflight-notes.sh")
+
+FAILURES = []
+
+
+def _check(cond, msg):
+    if not cond:
+        FAILURES.append(msg)
+        print(f"FAIL: {msg}")
+    else:
+        print(f"ok: {msg}")
+
+
+def _git(repo, *args, **kw):
+    return subprocess.run(["git", "-C", repo, *args], check=True,
+                          capture_output=True, text=True, **kw)
+
+
+def _commit(repo, path, subject):
+    full = os.path.join(repo, path)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "a", encoding="utf-8") as f:
+        f.write(subject + "\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", subject)
+
+
+def _gen(repo, base, audience="internal"):
+    env = dict(os.environ)
+    out = subprocess.run(["bash", SCRIPT, base, "--audience", audience],
+                         cwd=repo, capture_output=True, text=True, env=env)
+    return out.stdout
+
+
+def main():
+    _check(os.access(SCRIPT, os.X_OK), "generator script is executable")
+
+    with tempfile.TemporaryDirectory() as repo:
+        _git(repo, "init", "-q", "-b", "main")
+        _git(repo, "config", "user.email", "t@t.test")
+        _git(repo, "config", "user.name", "Test")
+
+        _commit(repo, "README.md", "root")
+        base = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        # iOS-affecting commits (should appear), one per filtered path family.
+        _commit(repo, "ios/cmux/App.swift", "ios: fix the thing (#101)")
+        _commit(repo, "Packages/iOS/Foo/Bar.swift", "Mobile: add a feature (#102)")
+        _commit(repo, "Packages/Shared/Baz/Qux.swift", "Shared: shared change (#103)")
+        # Non-iOS commit (should NOT appear).
+        _commit(repo, "web/app/page.tsx", "web: unrelated web change (#104)")
+        # Noise commits (should NOT appear).
+        _commit(repo, "ios/cmux/Chore.swift", "chore: bump deps (#105)")
+        _commit(repo, "ios/cmux/Ci.swift", "ci: tweak workflow (#106)")
+
+        internal = _gen(repo, base, "internal")
+        _check("fix the thing (#101)" in internal, "internal includes iOS PR title + number")
+        _check("add a feature (#102)" in internal, "internal includes Packages/iOS commit")
+        _check("shared change (#103)" in internal, "internal includes Packages/Shared commit")
+        _check("unrelated web change" not in internal, "internal excludes non-iOS commit")
+        _check("bump deps" not in internal and "tweak workflow" not in internal,
+               "internal excludes chore/ci noise")
+
+        external = _gen(repo, base, "external")
+        _check("#101" not in external and "#102" not in external,
+               "external strips PR numbers")
+        _check("ios:" not in external, "external strips the conventional prefix")
+        _check("fix the thing" in external.lower(), "external still carries the change text")
+
+        # Empty range and a bogus base both fall back deterministically (exit 0).
+        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        empty = _gen(repo, head, "internal")
+        _check("no notable iOS changes" in empty, "empty range -> fallback line")
+        bogus = _gen(repo, "deadbeefdeadbeef", "internal")
+        _check("no notable iOS changes" in bogus, "unreachable base -> fallback line")
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s)")
+        sys.exit(1)
+    print("\nall ios testflight notes generator tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Every internal TestFlight update showed the SAME "What to Test" and a frozen `MARKETING_VERSION`. The notes pipeline was well-built but manual: `ios/CHANGELOG.md`'s top entry feeds the build's `betaBuildLocalizations.whatsNew`, and `ios/Config/Shared.xcconfig` holds the version. The every-2h scheduled beta lane (`ios-testflight.yml`) uploads the latest `main` with a fresh timestamp build number but reused that stale top entry, so testers saw identical notes and `1.0.3` forever.

## What changed

Each beta build's "What to Test" is now auto-generated from what actually changed since the previous beta, and the version reflects the next release, with no commit-back. Internal lane is fully automatic; external/founders stays curated.

- **`ios/scripts/generate-testflight-notes.sh`** (new): turns the iOS-affecting commits in `<base>..HEAD` into terse notes (squash-merge PR title + `(#N)` for internal; a cleaned, number/prefix-stripped DRAFT for external). Drops `chore`/`ci`/`build`/`test`/`docs`/merge/version-bump noise, dedupes, caps at 20. Empty/unreachable/non-ancestor base emits a deterministic fallback line and exits 0, so the non-fatal notes step never breaks an upload.
- **`ios/scripts/upload-testflight.sh`**: adds `--notes-from-range <base>` (generate + feed `set-testflight-notes.sh --notes`) and `--auto-version` (stamp `MARKETING_VERSION` = newest `ios-v<X.Y.Z>` tag patch+1, fallback `Shared.xcconfig`; archive-only override, never committed, mirroring the timestamp build number). `--auto-version` implies range-notes mode so the stamped version never trips the changelog version-match guard.
- **`.github/workflows/ios-testflight.yml`**: `decide` outputs `last_uploaded_sha` (resolved from the newest successful `main` run, fail-closed if the lookup errors); `upload` runs `--auto-version --notes-from-range "$LAST_SHA"`. Lane stays internal-only; external remains the deliberate `ship ios founders` path.
- **`tests/test_ios_testflight_notes.py`** (new, wired into `ci.yml`): generator regression test — path filter, noise drop, external `#N` stripping, empty/bogus/non-ancestor base fallback.

While `ios-v1.0.3` is the last release, every internal beta now shows `1.0.4 (timestamp)` with notes listing the actual merged iOS PRs. A real release sets the version explicitly and tags `ios-v1.0.4`, which the stamp then tracks. The hand-maintained changelog stays the durable human record + external source.

## Verification

- Generator + version-compute + fail-closed paths covered by `tests/test_ios_testflight_notes.py` (13 assertions, all pass) and an isolated version-arithmetic check (6 cases incl. macOS `v1.x` tags correctly ignored).
- `$autoreview` clean (3 P2 findings found + fixed: feature-branch dispatch poisoning the notes base; first-beta changelog-guard abort under `--auto-version`; fail-open on history-lookup error). cmux-policy clean.

CI/release infra only, no app runtime change, so no tagged app reload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784637174&installation_id=133855650&pr_number=6544&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6544&signature=7f32273b796323c87dc9b4f7a6ca82deab1a4030898d57136307dad4f7537315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the primary TestFlight publish path (version stamping and notes content) and scheduled upload gating; mitigated by fail-closed history lookup, ancestor checks, and non-fatal notes with fallbacks.
> 
> **Overview**
> Internal TestFlight betas no longer reuse a static **ios/CHANGELOG.md** top entry and checked-in **MARKETING_VERSION** for every ~2h upload.
> 
> A new **`generate-testflight-notes.sh`** builds internal or external bullet lists from iOS-touching commits in `<last-beta>..HEAD`, with noise filtering, dedupe, caps, and safe fallbacks when the base is missing or invalid.
> 
> **`upload-testflight.sh`** adds **`--notes-from-range`** and **`--auto-version`** (next patch from newest `ios-v*` tag, archive-only). **`--auto-version`** enables range-notes mode so changelog preflight and version-match guards are skipped when appropriate.
> 
> **`ios-testflight.yml`** exports **`last_uploaded_sha`** from the latest successful **`main`** run (lookup errors fail scheduled uploads closed), checks out full history/tags, and invokes **`--auto-version`** plus **`--notes-from-range`** when a prior beta SHA exists.
> 
> **`tests/test_ios_testflight_notes.py`** is wired into **`ci.yml`** for generator regression coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56a06be1051ee1b67bd76c8372beb194b0a134f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-generate per-build TestFlight “What to Test” from commits since the last beta and stamp the next beta marketing version at archive time. Internal betas now show accurate notes and a moving version (e.g. 1.0.4), without committing changes back.

- **New Features**
  - `ios/scripts/generate-testflight-notes.sh`: builds notes from <base>..HEAD touching iOS paths, filters noise, de-dupes, caps at 20; internal keeps `(#N)`, external strips prefixes/PR numbers; empty/unreachable/non-ancestor base returns a deterministic fallback and exits 0.
  - `ios/scripts/upload-testflight.sh`: adds `--notes-from-range <base>` and `--auto-version` (next patch from newest `ios-v<X.Y.Z>` tag, else `Shared.xcconfig`); range-notes mode skips changelog guards; passes notes via `set-testflight-notes.sh --notes`.
  - `.github/workflows/ios-testflight.yml`: decide step exposes `last_uploaded_sha` from the latest successful run on `main`; upload uses `--auto-version` and, when present, `--notes-from-range "$LAST_SHA"`; fetches full history and tags.
  - `tests/test_ios_testflight_notes.py` added and run in `ci.yml`.

- **Bug Fixes**
  - Workflow: filter workflow-run lookup to `branch: 'main'`; fail closed on API lookup errors to avoid duplicate scheduled uploads.
  - Notes: reject non-ancestor bases; fix de-dup to handle subjects with `|`; surface generator stderr; guard against empty generator output by substituting the fallback line.
  - Versioning: `--auto-version` implies range-notes to fix first-beta abort; reject `--auto-version` with `--archive-path`; abort if a beta version cannot be computed.

<sup>Written for commit a56a06be1051ee1b67bd76c8372beb194b0a134f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TestFlight beta uploads now generate “What to Test” release notes from iOS-related commits since the last successful upload, with internal/external audience formatting.
  * Added `--notes-from-range` to derive notes from a commit range, plus `--auto-version` to set the marketing version from the latest iOS release tags.
  * Improved scheduled TestFlight build/upload decisions using tracked last-uploaded commit SHA to prevent duplicate uploads.
* **Tests**
  * Added a new test suite validating notes generation, formatting/deduplication, and deterministic “no notable changes” fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->