### PR TITLE
ci: route all macOS compile/test gates to Swift 6.3 Xcode (match what ships)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1298,7 +1298,6 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/select-ci-xcode.sh
-          xcrun --sdk macosx --show-sdk-path
 
       - name: Capture Ghostty revision
         id: ghostty-revision
@@ -1442,7 +1441,6 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/select-ci-xcode.sh
-          xcrun --sdk macosx --show-sdk-path
 
       - name: Prepare isolated DerivedData
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,25 +383,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Capture Ghostty revision
         id: ghostty-revision
@@ -752,25 +734,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Capture Ghostty revision
         id: ghostty-revision
@@ -981,25 +945,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Prepare isolated DerivedData
         run: |
@@ -1351,25 +1297,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
           xcrun --sdk macosx --show-sdk-path
 
       - name: Capture Ghostty revision
@@ -1513,25 +1441,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
           xcrun --sdk macosx --show-sdk-path
 
       - name: Prepare isolated DerivedData

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -152,25 +152,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Download pre-built GhosttyKit.xcframework
         env:

--- a/.github/workflows/reload-build.yml
+++ b/.github/workflows/reload-build.yml
@@ -78,16 +78,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort | tail -n 1 || true)"
-            [ -n "$XCODE_APP" ] || { echo "No Xcode.app under /Applications" >&2; exit 1; }
-            XCODE_DIR="$XCODE_APP/Contents/Developer"
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Install zig
         run: ./scripts/install-zig-ci.sh

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -52,25 +52,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
           xcrun --sdk macosx --show-sdk-path
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -53,7 +53,6 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/select-ci-xcode.sh
-          xcrun --sdk macosx --show-sdk-path
 
       - name: Download pre-built GhosttyKit.xcframework
         env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,25 +93,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
           xcrun --sdk macosx --show-sdk-path
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -94,7 +94,6 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/select-ci-xcode.sh
-          xcrun --sdk macosx --show-sdk-path
 
       - name: Download pre-built GhosttyKit.xcframework
         env:

--- a/.github/workflows/tmux-corpus.yml
+++ b/.github/workflows/tmux-corpus.yml
@@ -90,25 +90,7 @@ jobs:
       - name: Select Xcode
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
-          fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
-          export DEVELOPER_DIR="$XCODE_DIR"
-          xcodebuild -version
+          ./scripts/select-ci-xcode.sh
 
       - name: Cache GhosttyKit.xcframework
         id: cache-ghosttykit

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/FocusGuards/CommandPaletteFocusStealingTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/FocusGuards/CommandPaletteFocusStealingTests.swift
@@ -41,7 +41,7 @@ private final class NonViewTextDelegate: NSObject, NSTextViewDelegate {}
     @Test func doesNotReadTextViewDelegateForClassification() {
         final class DelegateTrackingTextView: NSTextView {
             private(set) var delegateReadCount = 0
-            override var delegate: NSTextViewDelegate? {
+            override var delegate: (any NSTextViewDelegate)? {
                 get {
                     delegateReadCount += 1
                     return super.delegate

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
@@ -93,7 +93,7 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
     var webSocketSession: URLSession?
     var webSocketTask: URLSessionWebSocketTask?
     var webSocketDelegate: RemoteDaemonWebSocketDelegate?
-    var webSocketKeepaliveTimer: DispatchSourceTimer?
+    var webSocketKeepaliveTimer: (any DispatchSourceTimer)?
     var webSocketKeepaliveTimeoutWorkItem: DispatchWorkItem?
     var webSocketKeepaliveInFlight = false
     var isClosed = true

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Process/RemoteSessionProcessRunner.swift
@@ -46,8 +46,8 @@ public struct RemoteSessionProcessRunner: RemoteSessionProcessRunning {
     private final class PipeCaptureState: @unchecked Sendable {
         var stdoutData = Data()
         var stderrData = Data()
-        var stdoutReadError: Error?
-        var stderrReadError: Error?
+        var stdoutReadError: (any Error)?
+        var stderrReadError: (any Error)?
     }
 
     /// Runs the request to completion on the calling thread; see

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PTYBridge.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+PTYBridge.swift
@@ -90,7 +90,7 @@ extension RemoteSessionCoordinator {
         let isCancelled: @Sendable () -> Bool = {
             box.hasValue
         }
-        let complete: @Sendable (Result<RemotePTYBridgeServer.Endpoint, Error>) -> Void = { result in
+        let complete: @Sendable (Result<RemotePTYBridgeServer.Endpoint, any Error>) -> Void = { result in
             if box.setIfEmpty(result) {
                 semaphore.signal()
             }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Upload.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+Upload.swift
@@ -15,7 +15,7 @@ extension RemoteSessionCoordinator {
     public func uploadDroppedFiles(
         _ fileURLs: [URL],
         operation: any RemoteTransferCancelling,
-        completion: @escaping @Sendable (Result<[String], Error>) -> Void
+        completion: @escaping @Sendable (Result<[String], any Error>) -> Void
     ) {
         queue.async { [weak self] in
             guard let self else {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -91,7 +91,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
     var remotePortScanCoalesceTask: Task<Void, Never>?
     var remotePortScanCoalesceToken: UUID?
     var remotePortScanBurstTask: Task<Void, Never>?
-    var remotePortPollTimer: DispatchSourceTimer?
+    var remotePortPollTimer: (any DispatchSourceTimer)?
     var remotePortPollMode: RemotePortPollingMode?
     var polledRemotePorts: [Int] = []
     var remotePortPollBaselinePorts: Set<Int>?

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/LockedResult.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/LockedResult.swift
@@ -9,11 +9,11 @@ internal import Foundation
 /// shape, not a state machine).
 final class LockedResult<T>: @unchecked Sendable {
     private let lock = NSLock()
-    private var value: Result<T, Error>?
+    private var value: Result<T, any Error>?
 
     /// Stores `result` only when no result is set yet; returns whether this
     /// call stored it (the first-writer-wins latch).
-    func setIfEmpty(_ result: Result<T, Error>) -> Bool {
+    func setIfEmpty(_ result: Result<T, any Error>) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         guard value == nil else { return false }
@@ -29,7 +29,7 @@ final class LockedResult<T>: @unchecked Sendable {
     }
 
     /// The stored result, if any.
-    var current: Result<T, Error>? {
+    var current: Result<T, any Error>? {
         lock.lock()
         defer { lock.unlock() }
         return value

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/PendingPTYBridgeStart.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Values/PendingPTYBridgeStart.swift
@@ -9,5 +9,5 @@ struct PendingPTYBridgeStart {
     let command: String?
     let requireExisting: Bool
     let isCancelled: () -> Bool
-    let completion: (Result<RemotePTYBridgeServer.Endpoint, Error>) -> Void
+    let completion: (Result<RemotePTYBridgeServer.Endpoint, any Error>) -> Void
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
@@ -314,8 +314,7 @@ public struct SocketControlSettings {
         var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
         let length = readlink(path, &buffer, buffer.count - 1)
         guard length > 0 else { return nil }
-        buffer[Int(length)] = 0
-        let target = String(cString: buffer)
+        let target = String(decoding: buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }, as: UTF8.self)
         if target.hasPrefix("/") {
             return target
         }

--- a/scripts/select-ci-xcode.sh
+++ b/scripts/select-ci-xcode.sh
@@ -62,3 +62,8 @@ if [ -n "${GITHUB_ENV:-}" ]; then
 fi
 export DEVELOPER_DIR="$BEST_DIR"
 xcodebuild -version
+# Diagnostic: resolve the SDK with DEVELOPER_DIR set in-process. The workflow
+# step that calls this script gets DEVELOPER_DIR only via GITHUB_ENV, which
+# applies to *later* steps, not the current shell, so a bare `xcrun` on the
+# next line of the same step would still resolve the old xcode-select default.
+xcrun --sdk macosx --show-sdk-path

--- a/scripts/select-ci-xcode.sh
+++ b/scripts/select-ci-xcode.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Select the newest Xcode for CI compile/test gates.
+#
+# The runner images ship multiple Xcodes (16.x with the macOS 15 SDK / Swift 6.1
+# and 26.x with the macOS 26 SDK / Swift 6.3), but `/Applications/Xcode.app` is
+# symlinked to an old 16.x. The previous "prefer /Applications/Xcode.app" logic
+# therefore pinned the test/compile gate to Swift 6.1, while nightly and release
+# already build on 26.x (see select-nightly-xcodes.sh). That divergence let code
+# that compiles locally (6.3) and ships (6.3) fail only on the 6.1 test gate
+# (e.g. `isolated deinit`, region-based isolation differences).
+#
+# Pick the highest macOS SDK Xcode so the test gate matches what ships. Fall back
+# to the newest available if no 26+ is installed, so this never hard-fails a
+# runner that lacks the newer Xcode. Exports DEVELOPER_DIR to GITHUB_ENV.
+set -euo pipefail
+
+APPLICATIONS_DIR="${CMUX_XCODE_APPLICATIONS_DIR:-/Applications}"
+
+# Rank by macOS SDK as maj*1000+min so 26.2 (26002) outranks 15.5 (15005).
+sdk_rank() {
+  local v="$1" maj min
+  maj="${v%%.*}"
+  min="${v#*.}"
+  [ "$min" = "$v" ] && min=0
+  min="${min%%.*}"
+  case "$maj" in ''|*[!0-9]*) return 1 ;; esac
+  case "$min" in ''|*[!0-9]*) min=0 ;; esac
+  printf '%d' "$(( maj * 1000 + min ))"
+}
+
+BEST_DIR=""
+BEST_VER=""
+BEST_RANK=-1
+while IFS= read -r app; do
+  [ -n "$app" ] || continue
+  dev="$app/Contents/Developer"
+  [ -d "$dev" ] || continue
+  sdk_ver="$(DEVELOPER_DIR="$dev" xcrun --sdk macosx --show-sdk-version 2>/dev/null || true)"
+  [ -n "$sdk_ver" ] || continue
+  if ! rank="$(sdk_rank "$sdk_ver")"; then
+    echo "Ignoring $app with unparsable macOS SDK version: $sdk_ver" >&2
+    continue
+  fi
+  echo "Found $app -> macOS SDK $sdk_ver (rank $rank)"
+  # `-ge` so among equal-SDK Xcodes the alphabetically-last (newest point
+  # release, e.g. Xcode_26.3.app over Xcode_26.2.0.app) wins.
+  if [ "$rank" -ge "$BEST_RANK" ]; then
+    BEST_DIR="$dev"
+    BEST_VER="$sdk_ver"
+    BEST_RANK="$rank"
+  fi
+done < <(find "$APPLICATIONS_DIR" -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null | sort)
+
+if [ -z "$BEST_DIR" ]; then
+  echo "No Xcode.app found under $APPLICATIONS_DIR" >&2
+  exit 1
+fi
+
+echo "Selected Xcode (DEVELOPER_DIR): $BEST_DIR (macOS SDK $BEST_VER)"
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "DEVELOPER_DIR=$BEST_DIR" >> "$GITHUB_ENV"
+fi
+export DEVELOPER_DIR="$BEST_DIR"
+xcodebuild -version


### PR DESCRIPTION
## What

Route **all macOS compile/test CI gates** at the newest macOS-26-SDK Xcode (Swift 6.3) instead of the runner's default `/Applications/Xcode.app` (Xcode 16.4 / Swift 6.1), via a shared `scripts/select-ci-xcode.sh`, and fix the warnings the 6.3 toolchain newly surfaces.

## Why

The Blacksmith/Warp runner images already have Xcode 16.0–16.4 **and** 26.0–26.3 installed. `/Applications/Xcode.app` is symlinked to 16.4, and the old "prefer `/Applications/Xcode.app`" inline selection pinned the test/compile gates to **Swift 6.1**, while nightly and release already build on **26.x / Swift 6.3** via `select-nightly-xcodes.sh`. So the gates were *older than what we ship*: code that compiles locally (6.3) and in release (6.3) could fail only on the 6.1 gates (e.g. `isolated deinit`, region-based isolation).

## How

`scripts/select-ci-xcode.sh` ranks installed Xcodes by macOS SDK version and picks the highest (falls back to newest available, so it never hard-fails a runner lacking 26.x), exports `DEVELOPER_DIR` to `GITHUB_ENV`, and prints `xcodebuild -version` + `xcrun --sdk macosx --show-sdk-path` in-process. Each macOS gate's "Select Xcode" step calls it.

## Workflows changed

- `test-e2e.yml` — e2e gate.
- `ci.yml` — all five macOS jobs (`app-host-unit-tests`, `swift-package-tests`, `tests-build-and-lag`, `release-build`, `ui-regressions`).
- `perf-activation.yml`, `reload-build.yml`, `tmux-corpus.yml`, `test-depot.yml` — one macOS job each.
- The SDK-path diagnostic now lives inside `select-ci-xcode.sh`. Previously the trailing `xcrun --sdk macosx --show-sdk-path` sat in the workflow step *after* the script and resolved the stale xcode-select default (printed `MacOSX15.5.sdk`), because the subshell's `DEVELOPER_DIR` reaches only later steps via `GITHUB_ENV`. Builds were always correct; only that log line lied.

## Warnings surfaced by the 6.3 toolchain (triage)

Diffing the 26.x run against the prior mixed run isolates **66 unique new compiler warnings** (the mass `XCTest inconsistently imported` warnings pre-date the bump). Zero new compile **errors**. Fixed here (safe, self-contained, root-cause):

- **Deprecation:** `String(cString:)` → `String(decoding:as: UTF8.self)` in `CmuxSettings/SocketControlSettings.swift`.
- **`#ExistentialAny`** (`any P`): 11 sites in `CmuxRemoteSession`, `CmuxRemoteDaemon`, `CmuxCommandPalette` (tests). Purely syntactic; `any` compiles identically on the 16.x fallback.

Deferred to a focused follow-up (substantive but risky / submodule / non-shipping):

- `Sources/AppDelegate.swift` main-actor-isolation + non-Sendable-capture warnings (~20) — typing/focus-sensitive file, needs careful concurrency review + dogfood.
- `CmuxRemoteSession` captured-`self` `[#SendableClosureCaptures]` (3) — actor-model review.
- `vendor/bonsplit` submodule: `onChange(of:perform:)` deprecation (3) + nonisolated `bounds` (1) — requires a submodule PR.
- Sparkle `SUAppcastItem(dictionary:)` deprecation (1) — vendor private-API.
- Test-target concurrency warnings in `cmuxTests/` (~22) — non-shipping.

## Deliberately left on the old toolchain

- `release.yml`, `nightly.yml`, `build-ghosttykit.yml` — deliberate dual-Xcode split building the Ghostty universal CLI helper on a **pre-26** Xcode (`HELPER_DEVELOPER_DIR` via `select-nightly-xcodes.sh`). Untouched. (ci.yml's `release-ghostty-cli-helper` builds the helper with **zig**, no Xcode selection, and `release-build` downloads the prebuilt GhosttyKit — so converting `release-build` to 26.x is correct.)
- `ci-macos-compat.yml` — `workflow_dispatch`-only macOS-version compat matrix; already selects the newest Xcode (not the buggy symlink-preferring logic) and exports `XCODE_VER` for its cache key, so converting it would gain nothing and risk the cache key. Left as-is.
- `test-ios.yml`, `ios-testflight.yml` — iOS gates that still carry the identical buggy inline block on `macos-26` runners. **Out of scope** for this macOS-gate PR (`ios-testflight.yml` is a TestFlight submission path). Flagged as a recommended follow-up.

## Verification

ci.yml run on this branch selected **Xcode 26.3 / `MacOSX26.2.sdk`** and all macOS jobs are green: `app-host unit tests (1-4/4)`, `swift-package-tests`, `tests-build-and-lag`, `ui-regressions`, `release-build`. The standalone e2e `AutomationSocketUITests` run confirms `Selected Xcode … macOS SDK 26.2`; its 4 test failures are a **pre-existing GUI-activation limitation** on the default runner (`Failed to activate application … Running Background`), reproduced identically on Xcode 16.4, not a toolchain regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743075&installation_id=133855650&pr_number=6603&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6603&signature=ee98fbd45a3688b7a1c5824aba4046f72fbd6d2c3880efc36fb276042e50cbd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all macOS compile/test CI gates to the newest Xcode with the macOS 26 SDK (Swift 6.3) via `scripts/select-ci-xcode.sh`. This aligns CI with release builds, replaces inline Xcode selection, and prints accurate SDK diagnostics; release/nightly and Ghostty dual-Xcode jobs are unchanged.

- **Bug Fixes**
  - Replace deprecated `String(cString:)` with `String(decoding:as:)` in `CmuxSettings/SocketControlSettings`.
  - Adopt `any` existentials in `CmuxRemoteSession`, `CmuxRemoteDaemon`, and `CmuxCommandPalette` tests.

<sup>Written for commit b321e3425fbf328c304ec670f111ef592cf25d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS CI workflows to use a single, consistent Xcode selection process based on installed SDK versions.
  * This improves reliability and consistency across automated gates (builds, unit tests, Swift package tests, and UI regressions) by ensuring the intended Xcode environment is used.
  * Reduced duplicated “select Xcode” logic across workflows for easier maintenance.
* **Chores**
  * Added a shared CI helper to select Xcode, export the developer directory, and run SDK diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
