### PR TITLE
Allow m4r notification sound files

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+NotificationSoundTypes.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+NotificationSoundTypes.swift
@@ -1,0 +1,15 @@
+import UniformTypeIdentifiers
+
+extension AppSection {
+    static var customNotificationSoundAllowedContentTypes: [UTType] {
+        [
+            UTType(filenameExtension: "aiff"),
+            UTType(filenameExtension: "wav"),
+            UTType(filenameExtension: "caf"),
+            UTType(filenameExtension: "m4a"),
+            UTType(filenameExtension: "m4r"),
+            UTType.mpeg4Audio,
+            UTType(filenameExtension: "mp3"),
+        ].compactMap { $0 }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+NotificationSoundTypes.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+NotificationSoundTypes.swift
@@ -1,7 +1,7 @@
 import UniformTypeIdentifiers
 
 extension AppSection {
-    static var customNotificationSoundAllowedContentTypes: [UTType] {
+    static let customNotificationSoundAllowedContentTypes: [UTType] = {
         [
             UTType(filenameExtension: "aiff"),
             UTType(filenameExtension: "wav"),
@@ -11,5 +11,5 @@ extension AppSection {
             UTType.mpeg4Audio,
             UTType(filenameExtension: "mp3"),
         ].compactMap { $0 }
-    }
+    }()
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -111,6 +111,15 @@ public struct AppSection: View {
 
     private static let columnWidth: CGFloat = 196
     private static let notificationSoundControlWidth: CGFloat = 280
+    static var customNotificationSoundAllowedContentTypes: [UTType] {
+        [
+            UTType(filenameExtension: "aiff"),
+            UTType(filenameExtension: "wav"),
+            UTType(filenameExtension: "caf"),
+            UTType(filenameExtension: "m4a"),
+            UTType(filenameExtension: "mp3"),
+        ].compactMap { $0 }
+    }
 
     /// Languages legacy `AppLanguage` exposes (cmuxApp.swift line
     /// 4338). The shared `CmuxSettings.AppLanguage` adds `.vi` for a
@@ -800,13 +809,7 @@ public struct AppSection: View {
         panel.canChooseDirectories = false
         panel.canChooseFiles = true
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [
-            UTType(filenameExtension: "aiff"),
-            UTType(filenameExtension: "wav"),
-            UTType(filenameExtension: "caf"),
-            UTType(filenameExtension: "m4a"),
-            UTType(filenameExtension: "mp3"),
-        ].compactMap { $0 }
+        panel.allowedContentTypes = Self.customNotificationSoundAllowedContentTypes
         panel.title = String(localized: "settings.notifications.sound.custom.panelTitle", defaultValue: "Choose Notification Sound")
         if panel.runModal() == .OK, let url = panel.url {
             model.set(url.path)

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -2,7 +2,6 @@ import AppKit
 import CmuxFoundation
 import CmuxSettings
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// **App** section — mirrors the legacy in-app section row-for-row
 /// inside a single `SettingsCard`: Language, Appearance, App Icon,
@@ -111,17 +110,6 @@ public struct AppSection: View {
 
     private static let columnWidth: CGFloat = 196
     private static let notificationSoundControlWidth: CGFloat = 280
-    static var customNotificationSoundAllowedContentTypes: [UTType] {
-        [
-            UTType(filenameExtension: "aiff"),
-            UTType(filenameExtension: "wav"),
-            UTType(filenameExtension: "caf"),
-            UTType(filenameExtension: "m4a"),
-            UTType(filenameExtension: "m4r"),
-            UTType.mpeg4Audio,
-            UTType(filenameExtension: "mp3"),
-        ].compactMap { $0 }
-    }
 
     /// Languages legacy `AppLanguage` exposes (cmuxApp.swift line
     /// 4338). The shared `CmuxSettings.AppLanguage` adds `.vi` for a

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -117,6 +117,8 @@ public struct AppSection: View {
             UTType(filenameExtension: "wav"),
             UTType(filenameExtension: "caf"),
             UTType(filenameExtension: "m4a"),
+            UTType(filenameExtension: "m4r"),
+            UTType.mpeg4Audio,
             UTType(filenameExtension: "mp3"),
         ].compactMap { $0 }
     }

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
@@ -1,0 +1,20 @@
+import Testing
+import UniformTypeIdentifiers
+
+@testable import CmuxSettingsUI
+
+@MainActor
+@Suite struct AppSectionNotificationSoundTests {
+    @Test func customSoundPickerAllowsM4RFiles() throws {
+        let ringtoneType = try #require(UTType(filenameExtension: "m4r"))
+        let allowedTypes = AppSection.customNotificationSoundAllowedContentTypes
+
+        #expect(allowedTypes.contains { allowedType in
+            ringtoneType == allowedType || ringtoneType.conforms(to: allowedType)
+        })
+    }
+
+    @Test func customSoundPickerAllowsMPEG4AudioFamily() {
+        #expect(AppSection.customNotificationSoundAllowedContentTypes.contains(.mpeg4Audio))
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
@@ -5,10 +5,8 @@ import UniformTypeIdentifiers
 
 @MainActor
 @Suite struct AppSectionNotificationSoundTests {
-    @Test func customSoundPickerAllowsM4RFilesWhenSystemTypeIsAvailable() {
-        guard let ringtoneType = UTType(filenameExtension: "m4r") else {
-            return
-        }
+    @Test func customSoundPickerAllowsM4RFiles() throws {
+        let ringtoneType = try #require(UTType(filenameExtension: "m4r"))
         let allowedTypes = AppSection.customNotificationSoundAllowedContentTypes
 
         #expect(allowedTypes.contains { allowedType in

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/AppSectionNotificationSoundTests.swift
@@ -5,8 +5,10 @@ import UniformTypeIdentifiers
 
 @MainActor
 @Suite struct AppSectionNotificationSoundTests {
-    @Test func customSoundPickerAllowsM4RFiles() throws {
-        let ringtoneType = try #require(UTType(filenameExtension: "m4r"))
+    @Test func customSoundPickerAllowsM4RFilesWhenSystemTypeIsAvailable() {
+        guard let ringtoneType = UTType(filenameExtension: "m4r") else {
+            return
+        }
         let allowedTypes = AppSection.customNotificationSoundAllowedContentTypes
 
         #expect(allowedTypes.contains { allowedType in

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1025,6 +1025,7 @@ final class NotificationDockBadgeTests: XCTestCase {
             ("mp3", "caf"),
             ("M4A", "caf"),
             ("m4r", "caf"),
+            ("M4R", "caf"),
             ("wav", "wav"),
             ("AIFF", "aiff"),
         ].forEach { sourceExtension, stagedExtension in

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1021,19 +1021,22 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomUnsupportedExtensionsStageAsCaf() {
-        [
-            ("mp3", "caf"),
-            ("M4A", "caf"),
-            ("m4r", "caf"),
-            ("M4R", "caf"),
-            ("wav", "wav"),
-            ("AIFF", "aiff"),
-        ].forEach { sourceExtension, stagedExtension in
-            XCTAssertEqual(
-                NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: sourceExtension),
-                stagedExtension
-            )
-        }
+        XCTAssertEqual(
+            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "mp3"),
+            "caf"
+        )
+        XCTAssertEqual(
+            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "M4A"),
+            "caf"
+        )
+        XCTAssertEqual(
+            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "wav"),
+            "wav"
+        )
+        XCTAssertEqual(
+            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "AIFF"),
+            "aiff"
+        )
 
         let sourceA = URL(fileURLWithPath: "/tmp/custom-a.mp3")
         let sourceB = URL(fileURLWithPath: "/tmp/custom-b.mp3")

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1030,6 +1030,10 @@ final class NotificationDockBadgeTests: XCTestCase {
             "caf"
         )
         XCTAssertEqual(
+            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "m4r"),
+            "caf"
+        )
+        XCTAssertEqual(
             NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "wav"),
             "wav"
         )

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1021,26 +1021,18 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomUnsupportedExtensionsStageAsCaf() {
-        XCTAssertEqual(
-            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "mp3"),
-            "caf"
-        )
-        XCTAssertEqual(
-            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "M4A"),
-            "caf"
-        )
-        XCTAssertEqual(
-            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "m4r"),
-            "caf"
-        )
-        XCTAssertEqual(
-            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "wav"),
-            "wav"
-        )
-        XCTAssertEqual(
-            NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: "AIFF"),
-            "aiff"
-        )
+        [
+            ("mp3", "caf"),
+            ("M4A", "caf"),
+            ("m4r", "caf"),
+            ("wav", "wav"),
+            ("AIFF", "aiff"),
+        ].forEach { sourceExtension, stagedExtension in
+            XCTAssertEqual(
+                NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: sourceExtension),
+                stagedExtension
+            )
+        }
 
         let sourceA = URL(fileURLWithPath: "/tmp/custom-a.mp3")
         let sourceB = URL(fileURLWithPath: "/tmp/custom-b.mp3")

--- a/cmuxTests/NotificationSoundSettingsTests.swift
+++ b/cmuxTests/NotificationSoundSettingsTests.swift
@@ -36,6 +36,11 @@ import Testing
         #expect(NotificationSoundSettings.stagedSystemSoundName(for: NotificationSoundSettings.customFileValue) == nil)
     }
 
+    @Test(arguments: ["m4r", "M4R"])
+    func m4rCustomSoundFilesStageAsCaf(sourceExtension: String) {
+        #expect(NotificationSoundSettings.stagedCustomSoundFileExtension(forSourceExtension: sourceExtension) == "caf")
+    }
+
     @Test func activeFocusAssertionSuppressesFallbackSound() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory


### PR DESCRIPTION
## Summary

- Allow the custom notification sound picker to select `.m4r` ringtone files by adding the explicit `.m4r` UTType and the MPEG-4 audio umbrella type.
- The picker previously omitted `.m4r` even though `.m4r` is AAC audio like the already accepted `.m4a` container.
- Keep playback on the existing staging path: unsupported/non-PCM custom sound extensions, including `.m4r`, route through `/usr/bin/afconvert` to produce a `.caf` file for notifications.

Closes #6632

## Verification

- Added Swift Testing coverage for the picker allowed-content-type list.
- Added backend mapping coverage asserting `m4r` stages as `caf`.
- Verified `/usr/bin/afconvert -f caff -d LEI16` successfully transcodes a generated `.m4r` AAC file into playable CAF output.
- Did not run a cmux app build/reload per issue instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784776292&installation_id=133855650&pr_number=6635&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6635&signature=92326c6ccb3fdf83e30f4307bc00d1855d32e37081603483f11f3fd7eb882938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `.m4r` ringtone files in the custom notification sound picker and includes the MPEG‑4 audio umbrella type. Playback is unchanged: unsupported or non‑PCM formats (including `.m4r`) are staged to `.caf` via `afconvert` (closes #6632).

- **New Features**
  - Allow `.m4r` in the picker and include the MPEG‑4 audio umbrella type.

- **Refactors**
  - Centralized allowed types in `AppSection.customNotificationSoundAllowedContentTypes` (moved to `AppSection+NotificationSoundTypes.swift`) and switched to Swift Testing for picker types and `.m4r`→`.caf` staging; no behavior changes.

<sup>Written for commit a60d0159b5457529edce32c46257a61aa4aec32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded custom notification sound format support to include M4A, M4R, and MPEG-4 audio files, in addition to existing formats (AIFF, WAV, CAF, MP3).

* **Tests**
  * Added test coverage for new notification sound format support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->