### PR TITLE
Fix sidebar tab selection highlight timing

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13761,7 +13761,6 @@ struct TabItemView: View, Equatable {
             tabManager.selectedTabIdPublisher
                 .map { $0 == tab.id }
                 .removeDuplicates()
-                .receive(on: RunLoop.main)
         ) { isSelected in
             updateObservedActiveState(isSelected)
         }


### PR DESCRIPTION
## Summary

Closes #6626

Fixes the vertical-tab visual regression where selecting a workspace paints in two visible phases: first the translucent multi-selected background, then the solid active selected background a moment later.

## Regression provenance

The last known-good tag is `v0.64.16` (`e647c3049c03786299d81f3c287571373d635269`). Diff/blame against HEAD points to `5ea81da1a5` / PR #6460 (`Fix title-churn beachball in transcript adoption and sidebar rows`) as the selection-highlight regression source.

That PR intentionally moved active workspace selection out of the `VerticalTabsSidebar` parent and into row-local `TabItemView` state so a selected-workspace change only invalidates the previous and new rows instead of every row under the `ForEach`. The problem was the row-local state pipeline added `.receive(on: RunLoop.main)`, while the click path still updates `selectedTabIds` synchronously. On a normal click, the row first rendered as merely multi-selected (`opacity: 0.25`), then the scheduled active-state update arrived and repainted the solid selected fill (`opacity: 1`).

## Fix

`TabManager` is `@MainActor` and sends `selectedTabIdPublisher` from its selected-workspace will-change hook, so the row-local active-state update is already main-thread delivered. Removing the extra run-loop scheduler hop keeps #6460's scoped two-row invalidation, but lets the active-state change settle in the same interaction transaction as the sidebar selection set. The selected row now paints the solid selection highlight immediately in one phase.

## Verification

- `git diff --check`
- Inspected `v0.64.16..HEAD` diffs/blame for `ContentView.swift`, `SidebarAppearanceSupport.swift`, and `TabManager.swift`.
- No regression test added: this is a SwiftUI frame-ordering/visual timing bug, and a meaningful behavioral test would require an app/UI runtime build. A source-shape test would not prove the user-visible flash is fixed.
- No local/cloud app build or launch was run per the issue handoff instructions; the sanctioned dev build is intentionally deferred until CI is green and the user explicitly asks for it.

## Localization

No user-facing strings were added or changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784767418&installation_id=133855650&pr_number=6627&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6627&signature=da6b47b134eefedc9fc41bdacd425ba9d8a0d68a954723288baa7ac3eda29662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar vertical-tab highlight lag that briefly shows a translucent highlight before the solid active state when selecting a workspace (fixes #6626). Removes the extra `.receive(on: RunLoop.main)` in `TabItemView` so `TabManager`’s main-thread `selectedTabIdPublisher` updates the active state in the same interaction, preventing the two-phase paint.

<sup>Written for commit e22a1acb0a2c1af5ad878d3f57218d4cad978b0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab switching responsiveness by optimizing how selection state updates are processed, reducing unnecessary duplicate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->