### PR TITLE
Fix explicit surface routing for read-screen and send

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4463,7 +4463,7 @@ struct CMUXCLI {
             }
 
             let windowRaw = windowOpt ?? windowId
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(sfArg, windowRaw: windowRaw)
             let surfaceArg = sfArg ?? (wsArg == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
             var params: [String: Any] = [:]
@@ -4498,7 +4498,7 @@ struct CMUXCLI {
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let windowRaw = windowOpt ?? windowId
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(sfArg, windowRaw: windowRaw)
             let surfaceArg = sfArg ?? (wsArg == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             let rawText = rem2.dropFirst(rem2.first == "--" ? 1 : 0).joined(separator: " ")
             guard !rawText.isEmpty else { throw CLIError(message: "send requires text") }
@@ -4518,7 +4518,7 @@ struct CMUXCLI {
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let windowRaw = windowOpt ?? windowId
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(sfArg, windowRaw: windowRaw)
             let surfaceArg = sfArg ?? (wsArg == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             let keyArgs = rem2.first == "--" ? Array(rem2.dropFirst()) : rem2
             guard let key = keyArgs.first else { throw CLIError(message: "send-key requires a key") }
@@ -4537,10 +4537,10 @@ struct CMUXCLI {
             let (panelArg, rem1) = parseOption(rem0, name: "--panel")
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let windowRaw = windowOpt ?? windowId
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             guard let panelArg else {
                 throw CLIError(message: "send-panel requires --panel")
             }
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(panelArg, windowRaw: windowRaw)
             let rawText = rem2.dropFirst(rem2.first == "--" ? 1 : 0).joined(separator: " ")
             guard !rawText.isEmpty else { throw CLIError(message: "send-panel requires text") }
             let text = unescapeSendText(rawText)
@@ -4559,10 +4559,10 @@ struct CMUXCLI {
             let (panelArg, rem1) = parseOption(rem0, name: "--panel")
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let windowRaw = windowOpt ?? windowId
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             guard let panelArg else {
                 throw CLIError(message: "send-key-panel requires --panel")
             }
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(panelArg, windowRaw: windowRaw)
             let skpArgs = rem2.first == "--" ? Array(rem2.dropFirst()) : rem2
             let key = skpArgs.first ?? ""
             guard !key.isEmpty else { throw CLIError(message: "send-key-panel requires a key") }
@@ -6108,9 +6108,6 @@ struct CMUXCLI {
         if let workspaceHandle {
             params["workspace_id"] = workspaceHandle
         }
-        if let windowHandle {
-            params["window_id"] = windowHandle
-        }
         let listed = try client.sendV2(method: "surface.list", params: params)
         let items = listed["surfaces"] as? [[String: Any]] ?? []
         for item in items where intFromAny(item["index"]) == wantedIndex {
@@ -6118,7 +6115,10 @@ struct CMUXCLI {
         }
         throw CLIError(message: "Surface index not found")
     }
-
+    private static func callerWorkspaceForSurfaceHandle(_ raw: String?, windowRaw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return windowRaw == nil && (trimmed.isEmpty || Int(trimmed) != nil) ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil
+    }
     private func validateSurfaceHandleInWindow(
         _ surfaceHandle: String,
         client: SocketClient,
@@ -22453,7 +22453,7 @@ struct CMUXCLI {
             let (windowOpt, rem2) = parseOption(rem1, name: "--window")
             let (linesArg, rem3) = parseOption(rem2, name: "--lines")
             let windowRaw = windowOpt ?? windowOverride
-            let workspaceArg = wsArg ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceArg = wsArg ?? Self.callerWorkspaceForSurfaceHandle(sfArg, windowRaw: windowRaw)
             let surfaceArg = sfArg ?? (wsArg == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
             var params: [String: Any] = [:]
@@ -22516,7 +22516,7 @@ struct CMUXCLI {
             let (windowOpt, pipeRem2) = parseOption(pipeRem1, name: "--window")
             let (cmdOpt, pipeRem3) = parseOption(pipeRem2, name: "--command")
             let effectiveWindowRaw = windowOpt ?? windowOverride
-            let workspaceArg = workspaceOpt ?? (effectiveWindowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let workspaceArg = workspaceOpt ?? Self.callerWorkspaceForSurfaceHandle(surfaceArg, windowRaw: effectiveWindowRaw)
             let commandText: String = {
                 if let cmdOpt { return cmdOpt }
                 let trimmed = pipeRem3.dropFirst(pipeRem3.first == "--" ? 1 : 0).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -22525,11 +22525,11 @@ struct CMUXCLI {
             guard !commandText.isEmpty else {
                 throw CLIError(message: "pipe-pane requires --command <shell-command>")
             }
-
             var params: [String: Any] = ["scrollback": true]
             let winId = try normalizeWindowHandle(effectiveWindowRaw, client: client)
             if let winId { params["window_id"] = winId }
-            let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId, allowCurrent: winId == nil)
+            let allowCurrentWorkspace = winId == nil && (surfaceArg.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.map { $0.isEmpty || Int($0) != nil } ?? true)
+            let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, windowHandle: winId, allowCurrent: allowCurrentWorkspace)
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId, windowHandle: winId, allowFocused: true)
             if let sfId { params["surface_id"] = sfId }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		A9F200000000000000000015 /* ClaudeStreamJSONAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
 		C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */; };
+		E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */; };
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
 		C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */; };
 		A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */; };
@@ -1288,6 +1289,7 @@
 		A9F100000000000000000015 /* ClaudeStreamJSONAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ClaudeStreamJSONAccumulator.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
 		C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTests.swift; sourceTree = "<group>"; };
+		1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExplicitSurfaceRoutingTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CLIForwardingLaunchRouter.swift; sourceTree = "<group>"; };
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
@@ -3164,6 +3166,7 @@
 				C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */,
 					C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */,
 					C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
+					1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */,
 					C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 					C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
 					C0DE64950000000000000004 /* CMUXCLITestAssertions.swift */,
@@ -4491,6 +4494,7 @@
 				A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */,
 				A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
+					E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,
 				A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
 				A5D41211A1B2C3D4E5F60718 /* CLIHookNoResponseTests.swift in Sources */,

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -1,0 +1,392 @@
+import Darwin
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct CLIExplicitSurfaceRoutingTests {
+    @Test func explicitSurfaceCommandsDoNotInheritCallerWorkspace() throws {
+        try assertExplicitSurfaceCommand(
+            arguments: ["read-screen", "--surface", Self.targetSurfaceRef, "--lines", "5"],
+            expectedMethod: "surface.read_text"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["send", "--surface", Self.targetSurfaceRef, "hello"],
+            expectedMethod: "surface.send_text",
+            expectedText: "hello"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["send-key", "--surface", Self.targetSurfaceRef, "enter"],
+            expectedMethod: "surface.send_key",
+            expectedKey: "enter"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["send-panel", "--panel", Self.targetSurfaceRef, "hello"],
+            expectedMethod: "surface.send_text",
+            expectedText: "hello"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["send-key-panel", "--panel", Self.targetSurfaceRef, "enter"],
+            expectedMethod: "surface.send_key",
+            expectedKey: "enter"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["capture-pane", "--surface", Self.targetSurfaceRef, "--lines", "5"],
+            expectedMethod: "surface.read_text"
+        )
+        try assertExplicitSurfaceCommand(
+            arguments: ["pipe-pane", "--surface", Self.targetSurfaceRef, "--command", "cat"],
+            expectedMethod: "surface.read_text"
+        )
+    }
+
+    @Test func numericSurfaceHandleStillInheritsCallerWorkspaceForIndexResolution() throws {
+        let socketPath = Self.makeSocketPath("numeric")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "surface.list":
+                return Self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: ["surfaces": [["id": Self.numericSurfaceId, "ref": "surface:5", "index": 5]]]
+                )
+            case "surface.read_text":
+                return Self.v2Response(id: id, ok: true, result: ["text": "numeric screen\n"])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: ["read-screen", "--surface", "5", "--lines", "1"],
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        #expect(result.stdout.contains("numeric screen"), Comment(rawValue: result.stdout))
+
+        let requests = try state.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == ["surface.list", "surface.read_text"])
+
+        let listParams = try #require(requests.first?["params"] as? [String: Any])
+        #expect(listParams["workspace_id"] as? String == Self.callerWorkspaceId)
+
+        let readParams = try #require(requests.last?["params"] as? [String: Any])
+        #expect(readParams["workspace_id"] as? String == Self.callerWorkspaceId)
+        #expect(readParams["surface_id"] as? String == Self.numericSurfaceId)
+    }
+
+    private func assertExplicitSurfaceCommand(
+        arguments: [String],
+        expectedMethod: String,
+        expectedText: String? = nil,
+        expectedKey: String? = nil
+    ) throws {
+        let socketPath = Self.makeSocketPath(expectedMethod)
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "surface.read_text":
+                return Self.v2Response(id: id, ok: true, result: ["text": "agent screen\n"])
+            case "surface.send_text", "surface.send_key":
+                return Self.v2Response(id: id, ok: true, result: ["surface_id": Self.targetSurfaceRef])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: arguments,
+            environment: cliEnvironment(socketPath: socketPath),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+
+        let requests = try state.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == [expectedMethod])
+        let request = try #require(requests.first)
+        let params = try #require(request["params"] as? [String: Any])
+        #expect(params["surface_id"] as? String == Self.targetSurfaceRef)
+        #expect(params["workspace_id"] == nil)
+        #expect(params["window_id"] == nil)
+        if let expectedText {
+            #expect(params["text"] as? String == expectedText)
+        }
+        if let expectedKey {
+            #expect(params["key"] as? String == expectedKey)
+        }
+    }
+
+    private func cliEnvironment(socketPath: String) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = Self.callerWorkspaceId
+        environment["CMUX_SURFACE_ID"] = Self.callerSurfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+        return environment
+    }
+
+    private static let callerWorkspaceId = "11111111-1111-1111-1111-111111111111"
+    private static let callerSurfaceId = "22222222-2222-2222-2222-222222222222"
+    private static let targetSurfaceRef = "surface:11"
+    private static let numericSurfaceId = "33333333-3333-3333-3333-333333333333"
+
+    private final class CLIExplicitSurfaceRoutingBundleToken {}
+
+    // Records socket callbacks from a background queue; `lock` guards both arrays.
+    private final class ServerState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var requestLines: [String] = []
+        private var errors: [String] = []
+
+        func record(_ line: String) {
+            lock.lock()
+            requestLines.append(line)
+            lock.unlock()
+        }
+
+        func recordError(_ message: String) {
+            lock.lock()
+            errors.append(message)
+            lock.unlock()
+        }
+
+        func errorsSnapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return errors
+        }
+
+        func requestObjects() throws -> [[String: Any]] {
+            lock.lock()
+            let lines = requestLines
+            lock.unlock()
+            return try lines.map { line in
+                try #require(CLIExplicitSurfaceRoutingTests.jsonObject(line))
+            }
+        }
+    }
+
+    private struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    private static func bundledCLIPath() throws -> String {
+        try BundledCLITestSupport.bundledCLIPath(for: CLIExplicitSurfaceRoutingBundleToken.self)
+    }
+
+    private static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
+            .path
+    }
+
+    private static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
+            ])
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return fd
+    }
+
+    private static func startMockServer(
+        listenerFD: Int32,
+        state: ServerState,
+        handler: @escaping @Sendable (String) -> String
+    ) -> DispatchSemaphore {
+        let handled = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.signal() }
+
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else {
+                state.recordError("mock socket server failed to accept a client")
+                return
+            }
+            defer { Darwin.close(clientFD) }
+
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    state.recordError("mock socket server read failed with errno \(errno)")
+                    return
+                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.record(line)
+                    let response = handler(line) + "\n"
+                    _ = response.withCString { pointer in
+                        Darwin.write(clientFD, pointer, strlen(pointer))
+                    }
+                }
+            }
+        }
+        return handled
+    }
+
+    private static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private static func malformedRequestResponse(id: String? = nil, raw: String) -> String {
+        v2Response(
+            id: id ?? "unknown",
+            ok: false,
+            error: ["code": "malformed_request", "message": "invalid or non-JSON payload", "raw": raw]
+        )
+    }
+
+    private static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Stop `read-screen`, `send`, `send-key`, and panel send aliases from inheriting the caller workspace when an explicit surface ref/UUID is supplied.
- Keep caller-workspace fallback for omitted surfaces and numeric surface indexes, where workspace scope is needed.
- Add a regression test for explicit `surface:N` CLI routing from a caller surface with ambient `CMUX_WORKSPACE_ID`.

## Reproduction
- Reproduced locally before the fix: `cmux read-screen --surface surface:11 --lines 5` failed with `invalid_params: Surface is not a terminal` when run from another workspace.
- `cmux read-screen --workspace workspace:3 --surface surface:11 --lines 5` succeeded, confirming the explicit surface was being scoped to the wrong caller workspace.
- `cmux send --surface surface:11 " "` hit the same invalid terminal error.

## Verification
- Not run: local tests and local builds per issue instructions; CI is the validation gate for this PR.

Fixes #6598

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784747092&installation_id=133855650&pr_number=6605&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6605&signature=858a2c809a5efca885c37636864de10ad552f211075cc5c48876246d84356abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect CLI routing when an explicit surface or panel ref/UUID is provided. `read-screen`, `capture-pane`, `pipe-pane`, `send`, `send-key`, `send-panel`, and `send-key-panel` now route globally to the target instead of inheriting the caller workspace, fixing #6598.

- **Bug Fixes**
  - Scope `workspace_id` only for numeric or omitted handles; for explicit refs/UUIDs, omit `workspace_id` and `window_id` in RPCs.
  - Resolve numeric handles via `surface.list` within the caller workspace; do not pass `window_id` to `surface.list`.
  - Added tests for all seven commands with explicit refs, plus a numeric-index path test on `read-screen`.

<sup>Written for commit 395029f42204ff2ac156fa60173e73ac361c4b29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI routing for explicit surface and panel commands so workspace/window parameters are included only when appropriate, matching expected behavior for string vs numeric surface handles.
  * Adjusted workspace-argument logic to validate panel input before computing workspace routing, and tightened rules around whether the current workspace may be used.

* **Tests**
  * Added a new serialized CLI routing test suite that uses a mock Unix-socket server to verify outgoing requests for `read-screen`, `send`, `send-key`, `send-panel`, and `send-key-panel`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->