### PR TITLE
fix: filter ghosttyDidSetTitle at TabManager boundary (#6551)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -17,7 +17,7 @@
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6359	cmuxTests/SessionPersistenceTests.swift
 6255	cmuxTests/GhosttyConfigTests.swift
-6166	Sources/TabManager.swift
+6173	Sources/TabManager.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5809	Sources/TextBoxInput.swift
 5573	cmuxTests/BrowserConfigTests.swift
@@ -26,8 +26,8 @@
 4367	cmuxTests/BrowserPanelTests.swift
 4239	Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
 4121	Sources/BrowserWindowPortal.swift
+3981	cmuxTests/TabManagerUnitTests.swift
 3934	Sources/Feed/FeedPanelView.swift
-3926	cmuxTests/TabManagerUnitTests.swift
 3896	cmuxTests/WindowAndDragTests.swift
 3668	cmuxTests/CLIGenericHookPersistenceTests.swift
 3397	Sources/CmuxConfig.swift

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3300,6 +3300,11 @@ class TabManager: ObservableObject {
         }
     }
     func flushPendingPanelTitleUpdatesForWorkspaceSnapshot() { panelTitleUpdateCoalescer.flushNow() }
+
+    func pendingPanelTitleUpdateCountForTesting() -> Int {
+        pendingPanelTitleUpdates.count
+    }
+
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String, sourceSurface: TerminalSurface) {
         guard let tab = workspacesById[tabId], let terminalPanel = tab.terminalPanel(for: panelId), terminalPanel.surface === sourceSurface else { return }
         let previousDisplayTitle = resolvedWorkspaceDisplayTitle(for: tab).trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -371,12 +371,18 @@ class TabManager: ObservableObject {
     }
     private var observers: [NSObjectProtocol] = []
     private var lastFocusedPanelByTab: [UUID: UUID] = [:]
-    private struct PanelTitleUpdateKey: Hashable {
+    /// Key into `pendingPanelTitleUpdates`. Internal so the dictionary's
+    /// access level (internal, for `@testable` test observability of the
+    /// coalescing queue) is well-formed.
+    struct PanelTitleUpdateKey: Hashable {
         let tabId: UUID
         let panelId: UUID
     }
-    private struct PendingPanelTitleUpdate { let title: String; weak var sourceSurface: TerminalSurface? }
-    private var pendingPanelTitleUpdates: [PanelTitleUpdateKey: PendingPanelTitleUpdate] = [:]
+    struct PendingPanelTitleUpdate { let title: String; weak var sourceSurface: TerminalSurface? }
+    /// Coalesced panel-title updates awaiting the next 30 Hz flush.
+    /// Internal so regression tests can assert queue depth via
+    /// `@testable import` instead of a `ForTesting` accessor in production.
+    var pendingPanelTitleUpdates: [PanelTitleUpdateKey: PendingPanelTitleUpdate] = [:]
     private let panelTitleUpdateCoalescer: NotificationBurstCoalescer
 
     // Wave-3 sub-models (TabManager decomposition): TabManager is the
@@ -3300,10 +3306,6 @@ class TabManager: ObservableObject {
         }
     }
     func flushPendingPanelTitleUpdatesForWorkspaceSnapshot() { panelTitleUpdateCoalescer.flushNow() }
-
-    func pendingPanelTitleUpdateCountForTesting() -> Int {
-        pendingPanelTitleUpdates.count
-    }
 
     private func updatePanelTitle(tabId: UUID, panelId: UUID, title: String, sourceSurface: TerminalSurface) {
         guard let tab = workspacesById[tabId], let terminalPanel = tab.terminalPanel(for: panelId), terminalPanel.surface === sourceSurface else { return }

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -862,7 +862,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         )
 
         let enqueued = waitForCondition(timeout: 1.0, pollInterval: 0.002) {
-            manager.pendingPanelTitleUpdateCountForTesting() > 0
+            manager.pendingPanelTitleUpdates.count > 0
         }
         XCTAssertTrue(enqueued, "owning manager should enqueue title update for its own tab")
     }
@@ -887,7 +887,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         // TabManager receives it. Waiting for the owning manager to enqueue
         // proves the notification has been delivered to both observers.
         let delivered = waitForCondition(timeout: 1.0, pollInterval: 0.002) {
-            owningManager.pendingPanelTitleUpdateCountForTesting() > 0
+            owningManager.pendingPanelTitleUpdates.count > 0
         }
         XCTAssertTrue(delivered, "owning manager should enqueue title update for its own tab")
 
@@ -895,7 +895,7 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         // pending queue must still be empty if the boundary guard held.
         // Before the fix this was 1 (2x fan-out across managers — see #6551).
         XCTAssertEqual(
-            foreignManager.pendingPanelTitleUpdateCountForTesting(),
+            foreignManager.pendingPanelTitleUpdates.count,
             0,
             "non-owning manager must not enqueue title updates for foreign tabs"
         )

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -845,6 +845,61 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
         XCTAssertNil(workspace.customTitle)
         XCTAssertNotEqual(workspace.panelTitles[splitPanel.id], Optional(workspace.title))
     }
+
+    func testGhosttyDidSetTitleEnqueuesTitleUpdateForOwnedTab() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "Owned Title"
+            ]
+        )
+
+        let enqueued = waitForCondition(timeout: 1.0, pollInterval: 0.002) {
+            manager.pendingPanelTitleUpdateCountForTesting() > 0
+        }
+        XCTAssertTrue(enqueued, "owning manager should enqueue title update for its own tab")
+    }
+
+    func testGhosttyDidSetTitleDoesNotEnqueueForTabOwnedByAnotherManager() throws {
+        let owningManager = TabManager()
+        let foreignManager = TabManager()
+        let workspace = try XCTUnwrap(owningManager.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "Owner Only"
+            ]
+        )
+
+        // .ghosttyDidSetTitle is observed with object: nil, so every alive
+        // TabManager receives it. Waiting for the owning manager to enqueue
+        // proves the notification has been delivered to both observers.
+        let delivered = waitForCondition(timeout: 1.0, pollInterval: 0.002) {
+            owningManager.pendingPanelTitleUpdateCountForTesting() > 0
+        }
+        XCTAssertTrue(delivered, "owning manager should enqueue title update for its own tab")
+
+        // Checked before the 30 Hz coalescer fires, so the non-owning manager's
+        // pending queue must still be empty if the boundary guard held.
+        // Before the fix this was 1 (2x fan-out across managers — see #6551).
+        XCTAssertEqual(
+            foreignManager.pendingPanelTitleUpdateCountForTesting(),
+            0,
+            "non-owning manager must not enqueue title updates for foreign tabs"
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary

Filters `.ghosttyDidSetTitle` notifications at the `TabManager` observer boundary so a non-owning manager never enqueues title work for a foreign workspace. Fixes #6551.

## Problem

`.ghosttyDidSetTitle` is posted as a **global notification** while every `TabManager` registers its observer with `object: nil`. Before this change, each alive manager parsed the notification and called `enqueuePanelTitleUpdate` **before** checking whether it owned the referenced workspace. With multiple managers alive, one Ghostty title event fanned out through every manager's title coalescer, then was silently discarded by the downstream ownership guard in `updatePanelTitle`.

The issue author measured the impact with two managers alive:

```text
ghostty.title.post              313
workspace.title.enqueue          626   ← 2.0x the source rate
workspace.title.flush            104
```

## Fix

Add an ownership guard before the enqueue call in the `.ghosttyDidSetTitle` observer (`Sources/TabManager.swift`), matching the existing `tabs.contains(where:)` pattern already used at lines 2291, 1044, and 5066 in the same file:

```swift
guard tabs.contains(where: { $0.id == change.tabId }) else { return }
```

After the guard, the same measurement shows the enqueue/post ratio dropping from **2.00 → 1.00** and the extra non-owner coalescer flushes disappearing:

```text
ghostty.title.post              314
workspace.title.enqueue          314   ← 1.0x
workspace.title.flush             52
```

This is the issue-author-approved fix. The opt-in title-coalescing settings proposed in #6551 are intentionally left out of scope here to keep this PR narrowly focused on the fan-out fix.

## Test plan

Two new tests in `TabManagerWorkspaceOwnershipTests` (`cmuxTests/TabManagerUnitTests.swift`):

1. **`testGhosttyDidSetTitleEnqueuesTitleUpdateForOwnedTab`** — positive control: an owned tab's title change is enqueued.
2. **`testGhosttyDidSetTitleDoesNotEnqueueForTabOwnedByAnotherManager`** — regression test: creates two managers, posts a title change for one manager's workspace, and asserts the **non-owning** manager's pending-queue count stays `0`.

The regression test uses a new `pendingPanelTitleUpdateCountForTesting()` accessor (following the existing `ForTesting` accessor convention in this file — see lines 685–703) to observe the enqueue state **before** the 30 Hz coalescer flushes. Without the boundary guard this count is `1` (test fails); with the guard it is `0` (test passes).

Submitted as a two-commit red/green sequence per the repo regression-test policy:
- Commit 1: failing test + accessor (CI red)
- Commit 2: the one-line boundary guard (CI green)

## AI disclosure

Human-reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784698265&installation_id=133855650&pr_number=6570&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6570&signature=85279745587b47cbd1ecc2e303872dd8971a11cc89963e6dcbdc26e5f1f44835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter the global `.ghosttyDidSetTitle` at the `TabManager` boundary using an O(1) ownership lookup (`workspacesById` + owning-manager identity) so only the owner enqueues title updates, restoring a 1.0x enqueue/post rate. Fixes #6551.

- **Bug Fixes**
  - Guard enqueue in the `.ghosttyDidSetTitle` observer with the O(1) ownership check to stop fan-out across managers.
  - Make `PanelTitleUpdateKey`, `PendingPanelTitleUpdate`, and `pendingPanelTitleUpdates` internal for `@testable` assertions; remove the testing seam and add two unit tests for owned vs. non-owned tabs.

<sup>Written for commit fa26e826d58788a95a02ef3be5e42ea2d3ce9098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale tab title updates from being processed: title notifications are now ignored unless the notification refers to a tab still owned by the active tab manager, avoiding incorrect pending updates after tab ownership changes.

* **Tests**
  * Added coverage to verify title-notification fan-out across multiple tab manager instances, including confirmation that only the owning manager enqueues pending updates while others ignore them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->