### PR TITLE
feat(session): per-tab shell history and configurable session restore

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/OSC133CommandParser.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/OSC133CommandParser.swift
@@ -45,6 +45,30 @@ public struct OSC133CommandParser {
     /// Creates an empty parser.
     public init() {}
 
+    /// Removes and returns all completed (non-running) blocks, keeping any
+    /// still-open block so streaming continues uninterrupted.
+    ///
+    /// A long-lived consumer (e.g. per-tab command-history recording) calls
+    /// this after ``consume(_:)`` to drain finished commands and bound memory,
+    /// instead of retaining every block's output for the whole session. The
+    /// `id` counter keeps advancing, so drained and future blocks never collide.
+    /// The chat transcript view does not call this (it reads ``blocks``
+    /// cumulatively), so its own parser instance is unaffected.
+    public mutating func takeCompletedBlocks() -> [TerminalCommandBlock] {
+        guard let openIndex else {
+            let all = blocks
+            blocks = []
+            return all
+        }
+        // The open block is always the last element; everything before it is
+        // completed and safe to hand off.
+        let completed = Array(blocks[..<openIndex])
+        let open = blocks[openIndex]
+        blocks = [open]
+        self.openIndex = 0
+        return completed
+    }
+
     /// Feeds a chunk of raw terminal output through the state machine.
     ///
     /// - Parameter text: A slice of the PTY stream, any length.

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/OSC133CommandParserDrainTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/OSC133CommandParserDrainTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+/// `takeCompletedBlocks()` lets a long-lived consumer (per-tab command-history
+/// recording) drain finished commands and bound memory while a command may
+/// still be streaming.
+@Suite("OSC133CommandParser.takeCompletedBlocks")
+struct OSC133CommandParserDrainTests {
+    private func esc(_ body: String) -> String { "\u{1b}]\(body)\u{07}" }
+    private func mark(_ k: String) -> String { esc("133;\(k)") }
+
+    @Test("drains finished blocks and empties when nothing is open")
+    func drainsFinished() {
+        var parser = OSC133CommandParser()
+        parser.consume(mark("A") + mark("B") + "ls" + mark("C") + "out\n" + mark("D;0"))
+        parser.consume(mark("A") + mark("B") + "pwd" + mark("C") + "/tmp\n" + mark("D;0"))
+
+        let drained = parser.takeCompletedBlocks()
+        #expect(drained.map(\.command) == ["ls", "pwd"])
+        #expect(parser.blocks.isEmpty)
+    }
+
+    @Test("keeps the still-open block and continues streaming into it")
+    func keepsOpenBlock() {
+        var parser = OSC133CommandParser()
+        parser.consume(mark("A") + mark("B") + "ls" + mark("C") + "a\n" + mark("D;0"))
+        parser.consume(mark("A") + mark("B") + "sleep 5" + mark("C") + "work")
+
+        let drained = parser.takeCompletedBlocks()
+        #expect(drained.map(\.command) == ["ls"])
+        #expect(parser.blocks.count == 1)
+        #expect(parser.blocks[0].command == "sleep 5")
+        #expect(parser.blocks[0].isRunning)
+
+        // More output for the kept-open block still lands on it…
+        parser.consume("ing\n" + mark("D;0"))
+        #expect(parser.blocks[0].output == "working\n")
+        #expect(parser.blocks[0].isRunning == false)
+    }
+
+    @Test("ids stay unique across drains")
+    func idsStayUniqueAcrossDrains() {
+        var parser = OSC133CommandParser()
+        parser.consume(mark("A") + mark("B") + "one" + mark("C") + mark("D;0"))
+        let first = parser.takeCompletedBlocks()
+
+        parser.consume(mark("A") + mark("B") + "two" + mark("C") + mark("D;0"))
+        let second = parser.takeCompletedBlocks()
+
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(first[0].id != second[0].id)
+    }
+
+    @Test("draining an empty parser returns nothing")
+    func drainEmpty() {
+        var parser = OSC133CommandParser()
+        #expect(parser.takeCompletedBlocks().isEmpty)
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SessionCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SessionCatalogSection.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Settings for session restore and per-tab shell history, the `session.*`
+/// keys. Both are JSON-backed so they can be edited directly in
+/// `~/.config/cmux/cmux.json`.
+public struct SessionCatalogSection: SettingCatalogSection {
+    /// How a previously saved session is handled on launch: `always`
+    /// (restore silently), `ask` (prompt first; the default), or `never`
+    /// (start fresh, leaving the session reopenable from the File menu).
+    ///
+    /// ```json
+    /// { "session": { "restoreMode": "ask" } }
+    /// ```
+    public let restoreMode = JSONKey<SessionRestoreMode>(
+        id: "session.restoreMode",
+        defaultValue: .ask
+    )
+
+    /// Whether each terminal tab keeps its own shell history (up-arrow /
+    /// Ctrl-R recall) namespaced by project directory, plus a recorded cmux
+    /// command history per tab. When off, tabs use the shell's normal global
+    /// history.
+    ///
+    /// ```json
+    /// { "session": { "persistShellHistory": true } }
+    /// ```
+    public let persistShellHistory = JSONKey<Bool>(
+        id: "session.persistShellHistory",
+        defaultValue: true
+    )
+
+    public init() {}
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
@@ -46,6 +46,8 @@ public struct SettingCatalog: SettingCatalogSection {
     public let shortcuts = KeyboardShortcutsCatalogSection()
     public let integrations = IntegrationsCatalogSection()
     public let account = AccountCatalogSection()
+    /// Settings for session restore and per-tab shell history (the `session.*` keys).
+    public let session = SessionCatalogSection()
 
     public init() {}
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/SessionRestoreMode.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/SessionRestoreMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// How cmux handles a previously saved session when it launches.
+///
+/// Stored under the catalog entry ``SessionCatalogSection/restoreMode``
+/// (`session.restoreMode` in `~/.config/cmux/cmux.json`). The raw values are
+/// the on-disk strings, so they must not be renamed without a migration.
+public enum SessionRestoreMode: String, CaseIterable, Sendable, SettingCodable {
+    /// Silently restore the previous windows, tabs, and panes on launch
+    /// (the historical cmux behavior).
+    case always
+
+    /// Prompt before restoring; the user chooses Restore or Start Fresh.
+    /// This is the default.
+    case ask
+
+    /// Never restore automatically; start with a fresh window. The previous
+    /// session stays reopenable from File ▸ Reopen Previous Session.
+    case never
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionSettingsTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionSettingsTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import CmuxSettings
+
+/// Behavior of the `session.*` settings through the real JSON store: the
+/// defaults users get out of the box (restore = ask, per-tab shell history
+/// on), hand-edited values, unknown fallbacks, and the synchronous
+/// ``JSONConfigStore/snapshotValue(for:)`` read used at launch and spawn time.
+@Suite("session.*")
+struct SessionSettingsTests {
+    private func makeStore() -> (JSONConfigStore, URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("cmux.json", isDirectory: false)
+        return (JSONConfigStore(fileURL: fileURL), fileURL)
+    }
+
+    @Test func restoreModeDefaultsToAsk() async {
+        #expect(SettingCatalog().session.restoreMode.defaultValue == .ask)
+        let (store, _) = makeStore()
+        let value = await store.value(for: SettingCatalog().session.restoreMode)
+        #expect(value == .ask)
+    }
+
+    @Test func persistShellHistoryDefaultsToTrue() async {
+        #expect(SettingCatalog().session.persistShellHistory.defaultValue == true)
+        let (store, _) = makeStore()
+        let value = await store.value(for: SettingCatalog().session.persistShellHistory)
+        #expect(value == true)
+    }
+
+    @Test func readsEachRestoreModeFromHandEditedConfigFile() async throws {
+        for raw in ["always", "ask", "never"] {
+            let (store, fileURL) = makeStore()
+            try "{ \"session\": { \"restoreMode\": \"\(raw)\" } }"
+                .write(to: fileURL, atomically: true, encoding: .utf8)
+            let value = await store.value(for: SettingCatalog().session.restoreMode)
+            #expect(value == SessionRestoreMode(rawValue: raw))
+        }
+    }
+
+    @Test func unknownRestoreModeFallsBackToAsk() async throws {
+        let (store, fileURL) = makeStore()
+        try #"{ "session": { "restoreMode": "yolo" } }"#
+            .write(to: fileURL, atomically: true, encoding: .utf8)
+        let value = await store.value(for: SettingCatalog().session.restoreMode)
+        #expect(value == .ask)
+    }
+
+    @Test func persistShellHistoryReadsFalseFromConfigFile() async throws {
+        let (store, fileURL) = makeStore()
+        try #"{ "session": { "persistShellHistory": false } }"#
+            .write(to: fileURL, atomically: true, encoding: .utf8)
+        let value = await store.value(for: SettingCatalog().session.persistShellHistory)
+        #expect(value == false)
+    }
+
+    @Test func roundTripsRestoreModeThroughTheStore() async throws {
+        let (store, fileURL) = makeStore()
+        try await store.set(.never, for: SettingCatalog().session.restoreMode)
+        let value = await store.value(for: SettingCatalog().session.restoreMode)
+        #expect(value == .never)
+
+        // The on-disk representation is the raw string, hand-editable.
+        let parsed = try JSONSerialization.jsonObject(with: Data(contentsOf: fileURL)) as? [String: Any]
+        let section = parsed?["session"] as? [String: Any]
+        #expect(section?["restoreMode"] as? String == "never")
+    }
+
+    /// The launch/spawn paths read these keys synchronously off the main
+    /// actor via ``JSONConfigStore/snapshotValue(for:)``; confirm it observes
+    /// hand-edited values and the defaults.
+    @Test func snapshotValueReadsSynchronously() async throws {
+        let (store, fileURL) = makeStore()
+        #expect(store.snapshotValue(for: SettingCatalog().session.restoreMode) == .ask)
+        #expect(store.snapshotValue(for: SettingCatalog().session.persistShellHistory) == true)
+
+        try #"{ "session": { "restoreMode": "never", "persistShellHistory": false } }"#
+            .write(to: fileURL, atomically: true, encoding: .utf8)
+        #expect(store.snapshotValue(for: SettingCatalog().session.restoreMode) == .never)
+        #expect(store.snapshotValue(for: SettingCatalog().session.persistShellHistory) == false)
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -13,6 +13,8 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     case account
     case app
     case terminal
+    /// Session restore behavior and per-tab shell history.
+    case session
     case textBox
     /// Mobile pairing and sync settings.
     case mobile
@@ -37,6 +39,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .account: return "Account"
         case .app: return "App"
         case .terminal: return "Terminal"
+        case .session: return String(localized: "settings.section.session", defaultValue: "Sessions")
         case .textBox: return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
         case .mobile: return String(localized: "settings.section.mobile", defaultValue: "Mobile")
         case .sidebarAppearance: return "Sidebar"
@@ -59,6 +62,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .account: return "person.crop.circle"
         case .app: return "gearshape"
         case .terminal: return "terminal"
+        case .session: return "clock.arrow.circlepath"
         case .textBox: return "textformat"
         case .mobile: return "iphone"
         case .sidebarAppearance: return "sidebar.left"
@@ -83,6 +87,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .account: return "sign in team sync user profile"
         case .app: return "appearance language workspace notifications menu bar telemetry"
         case .terminal: return "scrollbar copy on select agent resume hibernation"
+        case .session: return "session restore reopen previous launch shell history histfile per tab project command history ask always never"
         case .textBox: return "textbox text box rich input prompt default new terminal workspace split tab focus show beta"
         case .mobile: return "ios iphone ipad mobile pairing local network sync"
         case .sidebarAppearance: return "sidebar details branches material terminal background"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -426,8 +426,8 @@ public struct SettingsWindowRoot: View {
     @ViewBuilder
     private var sectionStack: some View {
         // Order matches the legacy in-app SettingsView scroll order:
-        // Account, App, Terminal, TextBox, Mobile, Sidebar, Beta Features,
-        // Automation, Browser (with embedded Import), Global Hotkey,
+        // Account, App, Terminal, Sessions, TextBox, Mobile, Sidebar, Beta
+        // Features, Automation, Browser (with embedded Import), Global Hotkey,
         // Keyboard Shortcuts, Workspace Colors, cmux.json, Reset.
         AccountSection(
             defaultsStore: defaultsStore,
@@ -450,6 +450,13 @@ public struct SettingsWindowRoot: View {
             hostActions: hostActions
         )
         .id(anchorID(for: .terminal))
+
+        SessionSection(
+            jsonStore: jsonStore,
+            catalog: catalog,
+            errorLog: runtime.errorLog
+        )
+        .id(anchorID(for: .session))
 
         TextBoxSection(defaultsStore: defaultsStore, catalog: catalog)
             .id(anchorID(for: .textBox))

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SessionSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SessionSection.swift
@@ -1,0 +1,83 @@
+import CmuxSettings
+import SwiftUI
+
+/// **Sessions** section — controls how cmux restores a previous session on
+/// launch and whether each terminal tab keeps its own persistent shell
+/// history (grouped by project). Both settings are JSON-backed
+/// (`session.*` in `~/.config/cmux/cmux.json`).
+@MainActor
+public struct SessionSection: View {
+    @State private var restoreMode: JSONValueModel<SessionRestoreMode>
+    @State private var persistShellHistory: JSONValueModel<Bool>
+
+    public init(
+        jsonStore: JSONConfigStore,
+        catalog: SettingCatalog,
+        errorLog: SettingsErrorLog
+    ) {
+        _restoreMode = State(initialValue: JSONValueModel(
+            store: jsonStore,
+            key: catalog.session.restoreMode,
+            errorLog: errorLog
+        ))
+        _persistShellHistory = State(initialValue: JSONValueModel(
+            store: jsonStore,
+            key: catalog.session.persistShellHistory,
+            errorLog: errorLog
+        ))
+    }
+
+    public var body: some View {
+        Group {
+            SettingsSectionHeader(String(localized: "settings.section.session", defaultValue: "Sessions"), section: .session)
+            SettingsCard {
+                restoreModeRow
+                SettingsCardDivider()
+                persistShellHistoryRow
+            }
+        }
+        .task { startObservingSettings() }
+    }
+
+    private func startObservingSettings() {
+        let models: [any SettingObservationStarting] = [
+            restoreMode,
+            persistShellHistory,
+        ]
+        models.forEach { $0.startObserving() }
+    }
+
+    @ViewBuilder
+    private var restoreModeRow: some View {
+        SettingsCardRow(
+            configurationReview: .json("session.restoreMode"),
+            String(localized: "settings.session.restoreMode", defaultValue: "Restore Previous Session"),
+            subtitle: restoreMode.current.modeDescription
+        ) {
+            Picker("", selection: Binding(get: { restoreMode.current }, set: { restoreMode.set($0) })) {
+                ForEach(SessionRestoreMode.uiCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .accessibilityIdentifier("SettingsSessionRestoreModePicker")
+        }
+    }
+
+    @ViewBuilder
+    private var persistShellHistoryRow: some View {
+        SettingsCardRow(
+            configurationReview: .json("session.persistShellHistory"),
+            String(localized: "settings.session.persistShellHistory", defaultValue: "Per-Tab Shell History"),
+            subtitle: persistShellHistory.current
+                ? String(localized: "settings.session.persistShellHistory.subtitleOn", defaultValue: "Each tab keeps its own command history (up-arrow / Ctrl-R), grouped by project, and records a cmux command history.")
+                : String(localized: "settings.session.persistShellHistory.subtitleOff", defaultValue: "Tabs use your shell's normal global history (e.g. ~/.zsh_history).")
+        ) {
+            Toggle("", isOn: Binding(get: { persistShellHistory.current }, set: { persistShellHistory.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsSessionPersistShellHistoryToggle")
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Values/SessionRestoreMode+Display.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Values/SessionRestoreMode+Display.swift
@@ -1,0 +1,35 @@
+import CmuxSettings
+import Foundation
+
+/// UI-facing labels for ``SessionRestoreMode`` shown in the Sessions
+/// settings picker.
+extension SessionRestoreMode {
+    /// Canonical UI ordering of the three modes.
+    static var uiCases: [SessionRestoreMode] {
+        [.always, .ask, .never]
+    }
+
+    /// Short label shown in the restore-mode picker.
+    var displayName: String {
+        switch self {
+        case .always:
+            return String(localized: "settings.session.restoreMode.always", defaultValue: "Always restore")
+        case .ask:
+            return String(localized: "settings.session.restoreMode.ask", defaultValue: "Ask each time")
+        case .never:
+            return String(localized: "settings.session.restoreMode.never", defaultValue: "Never restore")
+        }
+    }
+
+    /// One-sentence row subtitle explaining the behavior.
+    var modeDescription: String {
+        switch self {
+        case .always:
+            return String(localized: "settings.session.restoreMode.always.description", defaultValue: "Reopen your previous windows, tabs, and panes automatically on launch.")
+        case .ask:
+            return String(localized: "settings.session.restoreMode.ask.description", defaultValue: "Ask whether to restore the previous session each time cmux launches.")
+        case .never:
+            return String(localized: "settings.session.restoreMode.never.description", defaultValue: "Start fresh on launch. The previous session stays reopenable from File ▸ Restore Previous Launch.")
+        }
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/ShellHistoryLocator.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/ShellHistoryLocator.swift
@@ -1,0 +1,60 @@
+public import Foundation
+
+/// Computes per-tab shell-history file locations under Application Support so a
+/// terminal tab recovers its own command history (up-arrow / Ctrl-R) when it
+/// reopens.
+///
+/// Files are keyed **only by the terminal surface id**, which session restore
+/// reuses across restarts — so the exact tab finds the exact same file every
+/// time. The working directory is deliberately *not* part of the key: a tab's
+/// cwd is not stable between first open (often unset) and restore (the captured
+/// directory), so hashing it into the path would send the restored tab to a
+/// different, empty file and break ↑ recall. History is still per-tab (distinct
+/// tabs get distinct files).
+///
+/// Layout:
+/// - history:  `<AppSupport>/cmux/shell-history/<surface-uuid>.<ext>`
+/// - commands: `<AppSupport>/cmux/shell-history/_commands/<surface-uuid>.commands.json`
+///
+/// Pure and dependency-injected (`appSupportDirectory`, `fileManager`) so it is
+/// exercised directly by unit tests.
+public enum ShellHistoryLocator {
+    /// The shell-history root: `<AppSupport>/cmux/shell-history`.
+    public static func rootDirectory(
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let base: URL?
+        if let appSupportDirectory {
+            base = appSupportDirectory
+        } else {
+            base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        }
+        return base?
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("shell-history", isDirectory: true)
+    }
+
+    /// The per-tab shell-history file: `<root>/<surface-uuid>.<ext>`.
+    public static func historyFileURL(
+        surfaceID: UUID,
+        fileExtension: String,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        rootDirectory(appSupportDirectory: appSupportDirectory, fileManager: fileManager)?
+            .appendingPathComponent("\(surfaceID.uuidString).\(fileExtension)", isDirectory: false)
+    }
+
+    /// The per-tab cmux command-history side file:
+    /// `<root>/_commands/<surface-uuid>.commands.json`.
+    public static func commandsFileURL(
+        surfaceID: UUID,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        rootDirectory(appSupportDirectory: appSupportDirectory, fileManager: fileManager)?
+            .appendingPathComponent("_commands", isDirectory: true)
+            .appendingPathComponent("\(surfaceID.uuidString).commands.json", isDirectory: false)
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -74,6 +74,43 @@ extension TerminalSurface {
         protectedKeys.insert("CMUX_NO_PR_WATCH")
     }
 
+    /// Sets `CMUX_SHELL_HISTFILE` to this tab's per-project history file so the
+    /// cmux shell-integration prompt hook can point `HISTFILE` at it *after*
+    /// the user's rc runs (the only place that reliably wins, since the user's
+    /// rc and `/etc/zshrc` set `HISTFILE` themselves). Only zsh and bash use a
+    /// `HISTFILE`; fish and unknown shells are left untouched. Creates the
+    /// per-project directory (`0700`) so the shell can create the file on first
+    /// write. The key is protected so user/override env cannot clobber it.
+    public static func applyManagedShellHistoryEnvironment(
+        shell: String,
+        surfaceID: UUID,
+        to environment: inout [String: String],
+        protectedKeys: inout Set<String>,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        let shellName = URL(fileURLWithPath: shell).lastPathComponent
+        let fileExtension: String
+        switch shellName {
+        case "zsh": fileExtension = "zsh_history"
+        case "bash": fileExtension = "bash_history"
+        default: return
+        }
+        guard let historyURL = ShellHistoryLocator.historyFileURL(
+            surfaceID: surfaceID,
+            fileExtension: fileExtension,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        ) else { return }
+        try? fileManager.createDirectory(
+            at: historyURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        environment["CMUX_SHELL_HISTFILE"] = historyURL.path
+        protectedKeys.insert("CMUX_SHELL_HISTFILE")
+    }
+
     /// Prepends `directory` to a `PATH`-style string exactly once.
     public static func pathByPrependingUniqueDirectory(_ directory: String, to path: String) -> String {
         let trimmedDirectory = directory.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurfaceSpawnPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurfaceSpawnPolicy.swift
@@ -47,6 +47,11 @@ public struct TerminalSurfaceSpawnPolicy: Sendable {
     /// Whether sidebar pull-request watching is enabled (`CMUX_NO_PR_WATCH`).
     public var showPullRequestsEnabled: Bool
 
+    /// Whether per-tab shell history is enabled (the `session.persistShellHistory`
+    /// setting). When true, the spawn injects `CMUX_SHELL_HISTFILE` so the tab
+    /// keeps its own project-scoped history.
+    public var persistShellHistory: Bool
+
     /// Creates a spawn policy snapshot.
     public init(
         claudeHooksEnabled: Bool,
@@ -60,7 +65,8 @@ public struct TerminalSurfaceSpawnPolicy: Sendable {
         ampHooksEnabled: Bool,
         shellIntegrationEnabled: Bool,
         watchGitStatusEnabled: Bool,
-        showPullRequestsEnabled: Bool
+        showPullRequestsEnabled: Bool,
+        persistShellHistory: Bool
     ) {
         self.claudeHooksEnabled = claudeHooksEnabled
         self.customClaudePath = customClaudePath
@@ -74,5 +80,6 @@ public struct TerminalSurfaceSpawnPolicy: Sendable {
         self.shellIntegrationEnabled = shellIntegrationEnabled
         self.watchGitStatusEnabled = watchGitStatusEnabled
         self.showPullRequestsEnabled = showPullRequestsEnabled
+        self.persistShellHistory = persistShellHistory
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
@@ -181,6 +181,19 @@ extension TerminalSurface {
             ) {
                 if baseConfig.command?.isEmpty != false { baseConfig.command = command }
             }
+
+            // Per-tab shell history: inject CMUX_SHELL_HISTFILE so the cmux
+            // shell-integration prompt hook can point HISTFILE at this tab's
+            // project-scoped file after the user's rc runs. Gated inside the
+            // shell-integration block because that hook is what applies it.
+            if spawnPolicy.persistShellHistory {
+                Self.applyManagedShellHistoryEnvironment(
+                    shell: shell,
+                    surfaceID: id,
+                    to: &env,
+                    protectedKeys: &protectedStartupEnvironmentKeys
+                )
+            }
         }
         env = Self.mergedStartupEnvironment(
             base: env,

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeSpawnPolicyProvider.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeSpawnPolicyProvider.swift
@@ -15,7 +15,8 @@ final class FakeSpawnPolicyProvider: TerminalSurfaceSpawnPolicyProviding {
             ampHooksEnabled: true,
             shellIntegrationEnabled: false,
             watchGitStatusEnabled: false,
-            showPullRequestsEnabled: false
+            showPullRequestsEnabled: false,
+            persistShellHistory: false
         )
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/ShellHistoryLocatorTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/ShellHistoryLocatorTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import CmuxTerminal
+
+/// Per-tab shell-history keying and the spawn-time `CMUX_SHELL_HISTFILE` env
+/// injection. The key is the surface id alone (stable across restore), which is
+/// what lets a tab recover its own history for ↑ recall on reopen.
+@Suite("ShellHistoryLocator")
+struct ShellHistoryLocatorTests {
+    private let tempAppSupport = FileManager.default.temporaryDirectory
+        .appendingPathComponent("cmux-shell-history-tests-\(UUID().uuidString)", isDirectory: true)
+
+    @Test func sameSurfaceIsStable() {
+        let id = UUID()
+        let a = ShellHistoryLocator.historyFileURL(
+            surfaceID: id, fileExtension: "zsh_history", appSupportDirectory: tempAppSupport
+        )
+        let b = ShellHistoryLocator.historyFileURL(
+            surfaceID: id, fileExtension: "zsh_history", appSupportDirectory: tempAppSupport
+        )
+        #expect(a == b)
+        #expect(a != nil)
+    }
+
+    @Test func differentSurfacesGetDifferentFiles() {
+        let a = ShellHistoryLocator.historyFileURL(
+            surfaceID: UUID(), fileExtension: "zsh_history", appSupportDirectory: tempAppSupport
+        )
+        let b = ShellHistoryLocator.historyFileURL(
+            surfaceID: UUID(), fileExtension: "zsh_history", appSupportDirectory: tempAppSupport
+        )
+        #expect(a != b)
+        // Same flat directory (keyed only by surface id, not by project).
+        #expect(a?.deletingLastPathComponent() == b?.deletingLastPathComponent())
+    }
+
+    @Test func pathLayoutIsAppSupportShellHistorySurface() {
+        let id = UUID()
+        let url = ShellHistoryLocator.historyFileURL(
+            surfaceID: id, fileExtension: "zsh_history", appSupportDirectory: tempAppSupport
+        )
+        #expect(url?.lastPathComponent == "\(id.uuidString).zsh_history")
+        #expect(url?.path.contains("/cmux/shell-history/") == true)
+    }
+
+    @Test func commandsFileIsKeyedBySurfaceUnderCommandsBucket() {
+        let id = UUID()
+        let url = ShellHistoryLocator.commandsFileURL(surfaceID: id, appSupportDirectory: tempAppSupport)
+        #expect(url?.lastPathComponent == "\(id.uuidString).commands.json")
+        #expect(url?.deletingLastPathComponent().lastPathComponent == "_commands")
+    }
+
+    // MARK: - applyManagedShellHistoryEnvironment
+
+    @Test func zshSpawnInjectsProtectedHistfile() {
+        var env: [String: String] = [:]
+        var protected: Set<String> = []
+        let id = UUID()
+        TerminalSurface.applyManagedShellHistoryEnvironment(
+            shell: "/bin/zsh",
+            surfaceID: id,
+            to: &env,
+            protectedKeys: &protected,
+            appSupportDirectory: tempAppSupport
+        )
+        #expect(env["CMUX_SHELL_HISTFILE"]?.hasSuffix("\(id.uuidString).zsh_history") == true)
+        #expect(protected.contains("CMUX_SHELL_HISTFILE"))
+    }
+
+    @Test func bashSpawnUsesBashHistoryExtension() {
+        var env: [String: String] = [:]
+        var protected: Set<String> = []
+        TerminalSurface.applyManagedShellHistoryEnvironment(
+            shell: "/bin/bash",
+            surfaceID: UUID(),
+            to: &env,
+            protectedKeys: &protected,
+            appSupportDirectory: tempAppSupport
+        )
+        #expect(env["CMUX_SHELL_HISTFILE"]?.hasSuffix(".bash_history") == true)
+    }
+
+    @Test func fishAndUnknownShellsAreSkipped() {
+        for shell in ["/opt/homebrew/bin/fish", "/usr/local/bin/nu"] {
+            var env: [String: String] = [:]
+            var protected: Set<String> = []
+            TerminalSurface.applyManagedShellHistoryEnvironment(
+                shell: shell,
+                surfaceID: UUID(),
+                to: &env,
+                protectedKeys: &protected,
+                appSupportDirectory: tempAppSupport
+            )
+            #expect(env["CMUX_SHELL_HISTFILE"] == nil)
+            #expect(!protected.contains("CMUX_SHELL_HISTFILE"))
+        }
+    }
+
+    @Test func sameSurfaceResolvesToSameHistfileAcrossSpawns() {
+        // The core invariant behind ↑ recall on reopen: a tab's surface id maps
+        // to the same file on every spawn, independent of working directory.
+        let id = UUID()
+        func histfile() -> String? {
+            var env: [String: String] = [:]
+            var protected: Set<String> = []
+            TerminalSurface.applyManagedShellHistoryEnvironment(
+                shell: "/bin/zsh",
+                surfaceID: id,
+                to: &env,
+                protectedKeys: &protected,
+                appSupportDirectory: tempAppSupport
+            )
+            return env["CMUX_SHELL_HISTFILE"]
+        }
+        #expect(histfile() == histfile())
+    }
+
+    @Test func injectionCreatesParentDirectory() {
+        var env: [String: String] = [:]
+        var protected: Set<String> = []
+        TerminalSurface.applyManagedShellHistoryEnvironment(
+            shell: "/bin/zsh",
+            surfaceID: UUID(),
+            to: &env,
+            protectedKeys: &protected,
+            appSupportDirectory: tempAppSupport
+        )
+        let parent = (env["CMUX_SHELL_HISTFILE"]! as NSString).deletingLastPathComponent
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: parent, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+    }
+}

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1480,6 +1480,22 @@ _cmux_bash_preexec_hook_subshell() {
 
 _cmux_prompt_command() {
     local last_status=$?
+    # Per-tab shell history: point HISTFILE at this tab's project-scoped file
+    # once, after the user's rc has set its own HISTFILE (PROMPT_COMMAND runs
+    # post-rc). cmux exports CMUX_SHELL_HISTFILE at spawn when
+    # session.persistShellHistory is on.
+    if [[ -n "${CMUX_SHELL_HISTFILE:-}" ]]; then
+        if [[ -z "${_CMUX_HISTFILE_APPLIED:-}" ]]; then
+            _CMUX_HISTFILE_APPLIED=1
+            export HISTFILE="$CMUX_SHELL_HISTFILE"
+            shopt -s histappend 2>/dev/null || true
+            # Load this tab's prior history so ↑ / Ctrl-R recall it after reopen.
+            history -r "$HISTFILE" 2>/dev/null || true
+        fi
+        # Append new commands to this tab's file each prompt, so a hard quit
+        # still persists history.
+        history -a "$HISTFILE" 2>/dev/null || true
+    fi
     _cmux_tmux_sync_cmux_environment
 
     local cmux_has_unix_socket=0

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1655,6 +1655,22 @@ _cmux_preexec() {
 
 _cmux_precmd() {
     local last_status=$?
+    # Per-tab shell history: point HISTFILE at this tab's project-scoped file
+    # once, after the user's rc and /etc/zshrc have set their own HISTFILE
+    # (precmd runs post-rc, so this is the only place that wins). cmux exports
+    # CMUX_SHELL_HISTFILE at spawn when session.persistShellHistory is on.
+    if [[ -z "${_CMUX_HISTFILE_APPLIED:-}" && -n "${CMUX_SHELL_HISTFILE:-}" ]]; then
+        typeset -g _CMUX_HISTFILE_APPLIED=1
+        export HISTFILE="$CMUX_SHELL_HISTFILE"
+        : "${SAVEHIST:=10000}"
+        : "${HISTSIZE:=10000}"
+        # Write each command to this tab's file as it runs, so a hard quit
+        # (not a clean shell exit) still persists history for ↑ recall.
+        setopt INC_APPEND_HISTORY
+        # Load this tab's prior history into the live session so ↑ / Ctrl-R
+        # immediately recall it after a reopen.
+        fc -R "$HISTFILE" 2>/dev/null || true
+    fi
     # Handle cases where Ghostty integration initializes after this file. This
     # is pure function-body patching, so it remains safe under job saturation.
     _cmux_patch_ghostty_job_table_guard

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -992,6 +992,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isFirstResponder: Bool
     }
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
+    /// Test seam: when set, ``confirmRestorePreviousSession()`` returns this
+    /// instead of running the modal restore prompt, so launch-restore tests can
+    /// drive the Restore/Start-Fresh decision without UI.
+    var debugRestoreSessionConfirmationHandler: (() -> Bool)?
     /// Test seam: when set, ``openDiffViewerForFocusedWorkspace(for:)`` invokes this
     /// instead of spawning the bundled `cmux diff` CLI, so shortcut-dispatch tests can
     /// assert routing without launching a subprocess.
@@ -1045,6 +1049,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// Reset to `.zero` so the first window seeds the point from its own position.
     private var lastCascadePoint = NSPoint.zero
     private(set) var startupSessionSnapshot: AppSessionSnapshot?
+    /// The session-restore behavior resolved at launch from
+    /// `session.restoreMode`. `.ask` defers to a prompt before applying the
+    /// snapshot; `.always`/`.never` are handled by ``SessionRestorePolicy``.
+    private var startupRestoreMode: SessionRestoreMode = .ask
     private var didPrepareStartupSessionSnapshot = false
     var didAttemptStartupSessionRestore = false
     private var isApplyingSessionRestore = false
@@ -2032,6 +2040,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         auth.start()
         ensureMobileWorkspaceListObserver(for: tabManager)
         MobileTerminalRenderObserver.shared.start()
+        TerminalCommandHistoryRecorder.shared.setEnabled(Self.resolvedPersistShellHistory())
         agentChatTranscriptService.start { TerminalController.shared.adoptDetectedAgentSession(titleChange: $0) }
         installMobileHostSettingsObserver()
         scheduleGhosttyCrashBreadcrumbIfNeeded(notificationStore: notificationStore)
@@ -3165,8 +3174,60 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         didPrepareStartupSessionSnapshot = true
         Self.removeLegacyPersistedWindowGeometry()
         sessionSnapshotStore.syncManualRestoreSnapshotCache()
-        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        startupRestoreMode = Self.resolvedSessionRestoreMode()
+        guard SessionRestorePolicy.shouldAttemptRestore(restoreMode: startupRestoreMode) else { return }
         startupSessionSnapshot = sessionSnapshotStore.loadStartupSnapshot()
+    }
+
+    /// Resolves the configured session restore behavior from
+    /// `~/.config/cmux/cmux.json`. Read synchronously off the main actor at
+    /// launch, before any window exists, from the same file the
+    /// Settings ▸ Sessions pane writes.
+    private static func resolvedSessionRestoreMode() -> SessionRestoreMode {
+        JSONConfigStore(fileURL: CmuxConfigLocation().userConfigFile)
+            .snapshotValue(for: SettingCatalog().session.restoreMode)
+    }
+
+    /// Reads `session.persistShellHistory` from `~/.config/cmux/cmux.json`
+    /// (the per-tab shell-history master toggle) for the command-history
+    /// recorder's launch-time gate.
+    static func resolvedPersistShellHistory() -> Bool {
+        JSONConfigStore(fileURL: CmuxConfigLocation().userConfigFile)
+            .snapshotValue(for: SettingCatalog().session.persistShellHistory)
+    }
+
+    /// Asks whether to restore the previous session. Mirrors
+    /// ``confirmCloseMainWindow(_:)`` including the DEBUG test seam. Returns
+    /// `true` to restore, `false` to start fresh.
+    private func confirmRestorePreviousSession() -> Bool {
+#if DEBUG
+        if let debugRestoreSessionConfirmationHandler {
+            return debugRestoreSessionConfirmationHandler()
+        }
+#endif
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(
+            localized: "dialog.restoreSession.title",
+            defaultValue: "Restore previous session?"
+        )
+        alert.informativeText = String(
+            localized: "dialog.restoreSession.message",
+            defaultValue: "cmux can reopen the windows, tabs, and panes from your last session."
+        )
+        alert.addButton(withTitle: String(localized: "dialog.restoreSession.restore", defaultValue: "Restore"))
+        alert.addButton(withTitle: String(localized: "dialog.restoreSession.startFresh", defaultValue: "Start Fresh"))
+
+        let alertWindow = alert.window
+        if let restoreButton = alert.buttons.first {
+            alertWindow.defaultButtonCell = restoreButton.cell as? NSButtonCell
+            alertWindow.initialFirstResponder = restoreButton
+            DispatchQueue.main.async {
+                _ = alertWindow.makeFirstResponder(restoreButton)
+            }
+        }
+
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private func persistedWindowGeometry(defaults: UserDefaults = .standard) -> PersistedWindowGeometry? {
@@ -3263,6 +3324,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         didAttemptStartupSessionRestore = true
         guard !didHandleExplicitOpenIntentAtStartup else { return false }
         guard let primaryContext = contextForMainTerminalWindow(primaryWindow) else { return false }
+
+        if startupRestoreMode == .ask, startupSessionSnapshot != nil, !confirmRestorePreviousSession() {
+            // Start Fresh: drop the in-memory snapshot so launch proceeds like a
+            // normal fresh start (still applying last-known window geometry
+            // below). The on-disk snapshot is kept, so File ▸ Restore Previous
+            // Launch can still reopen it.
+            startupSessionSnapshot = nil
+        }
 
         let startupSnapshot = startupSessionSnapshot
         let primaryWindowSnapshot = startupSnapshot?.windows.first
@@ -6443,6 +6512,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         return nil
+    }
+
+    /// Shared action: opens the command-history window for the focused tab's
+    /// terminal surface. The surface lookup + presentation live here so every
+    /// entrypoint (command palette today; menu/shortcut later) routes through
+    /// one path, per the shared-behavior policy.
+    @MainActor
+    func showCommandHistoryForFocusedSurface(preferredWindow: NSWindow? = nil) {
+        guard
+            let target = resolveFocusedNotificationTarget(preferredWindow: preferredWindow),
+            let surfaceId = target.surfaceId
+        else {
+            NSSound.beep()
+            return
+        }
+        let entries = TerminalCommandHistoryRecorder.load(surfaceID: surfaceId)
+        CommandHistoryWindowController.shared.show(entries: entries)
     }
 
     private func focusedTerminalShortcutContext(preferredWindow: NSWindow? = nil) -> FocusedTerminalShortcutContext? {
@@ -12393,6 +12479,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func reloadCmuxConfigStores(source: String) {
         configStoreReloadCoordinator.reload(source: source)
+        // Keep the command-history recorder's gate in sync when
+        // session.persistShellHistory is toggled at runtime. (The HISTFILE
+        // injection is already read live per spawn by the spawn-policy bridge.)
+        TerminalCommandHistoryRecorder.shared.setEnabled(Self.resolvedPersistShellHistory())
     }
 
     var reloadableConfigStores: [any CmuxConfigStoreReloading] {

--- a/Sources/CommandHistoryWindowController.swift
+++ b/Sources/CommandHistoryWindowController.swift
@@ -1,0 +1,115 @@
+import AppKit
+import SwiftUI
+
+/// A per-tab command-history window. Lists the commands recorded for one
+/// terminal surface by ``TerminalCommandHistoryRecorder`` so they stay
+/// available after the tab is closed and reopened.
+///
+/// Mirrors ``TitlebarLayoutDebugWindowController``: a ``ReleasingWindowController``
+/// singleton whose window exists only while open. Content is rebuilt on each
+/// ``show(entries:)`` so it always reflects the currently focused tab.
+@MainActor
+final class CommandHistoryWindowController: ReleasingWindowController {
+    static let shared = CommandHistoryWindowController()
+
+    private var entries: [TerminalCommandHistoryEntry] = []
+
+    private override init() {
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func makeWindow() -> NSWindow {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 560),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "commandHistory.window.title", defaultValue: "Command History")
+        window.titleVisibility = .visible
+        window.isMovableByWindowBackground = true
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.commandHistory")
+        window.center()
+        window.contentView = NSHostingView(rootView: CommandHistoryView(entries: entries))
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        return window
+    }
+
+    /// Shows (or refreshes) the window for the given tab's recorded commands.
+    func show(entries: [TerminalCommandHistoryEntry]) {
+        self.entries = entries
+        let window = showManagedWindow()
+        // managedWindow() reuses an already-open window, so rebuild the content
+        // to reflect the currently focused tab's history.
+        window.contentView = NSHostingView(rootView: CommandHistoryView(entries: entries))
+    }
+}
+
+/// Immutable list of one tab's recorded commands. Receives a value snapshot
+/// (no store / `ObservableObject` below the `List`), per the cmux SwiftUI
+/// snapshot-boundary rule.
+private struct CommandHistoryView: View {
+    let entries: [TerminalCommandHistoryEntry]
+
+    var body: some View {
+        Group {
+            if entries.isEmpty {
+                ContentUnavailableView(
+                    String(localized: "commandHistory.empty.title", defaultValue: "No Command History"),
+                    systemImage: "clock",
+                    description: Text(String(
+                        localized: "commandHistory.empty.message",
+                        defaultValue: "Commands you run in this tab appear here and stay available after you reopen it."
+                    ))
+                )
+            } else {
+                // Newest first.
+                List(Array(entries.reversed())) { entry in
+                    CommandHistoryRow(entry: entry)
+                }
+                .listStyle(.inset)
+            }
+        }
+        .frame(minWidth: 360, minHeight: 240)
+    }
+}
+
+private struct CommandHistoryRow: View {
+    let entry: TerminalCommandHistoryEntry
+
+    var body: some View {
+        HStack(spacing: 8) {
+            statusIcon
+            Text(entry.command)
+                .font(.system(.body, design: .monospaced))
+                .lineLimit(2)
+                .textSelection(.enabled)
+            Spacer(minLength: 8)
+            Button {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(entry.command, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "commandHistory.copy", defaultValue: "Copy command"))
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder private var statusIcon: some View {
+        if let code = entry.exitCode {
+            Image(systemName: code == 0 ? "checkmark.circle" : "xmark.circle")
+                .foregroundStyle(code == 0 ? Color.green : Color.red)
+        } else {
+            Image(systemName: "circle.dotted")
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6384,6 +6384,14 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.showCommandHistory",
+                title: constant(String(localized: "command.showCommandHistory.title", defaultValue: "Show Command History")),
+                subtitle: constant(String(localized: "command.showCommandHistory.subtitle", defaultValue: "Terminal")),
+                keywords: ["command", "history", "shell", "commands", "log", "tab", "recent", "previous"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.newTerminalTab",
                 title: constant(String(localized: "command.newTerminalTab.title", defaultValue: "New Tab (Terminal)")),
                 subtitle: constant(String(localized: "command.newTerminalTab.subtitle", defaultValue: "Tab")),
@@ -7585,6 +7593,11 @@ struct ContentView: View {
             if AppDelegate.shared?.reopenPreviousSession() != true {
                 NSSound.beep()
             }
+        }
+        registry.register(commandId: "palette.showCommandHistory") {
+            AppDelegate.shared?.showCommandHistoryForFocusedSurface(
+                preferredWindow: AppDelegate.shared?.mainWindow(for: windowId)
+            )
         }
         registry.register(commandId: "palette.newWindow") {
             guard let appDelegate = AppDelegate.shared else { return }

--- a/Sources/Mobile/MobileTerminalByteTee.swift
+++ b/Sources/Mobile/MobileTerminalByteTee.swift
@@ -150,6 +150,10 @@ public let cmuxMobileTerminalByteTeeCallback: @convention(c) (
     bytes.withMemoryRebound(to: UInt8.self, capacity: count) { rebound in
         let buffer = UnsafeBufferPointer(start: rebound, count: count)
         MobileTerminalByteTee.shared.append(surfaceID: box.surfaceID, bytes: buffer)
+        // Per-tab command-history capture shares this single PTY tee. Its
+        // append is O(1) when recording is disabled, so the desktop hot path
+        // pays nothing extra unless session.persistShellHistory is on.
+        TerminalCommandHistoryRecorder.shared.append(surfaceID: box.surfaceID, bytes: buffer)
     }
 }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import CmuxCore
 import Foundation
 import Bonsplit
+import CmuxSettings
 import CmuxWorkspaces
 #if canImport(CryptoKit)
 import CryptoKit
@@ -156,12 +157,19 @@ enum SessionRestorePolicy {
 
     static func shouldAttemptRestore(
         arguments: [String] = CommandLine.arguments,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        restoreMode: SessionRestoreMode = .ask
     ) -> Bool {
         if environment["CMUX_DISABLE_SESSION_RESTORE"] == "1" {
             return false
         }
         if isRunningUnderAutomatedTests(environment: environment) {
+            return false
+        }
+        // `never` opts out entirely; `always` and `ask` both load the snapshot
+        // here. `ask` is gated later by a launch-time prompt before the
+        // snapshot is applied.
+        if restoreMode == .never {
             return false
         }
 

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -4,6 +4,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
     case account
     case app
     case terminal
+    case session
     case textBox
     case mobile
     case sidebarAppearance
@@ -28,6 +29,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return String(localized: "settings.section.app", defaultValue: "App")
         case .terminal:
             return String(localized: "settings.section.terminal", defaultValue: "Terminal")
+        case .session:
+            return String(localized: "settings.section.session", defaultValue: "Sessions")
         case .textBox:
             return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
         case .mobile:
@@ -65,6 +68,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "gearshape"
         case .terminal:
             return "terminal"
+        case .session:
+            return "clock.arrow.circlepath"
         case .textBox:
             return "textformat"
         case .mobile:
@@ -102,6 +107,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "\(title) appearance language workspace notifications menu bar telemetry default terminal"
         case .terminal:
             return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev hibernation idle suspend commands approvals prefixes toggle"
+        case .session:
+            return "\(title) session restore reopen previous launch relaunch shell history histfile per tab project command history ask always never start fresh"
         case .textBox:
             return "\(title) textbox text box rich input prompt beta new terminal workspace split tab focus height"
         case .mobile:

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -9,6 +9,8 @@ enum SettingsSearchAliasIndex {
             return localized("settings.search.alias.section.app", defaultValue: "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry")
         case .terminal:
             return localized("settings.search.alias.section.terminal", defaultValue: "shell scrollback scrollbar scroll bar ghostty tty pty")
+        case .session:
+            return localized("settings.search.alias.section.session", defaultValue: "session restore reopen previous launch relaunch shell history histfile per tab project command history ask always never start fresh")
         case .textBox:
             return localized("settings.search.alias.section.textBox", defaultValue: "textbox text box rich input prompt beta focus composer compose attachments")
         case .mobile:

--- a/Sources/TerminalCommandHistoryRecorder.swift
+++ b/Sources/TerminalCommandHistoryRecorder.swift
@@ -1,0 +1,186 @@
+import CmuxAgentChat
+import CmuxTerminal
+import Foundation
+import os
+
+/// One persisted command-history entry for a terminal tab.
+struct TerminalCommandHistoryEntry: Codable, Equatable, Identifiable, Sendable {
+    /// Stable ordinal within the tab's history file (monotonic across reopens).
+    let id: Int
+    /// The command line the user ran (OSC 133 `B`…`C` text), trimmed.
+    let command: String
+    /// The command's exit code, or `nil` if it never reported one.
+    let exitCode: Int?
+    /// When the command finished, as seconds since 1970.
+    let recordedAt: TimeInterval
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case command
+        case exitCode = "exit_code"
+        case recordedAt = "recorded_at"
+    }
+}
+
+/// Records each terminal tab's executed commands — parsed from the OSC 133
+/// shell-integration marks already present in the live PTY stream — into a
+/// per-tab side file (`<AppSupport>/cmux/shell-history/_commands/<surface>.commands.json`)
+/// so the command-history view can show them again after the tab reopens.
+///
+/// **Hot-path discipline (CLAUDE.md typing-latency rule):** ``append(surfaceID:bytes:)``
+/// runs on the Ghostty IO read thread for *every* surface. It does an O(1)
+/// enabled check and, only when recording is on, a single byte copy plus a
+/// non-blocking enqueue onto a private serial queue. All UTF-8 decoding, OSC 133
+/// parsing, and disk I/O happen on that queue — never on the IO thread or the
+/// main thread.
+///
+/// `@unchecked Sendable`: every mutable field except the lock-guarded enabled
+/// flag is touched only on ``queue`` (serial), so cross-thread access is
+/// serialized by construction.
+final class TerminalCommandHistoryRecorder: @unchecked Sendable {
+    nonisolated static let shared = TerminalCommandHistoryRecorder()
+
+    /// Max entries kept per tab; the oldest are dropped past this.
+    private static let maxEntriesPerSurface = 1000
+
+    /// Hot-path gate, mirrored from `session.persistShellHistory`. Behind an
+    /// unfair lock so the IO read thread reads it cheaply and race-free.
+    private let enabled = OSAllocatedUnfairLock(initialState: false)
+
+    private struct SurfaceState {
+        var parser = OSC133CommandParser()
+        var entries: [TerminalCommandHistoryEntry] = []
+        var nextID = 0
+        var loaded = false
+    }
+
+    /// Touched only on ``queue`` (or synchronously in tests via ``ingest``).
+    private var statesBySurfaceID: [UUID: SurfaceState] = [:]
+    private let queue = DispatchQueue(label: "dev.cmux.command-history.recorder", qos: .utility)
+    private let fileManager = FileManager.default
+    private let clock: @Sendable () -> TimeInterval
+    /// Overridable Application Support root (tests point this at a temp dir).
+    private let appSupportDirectory: URL?
+
+    nonisolated init(
+        clock: @escaping @Sendable () -> TimeInterval = { Date().timeIntervalSince1970 },
+        appSupportDirectory: URL? = nil
+    ) {
+        self.clock = clock
+        self.appSupportDirectory = appSupportDirectory
+    }
+
+    /// Turns recording on/off from `session.persistShellHistory`.
+    func setEnabled(_ value: Bool) {
+        enabled.withLock { $0 = value }
+    }
+
+    private var isEnabled: Bool { enabled.withLock { $0 } }
+
+    /// IO-thread entry point from the PTY tee trampoline. O(1) when disabled.
+    nonisolated func append(surfaceID: UUID, bytes: UnsafeBufferPointer<UInt8>) {
+        guard isEnabled else { return }
+        guard let base = bytes.baseAddress, bytes.count > 0 else { return }
+        let copy = Data(bytes: base, count: bytes.count)
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.ingest(surfaceID: surfaceID, text: String(decoding: copy, as: UTF8.self))
+        }
+    }
+
+    /// Flushes and forgets a surface when it closes.
+    func dropSurface(surfaceID: UUID) {
+        queue.async { [weak self] in
+            self?.statesBySurfaceID.removeValue(forKey: surfaceID)
+        }
+    }
+
+    // MARK: - Core (serial-queue confined; called synchronously in tests)
+
+    func ingest(surfaceID: UUID, text: String) {
+        var state = statesBySurfaceID[surfaceID] ?? SurfaceState()
+        if !state.loaded {
+            let existing = Self.load(
+                surfaceID: surfaceID,
+                appSupportDirectory: appSupportDirectory,
+                fileManager: fileManager
+            )
+            state.entries = existing
+            state.nextID = (existing.map(\.id).max() ?? -1) + 1
+            state.loaded = true
+        }
+
+        state.parser.consume(text)
+        var changed = false
+        for block in state.parser.takeCompletedBlocks() {
+            let command = block.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !command.isEmpty else { continue }
+            state.entries.append(TerminalCommandHistoryEntry(
+                id: state.nextID,
+                command: command,
+                exitCode: block.exitCode,
+                recordedAt: clock()
+            ))
+            state.nextID += 1
+            changed = true
+        }
+
+        if changed {
+            if state.entries.count > Self.maxEntriesPerSurface {
+                state.entries.removeFirst(state.entries.count - Self.maxEntriesPerSurface)
+            }
+            Self.persist(
+                surfaceID: surfaceID,
+                entries: state.entries,
+                appSupportDirectory: appSupportDirectory,
+                fileManager: fileManager
+            )
+        }
+        statesBySurfaceID[surfaceID] = state
+    }
+
+    // MARK: - File IO (shared with the view)
+
+    /// Loads a tab's persisted command history, oldest first. Returns `[]` when
+    /// the tab has no history yet.
+    static func load(
+        surfaceID: UUID,
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> [TerminalCommandHistoryEntry] {
+        guard
+            let url = ShellHistoryLocator.commandsFileURL(
+                surfaceID: surfaceID,
+                appSupportDirectory: appSupportDirectory,
+                fileManager: fileManager
+            ),
+            let data = try? Data(contentsOf: url),
+            let entries = try? JSONDecoder().decode([TerminalCommandHistoryEntry].self, from: data)
+        else { return [] }
+        return entries
+    }
+
+    static func persist(
+        surfaceID: UUID,
+        entries: [TerminalCommandHistoryEntry],
+        appSupportDirectory: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        guard let url = ShellHistoryLocator.commandsFileURL(
+            surfaceID: surfaceID,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        ) else { return }
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let data = try JSONEncoder().encode(entries)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            // Best-effort: a failed history write must never disrupt the terminal.
+        }
+    }
+}

--- a/Sources/TerminalSurfaceRuntimeWiring.swift
+++ b/Sources/TerminalSurfaceRuntimeWiring.swift
@@ -54,7 +54,9 @@ final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProvidin
             ampHooksEnabled: integrations.ampHooksEnabled,
             shellIntegrationEnabled: UserDefaults.standard.object(forKey: "sidebarShellIntegration") as? Bool ?? true,
             watchGitStatusEnabled: SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard),
-            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: .standard)
+            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: .standard),
+            persistShellHistory: JSONConfigStore(fileURL: CmuxConfigLocation().userConfigFile)
+                .snapshotValue(for: SettingCatalog().session.persistShellHistory)
         )
     }
 
@@ -102,6 +104,7 @@ final class TerminalMobileByteTeeBridge: TerminalByteTeeBinding {
     @MainActor
     func dropSurface(surfaceID: UUID) {
         MobileTerminalByteTee.shared.dropSurface(surfaceID: surfaceID)
+        TerminalCommandHistoryRecorder.shared.dropSurface(surfaceID: surfaceID)
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 		C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */; };
 		2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
+		059238DB168F0D4D4FD02F84 /* TerminalCommandHistoryRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F5F0DE1991A6B02E538FA4 /* TerminalCommandHistoryRecorderTests.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
 		C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A503000000000000000001 /* TaskManagerSnapshot.swift */; };
 		C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A504000000000000000001 /* TaskManagerTypes.swift */; };
@@ -893,6 +894,8 @@
 		A5001543 /* TerminalSSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* TerminalSSHSessionDetector.swift */; };
 		D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */; };
 		C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */; };
+		60EC64D84BA0BB07A537738F /* CommandHistoryWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128ECEF31FCE3622F4BF9263 /* CommandHistoryWindowController.swift */; };
+		72CF6B66804DA7A8762B626B /* TerminalCommandHistoryRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6737EF3498BFE3E4DEA66596 /* TerminalCommandHistoryRecorder.swift */; };
 		5154BEAB50364B86A9E36E4B /* TerminalViewportUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */; };
 		A5001532 /* TerminalWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001531 /* TerminalWindowPortal.swift */; };
 		D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */; };
@@ -1836,6 +1839,7 @@
 		C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerNotificationFocusRegressionTests.swift; sourceTree = "<group>"; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
+		48F5F0DE1991A6B02E538FA4 /* TerminalCommandHistoryRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCommandHistoryRecorderTests.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
 		C7A503000000000000000001 /* TaskManagerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerSnapshot.swift; sourceTree = "<group>"; };
 		C7A504000000000000000001 /* TaskManagerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerTypes.swift; sourceTree = "<group>"; };
@@ -1904,6 +1908,8 @@
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
 		D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceResizePolicyTests.swift; sourceTree = "<group>"; };
 		C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceRuntimeWiring.swift; sourceTree = "<group>"; };
+		128ECEF31FCE3622F4BF9263 /* CommandHistoryWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHistoryWindowController.swift; sourceTree = "<group>"; };
+		6737EF3498BFE3E4DEA66596 /* TerminalCommandHistoryRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCommandHistoryRecorder.swift; sourceTree = "<group>"; };
 		31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalViewportUITestRecorder.swift; sourceTree = "<group>"; };
 		A5001531 /* TerminalWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortal.swift; sourceTree = "<group>"; };
 		D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortalDebug.swift; sourceTree = "<group>"; };
@@ -2488,6 +2494,8 @@
 				D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */,
 				A5001531 /* TerminalWindowPortal.swift */,
 				C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */,
+				128ECEF31FCE3622F4BF9263 /* CommandHistoryWindowController.swift */,
+				6737EF3498BFE3E4DEA66596 /* TerminalCommandHistoryRecorder.swift */,
 				606600020000000000000002 /* WindowTerminalHostViewHitTesting.swift */,
 				D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */,
 				D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */,
@@ -3076,6 +3084,7 @@
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
 				C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				48F5F0DE1991A6B02E538FA4 /* TerminalCommandHistoryRecorderTests.swift */,
 				C0793DC7D7B61CF54886EC36 /* RemoteTmuxControlParserTests.swift */,
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
 				B0555304B0555304B0555304 /* DetachedFolderPathLookupCacheTests.swift */,
@@ -4082,6 +4091,8 @@
 				C0DE53350000000000000001 /* TerminalSearchOverlayHostingView.swift in Sources */,
 				A5001543 /* TerminalSSHSessionDetector.swift in Sources */,
 				C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */,
+				60EC64D84BA0BB07A537738F /* CommandHistoryWindowController.swift in Sources */,
+				72CF6B66804DA7A8762B626B /* TerminalCommandHistoryRecorder.swift in Sources */,
 				5154BEAB50364B86A9E36E4B /* TerminalViewportUITestRecorder.swift in Sources */,
 				A5001532 /* TerminalWindowPortal.swift in Sources */,
 				D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */,
@@ -4491,6 +4502,7 @@
 				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
+				059238DB168F0D4D4FD02F84 /* TerminalCommandHistoryRecorderTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,
 				C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1,6 +1,7 @@
 import CMUXAgentLaunch
 import CmuxCore
 import CmuxFoundation
+import CmuxSettings
 import CmuxWorkspaces
 import Darwin
 import XCTest
@@ -436,6 +437,60 @@ final class SessionPersistenceTests: XCTestCase {
         let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
             arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
             environment: ["XCTestConfigurationFilePath": "/tmp/xctest.xctestconfiguration"]
+        )
+
+        XCTAssertFalse(shouldRestore)
+    }
+
+    func testRestorePolicyNeverModeSkipsRestoreOnCleanLaunch() {
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
+            environment: [:],
+            restoreMode: .never
+        )
+
+        XCTAssertFalse(shouldRestore)
+    }
+
+    func testRestorePolicyNeverModeSkipsEvenForFinderStyleLaunch() {
+        // `never` overrides the default clean-launch restore even without the
+        // legacy CMUX_DISABLE_SESSION_RESTORE env var.
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux", "-psn_0_12345"],
+            environment: [:],
+            restoreMode: .never
+        )
+
+        XCTAssertFalse(shouldRestore)
+    }
+
+    func testRestorePolicyAlwaysModeRestoresOnCleanLaunch() {
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
+            environment: [:],
+            restoreMode: .always
+        )
+
+        XCTAssertTrue(shouldRestore)
+    }
+
+    func testRestorePolicyAskModePassesPolicyAndDefersToPrompt() {
+        // `ask` reaches the snapshot-load path like `always`; the prompt that
+        // gates whether the snapshot is applied lives in AppDelegate, not here.
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
+            environment: [:],
+            restoreMode: .ask
+        )
+
+        XCTAssertTrue(shouldRestore)
+    }
+
+    func testRestorePolicyNeverModeStillHonorsExplicitArguments() {
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux", "--window", "window:1"],
+            environment: [:],
+            restoreMode: .always
         )
 
         XCTAssertFalse(shouldRestore)

--- a/cmuxTests/TerminalCommandHistoryRecorderTests.swift
+++ b/cmuxTests/TerminalCommandHistoryRecorderTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Round-trips the per-tab command-history recorder: OSC 133 marks in the PTY
+/// stream become persisted entries (command + exit code, no output), survive a
+/// reopen (new recorder, same tab), and keep unique ids.
+final class TerminalCommandHistoryRecorderTests: XCTestCase {
+    private func esc(_ body: String) -> String { "\u{1b}]\(body)\u{07}" }
+    private func mark(_ k: String) -> String { esc("133;\(k)") }
+
+    private func makeTempAppSupport() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cmdhist-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    func testRecordsCommandsWithExitCodesAndDropsOutput() {
+        let appSupport = makeTempAppSupport()
+        let surfaceID = UUID()
+        let recorder = TerminalCommandHistoryRecorder(clock: { 100 }, appSupportDirectory: appSupport)
+
+        recorder.ingest(surfaceID: surfaceID, text:
+            mark("A") + mark("B") + "echo hi" + mark("C") + "hi\n" + mark("D;0")
+            + mark("A") + mark("B") + "false" + mark("C") + mark("D;1")
+        )
+
+        let entries = TerminalCommandHistoryRecorder.load(surfaceID: surfaceID, appSupportDirectory: appSupport)
+        XCTAssertEqual(entries.map(\.command), ["echo hi", "false"])
+        XCTAssertEqual(entries.map(\.exitCode), [0, 1])
+        XCTAssertEqual(entries.map(\.recordedAt), [100, 100])
+        // The model has no output field — verify size stays bounded regardless
+        // of command output volume.
+        XCTAssertTrue(entries.allSatisfy { !$0.command.contains("hi\n") })
+    }
+
+    func testEmptyCommandsAreSkipped() {
+        let appSupport = makeTempAppSupport()
+        let surfaceID = UUID()
+        let recorder = TerminalCommandHistoryRecorder(clock: { 1 }, appSupportDirectory: appSupport)
+
+        // A bare prompt with no command between B and C must not be recorded.
+        recorder.ingest(surfaceID: surfaceID, text: mark("A") + mark("B") + mark("C") + mark("D;0"))
+        recorder.ingest(surfaceID: surfaceID, text: mark("A") + mark("B") + "ls" + mark("C") + mark("D;0"))
+
+        let entries = TerminalCommandHistoryRecorder.load(surfaceID: surfaceID, appSupportDirectory: appSupport)
+        XCTAssertEqual(entries.map(\.command), ["ls"])
+    }
+
+    func testReopenAppendsWithUniqueIDs() {
+        let appSupport = makeTempAppSupport()
+        let surfaceID = UUID()
+
+        let first = TerminalCommandHistoryRecorder(clock: { 1 }, appSupportDirectory: appSupport)
+        first.ingest(surfaceID: surfaceID, text: mark("A") + mark("B") + "one" + mark("C") + mark("D;0"))
+
+        // Reopen: a fresh recorder with the same tab loads prior history and
+        // appends, keeping ids monotonic across sessions.
+        let second = TerminalCommandHistoryRecorder(clock: { 2 }, appSupportDirectory: appSupport)
+        second.ingest(surfaceID: surfaceID, text: mark("A") + mark("B") + "two" + mark("C") + mark("D;0"))
+
+        let entries = TerminalCommandHistoryRecorder.load(surfaceID: surfaceID, appSupportDirectory: appSupport)
+        XCTAssertEqual(entries.map(\.command), ["one", "two"])
+        XCTAssertEqual(Set(entries.map(\.id)).count, 2, "ids must be unique across reopen")
+    }
+
+    func testSeparateTabsGetSeparateHistory() {
+        let appSupport = makeTempAppSupport()
+        let tabA = UUID()
+        let tabB = UUID()
+        let recorder = TerminalCommandHistoryRecorder(clock: { 1 }, appSupportDirectory: appSupport)
+
+        recorder.ingest(surfaceID: tabA, text: mark("A") + mark("B") + "cmdA" + mark("C") + mark("D;0"))
+        recorder.ingest(surfaceID: tabB, text: mark("A") + mark("B") + "cmdB" + mark("C") + mark("D;0"))
+
+        XCTAssertEqual(
+            TerminalCommandHistoryRecorder.load(surfaceID: tabA, appSupportDirectory: appSupport).map(\.command),
+            ["cmdA"]
+        )
+        XCTAssertEqual(
+            TerminalCommandHistoryRecorder.load(surfaceID: tabB, appSupportDirectory: appSupport).map(\.command),
+            ["cmdB"]
+        )
+    }
+}

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -390,6 +390,27 @@
         }
       }
     },
+    "session": {
+      "title": "session",
+      "description": "Session restore and per-tab shell history settings from Settings > Sessions.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "restoreMode": {
+          "type": "string",
+          "enum": ["always", "ask", "never"],
+          "default": "ask",
+          "descriptionKey": "schemaDescriptions.session.restoreMode",
+          "description": "When cmux launches with a previous session available: \"always\" restores it silently, \"ask\" prompts before restoring (the default), and \"never\" starts fresh (the previous session stays reopenable via File > Restore Previous Launch)."
+        },
+        "persistShellHistory": {
+          "type": "boolean",
+          "default": true,
+          "descriptionKey": "schemaDescriptions.session.persistShellHistory",
+          "description": "Give each terminal tab its own shell history (up-arrow / Ctrl-R) namespaced by project directory, and record a cmux command history per tab. When off, tabs use your shell's normal global history (e.g. ~/.zsh_history)."
+        }
+      }
+    },
     "terminal": {
       "title": "terminal",
       "description": "Terminal presentation settings from Settings > Terminal.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -955,6 +955,10 @@
           "showTextBoxOnNewTerminals": "Show the beta TextBox input by default for newly created workspaces, terminal tabs, and terminal splits.",
           "focusTextBoxOnNewTerminals": "Focus the beta TextBox input by default for newly created workspaces, terminal tabs, and terminal splits. Focusing also shows the TextBox."
         },
+        "session": {
+          "restoreMode": "When cmux launches with a previous session available: \"always\" restores it silently, \"ask\" prompts before restoring (the default), and \"never\" starts fresh (the previous session stays reopenable via File > Restore Previous Launch).",
+          "persistShellHistory": "Give each terminal tab its own shell history (up-arrow / Ctrl-R) namespaced by project directory, and record a cmux command history per tab. When off, tabs use your shell's normal global history (e.g. ~/.zsh_history)."
+        },
         "browser": {
           "defaultSearchEngine": "Default search engine for non-URL browser address bar queries. Use custom with customSearchEngineURLTemplate for arbitrary providers.",
           "customSearchEngineName": "Display name used when defaultSearchEngine is custom.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -914,6 +914,10 @@
           "showTextBoxOnNewTerminals": "新しいワークスペース、ターミナルタブ、ターミナル分割でベータ版の TextBox 入力を既定で表示します。",
           "focusTextBoxOnNewTerminals": "新しいワークスペース、ターミナルタブ、ターミナル分割でベータ版の TextBox 入力に既定でフォーカスします。フォーカスする場合は TextBox も表示されます。"
         },
+        "session": {
+          "restoreMode": "前回のセッションがある状態で cmux を起動したときの動作です。\"always\" は確認せずに復元し、\"ask\" は復元する前に確認します（既定）。\"never\" は新規状態で開始します（前回のセッションは「ファイル > 前回の起動を復元」からいつでも復元できます）。",
+          "persistShellHistory": "各ターミナルタブにプロジェクトディレクトリ単位の独立したシェル履歴（上矢印 / Ctrl-R）を持たせ、タブごとに cmux のコマンド履歴を記録します。オフの場合、タブはシェル通常のグローバル履歴（例: ~/.zsh_history）を使用します。"
+        },
         "browser": {
           "defaultSearchEngine": "ブラウザのアドレスバーでURLではない入力に使う既定の検索エンジンです。任意のプロバイダには custom と customSearchEngineURLTemplate を使います。",
           "customSearchEngineName": "defaultSearchEngine が custom のときに使う表示名です。",


### PR DESCRIPTION
Adds a "Sessions" settings area (session.* in cmux.json, both default-on) with two capabilities:

- Per-tab shell history (session.persistShellHistory): each terminal tab gets its own HISTFILE keyed by the tab's stable surface UUID, injected via the existing per-shell startup hooks and applied in the zsh/bash prompt hook (after the user's rc, with incremental writes) so up-arrow / Ctrl-R recall the tab's commands after a reopen. Also records a per-tab cmux command history (OSC 133, via the existing PTY tee) viewable from the command palette ("Show Command History"). Keyed by surface UUID — not working directory — because a tab's cwd is not stable between first open and restore.

- Configurable session restore (session.restoreMode: always | ask | never, default ask): SessionRestorePolicy honors the mode and, in "ask", AppDelegate prompts before applying the restore (keeping the snapshot reopenable from File > Restore Previous Launch).

Wired through the settings catalog, Settings UI, JSON schema, docs messages, and Localizable.xcstrings (en + ja). Tests: restore-mode policy, HISTFILE keying + env injection, OSC 133 drain, command-history round-trip, and config defaults.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784648499&installation_id=133855650&pr_number=6548&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6548&signature=7fd7580f9114b2024147d116b2537a0c99cc28d924d1b1fe4b242bf5373abbff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sessions settings area with per-tab shell history and a configurable session restore mode. Tabs keep their own history across reopens, and launch behavior is now controllable.

- **New Features**
  - Per-tab shell history (`session.persistShellHistory`, default true)
    - zsh/bash tabs get a unique `HISTFILE` via `CMUX_SHELL_HISTFILE`, keyed by the tab’s surface UUID; applied after user rc with incremental writes for safe persistence.
    - Records a per-tab cmux command history (OSC 133) under Application Support; open via Command Palette → “Show Command History”.
  - Configurable session restore (`session.restoreMode`: `always` | `ask` | `never`, default `ask`)
    - `ask` shows a launch prompt; `never` starts fresh; `always` restores silently. Previous sessions stay available via File → Restore Previous Launch.
  - Settings/UI/schema/localization
    - New Settings > Sessions pane; keys under `session.*` in `~/.config/cmux/cmux.json`; schema and en/ja strings added.

- **Migration**
  - No action needed; both features default on.
  - Change behavior in Settings > Sessions or edit `session.restoreMode` / `session.persistShellHistory` in `~/.config/cmux/cmux.json`.

<sup>Written for commit 381b9e81abca615dc6f44d0aa4dc1b7cdb6da443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session restoration modes (always, ask, never) to control startup behavior
  * Added per-tab shell history persistence for bash and zsh
  * Added command history viewer to display executed commands for the current terminal tab
  * Added Sessions settings section with restore mode and history persistence toggles
  * Enhanced shell integration scripts for independent per-tab command tracking

* **Documentation**
  * Updated localization strings and configuration schema for new session settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->