### PR TITLE
Sync remote tmux session rename to the mirror workspace title

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -16,7 +16,7 @@
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift
-6178	Sources/TabManager.swift
+6183	Sources/TabManager.swift
 6084	Sources/TextBoxInput.swift
 5915	cmuxTests/TerminalAndGhosttyTests.swift
 5573	cmuxTests/BrowserConfigTests.swift
@@ -84,7 +84,7 @@
 1110	Sources/AppDelegate+CmuxSSHURL.swift
 1093	cmuxUITests/BonsplitTabDragUITests.swift
 1087	Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
-1042	Sources/RemoteTmuxController.swift
+1043	Sources/RemoteTmuxController.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1009	cmuxTests/CmuxTopSnapshotScopeTests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -224,4 +224,5 @@
 503	Sources/Settings/ConfigSource.swift
 502	Sources/CmuxEventPublishing.swift
 502	Sources/KeyboardShortcutContext.swift
+502	Sources/RemoteTmuxSessionMirror.swift
 500	Sources/KeyboardShortcutRecorder.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -153,10 +153,10 @@
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
+637	cmuxTests/RemoteTmuxControlParserTests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 629	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
-627	cmuxTests/RemoteTmuxControlParserTests.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -63,7 +63,7 @@
 1500	cmuxUITests/MultiWindowNotificationsUITests.swift
 1499	cmuxTests/OmnibarAndToolsTests.swift
 1447	Sources/FileExplorerStore.swift
-1412	Sources/RemoteTmuxControlConnection.swift
+1436	Sources/RemoteTmuxControlConnection.swift
 1384	cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
 1380	cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
 1373	cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -84,7 +84,7 @@
 1110	Sources/AppDelegate+CmuxSSHURL.swift
 1093	cmuxUITests/BonsplitTabDragUITests.swift
 1087	Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
-1037	Sources/RemoteTmuxController.swift
+1042	Sources/RemoteTmuxController.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1009	cmuxTests/CmuxTopSnapshotScopeTests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift
@@ -156,10 +156,10 @@
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 629	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
+627	cmuxTests/RemoteTmuxControlParserTests.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
 620	cmuxTests/FinderFileDropRegressionTests.swift
 620	cmuxTests/TerminalNotificationQueueTests.swift
-615	cmuxTests/RemoteTmuxControlParserTests.swift
 612	cmuxUITests/FeedSidebarUITests.swift
 608	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
 606	Sources/SettingsNavigation.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -63,7 +63,7 @@
 1500	cmuxUITests/MultiWindowNotificationsUITests.swift
 1499	cmuxTests/OmnibarAndToolsTests.swift
 1447	Sources/FileExplorerStore.swift
-1436	Sources/RemoteTmuxControlConnection.swift
+1446	Sources/RemoteTmuxControlConnection.swift
 1384	cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
 1380	cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
 1373	cmuxTests/AppDelegateIssue2907RoutingTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -82,9 +82,9 @@
 1144	cmuxTests/PiVaultAgentPersistenceTests.swift
 1121	cmuxTests/AgentHibernationTests.swift
 1110	Sources/AppDelegate+CmuxSSHURL.swift
+1099	Sources/RemoteTmuxController.swift
 1093	cmuxUITests/BonsplitTabDragUITests.swift
 1087	Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
-1043	Sources/RemoteTmuxController.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift
 1009	cmuxTests/CmuxTopSnapshotScopeTests.swift
 1006	cmuxTests/CmuxSSHURLRequestTests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -82,7 +82,7 @@
 1144	cmuxTests/PiVaultAgentPersistenceTests.swift
 1121	cmuxTests/AgentHibernationTests.swift
 1110	Sources/AppDelegate+CmuxSSHURL.swift
-1099	Sources/RemoteTmuxController.swift
+1093	Sources/RemoteTmuxController.swift
 1093	cmuxUITests/BonsplitTabDragUITests.swift
 1087	Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteFuzzyMatcher.swift
 1021	cmuxUITests/TerminalCmdClickUITests.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -62,8 +62,8 @@
 1547	cmuxTests/TerminalControllerSocketSecurityTests.swift
 1500	cmuxUITests/MultiWindowNotificationsUITests.swift
 1499	cmuxTests/OmnibarAndToolsTests.swift
+1452	Sources/RemoteTmuxControlConnection.swift
 1447	Sources/FileExplorerStore.swift
-1446	Sources/RemoteTmuxControlConnection.swift
 1384	cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
 1380	cmuxUITests/MenuKeyEquivalentRoutingUITests.swift
 1373	cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -152,8 +152,8 @@
 655	Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
 653	Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Import/Detection/BrowserInstalledBrowserDetector.swift
 650	Sources/Panels/MarkdownRemoteImageLoader.swift
+642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
-637	cmuxTests/RemoteTmuxControlParserTests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 629	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift

--- a/Sources/RemoteTmuxConnectionObservers.swift
+++ b/Sources/RemoteTmuxConnectionObservers.swift
@@ -41,9 +41,9 @@ final class RemoteTmuxConnectionObservers {
     ///   - onActivePaneChanged: fires when a window's active pane changes
     ///     (`%window-pane-changed`), so consumers can re-project per-pane state
     ///     (e.g. the active pane's directory) onto the window's tab.
-    ///   - onSessionChanged: fires when tmux confirms a session rename via
-    ///     `%session-changed`; consumers must treat this as the authoritative
-    ///     point for re-keying session-owned state.
+    ///   - onSessionChanged: fires when tmux confirms a session name change via
+    ///     `%session-changed` or `%session-renamed`; consumers must treat this as
+    ///     the authoritative point for re-keying session-owned state.
     ///   - onTopologyChanged: fires when the window/pane topology changes.
     ///   - onExit: fires once when the connection PERMANENTLY ends (a genuine tmux
     ///     `%exit`, or a session found gone on reconnect). A transient transport loss

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1152,6 +1152,7 @@ final class RemoteTmuxControlConnection {
             // the name-change observers that re-key controller state and re-title
             // the mirror workspace), but a rename does NOT change the window set,
             // so skip the topology re-fetch.
+            guard shouldApplySessionRenamed(sessionId: id) else { return }
             applySessionNameChange(sessionId: id, name: name, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
@@ -1222,8 +1223,8 @@ final class RemoteTmuxControlConnection {
     }
 
     /// Shared handling for `%session-changed` and `%session-renamed`: validate the
-    /// name, update the tracked `sessionName` (and `sessionId` when the protocol
-    /// supplies one), then emit the name-change observers (which re-key controller
+    /// name, update the tracked `sessionName` (and `sessionId` for session
+    /// switches), then emit the name-change observers (which re-key controller
     /// state and re-title the mirror workspace). `sessionName` is reused for
     /// attach/reconnect, so a stale value would make the next reconnect target the
     /// wrong session and wrongly declare it gone.
@@ -1247,6 +1248,15 @@ final class RemoteTmuxControlConnection {
         record("\(event)\(idSuffix)")
         observers.emitSessionChanged(oldName: oldName, newName: safeName)
         if refetchWindows { requestWindows() }
+    }
+
+    private func shouldApplySessionRenamed(sessionId renamedSessionId: Int?) -> Bool {
+        guard let renamedSessionId else { return true }
+        guard let currentSessionId = sessionId, currentSessionId == renamedSessionId else {
+            record("session-renamed-ignored $\(renamedSessionId)")
+            return false
+        }
+        return true
     }
 
     private func handleCommandResult(lines: [String], isError: Bool) {

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -217,8 +217,8 @@ final class RemoteTmuxControlConnection {
     ///   - onActivePaneChanged: fires when a window's active pane changes
     ///     (`%window-pane-changed`), so consumers can re-project per-pane state
     ///     (e.g. the active pane's directory) onto the window's tab.
-    ///   - onSessionChanged: fires when tmux confirms a session rename via
-    ///     `%session-changed`.
+    ///   - onSessionChanged: fires when tmux confirms a session name change via
+    ///     `%session-changed` or `%session-renamed`.
     ///   - onTopologyChanged: fires when the window/pane topology changes.
     ///   - onExit: fires once when the connection PERMANENTLY ends (a genuine tmux
     ///     `%exit`, or a session found gone on reconnect). A transient transport loss

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1145,14 +1145,14 @@ final class RemoteTmuxControlConnection {
         case let .sessionChanged(id, name):
             // An attached-session SWITCH: the window set changes with it, so
             // re-fetch the topology.
-            applySessionNameChange(id: id, name: name, event: "session-changed", refetchWindows: true)
-        case let .sessionRenamed(id, name):
+            applySessionNameChange(sessionId: id, name: name, event: "session-changed", refetchWindows: true)
+        case let .sessionRenamed(name):
             // tmux's `rename-session` notification. Same name handling as
             // `%session-changed` (track the new name for attach/reconnect and emit
             // the name-change observers that re-key controller state and re-title
-            // the mirror workspace), but a rename does NOT change the window set,
-            // so skip the topology re-fetch.
-            applySessionNameChange(id: id, name: name, event: "session-renamed", refetchWindows: false)
+            // the mirror workspace), but a rename carries no session id and does
+            // NOT change the window set, so skip the topology re-fetch.
+            applySessionNameChange(sessionId: nil, name: name, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
         case let .windowAdd(id):
@@ -1222,26 +1222,29 @@ final class RemoteTmuxControlConnection {
     }
 
     /// Shared handling for `%session-changed` and `%session-renamed`: validate the
-    /// name, update the tracked `sessionId`/`sessionName` (reused for
+    /// name, update the tracked `sessionName` (and `sessionId` when the protocol
+    /// supplies one), then emit the name-change observers (which re-key controller
+    /// state and re-title the mirror workspace). `sessionName` is reused for
     /// attach/reconnect, so a stale value would make the next reconnect target the
-    /// wrong session and wrongly declare it gone), then emit the name-change
-    /// observers (which re-key controller state and re-title the mirror workspace).
+    /// wrong session and wrongly declare it gone.
     ///
     /// - Parameter refetchWindows: re-fetch the window topology afterwards. A
     ///   session SWITCH (`%session-changed`) brings a different window set, so it
     ///   must; a rename (`%session-renamed`) keeps the same windows, so it skips
     ///   the extra round trip. An invalid name always re-fetches as a recovery
     ///   resync regardless.
-    private func applySessionNameChange(id: Int, name: String, event: String, refetchWindows: Bool) {
+    private func applySessionNameChange(sessionId newSessionId: Int?, name: String, event: String, refetchWindows: Bool) {
         guard let safeName = RemoteTmuxHost.controlModeLineSafeName(name) else {
-            record("\(event)-invalid $\(id)")
+            let idSuffix = newSessionId.map { " $\($0)" } ?? ""
+            record("\(event)-invalid\(idSuffix)")
             requestWindows()
             return
         }
         let oldName = sessionName
-        sessionId = id
+        if let newSessionId { sessionId = newSessionId }
         sessionName = safeName
-        record("\(event) $\(id)")
+        let idSuffix = newSessionId.map { " $\($0)" } ?? ""
+        record("\(event)\(idSuffix)")
         observers.emitSessionChanged(oldName: oldName, newName: safeName)
         if refetchWindows { requestWindows() }
     }

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1143,20 +1143,16 @@ final class RemoteTmuxControlConnection {
             totalOutputBytes += data.count
             observers.emitPaneOutput(paneId, data)
         case let .sessionChanged(id, name):
-            guard let safeName = RemoteTmuxHost.controlModeLineSafeName(name) else {
-                record("session-changed-invalid $\(id)")
-                requestWindows()
-                return
-            }
-            let oldName = sessionName
-            sessionId = id
-            // Track the new name too: `sessionName` is the value reused for
-            // attach/reconnect, so a remote rename must update it or the next
-            // reconnect targets a stale session and is wrongly declared gone.
-            sessionName = safeName
-            record("session-changed $\(id)")
-            observers.emitSessionChanged(oldName: oldName, newName: safeName)
-            requestWindows()
+            // An attached-session SWITCH: the window set changes with it, so
+            // re-fetch the topology.
+            applySessionNameChange(id: id, name: name, event: "session-changed", refetchWindows: true)
+        case let .sessionRenamed(id, name):
+            // tmux's `rename-session` notification. Same name handling as
+            // `%session-changed` (track the new name for attach/reconnect and emit
+            // the name-change observers that re-key controller state and re-title
+            // the mirror workspace), but a rename does NOT change the window set,
+            // so skip the topology re-fetch.
+            applySessionNameChange(id: id, name: name, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
         case let .windowAdd(id):
@@ -1223,6 +1219,31 @@ final class RemoteTmuxControlConnection {
         case .ignoredNotification, .unparsed:
             break
         }
+    }
+
+    /// Shared handling for `%session-changed` and `%session-renamed`: validate the
+    /// name, update the tracked `sessionId`/`sessionName` (reused for
+    /// attach/reconnect, so a stale value would make the next reconnect target the
+    /// wrong session and wrongly declare it gone), then emit the name-change
+    /// observers (which re-key controller state and re-title the mirror workspace).
+    ///
+    /// - Parameter refetchWindows: re-fetch the window topology afterwards. A
+    ///   session SWITCH (`%session-changed`) brings a different window set, so it
+    ///   must; a rename (`%session-renamed`) keeps the same windows, so it skips
+    ///   the extra round trip. An invalid name always re-fetches as a recovery
+    ///   resync regardless.
+    private func applySessionNameChange(id: Int, name: String, event: String, refetchWindows: Bool) {
+        guard let safeName = RemoteTmuxHost.controlModeLineSafeName(name) else {
+            record("\(event)-invalid $\(id)")
+            requestWindows()
+            return
+        }
+        let oldName = sessionName
+        sessionId = id
+        sessionName = safeName
+        record("\(event) $\(id)")
+        observers.emitSessionChanged(oldName: oldName, newName: safeName)
+        if refetchWindows { requestWindows() }
     }
 
     private func handleCommandResult(lines: [String], isError: Bool) {

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1146,13 +1146,13 @@ final class RemoteTmuxControlConnection {
             // An attached-session SWITCH: the window set changes with it, so
             // re-fetch the topology.
             applySessionNameChange(sessionId: id, name: name, event: "session-changed", refetchWindows: true)
-        case let .sessionRenamed(name):
+        case let .sessionRenamed(id, name):
             // tmux's `rename-session` notification. Same name handling as
             // `%session-changed` (track the new name for attach/reconnect and emit
             // the name-change observers that re-key controller state and re-title
-            // the mirror workspace), but a rename carries no session id and does
-            // NOT change the window set, so skip the topology re-fetch.
-            applySessionNameChange(sessionId: nil, name: name, event: "session-renamed", refetchWindows: false)
+            // the mirror workspace), but a rename does NOT change the window set,
+            // so skip the topology re-fetch.
+            applySessionNameChange(sessionId: id, name: name, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
         case let .windowAdd(id):

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -1146,14 +1146,18 @@ final class RemoteTmuxControlConnection {
             // An attached-session SWITCH: the window set changes with it, so
             // re-fetch the topology.
             applySessionNameChange(sessionId: id, name: name, event: "session-changed", refetchWindows: true)
-        case let .sessionRenamed(id, name):
+        case let .sessionRenamed(id, name, idBearingName):
             // tmux's `rename-session` notification. Same name handling as
             // `%session-changed` (track the new name for attach/reconnect and emit
             // the name-change observers that re-key controller state and re-title
             // the mirror workspace), but a rename does NOT change the window set,
             // so skip the topology re-fetch.
-            guard shouldApplySessionRenamed(sessionId: id) else { return }
-            applySessionNameChange(sessionId: id, name: name, event: "session-renamed", refetchWindows: false)
+            guard let renameName = sessionRenamedName(
+                sessionId: id,
+                documentedName: name,
+                idBearingName: idBearingName
+            ) else { return }
+            applySessionNameChange(sessionId: id, name: renameName, event: "session-renamed", refetchWindows: false)
         case .sessionsChanged:
             record("sessions-changed")
         case let .windowAdd(id):
@@ -1250,13 +1254,15 @@ final class RemoteTmuxControlConnection {
         if refetchWindows { requestWindows() }
     }
 
-    private func shouldApplySessionRenamed(sessionId renamedSessionId: Int?) -> Bool {
-        guard let renamedSessionId else { return true }
+    private func sessionRenamedName(sessionId renamedSessionId: Int?, documentedName: String, idBearingName: String?) -> String? {
+        guard let renamedSessionId else { return documentedName }
+        // Real tmux id-bearing renames are broadcast for every session; only this
+        // connection's id may use the id-bearing interpretation.
         guard let currentSessionId = sessionId, currentSessionId == renamedSessionId else {
             record("session-renamed-ignored $\(renamedSessionId)")
-            return false
+            return nil
         }
-        return true
+        return idBearingName ?? documentedName
     }
 
     private func handleCommandResult(lines: [String], isError: Bool) {

--- a/Sources/RemoteTmuxControlMessage.swift
+++ b/Sources/RemoteTmuxControlMessage.swift
@@ -21,9 +21,10 @@ enum RemoteTmuxControlMessage: Sendable, Equatable {
 
     /// `%session-renamed [session-id] <name>` — the current session was renamed.
     /// tmux emits this for `rename-session` — distinct from `%session-changed`
-    /// (which fires when the attached session switches). Some tmux builds include
-    /// the session id even though the man page documents only the name.
-    case sessionRenamed(sessionId: Int?, name: String)
+    /// (which fires when the attached session switches). `name` preserves the
+    /// documented name-only interpretation; `idBearingName` is the alternative
+    /// interpretation when the first field looks like a tmux session id.
+    case sessionRenamed(sessionId: Int?, name: String, idBearingName: String?)
 
     /// `%sessions-changed` — the set of sessions changed (re-list to refresh).
     case sessionsChanged

--- a/Sources/RemoteTmuxControlMessage.swift
+++ b/Sources/RemoteTmuxControlMessage.swift
@@ -19,12 +19,11 @@ enum RemoteTmuxControlMessage: Sendable, Equatable {
     /// `%session-changed $<id> <name>` — the attached session changed.
     case sessionChanged(sessionId: Int, name: String)
 
-    /// `%session-renamed <name>` — the current session was renamed.
+    /// `%session-renamed [session-id] <name>` — the current session was renamed.
     /// tmux emits this for `rename-session` — distinct from `%session-changed`
-    /// (which fires when the attached session switches). Carries only the new
-    /// name, so the mirror tracks it and re-titles its workspace just like a
-    /// window rename.
-    case sessionRenamed(name: String)
+    /// (which fires when the attached session switches). Some tmux builds include
+    /// the session id even though the man page documents only the name.
+    case sessionRenamed(sessionId: Int?, name: String)
 
     /// `%sessions-changed` — the set of sessions changed (re-list to refresh).
     case sessionsChanged

--- a/Sources/RemoteTmuxControlMessage.swift
+++ b/Sources/RemoteTmuxControlMessage.swift
@@ -19,11 +19,12 @@ enum RemoteTmuxControlMessage: Sendable, Equatable {
     /// `%session-changed $<id> <name>` — the attached session changed.
     case sessionChanged(sessionId: Int, name: String)
 
-    /// `%session-renamed $<id> <name>` — the (attached) session was renamed.
+    /// `%session-renamed <name>` — the current session was renamed.
     /// tmux emits this for `rename-session` — distinct from `%session-changed`
-    /// (which fires when the attached session switches). Carries the new name, so
-    /// the mirror tracks it and re-titles its workspace just like a window rename.
-    case sessionRenamed(sessionId: Int, name: String)
+    /// (which fires when the attached session switches). Carries only the new
+    /// name, so the mirror tracks it and re-titles its workspace just like a
+    /// window rename.
+    case sessionRenamed(name: String)
 
     /// `%sessions-changed` — the set of sessions changed (re-list to refresh).
     case sessionsChanged

--- a/Sources/RemoteTmuxControlMessage.swift
+++ b/Sources/RemoteTmuxControlMessage.swift
@@ -19,6 +19,12 @@ enum RemoteTmuxControlMessage: Sendable, Equatable {
     /// `%session-changed $<id> <name>` — the attached session changed.
     case sessionChanged(sessionId: Int, name: String)
 
+    /// `%session-renamed $<id> <name>` — the (attached) session was renamed.
+    /// tmux emits this for `rename-session` — distinct from `%session-changed`
+    /// (which fires when the attached session switches). Carries the new name, so
+    /// the mirror tracks it and re-titles its workspace just like a window rename.
+    case sessionRenamed(sessionId: Int, name: String)
+
     /// `%sessions-changed` — the set of sessions changed (re-list to refresh).
     case sessionsChanged
 

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -189,6 +189,13 @@ struct RemoteTmuxControlStreamParser {
             // Session names may contain spaces; join the remaining fields.
             return .sessionChanged(sessionId: id, name: Self.fieldsFrom(line, 2))
         }
+        if line.hasPrefix("%session-renamed ") {
+            // tmux emits this for `rename-session` (NOT `%session-changed`, which
+            // fires on an attached-session switch). Session names may contain
+            // spaces; join the remaining fields.
+            guard let id = Self.fieldId(line, 1, sigil: "$") else { return .unparsed(line) }
+            return .sessionRenamed(sessionId: id, name: Self.fieldsFrom(line, 2))
+        }
         if line == "%sessions-changed" { return .sessionsChanged }
         if line.hasPrefix("%window-add ") {
             guard let id = Self.fieldId(line, 1, sigil: "@") else { return .unparsed(line) }

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -191,9 +191,13 @@ struct RemoteTmuxControlStreamParser {
         }
         if line.hasPrefix("%session-renamed ") {
             // tmux emits this for `rename-session` (NOT `%session-changed`, which
-            // fires on an attached-session switch). The control-mode notification
-            // carries only the new name, and names may contain spaces.
-            return .sessionRenamed(name: Self.fieldsFrom(line, 1))
+            // fires on an attached-session switch). The man page documents only a
+            // name, while tmux 3.6a emits "$<id> <name>"; accept both forms.
+            if let id = Self.fieldId(line, 1, sigil: "$") {
+                let name = Self.fieldsFrom(line, 2)
+                if !name.isEmpty { return .sessionRenamed(sessionId: id, name: name) }
+            }
+            return .sessionRenamed(sessionId: nil, name: Self.fieldsFrom(line, 1))
         }
         if line == "%sessions-changed" { return .sessionsChanged }
         if line.hasPrefix("%window-add ") {

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -191,10 +191,9 @@ struct RemoteTmuxControlStreamParser {
         }
         if line.hasPrefix("%session-renamed ") {
             // tmux emits this for `rename-session` (NOT `%session-changed`, which
-            // fires on an attached-session switch). Session names may contain
-            // spaces; join the remaining fields.
-            guard let id = Self.fieldId(line, 1, sigil: "$") else { return .unparsed(line) }
-            return .sessionRenamed(sessionId: id, name: Self.fieldsFrom(line, 2))
+            // fires on an attached-session switch). The control-mode notification
+            // carries only the new name, and names may contain spaces.
+            return .sessionRenamed(name: Self.fieldsFrom(line, 1))
         }
         if line == "%sessions-changed" { return .sessionsChanged }
         if line.hasPrefix("%window-add ") {

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -195,9 +195,15 @@ struct RemoteTmuxControlStreamParser {
             // name, while tmux 3.6a emits "$<id> <name>"; accept both forms.
             if let id = Self.fieldId(line, 1, sigil: "$") {
                 let name = Self.fieldsFrom(line, 2)
-                if !name.isEmpty { return .sessionRenamed(sessionId: id, name: name) }
+                if !name.isEmpty {
+                    return .sessionRenamed(
+                        sessionId: id,
+                        name: Self.fieldsFrom(line, 1),
+                        idBearingName: name
+                    )
+                }
             }
-            return .sessionRenamed(sessionId: nil, name: Self.fieldsFrom(line, 1))
+            return .sessionRenamed(sessionId: nil, name: Self.fieldsFrom(line, 1), idBearingName: nil)
         }
         if line == "%sessions-changed" { return .sessionsChanged }
         if line.hasPrefix("%window-add ") {

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -125,7 +125,8 @@ final class RemoteTmuxController {
         removeCachedConnection(forKey: key)?.stop()
     }
 
-    private func cacheConnection(_ connection: RemoteTmuxControlConnection, key: String) {
+    func cacheConnection(_ connection: RemoteTmuxControlConnection, key: String? = nil) {
+        let key = key ?? Self.connectionKey(host: connection.host, sessionName: connection.sessionName)
         connectionsByHostSession[key] = connection
         connectionObserverTokensByHostSession[key] = connection.addObserver(
             onSessionChanged: { [weak self, weak connection] oldName, newName in
@@ -255,13 +256,6 @@ final class RemoteTmuxController {
 
     func unbindDedicatedWindowForTesting(windowId: UUID) {
         windowRegistry.unbind(windowId: windowId)
-    }
-
-    func cacheConnectionForTesting(_ connection: RemoteTmuxControlConnection) {
-        cacheConnection(
-            connection,
-            key: Self.connectionKey(host: connection.host, sessionName: connection.sessionName)
-        )
     }
 #endif
 

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -378,6 +378,7 @@ final class RemoteTmuxController {
             host: host,
             sessionName: sessionName,
             connection: connection,
+            tabManager: tabManager,
             workspace: workspace
         )
         return true

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -441,6 +441,11 @@ final class RemoteTmuxController {
 
         mirror.setSessionName(safeName)
         mirror.connection.setSessionName(safeName)
+        // Reverse of the cmux→tmux rename push: a remote `rename-session` (or an
+        // automatic session rename) re-titles the mirror's sidebar workspace.
+        // This updates the workspace title directly (no `rename-session`
+        // feedback); see `applySessionNameToWorkspaceTitle`.
+        mirror.applySessionNameToWorkspaceTitle(safeName)
 
         if oldKey != newKey {
             if let entry = sessionMirrors.removeValue(forKey: oldKey) {

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -25,6 +25,7 @@ final class RemoteTmuxController {
     /// (see ``connectionKey(host:sessionName:)``), so repeated attach requests for
     /// the same endpoint+session reuse the existing connection.
     private var connectionsByHostSession: [String: RemoteTmuxControlConnection] = [:]
+    private var connectionObserverTokensByHostSession: [String: RemoteTmuxControlConnection.ObserverToken] = [:]
 
     init() {}
 
@@ -69,8 +70,7 @@ final class RemoteTmuxController {
             // Replace a dead connection — fully tear down the old one first so
             // its ssh process, stdin fd, stream continuation and ingest task
             // don't leak.
-            existing.stop()
-            connectionsByHostSession.removeValue(forKey: key)
+            removeCachedConnection(forKey: key)?.stop()
         }
         let connection = RemoteTmuxControlConnection(
             host: host,
@@ -81,7 +81,7 @@ final class RemoteTmuxController {
         // leaves a dead (never-started, `exited == false`) connection that a
         // later attach would wrongly reuse.
         try connection.start()
-        connectionsByHostSession[key] = connection
+        cacheConnection(connection, key: key)
         return connection
     }
 
@@ -122,8 +122,61 @@ final class RemoteTmuxController {
     ) {
         let key = Self.connectionKey(host: host, sessionName: sessionName)
         guard connectionsByHostSession[key] === connection else { return }
-        connectionsByHostSession.removeValue(forKey: key)
-        connection.stop()
+        removeCachedConnection(forKey: key)?.stop()
+    }
+
+    private func cacheConnection(_ connection: RemoteTmuxControlConnection, key: String) {
+        connectionsByHostSession[key] = connection
+        connectionObserverTokensByHostSession[key] = connection.addObserver(
+            onSessionChanged: { [weak self, weak connection] oldName, newName in
+                guard let self, let connection else { return }
+                self.handleCachedConnectionSessionNameChanged(
+                    connection: connection,
+                    oldName: oldName,
+                    newName: newName
+                )
+            }
+        )
+    }
+
+    @discardableResult
+    private func removeCachedConnection(forKey key: String) -> RemoteTmuxControlConnection? {
+        guard let connection = connectionsByHostSession.removeValue(forKey: key) else { return nil }
+        if let token = connectionObserverTokensByHostSession.removeValue(forKey: key) {
+            connection.removeObserver(token)
+        }
+        return connection
+    }
+
+    private func handleCachedConnectionSessionNameChanged(
+        connection: RemoteTmuxControlConnection,
+        oldName: String,
+        newName: String
+    ) {
+        let oldKey = Self.connectionKey(host: connection.host, sessionName: oldName)
+        let newKey = Self.connectionKey(host: connection.host, sessionName: newName)
+        guard oldKey != newKey else { return }
+        if let existing = connectionsByHostSession[newKey], existing !== connection { return }
+        if connectionsByHostSession[oldKey] === connection {
+            connectionsByHostSession.removeValue(forKey: oldKey)
+            connectionsByHostSession[newKey] = connection
+            if let token = connectionObserverTokensByHostSession.removeValue(forKey: oldKey) {
+                connectionObserverTokensByHostSession[newKey] = token
+            }
+            return
+        }
+        guard let currentKey = connectionsByHostSession.first(where: { $0.value === connection })?.key,
+              currentKey != newKey else {
+            if let token = connectionObserverTokensByHostSession.removeValue(forKey: oldKey) {
+                connectionObserverTokensByHostSession[newKey] = token
+            }
+            return
+        }
+        connectionsByHostSession.removeValue(forKey: currentKey)
+        connectionsByHostSession[newKey] = connection
+        if let token = connectionObserverTokensByHostSession.removeValue(forKey: currentKey) {
+            connectionObserverTokensByHostSession[newKey] = token
+        }
     }
 
     /// Ensures the requested session is attachable via a non-interactive tmux
@@ -202,6 +255,13 @@ final class RemoteTmuxController {
 
     func unbindDedicatedWindowForTesting(windowId: UUID) {
         windowRegistry.unbind(windowId: windowId)
+    }
+
+    func cacheConnectionForTesting(_ connection: RemoteTmuxControlConnection) {
+        cacheConnection(
+            connection,
+            key: Self.connectionKey(host: connection.host, sessionName: connection.sessionName)
+        )
     }
 #endif
 
@@ -456,12 +516,6 @@ final class RemoteTmuxController {
                 sessionMirrors[newKey] = mirror
             }
 
-            if let connection = connectionsByHostSession.removeValue(forKey: oldKey) {
-                connectionsByHostSession[newKey] = connection
-            } else if let currentKey = connectionsByHostSession.first(where: { $0.value === mirror.connection })?.key {
-                connectionsByHostSession.removeValue(forKey: currentKey)
-                connectionsByHostSession[newKey] = mirror.connection
-            }
         }
     }
 
@@ -764,7 +818,7 @@ final class RemoteTmuxController {
         if let mirror = sessionMirrors.removeValue(forKey: key) {
             mirror.detachObserver()
         }
-        connectionsByHostSession.removeValue(forKey: key)?.stop()
+        removeCachedConnection(forKey: key)?.stop()
         let hostHasOtherMirrors = sessionMirrors.values.contains(where: { $0.host.connectionHash == host.connectionHash })
         // Capture the dedicated window before teardown; if other sessions remain,
         // losing one session only closes its workspace.
@@ -868,7 +922,7 @@ final class RemoteTmuxController {
             affectedHosts[mirror.host.connectionHash] = mirror.host
             mirror.detachObserver()
             sessionMirrors.removeValue(forKey: key)
-            connectionsByHostSession.removeValue(forKey: key)?.stop()
+            removeCachedConnection(forKey: key)?.stop()
         }
         // For any host left with no live mirror or connection, close its shared SSH
         // ControlMaster now — the dedicated-window/last-session paths already do this,
@@ -936,7 +990,7 @@ final class RemoteTmuxController {
         for (key, mirror) in mirrorsInWindow {
             mirror.detachObserver()
             sessionMirrors.removeValue(forKey: key)
-            connectionsByHostSession.removeValue(forKey: key)?.stop()
+            removeCachedConnection(forKey: key)?.stop()
         }
         let stillUsed = sessionMirrors.values.contains { $0.host.connectionHash == host.connectionHash } || connectionsByHostSession.values.contains { $0.host.connectionHash == host.connectionHash }
         if !stillUsed {
@@ -947,7 +1001,10 @@ final class RemoteTmuxController {
 
     func detachMirrorWorkspaceKeptOpenLocally(workspaceId: UUID) {
         guard let entry = sessionMirrors.first(where: { $0.value.mirroredWorkspaceId == workspaceId }) else { return }
-        let host = entry.value.host; sessionMirrors.removeValue(forKey: entry.key); entry.value.detachObserver(); connectionsByHostSession.removeValue(forKey: entry.key)?.stop()
+        let host = entry.value.host
+        sessionMirrors.removeValue(forKey: entry.key)
+        entry.value.detachObserver()
+        removeCachedConnection(forKey: entry.key)?.stop()
         let hostHasOtherMirrors = sessionMirrors.values.contains { $0.host.connectionHash == host.connectionHash }
         if !hostHasOtherMirrors { windowRegistry.unbind(hostHash: host.connectionHash) }
         if !hostHasOtherMirrors, !connectionsByHostSession.values.contains(where: { $0.host.connectionHash == host.connectionHash }) { transportRegistry.remove(connectionHash: host.connectionHash); RemoteTmuxSSHTransport.spawnControlMasterExit(host: host) }
@@ -1008,7 +1065,7 @@ final class RemoteTmuxController {
     /// Detaches and forgets a control connection (leaves the remote session alive).
     func detach(host: RemoteTmuxHost, sessionName: String) {
         let key = Self.connectionKey(host: host, sessionName: sessionName)
-        connectionsByHostSession.removeValue(forKey: key)?.stop()
+        removeCachedConnection(forKey: key)?.stop()
     }
 
     /// Detaches every control connection on app quit and closes the shared SSH
@@ -1016,8 +1073,7 @@ final class RemoteTmuxController {
     /// CLI's `ssh -f` left them persistent). Does NOT kill any remote tmux
     /// server/session — only the local control clients and masters.
     func detachAll() {
-        let connections = Array(connectionsByHostSession.values)
-        connectionsByHostSession.removeAll()
+        let connections = Array(connectionsByHostSession.keys).compactMap { removeCachedConnection(forKey: $0) }
         for connection in connections { connection.stop() }
         // Fire-and-forget `ssh -O exit` per endpoint: it hits the local control
         // socket and runs independently of cmux, so the masters are torn down even as

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -28,11 +28,17 @@ final class RemoteTmuxSessionMirror {
     func applySessionNameToWorkspaceTitle(_ name: String) {
         guard let safe = RemoteTmuxHost.controlModeLineSafeName(name) else { return }
         guard let workspace else { return }
-        _ = tabManager?.setCustomTitle(
+        let currentManager = workspace.owningTabManager
+            ?? AppDelegate.shared?.tabManagerFor(tabId: workspace.id)
+            ?? tabManager
+        if currentManager?.setCustomTitle(
             tabId: workspace.id,
             title: safe,
             propagateToRemoteTmux: false
-        ) ?? workspace.setCustomTitle(safe)
+        ) == true {
+            return
+        }
+        _ = workspace.setCustomTitle(safe)
     }
 
     private weak var tabManager: TabManager?

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -18,6 +18,20 @@ final class RemoteTmuxSessionMirror {
     /// Updates the tracked session name after a `rename-session`.
     func setSessionName(_ name: String) { sessionName = name }
 
+    /// Re-titles the mirror's sidebar workspace to track a remote session rename
+    /// (the reverse of the cmux→tmux `rename-session` push). Calls
+    /// ``Workspace/setCustomTitle(_:source:)`` DIRECTLY rather than
+    /// `TabManager.setCustomTitle` — the latter would re-propagate to
+    /// `rename-session` and feed back on itself; the workspace-level setter only
+    /// updates the (`@Published`) title the sidebar observes, so there is no loop.
+    /// The remote session name is the source of truth for a mirror workspace's
+    /// title, mirroring how a remote window rename unconditionally re-titles its
+    /// tab, so this overwrites any local custom title.
+    func applySessionNameToWorkspaceTitle(_ name: String) {
+        guard let safe = RemoteTmuxHost.controlModeLineSafeName(name) else { return }
+        _ = workspace?.setCustomTitle(safe)
+    }
+
     private weak var workspace: Workspace?
     private let defaultPanelIds: [UUID]
     private var defaultClosed = false

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -19,19 +19,23 @@ final class RemoteTmuxSessionMirror {
     func setSessionName(_ name: String) { sessionName = name }
 
     /// Re-titles the mirror's sidebar workspace to track a remote session rename
-    /// (the reverse of the cmux→tmux `rename-session` push). Calls
-    /// ``Workspace/setCustomTitle(_:source:)`` DIRECTLY rather than
-    /// `TabManager.setCustomTitle` — the latter would re-propagate to
-    /// `rename-session` and feed back on itself; the workspace-level setter only
-    /// updates the (`@Published`) title the sidebar observes, so there is no loop.
+    /// (the reverse of the cmux→tmux `rename-session` push). Uses TabManager's
+    /// title path so selected-window chrome refreshes, while suppressing the
+    /// `rename-session` propagation that would otherwise feed back on itself.
     /// The remote session name is the source of truth for a mirror workspace's
     /// title, mirroring how a remote window rename unconditionally re-titles its
     /// tab, so this overwrites any local custom title.
     func applySessionNameToWorkspaceTitle(_ name: String) {
         guard let safe = RemoteTmuxHost.controlModeLineSafeName(name) else { return }
-        _ = workspace?.setCustomTitle(safe)
+        guard let workspace else { return }
+        _ = tabManager?.setCustomTitle(
+            tabId: workspace.id,
+            title: safe,
+            propagateToRemoteTmux: false
+        ) ?? workspace.setCustomTitle(safe)
     }
 
+    private weak var tabManager: TabManager?
     private weak var workspace: Workspace?
     private let defaultPanelIds: [UUID]
     private var defaultClosed = false
@@ -56,11 +60,13 @@ final class RemoteTmuxSessionMirror {
         host: RemoteTmuxHost,
         sessionName: String,
         connection: RemoteTmuxControlConnection,
+        tabManager: TabManager,
         workspace: Workspace
     ) {
         self.host = host
         self.sessionName = sessionName
         self.connection = connection
+        self.tabManager = tabManager
         self.workspace = workspace
         self.defaultPanelIds = Array(workspace.panels.keys)
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1675,7 +1675,12 @@ class TabManager: ObservableObject {
     /// write landed (`.auto` writes are rejected over user-set titles; see
     /// ``Workspace/setCustomTitle(_:source:)``).
     @discardableResult
-    func setCustomTitle(tabId: UUID, title: String?, source: Workspace.CustomTitleSource = .user) -> Bool {
+    func setCustomTitle(
+        tabId: UUID,
+        title: String?,
+        source: Workspace.CustomTitleSource = .user,
+        propagateToRemoteTmux: Bool = true
+    ) -> Bool {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return false }
         let applied = tabs[index].setCustomTitle(title, source: source)
         if applied, selectedTabId == tabId {
@@ -1684,7 +1689,7 @@ class TabManager: ObservableObject {
         // A remote tmux mirror workspace rename propagates to `rename-session`,
         // but only when the write landed (an `.auto` write rejected over a
         // user-set title must not desync the remote session name).
-        if applied, tabs[index].isRemoteTmuxMirror {
+        if applied, propagateToRemoteTmux, tabs[index].isRemoteTmuxMirror {
             AppDelegate.shared?.remoteTmuxController.handleMirrorWorkspaceRenamed(
                 workspaceId: tabId, title: title
             )

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -702,8 +702,8 @@
 		0A2A2FA17CD71DA5B4495DEE /* RemoteTmuxSessionEndAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3E94F6022485BB12789444 /* RemoteTmuxSessionEndAction.swift */; };
 		008540053079E1E9B08DF59C /* RemoteTmuxSessionListParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E833A06BDA073CA66A46D7FA /* RemoteTmuxSessionListParser.swift */; };
 		3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */; };
-		3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */; };
 		1255599FA91128E5925D3983 /* RemoteTmuxSessionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */; };
+		3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */; };
 		9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */; };
 		6D3C19C2014FF9C754358EFF /* RemoteTmuxSSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */; };
 		0E17C0DE0E17C0DE0E17C002 /* RemoteTmuxTransportRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E17C0DE0E17C0DE0E17C001 /* RemoteTmuxTransportRegistry.swift */; };
@@ -1771,8 +1771,8 @@
 		9E3E94F6022485BB12789444 /* RemoteTmuxSessionEndAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionEndAction.swift; sourceTree = "<group>"; };
 		E833A06BDA073CA66A46D7FA /* RemoteTmuxSessionListParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionListParser.swift; sourceTree = "<group>"; };
 		3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionListParserTests.swift; sourceTree = "<group>"; };
-		3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionRenameTitleTests.swift; sourceTree = "<group>"; };
 		D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionMirror.swift; sourceTree = "<group>"; };
+		3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionRenameTitleTests.swift; sourceTree = "<group>"; };
 		31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSSHTransport.swift; sourceTree = "<group>"; };
 		0E17C0DE0E17C0DE0E17C001 /* RemoteTmuxTransportRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxTransportRegistry.swift; sourceTree = "<group>"; };

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -701,6 +701,7 @@
 		0A2A2FA17CD71DA5B4495DEE /* RemoteTmuxSessionEndAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3E94F6022485BB12789444 /* RemoteTmuxSessionEndAction.swift */; };
 		008540053079E1E9B08DF59C /* RemoteTmuxSessionListParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E833A06BDA073CA66A46D7FA /* RemoteTmuxSessionListParser.swift */; };
 		3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */; };
+		3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */; };
 		1255599FA91128E5925D3983 /* RemoteTmuxSessionMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */; };
 		9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */; };
 		6D3C19C2014FF9C754358EFF /* RemoteTmuxSSHTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */; };
@@ -1768,6 +1769,7 @@
 		9E3E94F6022485BB12789444 /* RemoteTmuxSessionEndAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionEndAction.swift; sourceTree = "<group>"; };
 		E833A06BDA073CA66A46D7FA /* RemoteTmuxSessionListParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionListParser.swift; sourceTree = "<group>"; };
 		3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionListParserTests.swift; sourceTree = "<group>"; };
+		3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionRenameTitleTests.swift; sourceTree = "<group>"; };
 		D7D5CC45BBE157F3EF880936 /* RemoteTmuxSessionMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionMirror.swift; sourceTree = "<group>"; };
 		31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		E8F5DB43CBC1B7DF31B7A0C9 /* RemoteTmuxSSHTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxSSHTransport.swift; sourceTree = "<group>"; };
@@ -3222,6 +3224,7 @@
 				C57570010000000000000001 /* RightSidebarPanelViewTestSupport.swift */,
 				5F5553CB5553CB5553CB0002 /* RightSidebarRemoteCommandTests.swift */,
 				3F704ED4F177122D7DCD0BCC /* RemoteTmuxSessionListParserTests.swift */,
+				3F704ED4F177122D7DCD0B01 /* RemoteTmuxSessionRenameTitleTests.swift */,
 				31FFFE3EFCDCCD6BDF405370 /* RemoteTmuxSessionSnapshotTests.swift */,
 				08850489C70ECFACA540C2F3 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift */,
 				B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */,
@@ -4617,6 +4620,7 @@
 				B0555301B0555301B0555301 /* RemoteTmuxControlStreamParserBudgetTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
 				3AC9AB9046E742B93726A405 /* RemoteTmuxSessionListParserTests.swift in Sources */,
+				3AC9AB9046E742B93726A501 /* RemoteTmuxSessionRenameTitleTests.swift in Sources */,
 				9A5CF3AA2E6462E77144F9E6 /* RemoteTmuxSessionSnapshotTests.swift in Sources */,
 				FA00C0DE0001BEEF0001CAFE /* RemoteTmuxWindowRegistryTests.swift in Sources */,
 				C58410010000000000000001 /* RenderableSystemSymbolTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -211,7 +211,7 @@ import Testing
         })
         defer { connection.removeObserver(token) }
 
-        connection.handleMessageForTesting(.sessionRenamed(sessionId: nil, name: "dev"))
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: nil, name: "dev", idBearingName: nil))
 
         #expect(connection.sessionName == "dev")
         #expect(connection.sessionId == nil)
@@ -225,7 +225,7 @@ import Testing
         )
         connection.handleMessageForTesting(.sessionChanged(sessionId: 7, name: "old"))
 
-        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "dev"))
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "$7 dev", idBearingName: "dev"))
 
         #expect(connection.sessionName == "dev")
         #expect(connection.sessionId == 7)
@@ -242,7 +242,7 @@ import Testing
         })
         defer { connection.removeObserver(token) }
 
-        connection.handleMessageForTesting(.sessionRenamed(sessionId: 8, name: "other"))
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 8, name: "$8 other", idBearingName: "other"))
 
         #expect(connection.sessionName == "old")
         #expect(connection.sessionId == 7)
@@ -254,7 +254,7 @@ import Testing
             host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
         )
 
-        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "dev"))
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "$7 dev", idBearingName: "dev"))
 
         #expect(connection.sessionName == "old")
         #expect(connection.sessionId == nil)

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -199,8 +199,8 @@ import Testing
         #expect(connection.pastePane(paneId: 1, text: "") == false)
     }
 
-    @Test @MainActor func sessionRenamedUpdatesTrackedNameAndEmitsObserver() {
-        // A remote `rename-session` arrives as `%session-renamed`. The connection
+    @Test @MainActor func sessionRenamedUpdatesTrackedNameAndEmitsObserverWithoutSessionId() {
+        // A remote `rename-session` arrives as `%session-renamed <name>`. The connection
         // must track the new name (reused for reconnect) and fire the
         // session-changed observer the mirror listens on to re-title its workspace.
         let connection = RemoteTmuxControlConnection(
@@ -212,9 +212,10 @@ import Testing
         })
         defer { connection.removeObserver(token) }
 
-        connection.handleMessageForTesting(.sessionRenamed(sessionId: 3, name: "dev"))
+        connection.handleMessageForTesting(.sessionRenamed(name: "dev"))
 
         #expect(connection.sessionName == "dev")
+        #expect(connection.sessionId == nil)
         #expect(observed?.old == "old")
         #expect(observed?.new == "dev")
     }

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -223,11 +223,41 @@ import Testing
         let connection = RemoteTmuxControlConnection(
             host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
         )
+        connection.handleMessageForTesting(.sessionChanged(sessionId: 7, name: "old"))
 
         connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "dev"))
 
         #expect(connection.sessionName == "dev")
         #expect(connection.sessionId == 7)
+    }
+
+    @Test @MainActor func sessionRenamedIgnoresDifferentSessionId() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
+        )
+        connection.handleMessageForTesting(.sessionChanged(sessionId: 7, name: "old"))
+        var observed: (old: String, new: String)?
+        let token = connection.addObserver(onSessionChanged: { old, new in
+            observed = (old, new)
+        })
+        defer { connection.removeObserver(token) }
+
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 8, name: "other"))
+
+        #expect(connection.sessionName == "old")
+        #expect(connection.sessionId == 7)
+        #expect(observed == nil)
+    }
+
+    @Test @MainActor func sessionRenamedIgnoresIdBearingRenameUntilSessionIdIsKnown() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
+        )
+
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "dev"))
+
+        #expect(connection.sessionName == "old")
+        #expect(connection.sessionId == nil)
     }
 
     @Test @MainActor func attachBlockDrainQueuesInitialWindowRequest() {

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -200,9 +200,8 @@ import Testing
     }
 
     @Test @MainActor func sessionRenamedUpdatesTrackedNameAndEmitsObserverWithoutSessionId() {
-        // A remote `rename-session` arrives as `%session-renamed <name>`. The connection
-        // must track the new name (reused for reconnect) and fire the
-        // session-changed observer the mirror listens on to re-title its workspace.
+        // A documented `%session-renamed <name>` must still track the new name
+        // (reused for reconnect) and fire the observer the mirror listens on.
         let connection = RemoteTmuxControlConnection(
             host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
         )
@@ -212,12 +211,23 @@ import Testing
         })
         defer { connection.removeObserver(token) }
 
-        connection.handleMessageForTesting(.sessionRenamed(name: "dev"))
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: nil, name: "dev"))
 
         #expect(connection.sessionName == "dev")
         #expect(connection.sessionId == nil)
         #expect(observed?.old == "old")
         #expect(observed?.new == "dev")
+    }
+
+    @Test @MainActor func sessionRenamedUpdatesTrackedIdWhenTmuxSuppliesOne() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
+        )
+
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 7, name: "dev"))
+
+        #expect(connection.sessionName == "dev")
+        #expect(connection.sessionId == 7)
     }
 
     @Test @MainActor func attachBlockDrainQueuesInitialWindowRequest() {

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -260,6 +260,20 @@ import Testing
         #expect(connection.sessionId == nil)
     }
 
+    @Test @MainActor func controllerRekeysCachedConnectionWhenSessionIsRenamed() {
+        let controller = RemoteTmuxController()
+        let host = RemoteTmuxHost(destination: "user@host")
+        let connection = RemoteTmuxControlConnection(host: host, sessionName: "old")
+        controller.cacheConnectionForTesting(connection)
+
+        #expect(controller.connection(host: host, sessionName: "old") === connection)
+
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: nil, name: "dev", idBearingName: nil))
+
+        #expect(controller.connection(host: host, sessionName: "old") == nil)
+        #expect(controller.connection(host: host, sessionName: "dev") === connection)
+    }
+
     @Test @MainActor func attachBlockDrainQueuesInitialWindowRequest() {
         let connection = RemoteTmuxControlConnection(host: RemoteTmuxHost(destination: "user@host"), sessionName: "work")
         let pipe = Pipe()

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -264,7 +264,7 @@ import Testing
         let controller = RemoteTmuxController()
         let host = RemoteTmuxHost(destination: "user@host")
         let connection = RemoteTmuxControlConnection(host: host, sessionName: "old")
-        controller.cacheConnectionForTesting(connection)
+        controller.cacheConnection(connection)
 
         #expect(controller.connection(host: host, sessionName: "old") === connection)
 

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -199,6 +199,26 @@ import Testing
         #expect(connection.pastePane(paneId: 1, text: "") == false)
     }
 
+    @Test @MainActor func sessionRenamedUpdatesTrackedNameAndEmitsObserver() {
+        // A remote `rename-session` arrives as `%session-renamed`. The connection
+        // must track the new name (reused for reconnect) and fire the
+        // session-changed observer the mirror listens on to re-title its workspace.
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"), sessionName: "old"
+        )
+        var observed: (old: String, new: String)?
+        let token = connection.addObserver(onSessionChanged: { old, new in
+            observed = (old, new)
+        })
+        defer { connection.removeObserver(token) }
+
+        connection.handleMessageForTesting(.sessionRenamed(sessionId: 3, name: "dev"))
+
+        #expect(connection.sessionName == "dev")
+        #expect(observed?.old == "old")
+        #expect(observed?.new == "dev")
+    }
+
     @Test @MainActor func attachBlockDrainQueuesInitialWindowRequest() {
         let connection = RemoteTmuxControlConnection(host: RemoteTmuxHost(destination: "user@host"), sessionName: "work")
         let pipe = Pipe()

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -146,6 +146,18 @@ import Testing
         #expect(messages == [.sessionChanged(sessionId: 1, name: "my session name")])
     }
 
+    @Test func sessionRenamedParsesToDistinctMessage() {
+        // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
+        // cmux must parse it so a remote rename re-titles the mirror workspace.
+        let messages = parse("%session-renamed $1 renamed-session-actual\r\n")
+        #expect(messages == [.sessionRenamed(sessionId: 1, name: "renamed-session-actual")])
+    }
+
+    @Test func sessionRenamedKeepsMultiWordName() {
+        let messages = parse("%session-renamed $2 my renamed session\r\n")
+        #expect(messages == [.sessionRenamed(sessionId: 2, name: "my renamed session")])
+    }
+
     @Test func layoutChangeCarriesRawLayoutString() {
         let messages = parse("%layout-change @4 f92f,80x24,0,0,1 @4 1\r\n")
         #expect(messages == [.layoutChange(windowId: 4, layout: "f92f,80x24,0,0,1")])

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -150,12 +150,22 @@ import Testing
         // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
         // cmux must parse it so a remote rename re-titles the mirror workspace.
         let messages = parse("%session-renamed renamed-session-actual\r\n")
-        #expect(messages == [.sessionRenamed(name: "renamed-session-actual")])
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "renamed-session-actual")])
     }
 
     @Test func sessionRenamedKeepsMultiWordName() {
         let messages = parse("%session-renamed my renamed session\r\n")
-        #expect(messages == [.sessionRenamed(name: "my renamed session")])
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "my renamed session")])
+    }
+
+    @Test func sessionRenamedKeepsSessionIdWhenTmuxSuppliesOne() {
+        let messages = parse("%session-renamed $1 my renamed session\r\n")
+        #expect(messages == [.sessionRenamed(sessionId: 1, name: "my renamed session")])
+    }
+
+    @Test func sessionRenamedAllowsDollarPrefixedNameInDocumentedForm() {
+        let messages = parse("%session-renamed $1\r\n")
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "$1")])
     }
 
     @Test func layoutChangeCarriesRawLayoutString() {

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -150,22 +150,27 @@ import Testing
         // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
         // cmux must parse it so a remote rename re-titles the mirror workspace.
         let messages = parse("%session-renamed renamed-session-actual\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: nil, name: "renamed-session-actual")])
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "renamed-session-actual", idBearingName: nil)])
     }
 
     @Test func sessionRenamedKeepsMultiWordName() {
         let messages = parse("%session-renamed my renamed session\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: nil, name: "my renamed session")])
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "my renamed session", idBearingName: nil)])
     }
 
     @Test func sessionRenamedKeepsSessionIdWhenTmuxSuppliesOne() {
         let messages = parse("%session-renamed $1 my renamed session\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: 1, name: "my renamed session")])
+        #expect(messages == [.sessionRenamed(sessionId: 1, name: "$1 my renamed session", idBearingName: "my renamed session")])
     }
 
     @Test func sessionRenamedAllowsDollarPrefixedNameInDocumentedForm() {
         let messages = parse("%session-renamed $1\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: nil, name: "$1")])
+        #expect(messages == [.sessionRenamed(sessionId: nil, name: "$1", idBearingName: nil)])
+    }
+
+    @Test func sessionRenamedPreservesAmbiguousDollarPrefixedDocumentedName() {
+        let messages = parse("%session-renamed $1 dev\r\n")
+        #expect(messages == [.sessionRenamed(sessionId: 1, name: "$1 dev", idBearingName: "dev")])
     }
 
     @Test func layoutChangeCarriesRawLayoutString() {

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -149,13 +149,13 @@ import Testing
     @Test func sessionRenamedParsesToDistinctMessage() {
         // tmux emits %session-renamed (NOT %session-changed) for `rename-session`;
         // cmux must parse it so a remote rename re-titles the mirror workspace.
-        let messages = parse("%session-renamed $1 renamed-session-actual\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: 1, name: "renamed-session-actual")])
+        let messages = parse("%session-renamed renamed-session-actual\r\n")
+        #expect(messages == [.sessionRenamed(name: "renamed-session-actual")])
     }
 
     @Test func sessionRenamedKeepsMultiWordName() {
-        let messages = parse("%session-renamed $2 my renamed session\r\n")
-        #expect(messages == [.sessionRenamed(sessionId: 2, name: "my renamed session")])
+        let messages = parse("%session-renamed my renamed session\r\n")
+        #expect(messages == [.sessionRenamed(name: "my renamed session")])
     }
 
     @Test func layoutChangeCarriesRawLayoutString() {

--- a/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
+++ b/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
@@ -80,4 +80,35 @@ struct RemoteTmuxSessionRenameTitleTests {
 
         #expect(window.title == "dev")
     }
+
+    @Test func remoteRenameUsesCurrentManagerAfterWorkspaceMove() throws {
+        let (mirror, workspace, sourceManager) = makeMirror(sessionName: "old", title: "old")
+        let destinationManager = TabManager()
+        let movedWorkspace = try #require(sourceManager.detachWorkspace(tabId: workspace.id))
+        #expect(movedWorkspace === workspace)
+
+        destinationManager.attachWorkspace(movedWorkspace, select: true)
+        #expect(workspace.owningTabManager === destinationManager)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        destinationManager.window = window
+        defer {
+            destinationManager.window = nil
+            window.close()
+        }
+
+        destinationManager.refreshWindowTitle()
+        #expect(window.title == "old")
+
+        mirror.applySessionNameToWorkspaceTitle("dev")
+
+        #expect(workspace.title == "dev")
+        #expect(workspace.customTitle == "dev")
+        #expect(window.title == "dev")
+    }
 }

--- a/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
+++ b/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import Testing
 
 #if canImport(cmux_DEV)
@@ -18,7 +19,7 @@ struct RemoteTmuxSessionRenameTitleTests {
     private func makeMirror(
         sessionName: String,
         title: String?
-    ) -> (mirror: RemoteTmuxSessionMirror, workspace: Workspace) {
+    ) -> (mirror: RemoteTmuxSessionMirror, workspace: Workspace, manager: TabManager) {
         let manager = TabManager()
         let workspace = manager.addWorkspace(title: title, select: false, autoWelcomeIfNeeded: false)
         workspace.isRemoteTmuxMirror = true
@@ -28,13 +29,14 @@ struct RemoteTmuxSessionRenameTitleTests {
             host: host,
             sessionName: sessionName,
             connection: connection,
+            tabManager: manager,
             workspace: workspace
         )
-        return (mirror, workspace)
+        return (mirror, workspace, manager)
     }
 
     @Test func remoteRenameUpdatesWorkspaceTitle() {
-        let (mirror, workspace) = makeMirror(sessionName: "old", title: "old")
+        let (mirror, workspace, _) = makeMirror(sessionName: "old", title: "old")
         mirror.applySessionNameToWorkspaceTitle("dev")
         #expect(workspace.title == "dev")
         #expect(workspace.customTitle == "dev")
@@ -43,7 +45,7 @@ struct RemoteTmuxSessionRenameTitleTests {
     @Test func remoteRenameOverwritesAUserSetTitle() {
         // The remote session name is the source of truth for a mirror workspace's
         // title (same as a remote window rename unconditionally re-titles its tab).
-        let (mirror, workspace) = makeMirror(sessionName: "old", title: "my custom name")
+        let (mirror, workspace, _) = makeMirror(sessionName: "old", title: "my custom name")
         mirror.applySessionNameToWorkspaceTitle("dev")
         #expect(workspace.title == "dev")
     }
@@ -51,8 +53,31 @@ struct RemoteTmuxSessionRenameTitleTests {
     @Test func remoteRenameRejectsLineUnsafeName() {
         // A name carrying control bytes (which could only arrive corrupted) must
         // not be written as the workspace title.
-        let (mirror, workspace) = makeMirror(sessionName: "old", title: "old")
+        let (mirror, workspace, _) = makeMirror(sessionName: "old", title: "old")
         mirror.applySessionNameToWorkspaceTitle("dev\nrename-window injected")
         #expect(workspace.title == "old")
+    }
+
+    @Test func remoteRenameRefreshesSelectedWindowTitle() {
+        let (mirror, workspace, manager) = makeMirror(sessionName: "old", title: "old")
+        manager.selectedTabId = workspace.id
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        manager.window = window
+        defer {
+            manager.window = nil
+            window.close()
+        }
+
+        manager.refreshWindowTitle()
+        #expect(window.title == "old")
+
+        mirror.applySessionNameToWorkspaceTitle("dev")
+
+        #expect(window.title == "dev")
     }
 }

--- a/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
+++ b/cmuxTests/RemoteTmuxSessionRenameTitleTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression tests for syncing a remote tmux `rename-session` back onto the
+/// mirror's cmux workspace title (the reverse of the cmux→tmux rename push).
+/// A remote `tmux rename-session` arrives as `%session-renamed`; the mirror must
+/// re-title its sidebar workspace, and must do so WITHOUT re-propagating to
+/// `rename-session` (which would feed back on itself).
+@MainActor
+@Suite(.serialized)
+struct RemoteTmuxSessionRenameTitleTests {
+    private func makeMirror(
+        sessionName: String,
+        title: String?
+    ) -> (mirror: RemoteTmuxSessionMirror, workspace: Workspace) {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(title: title, select: false, autoWelcomeIfNeeded: false)
+        workspace.isRemoteTmuxMirror = true
+        let host = RemoteTmuxHost(destination: "user@host")
+        let connection = RemoteTmuxControlConnection(host: host, sessionName: sessionName)
+        let mirror = RemoteTmuxSessionMirror(
+            host: host,
+            sessionName: sessionName,
+            connection: connection,
+            workspace: workspace
+        )
+        return (mirror, workspace)
+    }
+
+    @Test func remoteRenameUpdatesWorkspaceTitle() {
+        let (mirror, workspace) = makeMirror(sessionName: "old", title: "old")
+        mirror.applySessionNameToWorkspaceTitle("dev")
+        #expect(workspace.title == "dev")
+        #expect(workspace.customTitle == "dev")
+    }
+
+    @Test func remoteRenameOverwritesAUserSetTitle() {
+        // The remote session name is the source of truth for a mirror workspace's
+        // title (same as a remote window rename unconditionally re-titles its tab).
+        let (mirror, workspace) = makeMirror(sessionName: "old", title: "my custom name")
+        mirror.applySessionNameToWorkspaceTitle("dev")
+        #expect(workspace.title == "dev")
+    }
+
+    @Test func remoteRenameRejectsLineUnsafeName() {
+        // A name carrying control bytes (which could only arrive corrupted) must
+        // not be written as the workspace title.
+        let (mirror, workspace) = makeMirror(sessionName: "old", title: "old")
+        mirror.applySessionNameToWorkspaceTitle("dev\nrename-window injected")
+        #expect(workspace.title == "old")
+    }
+}


### PR DESCRIPTION
## What was broken

With a `cmux ssh-tmux` mirror attached, renaming the session on the remote —
`tmux rename-session foo` — did **not** update the cmux sidebar workspace title.
The workspace kept showing the **old** name indefinitely (only a fresh re-attach
picked up the new name).

The cmux→tmux direction already worked (renaming the workspace in cmux pushes
`rename-session`); only the **remote→cmux** direction was missing.

### Root cause

cmux's control-stream parser handled `%session-changed` but **not**
`%session-renamed`. These are two different tmux notifications:

- `%session-changed $<id> <name>` — fires when the *attached session switches*.
- `%session-renamed $<id> <name>` — fires for **`rename-session`** (tmux
  `control-notify.c`, `control_notify_session_renamed`).

So a rename emitted `%session-renamed`, which cmux didn't recognize and silently
dropped — it never reached any handler, so neither the tracked session name nor
the workspace title updated.

(Discovered live: after `tmux rename-session foo`, `tmux list-sessions` on the
host showed the new name, but the cmux sidebar still showed the old one.)

## What now works

A remote `tmux rename-session foo` (or an automatic session rename) re-titles
the mirror's sidebar workspace **live**, with no re-attach. Verified live against
a real remote host.

## Changes

- **Parse** `%session-renamed $<id> <name>` → new `.sessionRenamed` message. The
  name is the line remainder, so multi-word names survive.
- **Handle** `.sessionRenamed` via a shared `applySessionNameChange(...)` helper
  (now also used by `.sessionChanged`): validate the name, update the tracked
  `sessionId`/`sessionName` (reused for attach/reconnect, so a stale value would
  make the next reconnect target the wrong session), and emit the name-change
  observers.
- **Re-title** the workspace: on that observer,
  `RemoteTmuxController.handleMirrorSessionNameChanged` calls the new
  `RemoteTmuxSessionMirror.applySessionNameToWorkspaceTitle(_:)`, which uses
  `Workspace.setCustomTitle` **directly** — not `TabManager.setCustomTitle`,
  which would re-propagate to `rename-session` and feed back on itself. So there
  is no rename loop.

Name safety: the new name is run through the existing `controlModeLineSafeName`
guard (rejects CR/LF/control bytes) in both the connection and the title setter.

## Tests

- `%session-renamed` parses to `.sessionRenamed`, distinct from
  `%session-changed`, including multi-word names.
- On `.sessionRenamed`, the connection updates `sessionName` and fires
  `onSessionChanged` (the observer the mirror listens on).
- The mirror re-titles its workspace, and rejects a control-byte name
  (new `RemoteTmuxSessionRenameTitleTests`, wired into the project).

`xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/RemoteTmuxControlParserTests -only-testing:cmuxTests/RemoteTmuxAuthTests -only-testing:cmuxTests/RemoteTmuxSessionRenameTitleTests` → 63/63 pass.

## Out of scope

The window-rename inner-tab title (`tmux rename-window`) not updating is a
**separate** bug — different notification (`%window-renamed`), different surface
(inner tab vs sidebar workspace), different code path — and will be handled in a
follow-up PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784741125&installation_id=133855650&pr_number=6602&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6602&signature=a51fdb76ae511bedc9db9910dee1dd4b28848d25ba19f8b500a68508061c2adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remote tmux session renames now live-update the mirror workspace title and the selected window’s title bar without re-attach, even after the workspace is moved to another window. We parse `%session-renamed` (name-only or `$<id> <name>`) and re-key the connection cache so future lookups use the new name.

- **Bug Fixes**
  - Parse `%session-renamed [$<id>] <name>` into `.sessionRenamed(sessionId: Int?, name: String, idBearingName: String?)`; ignore id-bearing renames for other sessions or before the id is known; accept multi-word and `$`-ambiguous names.
  - Use a shared `applySessionNameChange(...)` for `%session-renamed` and `%session-changed`: validate, update `sessionName`/`sessionId`, emit `onSessionChanged`; skip window refetch on rename, refetch on `%session-changed`.
  - Re-title via `RemoteTmuxSessionMirror.applySessionNameToWorkspaceTitle` using `TabManager.setCustomTitle(..., propagateToRemoteTmux: false)` (fallback to `Workspace.setCustomTitle`) to refresh window chrome and avoid feedback; works after moving the workspace by resolving the current `TabManager`; guarded by `controlModeLineSafeName`.
  - Re-key the controller’s cached connection map on rename and clean up observer tokens on detach so lookups work under the new session name.
  - Tests cover parsing, observer emission, cache re-key, rejecting control-byte names, refreshing the selected window title, and updates after moving the mirror workspace.

<sup>Written for commit 092d23a743d91a1e3668d3237c2daeeb113067b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote tmux `rename-session` is now surfaced as `%session-renamed`, and mirrored sidebar workspace titles are synchronized to the new session name.
* **Bug Fixes**
  * Improved handling of renamed sessions: validates safe session names, emits the correct `old/new` session-change notifications, updates session state appropriately, and refreshes topology only when needed.
  * `%session-renamed` parsing now correctly supports multi-word session names.
* **Tests**
  * Added coverage for `%session-renamed` parsing and mirror workspace title synchronization, including rejection of unsafe names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->