### PR TITLE
Fix Inline VS Code auth persistence

### DIFF
--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -362,14 +362,12 @@ nonisolated struct VSCodeCLILaunchConfiguration {
 nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
     static let portEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_PORT"
     static let dataDirectoryEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_DATA_DIR"
-    static let extraArgumentsEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_ARGS"
     static let portDefaultsKey = "vscodeServeWeb.port"
 
     let port: Int
     let serverDataDirectoryURL: URL
     let userDataDirectoryURL: URL
     let connectionTokenFileURL: URL
-    let extraArguments: [String]
     let allowsEphemeralPortFallback: Bool
 
     var arguments: [String] {
@@ -389,7 +387,6 @@ nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
         arguments.append(contentsOf: [
             "--connection-token-file", connectionTokenFileURL.path,
         ])
-        arguments.append(contentsOf: extraArguments)
         return arguments
     }
 
@@ -421,7 +418,7 @@ nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
             )
         } catch {
             vscodeServeWebLogger.error(
-                "Failed to create VS Code serve-web directories serverDataDir=\(serverDataDirectoryURL.path, privacy: .public) userDataDir=\(userDataDirectoryURL.path, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+                "Failed to create VS Code serve-web directories: \(error.localizedDescription, privacy: .private)"
             )
             return nil
         }
@@ -442,7 +439,6 @@ nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
             serverDataDirectoryURL: serverDataDirectoryURL,
             userDataDirectoryURL: userDataDirectoryURL,
             connectionTokenFileURL: connectionTokenFileURL,
-            extraArguments: extraArguments(from: environment[extraArgumentsEnvironmentKey]),
             allowsEphemeralPortFallback: portResolution.allowsEphemeralFallback
         )
     }
@@ -454,7 +450,6 @@ nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
             serverDataDirectoryURL: serverDataDirectoryURL,
             userDataDirectoryURL: userDataDirectoryURL,
             connectionTokenFileURL: connectionTokenFileURL,
-            extraArguments: extraArguments,
             allowsEphemeralPortFallback: false
         )
     }
@@ -561,27 +556,13 @@ nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
         guard let attributes = try? fileManager.attributesOfItem(atPath: tokenFileURL.path),
               let fileSize = attributes[.size] as? NSNumber,
               fileSize.intValue == 32,
+              let permissions = attributes[.posixPermissions] as? NSNumber,
+              permissions.intValue & 0o777 == 0o600,
               let data = try? Data(contentsOf: tokenFileURL),
               let token = String(data: data, encoding: .utf8) else {
             return false
         }
         return token.range(of: #"^[0-9A-Fa-f]{32}$"#, options: .regularExpression) != nil
-    }
-
-    private static func extraArguments(from rawValue: String?) -> [String] {
-        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !rawValue.isEmpty else {
-            return []
-        }
-
-        if let data = rawValue.data(using: .utf8),
-           let decoded = try? JSONDecoder().decode([String].self, from: data) {
-            return decoded.filter { !$0.isEmpty }
-        }
-
-        return rawValue
-            .split(whereSeparator: { $0.isWhitespace })
-            .map(String.init)
     }
 
     private static func expandedHomePath(_ path: String) -> String {

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -4,6 +4,12 @@ import AppKit
 import CmuxCommandPalette
 import Darwin
 import Foundation
+import os
+
+nonisolated private let vscodeServeWebLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "vscode.serve-web"
+)
 
 enum FinderServicePathResolver {
     private static func canonicalDirectoryPath(_ path: String) -> String {
@@ -326,7 +332,7 @@ enum VSCodeServeWebURLBuilder {
     }
 }
 
-struct VSCodeCLILaunchConfiguration {
+nonisolated struct VSCodeCLILaunchConfiguration {
     let executableURL: URL
     let argumentsPrefix: [String]
     let environment: [String: String]
@@ -353,7 +359,7 @@ struct VSCodeCLILaunchConfiguration {
     }
 }
 
-struct VSCodeServeWebLaunchOptions: Equatable {
+nonisolated struct VSCodeServeWebLaunchOptions: Equatable {
     static let portEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_PORT"
     static let dataDirectoryEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_DATA_DIR"
     static let extraArgumentsEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_ARGS"
@@ -414,6 +420,9 @@ struct VSCodeServeWebLaunchOptions: Equatable {
                 withIntermediateDirectories: true
             )
         } catch {
+            vscodeServeWebLogger.error(
+                "Failed to create VS Code serve-web directories serverDataDir=\(serverDataDirectoryURL.path, privacy: .public) userDataDir=\(userDataDirectoryURL.path, privacy: .public) error=\(error.localizedDescription, privacy: .public)"
+            )
             return nil
         }
 
@@ -511,7 +520,10 @@ struct VSCodeServeWebLaunchOptions: Equatable {
             isDirectory: false
         )
         if fileManager.fileExists(atPath: tokenFileURL.path) {
-            return tokenFileURL
+            if isUsableConnectionTokenFile(tokenFileURL, fileManager: fileManager) {
+                return tokenFileURL
+            }
+            try? fileManager.removeItem(at: tokenFileURL)
         }
 
         let token = randomConnectionToken()
@@ -519,7 +531,10 @@ struct VSCodeServeWebLaunchOptions: Equatable {
 
         let fileDescriptor = open(tokenFileURL.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
         if fileDescriptor < 0 {
-            return fileManager.fileExists(atPath: tokenFileURL.path) ? tokenFileURL : nil
+            return fileManager.fileExists(atPath: tokenFileURL.path)
+                && isUsableConnectionTokenFile(tokenFileURL, fileManager: fileManager)
+                ? tokenFileURL
+                : nil
         }
         defer { _ = close(fileDescriptor) }
 
@@ -537,6 +552,20 @@ struct VSCodeServeWebLaunchOptions: Equatable {
 
     private static func randomConnectionToken() -> String {
         UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
+    private static func isUsableConnectionTokenFile(
+        _ tokenFileURL: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: tokenFileURL.path),
+              let fileSize = attributes[.size] as? NSNumber,
+              fileSize.intValue == 32,
+              let data = try? Data(contentsOf: tokenFileURL),
+              let token = String(data: data, encoding: .utf8) else {
+            return false
+        }
+        return token.range(of: #"^[0-9A-Fa-f]{32}$"#, options: .regularExpression) != nil
     }
 
     private static func extraArguments(from rawValue: String?) -> [String] {
@@ -739,47 +768,15 @@ final class VSCodeServeWebController {
     private let launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)?
     private var serveWebProcess: Process?
     private var launchingProcess: Process?
-    private var connectionTokenFilesByProcessID: [ObjectIdentifier: URL] = [:]
     private var serveWebURL: URL?
     private var pendingCompletions: [(generation: UInt64, completion: (URL?) -> Void)] = []
     private var isLaunching = false
     private var activeLaunchGeneration: UInt64?
     private var lifecycleGeneration: UInt64 = 0
-#if DEBUG
-    private var testingTrackedProcesses: [Process] = []
-#endif
 
-    private init(launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)? = nil) {
+    init(launchProcessOverride: ((URL, UInt64) -> (process: Process, url: URL)?)? = nil) {
         self.launchProcessOverride = launchProcessOverride
     }
-
-#if DEBUG
-    static func makeForTesting(
-        launchProcessOverride: @escaping (URL, UInt64) -> (process: Process, url: URL)?
-    ) -> VSCodeServeWebController {
-        VSCodeServeWebController(launchProcessOverride: launchProcessOverride)
-    }
-
-    func trackConnectionTokenFileForTesting(
-        _ connectionTokenFileURL: URL,
-        setAsLaunchingProcess: Bool = false,
-        setAsServeWebProcess: Bool = false
-    ) {
-        let process = Process()
-        queue.sync {
-            if setAsLaunchingProcess {
-                self.launchingProcess = process
-            }
-            if setAsServeWebProcess {
-                self.serveWebProcess = process
-            }
-            if !setAsLaunchingProcess && !setAsServeWebProcess {
-                self.testingTrackedProcesses.append(process)
-            }
-            self.connectionTokenFilesByProcessID[ObjectIdentifier(process)] = connectionTokenFileURL
-        }
-    }
-#endif
 
     func ensureServeWebURL(vscodeApplicationURL: URL, completion: @escaping (URL?) -> Void) {
         queue.async {
@@ -867,7 +864,7 @@ final class VSCodeServeWebController {
     }
 
     func stop() {
-        let (processes, tokenFileURLs, completions): ([Process], [URL], [(URL?) -> Void]) = queue.sync {
+        let (processes, completions): ([Process], [(URL?) -> Void]) = queue.sync {
             self.lifecycleGeneration &+= 1
             self.isLaunching = false
             self.activeLaunchGeneration = nil
@@ -881,22 +878,10 @@ final class VSCodeServeWebController {
             }
             self.serveWebProcess = nil
             self.launchingProcess = nil
-#if DEBUG
-            self.testingTrackedProcesses.removeAll()
-#endif
-            var tokenFileURLs = processes.compactMap {
-                self.connectionTokenFilesByProcessID.removeValue(forKey: ObjectIdentifier($0))
-            }
-            tokenFileURLs.append(contentsOf: self.connectionTokenFilesByProcessID.values)
-            self.connectionTokenFilesByProcessID.removeAll()
             self.serveWebURL = nil
             let completions = self.pendingCompletions.map(\.completion)
             self.pendingCompletions.removeAll()
-            return (processes, tokenFileURLs, completions)
-        }
-
-        for tokenFileURL in tokenFileURLs {
-            Self.removeConnectionTokenFile(at: tokenFileURL)
+            return (processes, completions)
         }
 
         for process in processes where process.isRunning {
@@ -935,6 +920,8 @@ final class VSCodeServeWebController {
             vscodeApplicationURL: vscodeApplicationURL
         ) else { return nil }
 
+        // Use the child-process environment so CMUX_* overrides that survive
+        // nodeSafeEnvironment are also honored by serve-web option resolution.
         guard let launchOptions = VSCodeServeWebLaunchOptions.resolve(
             environment: launchConfiguration.environment
         ) else { return nil }
@@ -996,11 +983,6 @@ final class VSCodeServeWebController {
                     self.serveWebProcess = nil
                     self.serveWebURL = nil
                 }
-                if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
-                    forKey: ObjectIdentifier(terminatedProcess)
-                ) {
-                    Self.removeConnectionTokenFile(at: tokenFileURL)
-                }
             }
         }
 
@@ -1016,11 +998,6 @@ final class VSCodeServeWebController {
             } catch {
                 if self.launchingProcess === process {
                     self.launchingProcess = nil
-                }
-                if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
-                    forKey: ObjectIdentifier(process)
-                ) {
-                    Self.removeConnectionTokenFile(at: tokenFileURL)
                 }
                 return false
             }
@@ -1046,11 +1023,6 @@ final class VSCodeServeWebController {
                         self.serveWebProcess = nil
                         self.serveWebURL = nil
                     }
-                    if let tokenFileURL = self.connectionTokenFilesByProcessID.removeValue(
-                        forKey: ObjectIdentifier(process)
-                    ) {
-                        Self.removeConnectionTokenFile(at: tokenFileURL)
-                    }
                 }
             }
             return nil
@@ -1068,10 +1040,6 @@ final class VSCodeServeWebController {
                 return
             }
         }
-    }
-
-    private static func removeConnectionTokenFile(at url: URL) {
-        try? FileManager.default.removeItem(at: url)
     }
 
     private static func urlsShareLoopbackOrigin(_ lhs: URL, _ rhs: URL?) -> Bool {

--- a/Sources/App/TerminalDirectoryOpenSupport.swift
+++ b/Sources/App/TerminalDirectoryOpenSupport.swift
@@ -330,6 +330,248 @@ struct VSCodeCLILaunchConfiguration {
     let executableURL: URL
     let argumentsPrefix: [String]
     let environment: [String: String]
+    let usesCodeTunnelWrapper: Bool
+    let supportsUserDataDirectoryArgument: Bool
+
+    func processArguments(for launchOptions: VSCodeServeWebLaunchOptions) -> [String] {
+        argumentsPrefix + launchOptions.arguments(
+            includeUserDataDirectory: supportsUserDataDirectoryArgument
+        )
+    }
+
+    func processEnvironment(for launchOptions: VSCodeServeWebLaunchOptions) -> [String: String] {
+        var processEnvironment = environment
+        if usesCodeTunnelWrapper {
+            processEnvironment["VSCODE_CLI_USE_FILE_KEYRING"] = "1"
+            if processEnvironment["VSCODE_CLI_DATA_DIR"]?.isEmpty ?? true {
+                processEnvironment["VSCODE_CLI_DATA_DIR"] = launchOptions.serverDataDirectoryURL
+                    .appendingPathComponent("cli-data", isDirectory: true)
+                    .path
+            }
+        }
+        return processEnvironment
+    }
+}
+
+struct VSCodeServeWebLaunchOptions: Equatable {
+    static let portEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_PORT"
+    static let dataDirectoryEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_DATA_DIR"
+    static let extraArgumentsEnvironmentKey = "CMUX_VSCODE_SERVE_WEB_ARGS"
+    static let portDefaultsKey = "vscodeServeWeb.port"
+
+    let port: Int
+    let serverDataDirectoryURL: URL
+    let userDataDirectoryURL: URL
+    let connectionTokenFileURL: URL
+    let extraArguments: [String]
+    let allowsEphemeralPortFallback: Bool
+
+    var arguments: [String] {
+        arguments(includeUserDataDirectory: true)
+    }
+
+    func arguments(includeUserDataDirectory: Bool) -> [String] {
+        var arguments = [
+            "--accept-server-license-terms",
+            "--host", "127.0.0.1",
+            "--port", String(port),
+            "--server-data-dir", serverDataDirectoryURL.path,
+        ]
+        if includeUserDataDirectory {
+            arguments.append(contentsOf: ["--user-data-dir", userDataDirectoryURL.path])
+        }
+        arguments.append(contentsOf: [
+            "--connection-token-file", connectionTokenFileURL.path,
+        ])
+        arguments.append(contentsOf: extraArguments)
+        return arguments
+    }
+
+    static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        applicationSupportDirectoryURL: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> VSCodeServeWebLaunchOptions? {
+        guard let serverDataDirectoryURL = resolveServerDataDirectoryURL(
+            environment: environment,
+            bundleIdentifier: bundleIdentifier,
+            applicationSupportDirectoryURL: applicationSupportDirectoryURL
+        ) else { return nil }
+        let userDataDirectoryURL = serverDataDirectoryURL.appendingPathComponent("user-data", isDirectory: true)
+
+        do {
+            try fileManager.createDirectory(
+                at: serverDataDirectoryURL,
+                withIntermediateDirectories: true
+            )
+            try fileManager.createDirectory(
+                at: userDataDirectoryURL,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            return nil
+        }
+
+        guard let connectionTokenFileURL = ensureConnectionTokenFile(
+            in: serverDataDirectoryURL,
+            fileManager: fileManager
+        ) else { return nil }
+
+        let portResolution = resolvePort(
+            environment: environment,
+            defaults: defaults,
+            bundleIdentifier: bundleIdentifier
+        )
+
+        return VSCodeServeWebLaunchOptions(
+            port: portResolution.port,
+            serverDataDirectoryURL: serverDataDirectoryURL,
+            userDataDirectoryURL: userDataDirectoryURL,
+            connectionTokenFileURL: connectionTokenFileURL,
+            extraArguments: extraArguments(from: environment[extraArgumentsEnvironmentKey]),
+            allowsEphemeralPortFallback: portResolution.allowsEphemeralFallback
+        )
+    }
+
+    func ephemeralPortFallback() -> VSCodeServeWebLaunchOptions? {
+        guard allowsEphemeralPortFallback else { return nil }
+        return VSCodeServeWebLaunchOptions(
+            port: 0,
+            serverDataDirectoryURL: serverDataDirectoryURL,
+            userDataDirectoryURL: userDataDirectoryURL,
+            connectionTokenFileURL: connectionTokenFileURL,
+            extraArguments: extraArguments,
+            allowsEphemeralPortFallback: false
+        )
+    }
+
+    private static func resolveServerDataDirectoryURL(
+        environment: [String: String],
+        bundleIdentifier: String?,
+        applicationSupportDirectoryURL: URL?
+    ) -> URL? {
+        if let rawPath = environment[dataDirectoryEnvironmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !rawPath.isEmpty {
+            return URL(fileURLWithPath: expandedHomePath(rawPath), isDirectory: true)
+        }
+
+        guard let applicationSupportDirectoryURL else { return nil }
+        let namespace = normalizedNamespace(bundleIdentifier)
+        return applicationSupportDirectoryURL
+            .appendingPathComponent(namespace, isDirectory: true)
+            .appendingPathComponent("vscode-serve-web", isDirectory: true)
+    }
+
+    private static func resolvePort(
+        environment: [String: String],
+        defaults: UserDefaults,
+        bundleIdentifier: String?
+    ) -> (port: Int, allowsEphemeralFallback: Bool) {
+        if let rawPort = environment[portEnvironmentKey],
+           let port = Int(rawPort),
+           isValidPort(port) {
+            return (port, false)
+        }
+
+        let storedPort = defaults.integer(forKey: portDefaultsKey)
+        if isValidPort(storedPort) {
+            return (storedPort, true)
+        }
+
+        let port = defaultStablePort(bundleIdentifier)
+        defaults.set(port, forKey: portDefaultsKey)
+        return (port, true)
+    }
+
+    private static func defaultStablePort(_ bundleIdentifier: String?) -> Int {
+        let identifier = bundleIdentifier?.isEmpty == false ? bundleIdentifier! : "cmux"
+        let dynamicPortStart = 49152
+        let dynamicPortCount = 16384
+        let offset = identifier.unicodeScalars.reduce(0) { partial, scalar in
+            (partial &* 31 &+ Int(scalar.value)) % dynamicPortCount
+        }
+        return dynamicPortStart + offset
+    }
+
+    private static func isValidPort(_ port: Int) -> Bool {
+        port > 0 && port <= 65535
+    }
+
+    private static func ensureConnectionTokenFile(
+        in serverDataDirectoryURL: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        let tokenFileURL = serverDataDirectoryURL.appendingPathComponent(
+            "connection-token",
+            isDirectory: false
+        )
+        if fileManager.fileExists(atPath: tokenFileURL.path) {
+            return tokenFileURL
+        }
+
+        let token = randomConnectionToken()
+        guard let tokenData = token.data(using: .utf8) else { return nil }
+
+        let fileDescriptor = open(tokenFileURL.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
+        if fileDescriptor < 0 {
+            return fileManager.fileExists(atPath: tokenFileURL.path) ? tokenFileURL : nil
+        }
+        defer { _ = close(fileDescriptor) }
+
+        let wroteAllBytes = tokenData.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return false }
+            return write(fileDescriptor, baseAddress, rawBuffer.count) == rawBuffer.count
+        }
+        guard wroteAllBytes else {
+            try? fileManager.removeItem(at: tokenFileURL)
+            return nil
+        }
+
+        return tokenFileURL
+    }
+
+    private static func randomConnectionToken() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
+    private static func extraArguments(from rawValue: String?) -> [String] {
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else {
+            return []
+        }
+
+        if let data = rawValue.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            return decoded.filter { !$0.isEmpty }
+        }
+
+        return rawValue
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+    }
+
+    private static func expandedHomePath(_ path: String) -> String {
+        guard path == "~" || path.hasPrefix("~/") else { return path }
+        let homePath = FileManager.default.homeDirectoryForCurrentUser.path
+        if path == "~" {
+            return homePath
+        }
+        return homePath + String(path.dropFirst())
+    }
+
+    private static func normalizedNamespace(_ bundleIdentifier: String?) -> String {
+        guard let bundleIdentifier,
+              !bundleIdentifier.isEmpty else {
+            return "cmux"
+        }
+        return bundleIdentifier
+            .replacingOccurrences(of: "[^A-Za-z0-9.-]", with: "-", options: .regularExpression)
+    }
 }
 
 enum VSCodeCLILaunchConfigurationBuilder {
@@ -356,6 +598,19 @@ enum VSCodeCLILaunchConfigurationBuilder {
     ) -> VSCodeCLILaunchConfiguration? {
         let contentsURL = vscodeApplicationURL.appendingPathComponent("Contents", isDirectory: true)
         let environment = nodeSafeEnvironment(from: baseEnvironment)
+        let codeTunnelURL = contentsURL.appendingPathComponent("Resources/app/bin/code-tunnel", isDirectory: false)
+
+        if isExecutableAtPath(codeTunnelURL.path) {
+            var codeTunnelEnvironment = environment
+            codeTunnelEnvironment["ELECTRON_RUN_AS_NODE"] = "1"
+            return VSCodeCLILaunchConfiguration(
+                executableURL: codeTunnelURL,
+                argumentsPrefix: ["serve-web"],
+                environment: codeTunnelEnvironment,
+                usesCodeTunnelWrapper: true,
+                supportsUserDataDirectoryArgument: false
+            )
+        }
 
         if let codeServerURL = preferredCachedCodeServerURL(
             contentsURL: contentsURL,
@@ -370,20 +625,13 @@ enum VSCodeCLILaunchConfigurationBuilder {
             return VSCodeCLILaunchConfiguration(
                 executableURL: codeServerURL,
                 argumentsPrefix: [],
-                environment: codeServerEnvironment
+                environment: codeServerEnvironment,
+                usesCodeTunnelWrapper: false,
+                supportsUserDataDirectoryArgument: true
             )
         }
 
-        let codeTunnelURL = contentsURL.appendingPathComponent("Resources/app/bin/code-tunnel", isDirectory: false)
-        guard isExecutableAtPath(codeTunnelURL.path) else { return nil }
-        var codeTunnelEnvironment = environment
-        codeTunnelEnvironment["ELECTRON_RUN_AS_NODE"] = "1"
-
-        return VSCodeCLILaunchConfiguration(
-            executableURL: codeTunnelURL,
-            argumentsPrefix: ["serve-web"],
-            environment: codeTunnelEnvironment
-        )
+        return nil
     }
 
     private static func nodeSafeEnvironment(from baseEnvironment: [String: String]) -> [String: String] {
@@ -687,19 +935,32 @@ final class VSCodeServeWebController {
             vscodeApplicationURL: vscodeApplicationURL
         ) else { return nil }
 
-        guard let connectionTokenFileURL = Self.makeConnectionTokenFile() else {
-            return nil
-        }
+        guard let launchOptions = VSCodeServeWebLaunchOptions.resolve(
+            environment: launchConfiguration.environment
+        ) else { return nil }
 
+        let launchOptionCandidates = [launchOptions] + [launchOptions.ephemeralPortFallback()].compactMap { $0 }
+        for launchOptions in launchOptionCandidates {
+            if let launchResult = launchServeWebProcess(
+                launchConfiguration: launchConfiguration,
+                launchOptions: launchOptions,
+                expectedGeneration: expectedGeneration
+            ) {
+                return launchResult
+            }
+        }
+        return nil
+    }
+
+    private func launchServeWebProcess(
+        launchConfiguration: VSCodeCLILaunchConfiguration,
+        launchOptions: VSCodeServeWebLaunchOptions,
+        expectedGeneration: UInt64
+    ) -> (process: Process, url: URL)? {
         let process = Process()
         process.executableURL = launchConfiguration.executableURL
-        process.arguments = launchConfiguration.argumentsPrefix + [
-            "--accept-server-license-terms",
-            "--host", "127.0.0.1",
-            "--port", "0",
-            "--connection-token-file", connectionTokenFileURL.path,
-        ]
-        process.environment = launchConfiguration.environment
+        process.arguments = launchConfiguration.processArguments(for: launchOptions)
+        process.environment = launchConfiguration.processEnvironment(for: launchOptions)
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
@@ -749,7 +1010,6 @@ final class VSCodeServeWebController {
                 return false
             }
             self.launchingProcess = process
-            self.connectionTokenFilesByProcessID[ObjectIdentifier(process)] = connectionTokenFileURL
             do {
                 try process.run()
                 return true
@@ -768,7 +1028,6 @@ final class VSCodeServeWebController {
         guard didStart else {
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            Self.removeConnectionTokenFile(at: connectionTokenFileURL)
             return nil
         }
 
@@ -809,33 +1068,6 @@ final class VSCodeServeWebController {
                 return
             }
         }
-    }
-
-    private static func randomConnectionToken() -> String {
-        UUID().uuidString.replacingOccurrences(of: "-", with: "")
-    }
-
-    private static func makeConnectionTokenFile() -> URL? {
-        let token = randomConnectionToken()
-        let tokenFileName = "cmux-vscode-token-\(UUID().uuidString)"
-        let tokenFileURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent(tokenFileName, isDirectory: false)
-        guard let tokenData = token.data(using: .utf8) else { return nil }
-
-        let fileDescriptor = open(tokenFileURL.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
-        guard fileDescriptor >= 0 else { return nil }
-        defer { _ = close(fileDescriptor) }
-
-        let wroteAllBytes = tokenData.withUnsafeBytes { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress else { return false }
-            return write(fileDescriptor, baseAddress, rawBuffer.count) == rawBuffer.count
-        }
-        guard wroteAllBytes else {
-            removeConnectionTokenFile(at: tokenFileURL)
-            return nil
-        }
-
-        return tokenFileURL
     }
 
     private static func removeConnectionTokenFile(at url: URL) {

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -396,6 +396,16 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
         return try body(defaults)
     }
 
+    private func assertCmuxGeneratedToken(_ data: Data, file: StaticString = #filePath, line: UInt = #line) throws {
+        let token = try XCTUnwrap(String(data: data, encoding: .utf8), file: file, line: line)
+        XCTAssertNotNil(
+            token.range(of: #"^[0-9A-Fa-f]{32}$"#, options: .regularExpression),
+            "Expected a 32-character hexadecimal token, got \(token)",
+            file: file,
+            line: line
+        )
+    }
+
     func testResolveCreatesStableDataDirectoryPortAndTokenFile() throws {
         try withTemporaryDirectory { appSupportURL in
             try withDefaults { defaults in
@@ -415,6 +425,7 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
                 ))
                 let secondTokenData = try Data(contentsOf: second.connectionTokenFileURL)
 
+                try assertCmuxGeneratedToken(firstTokenData)
                 XCTAssertEqual(first.port, second.port)
                 XCTAssertTrue(first.allowsEphemeralPortFallback)
                 XCTAssertEqual(first.ephemeralPortFallback()?.port, 0)
@@ -476,6 +487,54 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
                 XCTAssertEqual(options.connectionTokenFileURL.deletingLastPathComponent().path, dataDirectoryURL.path)
                 XCTAssertEqual(options.extraArguments, ["--future-flag", "value with spaces"])
                 XCTAssertEqual(Array(options.arguments.suffix(2)), ["--future-flag", "value with spaces"])
+            }
+        }
+    }
+
+    func testResolveReusesValidConnectionTokenFile() throws {
+        try withTemporaryDirectory { rootURL in
+            let dataDirectoryURL = rootURL.appendingPathComponent("valid-token", isDirectory: true)
+            try FileManager.default.createDirectory(at: dataDirectoryURL, withIntermediateDirectories: true)
+            let tokenFileURL = dataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false)
+            let existingToken = "0123456789abcdef0123456789ABCDEF"
+            try Data(existingToken.utf8).write(to: tokenFileURL)
+
+            let options = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
+                applicationSupportDirectoryURL: rootURL
+            ))
+            let tokenData = try Data(contentsOf: options.connectionTokenFileURL)
+
+            XCTAssertEqual(options.connectionTokenFileURL, tokenFileURL)
+            XCTAssertEqual(String(data: tokenData, encoding: .utf8), existingToken)
+        }
+    }
+
+    func testResolveReplacesInvalidConnectionTokenFiles() throws {
+        let invalidTokens = [
+            "",
+            "partial",
+            String(repeating: "0", count: 31),
+            String(repeating: "0", count: 33),
+            String(repeating: "g", count: 32),
+        ]
+
+        try withTemporaryDirectory { rootURL in
+            for (index, invalidToken) in invalidTokens.enumerated() {
+                let dataDirectoryURL = rootURL.appendingPathComponent("invalid-token-\(index)", isDirectory: true)
+                try FileManager.default.createDirectory(at: dataDirectoryURL, withIntermediateDirectories: true)
+                let tokenFileURL = dataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false)
+                try Data(invalidToken.utf8).write(to: tokenFileURL)
+
+                let options = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
+                    applicationSupportDirectoryURL: rootURL
+                ))
+                let tokenData = try Data(contentsOf: options.connectionTokenFileURL)
+
+                XCTAssertEqual(options.connectionTokenFileURL, tokenFileURL)
+                try assertCmuxGeneratedToken(tokenData)
+                XCTAssertNotEqual(String(data: tokenData, encoding: .utf8), invalidToken)
             }
         }
     }

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -321,8 +321,10 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
             port: 64120,
             serverDataDirectoryURL: serverDataDirectoryURL,
             userDataDirectoryURL: serverDataDirectoryURL.appendingPathComponent("user-data", isDirectory: true),
-            connectionTokenFileURL: serverDataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false),
-            extraArguments: [],
+            connectionTokenFileURL: serverDataDirectoryURL.appendingPathComponent(
+                "connection-token",
+                isDirectory: false
+            ),
             allowsEphemeralPortFallback: true
         )
 
@@ -459,7 +461,7 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
         }
     }
 
-    func testResolveUsesEnvironmentOverridesAndJsonExtraArguments() throws {
+    func testResolveUsesEnvironmentOverrides() throws {
         try withTemporaryDirectory { rootURL in
             try withDefaults { defaults in
                 defaults.set(5555, forKey: VSCodeServeWebLaunchOptions.portDefaultsKey)
@@ -469,7 +471,6 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
                     environment: [
                         VSCodeServeWebLaunchOptions.portEnvironmentKey: "8123",
                         VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path,
-                        VSCodeServeWebLaunchOptions.extraArgumentsEnvironmentKey: #"["--future-flag","value with spaces"]"#,
                     ],
                     defaults: defaults,
                     bundleIdentifier: "dev.cmux.test",
@@ -485,8 +486,6 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
                     dataDirectoryURL.appendingPathComponent("user-data", isDirectory: true).path
                 )
                 XCTAssertEqual(options.connectionTokenFileURL.deletingLastPathComponent().path, dataDirectoryURL.path)
-                XCTAssertEqual(options.extraArguments, ["--future-flag", "value with spaces"])
-                XCTAssertEqual(Array(options.arguments.suffix(2)), ["--future-flag", "value with spaces"])
             }
         }
     }
@@ -498,11 +497,15 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
             let tokenFileURL = dataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false)
             let existingToken = "0123456789abcdef0123456789ABCDEF"
             try Data(existingToken.utf8).write(to: tokenFileURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenFileURL.path)
 
-            let options = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
-                environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
-                applicationSupportDirectoryURL: rootURL
-            ))
+            let options = try withDefaults { defaults in
+                try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
+                    defaults: defaults,
+                    applicationSupportDirectoryURL: rootURL
+                ))
+            }
             let tokenData = try Data(contentsOf: options.connectionTokenFileURL)
 
             XCTAssertEqual(options.connectionTokenFileURL, tokenFileURL)
@@ -525,17 +528,44 @@ final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
                 try FileManager.default.createDirectory(at: dataDirectoryURL, withIntermediateDirectories: true)
                 let tokenFileURL = dataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false)
                 try Data(invalidToken.utf8).write(to: tokenFileURL)
+                try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenFileURL.path)
 
-                let options = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
-                    environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
-                    applicationSupportDirectoryURL: rootURL
-                ))
+                let options = try withDefaults { defaults in
+                    try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                        environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
+                        defaults: defaults,
+                        applicationSupportDirectoryURL: rootURL
+                    ))
+                }
                 let tokenData = try Data(contentsOf: options.connectionTokenFileURL)
 
                 XCTAssertEqual(options.connectionTokenFileURL, tokenFileURL)
                 try assertCmuxGeneratedToken(tokenData)
                 XCTAssertNotEqual(String(data: tokenData, encoding: .utf8), invalidToken)
             }
+
+            let dataDirectoryURL = rootURL.appendingPathComponent("group-readable-token", isDirectory: true)
+            try FileManager.default.createDirectory(at: dataDirectoryURL, withIntermediateDirectories: true)
+            let tokenFileURL = dataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false)
+            let groupReadableToken = String(repeating: "0", count: 32)
+            try Data(groupReadableToken.utf8).write(to: tokenFileURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: tokenFileURL.path)
+
+            let options = try withDefaults { defaults in
+                try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path],
+                    defaults: defaults,
+                    applicationSupportDirectoryURL: rootURL
+                ))
+            }
+            let tokenData = try Data(contentsOf: options.connectionTokenFileURL)
+
+            XCTAssertEqual(options.connectionTokenFileURL, tokenFileURL)
+            try assertCmuxGeneratedToken(tokenData)
+            XCTAssertNotEqual(String(data: tokenData, encoding: .utf8), groupReadableToken)
+            let attributes = try FileManager.default.attributesOfItem(atPath: tokenFileURL.path)
+            let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+            XCTAssertEqual(permissions.intValue & 0o777, 0o600)
         }
     }
 }

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -594,7 +594,7 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         let launchCallLock = NSLock()
         var launchCallCount = 0
 
-        let controller = VSCodeServeWebController.makeForTesting { _, _ in
+        let controller = VSCodeServeWebController { _, _ in
             launchCallLock.lock()
             launchCallCount += 1
             let callNumber = launchCallCount
@@ -652,22 +652,6 @@ final class VSCodeServeWebControllerTests: XCTestCase {
         XCTAssertEqual(launchCalls, 2)
     }
 
-    func testStopRemovesOrphanedConnectionTokenFiles() throws {
-        let tokenFileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: tokenFileURL) }
-        try Data("token".utf8).write(to: tokenFileURL)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: tokenFileURL.path))
-
-        let controller = VSCodeServeWebController.makeForTesting { _, _ in
-            XCTFail("Expected no launch")
-            return nil
-        }
-        controller.trackConnectionTokenFileForTesting(tokenFileURL)
-
-        controller.stop()
-
-        XCTAssertFalse(FileManager.default.fileExists(atPath: tokenFileURL.path))
-    }
 }
 
 final class OmnibarStateMachineTests: XCTestCase {

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -219,7 +219,37 @@ final class VSCodeServeWebURLBuilderTests: XCTestCase {
 
 
 final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
-    func testLaunchConfigurationPrefersCachedCodeServerOverCodeTunnelWrapper() {
+    func testLaunchConfigurationPrefersCodeTunnelWrapperOverCachedCodeServer() {
+        let appURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
+        let codeTunnelPath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
+        let cachedCodeServerPath = "/Users/tester/.vscode/cli/serve-web/server-new/bin/code-server"
+
+        let configuration = VSCodeCLILaunchConfigurationBuilder.launchConfiguration(
+            vscodeApplicationURL: appURL,
+            homeDirectoryURL: URL(fileURLWithPath: "/Users/tester", isDirectory: true),
+            baseEnvironment: [
+                "ELECTRON_RUN_AS_NODE": "stale",
+            ],
+            isExecutableAtPath: { $0 == codeTunnelPath || $0 == cachedCodeServerPath },
+            dataAtURL: { _ in
+                XCTFail("Expected code-tunnel wrapper selection to skip cached serve-web discovery")
+                return nil
+            },
+            contentsOfDirectoryAtURL: { _ in
+                XCTFail("Expected code-tunnel wrapper selection to skip cached serve-web discovery")
+                return []
+            },
+            contentModificationDateAtURL: { _ in nil }
+        )
+
+        XCTAssertEqual(configuration?.executableURL.path, codeTunnelPath)
+        XCTAssertEqual(configuration?.argumentsPrefix, ["serve-web"])
+        XCTAssertEqual(configuration?.environment["ELECTRON_RUN_AS_NODE"], "1")
+        XCTAssertEqual(configuration?.usesCodeTunnelWrapper, true)
+        XCTAssertEqual(configuration?.supportsUserDataDirectoryArgument, false)
+    }
+
+    func testLaunchConfigurationFallsBackToCachedCodeServerWhenCodeTunnelIsMissing() {
         let appURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
         let productURL = appURL.appendingPathComponent("Contents/Resources/app/product.json", isDirectory: false)
         let cacheURL = URL(fileURLWithPath: "/Users/tester/.vscode/cli/serve-web", isDirectory: true)
@@ -233,7 +263,7 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
             baseEnvironment: [
                 "ELECTRON_RUN_AS_NODE": "stale",
             ],
-            isExecutableAtPath: { $0 == codeTunnelPath || $0 == expectedExecutablePath },
+            isExecutableAtPath: { $0 != codeTunnelPath && $0 == expectedExecutablePath },
             dataAtURL: { url in
                 if url == productURL {
                     return Data(#"{"dataFolderName": ".vscode"}"#.utf8)
@@ -253,9 +283,11 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
         XCTAssertEqual(configuration?.executableURL.path, expectedExecutablePath)
         XCTAssertEqual(configuration?.argumentsPrefix, [])
         XCTAssertNil(configuration?.environment["ELECTRON_RUN_AS_NODE"])
+        XCTAssertEqual(configuration?.usesCodeTunnelWrapper, false)
+        XCTAssertEqual(configuration?.supportsUserDataDirectoryArgument, true)
     }
 
-    func testLaunchConfigurationFallsBackToCodeTunnelBinary() {
+    func testLaunchConfigurationUsesCodeTunnelBinaryWhenNoCacheExists() {
         let appURL = URL(fileURLWithPath: "/Applications/Visual Studio Code.app", isDirectory: true)
         let expectedExecutablePath = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
 
@@ -272,6 +304,43 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
         XCTAssertEqual(configuration?.executableURL.path, expectedExecutablePath)
         XCTAssertEqual(configuration?.argumentsPrefix, ["serve-web"])
         XCTAssertEqual(configuration?.environment["ELECTRON_RUN_AS_NODE"], "1")
+        XCTAssertEqual(configuration?.usesCodeTunnelWrapper, true)
+        XCTAssertEqual(configuration?.supportsUserDataDirectoryArgument, false)
+    }
+
+    func testCodeTunnelProcessLaunchEnablesFileKeyringWithoutUnsupportedUserDataArgument() {
+        let configuration = VSCodeCLILaunchConfiguration(
+            executableURL: URL(fileURLWithPath: "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"),
+            argumentsPrefix: ["serve-web"],
+            environment: [:],
+            usesCodeTunnelWrapper: true,
+            supportsUserDataDirectoryArgument: false
+        )
+        let serverDataDirectoryURL = URL(fileURLWithPath: "/tmp/cmux-vscode/server-data", isDirectory: true)
+        let launchOptions = VSCodeServeWebLaunchOptions(
+            port: 64120,
+            serverDataDirectoryURL: serverDataDirectoryURL,
+            userDataDirectoryURL: serverDataDirectoryURL.appendingPathComponent("user-data", isDirectory: true),
+            connectionTokenFileURL: serverDataDirectoryURL.appendingPathComponent("connection-token", isDirectory: false),
+            extraArguments: [],
+            allowsEphemeralPortFallback: true
+        )
+
+        let arguments = configuration.processArguments(for: launchOptions)
+        let environment = configuration.processEnvironment(for: launchOptions)
+
+        XCTAssertEqual(Array(arguments.prefix(2)), ["serve-web", "--accept-server-license-terms"])
+        XCTAssertTrue(arguments.contains("--server-data-dir"))
+        XCTAssertTrue(arguments.contains(serverDataDirectoryURL.path))
+        XCTAssertTrue(arguments.contains("--connection-token-file"))
+        XCTAssertFalse(arguments.contains("--user-data-dir"))
+        XCTAssertFalse(arguments.contains(launchOptions.userDataDirectoryURL.path))
+        XCTAssertEqual(environment["VSCODE_CLI_USE_FILE_KEYRING"], "1")
+        XCTAssertEqual(
+            environment["VSCODE_CLI_DATA_DIR"],
+            serverDataDirectoryURL.appendingPathComponent("cli-data", isDirectory: true).path
+        )
+        XCTAssertNil(environment["VSCODE_CLI_DISABLE_KEYCHAIN_ENCRYPT"])
     }
 
     func testLaunchConfigurationMapsNodeEnvironmentVariables() {
@@ -306,6 +375,109 @@ final class VSCodeCLILaunchConfigurationBuilderTests: XCTestCase {
         XCTAssertEqual(configuration?.environment["PATH"], "/usr/bin:/bin")
         XCTAssertNil(configuration?.environment["VSCODE_NODE_OPTIONS"])
         XCTAssertNil(configuration?.environment["VSCODE_NODE_REPL_EXTERNAL_MODULE"])
+    }
+}
+
+final class VSCodeServeWebLaunchOptionsTests: XCTestCase {
+    private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-vscode-serve-web-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        return try body(root)
+    }
+
+    private func withDefaults<T>(_ body: (UserDefaults) throws -> T) throws -> T {
+        let suiteName = "cmux-vscode-serve-web-tests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        return try body(defaults)
+    }
+
+    func testResolveCreatesStableDataDirectoryPortAndTokenFile() throws {
+        try withTemporaryDirectory { appSupportURL in
+            try withDefaults { defaults in
+                let first = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [:],
+                    defaults: defaults,
+                    bundleIdentifier: "dev.cmux.test",
+                    applicationSupportDirectoryURL: appSupportURL
+                ))
+                let firstTokenData = try Data(contentsOf: first.connectionTokenFileURL)
+
+                let second = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [:],
+                    defaults: defaults,
+                    bundleIdentifier: "dev.cmux.test",
+                    applicationSupportDirectoryURL: appSupportURL
+                ))
+                let secondTokenData = try Data(contentsOf: second.connectionTokenFileURL)
+
+                XCTAssertEqual(first.port, second.port)
+                XCTAssertTrue(first.allowsEphemeralPortFallback)
+                XCTAssertEqual(first.ephemeralPortFallback()?.port, 0)
+                XCTAssertEqual(defaults.integer(forKey: VSCodeServeWebLaunchOptions.portDefaultsKey), first.port)
+                XCTAssertEqual(
+                    first.serverDataDirectoryURL.path,
+                    appSupportURL
+                        .appendingPathComponent("dev.cmux.test", isDirectory: true)
+                        .appendingPathComponent("vscode-serve-web", isDirectory: true)
+                        .path
+                )
+                XCTAssertEqual(
+                    first.userDataDirectoryURL.path,
+                    first.serverDataDirectoryURL.appendingPathComponent("user-data", isDirectory: true).path
+                )
+                XCTAssertTrue(FileManager.default.fileExists(atPath: first.userDataDirectoryURL.path))
+                XCTAssertEqual(first.connectionTokenFileURL, second.connectionTokenFileURL)
+                XCTAssertEqual(first.connectionTokenFileURL.lastPathComponent, "connection-token")
+                XCTAssertEqual(firstTokenData, secondTokenData)
+                XCTAssertTrue(first.arguments.contains("--server-data-dir"))
+                XCTAssertTrue(first.arguments.contains(first.serverDataDirectoryURL.path))
+                XCTAssertTrue(first.arguments.contains("--user-data-dir"))
+                XCTAssertTrue(first.arguments.contains(first.userDataDirectoryURL.path))
+                XCTAssertTrue(first.arguments.contains("--connection-token-file"))
+                XCTAssertTrue(first.arguments.contains(first.connectionTokenFileURL.path))
+                XCTAssertTrue(first.arguments.contains("--port"))
+                XCTAssertTrue(first.arguments.contains(String(first.port)))
+                XCTAssertFalse(first.arguments(includeUserDataDirectory: false).contains("--user-data-dir"))
+                XCTAssertFalse(first.arguments(includeUserDataDirectory: false).contains(first.userDataDirectoryURL.path))
+            }
+        }
+    }
+
+    func testResolveUsesEnvironmentOverridesAndJsonExtraArguments() throws {
+        try withTemporaryDirectory { rootURL in
+            try withDefaults { defaults in
+                defaults.set(5555, forKey: VSCodeServeWebLaunchOptions.portDefaultsKey)
+                let dataDirectoryURL = rootURL.appendingPathComponent("custom data", isDirectory: true)
+
+                let options = try XCTUnwrap(VSCodeServeWebLaunchOptions.resolve(
+                    environment: [
+                        VSCodeServeWebLaunchOptions.portEnvironmentKey: "8123",
+                        VSCodeServeWebLaunchOptions.dataDirectoryEnvironmentKey: dataDirectoryURL.path,
+                        VSCodeServeWebLaunchOptions.extraArgumentsEnvironmentKey: #"["--future-flag","value with spaces"]"#,
+                    ],
+                    defaults: defaults,
+                    bundleIdentifier: "dev.cmux.test",
+                    applicationSupportDirectoryURL: rootURL
+                ))
+
+                XCTAssertEqual(options.port, 8123)
+                XCTAssertFalse(options.allowsEphemeralPortFallback)
+                XCTAssertNil(options.ephemeralPortFallback())
+                XCTAssertEqual(options.serverDataDirectoryURL.path, dataDirectoryURL.path)
+                XCTAssertEqual(
+                    options.userDataDirectoryURL.path,
+                    dataDirectoryURL.appendingPathComponent("user-data", isDirectory: true).path
+                )
+                XCTAssertEqual(options.connectionTokenFileURL.deletingLastPathComponent().path, dataDirectoryURL.path)
+                XCTAssertEqual(options.extraArguments, ["--future-flag", "value with spaces"])
+                XCTAssertEqual(Array(options.arguments.suffix(2)), ["--future-flag", "value with spaces"])
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Prefer VS Code's `code-tunnel serve-web` wrapper for Inline VS Code launches so auth/settings use the CLI keyring path instead of direct cached `code-server`.
- Keep the cached `code-server` fallback for installs where the wrapper is unavailable.
- Use stable serve-web server data/token/CLI data paths, while omitting unsupported wrapper-only args.

Closes #6595

## Test plan

- `git diff --check`
- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-fix-6595-inline-vscode-auth-persistence -only-testing:cmuxTests/VSCodeServeWebURLBuilderTests -only-testing:cmuxTests/VSCodeCLILaunchConfigurationBuilderTests -only-testing:cmuxTests/VSCodeServeWebLaunchOptionsTests -only-testing:cmuxTests/ServeWebOutputCollectorTests -only-testing:cmuxTests/VSCodeServeWebControllerTests`
- `./scripts/reload.sh --tag fix-6595-vscode`
- Live verification: the tagged app launched `code-tunnel serve-web` on its stable per-bundle port; GitHub auth persisted across reload, folder changes/open again, and app relaunch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784769981&installation_id=133855650&pr_number=6628&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6628&signature=9079d1ffe4846d718e58b98fbf785324c369b582ca2595d33967e523e5a4f386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Inline VS Code auth persistence by launching via VS Code’s `code-tunnel serve-web` wrapper, with a fallback to cached `code-server`. Auth and settings now persist across reloads using a stable data dir/port and a validated, persistent connection token.

- **Bug Fixes**
  - Prefer `code-tunnel serve-web`; fall back to cached `code-server` only if the wrapper is missing.
  - Enable the CLI file keyring in wrapper mode by setting `VSCODE_CLI_USE_FILE_KEYRING=1` and defaulting `VSCODE_CLI_DATA_DIR` to `<server-data>/cli-data` when unset; set `ELECTRON_RUN_AS_NODE=1` for the wrapper.
  - Use a stable server data dir under Application Support (or `CMUX_VSCODE_SERVE_WEB_DATA_DIR`) with a `user-data` subdir and `connection-token`; validate 32‑hex tokens and 0600 perms, reuse if valid, replace if invalid.
  - Compute a stable default port (stored in `vscodeServeWeb.port`), allow `CMUX_VSCODE_SERVE_WEB_PORT` override, and try an ephemeral port if the chosen port fails.
  - Normalize args/env per launcher: omit unsupported `--user-data-dir` in wrapper mode; include it for `code-server`.
  - Add tests for wrapper preference, env overrides, env/arg mapping, stable data/port selection, and invalid token handling.
  - Closes #6595.

<sup>Written for commit 89fa654fd68a7a7fe07a0cd94df5cb9e95d7d542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced VS Code web (serve-web) startup with more reliable port resolution, including controlled retry with an ephemeral port when needed.
  * Improved determination of server and user-data directories, creating required paths automatically.
  * More robust connection-token handling: validate existing tokens and safely recreate invalid ones; improved launch and failure behavior without unnecessary cleanup.
  * Refined code-tunnel vs cached code-server selection and adjusted command-line and environment shaping accordingly.
* **Tests**
  * Updated and expanded coverage for launch selection, argument/environment construction, option resolution, and controller lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


