### PR TITLE
fix: stop forcing scrollback when only --lines N is passed (#6500)

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface2.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface2.swift
@@ -287,9 +287,6 @@ extension ControlCommandCoordinator {
         if let lineLimit, lineLimit <= 0 {
             return .err(code: "invalid_params", message: "lines must be greater than 0", data: nil)
         }
-        if lineLimit != nil {
-            includeScrollback = true
-        }
         let resolution = context?.controlSurfaceReadText(
             routing: routing,
             surfaceID: uuid(params, "surface_id"),

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceReadTextTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceReadTextTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+/// Surface-domain overrides for the `surface.read_text` regression test (#6500).
+///
+/// Only the workspace-domain tests share `FakeWorkspaceControlCommandContext`, and
+/// they never dispatch `surface.*` methods, so these surface overrides do not leak
+/// into any other test. The `includeScrollback` argument is encoded into the return
+/// value so the test needs no stored capture state: a forced scrollback produces a
+/// distinct error that the coordinator surfaces as `internal_error`.
+extension FakeWorkspaceControlCommandContext {
+    func controlSurfaceRoutingResolvesTabManager(routing: ControlRoutingSelectors) -> Bool { true }
+
+    func controlSurfaceReadText(
+        routing: ControlRoutingSelectors,
+        surfaceID: UUID?,
+        hasSurfaceIDParam: Bool,
+        includeScrollback: Bool,
+        lineLimit: Int?
+    ) -> ControlSurfaceReadTextResolution {
+        if includeScrollback {
+            return .internalError(message: "scrollback-forced")
+        }
+        return .read(
+            text: "viewport-tail",
+            base64: Data("viewport-tail".utf8).base64EncodedString(),
+            windowID: nil,
+            workspaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            surfaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        )
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator surface.read_text")
+struct ControlCommandCoordinatorSurfaceReadTextTests {
+    private func request(_ method: String, _ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: method, params: params)
+    }
+
+    /// Regression test for https://github.com/manaflow-ai/cmux/issues/6500.
+    ///
+    /// `surface.read_text --lines N` (without `scrollback: true`) must NOT force
+    /// `includeScrollback = true` on the context. The pre-fix coordinator
+    /// unconditionally set `includeScrollback = true` whenever `lineLimit` was
+    /// non-nil, triggering full-history `PageFormatter` work on the main actor.
+    /// The fake context returns `internal_error` when scrollback is forced, so this
+    /// test is red without the fix and green with it.
+    @Test func readTextWithLinesDoesNotForceScrollback() throws {
+        let context = FakeWorkspaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(request("surface.read_text", ["lines": .int(5)]))
+
+        guard case .ok(.object(let payload)) = result,
+              case .string(let text) = payload["text"] else {
+            Issue.record("expected .ok with text payload (scrollback was forced). Got: \(String(describing: result))")
+            return
+        }
+        #expect(text == "viewport-tail")
+    }
+
+    /// Explicit `scrollback: true` still reaches the context with
+    /// `includeScrollback = true` — the fix only removes the *forced* scrollback
+    /// for `--lines N`, not the explicit opt-in.
+    @Test func readTextWithExplicitScrollbackStillForcesIt() throws {
+        let context = FakeWorkspaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(request("surface.read_text", ["scrollback": .bool(true)]))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("expected .err (fake returns internal_error for scrollback). Got: \(String(describing: result))")
+            return
+        }
+        #expect(code == "internal_error")
+    }
+
+    /// Without `--lines` and without `--scrollback`, `includeScrollback` stays
+    /// `false` — the baseline that the fix preserves.
+    @Test func readTextWithoutLinesOrScrollbackStaysFalse() throws {
+        let context = FakeWorkspaceControlCommandContext()
+        let coordinator = ControlCommandCoordinator(context: context)
+
+        let result = coordinator.handle(request("surface.read_text"))
+
+        guard case .ok(.object(let payload)) = result,
+              case .string(let text) = payload["text"] else {
+            Issue.record("expected .ok with text payload. Got: \(String(describing: result))")
+            return
+        }
+        #expect(text == "viewport-tail")
+    }
+}

--- a/cmuxTests/TerminalControllerTerminalTextTests.swift
+++ b/cmuxTests/TerminalControllerTerminalTextTests.swift
@@ -34,4 +34,31 @@ final class TerminalControllerTerminalTextTests: XCTestCase {
         XCTAssertEqual(payload.base64, Data("three\nfour\nfive".utf8).base64EncodedString())
     }
 
+    /// Regression test for https://github.com/manaflow-ai/cmux/issues/6500.
+    ///
+    /// `surface.read_text --lines N` must NOT force `includeScrollback = true`.
+    /// When `includeScrollback` is false, the payload is built from `viewport`
+    /// only and tailed to `lineLimit` — `screen`/`history`/`active` are never
+    /// consulted, so the heavy `PageFormatter` pass over full scrollback history
+    /// is skipped. This test pins that contract: with `includeScrollback: false`
+    /// and a `lineLimit`, the result is the tailed viewport even when scrollback
+    /// fields would otherwise have produced more content.
+    func testTerminalTextPayloadLineLimitTailsViewportWithoutScrollback() throws {
+        let viewport = "alpha\nbeta\ngamma\ndelta\nepsilon"
+        let result = TerminalController.terminalTextPayload(
+            from: TerminalController.TerminalTextRawSnapshot(
+                viewport: viewport,
+                screen: "screen-line-1\nscreen-line-2",
+                history: "history-line-1\nhistory-line-2\nhistory-line-3",
+                active: "active-line-1\nactive-line-2"
+            ),
+            includeScrollback: false,
+            lineLimit: 2
+        )
+        let payload = try result.get()
+
+        XCTAssertEqual(payload.text, "delta\nepsilon")
+        XCTAssertEqual(payload.base64, Data("delta\nepsilon".utf8).base64EncodedString())
+    }
+
 }


### PR DESCRIPTION
## Summary

- `surface.read_text` unconditionally forced `includeScrollback = true` whenever `--lines N` was present, pulling full scrollback history through `PageFormatter` on the main actor even when the caller only asked for the last N lines. This caused the stable-release CPU/memory spike in #6500.
- **Fix:** delete the 3-line block that forced scrollback for non-nil `lineLimit`. The non-scrollback branch of `terminalTextPayload` already honors `lineLimit` via `tailTerminalLines` on the viewport (`Sources/TerminalController.swift:4877-4879`), so `--lines N` still returns the last N lines without the heavyweight scrollback processing. Explicit `scrollback: true` is unaffected.

This is **option #1 from the issue** (issue-author-approved): "Do not force scrollback merely because `lines` is present. Treat `--lines N` without explicit scrollback as a viewport tail."

Closes #6500.

## Testing

- **Coordinator-level regression test** (`ControlCommandCoordinatorSurfaceReadTextTests.swift`): a capturing fake context encodes the `includeScrollback` argument into its return value, so `readTextWithLinesDoesNotForceScrollback` is **red without the fix** (forced scrollback → `internal_error`) and **green with it** (viewport tail → `.ok`). Also covers explicit `scrollback: true` still forcing it, and the baseline no-params case.
- **Contract test** (`TerminalControllerTerminalTextTests.swift`): pins that `terminalTextPayload` with `includeScrollback: false` and `lineLimit` returns the tailed viewport — the property that makes removing the forced scrollback safe.
- **Two-commit structure:** commit 1 adds the failing test, commit 2 adds the fix — CI should go red then green, visible in the Commits tab.
- Cannot compile on this Linux VPS; CI (macOS) will validate.

## Demo Video

N/A — no UI change; this is a socket/coordinator performance fix.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

---

**AI disclosure:** Human-reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784697563&installation_id=133855650&pr_number=6569&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6569&signature=5bed538ed8f73dbc6a048b22f62ef02bff09cdf025274089045fc699c19cf735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing scrollback when `--lines N` is passed to `surface.read_text`. The command now tails the viewport only, removing the full-history pass and fixing the CPU/memory spike in #6500.

- **Bug Fixes**
  - Removed the code that set `includeScrollback = true` when `lineLimit` was present; `scrollback: true` still forces scrollback.
  - Added regression tests for the coordinator and for `TerminalController.terminalTextPayload` to pin viewport tailing with `includeScrollback: false`.

<sup>Written for commit fb10b1f434249028805e761f6bbad3ccb21ba87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal text reading to properly validate line count parameter and prevent invalid values.
  * Fixed scrollback behavior to respect only explicit user settings instead of automatically including scrollback when requesting specific line counts.

* **Tests**
  * Added test coverage for terminal text reading behavior with line limits and scrollback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->