### PR TITLE
Add opt-in terminal title update coalescing

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -8,6 +8,14 @@ public struct TerminalCatalogSection: SettingCatalogSection {
     public static let scrollSpeedMinimum = 0.25
     /// Maximum allowed multiplier for terminal scroll deltas.
     public static let scrollSpeedMaximum = 3.0
+    /// Default state for terminal title update coalescing.
+    public static let titleUpdateCoalescingDefaultEnabled = false
+    /// Default coalescing delay when terminal title update coalescing is enabled.
+    public static let titleUpdateCoalescingDefaultMilliseconds = 1_000
+    /// Minimum allowed delay for terminal title update coalescing.
+    public static let titleUpdateCoalescingMinimumMilliseconds = 33
+    /// Maximum allowed delay for terminal title update coalescing.
+    public static let titleUpdateCoalescingMaximumMilliseconds = 5_000
 
     public let showScrollBar = DefaultsKey<Bool>(
         id: "terminal.showScrollBar",
@@ -67,6 +75,18 @@ public struct TerminalCatalogSection: SettingCatalogSection {
         id: "terminal.rendererRealization.maxWarmRenderers",
         defaultValue: 12,
         userDefaultsKey: "terminal.rendererRealization.maxWarmRenderers"
+    )
+
+    public let titleUpdateCoalescingEnabled = DefaultsKey<Bool>(
+        id: "terminal.titleUpdates.coalescing.enabled",
+        defaultValue: TerminalCatalogSection.titleUpdateCoalescingDefaultEnabled,
+        userDefaultsKey: "terminal.titleUpdates.coalescing.enabled"
+    )
+
+    public let titleUpdateCoalescingMilliseconds = DefaultsKey<Int>(
+        id: "terminal.titleUpdates.coalescing.milliseconds",
+        defaultValue: TerminalCatalogSection.titleUpdateCoalescingDefaultMilliseconds,
+        userDefaultsKey: "terminal.titleUpdates.coalescing.milliseconds"
     )
 
     public let showTextBoxOnNewTerminals = DefaultsKey<Bool>(

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CmuxSettings
 import Foundation
 
 enum WorkspaceTitlebarSettings {
@@ -455,6 +456,31 @@ enum RendererRealizationSettings {
 
     static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
         notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}
+
+enum TerminalTitleUpdateCoalescingSettings {
+    static let enabledKey = SettingCatalog().terminal.titleUpdateCoalescingEnabled.userDefaultsKey
+    static let millisecondsKey = SettingCatalog().terminal.titleUpdateCoalescingMilliseconds.userDefaultsKey
+
+    static let defaultEnabled = TerminalCatalogSection.titleUpdateCoalescingDefaultEnabled
+    static let defaultMilliseconds = TerminalCatalogSection.titleUpdateCoalescingDefaultMilliseconds
+    static let minimumMilliseconds = TerminalCatalogSection.titleUpdateCoalescingMinimumMilliseconds
+    static let maximumMilliseconds = TerminalCatalogSection.titleUpdateCoalescingMaximumMilliseconds
+    static let passthroughDelay: TimeInterval = 1.0 / 30.0
+
+    static func sanitizedMilliseconds(_ value: Int) -> Int {
+        min(max(value, minimumMilliseconds), maximumMilliseconds)
+    }
+
+    static func delay(settings: any SettingsReading) -> TimeInterval {
+        let terminal = SettingCatalog().terminal
+        guard settings.value(for: terminal.titleUpdateCoalescingEnabled) else {
+            return passthroughDelay
+        }
+        return TimeInterval(
+            sanitizedMilliseconds(settings.value(for: terminal.titleUpdateCoalescingMilliseconds))
+        ) / 1_000.0
     }
 }
 

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -355,6 +355,8 @@ extension CmuxSettingsFileStore {
         "terminal.rendererRealization.enabled",
         "terminal.rendererRealization.idleSeconds",
         "terminal.rendererRealization.maxWarmRenderers",
+        "terminal.titleUpdates.coalescing.enabled",
+        "terminal.titleUpdates.coalescing.milliseconds",
         "terminal.textBoxMaxLines",
         "terminal.resumeCommands",
         "notifications.dockBadge",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -105,6 +105,12 @@ extension CmuxSettingsFileStore {
                         "idleSeconds": Int(RendererRealizationSettings.defaultIdleSeconds),
                         "maxWarmRenderers": RendererRealizationSettings.defaultMaxWarmRenderers,
                     ],
+                    "titleUpdates": [
+                        "coalescing": [
+                            "enabled": TerminalTitleUpdateCoalescingSettings.defaultEnabled,
+                            "milliseconds": TerminalTitleUpdateCoalescingSettings.defaultMilliseconds,
+                        ],
+                    ],
                     "textBoxMaxLines": TerminalTextBoxInputSettings.defaultMaxLines,
                     "resumeCommands": [],
                 ],

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -569,6 +569,29 @@ final class CmuxSettingsFileStore {
             logInvalid("terminal.rendererRealization", sourcePath: sourcePath)
         }
 
+        if let rawTitleUpdates = section["titleUpdates"],
+           let titleUpdates = rawTitleUpdates as? [String: Any] {
+            if let rawCoalescing = titleUpdates["coalescing"],
+               let coalescing = rawCoalescing as? [String: Any] {
+                if let value = jsonBool(coalescing["enabled"]) {
+                    snapshot.managedUserDefaults[TerminalTitleUpdateCoalescingSettings.enabledKey] = .bool(value)
+                } else if coalescing.keys.contains("enabled") {
+                    logInvalid("terminal.titleUpdates.coalescing.enabled", sourcePath: sourcePath)
+                }
+                if let value = jsonInt(coalescing["milliseconds"]) {
+                    snapshot.managedUserDefaults[TerminalTitleUpdateCoalescingSettings.millisecondsKey] = .int(
+                        TerminalTitleUpdateCoalescingSettings.sanitizedMilliseconds(value)
+                    )
+                } else if coalescing.keys.contains("milliseconds") {
+                    logInvalid("terminal.titleUpdates.coalescing.milliseconds", sourcePath: sourcePath)
+                }
+            } else if titleUpdates.keys.contains("coalescing") {
+                logInvalid("terminal.titleUpdates.coalescing", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("titleUpdates") {
+            logInvalid("terminal.titleUpdates", sourcePath: sourcePath)
+        }
+
         if let value = jsonInt(section["textBoxMaxLines"]) {
             if value >= TerminalTextBoxInputSettings.minimumMaxLines,
                value <= TerminalTextBoxInputSettings.maximumMaxLines {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -32,31 +32,50 @@ enum WorkspaceOrderChangeNotificationKey {
 /// Coalesces repeated main-thread signals into one callback after a short delay.
 /// Useful for notification storms where only the latest update matters.
 final class NotificationBurstCoalescer {
-    private let delay: TimeInterval
-    private var isFlushScheduled = false
+    typealias Cancellation = () -> Void
+    typealias Scheduler = (TimeInterval, @escaping () -> Void) -> Cancellation
+
+    private var delay: TimeInterval
+    private let schedule: Scheduler
+    private var cancelScheduledFlush: Cancellation?
     private var pendingAction: (() -> Void)?
 
-    init(delay: TimeInterval = 1.0 / 30.0) {
+    init(
+        delay: TimeInterval = 1.0 / 30.0,
+        schedule: @escaping Scheduler = { delay, action in
+            let workItem = DispatchWorkItem(block: action)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+            return { workItem.cancel() }
+        }
+    ) {
         self.delay = max(0, delay)
+        self.schedule = schedule
     }
 
-    func signal(_ action: @escaping () -> Void) {
+    func signal(delay newDelay: TimeInterval? = nil, _ action: @escaping () -> Void) {
         precondition(Thread.isMainThread, "NotificationBurstCoalescer must be used on the main thread")
+        let previousDelay = delay
+        if let newDelay {
+            delay = max(0, newDelay)
+        }
         pendingAction = action
+        if cancelScheduledFlush != nil, delay != previousDelay {
+            cancelScheduledFlush?()
+            cancelScheduledFlush = nil
+        }
         scheduleFlushIfNeeded()
     }
 
     private func scheduleFlushIfNeeded() {
-        guard !isFlushScheduled else { return }
-        isFlushScheduled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        guard cancelScheduledFlush == nil else { return }
+        cancelScheduledFlush = schedule(delay) { [weak self] in
             self?.flush()
         }
     }
 
     private func flush() {
         precondition(Thread.isMainThread, "NotificationBurstCoalescer must be used on the main thread")
-        isFlushScheduled = false
+        cancelScheduledFlush = nil
         guard let action = pendingAction else { return }
         pendingAction = nil
         action()
@@ -411,7 +430,7 @@ class TabManager: ObservableObject {
         let panelId: UUID
     }
     private var pendingPanelTitleUpdates: [PanelTitleUpdateKey: String] = [:]
-    private let panelTitleUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
+    private let panelTitleUpdateCoalescer: NotificationBurstCoalescer
 
     // Wave-3 sub-models (TabManager decomposition): TabManager is the
     // per-window composition point. It owns the concrete sub-models, hosts
@@ -501,10 +520,12 @@ class TabManager: ObservableObject {
         workspaceGitMetadataReader: (any WorkspaceGitMetadataReading)? = nil,
         gitPollClock: any GitPollClock = SystemGitPollClock(),
         gitProbeLimiter: WorkspaceGitMetadataProbeLimiter? = nil,
+        panelTitleUpdateCoalescer: NotificationBurstCoalescer = NotificationBurstCoalescer(),
         settings: any SettingsWriting = UserDefaultsSettingsClient(defaults: .standard),
         closeTabWarningDefaults: UserDefaults = .standard
     ) {
         self.settings = settings
+        self.panelTitleUpdateCoalescer = panelTitleUpdateCoalescer
         self.closeTabWarningDefaults = closeTabWarningDefaults
         workspaceReordering = WorkspaceReorderCoordinator(model: workspaces)
         workspaceGrouping = WorkspaceGroupCoordinator(model: workspaces)
@@ -2086,6 +2107,7 @@ class TabManager: ObservableObject {
     @discardableResult
     func detachWorkspace(tabId: UUID) -> Workspace? {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return nil }
+        flushPendingPanelTitleUpdates()
         sidebarGitMetadataService.clearWorkspaceGitProbes(workspaceId: tabId)
         sidebarMultiSelection.removeFromSelection(tabId)
         invalidateFocusHistoryTarget(workspaceId: tabId, panelId: nil)
@@ -3302,7 +3324,9 @@ class TabManager: ObservableObject {
 #endif
         let key = PanelTitleUpdateKey(tabId: tabId, panelId: panelId)
         pendingPanelTitleUpdates[key] = trimmed
-        panelTitleUpdateCoalescer.signal { [weak self] in
+        panelTitleUpdateCoalescer.signal(
+            delay: TerminalTitleUpdateCoalescingSettings.delay(settings: settings)
+        ) { [weak self] in
             self?.flushPendingPanelTitleUpdates()
         }
     }

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -1126,6 +1126,54 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
         }
     }
 
+    func testSettingsFileStoreAppliesTerminalTitleUpdateCoalescingSettings() throws {
+        let defaults = UserDefaults.standard
+        let enabledKey = TerminalTitleUpdateCoalescingSettings.enabledKey
+        let millisecondsKey = TerminalTitleUpdateCoalescingSettings.millisecondsKey
+
+        try preservingDefaults(keys: [
+            enabledKey,
+            millisecondsKey,
+            settingsFileBackupsDefaultsKey,
+            importedManagedDefaultsKey,
+        ]) {
+            defaults.removeObject(forKey: enabledKey)
+            defaults.removeObject(forKey: millisecondsKey)
+            defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            defaults.removeObject(forKey: importedManagedDefaultsKey)
+
+            let directoryURL = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+            let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+            try writeSettingsFile(
+                """
+                {
+                  "terminal": {
+                    "titleUpdates": {
+                      "coalescing": {
+                        "enabled": true,
+                        "milliseconds": 1000
+                      }
+                    }
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+
+            _ = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+
+            XCTAssertEqual(defaults.object(forKey: enabledKey) as? Bool, true)
+            XCTAssertEqual(defaults.object(forKey: millisecondsKey) as? Int, 1_000)
+        }
+    }
+
     func testSettingsFileStoreAppliesTerminalCopyOnSelectSetting() throws {
         let defaults = UserDefaults.standard
         let key = TerminalCopyOnSelectSettings.copyOnSelectKey

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -848,6 +848,149 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
 }
 
 @MainActor
+final class TabManagerTitleUpdateCoalescingTests: XCTestCase {
+    func testTitleCoalescingDelayIsDefaultOffAndClampedWhenEnabled() throws {
+        let suiteName = "TabManagerTitleCoalescingClamp.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let catalog = SettingCatalog()
+
+        settings.set(1_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+        XCTAssertEqual(
+            TerminalTitleUpdateCoalescingSettings.delay(settings: settings),
+            TerminalTitleUpdateCoalescingSettings.passthroughDelay,
+            accuracy: 0.000_1
+        )
+
+        settings.set(true, for: catalog.terminal.titleUpdateCoalescingEnabled)
+        settings.set(1, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+        XCTAssertEqual(TerminalTitleUpdateCoalescingSettings.delay(settings: settings), 0.033, accuracy: 0.000_1)
+
+        settings.set(10_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+        XCTAssertEqual(TerminalTitleUpdateCoalescingSettings.delay(settings: settings), 5.0, accuracy: 0.000_1)
+    }
+
+    func testTitleCoalescingDelayUsesCurrentSettingsAtNotificationTime() throws {
+        let suiteName = "TabManagerTitleCoalescingSettings.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let catalog = SettingCatalog()
+        let scheduler = ManualCoalescerScheduler()
+        let manager = TabManager(
+            panelTitleUpdateCoalescer: NotificationBurstCoalescer(
+                schedule: scheduler.schedule(delay:action:)
+            ),
+            settings: settings
+        )
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        settings.set(true, for: catalog.terminal.titleUpdateCoalescingEnabled)
+        settings.set(1_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: "Runtime Delay - grok"
+            ]
+        )
+
+        drainMainQueue()
+        XCTAssertEqual(scheduler.delays, [1.0])
+        XCTAssertNotEqual(workspace.panelTitles[focusedPanelId], "Runtime Delay - grok")
+        XCTAssertNotEqual(workspace.title, "Runtime Delay - grok")
+
+        scheduler.fire(at: 0)
+        XCTAssertEqual(workspace.panelTitles[focusedPanelId], "Runtime Delay - grok")
+        XCTAssertEqual(workspace.title, "Runtime Delay - grok")
+    }
+
+    func testPendingTitleUpdateFlushesBeforeWorkspaceTransfer() throws {
+        let suiteName = "TabManagerTitleTransfer.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let catalog = SettingCatalog()
+        settings.set(true, for: catalog.terminal.titleUpdateCoalescingEnabled)
+        settings.set(1_000, for: catalog.terminal.titleUpdateCoalescingMilliseconds)
+
+        let scheduler = ManualCoalescerScheduler()
+        let source = TabManager(
+            panelTitleUpdateCoalescer: NotificationBurstCoalescer(
+                schedule: scheduler.schedule(delay:action:)
+            ),
+            settings: settings
+        )
+        let destination = TabManager(settings: settings)
+        let workspace = try XCTUnwrap(source.selectedWorkspace)
+        let focusedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let transferredTitle = "Moved Workspace - grok"
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidSetTitle,
+            object: nil,
+            userInfo: [
+                GhosttyNotificationKey.tabId: workspace.id,
+                GhosttyNotificationKey.surfaceId: focusedPanelId,
+                GhosttyNotificationKey.title: transferredTitle
+            ]
+        )
+
+        drainMainQueue()
+        XCTAssertEqual(scheduler.delays, [1.0])
+        XCTAssertNotEqual(workspace.panelTitles[focusedPanelId], transferredTitle)
+        XCTAssertNotEqual(workspace.title, transferredTitle)
+
+        let detached = try XCTUnwrap(source.detachWorkspace(tabId: workspace.id))
+        XCTAssertTrue(detached === workspace)
+        XCTAssertEqual(workspace.panelTitles[focusedPanelId], transferredTitle)
+        XCTAssertEqual(workspace.title, transferredTitle)
+
+        destination.attachWorkspace(detached, select: true)
+        XCTAssertTrue(workspace.owningTabManager === destination)
+
+        scheduler.fire(at: 0)
+        XCTAssertEqual(workspace.panelTitles[focusedPanelId], transferredTitle)
+        XCTAssertEqual(workspace.title, transferredTitle)
+    }
+
+    private final class ManualCoalescerScheduler {
+        private struct PendingFlush {
+            var isCancelled = false
+            let action: () -> Void
+        }
+
+        private var pendingFlushes: [PendingFlush] = []
+        private(set) var delays: [TimeInterval] = []
+
+        func schedule(delay: TimeInterval, action: @escaping () -> Void) -> NotificationBurstCoalescer.Cancellation {
+            let index = pendingFlushes.count
+            delays.append(delay)
+            pendingFlushes.append(PendingFlush(action: action))
+            return { [weak self] in
+                self?.pendingFlushes[index].isCancelled = true
+            }
+        }
+
+        func fire(at index: Int) {
+            guard pendingFlushes.indices.contains(index), !pendingFlushes[index].isCancelled else { return }
+            pendingFlushes[index].action()
+        }
+    }
+}
+
+@MainActor
 final class TabManagerPullRequestProbeTests: XCTestCase {
 
     // Pure pull-request selection/policy tests moved to the CmuxGit package


### PR DESCRIPTION
## Summary

This adds an opt-in terminal title update coalescing setting for terminals that emit continuously changing OSC title updates:

```json
{
  "terminal": {
    "titleUpdates": {
      "coalescing": {
        "enabled": true,
        "milliseconds": 1000
      }
    }
  }
}
```

Default behavior is unchanged. When the setting is disabled, title updates continue to use the existing ~30 Hz coalescing path. When enabled, the configured interval is clamped to 33...5000ms and the latest pending title is flushed before workspace detach/transfer.

## Why

Issue #6599 tracks the remaining high-ROI title-churn path after #6551/#6570 removed cross-manager fanout. In the controlled title-spam repro, a single active terminal can still drive workspace/panel title refreshes, sidebar invalidation, and mobile workspace observation at the terminal's title-change cadence.

Local RCA on current main-derived builds:

```text
default title path:
  duration: 56.32s
  avg CPU: 36.99%
  workspace.title.updatePanel: 261

full TabManager title suppression experiment:
  avg CPU: 2.9%

1000ms title-update coalescing experiment:
  duration: 48.71s
  avg CPU: 3.18%
  workspace.title.updatePanel: 18
```

Runtime validation of this PR's implementation with the same high-frequency title workload:

```text
enabled setting:
  terminal.titleUpdates.coalescing.enabled = true
  terminal.titleUpdates.coalescing.milliseconds = 1000

observed app PID CPU:
  duration: 15s
  avg CPU: 4.77%
  max CPU: 19.9%

observed workspace.title.updatePanel cadence:
  before workload: 4
  after workload: 33
  visible cadence: roughly 1 update/second while the title-spam process was running

capture:
  /tmp/cmux-title-coalescing-config-20260622T130513Z/summary.json
```

## Changes

- Adds catalog/defaults keys for `terminal.titleUpdates.coalescing.enabled` and `terminal.titleUpdates.coalescing.milliseconds`.
- Reads the title coalescing delay dynamically from settings at notification time.
- Keeps the default path at the existing 1/30s delay.
- Allows the notification coalescer to reschedule when the configured delay changes.
- Flushes pending title updates before workspace detach/transfer.
- Adds cmux.json parsing, template support, and JSON path validation.
- Adds unit coverage for default-off/clamping, runtime delay selection, pending-title transfer behavior, and settings-file import.

## Validation

```text
git diff --check

DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
swift test --package-path Packages/macOS/CmuxSettings

DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig \
xcodebuild test -project cmux.xcodeproj \
  -scheme cmux-unit \
  -configuration Debug \
  -destination 'platform=macOS' \
  -only-testing:cmuxTests/TabManagerTitleUpdateCoalescingTests \
  -only-testing:cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests/testSettingsFileStoreAppliesTerminalTitleUpdateCoalescingSettings

DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
CMUX_ZIG=/opt/homebrew/opt/zig@0.15/bin/zig \
CMUX_XCODEBUILD_LOCK_CONCURRENCY=1 \
./scripts/reload.sh --tag title-coalescing-config --swift-frontend-workaround
```

All of the above passed locally.

## Risk

- Default behavior is unchanged because the new setting defaults to disabled.
- When enabled, workspace/panel title display can lag by up to the configured delay.
- The latest pending title is preserved; intermediate titles inside the coalescing window are intentionally dropped.
- This does not replace #6546. Sidebar snapshot splitting can still reduce the cost of each refresh; this PR reduces the source rate when title churn is the driver.

Fixes #6599.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784725683&installation_id=133855650&pr_number=6600&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6600&signature=cbde6720224e5682996fbda905e64001e65a95ee5c389b87224407ef7e7d1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in terminal title update coalescing feature to batch high-frequency OSC title changes and reduce UI churn/CPU. Default behavior is unchanged; when enabled, updates are coalesced at a user-configurable, clamped interval.

- **New Features**
  - Settings: `terminal.titleUpdates.coalescing.enabled` and `terminal.titleUpdates.coalescing.milliseconds` (33–5000 ms; default off; passthrough ~33 ms when off).
  - Coalescer reads the current delay at notification time and cancels/reschedules when the setting changes.
  - Flushes the latest pending title before workspace detach/transfer to preserve visible titles.
  - Settings file support: template entries, JSON path validation, and value clamping; tests cover defaults, clamping, runtime delay selection, pre-transfer flush, and settings-file import.

<sup>Written for commit 4a2b603f56ad44b42e4216032c4ce54e0af98305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

