### PR TITLE
Add opt-in performance diagnostics

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/PerformanceCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/PerformanceCatalogSection.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Settings under the dotted-id prefix `performance.*`.
+public struct PerformanceCatalogSection: SettingCatalogSection {
+    public let diagnosticsEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.enabled",
+        defaultValue: false,
+        userDefaultsKey: "performance.diagnostics.enabled"
+    )
+
+    public let diagnosticsIntervalSeconds = DefaultsKey<Double>(
+        id: "performance.diagnostics.intervalSeconds",
+        defaultValue: 5,
+        userDefaultsKey: "performance.diagnostics.intervalSeconds"
+    )
+
+    public let diagnosticsVerboseEventsEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.verboseEvents.enabled",
+        defaultValue: false,
+        userDefaultsKey: "performance.diagnostics.verboseEvents.enabled"
+    )
+
+    public let diagnosticsSignpostsEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.signposts.enabled",
+        defaultValue: true,
+        userDefaultsKey: "performance.diagnostics.signposts.enabled"
+    )
+
+    public let diagnosticsJSONDumpEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.jsonDump.enabled",
+        defaultValue: false,
+        userDefaultsKey: "performance.diagnostics.jsonDump.enabled"
+    )
+
+    public let diagnosticsJSONDumpPath = DefaultsKey<String>(
+        id: "performance.diagnostics.jsonDump.path",
+        defaultValue: "",
+        userDefaultsKey: "performance.diagnostics.jsonDump.path"
+    )
+
+    public let diagnosticsTitleScopeEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.scopes.title",
+        defaultValue: true,
+        userDefaultsKey: "performance.diagnostics.scopes.title"
+    )
+
+    public let diagnosticsSidebarScopeEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.scopes.sidebar",
+        defaultValue: true,
+        userDefaultsKey: "performance.diagnostics.scopes.sidebar"
+    )
+
+    public let diagnosticsMobileScopeEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.scopes.mobile",
+        defaultValue: true,
+        userDefaultsKey: "performance.diagnostics.scopes.mobile"
+    )
+
+    public let diagnosticsRendererScopeEnabled = DefaultsKey<Bool>(
+        id: "performance.diagnostics.scopes.renderer",
+        defaultValue: true,
+        userDefaultsKey: "performance.diagnostics.scopes.renderer"
+    )
+
+    public init() {}
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
@@ -46,6 +46,7 @@ public struct SettingCatalog: SettingCatalogSection {
     public let shortcuts = KeyboardShortcutsCatalogSection()
     public let integrations = IntegrationsCatalogSection()
     public let account = AccountCatalogSection()
+    public let performance = PerformanceCatalogSection()
 
     public init() {}
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
@@ -92,6 +92,7 @@ struct SettingCatalogTests {
         #expect(ids.contains("mobile.iOSPairingHost.enabled"))
         #expect(ids.contains("automation.socketControlMode"))
         #expect(ids.contains("automation.socketPassword"))
+        #expect(ids.contains("performance.diagnostics.enabled"))
     }
 
     @Test func keyIdsMatchTheirSectionPrefix() {
@@ -101,5 +102,6 @@ struct SettingCatalogTests {
         for key in catalog.app.all { #expect(key.id.hasPrefix("app.")) }
         for key in catalog.mobile.all { #expect(key.id.hasPrefix("mobile.")) }
         for key in catalog.automation.all { #expect(key.id.hasPrefix("automation.")) }
+        for key in catalog.performance.all { #expect(key.id.hasPrefix("performance.")) }
     }
 }

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
@@ -33,6 +33,11 @@ struct UserDefaultsSettingsClientTests {
         #expect(client.value(for: catalog.workspaceColors.indicatorStyle) == .leftRail)
         #expect(client.value(for: catalog.workspaceGroups.anchorCloseSuppressed) == false)
         #expect(client.value(for: catalog.workspaceGroups.newWorkspacePlacement) == .afterCurrent)
+        #expect(client.value(for: catalog.performance.diagnosticsEnabled) == false)
+        #expect(client.value(for: catalog.performance.diagnosticsIntervalSeconds) == 5)
+        #expect(client.value(for: catalog.performance.diagnosticsSignpostsEnabled) == true)
+        #expect(client.value(for: catalog.performance.diagnosticsTitleScopeEnabled) == true)
+        #expect(client.value(for: catalog.performance.diagnosticsRendererScopeEnabled) == true)
     }
 
     @Test func roundTripsEachConvergedKey() throws {
@@ -58,6 +63,13 @@ struct UserDefaultsSettingsClientTests {
         client.set(.end, for: catalog.workspaceGroups.newWorkspacePlacement)
         #expect(defaults.string(forKey: "workspaceGroup.newWorkspacePlacement") == "end")
         #expect(client.value(for: catalog.workspaceGroups.newWorkspacePlacement) == .end)
+
+        client.set(true, for: catalog.performance.diagnosticsEnabled)
+        client.set(2.5, for: catalog.performance.diagnosticsIntervalSeconds)
+        client.set(false, for: catalog.performance.diagnosticsRendererScopeEnabled)
+        #expect(defaults.bool(forKey: "performance.diagnostics.enabled") == true)
+        #expect(defaults.double(forKey: "performance.diagnostics.intervalSeconds") == 2.5)
+        #expect(defaults.bool(forKey: "performance.diagnostics.scopes.renderer") == false)
     }
 
     @Test func resetRestoresDefault() throws {

--- a/Sources/App/PerfDiagnostics.swift
+++ b/Sources/App/PerfDiagnostics.swift
@@ -1,0 +1,536 @@
+#if DEBUG
+import CMUXDebugLog
+import CmuxSettings
+import Foundation
+import os.signpost
+
+final class PerfDiagnostics: @unchecked Sendable {
+    static let shared = PerfDiagnostics()
+
+    enum Scope {
+        case title
+        case sidebar
+        case mobile
+        case renderer
+    }
+
+    private enum Counter: String, CaseIterable {
+        case titleNotifications
+        case titleDroppedEmpty
+        case titleEnqueues
+        case titleFlushes
+        case titleApplies
+        case titleMutations
+        case titleNoops
+        case sidebarImmediateInvalidations
+        case sidebarDebouncedInvalidations
+        case mobileObserverEmits
+        case mobileObserverSkips
+        case rendererVisibilityChanges
+        case rendererVisibilityRequests
+        case rendererRefreshes
+    }
+
+    private enum SignpostName {
+        case titleNotification
+        case titleFlush
+        case sidebarInvalidation
+        case mobileObserver
+        case rendererVisibility
+        case rendererRefresh
+    }
+
+    private struct Config: Equatable {
+        var enabled: Bool
+        var intervalSeconds: TimeInterval
+        var verboseEvents: Bool
+        var signposts: Bool
+        var jsonDump: Bool
+        var jsonDumpPath: String
+        var titleScope: Bool
+        var sidebarScope: Bool
+        var mobileScope: Bool
+        var rendererScope: Bool
+
+        static let disabled = Config(
+            enabled: false,
+            intervalSeconds: 5,
+            verboseEvents: false,
+            signposts: false,
+            jsonDump: false,
+            jsonDumpPath: "",
+            titleScope: true,
+            sidebarScope: true,
+            mobileScope: true,
+            rendererScope: true
+        )
+
+        func isEnabled(scope: Scope) -> Bool {
+            switch scope {
+            case .title:
+                return titleScope
+            case .sidebar:
+                return sidebarScope
+            case .mobile:
+                return mobileScope
+            case .renderer:
+                return rendererScope
+            }
+        }
+
+        var enabledScopesDescription: String {
+            var scopes: [String] = []
+            if titleScope { scopes.append("title") }
+            if sidebarScope { scopes.append("sidebar") }
+            if mobileScope { scopes.append("mobile") }
+            if rendererScope { scopes.append("renderer") }
+            return scopes.joined(separator: ",")
+        }
+
+        var resolvedJSONDumpPath: String {
+            if !jsonDumpPath.isEmpty {
+                return jsonDumpPath
+            }
+            let env = ProcessInfo.processInfo.environment
+            let rawTag = env["CMUX_TAG"] ?? Bundle.main.bundleIdentifier ?? "cmux"
+            let tag = PerfDiagnostics.token(rawTag)
+            return "/tmp/cmux-perf-\(tag)-\(ProcessInfo.processInfo.processIdentifier).jsonl"
+        }
+    }
+
+    private struct JSONRecord: Encodable {
+        var type: String
+        var uptime: Double
+        var pid: Int32
+        var kind: String?
+        var fields: [String: String]?
+        var counters: [String: Int]?
+        var config: [String: String]?
+    }
+
+    private static let signpostLog = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+        category: "PerfDiagnostics"
+    )
+
+    private let lock = NSLock()
+    private let defaults: UserDefaults
+    private let settingsCatalog = SettingCatalog()
+    private let ioQueue = DispatchQueue(label: "cmux.perf-diagnostics.io")
+
+    private var config = Config.disabled
+    private var lastConfigReadUptime = -Double.infinity
+    private var lastSummaryUptime = ProcessInfo.processInfo.systemUptime
+    private var counters: [String: Int] = [:]
+    private var emittedHeader = false
+
+    private init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func recordTitleNotification(tabId: UUID, panelId: UUID, title: String) {
+        record(
+            .titleNotifications,
+            scope: .title,
+            fields: titleFields(tabId: tabId, panelId: panelId, title: title),
+            signpost: .titleNotification
+        )
+    }
+
+    func recordTitleDroppedEmpty(tabId: UUID, panelId: UUID) {
+        record(
+            .titleDroppedEmpty,
+            scope: .title,
+            fields: [
+                "panel": Self.short(panelId),
+                "ws": Self.short(tabId),
+            ],
+            signpost: .titleNotification
+        )
+    }
+
+    func recordTitleEnqueue(tabId: UUID, panelId: UUID, title: String) {
+        record(
+            .titleEnqueues,
+            scope: .title,
+            fields: titleFields(tabId: tabId, panelId: panelId, title: title),
+            signpost: .titleNotification
+        )
+    }
+
+    func recordTitleFlush(pendingCount: Int) {
+        record(
+            .titleFlushes,
+            scope: .title,
+            fields: ["pending": "\(pendingCount)"],
+            signpost: .titleFlush
+        )
+    }
+
+    func recordTitleApply(
+        tabId: UUID,
+        panelId: UUID,
+        mutated: Bool,
+        focused: Bool,
+        selected: Bool,
+        title: String
+    ) {
+        var fields = titleFields(tabId: tabId, panelId: panelId, title: title)
+        fields["focused"] = Self.flag(focused)
+        fields["mutated"] = Self.flag(mutated)
+        fields["selected"] = Self.flag(selected)
+        record(.titleApplies, scope: .title, fields: fields, signpost: .titleNotification)
+    }
+
+    func recordTitleMutation(
+        workspaceId: UUID,
+        panelId: UUID,
+        mutated: Bool,
+        panelChanged: Bool,
+        workspaceChanged: Bool,
+        panelCount: Int,
+        hasCustomTitle: Bool,
+        title: String
+    ) {
+        var fields = titleFields(tabId: workspaceId, panelId: panelId, title: title)
+        fields["custom"] = Self.flag(hasCustomTitle)
+        fields["mutated"] = Self.flag(mutated)
+        fields["panelChanged"] = Self.flag(panelChanged)
+        fields["panelCount"] = "\(panelCount)"
+        fields["wsChanged"] = Self.flag(workspaceChanged)
+        record(
+            mutated ? .titleMutations : .titleNoops,
+            scope: .title,
+            fields: fields,
+            signpost: .titleNotification
+        )
+    }
+
+    func recordSidebarInvalidation(
+        workspaceId: UUID,
+        source: String,
+        title: String,
+        descriptionLength: Int
+    ) {
+        let normalizedSource = Self.token(source)
+        record(
+            normalizedSource == "immediate" ? .sidebarImmediateInvalidations : .sidebarDebouncedInvalidations,
+            scope: .sidebar,
+            fields: [
+                "descLen": "\(descriptionLength)",
+                "source": normalizedSource,
+                "titleHash": Self.fingerprint(title),
+                "titleLen": "\(Self.length(title))",
+                "ws": Self.short(workspaceId),
+            ],
+            signpost: .sidebarInvalidation
+        )
+    }
+
+    func recordMobileObserver(result: String, summaryHash: Int, tabCount: Int, force: Bool) {
+        let normalizedResult = Self.token(result)
+        record(
+            normalizedResult == "emit" ? .mobileObserverEmits : .mobileObserverSkips,
+            scope: .mobile,
+            fields: [
+                "force": Self.flag(force),
+                "result": normalizedResult,
+                "summaryHash": "\(summaryHash)",
+                "tabs": "\(tabCount)",
+            ],
+            signpost: .mobileObserver
+        )
+    }
+
+    func recordRendererVisibility(
+        surfaceId: UUID?,
+        workspaceId: UUID?,
+        visible: Bool,
+        changed: Bool
+    ) {
+        record(
+            changed ? .rendererVisibilityChanges : .rendererVisibilityRequests,
+            scope: .renderer,
+            fields: [
+                "changed": Self.flag(changed),
+                "surface": Self.short(surfaceId),
+                "visible": Self.flag(visible),
+                "ws": Self.short(workspaceId),
+            ],
+            signpost: .rendererVisibility
+        )
+    }
+
+    func recordRendererRefresh(surfaceId: UUID?, workspaceId: UUID?, reason: String) {
+        record(
+            .rendererRefreshes,
+            scope: .renderer,
+            fields: [
+                "surface": Self.short(surfaceId),
+                "why": Self.token(reason),
+                "ws": Self.short(workspaceId),
+            ],
+            signpost: .rendererRefresh
+        )
+    }
+
+    private func record(
+        _ counter: Counter,
+        scope: Scope,
+        fields: [String: String],
+        signpost: SignpostName
+    ) {
+        let now = ProcessInfo.processInfo.systemUptime
+        var lines: [String] = []
+        var jsonLines: [String] = []
+        var jsonPath: String?
+        var shouldSignpost = false
+
+        lock.lock()
+        refreshConfigIfNeededLocked(now: now)
+        let currentConfig = config
+        guard currentConfig.enabled, currentConfig.isEnabled(scope: scope) else {
+            lock.unlock()
+            return
+        }
+
+        if !emittedHeader {
+            let headerFields = makeHeaderFields(config: currentConfig)
+            lines.append("perf.diagnostics.enabled \(Self.formatFields(headerFields))")
+            if currentConfig.jsonDump {
+                jsonLines.append(Self.jsonLine(
+                    type: "header",
+                    uptime: now,
+                    config: headerFields
+                ))
+            }
+            emittedHeader = true
+        }
+
+        counters[counter.rawValue, default: 0] += 1
+        if currentConfig.verboseEvents {
+            lines.append("perf.event kind=\(counter.rawValue) \(Self.formatFields(fields))")
+        }
+        if currentConfig.jsonDump {
+            jsonLines.append(Self.jsonLine(
+                type: "event",
+                uptime: now,
+                kind: counter.rawValue,
+                fields: fields
+            ))
+        }
+
+        if now - lastSummaryUptime >= currentConfig.intervalSeconds {
+            let summary = currentCountersSnapshotLocked()
+            lines.append(
+                "perf.summary uptime=\(Self.formatSeconds(now)) " +
+                "interval=\(Self.formatSeconds(now - lastSummaryUptime)) " +
+                Self.formatCounters(summary)
+            )
+            if currentConfig.jsonDump {
+                jsonLines.append(Self.jsonLine(type: "summary", uptime: now, counters: summary))
+            }
+            counters.removeAll(keepingCapacity: true)
+            lastSummaryUptime = now
+            shouldSignpost = currentConfig.signposts
+        } else {
+            shouldSignpost = currentConfig.signposts
+        }
+
+        if currentConfig.jsonDump {
+            jsonPath = currentConfig.resolvedJSONDumpPath
+        }
+        lock.unlock()
+
+        if shouldSignpost {
+            Self.emitSignpost(signpost)
+        }
+        for line in lines {
+            cmuxDebugLog(line)
+        }
+        if let jsonPath, !jsonLines.isEmpty {
+            writeJSONLines(jsonLines, to: jsonPath)
+        }
+    }
+
+    private func refreshConfigIfNeededLocked(now: TimeInterval) {
+        guard now - lastConfigReadUptime >= 1 else { return }
+        lastConfigReadUptime = now
+
+        let client = UserDefaultsSettingsClient(defaults: defaults)
+        let performance = settingsCatalog.performance
+        let next = Config(
+            enabled: client.value(for: performance.diagnosticsEnabled),
+            intervalSeconds: max(1, client.value(for: performance.diagnosticsIntervalSeconds)),
+            verboseEvents: client.value(for: performance.diagnosticsVerboseEventsEnabled),
+            signposts: client.value(for: performance.diagnosticsSignpostsEnabled),
+            jsonDump: client.value(for: performance.diagnosticsJSONDumpEnabled),
+            jsonDumpPath: client.value(for: performance.diagnosticsJSONDumpPath)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            titleScope: client.value(for: performance.diagnosticsTitleScopeEnabled),
+            sidebarScope: client.value(for: performance.diagnosticsSidebarScopeEnabled),
+            mobileScope: client.value(for: performance.diagnosticsMobileScopeEnabled),
+            rendererScope: client.value(for: performance.diagnosticsRendererScopeEnabled)
+        )
+
+        if config != next {
+            emittedHeader = false
+            counters.removeAll(keepingCapacity: true)
+            lastSummaryUptime = now
+        }
+        config = next
+    }
+
+    private func currentCountersSnapshotLocked() -> [String: Int] {
+        var snapshot: [String: Int] = [:]
+        for counter in Counter.allCases {
+            snapshot[counter.rawValue] = counters[counter.rawValue] ?? 0
+        }
+        return snapshot
+    }
+
+    private func makeHeaderFields(config: Config) -> [String: String] {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let version = info["CFBundleShortVersionString"] as? String ?? "unknown"
+        let build = info["CFBundleVersion"] as? String ?? "unknown"
+        let commit = (info["CMUXGitCommit"] as? String)
+            ?? (info["GitCommit"] as? String)
+            ?? (info["GIT_COMMIT"] as? String)
+            ?? "unknown"
+
+        return [
+            "appBuild": Self.token(build),
+            "appVersion": Self.token(version),
+            "commit": Self.token(commit),
+            "debugLog": DebugEventLog.currentLogPath(),
+            "interval": Self.formatSeconds(config.intervalSeconds),
+            "jsonDump": Self.flag(config.jsonDump),
+            "jsonOut": config.resolvedJSONDumpPath,
+            "pid": "\(ProcessInfo.processInfo.processIdentifier)",
+            "scopes": config.enabledScopesDescription,
+            "signposts": Self.flag(config.signposts),
+            "tag": Self.token(ProcessInfo.processInfo.environment["CMUX_TAG"] ?? "none"),
+            "verbose": Self.flag(config.verboseEvents),
+        ]
+    }
+
+    private func writeJSONLines(_ lines: [String], to path: String) {
+        guard !lines.isEmpty else { return }
+        let payload = lines.joined(separator: "\n") + "\n"
+        ioQueue.async {
+            let url = URL(fileURLWithPath: path)
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            guard let data = payload.data(using: .utf8) else { return }
+            if let handle = FileHandle(forWritingAtPath: path) {
+                defer { try? handle.close() }
+                guard (try? handle.seekToEnd()) != nil else { return }
+                try? handle.write(contentsOf: data)
+            } else {
+                try? data.write(to: url, options: .atomic)
+            }
+        }
+    }
+
+    private func titleFields(tabId: UUID, panelId: UUID, title: String) -> [String: String] {
+        [
+            "panel": Self.short(panelId),
+            "titleHash": Self.fingerprint(title),
+            "titleLen": "\(Self.length(title))",
+            "ws": Self.short(tabId),
+        ]
+    }
+
+    private static func emitSignpost(_ name: SignpostName) {
+        switch name {
+        case .titleNotification:
+            os_signpost(.event, log: signpostLog, name: "title.notification")
+        case .titleFlush:
+            os_signpost(.event, log: signpostLog, name: "title.flush")
+        case .sidebarInvalidation:
+            os_signpost(.event, log: signpostLog, name: "sidebar.invalidation")
+        case .mobileObserver:
+            os_signpost(.event, log: signpostLog, name: "mobile.observer")
+        case .rendererVisibility:
+            os_signpost(.event, log: signpostLog, name: "renderer.visibility")
+        case .rendererRefresh:
+            os_signpost(.event, log: signpostLog, name: "renderer.refresh")
+        }
+    }
+
+    private static func jsonLine(
+        type: String,
+        uptime: TimeInterval,
+        kind: String? = nil,
+        fields: [String: String]? = nil,
+        counters: [String: Int]? = nil,
+        config: [String: String]? = nil
+    ) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let record = JSONRecord(
+            type: type,
+            uptime: uptime,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            kind: kind,
+            fields: fields,
+            counters: counters,
+            config: config
+        )
+        guard let data = try? encoder.encode(record),
+              let line = String(data: data, encoding: .utf8) else {
+            return #"{"type":"encodeError"}"#
+        }
+        return line
+    }
+
+    private static func formatFields(_ fields: [String: String]) -> String {
+        fields.keys.sorted().map { key in
+            "\(key)=\(fields[key] ?? "")"
+        }.joined(separator: " ")
+    }
+
+    private static func formatCounters(_ counters: [String: Int]) -> String {
+        Counter.allCases.map { counter in
+            "\(counter.rawValue)=\(counters[counter.rawValue] ?? 0)"
+        }.joined(separator: " ")
+    }
+
+    private static func flag(_ value: Bool) -> String {
+        value ? "1" : "0"
+    }
+
+    private static func formatSeconds(_ value: TimeInterval) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private static func short(_ id: UUID?) -> String {
+        guard let id else { return "nil" }
+        return String(id.uuidString.prefix(8))
+    }
+
+    private static func length(_ text: String) -> Int {
+        (text as NSString).length
+    }
+
+    private static func fingerprint(_ text: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+
+    private static func token(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "none" }
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-/:"))
+        return String(trimmed.unicodeScalars.map { scalar in
+            allowed.contains(scalar) ? Character(scalar) : "_"
+        })
+    }
+}
+#endif

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13737,6 +13737,12 @@ struct TabItemView: View, Equatable {
         ) { _ in
 #if DEBUG
             let description = tab.customDescription ?? ""
+            PerfDiagnostics.shared.recordSidebarInvalidation(
+                workspaceId: tab.id,
+                source: "immediate",
+                title: tab.title,
+                descriptionLength: (description as NSString).length
+            )
             cmuxDebugLog(
                 "sidebar.row.invalidate workspace=\(tab.id.uuidString.prefix(8)) " +
                 "source=immediate " +
@@ -13757,6 +13763,12 @@ struct TabItemView: View, Equatable {
         ) { _ in
 #if DEBUG
             let description = tab.customDescription ?? ""
+            PerfDiagnostics.shared.recordSidebarInvalidation(
+                workspaceId: tab.id,
+                source: "debounced",
+                title: tab.title,
+                descriptionLength: (description as NSString).length
+            )
             cmuxDebugLog(
                 "sidebar.row.invalidate workspace=\(tab.id.uuidString.prefix(8)) " +
                 "source=debounced " +

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8260,6 +8260,13 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.layoutSubtreeIfNeeded()
         displayIfNeeded()
         surfaceView.displayIfNeeded()
+#if DEBUG
+        PerfDiagnostics.shared.recordRendererRefresh(
+            surfaceId: surfaceView.terminalSurface?.id,
+            workspaceId: surfaceView.tabId,
+            reason: reason
+        )
+#endif
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
@@ -9232,6 +9239,12 @@ final class GhosttySurfaceScrollView: NSView {
             surfaceView.terminalSurface?.setOcclusion(visible)
         }
 #if DEBUG
+        PerfDiagnostics.shared.recordRendererVisibility(
+            surfaceId: surfaceView.terminalSurface?.id,
+            workspaceId: surfaceView.tabId,
+            visible: visible,
+            changed: wasVisible != visible
+        )
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"
             let suffix = debugVisibilityStateSuffix(transition: transition)

--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -208,6 +208,12 @@ final class MobileWorkspaceListObserver {
         )
         if !force, hash == lastSummaryHash {
             #if DEBUG
+            PerfDiagnostics.shared.recordMobileObserver(
+                result: "skip",
+                summaryHash: hash,
+                tabCount: tabManager.tabs.count,
+                force: force
+            )
             cmuxDebugLog("mobile.observer skip: hash unchanged=\(hash) tabs=\(tabManager.tabs.count)")
             #endif
             return
@@ -215,6 +221,12 @@ final class MobileWorkspaceListObserver {
         lastSummaryHash = hash
         mobileWorkspaceObserverLog.debug("emitting workspace.updated (hash=\(hash, privacy: .public))")
         #if DEBUG
+        PerfDiagnostics.shared.recordMobileObserver(
+            result: "emit",
+            summaryHash: hash,
+            tabCount: tabManager.tabs.count,
+            force: force
+        )
         cmuxDebugLog("mobile.observer EMIT workspace.updated hash=\(hash) tabs=\(tabManager.tabs.count) force=\(force)")
         #endif
         MobileHostService.shared.emitEvent(topic: "workspace.updated", payload: [:])

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -557,6 +557,13 @@ class TabManager: ObservableObject {
             MainActor.assumeIsolated { [weak self] in
                 guard let self else { return }
                 guard let change = GhosttyTitleChange(notification: notification) else { return }
+#if DEBUG
+                PerfDiagnostics.shared.recordTitleNotification(
+                    tabId: change.tabId,
+                    panelId: change.surfaceId,
+                    title: change.title
+                )
+#endif
                 enqueuePanelTitleUpdate(tabId: change.tabId, panelId: change.surfaceId, title: change.title)
             }
         })
@@ -3295,8 +3302,14 @@ class TabManager: ObservableObject {
 
     private func enqueuePanelTitleUpdate(tabId: UUID, panelId: UUID, title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
 #if DEBUG
+            PerfDiagnostics.shared.recordTitleDroppedEmpty(tabId: tabId, panelId: panelId)
+#endif
+            return
+        }
+#if DEBUG
+        PerfDiagnostics.shared.recordTitleEnqueue(tabId: tabId, panelId: panelId, title: trimmed)
         cmuxDebugLog(
             "workspace.title.enqueue workspace=\(Self.debugShortWorkspaceId(tabId)) " +
             "panel=\(panelId.uuidString.prefix(5)) title=\"\(Self.debugTitlePreview(trimmed))\""
@@ -3313,6 +3326,9 @@ class TabManager: ObservableObject {
         guard !pendingPanelTitleUpdates.isEmpty else { return }
         let updates = pendingPanelTitleUpdates
         pendingPanelTitleUpdates.removeAll(keepingCapacity: true)
+#if DEBUG
+        PerfDiagnostics.shared.recordTitleFlush(pendingCount: updates.count)
+#endif
         for (key, title) in updates {
             updatePanelTitle(tabId: key.tabId, panelId: key.panelId, title: title)
         }
@@ -3320,7 +3336,17 @@ class TabManager: ObservableObject {
 
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        _ = tab.updatePanelTitle(panelId: panelId, title: title)
+        let mutated = tab.updatePanelTitle(panelId: panelId, title: title)
+#if DEBUG
+        PerfDiagnostics.shared.recordTitleApply(
+            tabId: tabId,
+            panelId: panelId,
+            mutated: mutated,
+            focused: tab.focusedPanelId == panelId,
+            selected: selectedTabId == tabId,
+            title: title
+        )
+#endif
 
         if tab.focusedPanelId == panelId {
             tab.applyProcessTitle(title)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4898,6 +4898,16 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
 #if DEBUG
+        PerfDiagnostics.shared.recordTitleMutation(
+            workspaceId: id,
+            panelId: panelId,
+            mutated: didMutate,
+            panelChanged: didMutatePanelTitle,
+            workspaceChanged: didMutateWorkspaceTitle,
+            panelCount: panels.count,
+            hasCustomTitle: customTitle != nil,
+            title: trimmed
+        )
         if didMutate {
             cmuxDebugLog(
                 "workspace.title.updatePanel workspace=\(id.uuidString.prefix(5)) " +

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -593,6 +593,7 @@
 		6313B5A0 /* PaneMemorySample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313B5A1 /* PaneMemorySample.swift */; };
 		6313B6A0 /* PaneMemoryWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313B6A1 /* PaneMemoryWarning.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
+		D4C0DE010000000000000001 /* PerfDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C0DE010000000000000002 /* PerfDiagnostics.swift */; };
 		D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */; };
 		D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A2 /* PhonePushClient.swift */; };
 		D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A4 /* PhonePushPayload.swift */; };
@@ -1617,6 +1618,7 @@
 		6313B5A1 /* PaneMemorySample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemorySample.swift; sourceTree = "<group>"; };
 		6313B6A1 /* PaneMemoryWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryWarning.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
+		D4C0DE010000000000000002 /* PerfDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/PerfDiagnostics.swift; sourceTree = "<group>"; };
 		D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneForwardingMode.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A2 /* PhonePushClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushClient.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A4 /* PhonePushPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushPayload.swift; sourceTree = "<group>"; };
@@ -2392,6 +2394,7 @@
 				2F0C06000000000000000001 /* MainWindowVisibilityController.swift */,
 				A6D1F0000000000000000001 /* ReleasingWindowController.swift */,
 				A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */,
+				D4C0DE010000000000000002 /* PerfDiagnostics.swift */,
 				D35B71010000000000000002 /* StartupBreadcrumbLog.swift */,
 				A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */,
 				9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */,
@@ -3896,6 +3899,7 @@
 				6313B5A0 /* PaneMemorySample.swift in Sources */,
 				6313B6A0 /* PaneMemoryWarning.swift in Sources */,
 				A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */,
+				D4C0DE010000000000000001 /* PerfDiagnostics.swift in Sources */,
 				D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */,
 				D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */,
 				D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */,


### PR DESCRIPTION
## Summary

- Add a DEBUG-only, opt-in `PerfDiagnostics` collector for title updates, sidebar invalidations, mobile observer emits/skips, renderer realization, and tab/workspace summary counters.
- Add default-off settings under `performance.diagnostics.*` so normal runtime behavior stays unchanged.
- Wire lightweight counters into the existing title/sidebar/mobile/rendering hot paths without changing production behavior when diagnostics are disabled.

## Why

Recent profiling around #6546 / #6551 showed multiple overlapping performance paths:

- terminal title churn can drive `Workspace.title` changes even with a single panel
- `sidebarImmediateObservationPublisher` still routes title/immediate changes into the full `refreshWorkspaceSnapshot()` path
- `MobileWorkspaceListObserver` also re-emits when title-backed hashes change
- samples frequently collapse into SwiftUI / AttributeGraph layout work, so logs alone are not enough to explain fan-out or rate

This PR is intentionally instrumentation-only. It gives affected users and maintainers a cheap way to collect bounded counters before/after enabling experimental performance modes such as #6547.

## Behavior

Default behavior is unchanged:

```json
{
  "performance": {
    "diagnostics": {
      "enabled": false
    }
  }
}
```

When enabled in DEBUG builds, diagnostics can be dumped from the in-process collector and optionally logged through the existing debug log path. The collector stores bounded per-workspace/per-source counts rather than raw titles or full payloads.

## Validation

Passed locally:

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer swift test --package-path Packages/macOS/CmuxSettings --filter SettingCatalogTests`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer swift test --package-path Packages/macOS/CmuxSettings --filter UserDefaultsSettingsClientTests`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' build -quiet`

Refs #6546
Refs #6551

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784685119&installation_id=133855650&pr_number=6560&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6560&signature=d3eb0141329d230f8f08d30bddfafa331559db973d9980875912b510e7d7f991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in, DEBUG-only performance diagnostics collector to track title, sidebar, mobile, and renderer activity. Defaults are off; when enabled it emits lightweight counters, signposts, and optional JSONL dumps without changing runtime behavior.

- **New Features**
  - Introduced `PerfDiagnostics` with scoped counters and periodic summaries.
  - Wired into title updates, sidebar invalidations, mobile observer emits/skips, and renderer visibility/refresh.
  - Added `performance.diagnostics.*` settings in `CmuxSettings` (interval, verbose, signposts, JSON dump/path, per-scope toggles; default disabled).
  - Added tests for new keys and `UserDefaults` round-trips.

<sup>Written for commit 4712b3952aed5f1d2283c4bf98e5294abfe8ea9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

