### PR TITLE
Fix iMessage composer collapsing restored multi-line draft to one line

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -107,8 +107,8 @@
 859	Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Workspace/ControlCommandCoordinator+Workspace.swift
 847	cmuxTests/AgentSessionAutoResumeSettingsTests.swift
 845	cmuxTests/SSHStartupSignalLifecycleTests.swift
+840	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
 830	Sources/TaskManagerTypes.swift
-825	Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
 824	Sources/MainWindowFocusController.swift
 810	Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
 802	Sources/WorkspaceContentView.swift

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -165,6 +165,21 @@ struct TerminalComposerView: View {
         }
         .onAppear {
             recordComposerEvent(.composerViewAppear)
+            // Re-measure the band on appear. A RESTORED draft is written into
+            // `store.terminalInputText` while this composer is OFF-SCREEN (returning
+            // from the workspace list re-selects the same terminal, whose draft is
+            // already in the store, or it is re-loaded asynchronously before this view
+            // re-appears), so it produces NO content change during this view's
+            // lifecycle and the `.onChange(of: store.terminalInputText)` remeasure
+            // above never fires for it. The host's only mount-time measure can run
+            // before SwiftUI lays out the restored multi-line text, leaving the band
+            // one line tall. Deferred one runloop (like `focusField()` below) so the
+            // restored text is laid out before the host's `sizeThatFits` runs; the
+            // remeasure is idempotent (`setComposerBandHeight` no-ops on an unchanged
+            // height) and animated, so it is safe for the normal empty-composer open.
+            Task { @MainActor in
+                requestHeightRemeasure()
+            }
             // Focus only when an explicit request preceded this mount (an
             // explicit open after a dismissal, or a terminal switch while the
             // user was mid-compose). A default-open presentation arrives with no


### PR DESCRIPTION
## Bug (iPhone/iPad)

The iMessage-style terminal composer collapses a **restored** multi-line draft to a single visible line. Repro: type a multi-line draft into a terminal's composer, navigate back to the workspace list ("menu"), then re-open the same workspace. The full draft text is still in the field, but the composer band is only one line tall, so only the first line is visible.

## Root cause

The composer band height is owned by the host (`GhosttySurfaceRepresentable.Coordinator`), which measures the field's ideal height via `sizeThatFits` (`reportComposerHeight`) and applies it through `GhosttySurfaceView.setComposerBandHeight`. `TerminalComposerView` asks the host to re-measure via the `requestHeightRemeasure()` closure — but that was wired only to `.onChange(of: store.terminalInputText)` (plus attachment/send changes), **never `.onAppear`**.

A restored per-terminal draft is written back into `store.terminalInputText` while the composer is off-screen:
- Returning from the workspace list re-selects the **same** terminal, so the draft is **retained** in the store (no clear, no reload) while the surface + composer are torn down and rebuilt (`.id(terminalID)` + compact `NavigationStack` pop/push), or
- on a path that swaps selection, it is re-loaded asynchronously before the composer re-appears.

Either way the value does **not** change during this view's lifecycle, so the `.onChange` remeasure never fires for it. The host's only mount-time measure — `reportComposerHeight(animated: false)` inside `setComposerMounted` — can run before SwiftUI lays out the restored multi-line text, so it measures one line and the band stays one line tall.

## Fix (minimal)

Re-measure in `TerminalComposerView`'s `.onAppear`, deferred one runloop with `Task { @MainActor in requestHeightRemeasure() }` (mirroring the existing `focusField()` rationale: the field/host may not be laid out yet) so SwiftUI has laid out the restored text before the host's `sizeThatFits` runs. It is idempotent (`setComposerBandHeight` no-ops on an unchanged height) and animated, so it is also safe for the normal empty-composer open. No host-side changes were needed.

## Regression test — designed, but not CI-validatable (omitted)

I built a faithful XCUITest for this exact repro — type a wrapping draft, assert the dock probe's band height grew multi-line, navigate back to the workspace list, re-open the workspace, and assert the band stays multi-line (via a new DEBUG-only `bandHeight=` key on the existing `MobileComposerDockProbe`). It was a clean seam *in design*.

However, it cannot be validated in CI. iOS XCUITests are skipped in the PR gate (`-skip-testing:cmuxUITests` in `test-ios.yml`, "Full UI tests currently exceed the pull-request simulator budget"), so they only run on explicit dispatch. I ran the test via `test-ios.yml` (iPhone) on **3 separate dispatches** (with-fix ×2 and the test-only commit ×1); **all 3 died inside the shared `launchConnectedApp` harness** (`cmuxUITests.swift:540`, `waitForWorkspaceShell`) — the terminal surface never loaded, the simulator crashed ("Restarting after unexpected exit"), and the run hit a 600s diagnostic timeout — **before any composer assertion was reached**, including when run alone (so it is not concurrency contention). The connected-app XCUITest harness is simply not runnable in this CI dispatch environment, which is the same heaviness that causes the PR gate to skip `cmuxUITests`.

Per the contributor guidance (don't ship a brittle/unvalidated regression test — "say so explicitly in the PR" when there is no reliable automated seam), I've **omitted the test and the probe change and shipped the minimal fix alone**. The store-level draft-survival behavior is already covered by existing suites (`testComposerDraftSurvivesHideRevealCompose`, `DraftSwitchOwnershipTests`); the bug here is purely view-layer appear/layout timing, and the fix is minimal and mirrors the proven `focusField()` deferral. Happy to add the XCUITest under a `dispatch-only` lane if/when the connected-app harness is stabilized in CI.

## Localization audit

No user-facing strings were added or changed. The fix is logic-only (`#if os(iOS)`). No `Localizable.xcstrings` / message-catalog changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)