### PR TITLE
Fix Cmd+T opening in home after agent-resume session restore (#6617)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17825	Sources/AppDelegate.swift
 16093	Sources/ContentView.swift
 13952	Sources/TerminalController.swift
-12783	Sources/Workspace.swift
+12828	Sources/Workspace.swift
 12240	Sources/GhosttyTerminalView.swift
 12144	cmuxTests/AppDelegateShortcutRoutingTests.swift
 11929	Sources/Panels/BrowserPanel.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -2,8 +2,8 @@
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
 34366	CLI/cmux.swift
-17830	Sources/AppDelegate.swift
-16117	Sources/ContentView.swift
+17825	Sources/AppDelegate.swift
+16093	Sources/ContentView.swift
 13952	Sources/TerminalController.swift
 12783	Sources/Workspace.swift
 12240	Sources/GhosttyTerminalView.swift
@@ -41,7 +41,7 @@
 2524	cmuxTests/CommandPaletteSearchEngineTests.swift
 2395	Sources/Mobile/MobileHostService.swift
 2328	cmuxTests/CJKIMEInputTests.swift
-2257	Sources/TerminalNotificationStore.swift
+2242	Sources/TerminalNotificationStore.swift
 2233	Sources/TerminalWindowPortal.swift
 2126	cmuxTests/CmuxConfigTests.swift
 2091	cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -155,6 +155,7 @@
 642	cmuxTests/RemoteTmuxControlParserTests.swift
 641	cmuxTests/CommandPaletteNucleoFFITests.swift
 636	Sources/TerminalController+ControlPaneContext.swift
+632	cmuxTests/AgentSessionAutoResumeSwiftTests.swift
 630	Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutWhenClause.swift
 629	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/KeyboardShortcutsSection.swift
 621	cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -189,7 +190,6 @@
 558	Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Config.swift
 552	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/BrowserSection.swift
 549	Sources/Panels/BrowserAutomation.swift
-548	Sources/PaneMemoryGuardrail.swift
 541	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
 540	Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
 539	CLI/CMUXCLI+Themes.swift
@@ -203,7 +203,7 @@
 528	cmuxTests/CLINotifyProcessTestSupport.swift
 528	cmuxUITests/AutomationSocketUITests.swift
 527	CLI/CLISocketPathResolver.swift
-526	Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
+525	Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings.swift
 524	CLI/CMUXCLI+AutoNaming.swift
 523	Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AutomationSection.swift
 520	CLI/CMUXCLI+AmpExtension.swift

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1377,11 +1377,32 @@ extension Workspace {
             } else {
                 surfaceResumeBindingsByPanelId.removeValue(forKey: terminalPanel.id)
             }
+            // A terminal whose startup command cds itself (agent resume, tmux
+            // attach, agent-hook) is spawned without a working directory, so its
+            // shell starts in the default directory and shell integration reports
+            // that directory (typically home) before the startup command cds into
+            // the saved one. Remember the saved directory so the spurious initial
+            // report is ignored instead of overwriting the restored workspace cwd
+            // (#6617). `shouldIgnoreRestoredGuardedDirectoryReport` decides how long
+            // to guard: once while the saved directory still exists, persistently
+            // while it is on an unmounted volume, and not at all once it has been
+            // deleted (the shell's reported cwd is then the real fallback).
+            //
+            // Only guard LOCAL terminals. That guard's existence check stats the
+            // local Mac, so a remote terminal's remote saved path (e.g.
+            // /home/dev/repo) would be misclassified as deleted and its remote
+            // home report wrongly honored. Remote restores keep the prior
+            // behavior (no guard), which matches the original unmounted-volume
+            // guard that was inherently local (/Volumes paths only).
+            let restoredDirectoryIsLocalPath =
+                !restoresRemoteWorkspaceTerminalSnapshot &&
+                restoredRemotePTYSessionID == nil &&
+                snapshot.terminal?.isRemoteTerminal != true
             if startupHandlesWorkingDirectory,
                localWorkingDirectory == nil,
+               restoredDirectoryIsLocalPath,
                let guardedWorkingDirectory = savedWorkingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !guardedWorkingDirectory.isEmpty,
-               Self.unmountedVolumeRoot(for: guardedWorkingDirectory) != nil {
+               !guardedWorkingDirectory.isEmpty {
                 restoredGuardedWorkingDirectoriesByPanelId[terminalPanel.id] = guardedWorkingDirectory
             } else {
                 restoredGuardedWorkingDirectoriesByPanelId.removeValue(forKey: terminalPanel.id)
@@ -4500,23 +4521,47 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         if reportedDirectory == restoredDirectory {
+            // The resumed shell confirmed the restored directory; stop guarding so
+            // later navigation away from it is honored.
             restoredGuardedWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
             return false
         }
 
-        let missingVolumeRoot = Self.unmountedVolumeRoot(for: restoredDirectory)
-        guard missingVolumeRoot != nil else {
-            restoredGuardedWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
-            return false
+        if Self.unmountedVolumeRoot(for: restoredDirectory) != nil {
+            // The restored directory is on an unmounted volume: the resumed shell
+            // fell back to its default directory. Keep ignoring spurious reports
+            // until the volume remounts and the shell reports the restored
+            // directory (#5278). The guard stays registered (persistent).
+#if DEBUG
+            cmuxDebugLog(
+                "session.restore.cwdReport.ignored panel=\(panelId.uuidString.prefix(5)) " +
+                "saved=\(restoredDirectory) reported=\(reportedDirectory)"
+            )
+#endif
+            return true
         }
 
+        // The restored directory is on a mounted volume and differs from the first
+        // report. The resumed shell spawns before its startup command cds, so the
+        // initial report (typically home) is spurious — but ONLY when the restored
+        // directory still exists for that command to cd into. If it was deleted
+        // between sessions the cd fails and the shell's reported directory is the
+        // real fallback location, so honor it instead of stranding
+        // panelDirectories/currentDirectory on the deleted path (which would make
+        // Cmd+T inherit an invalid cwd). Either way this is a one-shot guard. (#6617)
+        restoredGuardedWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
+        var restoredDirectoryIsDirectory: ObjCBool = false
+        let restoredDirectoryStillExists = FileManager.default.fileExists(
+            atPath: restoredDirectory,
+            isDirectory: &restoredDirectoryIsDirectory
+        ) && restoredDirectoryIsDirectory.boolValue
 #if DEBUG
         cmuxDebugLog(
-            "session.restore.cwdReport.ignored panel=\(panelId.uuidString.prefix(5)) " +
-            "missingVolume=\(missingVolumeRoot ?? "") saved=\(restoredDirectory) reported=\(reportedDirectory)"
+            "session.restore.cwdReport.\(restoredDirectoryStillExists ? "ignoredOnce" : "accepted") " +
+            "panel=\(panelId.uuidString.prefix(5)) saved=\(restoredDirectory) reported=\(reportedDirectory)"
         )
 #endif
-        return true
+        return restoredDirectoryStillExists
     }
 
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -101,6 +101,141 @@ struct AgentSessionAutoResumeSwiftTests {
         }
     }
 
+    /// Regression for #6617: after Cmd+Q/restore of a workspace whose focused
+    /// terminal is running an auto-resumed agent in a project directory, the
+    /// resumed shell spawns in its default directory and shell integration
+    /// reports that directory (typically home) before the agent-resume command
+    /// cds into the project. While the project directory still exists that
+    /// spurious live report must not overwrite the restored workspace cwd,
+    /// otherwise Cmd+T opens the next tab in home (~) instead of the project
+    /// directory the agent is in.
+    @MainActor
+    @Test func cmdTAfterAgentResumeRestoreKeepsProjectCwdDespiteSpuriousHomePwdReport() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            UserDefaults.standard.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+            // A real on-disk project directory so the restore guard can confirm it
+            // still exists and treat the resumed shell's home report as spurious.
+            let projectDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-cmdt-resume-project-\(UUID().uuidString)", isDirectory: true)
+                .path
+            try FileManager.default.createDirectory(atPath: projectDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(atPath: projectDir) }
+
+            let (restored, restoredPanelId) = try restoreWorkspaceWithAutoResumedClaudeAgent(
+                savedDirectory: projectDir
+            )
+
+            // The resumed shell starts before its agent-resume command cds, so
+            // shell integration reports home first. Because the project directory
+            // still exists, this spurious live report must be ignored so the
+            // restored project cwd survives.
+            let spuriousHomeReport = FileManager.default.homeDirectoryForCurrentUser.path
+            try #require(spuriousHomeReport != projectDir)
+            restored.updatePanelDirectory(panelId: restoredPanelId, directory: spuriousHomeReport)
+
+            #expect(restored.currentDirectory == projectDir)
+            #expect(restored.panelDirectories[restoredPanelId] == projectDir)
+
+            // Cmd+T must open the new tab in the project directory, not home.
+            let createdPanel = try #require(restored.newTerminalSurfaceInFocusedPane(focus: false))
+            #expect(createdPanel.requestedWorkingDirectory == projectDir)
+        }
+    }
+
+    /// Companion to #6617: when the saved project directory was deleted between
+    /// sessions, the agent-resume `cd` fails and the resumed shell's reported
+    /// (home) directory is the real location, so it must be accepted rather than
+    /// dropped as a spurious post-restore report (which would strand the cwd on
+    /// the deleted path and make Cmd+T inherit an invalid directory).
+    @MainActor
+    @Test func agentResumeRestoreAcceptsHomePwdReportWhenSavedDirectoryWasDeleted() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            UserDefaults.standard.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+            // A saved directory that no longer exists on disk (deleted between
+            // sessions). It is intentionally never created.
+            let deletedDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-cmdt-deleted-project-\(UUID().uuidString)", isDirectory: true)
+                .path
+            #expect(!FileManager.default.fileExists(atPath: deletedDir))
+
+            let (restored, restoredPanelId) = try restoreWorkspaceWithAutoResumedClaudeAgent(
+                savedDirectory: deletedDir
+            )
+
+            // The saved directory is gone, so the shell's reported (home) cwd is
+            // the real fallback location and must be honored, not ignored.
+            let homeReport = FileManager.default.homeDirectoryForCurrentUser.path
+            try #require(homeReport != deletedDir)
+            restored.updatePanelDirectory(panelId: restoredPanelId, directory: homeReport)
+
+            #expect(restored.panelDirectories[restoredPanelId] == homeReport)
+            #expect(restored.currentDirectory == homeReport)
+        }
+    }
+
+    /// Builds a workspace whose focused terminal hosts an auto-resumable Claude
+    /// agent-hook session rooted at `savedDirectory`, snapshots it, and restores
+    /// it into a fresh workspace. Returns the restored workspace and the restored
+    /// focused panel id, asserting the saved directory was replayed onto both the
+    /// workspace cwd and the panel directory.
+    @MainActor
+    private func restoreWorkspaceWithAutoResumedClaudeAgent(
+        savedDirectory: String
+    ) throws -> (workspace: Workspace, panelId: UUID) {
+        let sessionId = "claude-cmdt-resume-\(UUID().uuidString)"
+        let source = Workspace()
+        source.currentDirectory = savedDirectory
+        let sourcePanelId = try #require(source.focusedPanelId)
+
+        let agent = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: sessionId,
+            workingDirectory: savedDirectory,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["/usr/local/bin/claude", "--resume", sessionId],
+                workingDirectory: savedDirectory,
+                environment: [:],
+                capturedAt: 1_777_777_777,
+                source: "process"
+            )
+        )
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(agent, panelId: sourcePanelId)
+
+        let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+            SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                name: "Claude",
+                kind: "claude",
+                command: "{ cd -- '\(savedDirectory)' 2>/dev/null || [ ! -d '\(savedDirectory)' ]; } && 'claude' '--resume' '\(sessionId)'",
+                cwd: savedDirectory,
+                checkpointId: sessionId,
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_777_777_777
+            ),
+        ])
+
+        let snapshot = source.sessionSnapshot(
+            includeScrollback: false,
+            surfaceResumeBindingIndex: bindingIndex
+        )
+        #expect(snapshot.currentDirectory == savedDirectory)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restored.focusedPanelId)
+
+        // Restore replays the persisted directory onto the workspace and panel.
+        #expect(restored.currentDirectory == savedDirectory)
+        #expect(restored.panelDirectories[restoredPanelId] == savedDirectory)
+
+        return (restored, restoredPanelId)
+    }
+
     @MainActor
     @Test func claudeAgentHookResumeBindingIgnoresStaleRestoredAgentSnapshot() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {


### PR DESCRIPTION
## Summary

Fixes #6617 — after Cmd+Q and session restore, **Cmd+T opened the new tab in home (`~`)** instead of the directory the resumed terminal/agent is in. This regressed the #6047 fix (whose Cmd+T workspace-cwd fallback is correct, but was being fed a clobbered value).

## Root cause

The snapshot **does** persist the workspace cwd, and restore **does** replay it onto `currentDirectory` / `panelDirectories`. The directory was being lost *after* restore:

- A terminal whose startup command cds itself — **agent resume, tmux attach, agent-hook** — is intentionally spawned with **no** working directory so it tolerates a since-deleted saved directory (see the `localWorkingDirectory == nil` branch).
- Its shell therefore starts in the **default** directory and shell integration emits a `report_pwd` (OSC-7) for that directory — **typically home** — *before* the resume command cds into the saved one.
- That spurious live report flows `report_pwd → updateSurfaceDirectory → Workspace.updatePanelDirectory(.liveReport)` and **overwrote** the restored `panelDirectories[focused]` and the focused workspace `currentDirectory`.
- Cmd+T's cwd-inheritance fallback (`panelDirectories[source]` → … → `currentDirectory`) then resolved to home.

A fresh (non-restored) terminal doesn't hit this: it's spawned **in** the project directory, so its first report already is the project directory.

The restore path already had a guard (`restoredGuardedWorkingDirectoriesByPanelId`) meant to ignore exactly these spurious post-resume reports — but it only armed when the saved directory was on an **unmounted volume**, so a normal (existing) project directory was left unprotected.

## Fix

- Arm the guard for **every** startup-handles-cwd restore with a non-empty saved directory (not just unmounted volumes).
- `shouldIgnoreRestoredGuardedDirectoryReport` now:
  - clears + allows when the report **matches** the restored directory (shell confirmed it);
  - for an **accessible** directory, **ignores the first mismatched report once** and then stops guarding (so the spurious home report is dropped while the user's own later navigation is honored);
  - keeps the existing **persistent** ignore for unmounted volumes.

This is surgical: only a report that *differs* from the restored directory is suppressed, and only the first one for accessible directories. `savedWorkingDirectory` is the panel's last-known directory, so legitimate same-directory reports (e.g. tmux panes) match and clear the guard immediately.

## Tests

Two-commit structure (red → green):

1. **`test:`** adds `cmdTAfterAgentResumeRestoreKeepsProjectCwdDespiteSpuriousHomePwdReport` in `AgentSessionAutoResumeSwiftTests` (a `.serialized` session-restore suite). It saves a workspace whose focused terminal runs an auto-resumed Claude agent in a project dir, restores it, simulates the resumed shell's spurious home `report_pwd`, and asserts `currentDirectory` survives and a new Cmd+T surface inherits the project directory. **Fails without the fix** (home clobbers the cwd).
2. **`fix:`** the guard change above.

## Localization

No user-facing strings changed (guard logic + a `#if DEBUG` diagnostic only); no `Localizable.xcstrings` updates required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784762405&installation_id=133855650&pr_number=6621&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6621&signature=8a1da0df8d4ddc32208c8ef5c0b0d82d2d03ddbb1da6cfcecfb33a77c6bb7bcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6617: after Cmd+Q and session restore, Cmd+T now opens in the project directory instead of home when resuming terminals whose startup command cds itself (agent resume, tmux attach, agent-hook). The restore path now guards the restored cwd for local terminals, ignoring the first spurious home PWD report and accepting it if the saved directory was deleted.

- **Bug Fixes**
  - Arm cwd guard for all startup-handles-cwd restores on local terminals; ignore the first mismatched report once when the saved dir still exists, persist ignore for unmounted volumes, accept the report if the saved dir was deleted; remote terminals keep prior behavior.
  - Added regression tests for both cases; updated `.github/swift-file-length-budget.tsv`.

<sup>Written for commit 2084b4fd342581203cc06ff903408562945dceb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added regression coverage for auto-resumed agent session restore, verifying the restored working directory stays correct for project vs. home directory cases, including when a saved directory was deleted.

* **Bug Fixes**
  * Improved terminal session restore to better preserve the intended working directory. When startup commands can change cwd, the restore now guards against spurious shell-reported directory updates and correctly falls back if the saved directory is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->