### PR TITLE
Fix main CI sidebar drop metrics test fixture

### DIFF
--- a/cmuxTests/SidebarWorkspaceDropMetricsTests.swift
+++ b/cmuxTests/SidebarWorkspaceDropMetricsTests.swift
@@ -275,7 +275,8 @@ import Testing
             branchLinesContainBranch: false,
             pullRequestRows: [],
             listeningPorts: [],
-            finderDirectoryPath: nil
+            finderDirectoryPath: nil,
+            mediaActivity: BrowserMediaActivity()
         )
     }
 }


### PR DESCRIPTION
Fixes the main CI compile failure from https://github.com/manaflow-ai/cmux/actions/runs/27930576162.

The `SidebarWorkspaceDropMetricsTests` snapshot helper lagged behind `SidebarWorkspaceSnapshotBuilder.Snapshot` after `mediaActivity` became a required field. The fix keeps the model initializer explicit and updates the fixture with the neutral `BrowserMediaActivity()` value, matching the existing snapshot-refresh test helper pattern.

Validation:
- `git diff --check`
- `scripts/lint-pbxproj-test-wiring.sh`
- Local `xcodebuild test` and `build-for-testing` were blocked by the cmux hq local test guard, so PR CI is the authoritative compile check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784705072&installation_id=133855650&pr_number=6575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6575&signature=794d3097f8c91744394ac00a7b2f630980cd7eebf0dba7bd4f04ccf93ae2a056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture update with no production or runtime behavior changes.
> 
> **Overview**
> Fixes a **main CI compile failure** in `SidebarWorkspaceDropMetricsTests` by updating the `workspaceSnapshot()` helper so it matches the current `SidebarWorkspaceSnapshotBuilder.Snapshot` initializer.
> 
> `Snapshot` now requires **`mediaActivity`**. The fixture passes a neutral **`BrowserMediaActivity()`**, consistent with other snapshot test helpers. Drop-target height behavior under test is unchanged; only the model construction is brought up to date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f870aa492a4bb41320889e794b0a1b0e736ddbc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the main CI compile error by updating `SidebarWorkspaceDropMetricsTests` to include the required `mediaActivity` field in the snapshot fixture.

- **Bug Fixes**
  - Added `mediaActivity: BrowserMediaActivity()` to the snapshot initializer to match `SidebarWorkspaceSnapshotBuilder.Snapshot` and keep the model constructor explicit.

<sup>Written for commit f870aa492a4bb41320889e794b0a1b0e736ddbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test snapshot construction to include default media activity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->