### PR TITLE
Reduce title-driven workspace list fanout

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -27,6 +27,12 @@ public struct TerminalCatalogSection: SettingCatalogSection {
         userDefaultsKey: "terminal.autoResumeAgentSessions"
     )
 
+    public let titleUpdateWorkspaceListFanoutEnabled = DefaultsKey<Bool>(
+        id: "terminal.titleUpdates.workspaceListFanout.enabled",
+        defaultValue: true,
+        userDefaultsKey: "terminal.titleUpdates.workspaceListFanout.enabled"
+    )
+
     public let agentHibernationEnabled = DefaultsKey<Bool>(
         id: "terminal.agentHibernation.enabled",
         defaultValue: false,

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
@@ -33,6 +33,7 @@ struct UserDefaultsSettingsClientTests {
         #expect(client.value(for: catalog.workspaceColors.indicatorStyle) == .leftRail)
         #expect(client.value(for: catalog.workspaceGroups.anchorCloseSuppressed) == false)
         #expect(client.value(for: catalog.workspaceGroups.newWorkspacePlacement) == .afterCurrent)
+        #expect(client.value(for: catalog.terminal.titleUpdateWorkspaceListFanoutEnabled) == true)
     }
 
     @Test func roundTripsEachConvergedKey() throws {
@@ -58,6 +59,10 @@ struct UserDefaultsSettingsClientTests {
         client.set(.end, for: catalog.workspaceGroups.newWorkspacePlacement)
         #expect(defaults.string(forKey: "workspaceGroup.newWorkspacePlacement") == "end")
         #expect(client.value(for: catalog.workspaceGroups.newWorkspacePlacement) == .end)
+
+        client.set(false, for: catalog.terminal.titleUpdateWorkspaceListFanoutEnabled)
+        #expect(defaults.bool(forKey: "terminal.titleUpdates.workspaceListFanout.enabled") == false)
+        #expect(client.value(for: catalog.terminal.titleUpdateWorkspaceListFanoutEnabled) == false)
     }
 
     @Test func resetRestoresDefault() throws {

--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -1,4 +1,5 @@
 import Combine
+import CmuxSettings
 import CmuxWorkspaces
 import Foundation
 import OSLog
@@ -26,16 +27,25 @@ final class MobileWorkspaceListObserver {
     private var unreadIndicatorsCancellable: AnyCancellable?
     private var perWorkspaceCancellables: [UUID: AnyCancellable] = [:]
     private var lastSummaryHash: Int = 0
+    private let settings: any SettingsReading
     /// Throttle window with `latest: true`. First event in a burst emits
     /// immediately (iPhone gets the change in milliseconds), subsequent
     /// events within the window collapse to one trailing emit carrying the
     /// final state. So a single action is instant; a burst caps at ~1 emit
     /// per 80 ms. Hash-diff suppresses no-op rebroadcasts.
     private let throttleMilliseconds: Int = 80
+    private var includesAutomaticPanelTitlesInWorkspaceList: Bool {
+        PanelTitleWorkspaceListFanoutSettings.isEnabled(settings: settings)
+    }
 
-    init(tabManager: TabManager, notificationStore: TerminalNotificationStore? = nil) {
+    init(
+        tabManager: TabManager,
+        notificationStore: TerminalNotificationStore? = nil,
+        settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard)
+    ) {
         self.tabManager = tabManager
         self.notificationStore = notificationStore
+        self.settings = settings
         #if DEBUG
         cmuxDebugLog("mobile.observer init tabs=\(tabManager.tabs.count)")
         #endif
@@ -50,7 +60,8 @@ final class MobileWorkspaceListObserver {
             for: tabManager.tabs,
             groups: tabManager.workspaceGroups,
             selectedTabID: tabManager.selectedTabId,
-            previewSignatures: currentPreviewSignatures(for: tabManager.tabs)
+            previewSignatures: currentPreviewSignatures(for: tabManager.tabs),
+            includesAutomaticPanelTitles: includesAutomaticPanelTitlesInWorkspaceList
         )
         lastSummaryHash = initial
         emitIfNeeded(force: true)
@@ -166,9 +177,8 @@ final class MobileWorkspaceListObserver {
         // directory fields. Directory changes can arrive from shell prompt
         // updates without changing the terminal set.
         for workspace in tabs where perWorkspaceCancellables[workspace.id] == nil {
-            let publishers: [AnyPublisher<Void, Never>] = [
+            var publishers: [AnyPublisher<Void, Never>] = [
                 workspace.panelsPublisher.map { _ in () }.eraseToAnyPublisher(),
-                workspace.$panelTitles.map { _ in () }.eraseToAnyPublisher(),
                 // Renaming a terminal sets `panelCustomTitles` (not `panelTitles`),
                 // so without this a terminal rename never re-emits to the phone.
                 workspace.$panelCustomTitles.map { _ in () }.eraseToAnyPublisher(),
@@ -190,6 +200,9 @@ final class MobileWorkspaceListObserver {
                 // is the only signal the observer gets for a reorder.
                 workspace.paneLayoutVersionPublisher.map { _ in () }.eraseToAnyPublisher(),
             ]
+            if includesAutomaticPanelTitlesInWorkspaceList {
+                publishers.append(workspace.$panelTitles.map { _ in () }.eraseToAnyPublisher())
+            }
             let merged = Publishers.MergeMany(publishers)
                 .throttle(for: .milliseconds(throttleMilliseconds), scheduler: RunLoop.main, latest: true)
             perWorkspaceCancellables[workspace.id] = merged.sink { [weak self] _ in
@@ -204,7 +217,8 @@ final class MobileWorkspaceListObserver {
             for: tabManager.tabs,
             groups: tabManager.workspaceGroups,
             selectedTabID: tabManager.selectedTabId,
-            previewSignatures: currentPreviewSignatures(for: tabManager.tabs)
+            previewSignatures: currentPreviewSignatures(for: tabManager.tabs),
+            includesAutomaticPanelTitles: includesAutomaticPanelTitlesInWorkspaceList
         )
         if !force, hash == lastSummaryHash {
             #if DEBUG
@@ -239,7 +253,8 @@ final class MobileWorkspaceListObserver {
         for tabs: [Workspace],
         groups: [WorkspaceGroup],
         selectedTabID: UUID?,
-        previewSignatures: [UUID: Int]
+        previewSignatures: [UUID: Int],
+        includesAutomaticPanelTitles: Bool
     ) -> Int {
         var hasher = Hasher()
         hasher.combine(tabs.count)
@@ -273,7 +288,13 @@ final class MobileWorkspaceListObserver {
             let panelIDs = workspace.orderedPanelIds
             hasher.combine(panelIDs)
             for id in panelIDs {
-                hasher.combine(workspace.panelTitle(panelId: id))
+                hasher.combine(
+                    workspaceListPanelTitle(
+                        workspace: workspace,
+                        panelId: id,
+                        includesAutomaticPanelTitles: includesAutomaticPanelTitles
+                    )
+                )
                 hasher.combine(workspace.panelDirectories[id])
             }
             hasher.combine(workspace.currentDirectory)
@@ -290,18 +311,35 @@ final class MobileWorkspaceListObserver {
         return hasher.finalize()
     }
 
+    private static func workspaceListPanelTitle(
+        workspace: Workspace,
+        panelId: UUID,
+        includesAutomaticPanelTitles: Bool
+    ) -> String? {
+        if includesAutomaticPanelTitles {
+            return workspace.panelTitle(panelId: panelId)
+        }
+        if let custom = workspace.panelCustomTitles[panelId],
+           !custom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return custom
+        }
+        return workspace.panels[panelId]?.displayTitle
+    }
+
     #if DEBUG
     static func summaryHashForTesting(
         tabs: [Workspace],
         groups: [WorkspaceGroup] = [],
         selectedTabID: UUID?,
-        previewSignatures: [UUID: Int] = [:]
+        previewSignatures: [UUID: Int] = [:],
+        includesAutomaticPanelTitles: Bool = true
     ) -> Int {
         summaryHash(
             for: tabs,
             groups: groups,
             selectedTabID: selectedTabID,
-            previewSignatures: previewSignatures
+            previewSignatures: previewSignatures,
+            includesAutomaticPanelTitles: includesAutomaticPanelTitles
         )
     }
     #endif

--- a/Sources/PanelTitleWorkspaceListFanoutSettings.swift
+++ b/Sources/PanelTitleWorkspaceListFanoutSettings.swift
@@ -1,0 +1,7 @@
+import CmuxSettings
+
+enum PanelTitleWorkspaceListFanoutSettings {
+    static func isEnabled(settings: any SettingsReading) -> Bool {
+        settings.value(for: SettingCatalog().terminal.titleUpdateWorkspaceListFanoutEnabled)
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3316,10 +3316,11 @@ class TabManager: ObservableObject {
 
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        _ = tab.updatePanelTitle(panelId: panelId, title: title)
+        let updatesWorkspaceTitle = PanelTitleWorkspaceListFanoutSettings.isEnabled(settings: settings)
+        _ = tab.updatePanelTitle(panelId: panelId, title: title, updatesWorkspaceTitle: updatesWorkspaceTitle)
 
         if tab.focusedPanelId == panelId {
-            tab.applyProcessTitle(title)
+            tab.applyProcessTitle(title, updatesWorkspaceTitle: updatesWorkspaceTitle)
             if selectedTabId == tabId {
                 updateWindowTitle(for: tab)
             }
@@ -3330,7 +3331,8 @@ class TabManager: ObservableObject {
         guard let tab = tabs.first(where: { $0.id == tabId }),
               let focusedPanelId = tab.focusedPanelId,
               let title = tab.panelTitles[focusedPanelId] else { return }
-        tab.applyProcessTitle(title)
+        let updatesWorkspaceTitle = PanelTitleWorkspaceListFanoutSettings.isEnabled(settings: settings)
+        tab.applyProcessTitle(title, updatesWorkspaceTitle: updatesWorkspaceTitle)
         if selectedTabId == tabId {
             updateWindowTitle(for: tab)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4306,10 +4306,11 @@ final class Workspace: Identifiable, ObservableObject {
         Self.normalizedCustomDescription(customDescription) != nil
     }
 
-    func applyProcessTitle(_ title: String) {
+    func applyProcessTitle(_ title: String, updatesWorkspaceTitle: Bool = true) {
         if processTitle != title {
             processTitle = title
         }
+        guard updatesWorkspaceTitle else { return }
         guard customTitle == nil else { return }
         guard self.title != title else { return }
 #if DEBUG
@@ -4950,7 +4951,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     @discardableResult
-    func updatePanelTitle(panelId: UUID, title: String) -> Bool {
+    func updatePanelTitle(panelId: UUID, title: String, updatesWorkspaceTitle: Bool = true) -> Bool {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         var didMutate = false
@@ -4978,7 +4979,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         // If this is the only panel and no custom title, update workspace title
         if panels.count == 1, customTitle == nil {
-            if self.title != trimmed {
+            if updatesWorkspaceTitle, self.title != trimmed {
                 self.title = trimmed
                 didMutate = true
                 didMutateWorkspaceTitle = true

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
+		B65640000000000000000001 /* PanelTitleWorkspaceListFanoutSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65640000000000000000002 /* PanelTitleWorkspaceListFanoutSettings.swift */; };
 		6313B1A0 /* PaneMemoryDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313B1A1 /* PaneMemoryDescriptor.swift */; };
 		6313A1A0 /* PaneMemoryGuardrail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313A1A1 /* PaneMemoryGuardrail.swift */; };
 		6313A2A0 /* PaneMemoryGuardrailBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313A2A1 /* PaneMemoryGuardrailBannerView.swift */; };
@@ -846,6 +847,7 @@
 		A5001003 /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001013 /* TabManager.swift */; };
 		C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */; };
 		2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
+		B65640000000000000000003 /* TabManagerTitleWorkspaceListFanoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65640000000000000000004 /* TabManagerTitleWorkspaceListFanoutTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
 		C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A503000000000000000001 /* TaskManagerSnapshot.swift */; };
@@ -1649,6 +1651,7 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
+		B65640000000000000000002 /* PanelTitleWorkspaceListFanoutSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelTitleWorkspaceListFanoutSettings.swift; sourceTree = "<group>"; };
 		6313B1A1 /* PaneMemoryDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryDescriptor.swift; sourceTree = "<group>"; };
 		6313A1A1 /* PaneMemoryGuardrail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryGuardrail.swift; sourceTree = "<group>"; };
 		6313A2A1 /* PaneMemoryGuardrailBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryGuardrailBannerView.swift; sourceTree = "<group>"; };
@@ -1880,6 +1883,7 @@
 		A5001013 /* TabManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManager.swift; sourceTree = "<group>"; };
 		C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerNotificationFocusRegressionTests.swift; sourceTree = "<group>"; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		B65640000000000000000004 /* TabManagerTitleWorkspaceListFanoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleWorkspaceListFanoutTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
 		C7A503000000000000000001 /* TaskManagerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerSnapshot.swift; sourceTree = "<group>"; };
@@ -2342,6 +2346,7 @@
 				C46790000000000000000006 /* RosettaNativeRelaunch.swift */,
 				5E2701020000000000000002 /* SentryEventScrubber.swift */,
 				D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */,
+				B65640000000000000000002 /* PanelTitleWorkspaceListFanoutSettings.swift */,
 				E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */,
 				C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */,
 				C4160A020000000000000002 /* FocusHistoryMenuInvalidator.swift */,
@@ -3144,6 +3149,7 @@
 				D7AB00000000000000B020 /* NotificationDismissSyncTests.swift */,
 				4E5F60720000000000000002 /* NotificationSoundSettingsTests.swift */,
 				C0DE64160000000000000002 /* TabManagerNotificationFocusRegressionTests.swift */,
+				B65640000000000000000004 /* TabManagerTitleWorkspaceListFanoutTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 				C0793DC7D7B61CF54886EC36 /* RemoteTmuxControlParserTests.swift */,
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
@@ -3971,6 +3977,7 @@
 				A5001400 /* Panel.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */,
+				B65640000000000000000001 /* PanelTitleWorkspaceListFanoutSettings.swift in Sources */,
 				6313B1A0 /* PaneMemoryDescriptor.swift in Sources */,
 				6313A1A0 /* PaneMemoryGuardrail.swift in Sources */,
 				6313A2A0 /* PaneMemoryGuardrailBannerView.swift in Sources */,
@@ -4582,6 +4589,7 @@
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
 				C0DE64160000000000000001 /* TabManagerNotificationFocusRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
+				B65640000000000000000003 /* TabManagerTitleWorkspaceListFanoutTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,
 				C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */,

--- a/cmuxTests/MobileWorkspaceListFidelityTests.swift
+++ b/cmuxTests/MobileWorkspaceListFidelityTests.swift
@@ -121,6 +121,49 @@ struct MobileWorkspaceListFidelityTests {
         #expect(before != after, "a terminal rename must change the mobile summary hash")
     }
 
+    @Test func automaticTerminalTitleCanBeExcludedFromObserverHash() throws {
+        let (workspace, ordered) = try makeWorkspaceWithTabTerminals(count: 1)
+        let panelId = try #require(ordered.first)
+
+        let includedBefore = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: [workspace],
+            selectedTabID: workspace.id
+        )
+        let excludedBefore = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: [workspace],
+            selectedTabID: workspace.id,
+            includesAutomaticPanelTitles: false
+        )
+
+        #expect(
+            workspace.updatePanelTitle(
+                panelId: panelId,
+                title: "Runtime title",
+                updatesWorkspaceTitle: false
+            )
+        )
+
+        let includedAfter = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: [workspace],
+            selectedTabID: workspace.id
+        )
+        let excludedAfter = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: [workspace],
+            selectedTabID: workspace.id,
+            includesAutomaticPanelTitles: false
+        )
+        #expect(includedBefore != includedAfter)
+        #expect(excludedBefore == excludedAfter)
+
+        workspace.setPanelCustomTitle(panelId: panelId, title: "Manual title")
+        let manualAfter = MobileWorkspaceListObserver.summaryHashForTesting(
+            tabs: [workspace],
+            selectedTabID: workspace.id,
+            includesAutomaticPanelTitles: false
+        )
+        #expect(excludedAfter != manualAfter)
+    }
+
     @Test func renamingWorkspaceChangesObserverHashAndDisplayedTitle() throws {
         let (workspace, _) = try makeWorkspaceWithTabTerminals(count: 1)
 

--- a/cmuxTests/TabManagerTitleWorkspaceListFanoutTests.swift
+++ b/cmuxTests/TabManagerTitleWorkspaceListFanoutTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import CmuxSettings
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@discardableResult
+private func waitForTitleFanoutCondition(
+    timeout: TimeInterval = 3.0,
+    pollInterval: TimeInterval = 0.05,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: @escaping () -> Bool
+) -> Bool {
+    if condition() {
+        return true
+    }
+
+    let expectation = XCTestExpectation(description: "wait for title fanout condition")
+    let deadline = Date().addingTimeInterval(timeout)
+
+    func poll() {
+        if condition() {
+            expectation.fulfill()
+            return
+        }
+        guard Date() < deadline else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + pollInterval) {
+            poll()
+        }
+    }
+
+    DispatchQueue.main.async {
+        poll()
+    }
+
+    let result = XCTWaiter().wait(for: [expectation], timeout: timeout + pollInterval + 0.1)
+    if result != .completed {
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+        return false
+    }
+    return true
+}
+
+@MainActor
+final class TabManagerTitleWorkspaceListFanoutTests: XCTestCase {
+    func testTitleWorkspaceListFanoutCanBeDisabled() throws {
+        let suiteName = "cmux-title-workspace-list-fanout-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        settings.set(false, for: SettingCatalog().terminal.titleUpdateWorkspaceListFanoutEnabled)
+
+        let manager = TabManager(settings: settings)
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let originalTitle = workspace.title
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: panelId,
+                GhosttyNotificationKey.title: "Runtime title"
+            ]
+        )
+
+        XCTAssertTrue(
+            waitForTitleFanoutCondition(timeout: 1.0) {
+                workspace.panelTitles[panelId] == "Runtime title" &&
+                    workspace.sessionSnapshot(includeScrollback: false).processTitle == "Runtime title"
+            }
+        )
+        XCTAssertEqual(workspace.title, originalTitle)
+        XCTAssertNil(workspace.customTitle)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a default-on `terminal.titleUpdates.workspaceListFanout.enabled` setting so existing title behavior stays unchanged.
- When disabled, automatic terminal title updates still update panel/process state, but no longer mutate `Workspace.title`.
- Teach the mobile workspace-list observer to stop subscribing to automatic `panelTitles` changes and exclude automatic panel titles from its hash while still tracking manual terminal renames.

## Root cause
Automatic terminal title updates can fan out through the workspace-list path: a runtime title update mutates `Workspace.panelTitles`, the focused/single-panel path mutates `Workspace.title`, and the mobile workspace-list observer hashes/subscribes to those automatic title changes.

This PR targets that fanout path directly. The setting defaults to `true`, so default behavior is unchanged. Users who set it to `false` trade live automatic runtime-title freshness in the workspace/mobile list for lower title-driven list churn.

## Relationship to other PRs
This PR is now independent from #6552 and is based on `main`.

- #6552: coalesces redundant title-update producer work.
- #6560: optional diagnostics/observability.
- #6547: experimental sidebar split work; this PR covers the direct title-driven workspace-list fanout path.

## Behavior
With `terminal.titleUpdates.workspaceListFanout.enabled = false`:
- `Workspace.panelTitles` still records the automatic terminal runtime title.
- Process title state still gets refreshed.
- `Workspace.title` remains stable for automatic runtime-title churn.
- Mobile workspace-list hashing ignores automatic panel title churn.
- Manual terminal renames still affect the mobile workspace-list hash.

## Validation
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py --repo-root . --budget .github/swift-file-length-budget.tsv`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer swift test --package-path Packages/macOS/CmuxSettings --filter UserDefaultsSettingsClientTests`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/TabManagerTitleWorkspaceListFanoutTests -only-testing:cmuxTests/MobileWorkspaceListFidelityTests test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting that controls whether automatic terminal titles are included in workspace list updates, providing granular control over workspace title display behavior.

* **Tests**
  * Expanded test coverage for workspace list title propagation behavior, including setting validation and workspace observer hash calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->