### PR TITLE
ios: fix workspace top bar menu hit testing

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileGlass.swift
@@ -49,8 +49,10 @@ extension View {
     /// so the pane shows through the whole header, which leaves a plain title
     /// floating over busy terminal text and hard to read. Wrap the title in this
     /// so it sits on its own Liquid Glass pill (iOS 26+). On iOS 18 the bar keeps
-    /// a translucent material background, so the title is already backed and this
-    /// is a no-op.
+    /// a translucent material background, so this is visually a no-op. The
+    /// principal title is visual chrome only; `navigationTitle` still carries the
+    /// semantic title, so it must not participate in toolbar hit-testing or it can
+    /// intercept taps meant for trailing bar controls.
     @ViewBuilder
     func mobileGlassNavigationTitle() -> some View {
         #if os(iOS)
@@ -63,11 +65,14 @@ extension View {
                 // multi-line chat header pill can still grow.
                 .padding(.vertical, 9)
                 .glassEffect(.regular, in: .capsule)
+                .allowsHitTesting(false)
         } else {
             self
+                .allowsHitTesting(false)
         }
         #else
         self
+            .allowsHitTesting(false)
         #endif
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileNavigationChrome.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/View+MobileNavigationChrome.swift
@@ -24,8 +24,8 @@ extension View {
     ///
     /// iOS 18 has no per-element glass, so keep a translucent material bar as the
     /// backing (which also backs the title); `mobileGlassNavigationTitle` is a
-    /// no-op there. Keep the dark color scheme so the title and toolbar buttons
-    /// stay light and legible over the dark panes.
+    /// visual no-op there. Keep the dark color scheme so the title and toolbar
+    /// buttons stay light and legible over the dark panes.
     @ViewBuilder
     func mobileTerminalNavigationChrome() -> some View {
         #if os(iOS)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -450,7 +450,7 @@ struct WorkspaceDetailView: View {
     /// A nav-bar title on its own Liquid Glass capsule (iOS 26+) so it stays
     /// readable over the pane showing through the cleared header bar. On iOS 18
     /// the bar keeps a material background, so `mobileGlassNavigationTitle` is a
-    /// no-op and this renders as plain text.
+    /// visual no-op and this renders as plain text.
     private func glassTitle(_ text: String) -> some View {
         Text(text)
             .font(.headline)


### PR DESCRIPTION
## Summary
- Make the iOS workspace detail principal title chrome ignore hit testing so it cannot swallow taps meant for trailing toolbar controls.
- Keep the Liquid Glass title visually unchanged; only toolbar touch routing changes.
- Update comments that described the title helper as a full no-op on older iOS.

## Root cause
Viewed /tmp/issue-6638-topbar.png and mapped the top bar:
- Back chevron + circled unread count: WorkspaceShellView topBarLeading -> WorkspaceBackButton.
- Center title "File issue fo...": WorkspaceDetailView principal ToolbarItem -> glassTitle(workspace.name) -> mobileGlassNavigationTitle().
- Chat bubble: WorkspaceDetailView chatToggleButton.
- Terminal >_ icon: WorkspaceDetailView terminalPickerToolbarButton, accessibility id MobileTerminalDropdown.

The title itself is not wired as a rename action in this code; rename is in terminalPickerMenuContent as MobileWorkspaceRenameMenuItem when the Mac advertises workspace.actions.v1. The recent title glass capsule is decorative/semantic title chrome, but it still participated in nav-bar hit testing, so it could intercept taps in the top toolbar area and make the terminal menu look dead.

## Testing
- git diff --check
- No live iPhone paired-Mac repro: a full paired-Mac setup was not available locally, and the task says not to run local XCUITests.
- Localization audit: no user-facing strings were added or changed; only comments and hit-testing behavior changed.

Closes #6638

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/6640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784777161&installation_id=133855650&pr_number=6640&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F6640&signature=4014c8da3ea61e607d82bbf9f0ef7e9f6b2fa7d00469e01348fa323eb22dafd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the decorative workspace title pill from intercepting taps in the iOS nav bar so trailing toolbar buttons (chat toggle and terminal menu) respond as expected. Visuals stay the same; only hit-testing changes. Fixes #6638.

- **Bug Fixes**
  - Set the principal title view to `allowsHitTesting(false)` in `mobileGlassNavigationTitle` so taps reach trailing controls.
  - Updated comments to note this is a visual no-op on iOS 18 and that `navigationTitle` still carries the semantic title.

<sup>Written for commit 7d571fcd3eb125cad703d4cb847148d8bcb5439c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/6640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified navigation title chrome behavior and rendering across iOS versions.

* **Bug Fixes**
  * Fixed inconsistent hit-testing behavior for navigation titles to ensure visual-only chrome doesn't respond to user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->