### PR TITLE
Swift 6.3 concurrency warnings: RemoteSession captured-self + a test Sendable flag (slice 1)

### DIFF
--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator+ReverseRelay.swift
@@ -77,8 +77,9 @@ extension RemoteSessionCoordinator {
             process.standardError = stderrPipe
 
             process.terminationHandler = { [weak self] terminated in
-                self?.queue.async {
-                    self?.handleReverseRelayTerminationLocked(process: terminated)
+                guard let self else { return }
+                self.queue.async {
+                    self.handleReverseRelayTerminationLocked(process: terminated)
                 }
             }
 
@@ -148,8 +149,8 @@ extension RemoteSessionCoordinator {
         stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
             switch handle.readAvailableDataOrEndOfFile() {
             case .data(let data):
-                self?.queue.async {
-                    guard let self else { return }
+                guard let self else { return }
+                self.queue.async {
                     if let chunk = String(data: data, encoding: .utf8), !chunk.isEmpty {
                         self.reverseRelayStderrBuffer.append(chunk)
                         if self.reverseRelayStderrBuffer.count > 8192 {

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -397,9 +397,7 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             remotePath: remotePath
         ) { [weak self] update in
             guard let self else { return }
-            self.queue.async {
-                self.handleProxyBrokerUpdateLocked(update)
-            }
+            self.queue.async { self.handleProxyBrokerUpdateLocked(update) }
         }
         proxyLease = lease
     }

--- a/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
+++ b/Packages/macOS/CmuxRemoteSession/Sources/CmuxRemoteSession/Session/RemoteSessionCoordinator.swift
@@ -396,8 +396,9 @@ public final class RemoteSessionCoordinator: @unchecked Sendable {
             configuration: configuration,
             remotePath: remotePath
         ) { [weak self] update in
-            self?.queue.async {
-                self?.handleProxyBrokerUpdateLocked(update)
+            guard let self else { return }
+            self.queue.async {
+                self.handleProxyBrokerUpdateLocked(update)
             }
         }
         proxyLease = lease

--- a/cmuxTests/AppDelegateRenameShortcutContextTests.swift
+++ b/cmuxTests/AppDelegateRenameShortcutContextTests.swift
@@ -35,11 +35,23 @@ private final class ShortcutContextGhosttyCommandEquivalentProbeView: GhosttyNSV
     }
 }
 
-private final class ShortcutNotificationFlag {
-    var wasPosted = false
+/// Lock-guarded flag so it is `Sendable` and can be flipped from the
+/// `@Sendable` NotificationCenter observer block and read back on the main
+/// actor without tripping Swift 6.3 concurrency diagnostics.
+private final class ShortcutNotificationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _wasPosted = false
+
+    var wasPosted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _wasPosted
+    }
 
     func markPosted() {
-        wasPosted = true
+        lock.lock()
+        defer { lock.unlock() }
+        _wasPosted = true
     }
 }
 


### PR DESCRIPTION
Follow-up to #6603 (which moved the macOS CI gates to Xcode 26.x / Swift 6.3). The 6.3 compiler surfaces concurrency/Sendable warnings the 6.1 gate did not. **None are build errors** (the main app + tests are `SWIFT_VERSION = 5.0` with no strict-concurrency; RemoteSession is Swift 6 mode but `@unchecked Sendable`/closure-capture diagnostics there are warnings). This is the first, highest-confidence, behavior-preserving slice.

**⚠️ Do not merge before review/dogfood** — it touches production `CmuxRemoteSession` runtime code.

## Fixed here (11 warnings)

**`CmuxRemoteSession` (3, production)** — `reference to captured var 'self' in concurrently-executing code [#SendableClosureCaptures]` in three Foundation callbacks (`Process.terminationHandler`, the stderr `readabilityHandler`, the proxy-broker update callback). Each dereferenced an optional `[weak self]` twice (outer callback + nested `queue.async`). Fix: bind `self` once with `guard let self` before touching `queue`. `[weak self]` release semantics and the serial-`queue` synchronization contract are unchanged; the `.endOfFile` handler-clearing path is preserved exactly (bind only inside `.data`).

**`cmuxTests/AppDelegateRenameShortcutContextTests` (8)** — `capture of '…' with non-Sendable type 'ShortcutNotificationFlag' in a '@Sendable' closure`. Make the flag `@unchecked Sendable` with an `NSLock`-guarded Bool (the repo's existing test-box idiom). Public API (`wasPosted`, `markPosted()`) unchanged, so no call sites move; one type change clears all 8.

## Remaining (catalogued for follow-up)

A full survey classified ~48 deferred warnings: **0 are RISKY hot-path** (none in `hitTest`/`forceRefresh`/`TabItemView`), but several need per-site judgment or carry submodule/vendor ceremony, so they're intentionally not in this slice:

- **`Sources/AppDelegate.swift` (~20)** — main-actor-isolation / non-Sendable-capture warnings, **all in `CMUX_UI_TEST_*`-gated diagnostic recorders** (`recordFocusedState`, `attemptResolve`, `attemptFocus`, `writeUITestDiagnosticsIfNeeded`, `feedSidebarUITestPush…`, etc.) plus one production `scheduleLaunchServicesBundleRegistration` `@convention(block)` site. Uniform fix is `MainActor.assumeIsolated { … }` (observers register `queue: .main`) or `Task { @MainActor in … }`. Deferred because AppDelegate is typing/focus-sensitive and warrants its own reviewed+dogfooded PR.
- **More `cmuxTests` sites (~13)** — hoist `let id = x.id.uuidString` before `DispatchQueue.global` (TerminalControllerSocketSecurityTests), convert capture-only helpers to `static nonisolated` (TerminalNotification{Caller,Queue}Tests), an `NSLock` counter box (BrowserConfigTests), and `assumeIsolated` for mid-flight-assertion observers (TabManagerSessionSnapshotTests, WorkspacePullRequestSidebarTests, WorkspaceUnitTests). Mechanical but per-site; held back so this PR's test-target delta stays trivially reviewable (the worktree can't resolve the test deps locally, so each is CI-verified).
- **Sparkle `SUAppcastItem(dictionary:)` deprecation (1, `CmuxUpdater/TestSupport`)** — no public non-deprecated initializer in Sparkle 2.8.1 (the designated init needs a private `SPUAppcastItemStateResolver`). Needs a decision: suppress at the call site or refactor the fake to drop the Sparkle-private dependency.
- **`vendor/bonsplit` submodule (4)** — `onChange(of:perform:)` deprecation ×3 (trivial: drop `_ in`, use the zero-arg macOS-14 form) + one nonisolated `bounds` read (mirror the in-file `nonisolated(unsafe)` cache sibling). Needs a submodule branch/push + parent-pointer bump, so it's its own PR.

## Verification

Push runs `swift-package-tests` (covers the RemoteSession change) and the app-host/`tests-build-and-lag` jobs (cover the test-target change) on Xcode 26.x. Expect green with the 11 warnings gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784763155&installation_id=133855650&pr_number=6623&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6623&signature=afc2603ea1c0d3498ee366a0daf7fbf01d922cda7e0dcd9a03d1df5a431aea9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears 11 Swift 6.3 concurrency/Sendable warnings in `CmuxRemoteSession` and tests by binding `self` once before dispatch and making a test flag `Sendable`. No behavior change; keeps Swift 6.3 builds quiet.

- **Bug Fixes**
  - `CmuxRemoteSession`: In `Process.terminationHandler`, stderr `readabilityHandler`, and the proxy-broker update callback, bind `self` with `guard let self` before `queue.async`; preserves `[weak self]` semantics and `.endOfFile` behavior.
  - Tests: `ShortcutNotificationFlag` in `AppDelegateRenameShortcutContextTests` is now `@unchecked Sendable` via an `NSLock`-guarded Bool; API unchanged and clears 8 Sendable-capture warnings.
  - CI: Xcode 26.x/Swift 6.3 jobs pass with these warnings removed.

- **Refactors**
  - `RemoteSessionCoordinator`: Collapsed the proxy-broker `queue.async` body to one line to stay within the Swift file-length budget; no behavior change.

<sup>Written for commit f544c1286db67a59a261c180d16745e811ac296d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session coordination so asynchronous callbacks safely stop when the coordinator is no longer available, avoiding unnecessary queued work.
  * Tightened reverse relay and stderr handling to ensure scheduled buffer processing only occurs when the relevant session object is still alive.
* **Tests**
  * Strengthened concurrency correctness in shortcut context tests by using a lock-guarded flag to track notification state reliably under Swift concurrency diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->