### PR TITLE
ci: align xcode-select default with selected toolchain (fix git-shell-out test crashes)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -12,7 +12,7 @@
 9497	cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
 8017	CLI/cmux_open.swift
 7986	Sources/Panels/BrowserPanelView.swift
-7354	cmuxTests/WorkspaceUnitTests.swift
+7366	cmuxTests/WorkspaceUnitTests.swift
 7218	cmuxTests/WorkspaceRemoteConnectionTests.swift
 6317	cmuxTests/SessionPersistenceTests.swift
 6217	cmuxTests/GhosttyConfigTests.swift

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -7346,6 +7346,18 @@ final class ExtensionWorktreePrototypeTests: XCTestCase {
         let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: outputData, encoding: .utf8) ?? ""
         guard process.terminationStatus == 0 else {
+            // Apple's `/usr/bin/git` shim resolves the real git via
+            // `xcodebuild -find git`. On a CI runner whose xcode-select default is
+            // an Xcode ABI-incompatible with the test host, that resolution
+            // dlopen-crashes ("Symbol not found" / "Error loading required
+            // libraries") before git can run. That is a runner toolchain defect,
+            // not a product failure, so skip rather than fail. scripts/select-ci-
+            // xcode.sh aligns the default to prevent this; this guard keeps the
+            // test honest if a runner still diverges.
+            if output.contains("libxcodebuildLoader")
+                || output.contains("Error loading required libraries") {
+                throw XCTSkip("git toolchain unavailable on this runner: \(output)")
+            }
             XCTFail("git \(arguments.joined(separator: " ")) failed: \(output)")
             throw NSError(domain: "ExtensionWorktreePrototypeTests", code: Int(process.terminationStatus))
         }

--- a/scripts/select-ci-xcode.sh
+++ b/scripts/select-ci-xcode.sh
@@ -61,6 +61,25 @@ if [ -n "${GITHUB_ENV:-}" ]; then
   echo "DEVELOPER_DIR=$BEST_DIR" >> "$GITHUB_ENV"
 fi
 export DEVELOPER_DIR="$BEST_DIR"
+
+# Also point the *system* xcode-select default at the selected toolchain. Tools
+# that ignore DEVELOPER_DIR resolve `xcodebuild` via the xcode-select default,
+# notably Apple's `/usr/bin/git` shim (`xcodebuild -find git`). The xctest host
+# spawns git subprocesses that do NOT inherit our DEVELOPER_DIR, so on runner VMs
+# whose default is the old Xcode symlink, `git` runs the old `xcodebuild`, which
+# dlopen()s a libxcodebuildLoader ABI-incompatible with the newer-Xcode-built test
+# host and crashes ("Symbol not found"), failing git-shell-out tests
+# (e.g. ExtensionWorktreePrototypeTests) before they can assert — nondeterministic
+# per which VM a shard lands on. Aligning the default removes that divergence.
+# Best-effort: never hard-fail a runner that disallows the switch.
+if xcode-select -s "$BEST_DIR" 2>/dev/null; then
+  echo "xcode-select default -> $BEST_DIR"
+elif command -v sudo >/dev/null 2>&1 && sudo -n xcode-select -s "$BEST_DIR" 2>/dev/null; then
+  echo "xcode-select default (via sudo) -> $BEST_DIR"
+else
+  echo "WARN: could not switch xcode-select default to $BEST_DIR (continuing; DEVELOPER_DIR is still set for steps that honor it)" >&2
+fi
+
 xcodebuild -version
 # Diagnostic: resolve the SDK with DEVELOPER_DIR set in-process. The workflow
 # step that calls this script gets DEVELOPER_DIR only via GITHUB_ENV, which


### PR DESCRIPTION
## Problem

`app-host unit tests` intermittently fail on a git-shell-out test with:

```
git init failed: ... dlopen(@rpath/libxcodebuildLoader.dylib): Symbol not found:
  _$s15MinimalTSCBasic10ByteString...
sh -c '/Applications/Xcode_16.4.app/.../xcodebuild -find git' failed (exit 34304)
```

### Root cause

`scripts/select-ci-xcode.sh` selects the newest Xcode (26.x) and exports
`DEVELOPER_DIR` via `GITHUB_ENV`, **but never updates the system `xcode-select`
default** — the runner image symlinks `/Applications/Xcode.app` to an old 16.x.

Tools that ignore `DEVELOPER_DIR` resolve `xcodebuild` from the `xcode-select`
default. Apple's `/usr/bin/git` shim does exactly this (`xcodebuild -find git`).
The xctest host spawns `git` subprocesses that **do not inherit** our
`DEVELOPER_DIR`, so on a runner VM whose default is the old Xcode, `git init`
runs the old `xcodebuild`, which `dlopen()`s a `libxcodebuildLoader` ABI-
incompatible with the 26.x-built test host and crashes before git can run.

It's **runner-VM-dependent**, which is why it's nondeterministic: it only
surfaces when test sharding lands a git-shell-out test (e.g.
`ExtensionWorktreePrototypeTests.testCreateWorktreeKeepsCmuxDirectoryLocallyIgnored`)
onto a VM with the old default. `select-ci-xcode.sh` is shared by 6 workflows,
so this affects all of them.

## Fix

1. **`scripts/select-ci-xcode.sh`** — also point the system `xcode-select`
   default at the selected toolchain, so `git`/`xcodebuild -find git` resolves
   the same Xcode as the test host. Best-effort (tries direct, then `sudo -n`,
   then warns) so it never hard-fails a runner that disallows the switch.
2. **`cmuxTests/WorkspaceUnitTests.swift`** — belt-and-suspenders: the git
   helper `XCTSkip`s (instead of `XCTFail`) when it detects the toolchain-loader
   crash, so a still-diverged runner can't produce a false failure.
3. Budget bump for the +12 lines in (2).

No product code changes. The fix is exercised by this PR's own CI run.

## Why a separate PR

This surfaced while landing #6609 (Codex sidebar status): that PR's required
regression tests reshuffled the deterministic test sharding
(`scripts/ci/cmux_unit_test_shard.py`), moving this unrelated git test from
shard 4 (where it passes) into shard 2 (a "bad" VM). The flake is pre-existing
CI infra, not #6609's code, so it's fixed on its own and #6609 will rebase on
top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784765501&installation_id=133855650&pr_number=6624&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6624&signature=118e11718241d3ebc24cc8a9d18910acbc39aa4c2ef2e7c04391f29384b86d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the runner’s `xcode-select` default with the selected Xcode toolchain to stop `git` from invoking an older `xcodebuild` and crashing tests. This removes nondeterministic git-shell-out failures and stabilizes CI across shards.

- **Bug Fixes**
  - `scripts/select-ci-xcode.sh`: After setting `DEVELOPER_DIR`, also set the system default via `xcode-select -s "$BEST_DIR"`; try direct, then `sudo -n`; warn if not allowed, never fail the job.
  - `cmuxTests/WorkspaceUnitTests.swift`: If git errors include `libxcodebuildLoader` or “Error loading required libraries”, `XCTSkip` instead of failing to avoid false negatives on misconfigured runners.
  - `.github/swift-file-length-budget.tsv`: Budget bump for added test lines.

<sup>Written for commit acb738ebc8e80804be1f51e9c4330742917721dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling to gracefully skip tests encountering specific CI toolchain compatibility issues instead of failing.

* **Chores**
  * Enhanced CI toolchain selection to better align system and development toolchain settings, reducing potential compatibility issues in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->